### PR TITLE
feat(hipsr): compute pool allocation sizes

### DIFF
--- a/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
@@ -19,6 +19,7 @@
 #include "llvm/ADT/SmallVector.h"
 
 #include <cstddef>
+#include <cstdint>
 #include <optional>
 
 namespace mlir {
@@ -33,6 +34,26 @@ struct Lifetime {
   size_t start;
   size_t end;
 };
+
+struct AllocationSize {
+  int64_t staticBytes;
+  llvm::SmallVector<Value> dynamicDims;
+};
+
+int64_t staticByteFactor(MemRefType memTy) {
+  int64_t factor = memTy.getElementTypeBitWidth() / 8;
+  for (int64_t dim : memTy.getShape()) {
+    if (!ShapedType::isDynamic(dim)) {
+      factor *= dim;
+    }
+  }
+  return factor;
+}
+
+AllocationSize computeAllocationSize(memref::AllocOp allocOp) {
+  return {staticByteFactor(allocOp.getType()),
+          llvm::to_vector(allocOp.getDynamicSizes())};
+}
 
 llvm::DenseMap<Value, Lifetime> computeLiveness(Block &body) {
   llvm::DenseMap<Operation *, size_t> opIndices;
@@ -130,9 +151,15 @@ void emitPoolingReport(Block &body,
     if (it == lifetimes.end()) {
       continue;
     }
-    allocOp.emitRemark() << "hipsr-pool-alloc: lifetime [" << it->second.start
-                         << "," << it->second.end << "] group "
-                         << groupIndices.lookup(allocOp.getResult());
+    AllocationSize size = computeAllocationSize(allocOp);
+    InFlightDiagnostic remark = allocOp.emitRemark();
+    remark << "hipsr-pool-alloc: lifetime [" << it->second.start << ","
+           << it->second.end << "] group "
+           << groupIndices.lookup(allocOp.getResult()) << " size "
+           << size.staticBytes;
+    if (!size.dynamicDims.empty()) {
+      remark << " x " << size.dynamicDims.size() << " dyn";
+    }
   }
 }
 

--- a/test/lit/Dialect/Hipsr/pool_alloc.mlir
+++ b/test/lit/Dialect/Hipsr/pool_alloc.mlir
@@ -1,8 +1,6 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// UNSUPPORTED: true
-
 // RUN: hip-mlir-opt %s -split-input-file -verify-diagnostics -hipsr-pool-alloc | FileCheck %s
 
 // CHECK-LABEL: func.func @empty_domain

--- a/test/lit/Dialect/Hipsr/pool_alloc_report.mlir
+++ b/test/lit/Dialect/Hipsr/pool_alloc_report.mlir
@@ -1,8 +1,6 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// UNSUPPORTED: true
-
 // RUN: hip-mlir-opt %s -split-input-file --verify-diagnostics \
 // RUN:   -hipsr-pool-alloc='emit-pool-report=true' \
 // RUN:   | FileCheck %s --implicit-check-not=hipsr.get_pool \
@@ -14,17 +12,17 @@ func.func @interleaved_allocs(%ctx: !hipsr.context,
   hipsr.pool_domain(%ctx, %in
       : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
   ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [1,3] group 0}}
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [1,3] group 0 size 8192}}
     %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
     hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>,
                                       memref<4x1024xf16, #hipsr.mem<device>>)
                outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [3,5] group 1}}
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [3,5] group 1 size 8192}}
     %a2 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
     hipsr.add(%dctx) ins(%a1, %a1 : memref<4x1024xf16, #hipsr.mem<device>>,
                                     memref<4x1024xf16, #hipsr.mem<device>>)
                outs(%a2 : memref<4x1024xf16, #hipsr.mem<device>>)
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [5,7] group 0}}
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [5,7] group 0 size 8192}}
     %a3 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
     hipsr.add(%dctx) ins(%a2, %a2 : memref<4x1024xf16, #hipsr.mem<device>>,
                                     memref<4x1024xf16, #hipsr.mem<device>>)
@@ -51,11 +49,11 @@ func.func @hoisted_allocs(%ctx: !hipsr.context,
   hipsr.pool_domain(%ctx, %in
       : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
   ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [3,4] group 0}}
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [3,4] group 0 size 8192}}
     %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [4,5] group 1}}
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [4,5] group 1 size 8192}}
     %a2 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [5,6] group 0}}
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [5,6] group 0 size 8192}}
     %a3 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
     hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>,
                                       memref<4x1024xf16, #hipsr.mem<device>>)
