### PR TITLE
feat(hipsr): emit pool group size arithmetic

### DIFF
--- a/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
@@ -40,6 +40,8 @@ struct AllocationSize {
   llvm::SmallVector<Value> dynamicDims;
 };
 
+constexpr int64_t kPoolAlignment = 256;
+
 int64_t staticByteFactor(MemRefType memTy) {
   int64_t factor = memTy.getElementTypeBitWidth() / 8;
   for (int64_t dim : memTy.getShape()) {
@@ -187,6 +189,37 @@ void emitPoolingReport(Block &body,
   }
 }
 
+Value emitAllocationSize(OpBuilder &builder, Location loc,
+                         memref::AllocOp allocOp) {
+  AllocationSize size = computeAllocationSize(allocOp);
+  Value bytes = arith::ConstantIndexOp::create(builder, loc, size.staticBytes);
+  for (Value dyn : size.dynamicDims) {
+    bytes = arith::MulIOp::create(builder, loc, bytes, dyn);
+  }
+  return bytes;
+}
+
+// Aligns up once per group rather than per member: members share the group's
+// base offset, so only the group extent has to land on a boundary.
+Value emitGroupSize(OpBuilder &builder, Location loc,
+                    llvm::ArrayRef<Value> group, int64_t alignment) {
+  llvm::SmallVector<Value> sizes;
+  for (Value alloc : group) {
+    sizes.push_back(emitAllocationSize(builder, loc,
+                                       alloc.getDefiningOp<memref::AllocOp>()));
+  }
+  Value maxSize = sizes.front();
+  for (Value size : llvm::ArrayRef<Value>(sizes).drop_front()) {
+    maxSize = arith::MaxUIOp::create(builder, loc, maxSize, size);
+  }
+  Value alignVal = arith::ConstantIndexOp::create(builder, loc, alignment);
+  Value alignMinus1 =
+      arith::ConstantIndexOp::create(builder, loc, alignment - 1);
+  Value numerator = arith::AddIOp::create(builder, loc, maxSize, alignMinus1);
+  Value divided = arith::DivUIOp::create(builder, loc, numerator, alignVal);
+  return arith::MulIOp::create(builder, loc, divided, alignVal);
+}
+
 struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
   using impl::HipsrPoolAllocPassBase<
       HipsrPoolAllocPass>::HipsrPoolAllocPassBase;
@@ -206,6 +239,12 @@ struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
           greedyGrouping(body, lifetimes);
       if (emitPoolReport) {
         emitPoolingReport(body, lifetimes, groups, insertionPoint);
+      }
+
+      OpBuilder builder(&getContext());
+      builder.setInsertionPointAfter(insertionPoint);
+      for (llvm::ArrayRef<Value> group : groups) {
+        emitGroupSize(builder, domain.getLoc(), group, kPoolAlignment);
       }
     });
   }

--- a/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
@@ -199,8 +199,6 @@ Value emitAllocationSize(OpBuilder &builder, Location loc,
   return bytes;
 }
 
