### PR TITLE
fix(qmoe): compute down_proj (fc2) in fp32 to avoid fp16 overflow

### DIFF
--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -553,14 +553,21 @@ __global__ void matmul_nbits_gemv_kernel_i8(
  * Launch: grid(ceil(N/TILE_N), M, batch), block(BLOCK_SIZE)
  * ======================================================================= */
 
-template <int BLOCK_SIZE, int TILE_N, bool COL_MAJOR = false>
+// OutT selects the store precision: __half (default — every existing caller,
+// byte-identical) or float. float is requested only by hip_matmul_nbits_fp32out
+// (QMoE down_proj), where a raw per-expert GEMM channel can exceed the fp16 max
+// (65504) and overflow to inf BEFORE the routing weight scales it back into
+// range. The accumulator (`partial`) is already fp32; OutT only changes the
+// final narrowing at the store, so the fp16 path is bit-for-bit unchanged.
+template <int BLOCK_SIZE, int TILE_N, bool COL_MAJOR = false,
+          typename OutT = __half>
 __global__ void matmul_nbits_gemv_kernel(
     const __half* __restrict__ A,
     const uint8_t* __restrict__ B,
     const __half* __restrict__ scales,
     const uint8_t* __restrict__ zp,
     const __half* __restrict__ bias,
-    __half* __restrict__ output,
+    OutT* __restrict__ output,
     int64_t M, int64_t N, int64_t K,
     int64_t block_size)
 {
@@ -826,10 +833,10 @@ __global__ void matmul_nbits_gemv_kernel(
                     // (28KB) to pollute cache, and NT writes compete with read
                     // traffic on the shared memory bus.
                     if constexpr (COL_MAJOR)
-                        output[n * M + m] = static_cast<__half>(val);
+                        output[n * M + m] = static_cast<OutT>(val);
                     else
                         output[batch * M * N + m * N + n] =
-                            static_cast<__half>(val);
+                            static_cast<OutT>(val);
                 }
             }
         }
@@ -857,10 +864,10 @@ __global__ void matmul_nbits_gemv_kernel(
                         if (bias)
                             val += static_cast<float>(bias[n]);
                         if constexpr (COL_MAJOR)
-                            output[n * M + m] = static_cast<__half>(val);
+                            output[n * M + m] = static_cast<OutT>(val);
                         else
                             output[batch * M * N + m * N + n] =
-                                static_cast<__half>(val);
+                                static_cast<OutT>(val);
                     }
                 }
             }