@@ -84,7 +82,7 @@ func.func @nested_region_user(%ctx: !hipsr.context,
   hipsr.pool_domain(%ctx, %in
       : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
   ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [1,2] group 0}}
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [1,2] group 0 size 8192}}
     %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
     hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>,
                                       memref<4x1024xf16, #hipsr.mem<device>>)
@@ -119,13 +117,13 @@ func.func @coalesce_static(%ctx: !hipsr.context,
        %d4a: memref<4x1024xf16, #hipsr.mem<device>>,
        %d2: memref<2x1024xf16, #hipsr.mem<device>>,
        %d4b: memref<4x1024xf16, #hipsr.mem<device>>):
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [4,5] group 0}}
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [4,5] group 0 size 16384}}
     %a1 = memref.alloc() : memref<8x1024xf16, #hipsr.mem<device>>
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [6,7] group 0}}
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [6,7] group 0 size 8192}}
     %a2 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [8,9] group 0}}
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [8,9] group 0 size 4096}}
     %a3 = memref.alloc() : memref<2x1024xf16, #hipsr.mem<device>>
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [10,11] group 0}}
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [10,11] group 0 size 8192}}
     %a4 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
     hipsr.add(%dctx) ins(%d8, %d8 : memref<8x1024xf16, #hipsr.mem<device>>, memref<8x1024xf16, #hipsr.mem<device>>) outs(%a1 : memref<8x1024xf16, #hipsr.mem<device>>)
     hipsr.add(%dctx) ins(%a1, %a1 : memref<8x1024xf16, #hipsr.mem<device>>, memref<8x1024xf16, #hipsr.mem<device>>) outs(%d8 : memref<8x1024xf16, #hipsr.mem<device>>)
@@ -146,11 +144,11 @@ func.func @coalesce_static(%ctx: !hipsr.context,
 func.func @split_three_groups(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr.mem<device>>) {
   hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
   ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [3,8] group 0}}
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [3,8] group 0 size 8192}}
     %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [4,7] group 1}}
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [4,7] group 1 size 8192}}
     %a2 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [5,8] group 2}}
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [5,8] group 2 size 8192}}
     %a3 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
     hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a2 : memref<4x1024xf16, #hipsr.mem<device>>)
@@ -158,6 +156,101 @@ func.func @split_three_groups(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hip
     hipsr.add(%dctx) ins(%a1, %a2 : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.add(%dctx) ins(%a2, %a3 : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.add(%dctx) ins(%a1, %a3 : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  }
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @dynamic_size
+func.func @dynamic_size(%ctx: !hipsr.context,
+                        %in: memref<?x512xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<?x512xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context, %din: memref<?x512xf16, #hipsr.mem<device>>):
+    %c0 = arith.constant 0 : index
+    %d = memref.dim %din, %c0 : memref<?x512xf16, #hipsr.mem<device>>
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [3,3] group 0 size 1024 x 1 dyn}}
+    %a1 = memref.alloc(%d) : memref<?x512xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%din, %din : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>)
+               outs(%a1 : memref<?x512xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  }
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @coalesce_mixed
+func.func @coalesce_mixed(%ctx: !hipsr.context,
+                          %inf32: memref<4x256xf32, #hipsr.mem<device>>,
+                          %inf16: memref<?x512xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %inf32, %inf16 :
+      !hipsr.context,
+      memref<4x256xf32, #hipsr.mem<device>>,
+      memref<?x512xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context,
+       %sf32: memref<4x256xf32, #hipsr.mem<device>>,
+       %sf16: memref<?x512xf16, #hipsr.mem<device>>):
+    %c0 = arith.constant 0 : index
+    %d = memref.dim %sf16, %c0 : memref<?x512xf16, #hipsr.mem<device>>
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [4,4] group 0 size 4096}}
+    %a1 = memref.alloc() : memref<4x256xf32, #hipsr.mem<device>>
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [5,5] group 0 size 1024 x 1 dyn}}
+    %a2 = memref.alloc(%d) : memref<?x512xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%sf32, %sf32 : memref<4x256xf32, #hipsr.mem<device>>, memref<4x256xf32, #hipsr.mem<device>>)
+               outs(%a1 : memref<4x256xf32, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%sf16, %sf16 : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>)
+               outs(%a2 : memref<?x512xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  }
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @coalesce_dynamic
+func.func @coalesce_dynamic(%ctx: !hipsr.context, %in: memref<?x1024xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<?x1024xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context, %din: memref<?x1024xf16, #hipsr.mem<device>>):
+    %c0 = arith.constant 0 : index
+    %d = memref.dim %din, %c0 : memref<?x1024xf16, #hipsr.mem<device>>
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [4,5] group 0 size 2048 x 1 dyn}}
+    %a1 = memref.alloc(%d) : memref<?x1024xf16, #hipsr.mem<device>>
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [6,7] group 0 size 2048 x 1 dyn}}
+    %a2 = memref.alloc(%d) : memref<?x1024xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%din, %din : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%a1 : memref<?x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a1, %din : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%din : memref<?x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%din, %din : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%a2 : memref<?x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a2, %din : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%din : memref<?x1024xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  }
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @split_two_groups_dynamic
+func.func @split_two_groups_dynamic(%ctx: !hipsr.context,
+                                    %inf16: memref<?x512xf16, #hipsr.mem<device>>,
+                                    %sin: memref<4x1024xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %inf16, %sin :
+      !hipsr.context,
+      memref<?x512xf16, #hipsr.mem<device>>,
+      memref<4x1024xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context,
+       %din: memref<?x512xf16, #hipsr.mem<device>>,
+       %dsin: memref<4x1024xf16, #hipsr.mem<device>>):
+    %c0 = arith.constant 0 : index
+    %d = memref.dim %din, %c0 : memref<?x512xf16, #hipsr.mem<device>>
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [4,6] group 0 size 1024 x 1 dyn}}
+    %a_dyn = memref.alloc(%d) : memref<?x512xf16, #hipsr.mem<device>>
+    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [5,7] group 1 size 8192}}
+    %a_static = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%din, %din : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>) outs(%a_dyn : memref<?x512xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%dsin, %dsin : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a_static : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a_dyn, %a_dyn : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>) outs(%din : memref<?x512xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a_static, %a_static : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%dsin : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
   }
   return