-// Aligns up once per group rather than per member: members share the group's
-// base offset, so only the group extent has to land on a boundary.
 Value emitGroupSize(OpBuilder &builder, Location loc,
                     llvm::ArrayRef<Value> group, int64_t alignment) {
   llvm::SmallVector<Value> sizes;

--- a/test/lit/Dialect/Hipsr/pool_alloc.mlir
+++ b/test/lit/Dialect/Hipsr/pool_alloc.mlir
@@ -1,0 +1,172 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s -split-input-file -hipsr-pool-alloc \
+// RUN:   | FileCheck %s --implicit-check-not=hipsr.get_pool \
+// RUN:       --implicit-check-not=memref.view
+
+// Cases are ordered by lifetime-interval topology (interference-graph chromatic
+// number chi = group count), ascending:
+//   chi=1  single point : align_up_rounding, dynamic_size, dead_alloc_skipped
+//   chi=1  independent  : coalesce_static
+//   chi=2  staggered    : split_two_groups
+
+// 3xf16 = 6 B is not a multiple of 256, so the alignUp chain must round up.
+// CHECK-LABEL: func.func @align_up_rounding
+// CHECK: %[[C6:.+]] = arith.constant 6 : index
+// CHECK-NEXT: %[[C256:.+]] = arith.constant 256 : index
+// CHECK-NEXT: %[[C255:.+]] = arith.constant 255 : index
+// CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[C6]], %[[C255]] : index
+// CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
+// CHECK-NEXT: arith.muli %[[DIV]], %[[C256]] : index
+// CHECK-NOT: arith.maxui
+func.func @align_up_rounding(%ctx: !hipsr.context,
+                        %in: memref<3xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<3xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context, %d: memref<3xf16, #hipsr.mem<device>>):
+    %a1 = memref.alloc() : memref<3xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%d, %d : memref<3xf16, #hipsr.mem<device>>, memref<3xf16, #hipsr.mem<device>>)
+               outs(%a1 : memref<3xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  }
+  return
+}
+
+// -----
+
+// The dynamic factor is the alloc's %dim operand, not a shape query on the
+// buffer itself, which would be cyclic SSA.
+// CHECK-LABEL: func.func @dynamic_size
+// CHECK: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[DIM:.+]] = memref.dim %{{.+}}, %[[C0]] : memref<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT: memref.alloc(%[[DIM]]) : memref<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[C1024:.+]] = arith.constant 1024 : index
+// CHECK-NEXT: %[[BYTES:.+]] = arith.muli %[[C1024]], %[[DIM]] : index
+// CHECK-NEXT: %[[C256:.+]] = arith.constant 256 : index
+// CHECK-NEXT: %[[C255:.+]] = arith.constant 255 : index
+// CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[BYTES]], %[[C255]] : index
+// CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
+// CHECK-NEXT: arith.muli %[[DIV]], %[[C256]] : index
+func.func @dynamic_size(%ctx: !hipsr.context,
+                   %in: memref<?x512xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<?x512xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context, %din: memref<?x512xf16, #hipsr.mem<device>>):
+    %c0 = arith.constant 0 : index
+    %d = memref.dim %din, %c0 : memref<?x512xf16, #hipsr.mem<device>>
+    %a1 = memref.alloc(%d) : memref<?x512xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%din, %din : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>)
+               outs(%a1 : memref<?x512xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  }
+  return
+}
+
+// -----
+
+// An alloc with no DPS write has no interval to place, so it joins no group and
+// the size chain covers the live alloc alone (8192, no maxui).
+// CHECK-LABEL: func.func @dead_alloc_skipped
+// CHECK: memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[LIVE:.+]] = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[C8192:.+]] = arith.constant 8192 : index
+// CHECK-NEXT: %[[C256:.+]] = arith.constant 256 : index
+// CHECK-NEXT: %[[C255:.+]] = arith.constant 255 : index
+// CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[C8192]], %[[C255]] : index
+// CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
+// CHECK-NEXT: arith.muli %[[DIV]], %[[C256]] : index
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%[[LIVE]] : memref<4x1024xf16, #hipsr.mem<device>>)
+// CHECK-NOT: arith.maxui
+func.func @dead_alloc_skipped(%ctx: !hipsr.context,
+                        %in: memref<4x1024xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
+    %dead = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>)
+               outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  }
+  return
+}
+
+// -----
+
+// Four disjoint allocs of differing sizes coalesce into one group: three
+// arith.maxui fold the sizes and the align chain runs once for the whole group
+// (the trailing CHECK-NOT rules out a second group).
+// CHECK-LABEL: func.func @coalesce_static
+// CHECK: %[[C16384:.+]] = arith.constant 16384 : index
+// CHECK-NEXT: %[[C8192A:.+]] = arith.constant 8192 : index
+// CHECK-NEXT: %[[C4096:.+]] = arith.constant 4096 : index
+// CHECK-NEXT: %[[C8192B:.+]] = arith.constant 8192 : index
+// CHECK-NEXT: %[[M0:.+]] = arith.maxui %[[C16384]], %[[C8192A]] : index
+// CHECK-NEXT: %[[M1:.+]] = arith.maxui %[[M0]], %[[C4096]] : index
+// CHECK-NEXT: %[[M2:.+]] = arith.maxui %[[M1]], %[[C8192B]] : index
+// CHECK-NEXT: %[[C256:.+]] = arith.constant 256 : index
+// CHECK-NEXT: %[[C255:.+]] = arith.constant 255 : index
+// CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[M2]], %[[C255]] : index
+// CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
+// CHECK-NEXT: arith.muli %[[DIV]], %[[C256]] : index
+// CHECK-NOT: arith.divui
+func.func @coalesce_static(%ctx: !hipsr.context,
+                               %in8: memref<8x1024xf16, #hipsr.mem<device>>,
+                               %in4a: memref<4x1024xf16, #hipsr.mem<device>>,
+                               %in2: memref<2x1024xf16, #hipsr.mem<device>>,
+                               %in4b: memref<4x1024xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %in8, %in4a, %in2, %in4b :
+      !hipsr.context,
+      memref<8x1024xf16, #hipsr.mem<device>>,
+      memref<4x1024xf16, #hipsr.mem<device>>,
+      memref<2x1024xf16, #hipsr.mem<device>>,
+      memref<4x1024xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context,
+       %d8: memref<8x1024xf16, #hipsr.mem<device>>,
+       %d4a: memref<4x1024xf16, #hipsr.mem<device>>,
+       %d2: memref<2x1024xf16, #hipsr.mem<device>>,
+       %d4b: memref<4x1024xf16, #hipsr.mem<device>>):
+    %a1 = memref.alloc() : memref<8x1024xf16, #hipsr.mem<device>>
+    %a2 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    %a3 = memref.alloc() : memref<2x1024xf16, #hipsr.mem<device>>
+    %a4 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%d8, %d8 : memref<8x1024xf16, #hipsr.mem<device>>, memref<8x1024xf16, #hipsr.mem<device>>) outs(%a1 : memref<8x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a1, %a1 : memref<8x1024xf16, #hipsr.mem<device>>, memref<8x1024xf16, #hipsr.mem<device>>) outs(%d8 : memref<8x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%d4a, %d4a : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a2 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a2, %a2 : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%d4a : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%d2, %d2 : memref<2x1024xf16, #hipsr.mem<device>>, memref<2x1024xf16, #hipsr.mem<device>>) outs(%a3 : memref<2x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a3, %a3 : memref<2x1024xf16, #hipsr.mem<device>>, memref<2x1024xf16, #hipsr.mem<device>>) outs(%d2 : memref<2x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%d4b, %d4b : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a4 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a4, %a4 : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%d4b : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  }
+  return
+}
+
+// -----
+
+// a1 is read while writing a2, so their lifetimes overlap and land in separate
+// groups: two independent size chains, each aligned on its own.
+// CHECK-LABEL: func.func @split_two_groups
+// CHECK: %[[C8192A:.+]] = arith.constant 8192 : index
+// CHECK-NEXT: %[[C256A:.+]] = arith.constant 256 : index
+// CHECK-NEXT: %[[C255A:.+]] = arith.constant 255 : index
+// CHECK-NEXT: %[[N0:.+]] = arith.addi %[[C8192A]], %[[C255A]] : index
+// CHECK-NEXT: %[[D0:.+]] = arith.divui %[[N0]], %[[C256A]] : index
+// CHECK-NEXT: arith.muli %[[D0]], %[[C256A]] : index
+// CHECK-NEXT: %[[C8192B:.+]] = arith.constant 8192 : index
+// CHECK-NEXT: %[[C256B:.+]] = arith.constant 256 : index
+// CHECK-NEXT: %[[C255B:.+]] = arith.constant 255 : index
+// CHECK-NEXT: %[[N1:.+]] = arith.addi %[[C8192B]], %[[C255B]] : index
+// CHECK-NEXT: %[[D1:.+]] = arith.divui %[[N1]], %[[C256B]] : index
+// CHECK-NEXT: arith.muli %[[D1]], %[[C256B]] : index
+// CHECK-NOT: arith.maxui
+func.func @split_two_groups(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
+    %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    %a2 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a1, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a2 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  }
+  return
+}


