### PR TITLE
refactor(hipsr): use a single shape yield operation

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
@@ -12,7 +12,7 @@
 
 def Hipsr_PlaceholderOp : Hipsr_Op<
     "placeholder",
-    [IsolatedFromAbove, SingleBlockImplicitTerminator<"ShapeYield2Op">]> {
+    [IsolatedFromAbove, SingleBlockImplicitTerminator<"ShapeYieldOp">]> {
   let summary = "Typed placeholder for hipsr DPS init operands";
   let description = [{
     Provides `outs` init values before a hipsr DPS op computes its output
@@ -28,7 +28,7 @@ def Hipsr_PlaceholderOp : Hipsr_Op<
     use upstream placeholder results rather than DPS data results.
 
     The optional `shape_region` defines the placeholder result shapes. It has
-    one block when present and ends with `hipsr.shape_yield2`.
+    one block when present and ends with `hipsr.shape_yield`.
     A `normal` region receives one `!shape.shape` argument per input and omits
     `ctx`. A `barrier` region receives `ctx` followed by its tensor inputs.
 

--- a/include/hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.td
@@ -2,8 +2,7 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 //
-// The hipsr.shape_yield op: the terminator of a hipsr shape region. Compute
-// ops and the shared Hipsr_Op base class live in HipsrOps.td.
+// The hipsr.shape_yield op terminates a placeholder shape region.
 //
 
 include "mlir/Dialect/Shape/IR/ShapeBase.td"
@@ -12,63 +11,8 @@ include "mlir/Dialect/Shape/IR/ShapeBase.td"
 // Hipsr_ShapeYieldOp
 //===----------------------------------------------------------------------===//
 
-def Hipsr_ShapeYieldOp : Hipsr_Op<"shape_yield", [Pure, Terminator]> {
-  let summary = "Yield the result shapes from a hipsr shape region";
-  let description = [{
-    Ends a shape region and yields the output shape of each of the enclosing
-    op's results. Every shape region ends with exactly one `shape_yield`.
-
-    A result is described by three lists that line up by index:
-
-    - `shapes[i]`        : result i's dimensions, as a group of `index` values.
-    - `ranks[i]`         : result i's rank (how many dims are in `shapes[i]`).
-    - `element_types[i]` : result i's element type.
-
-    An empty dim group means a rank-0 (scalar) result. Each dim group prints in
-    parentheses; the element types print as a bracketed list.
-
-    Examples:
-    ```mlir
-    // one 2-D f16 result
-    hipsr.shape_yield (%m, %n) : [f16]
-    // a 2-D f16 result and a 2-D i64 result
-    hipsr.shape_yield (%d0, %d1), (%N, %cap) : [f16, i64]
-    // one scalar (rank-0) result
-    hipsr.shape_yield () : [f32]
-    ```
-  }];
-
-  // `shapes` is a list of dim groups, one per result. `ranks` holds each
-  // group's size; it must be declared because VariadicOfVariadic looks it up by
-  // name (ODS does not add it for us) and fills it in from the shape groups.
-  // `element_types` holds each result's element type.
-  let arguments = (ins
-    VariadicOfVariadic<Index, "ranks">:$shapes,
-    DenseI32ArrayAttr:$ranks,
-    TypeArrayAttr:$element_types
-  );
-
-  // Dim groups print in parens; the element-type list prints in brackets. Dims
-  // are always `index`, so their types are left out (like scf.yield).
-  let assemblyFormat = "$shapes `:` $element_types attr-dict";
-
-  let hasVerifier = 1;
-
-  let builders = [
-    OpBuilder<(ins CArg<"::llvm::ArrayRef<::mlir::ValueRange>", "{}">:$shapes,
-                   CArg<"::mlir::TypeRange", "{}">:$elementTypes), [{
-      build($_builder, $_state, shapes,
-            $_builder.getTypeArrayAttr(elementTypes));
-    }]>
-  ];
-}
-
-//===----------------------------------------------------------------------===//
-// Hipsr_ShapeYield2Op
-//===----------------------------------------------------------------------===//
-
-def Hipsr_ShapeYield2Op : Hipsr_Op<
-    "shape_yield2", [Pure, Terminator, HasParent<"PlaceholderOp">]> {
+def Hipsr_ShapeYieldOp : Hipsr_Op<
+    "shape_yield", [Pure, Terminator, HasParent<"PlaceholderOp">]> {
   let summary = "Yield result shapes from a placeholder shape region";
   let description = [{
     Ends a `hipsr.placeholder` shape region and yields one `!shape.shape`
@@ -78,8 +22,8 @@ def Hipsr_ShapeYield2Op : Hipsr_Op<
     A scalar result still has one shape operand whose extent list is empty.
     For example:
     ```mlir
-    hipsr.shape_yield2 %shape : !shape.shape
-    hipsr.shape_yield2 %values_shape, %indices_shape
+    hipsr.shape_yield %shape : !shape.shape
+    hipsr.shape_yield %values_shape, %indices_shape
         : !shape.shape, !shape.shape
     ```
   }];

--- a/lib/Dialect/Hipsr/IR/HipsrAddOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrAddOp.cpp
@@ -38,7 +38,7 @@ LogicalResult populateAddShapeRegion(OpBuilder &builder, Block &shapeBlock,
   Value broadcast = builder.create<shape::BroadcastOp>(
       op.getLoc(), shape::ShapeType::get(builder.getContext()),
       ValueRange{args.getLhs(), args.getRhs()}, /*error=*/nullptr);
-  ShapeYield2Op::create(builder, op.getLoc(), ValueRange{broadcast});
+  ShapeYieldOp::create(builder, op.getLoc(), ValueRange{broadcast});
   return success();
 }
 

--- a/lib/Dialect/Hipsr/IR/HipsrCastOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrCastOp.cpp
@@ -37,7 +37,7 @@ LogicalResult populateCastShapeRegion(OpBuilder &builder, Block &shapeBlock,
   builder.setInsertionPointToStart(&shapeBlock);
 
   Value inputShape = CastShapeArgs{shapeBlock}.getInput();
-  ShapeYield2Op::create(builder, op.getLoc(), ValueRange{inputShape});
+  ShapeYieldOp::create(builder, op.getLoc(), ValueRange{inputShape});
   return success();
 }
 

--- a/lib/Dialect/Hipsr/IR/HipsrExpandOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrExpandOp.cpp
@@ -171,7 +171,7 @@ LogicalResult populateExpandShapeRegion(OpBuilder &builder, Block &shapeBlock,
         return SmallVector<Value, 2>{broadcastShape};
       });
 
-  ShapeYield2Op::create(builder, loc, assuming.getResults());
+  ShapeYieldOp::create(builder, loc, assuming.getResults());
   return success();
 }
 

--- a/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
@@ -113,7 +113,7 @@ LogicalResult populateMatMulShapeRegion(OpBuilder &builder, Block &shapeBlock,
         return {resultShape};
       });
 
-  ShapeYield2Op::create(builder, loc, ValueRange{assuming.getResult(0)});
+  ShapeYieldOp::create(builder, loc, ValueRange{assuming.getResult(0)});
   return success();
 }
 

--- a/lib/Dialect/Hipsr/IR/HipsrShapeYieldOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrShapeYieldOp.cpp
@@ -9,21 +9,6 @@ using namespace mlir;
 using namespace mlir::hipsr;
 
 LogicalResult ShapeYieldOp::verify() {
-  // ODS already checks that `ranks` sums to the operand count, and `shapes` is
-  // built by splitting the operands on `ranks`, so shapes.size() ==
-  // ranks.size() and each shapes[i].size() == ranks[i] hold by construction.
-  // The one thing ODS does not tie down is the element-type count, so check it
-  // here: there must be one element type per result.
-  size_t numResults = getRanks().size();
-  size_t numTypes = getElementTypes().size();
-  if (numTypes != numResults) {
-    return emitOpError() << "has " << numResults << " result(s) but "
-                         << numTypes << " element type(s)";
-  }
-  return success();
-}
-
-LogicalResult ShapeYield2Op::verify() {
   auto placeholder = cast<PlaceholderOp>(getOperation()->getParentOp());
   if (getShapes().size() != placeholder.getNumResults()) {
     return emitOpError(

--- a/lib/Dialect/Hipsr/Transforms/PopulateShapeRegionPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/PopulateShapeRegionPass.cpp
@@ -14,7 +14,7 @@
 //   %init = hipsr.placeholder(%ctx) ins(%input) : tensor<?x8xf16>
 //       shape_region {
 //   ^bb0(%input_shape: !shape.shape):
-//     hipsr.shape_yield2 %input_shape : !shape.shape
+//     hipsr.shape_yield %input_shape : !shape.shape
 //   }
 //   %0 = hipsr.cast(%ctx) ins(%input) outs(%init) : tensor<?x8xf16>
 //

--- a/test/lit/Dialect/Hipsr/IR/shape_yield.mlir
+++ b/test/lit/Dialect/Hipsr/IR/shape_yield.mlir
@@ -13,7 +13,7 @@
 // CHECK-NEXT: %[[C3:.+]] = arith.constant 3 : index
 // CHECK-NEXT: %[[VALUES_SHAPE:.+]] = shape.from_extents %[[C2]], %[[C3]]
 // CHECK-NEXT: %[[SCALAR_SHAPE:.+]] = shape.from_extents
-// CHECK-NEXT: hipsr.shape_yield2 %[[VALUES_SHAPE]], %[[SCALAR_SHAPE]]
+// CHECK-NEXT: hipsr.shape_yield %[[VALUES_SHAPE]], %[[SCALAR_SHAPE]]
 // CHECK-SAME: : !shape.shape, !shape.shape
 // CHECK-NEXT: }
 func.func @multiple_results_and_scalar(%ctx: !hipsr.context)
@@ -27,7 +27,7 @@ func.func @multiple_results_and_scalar(%ctx: !hipsr.context)
     %values_shape = "shape.from_extents"(%c2, %c3)
         : (index, index) -> !shape.shape
     %scalar_shape = "shape.from_extents"() : () -> !shape.shape
-    hipsr.shape_yield2 %values_shape, %scalar_shape
+    hipsr.shape_yield %values_shape, %scalar_shape
         : !shape.shape, !shape.shape
   }
   %results:2 = hipsr.compute(%ctx) ins()
@@ -50,7 +50,7 @@ func.func @non_shape_operand(%ctx: !hipsr.context) -> tensor<f16> {
   ^bb0(%shape_ctx: !hipsr.context):
     %extent = arith.constant 1 : index
     // expected-error @+1 {{operand #0 must be variadic of , but got 'index'}}
-    hipsr.shape_yield2 %extent : index
+    hipsr.shape_yield %extent : index
   }
   %result = hipsr.compute(%ctx) ins() outs(%init : tensor<f16>) {
   ^bb0(%body_ctx: !hipsr.context, %dest: tensor<f16>):
@@ -79,9 +79,9 @@ func.func @implicit_empty_yield(%ctx: !hipsr.context) -> tensor<f16> {
 
 // -----
 
-// ShapeYield2 terminates placeholder shape regions only.
+// ShapeYield terminates placeholder shape regions only.
 func.func @wrong_parent() {
   %shape = "shape.from_extents"() : () -> !shape.shape
   // expected-error @+1 {{expects parent op 'hipsr.placeholder'}}
-  hipsr.shape_yield2 %shape : !shape.shape
+  hipsr.shape_yield %shape : !shape.shape
 }

--- a/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/add.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/add.mlir
@@ -11,7 +11,7 @@
 // CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[LHS]], %[[RHS]] : tensor<?x1024xf16>, tensor<1024xf16>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x1024xf16> shape_region {
 // CHECK-NEXT: ^bb0(%[[LHS_SHAPE:.+]]: !shape.shape, %[[RHS_SHAPE:.+]]: !shape.shape):
 // CHECK-NEXT: %[[BROADCAST:.+]] = shape.broadcast %[[LHS_SHAPE]], %[[RHS_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT: hipsr.shape_yield2 %[[BROADCAST]] : !shape.shape
+// CHECK-NEXT: hipsr.shape_yield %[[BROADCAST]] : !shape.shape
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[RESULT:.+]] = hipsr.add(%[[CTX]]) ins(%[[LHS]], %[[RHS]] : tensor<?x1024xf16>, tensor<1024xf16>) outs(%[[INIT]] : tensor<?x1024xf16>) : tensor<?x1024xf16>
 // CHECK-NEXT: return

--- a/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/cast.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/cast.mlir
@@ -8,7 +8,7 @@
 // CHECK-SAME: %[[CTX:.+]]: !hipsr.context, %[[INPUT:.+]]: tensor<?x8xf32>) {
 // CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x8xf32>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16> shape_region {
 // CHECK-NEXT: ^bb0(%[[INPUT_SHAPE:.+]]: !shape.shape):
-// CHECK-NEXT: hipsr.shape_yield2 %[[INPUT_SHAPE]] : !shape.shape
+// CHECK-NEXT: hipsr.shape_yield %[[INPUT_SHAPE]] : !shape.shape
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[RESULT:.+]] = hipsr.cast(%[[CTX]]) ins(%[[INPUT]] : tensor<?x8xf32>) outs(%[[INIT]] : tensor<?x8xf16>) : tensor<?x8xf16>
 // CHECK-NEXT: return

--- a/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/expand.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/expand.mlir
@@ -27,7 +27,7 @@
 // CHECK-NEXT: %[[BROADCAST:.+]] = shape.broadcast %[[INPUT_SHAPE]], %[[REQUEST_SHAPE]] : tensor<2xindex>, !shape.shape -> !shape.shape
 // CHECK-NEXT: shape.assuming_yield %[[BROADCAST]] : !shape.shape
 // CHECK-NEXT: }
-// CHECK-NEXT: hipsr.shape_yield2 %[[RESULT_SHAPE]] : !shape.shape
+// CHECK-NEXT: hipsr.shape_yield %[[RESULT_SHAPE]] : !shape.shape
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[RESULT:.+]] = hipsr.expand(%[[CTX]]) ins(%[[INPUT]], %[[REQUEST]] : tensor<?x3xf16>, tensor<3xi64>) outs(%[[INIT]] : tensor<?x?x?xf16>) : tensor<?x?x?xf16>
 // CHECK-NEXT: return
@@ -59,7 +59,7 @@ func.func @expand_runtime_shape(
 // CHECK-NEXT: %[[BROADCAST:.+]] = shape.broadcast %[[INPUT_SHAPE]], %[[REQUEST_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
 // CHECK-NEXT: shape.assuming_yield %[[BROADCAST]] : !shape.shape
 // CHECK-NEXT: }
-// CHECK-NEXT: hipsr.shape_yield2 %[[RESULT_SHAPE]] : !shape.shape
+// CHECK-NEXT: hipsr.shape_yield %[[RESULT_SHAPE]] : !shape.shape
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[RESULT:.+]] = hipsr.expand(%[[CTX]]) ins(%[[INPUT]] : tensor<?x3xf16>) outs(%[[INIT]] : tensor<?x3xf16>) {shape_attr = array<i64: 3>} : tensor<?x3xf16>
 // CHECK-NEXT: return

--- a/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/matmul.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/matmul.mlir
@@ -32,7 +32,7 @@
 // CHECK-NEXT: %[[OUTPUT_SHAPE:.+]] = shape.concat %[[BATCH_SHAPE]], %[[MATRIX_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
 // CHECK-NEXT: shape.assuming_yield %[[OUTPUT_SHAPE]] : !shape.shape
 // CHECK-NEXT: }
-// CHECK-NEXT: hipsr.shape_yield2 %[[RESULT_SHAPE]] : !shape.shape
+// CHECK-NEXT: hipsr.shape_yield %[[RESULT_SHAPE]] : !shape.shape
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[RESULT:.+]] = hipsr.matmul(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x?xf16>, tensor<?x?xf16>) outs(%[[INIT]] : tensor<?x?xf16>) : tensor<?x?xf16>
 // CHECK-NEXT: return
@@ -67,7 +67,7 @@ func.func @matmul_2d(%ctx: !hipsr.context, %a: tensor<?x?xf16>,
 // CHECK-NEXT: %[[OUTPUT_SHAPE:.+]] = shape.concat %[[BROADCAST]], %[[MATRIX_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
 // CHECK-NEXT: shape.assuming_yield %[[OUTPUT_SHAPE]] : !shape.shape
 // CHECK-NEXT: }
-// CHECK-NEXT: hipsr.shape_yield2 %[[RESULT_SHAPE]] : !shape.shape
+// CHECK-NEXT: hipsr.shape_yield %[[RESULT_SHAPE]] : !shape.shape
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[RESULT:.+]] = hipsr.matmul
 // CHECK-NOT: shape_region
@@ -102,7 +102,7 @@ func.func @matmul_vector_matrix(%ctx: !hipsr.context, %a: tensor<?xf16>,
 // CHECK-NEXT: %[[OUTPUT_SHAPE:.+]] = shape.concat %[[BROADCAST]], %[[MATRIX_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
 // CHECK-NEXT: shape.assuming_yield %[[OUTPUT_SHAPE]] : !shape.shape
 // CHECK-NEXT: }
-// CHECK-NEXT: hipsr.shape_yield2 %[[RESULT_SHAPE]] : !shape.shape
+// CHECK-NEXT: hipsr.shape_yield %[[RESULT_SHAPE]] : !shape.shape
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[RESULT:.+]] = hipsr.matmul
 // CHECK-NOT: shape_region
@@ -134,7 +134,7 @@ func.func @matmul_matrix_vector(%ctx: !hipsr.context, %a: tensor<?x?xf16>,
 // CHECK-NEXT: %[[OUTPUT_SHAPE:.+]] = shape.concat %[[BROADCAST]], %[[EMPTY_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
 // CHECK-NEXT: shape.assuming_yield %[[OUTPUT_SHAPE]] : !shape.shape
 // CHECK-NEXT: }
-// CHECK-NEXT: hipsr.shape_yield2 %[[RESULT_SHAPE]] : !shape.shape
+// CHECK-NEXT: hipsr.shape_yield %[[RESULT_SHAPE]] : !shape.shape
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[RESULT:.+]] = hipsr.matmul
 // CHECK-NOT: shape_region
@@ -175,7 +175,7 @@ func.func @matmul_dot(%ctx: !hipsr.context, %a: tensor<?xf16>,
 // CHECK-NEXT: %[[OUTPUT_SHAPE:.+]] = shape.concat %[[BROADCAST]], %[[MATRIX_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
 // CHECK-NEXT: shape.assuming_yield %[[OUTPUT_SHAPE]] : !shape.shape
 // CHECK-NEXT: }
-// CHECK-NEXT: hipsr.shape_yield2 %[[RESULT_SHAPE]] : !shape.shape
+// CHECK-NEXT: hipsr.shape_yield %[[RESULT_SHAPE]] : !shape.shape
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[RESULT:.+]] = hipsr.matmul(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x1x?x?xf16>, tensor<3x?x?xf16>) outs(%[[INIT]] : tensor<?x3x?x?xf16>) : tensor<?x3x?x?xf16>
 // CHECK-NEXT: return

--- a/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/pass.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/pass.mlir
@@ -11,7 +11,7 @@
 // CHECK-NEXT: %[[C4:.+]] = arith.constant 4 : index
 // CHECK-NEXT: %[[C8:.+]] = arith.constant 8 : index
 // CHECK-NEXT: %[[OUTPUT_SHAPE:.+]] = shape.from_extents %[[C4]], %[[C8]] : index, index
-// CHECK-NEXT: hipsr.shape_yield2 %[[OUTPUT_SHAPE]] : !shape.shape
+// CHECK-NEXT: hipsr.shape_yield %[[OUTPUT_SHAPE]] : !shape.shape
 // CHECK-NEXT: }
 // CHECK-NEXT: %{{.+}} = hipsr.cast(%[[CTX]]) ins(%[[INPUT]] : tensor<4x8xf32>) outs(%[[INIT]] : tensor<4x8xf16>) : tensor<4x8xf16>
 // CHECK-NEXT: return
@@ -26,7 +26,7 @@ func.func @already_populated(
     %c4 = arith.constant 4 : index
     %c8 = arith.constant 8 : index
     %output_shape = shape.from_extents %c4, %c8 : index, index
-    hipsr.shape_yield2 %output_shape : !shape.shape
+    hipsr.shape_yield %output_shape : !shape.shape
   }
   %result = hipsr.cast(%ctx)
       ins(%input : tensor<4x8xf32>)


### PR DESCRIPTION
## Summary
- Remove the legacy grouped-index `ShapeYieldOp`.
- Promote the shape-valued placeholder terminator to canonical `ShapeYieldOp` / `hipsr.shape_yield`.
- Update production users and supported LIT tests.

## AI assistance
Cursor assisted with implementation and validation.