### PR DESCRIPTION
## Summary

Compute the byte size of each pooled allocation and report it through the existing `hipsr-pool-alloc` remark. Also restores the two pool-alloc LIT files so those assertions actually run.

## Related issue or design

`wcy123/onnx-hipdnn-ep#111`. Design: `pool-allocs-design-cn` HIPSR Pool Allocation Pass (Confluence v6). Reference implementation: #572.

## Why

Sizes come from an `arith` per-dimension product over the alloc's static shape and its `getDynamicSizes()` operands, not from the shape dialect. `shape.shape_of %alloc` consumes the alloc's result, which is exactly what the pass replaces with a `memref.view`, so it would be cyclic; reading the operands has no such problem. The upstream issue title still says "using shape dialect" and predates v6.

The two LIT files were gated by #618 while the hipsr refactor was in flight. The new assertions here are worthless while the files are skipped, and both were verified to pass unchanged against current `main`, so they are ungated in the same change that needs them.

## What

- `staticByteFactor` returns element bytes times every static dimension; `computeAllocationSize` pairs it with the alloc's dynamic-size operands. Both are pure functions that build no IR.
- The `#110` remark gains a size suffix: `size 8192` when the shape is fully static, `size 1024 x 1 dyn` when runtime extents remain.
- The 14 existing remark assertions carry the expected size, and four dynamic-shape cases (`dynamic_size`, `coalesce_mixed`, `coalesce_dynamic`, `split_two_groups_dynamic`) are ported from #572 as remark assertions.

## Test plan

- [x] `pool_alloc.mlir` and `pool_alloc_report.mlir` pass with `-verify-diagnostics`, so every `expected-remark` is matched exactly
- [x] Full `check-hip-mlir-lit` run shows no new failure: 338 passed, 1 pre-existing failure in `Conversion/onnx-to-hip/test_gather_block_quantized.mlir` (does not run this pass)
- [x] `pre-commit run --all-files` clean

## Notes for reviewers

- Only the two pool-alloc files are ungated; the other 28 files gated by #618 stay in that refactor's scope.
- The pass still does not modify IR. Turning this size into an `arith.muli` chain with alignment is `wcy123/onnx-hipdnn-ep#112`, and wiring the pass up is `#117`; until then the remark is the only observable output.
- `computeAllocationSize` returns the dynamic extents as `Value`s rather than a count so `#112` can feed them straight into the multiply chain.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