### PR DESCRIPTION
## Summary

`hipsr-pool-alloc` rewrites IR for the first time: after the last poolable alloc it emits one `index` size chain per lifetime group — a byte size per member, `arith.maxui` across the group, and a single alignUp to 256 for the whole group.

## Related issue or design

wcy123/onnx-hipdnn-ep#112

## Why

- The static part is one compile-time constant, not an `arith.muli` per static dimension: `computeAllocationSize` already collapses the static extents into `staticByteFactor`, so only the dynamic-size operands need a multiply chain at runtime.
- alignUp runs once per group instead of once per member. Members share the group's base offset, so only the group extent has to land on a 256 B boundary; aligning each member would pad every one of them.
- Alignment is hardcoded to 256. No caller needs a different value, so there is no pass option for it yet.
- The chain is emitted unconditionally, including for all-static groups, and left for `canonicalize` to fold rather than folded in the pass.

## What

- `kPoolAlignment`, `emitAllocationSize`, `emitGroupSize` in `HipsrPoolAllocPass.cpp`.
- `runOnOperation` sets the insertion point after the anchor `findInsertionPoint` returns and emits one chain per group. The report still runs before emission so it observes the input IR.
- The group sizes are discarded for now; `hipsr.get_pool` becomes their consumer in wcy123/onnx-hipdnn-ep#114, so until then they are dead `arith` values. The verifier is fine with that and the pass is not in a pipeline yet.

