### PR TITLE
feat(hipsr): add dependency-based domain assignment

### DIFF
--- a/include/hip/Dialect/Hipsr/Transforms/Passes.td
+++ b/include/hip/Dialect/Hipsr/Transforms/Passes.td
@@ -167,6 +167,12 @@ def PartitionPoolDomainsPass
     The end barrier stays in the first domain. Its first user starts the second
     domain. Expand is a start barrier, so it starts the third domain.
   }];
+  let options = [
+    Option<"emitAnalysisReport", "emit-analysis-report", "bool",
+           /*default=*/"false",
+           "Debug-only: emit remarks describing domain assignments. "
+           "No effect on generated code.">
+  ];
   let dependentDialects = [
     "::mlir::hipsr::HipsrDialect"
   ];

--- a/lib/Dialect/Hipsr/Transforms/PartitionPoolDomains.cpp
+++ b/lib/Dialect/Hipsr/Transforms/PartitionPoolDomains.cpp
@@ -13,11 +13,13 @@
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
 #include "mlir/Transforms/RegionUtils.h"
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/ErrorHandling.h"
 
 namespace mlir {
 namespace hipsr {
@@ -26,6 +28,97 @@ namespace hipsr {
 #include "hip/Dialect/Hipsr/Transforms/Passes.h.inc"
 
 namespace {
+namespace partition_analysis {
+
+struct Domain {
+  llvm::SmallVector<Operation *> operations;
+  llvm::SmallVector<OpResult> results;
+};
+
+using DomainId = unsigned;
+using OperationDomains = llvm::DenseMap<Operation *, DomainId>;
+
+struct DomainAssignment {
+  llvm::SmallVector<Domain> domains;
+  OperationDomains operationDomains;
+};
+
+// Each op uses the highest domain of the ops that feed it. This lets separate
+// branches share a pool domain. A barrier moves its branch to the next domain.
+// Two barriers can share that domain when their inputs are in the same domain.
+void assignOpToDomain(Operation &operation, DomainAssignment &assignment) {
+  llvm::SmallDenseSet<DomainId, 4> dependencies;
+  for (Value operand : operation.getOperands()) {
+    if (Operation *definingOp = operand.getDefiningOp()) {
+      auto dependency = assignment.operationDomains.find(definingOp);
+      if (dependency == assignment.operationDomains.end()) {
+        llvm_unreachable(
+            "pool-domain analysis expected an assigned dependency");
+      }
+      dependencies.insert(dependency->second);
+    }
+  }
+
+  DomainId domainId = 0;
+  if (!dependencies.empty()) {
+    domainId = *llvm::max_element(dependencies);
+    if (auto placeholder = dyn_cast<PlaceholderOp>(operation);
+        placeholder &&
+        placeholder.getPlaceholderType() == PlaceholderType::Barrier) {
+      ++domainId;
+    }
+  }
+
+  if (assignment.domains.size() <= domainId) {
+    assignment.domains.resize(domainId + 1);
+  }
+  assignment.domains[domainId].operations.push_back(&operation);
+  assignment.operationDomains.try_emplace(&operation, domainId);
+}
+
+DomainAssignment assignDomains(Block &block) {
+  DomainAssignment assignment;
+  for (Operation &operation : block.without_terminator()) {
+    assignOpToDomain(operation, assignment);
+  }
+  return assignment;
+}
+
+void emitAnalysisReport(Block &block, const DomainAssignment &assignment) {
+  llvm::DenseMap<Operation *, unsigned> operationIndices;
+  for (auto [index, operation] : llvm::enumerate(block.without_terminator())) {
+    operationIndices[&operation] = index;
+  }
+
+  InFlightDiagnostic operationReport = block.getParentOp()->emitRemark();
+  operationReport << "hipsr-partition-pool-domains: operation domains [";
+  for (auto [index, operation] : llvm::enumerate(block.without_terminator())) {
+    if (index != 0) {
+      operationReport << ",";
+    }
+    auto domain = assignment.operationDomains.find(&operation);
+    if (domain == assignment.operationDomains.end()) {
+      llvm_unreachable("pool-domain analysis expected an assigned operation");
+    }
+    operationReport << index << "->" << domain->second;
+  }
+  operationReport << "]";
+
+  for (auto [domainId, domain] : llvm::enumerate(assignment.domains)) {
+    InFlightDiagnostic report = domain.operations.front()->emitRemark();
+    report << "hipsr-partition-pool-domains: domain " << domainId << " ops [";
+    for (auto [index, operation] : llvm::enumerate(domain.operations)) {
+      if (index != 0) {
+        report << ",";
+      }
+      report << operationIndices.lookup(operation) << "="
+             << operation->getName().getStringRef();
+    }
+    report << "]";
+  }
+}
+
+} // namespace partition_analysis
 
 struct Domain {
   SmallVector<Operation *> operations;
@@ -301,6 +394,9 @@ static void materializeDomains(ArrayRef<Domain> domains, Value context) {
 
 struct PartitionPoolDomainsPass
     : impl::PartitionPoolDomainsPassBase<PartitionPoolDomainsPass> {
+  using impl::PartitionPoolDomainsPassBase<
+      PartitionPoolDomainsPass>::PartitionPoolDomainsPassBase;
+
   void runOnOperation() override {
     func::FuncOp funcOp = getOperation();
 
@@ -321,13 +417,11 @@ struct PartitionPoolDomainsPass
       return;
     }
 
-    SmallVector<Domain> domains = partitionIntoDomains(entryBlock);
-    Value context;
-    if (entryBlock.getNumArguments() > 0 &&
-        isa<ContextType>(entryBlock.getArgument(0).getType())) {
-      context = entryBlock.getArgument(0);
+    partition_analysis::DomainAssignment assignment =
+        partition_analysis::assignDomains(entryBlock);
+    if (emitAnalysisReport) {
+      partition_analysis::emitAnalysisReport(entryBlock, assignment);
     }
-    materializeDomains(domains, context);
   }
 };
 

--- a/lib/Dialect/Hipsr/Transforms/PartitionPoolDomains.cpp
+++ b/lib/Dialect/Hipsr/Transforms/PartitionPoolDomains.cpp
@@ -52,7 +52,7 @@ void assignOpToDomain(Operation &operation, DomainAssignment &assignment) {
     if (Operation *definingOp = operand.getDefiningOp()) {
       auto dependency = assignment.operationDomains.find(definingOp);
       if (dependency == assignment.operationDomains.end()) {
-        llvm_unreachable(
+        llvm::report_fatal_error(
             "pool-domain analysis expected an assigned dependency");
       }
       dependencies.insert(dependency->second);
@@ -84,6 +84,9 @@ DomainAssignment assignDomains(Block &block) {
   return assignment;
 }
 
+// Op numbers follow their order in the function. The first report maps each
+// op number to its domain. The other reports list the numbered ops in each
+// domain, so LIT can check both views of the same assignment.
 void emitAnalysisReport(Block &block, const DomainAssignment &assignment) {
   llvm::DenseMap<Operation *, unsigned> operationIndices;
   for (auto [index, operation] : llvm::enumerate(block.without_terminator())) {
@@ -98,7 +101,8 @@ void emitAnalysisReport(Block &block, const DomainAssignment &assignment) {
     }
     auto domain = assignment.operationDomains.find(&operation);
     if (domain == assignment.operationDomains.end()) {
-      llvm_unreachable("pool-domain analysis expected an assigned operation");
+      llvm::report_fatal_error(
+          "pool-domain analysis expected an assigned operation");
     }
     operationReport << index << "->" << domain->second;
   }

--- a/test/lit/Dialect/Hipsr/Transforms/PartitionPoolDomains/analysis_report.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PartitionPoolDomains/analysis_report.mlir
@@ -1,0 +1,162 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s -split-input-file --verify-diagnostics \
+// RUN:   -hipsr-partition-pool-domains='emit-analysis-report=true' \
+// RUN:   | FileCheck %s --implicit-check-not=hipsr.pool_domain
+
+// Parallel barriers over one producer share the same next domain.
+// CHECK-LABEL: func.func @parallel_barriers
+// expected-remark@+1 {{hipsr-partition-pool-domains: operation domains [0->0,1->0,2->1,3->1,4->1,5->1,6->1,7->1]}}
+func.func @parallel_barriers(
+    %ctx: !hipsr.context, %input: tensor<?x8xf16>) -> tensor<?x8xf16> {
+  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 0 ops [0=hipsr.placeholder,1=hipsr.cast]}}
+  %root_init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<?x8xf16>)
+      {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
+  %root = hipsr.cast(%ctx) ins(%input : tensor<?x8xf16>)
+      outs(%root_init : tensor<?x8xf16>) : tensor<?x8xf16>
+
+  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 1 ops [2=hipsr.placeholder,3=hipsr.cast,4=hipsr.placeholder,5=hipsr.cast,6=hipsr.placeholder,7=hipsr.add]}}
+  %lhs_init = hipsr.placeholder(%ctx)
+      ins(%root_init : tensor<?x8xf16>)
+      {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x8xf16>
+  %lhs = hipsr.cast(%ctx) ins(%root : tensor<?x8xf16>)
+      outs(%lhs_init : tensor<?x8xf16>) : tensor<?x8xf16>
+
+  %rhs_init = hipsr.placeholder(%ctx)
+      ins(%root_init : tensor<?x8xf16>)
+      {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x8xf16>
+  %rhs = hipsr.cast(%ctx) ins(%root : tensor<?x8xf16>)
+      outs(%rhs_init : tensor<?x8xf16>) : tensor<?x8xf16>
+
+  %sum_init = hipsr.placeholder(%ctx)
+      ins(%lhs_init, %rhs_init : tensor<?x8xf16>, tensor<?x8xf16>)
+      {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
+  %sum = hipsr.add(%ctx)
+      ins(%lhs, %rhs : tensor<?x8xf16>, tensor<?x8xf16>)
+      outs(%sum_init : tensor<?x8xf16>) : tensor<?x8xf16>
+  return %sum : tensor<?x8xf16>
+}
+
+// -----
+
+// A barrier with only block-argument dependencies remains in domain zero.
+// CHECK-LABEL: func.func @root_barrier
+// expected-remark@+1 {{hipsr-partition-pool-domains: operation domains [0->0,1->0]}}
+func.func @root_barrier(
+    %ctx: !hipsr.context, %input: tensor<?x8xf16>) -> tensor<?x8xf16> {
+  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 0 ops [0=hipsr.placeholder,1=hipsr.cast]}}
+  %init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<?x8xf16>)
+      {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x8xf16>
+  %result = hipsr.cast(%ctx) ins(%input : tensor<?x8xf16>)
+      outs(%init : tensor<?x8xf16>) : tensor<?x8xf16>
+  return %result : tensor<?x8xf16>
+}
+
+// -----
+
+// Normal placeholders do not move work beyond the barrier's domain.
+// CHECK-LABEL: func.func @normal_after_barrier
+// expected-remark@+1 {{hipsr-partition-pool-domains: operation domains [0->0,1->0,2->1,3->1,4->1,5->1,6->1,7->1]}}
+func.func @normal_after_barrier(
+    %ctx: !hipsr.context, %input: tensor<?x8xf16>) -> tensor<?x8xf16> {
+  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 0 ops [0=hipsr.placeholder,1=hipsr.cast]}}
+  %root_init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<?x8xf16>)
+      {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
+  %root = hipsr.cast(%ctx) ins(%input : tensor<?x8xf16>)
+      outs(%root_init : tensor<?x8xf16>) : tensor<?x8xf16>
+
+  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 1 ops [2=hipsr.placeholder,3=hipsr.cast,4=hipsr.placeholder,5=hipsr.cast,6=hipsr.placeholder,7=hipsr.cast]}}
+  %barrier_init = hipsr.placeholder(%ctx)
+      ins(%root_init : tensor<?x8xf16>)
+      {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x8xf16>
+  %barrier = hipsr.cast(%ctx) ins(%root : tensor<?x8xf16>)
+      outs(%barrier_init : tensor<?x8xf16>) : tensor<?x8xf16>
+
+  %normal_init = hipsr.placeholder(%ctx)
+      ins(%barrier_init : tensor<?x8xf16>)
+      {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
+  %normal = hipsr.cast(%ctx) ins(%barrier : tensor<?x8xf16>)
+      outs(%normal_init : tensor<?x8xf16>) : tensor<?x8xf16>
+
+  %next_init = hipsr.placeholder(%ctx)
+      ins(%normal_init : tensor<?x8xf16>)
+      {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
+  %next = hipsr.cast(%ctx) ins(%normal : tensor<?x8xf16>)
+      outs(%next_init : tensor<?x8xf16>) : tensor<?x8xf16>
+  return %next : tensor<?x8xf16>
+}
+
+// -----
+
+// Later branches can return to earlier domains. A normal join uses its deepest
+// input domain, while a barrier join starts the next domain.
+// CHECK-LABEL: func.func @mixed_depth_branches
+// expected-remark@+1 {{hipsr-partition-pool-domains: operation domains [0->0,1->0,2->1,3->1,4->2,5->2,6->1,7->1,8->0,9->0,10->1,11->1,12->3,13->3]}}
+func.func @mixed_depth_branches(
+    %ctx: !hipsr.context, %input: tensor<?x8xf16>) -> tensor<?x8xf16> {
+  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 0 ops [0=hipsr.placeholder,1=hipsr.cast,8=hipsr.placeholder,9=hipsr.cast]}}
+  %root_init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<?x8xf16>)
+      {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
+  %root = hipsr.cast(%ctx) ins(%input : tensor<?x8xf16>)
+      outs(%root_init : tensor<?x8xf16>) : tensor<?x8xf16>
+
+  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 1 ops [2=hipsr.placeholder,3=hipsr.cast,6=hipsr.placeholder,7=hipsr.cast,10=hipsr.placeholder,11=hipsr.add]}}
+  %deep1_init = hipsr.placeholder(%ctx)
+      ins(%root_init : tensor<?x8xf16>)
+      {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x8xf16>
+  %deep1 = hipsr.cast(%ctx) ins(%root : tensor<?x8xf16>)
+      outs(%deep1_init : tensor<?x8xf16>) : tensor<?x8xf16>
+
+  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 2 ops [4=hipsr.placeholder,5=hipsr.cast]}}
+  %deep2_init = hipsr.placeholder(%ctx)
+      ins(%deep1_init : tensor<?x8xf16>)
+      {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x8xf16>
+  %deep2 = hipsr.cast(%ctx) ins(%deep1 : tensor<?x8xf16>)
+      outs(%deep2_init : tensor<?x8xf16>) : tensor<?x8xf16>
+
+  %middle_init = hipsr.placeholder(%ctx)
+      ins(%deep1_init : tensor<?x8xf16>)
+      {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
+  %middle = hipsr.cast(%ctx) ins(%deep1 : tensor<?x8xf16>)
+      outs(%middle_init : tensor<?x8xf16>) : tensor<?x8xf16>
+
+  %shallow_init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<?x8xf16>)
+      {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
+  %shallow = hipsr.cast(%ctx) ins(%input : tensor<?x8xf16>)
+      outs(%shallow_init : tensor<?x8xf16>) : tensor<?x8xf16>
+
+  %middle_shallow_init = hipsr.placeholder(%ctx)
+      ins(%middle_init, %shallow_init : tensor<?x8xf16>, tensor<?x8xf16>)
+      {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
+  %middle_shallow = hipsr.add(%ctx)
+      ins(%middle, %shallow : tensor<?x8xf16>, tensor<?x8xf16>)
+      outs(%middle_shallow_init : tensor<?x8xf16>) : tensor<?x8xf16>
+
+  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 3 ops [12=hipsr.placeholder,13=hipsr.add]}}
+  %result_init = hipsr.placeholder(%ctx)
+      ins(%deep2_init, %middle_shallow_init
+          : tensor<?x8xf16>, tensor<?x8xf16>)
+      {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x8xf16>
+  %result = hipsr.add(%ctx)
+      ins(%deep2, %middle_shallow : tensor<?x8xf16>, tensor<?x8xf16>)
+      outs(%result_init : tensor<?x8xf16>) : tensor<?x8xf16>
+  return %result : tensor<?x8xf16>
+}
+
+// -----
+
+// An empty body has no assignments. Declarations are skipped.
+// CHECK-LABEL: func.func @empty()
+// expected-remark@+1 {{hipsr-partition-pool-domains: operation domains []}}
+func.func @empty() {
+  return
+}
+
+// CHECK-LABEL: func.func private @declaration
+func.func private @declaration(i32) -> i32


### PR DESCRIPTION
## Summary
- Assign each top-level op to a pool domain from its input dependencies.
- Move barrier branches to the next domain while allowing parallel barriers to share a domain.
- Add an optional analysis report and focused LIT coverage.
- This step does not materialize `hipsr.pool_domain` operations.

## AI assistance
Cursor assisted with implementation and validation. I reviewed and understand the changes.