@@ -2551,8 +2558,16 @@ hipdnn_wmma_f32_16x16x16_f16_w32_unavailable(half16, half16, float8 c) {
 
 #define WMMA_TILE 16
 
+// OutT selects the store precision: _Float16 (default — every existing WMMA
+// instantiation, byte-identical) or float. float is requested only by
+// hip_matmul_nbits_fp32out (QMoE down_proj), where a raw per-expert GEMM
+// channel can exceed the fp16 max (65504) and overflow to inf BEFORE the
+// routing weight scales it back into range. The WMMA accumulator (`acc`) is
+// already fp32; OutT only changes the final narrowing at the store, so the
+// fp16 path is bit-for-bit unchanged.
 template <int BM_T, int BN_T, int WT_M, int WT_N, bool USE_ZEROS,
-          bool BOUNDS_CHECK = false, bool FUSED_DQ = true>
+          bool BOUNDS_CHECK = false, bool FUSED_DQ = true,
+          typename OutT = _Float16>
 __device__ __forceinline__
 void GemmFp16U4Impl(
     int M, int N, int K,
@@ -2561,7 +2576,7 @@ void GemmFp16U4Impl(
     const _Float16* __restrict__ scales,
     const _Float16* __restrict__ zeros,
     int group_size, int num_groups_k,
-    _Float16* __restrict__ C, int ldc,
+    OutT* __restrict__ C, int ldc,
     int swizzle_n = 4)
 {
     constexpr int WM_L   = BM_T / (WT_M * 16);
@@ -2842,10 +2857,10 @@ void GemmFp16U4Impl(
                 if constexpr (BOUNDS_CHECK) {
                     if (mbase + r < M && nbase + lane < N)
                         C[(mbase + r) * ldc + nbase + lane] =
-                            (_Float16)acc[wm][wn][e];
+                            (OutT)acc[wm][wn][e];
                 } else {
                     C[(mbase + r) * ldc + nbase + lane] =
-                        (_Float16)acc[wm][wn][e];
+                        (OutT)acc[wm][wn][e];
                 }
             }
         }
@@ -2858,7 +2873,7 @@ void GemmFp16U4Impl(
     ((BM / (WM * 16)) * (BN / (WN * 16)) * 32)
 
 template <int BM_T = 128, int BN_T = 128, int WT_M = 2, int WT_N = 2,
-          int WAVES_EU = 8, bool BC = false>
+          int WAVES_EU = 8, bool BC = false, typename OutT = _Float16>
 __global__
 __attribute__((amdgpu_flat_work_group_size(
     GEMM_WG_SZ(BM_T, BN_T, WT_M, WT_N),
@@ -2871,16 +2886,16 @@ void MatMulNBitsWMMA_NoZP(
     const _Float16* __restrict__ scales,
     const _Float16* __restrict__ zeros,
     int group_size, int num_groups_k,
-    _Float16* __restrict__ C, int ldc,
+    OutT* __restrict__ C, int ldc,
     int swizzle_n = 4)
 {
-    GemmFp16U4Impl<BM_T, BN_T, WT_M, WT_N, false, BC>(
+    GemmFp16U4Impl<BM_T, BN_T, WT_M, WT_N, false, BC, true, OutT>(
         M, N, K, A, lda, B_packed, scales, zeros,
         group_size, num_groups_k, C, ldc, swizzle_n);
 }
 
 template <int BM_T = 128, int BN_T = 128, int WT_M = 2, int WT_N = 2,
-          int WAVES_EU = 8, bool BC = false>
+          int WAVES_EU = 8, bool BC = false, typename OutT = _Float16>
 __global__
 __attribute__((amdgpu_flat_work_group_size(
     GEMM_WG_SZ(BM_T, BN_T, WT_M, WT_N),
@@ -2893,10 +2908,10 @@ void MatMulNBitsWMMA_ZP(
     const _Float16* __restrict__ scales,
     const _Float16* __restrict__ zeros,
     int group_size, int num_groups_k,
-    _Float16* __restrict__ C, int ldc,
+    OutT* __restrict__ C, int ldc,
     int swizzle_n = 4)
 {
-    GemmFp16U4Impl<BM_T, BN_T, WT_M, WT_N, true, BC>(
+    GemmFp16U4Impl<BM_T, BN_T, WT_M, WT_N, true, BC, true, OutT>(
         M, N, K, A, lda, B_packed, scales, zeros,
         group_size, num_groups_k, C, ldc, swizzle_n);
 }
@@ -6191,6 +6206,150 @@ extern "C" int hip_matmul_nbits(
   if (err != hipSuccess) {
     fprintf(stderr,
             "[custom_kernels] hip_matmul_nbits naive launch failed: %s\n",
+            hipGetErrorString(err));
+  }
+  return static_cast<int>(err);
+}
+
+/* -----------------------------------------------------------------------
+ * hip_matmul_nbits_fp32out: bits=4 quantized GEMM with an fp32 output.
+ *
+ * WHY a separate entry point (rather than an out_elem_size flag on
+ * hip_matmul_nbits): the fp16 dispatch above has four data-dependent code
+ * paths (WMMA, col-major GEMV, row-major GEMV, naive) plus disk-persistent
+ * autotune caches that every other model depends on. Widening the output of
+ * ALL of them would ripple through the autotune timing/config machinery and
+ * risk a regression in the exact file the codebase warns is fragile. This
+ * function instead reuses the SAME two int4 kernels the fp16 dispatch uses —
+ * instantiated with OutT=float — and picks between them on M exactly like the
+ * fp16 path does, but with FIXED configs (no autotune, no autotune-cache
+ * touched):
+ *   - M >= kFp32OutWmmaMinM (16) and K % 32 == 0 → fused-dequant WMMA
+ *     (GemmFp16U4Impl, 128x128 tile, WT 2x2, bounds-checked). Needs fp16 zeros.
+ *   - otherwise                                  → row-major int4 GEMV
+ *     (matmul_nbits_gemv_kernel, 256x8; valid for any M). Needs uint8 zeros.
+ * The fp16 WMMA/GEMV code paths and their disk-persistent autotune caches are
+ * NOT touched — OutT only changes the final store narrowing (accumulators were
+ * always fp32).
+ *
+ * The sole caller is QMoE down_proj (fc2): a raw per-expert GEMM channel can
+ * exceed the fp16 max (65504) and overflow to inf BEFORE the routing weight
+ * scales it back into range, so the GEMM output must stay fp32 until the
+ * weighted cross-expert accumulation. Caller passes bias=null and folds the
+ * (weighted) bias in the fp32 scatter, so this only computes W . h in fp32.
+ *
+ *   A              : fp16 [M, K] row-major
+ *   B              : packed int4 weights [N, k_blocks*(block_size/2)]
+ *   scales         : fp16 [N, k_blocks]
+ *   zero_points_u8 : UNPACKED uint8 [N, k_blocks] for the GEMV path (asym),
+ *                    or null (sym → zp=8)
+ *   zero_points_fp16 : fp16 [N, k_blocks] for the WMMA path (asym), or null
+ *                    (sym). Only consulted when the WMMA path is taken; the
+ *                    caller may pass null when it knows M < 16.
+ *   bias           : fp16 [N], or null (GEMV path only — WMMA has no bias
+ *                    epilogue here; QMoE fc2 passes null)
+ *   output         : fp32 [M, N] row-major
+ * ----------------------------------------------------------------------- */
+static constexpr int64_t kFp32OutWmmaMinM = 16;
+
+extern "C" int hip_matmul_nbits_fp32out(
+    void* stream,
+    const void* A,
+    const void* B,
+    const void* scales,
+    const void* zero_points_u8,
+    const void* zero_points_fp16,
+    const void* bias,
+    void* output,
+    int64_t M, int64_t N, int64_t K,
+    int64_t bits,
+    int64_t block_size) {
+  if (bits != 4) {
+    fprintf(stderr,
+            "[custom_kernels] hip_matmul_nbits_fp32out: only bits=4 "
+            "supported, got %lld\n",
+            (long long)bits);
+    return -1;
+  }
+  if (M <= 0 || N <= 0 || K <= 0) return 0;
+
+  hipStream_t hip_stream = static_cast<hipStream_t>(stream);
+
+  // WMMA fused-dequant path for the larger-M (prefill) regime — same M>=16
+  // threshold the fp16 dispatch uses, gated on K%32==0 so the 32-wide K tile
+  // (BK_T = 128/(2*2)) is whole. bias must be folded by the caller (WMMA has
+  // no bias epilogue here); QMoE fc2 already passes bias=null.
+  if (M >= kFp32OutWmmaMinM && (K % 32) == 0) {
+    const bool has_zp = (zero_points_fp16 != nullptr);
+    const int ngk = static_cast<int>((K + block_size - 1) / block_size);
+    constexpr int BM = 128, BN = 128;
+    constexpr int WM_ = BM / (2 * 16);    // 4
+    constexpr int WN_ = BN / (2 * 16);    // 4
+    constexpr int THR_ = WM_ * WN_ * 32;  // 512
+    dim3 grid(static_cast<unsigned>((N + BN - 1) / BN),
+              static_cast<unsigned>((M + BM - 1) / BM));
+    dim3 block(THR_);
+
+    (void)hipGetLastError();  // clear any stale sticky error before launch
+    if (has_zp) {
+      hipLaunchKernelGGL(
+          HIP_KERNEL_NAME(
+              MatMulNBitsWMMA_ZP<128, 128, 2, 2, 8, true, float>),
+          grid, block, 0, hip_stream,
+          static_cast<int>(M), static_cast<int>(N), static_cast<int>(K),
+          static_cast<const _Float16*>(A), static_cast<int>(K),
+          static_cast<const unsigned char*>(B),
+          static_cast<const _Float16*>(scales),
+          static_cast<const _Float16*>(zero_points_fp16),
+          static_cast<int>(block_size), ngk,
+          static_cast<float*>(output), static_cast<int>(N), 4);
+    } else {
+      hipLaunchKernelGGL(
+          HIP_KERNEL_NAME(
+              MatMulNBitsWMMA_NoZP<128, 128, 2, 2, 8, true, float>),
+          grid, block, 0, hip_stream,
+          static_cast<int>(M), static_cast<int>(N), static_cast<int>(K),
+          static_cast<const _Float16*>(A), static_cast<int>(K),
+          static_cast<const unsigned char*>(B),
+          static_cast<const _Float16*>(scales),
+          static_cast<const _Float16*>(zero_points_fp16),
+          static_cast<int>(block_size), ngk,
+          static_cast<float*>(output), static_cast<int>(N), 4);
+    }
+
+    hipError_t err = hipGetLastError();
+    if (err != hipSuccess) {
+      fprintf(stderr,
+              "[custom_kernels] hip_matmul_nbits_fp32out WMMA launch failed: "
+              "%s\n",
+              hipGetErrorString(err));
+    }
+    return static_cast<int>(err);
+  }
+
+  // Decode / small-M regime (and non-32-aligned K): row-major int4 GEMV,
+  // valid for any M (grid.y = M, one block per output row).
+  constexpr int BS = 256;
+  constexpr int TN = 8;
+  dim3 grid(static_cast<unsigned>((N + TN - 1) / TN),
+            static_cast<unsigned>(M),
+            1u);
+  dim3 block(BS);
+
+  (void)hipGetLastError();  // clear any stale sticky error before launch
+  hipLaunchKernelGGL(
+      HIP_KERNEL_NAME(matmul_nbits_gemv_kernel<BS, TN, false, float>),
+      grid, block, 0, hip_stream,
+      static_cast<const __half*>(A), static_cast<const uint8_t*>(B),
+      static_cast<const __half*>(scales),
+      static_cast<const uint8_t*>(zero_points_u8),
+      static_cast<const __half*>(bias), static_cast<float*>(output),
+      M, N, K, block_size);
+
+  hipError_t err = hipGetLastError();
+  if (err != hipSuccess) {
+    fprintf(stderr,
+            "[custom_kernels] hip_matmul_nbits_fp32out launch failed: %s\n",
             hipGetErrorString(err));
   }
   return static_cast<int>(err);

--- a/lib/Runtime/Kernels/hip/qmoe_kernel.hip
+++ b/lib/Runtime/Kernels/hip/qmoe_kernel.hip
@@ -233,6 +233,52 @@ __global__ void scatter_add_kernel(
 }
 
 // ---------------------------------------------------------------------------
+// Scatter-add into an fp32 accumulator, applying the routing weight to the
+// WHOLE per-expert result (raw down_proj GEMM output PLUS the down_proj bias):
+//   out_accum[token_ids[i], j] += (float)weights[i]
+//                                 * ((float)expert_out[i, j] + (float)bias[j])
+//
+// `expert_out` is the RAW down_proj GEMM  W_dn . h_e  in FP32 (see
+// hip_matmul_nbits_fp32out) — NO routing weight and NO bias applied. Keeping it
+// fp32 is what fixes the overflow: an individual down_proj channel can exceed
+// the fp16 max (65504) even when the final weighted cross-expert sum is well in
+// range, so narrowing to fp16 before the weight scales it back down would turn
+// it into inf -> NaN. The per-expert bias b_e (`bias[j]`, broadcast over rows)
+// is added and then the SAME per-row routing weight scales the whole sum,
+// yielding the correct   w_e * (W_dn . h_e + b_e). Applying the weight to the
+// bias too (rather than adding a raw bias) avoids the "bias not scaled by the
+// routing weight" defect: summed over the k experts (Sum w_e = 1) a raw bias
+// would inject a systematic  Sum_e (1 - w_e) * b_e  offset (~k-1 average
+// biases) into every token, corrupting logits far beyond fp16 rounding.
+//
+// `bias` null => scatter w_e * (W_dn . h_e); `weights` null => weight 1.
+// Cross-expert accumulation stays in fp32 so partial sums never round or
+// overflow through fp16; the caller casts the accumulator to fp16 once at the
+// end. Safe without atomics when experts run serially (each expert launch
+// touches a token row at most once, and launches are ordered on one stream).
+// ---------------------------------------------------------------------------
+__global__ void scatter_add_fp32_kernel(
+    float* __restrict__ out_accum,
+    const float* __restrict__ expert_out,  // FP32 raw W_dn.h_e (no w, no bias)
+    const int32_t* __restrict__ token_ids,
+    const __half* __restrict__ bias,     // [width] per-channel, or null
+    const __half* __restrict__ weights,  // [count] per-row routing weight
+    int64_t width,
+    int64_t count) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= count * width) return;
+
+  int64_t row = idx / width;
+  int64_t col = idx % width;
+  int64_t dst_row = static_cast<int64_t>(token_ids[row]);
+
+  float w = weights ? static_cast<float>(weights[row]) : 1.0f;
+  float val = expert_out[idx];
+  if (bias) val += static_cast<float>(bias[col]);
+  out_accum[dst_row * width + col] += w * val;
+}
+
+// ---------------------------------------------------------------------------
 // GPU-side expert bucketing (Phase 2 foundation).
 //
 // Replaces the host-side bucket loop in wrap_qmoe that today requires a D2H
@@ -491,6 +537,46 @@ extern "C" int hip_qmoe_scatter_add(
   hipError_t err = hipGetLastError();
   if (err != hipSuccess)
     fprintf(stderr, "[custom_kernels] hip_qmoe_scatter_add failed: %s\n",
+            hipGetErrorString(err));
+  return static_cast<int>(err);
+}
+
+extern "C" int hip_qmoe_scatter_add_fp32(
+    void* stream,
+    void* out_accum,
+    const void* expert_out,
+    const void* token_ids,
+    const void* bias,
+    const void* weights,
+    int64_t width,
+    int64_t count,
+    int64_t element_size_bytes) {
+  if (count <= 0 || width <= 0) return 0;
+
+  hipStream_t s = static_cast<hipStream_t>(stream);
+  int64_t total = count * width;
+  int grid = static_cast<int>((total + kBlock - 1) / kBlock);
+
+  // expert_out is FP32; out_accum is fp32; bias/weights are fp16.
+  // element_size_bytes describes bias/weights (fp16=2).
+  if (element_size_bytes != 2) {
+    fprintf(stderr,
+            "[custom_kernels] hip_qmoe_scatter_add_fp32: only fp16 "
+            "bias/weights supported, got element_size %lld\n",
+            (long long)element_size_bytes);
+    return -1;
+  }
+
+  hipLaunchKernelGGL(scatter_add_fp32_kernel, dim3(grid), dim3(kBlock), 0, s,
+                     static_cast<float*>(out_accum),
+                     static_cast<const float*>(expert_out),
+                     static_cast<const int32_t*>(token_ids),
+                     static_cast<const __half*>(bias),
+                     static_cast<const __half*>(weights), width, count);
+
+  hipError_t err = hipGetLastError();
+  if (err != hipSuccess)
+    fprintf(stderr, "[custom_kernels] hip_qmoe_scatter_add_fp32 failed: %s\n",
             hipGetErrorString(err));
   return static_cast<int>(err);
 }

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -1675,6 +1675,39 @@ HIP_KERNEL_API int hip_matmul_nbits(
     const void* pre_unpacked_zp_u8,
     const void* pre_unpacked_zp_fp16);
 
+/* bits=4 quantized GEMM with an FP32 output. Reuses the SAME two int4 kernels
+ * the fp16 hip_matmul_nbits dispatch uses (instantiated with OutT=float) and
+ * picks between them on M with FIXED configs — no autotune, none of the fp16
+ * autotune caches touched:
+ *   - M >= 16 and K % 32 == 0 → fused-dequant WMMA (128x128, needs fp16 zeros)
+ *   - otherwise               → row-major int4 GEMV (any M, needs uint8 zeros)
+ * OutT only changes the final store narrowing; the fp16 paths are unchanged.
+ * Sole caller: QMoE down_proj (fc2), where a raw per-expert GEMM channel can
+ * exceed the fp16 max and overflow to inf before the routing weight scales it
+ * back into range. Caller passes bias=null and folds the weighted bias in the
+ * fp32 scatter, so this computes only W . h in fp32.
+ *   A              : fp16 [M, K] row-major
+ *   B              : packed int4 weights [N, k_blocks*(block_size/2)]
+ *   scales         : fp16 [N, k_blocks]
+ *   zero_points_u8   : UNPACKED uint8 [N, k_blocks] for the GEMV path (asym),
+ *                      or null (sym, zp=8)
+ *   zero_points_fp16 : fp16 [N, k_blocks] for the WMMA path (asym), or null
+ *                      (sym / caller knows M<16)
+ *   bias           : fp16 [N], or null (GEMV path only)
+ *   output         : fp32 [M, N] row-major */
+HIP_KERNEL_API int hip_matmul_nbits_fp32out(
+    void* stream,
+    const void* A,
+    const void* B,
+    const void* scales,
+    const void* zero_points_u8,
+    const void* zero_points_fp16,
+    const void* bias,
+    void* output,
+    int64_t M, int64_t N, int64_t K,
+    int64_t bits,
+    int64_t block_size);
+
 /* W4A8 integer-dot-product (dp4a) GEMV for a single decode row (M==1).
  * Dynamically quantizes the fp16 activation row to per-group int8 (into
  * caller-owned scratch) and runs a `v_dot4_i32_iu8` (`__builtin_amdgcn_sudot4`)
@@ -1850,6 +1883,32 @@ HIP_KERNEL_API int hip_qmoe_scatter_add(
     void* output,
     const void* expert_out,
     const void* token_ids,
+    const void* weights,
+    int64_t width,
+    int64_t count,
+    int64_t element_size_bytes);
+
+/* Scatter-add into an fp32 accumulator, applying the routing weight to the
+ * WHOLE per-expert result (GEMM output + down_proj bias):
+ *   out_accum[token_ids[i],:] += (float)weights[i]
+ *                                * ((float)expert_out[i,:] + (float)bias[:])
+ *   out_accum  - GPU [num_tokens, width] fp32
+ *   expert_out - GPU [count, width] FP32 (raw down_proj W_dn.h_e, NO routing
+ *                weight and NO bias applied — see hip_matmul_nbits_fp32out)
+ *   token_ids  - GPU [count] int32
+ *   bias       - GPU [width] fp16 per-channel down_proj bias, or null
+ *   weights    - GPU [count] fp16 per-row routing weight, or null (=> weight 1)
+ * expert_out is fp32 so a raw down_proj channel that exceeds the fp16 max
+ * never overflows before the weight scales it back into range; the bias is
+ * weighted here so the multi-token result equals w_e*(W_dn.h_e + b_e) with no
+ * Sum_e (1-w_e) b_e offset. Cross-expert accumulation stays in fp32; caller
+ * casts to fp16 once. element_size_bytes describes bias/weights (fp16=2). */
+HIP_KERNEL_API int hip_qmoe_scatter_add_fp32(
+    void* stream,
+    void* out_accum,
+    const void* expert_out,
+    const void* token_ids,
+    const void* bias,
     const void* weights,
     int64_t width,
     int64_t count,

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -145,6 +145,17 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
   size_t sz_a_scale_in = align_up_64(k_blocks_fc1 * sizeof(float));
   size_t sz_a_qb_mid = align_up_64(k * inter_size * sizeof(int8_t));
   size_t sz_a_scale_mid = align_up_64(k * k_blocks_fc2 * sizeof(float));
+  // fp32 output accumulator for the multi-pass path: cross-expert weighted sums
+  // are accumulated in fp32 so a single expert's down_proj (which can exceed
+  // the fp16 max) never overflows an fp16 intermediate. Cast to the fp16 graph
+  // output once after the expert loop. (Unused by the fused decode fast path.)
+  size_t sz_out_accum = align_up_64(num_tokens * hidden_size * sizeof(float));
+  // fp32 down_proj (fc2) output for the multi-pass path. The raw per-expert
+  // down_proj result is stored in fp32 (not the fp16 d_fc2_buf) so a channel
+  // that exceeds the fp16 max never overflows to inf before the routing weight
+  // scales it back into range; the weighted bias + weight are applied in the
+  // fp32 scatter below. Sized [count<=act_slots, hidden] in fp32.
+  size_t sz_fc2_f32 = align_up_64(act_slots * hidden_size * sizeof(float));
 
   size_t off_expert_indices = 0;
   size_t off_expert_weights = off_expert_indices + sz_expert_indices;
@@ -160,7 +171,9 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
   size_t off_a_scale_in = off_a_qb_in + sz_a_qb_in;
   size_t off_a_qb_mid = off_a_scale_in + sz_a_scale_in;
   size_t off_a_scale_mid = off_a_qb_mid + sz_a_qb_mid;
-  size_t total_scratch = off_a_scale_mid + sz_a_scale_mid;
+  size_t off_out_accum = off_a_scale_mid + sz_a_scale_mid;
+  size_t off_fc2_f32 = off_out_accum + sz_out_accum;
+  size_t total_scratch = off_fc2_f32 + sz_fc2_f32;
 
   if (hipdnn_ep_state_ensure_qmoe_scratch(state, total_scratch) != 0) {
     fprintf(stderr, "wrap_qmoe: ensure_qmoe_scratch(%zu) failed\n",
@@ -186,6 +199,8 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
   void *d_a_scale_in = scratch_base + off_a_scale_in;
   void *d_a_qb_mid = scratch_base + off_a_qb_mid;
   void *d_a_scale_mid = scratch_base + off_a_scale_mid;
+  float *d_out_accum = reinterpret_cast<float *>(scratch_base + off_out_accum);
+  float *d_fc2_f32 = reinterpret_cast<float *>(scratch_base + off_fc2_f32);
 
   RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: topk_routing(tokens=%lld, experts=%lld, "
                     "k=%lld, normalize=%lld)\n",
@@ -284,8 +299,11 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
       h_offsets[e + 1] = h_offsets[e] + static_cast<int64_t>(h_counts[e]);
     }
 
-    HIP_CHECK(hipMemsetAsync(output, 0, num_tokens * hidden_size * elem_size,
-                             hip_stream));
+    // Zero the fp32 accumulator (not the fp16 graph output): experts scatter
+    // their pre-weighted contributions here in fp32, then a single cast writes
+    // the fp16 graph output after the loop.
+    HIP_CHECK(hipMemsetAsync(
+        d_out_accum, 0, num_tokens * hidden_size * sizeof(float), hip_stream));
 
     int64_t active_experts = 0;
     for (int64_t e = 0; e < num_experts; e++) {
@@ -402,7 +420,12 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
                                            e * hidden_size * elem_size
                                      : nullptr;
 
-      // Same pre-unpack as fc1; per-expert distinct pointer.
+      // fp32out picks its path on count exactly like the fp16 dispatch: the
+      // small-M (decode) regime uses the row-major int4 GEMV (UNPACKED uint8
+      // zeros), while count >= 16 with inter_size % 32 == 0 uses fused-dequant
+      // WMMA (fp16 zeros). Prepare BOTH zp forms so fp32out can dispatch either
+      // way; the fp16 conversion is only computed when the WMMA path is
+      // reachable (avoids an unneeded convert kernel on decode).
       const void *fc2_pre_zp_u8 = nullptr;
       const void *fc2_pre_zp_fp16 = nullptr;
       if (fc2_zp_e && expert_weight_bits == 4 && block_size > 0) {
@@ -413,8 +436,8 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
           result = -1;
           goto cleanup;
         }
-        bool wmma_data_format = (inter_size % 32 == 0);
-        if (wmma_data_format && count > 1) {
+        bool fc2_wmma = (inter_size % 32 == 0) && (count >= 16);
+        if (fc2_wmma) {
           fc2_pre_zp_fp16 = hipdnn_ep_real::lookup_or_convert_zp_fp16(
               *zpc, stream, fc2_zp_e, static_cast<int>(hidden_size), ngk);
           if (!fc2_pre_zp_fp16) {
@@ -424,20 +447,40 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
         }
       }
 
-      RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: expert %lld: fc2 matmul_nbits "
-                        "[%lld x %lld] -> [%lld x %lld]\n",
-                        (long long)e, (long long)count, (long long)inter_size,
-                        (long long)count, (long long)hidden_size);
-      HIP_CHECK(hip_matmul_nbits(
-          stream, d_act_buf, fc2_w_e, fc2_s_e, fc2_zp_e, fc2_b_e, d_fc2_buf,
-          count, hidden_size, inter_size, 1, expert_weight_bits, block_size,
-          elem_size, /*zp_elem_size=*/1, fc2_pre_zp_u8, fc2_pre_zp_fp16));
+      // Down_proj GEMM into an FP32 output (no routing weight, no bias). A raw
+      // per-expert down_proj channel can exceed the fp16 max (65504); computing
+      // and storing it in fp32 (hip_matmul_nbits_fp32out) keeps it finite so it
+      // survives until the routing weight scales it back into range. The
+      // routing weight AND the (weighted) bias are both applied afterwards in
+      // the fp32 scatter, reconstructing w_e*(W_dn . h_e + b_e). fp32out picks
+      // WMMA (count>=16, fp16 zeros) vs GEMV (uint8 zeros) internally on count.
+      RUNTIME_DEBUG_LOG(
+          "[REAL] wrap_qmoe: expert %lld: fc2 matmul_nbits_fp32out "
+          "(no weight/bias) [%lld x %lld] -> [%lld x %lld]\n",
+          (long long)e, (long long)count, (long long)inter_size,
+          (long long)count, (long long)hidden_size);
+      HIP_CHECK(hip_matmul_nbits_fp32out(
+          stream, d_act_buf, fc2_w_e, fc2_s_e, fc2_pre_zp_u8, fc2_pre_zp_fp16,
+          /*bias=*/nullptr, d_fc2_f32, count, hidden_size, inter_size,
+          expert_weight_bits, block_size));
 
-      RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: expert %lld: scatter_add\n",
+      // expert_out (d_fc2_f32) is the raw fp32 W_dn . h_e. The scatter applies
+      // the routing weight to the whole (GEMM result + down_proj bias) under
+      // the SAME per-row weight -> w_e*(W_dn . h_e + b_e), accumulating across
+      // experts in fp32 (no fp16 rounding / overflow).
+      RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: expert %lld: scatter_add_fp32 "
+                        "(weighted result+bias)\n",
                         (long long)e);
-      HIP_CHECK(hip_qmoe_scatter_add(stream, output, d_fc2_buf, d_ids_e,
-                                     d_wts_e, hidden_size, count, elem_size));
+      HIP_CHECK(hip_qmoe_scatter_add_fp32(stream, d_out_accum, d_fc2_f32,
+                                          d_ids_e, fc2_b_e, d_wts_e,
+                                          hidden_size, count, elem_size));
     }
+
+    // Cast the fp32 accumulator down to the fp16 graph output once. This is the
+    // only fp16 narrowing of the cross-expert result, matching the ORT CPU
+    // kernel which keeps intermediates in fp32 and narrows only on final write.
+    HIP_CHECK(hip_cast(stream, d_out_accum, output, num_tokens * hidden_size,
+                       HIP_DTYPE_FLOAT32, HIP_DTYPE_FLOAT16));
   }
 
 cleanup:


### PR DESCRIPTION
## Summary

A single QMoE expert's raw `down_proj` (fc2) channel can exceed the fp16 max (65504) and overflow to `inf` **before** the routing weight scales it back into range. Narrowing that raw GEMM result to fp16 at store time therefore corrupts the MoE output (observed as NaN logits / perplexity blow-up on gpt-oss-120b, e.g. layer 34).

This PR keeps the fc2 GEMM result in **fp32** until the weighted cross-expert accumulation, then narrows to fp16 exactly once — so `w_e * (W_dn·h_e + b_e)` never rounds/overflows through fp16.

## What changed

- **`matmul_nbits_kernel.hip`** — template `GemmFp16U4Impl` and the two WMMA entry wrappers (`MatMulNBitsWMMA_ZP` / `_NoZP`) on an output type `OutT` (default `_Float16`, so **every existing fp16 instantiation is byte-identical** — only the final store narrowing changes; the fp32 accumulator was always fp32). `hip_matmul_nbits_fp32out` now dispatches on `M` exactly like the fp16 path, with **fixed configs** (no autotune, no autotune cache touched):
  - `M >= 16 && K % 32 == 0` → fused-dequant WMMA fp32 (128×128, bounds-checked; needs fp16 zeros)
  - otherwise → row-major int4 GEMV fp32 (valid for any M; needs uint8 zeros)
- **`hip_custom_kernels.h`** — add `zero_points_fp16` parameter to `hip_matmul_nbits_fp32out`.
- **`qmoe.cpp`** (prefill / multi-token path) — run fc2 into an fp32 scratch with **no** routing weight and **no** bias; prepare fp16 zeros only when the WMMA path is reachable (`count >= 16 && inter % 32 == 0`, identical to the launcher's WMMA gate so asym never silently falls back to zp=8). The scatter applies the routing weight to the full `(GEMM + bias)` result and accumulates across experts in fp32.
- **`qmoe_kernel.hip`** — `scatter_add_fp32` reads fp32 expert output and applies the routing weight to the whole `(GEMM + bias)`; the old pre-scaling helper was removed.

## Scope / notes

- Decode (`num_tokens == 1`) uses the separate fused-decode kernel and is **unchanged** by this PR.
- fp16 paths (Llama / gpt-oss decode, all non-fp32out callers) are byte-identical — `OutT` defaults preserve every existing instantiation.

## Test plan

- [ ] gpt-oss-120b: confirm NaN logits / PPL blow-up is resolved (prefill path), baseline `4b4dfa98` vs this branch.
- [ ] Confirm prefill uses WMMA fp32 for large per-expert `count` (long prompt) and GEMV fp32 for small `count`.
- [ ] Regression: Llama-8B / gpt-oss-20b logits unchanged vs baseline (fp16 paths byte-identical).