## Test plan

- [x] `test/lit/Dialect/Hipsr/pool_alloc.mlir` passes: five cases carried over from #572 (`align_up_rounding`, `dynamic_size`, `dead_alloc_skipped`, `coalesce_static`, `split_two_groups`) with the CHECK chains trimmed to the end of the align chain.
- [x] `pool_alloc_report.mlir` and `pool_alloc_invalid.mlir` show no regression when run for real. The report file only asserts `CHECK-LABEL` plus `--implicit-check-not` on `hipsr.get_pool` / `memref.view`, and the new `arith` ops are on neither list; the invalid file returns before emission.
- [x] Full `check-hip-mlir-lit`: 352 passed, 24 unsupported, and the single failure is `Conversion/onnx-to-hip/test_gather_block_quantized.mlir`, which reproduces identically on clean `main` (an MLIR `BuiltinAttributes.cpp` assertion in an unrelated conversion).
- [x] `pre-commit run --all-files` converges at the hip-ep root.

## Notes for reviewers

- `pool_alloc.mlir` is the file name #656 deleted; it comes back here as this pass's single transform test, so git renders it as a same-name delete-then-add. The remaining steps of the upstream series — `wcy123/onnx-hipdnn-ep` [#114](https://github.com/wcy123/onnx-hipdnn-ep/issues/114) (pool emission), [#115](https://github.com/wcy123/onnx-hipdnn-ep/issues/115) (offsets), [#116](https://github.com/wcy123/onnx-hipdnn-ep/issues/116) (`memref.view` substitution) — keep extending the CHECKs in this same file instead of adding new ones: every stage rewrites the IR the previous stage's CHECKs matched, and by the last one even `memref.alloc` is gone, so one file makes each PR's diff show exactly how much further the transform now reaches.
- There is deliberately no `-canonicalize` RUN. With no consumer the whole chain is trivially dead, so canonicalize deletes it rather than folding it, and alignUp's numeric correctness only becomes observable once wcy123/onnx-hipdnn-ep#114 wires up `hipsr.get_pool`.
- Open question, not triggered by this PR: the insertion point is anchored after the last poolable alloc. Emitting sizes there is always safe, but wcy123/onnx-hipdnn-ep#116 has to confirm the `memref.view` dominates its users — the `@interleaved_allocs` shape in `pool_alloc_report.mlir` is the counterexample.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
