### PR TITLE
feat(hipsr): emit the pool acquisition

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/HipsrGetPoolOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrGetPoolOp.td
@@ -10,12 +10,12 @@ def Hipsr_GetPoolOp : Hipsr_Op<"get_pool",
     Returns a runtime-managed GPU memory pool.
 
     - `pool_size` : minimum size in bytes the returned buffer must hold.
-    - `domain_id` : selects an independent pool (default 0); pools with distinct
+    - `domain_id` : selects which pool to draw from; pools with distinct
                     domain_ids grow independently.
   }];
 
   let arguments = (ins Hipsr_ContextType:$ctx, Index:$pool_size,
-                       DefaultValuedAttr<I64Attr, "0">:$domain_id);
+                       I64Attr:$domain_id);
   let results = (outs Hipsr_DeviceMemRef:$pool);
   let assemblyFormat = "`(` $ctx `,` $pool_size `)` attr-dict `:` type($pool)";
 }

--- a/include/hip/Dialect/Hipsr/IR/HipsrPoolDomainOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrPoolDomainOp.td
@@ -28,6 +28,11 @@ def Hipsr_PoolDomainOp : Hipsr_Op<"pool_domain", [
     `RecursiveMemoryEffects` keeps nested effects visible to analyses.
     `AnyType` lets the group stay in place during bufferization.
 
+    `domain_id` selects the runtime pool this domain draws from;
+    `hipsr-pool-alloc` conveys it unchanged to the `hipsr.get_pool` it emits.
+    Domains with different ids grow independently, and a repeated id means the
+    author wants those domains to share one pool.
+
     Example:
     ```mlir
     %out = hipsr.pool_domain(%ctx, %input : !hipsr.context, tensor<?xf32>) {
@@ -36,11 +41,11 @@ def Hipsr_PoolDomainOp : Hipsr_Op<"pool_domain", [
       %size = tensor.dim %domain_input, %c0 : tensor<?xf32>
       %buffer = tensor.empty(%size) : tensor<?xf32>
       hipsr.pool_domain_yield %buffer : tensor<?xf32>
-    } -> tensor<?xf32>
+    } -> tensor<?xf32> {domain_id = 0 : i64}
     ```
   }];
 
-  let arguments = (ins Variadic<AnyType>:$operands);
+  let arguments = (ins Variadic<AnyType>:$operands, I64Attr:$domain_id);
   let results = (outs Variadic<AnyType>:$results);
   let regions = (region SizedRegion<1>:$body);
 

--- a/include/hip/Dialect/Hipsr/Transforms/Passes.td
+++ b/include/hip/Dialect/Hipsr/Transforms/Passes.td
@@ -117,7 +117,7 @@ def PartitionPoolDomainsPass
             ins(%cast : tensor<?x4xf16>)
             outs(%ready_init : tensor<?x4xf16>) : tensor<?x4xf16>
         hipsr.pool_domain_yield %ready : tensor<?x4xf16>
-      } -> tensor<?x4xf16>
+      } -> tensor<?x4xf16> {domain_id = 0 : i64}
       %1 = hipsr.pool_domain(%ctx, %input, %0
           : !hipsr.context, tensor<?x4xf32>, tensor<?x4xf16>) {
       ^bb0(%domain_ctx: !hipsr.context,
@@ -133,7 +133,7 @@ def PartitionPoolDomainsPass
                 : tensor<?x4xf16>, tensor<?x4xf16>)
             outs(%add_init : tensor<?x4xf16>) : tensor<?x4xf16>
         hipsr.pool_domain_yield %sum : tensor<?x4xf16>
-      } -> tensor<?x4xf16>
+      } -> tensor<?x4xf16> {domain_id = 1 : i64}
       %2 = hipsr.pool_domain(%ctx, %input, %1, %shape
           : !hipsr.context, tensor<?x4xf32>, tensor<?x4xf16>,
             tensor<2xi64>) {
@@ -159,7 +159,7 @@ def PartitionPoolDomainsPass
             ins(%expanded, %expanded : tensor<?x4xf16>, tensor<?x4xf16>)
             outs(%result_init : tensor<?x4xf16>) : tensor<?x4xf16>
         hipsr.pool_domain_yield %result : tensor<?x4xf16>
-      } -> tensor<?x4xf16>
+      } -> tensor<?x4xf16> {domain_id = 2 : i64}
       return %2 : tensor<?x4xf16>
     }
     ```

--- a/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
@@ -218,11 +218,34 @@ Value emitGroupSize(OpBuilder &builder, Location loc,
   return arith::MulIOp::create(builder, loc, divided, alignVal);
 }
 
+Value findContext(Block &body) {
+  for (BlockArgument arg : body.getArguments()) {
+    if (isa<ContextType>(arg.getType())) {
+      return arg;
+    }
+  }
+  return nullptr;
+}
+
+Value emitPool(OpBuilder &builder, Location loc, Value ctx,
+               llvm::ArrayRef<Value> groupSizes, int64_t domainId) {
+  Value poolSize = groupSizes.front();
+  for (Value groupSize : groupSizes.drop_front()) {
+    poolSize = arith::AddIOp::create(builder, loc, poolSize, groupSize);
+  }
+  auto deviceSpace =
+      MemorySpaceAttr::get(builder.getContext(), MemorySpaceKind::Device);
+  auto poolType = MemRefType::get({ShapedType::kDynamic}, builder.getI8Type(),
+                                  MemRefLayoutAttrInterface{}, deviceSpace);
+  return GetPoolOp::create(builder, loc, poolType, ctx, poolSize, domainId);
+}
+
 struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
   using impl::HipsrPoolAllocPassBase<
       HipsrPoolAllocPass>::HipsrPoolAllocPassBase;
 
   void runOnOperation() override {
+    int64_t domainId = 0;
     getOperation().walk([&](PoolDomainOp domain) {
       Block &body = domain.getBody().front();
       llvm::DenseMap<Value, Lifetime> lifetimes = computeLiveness(body);
@@ -230,6 +253,12 @@ struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
       if (!insertionPoint) {
         domain.emitError(
             "hipsr-pool-alloc: pool_domain has no poolable allocation");
+        signalPassFailure();
+        return;
+      }
+      Value ctx = findContext(body);
+      if (!ctx) {
+        domain.emitError("hipsr-pool-alloc: pool_domain has no context");
         signalPassFailure();
         return;
       }
@@ -241,9 +270,12 @@ struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
 
       OpBuilder builder(&getContext());
       builder.setInsertionPointAfter(insertionPoint);
+      llvm::SmallVector<Value> groupSizes;
       for (llvm::ArrayRef<Value> group : groups) {
-        emitGroupSize(builder, domain.getLoc(), group, kPoolAlignment);
+        groupSizes.push_back(
+            emitGroupSize(builder, domain.getLoc(), group, kPoolAlignment));
       }
+      emitPool(builder, domain.getLoc(), ctx, groupSizes, domainId++);
     });
   }
 };

--- a/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
@@ -228,7 +228,7 @@ Value findContext(Block &body) {
 }
 
 Value emitPool(OpBuilder &builder, Location loc, Value ctx,
-               llvm::ArrayRef<Value> groupSizes, int64_t domainId) {
+               llvm::ArrayRef<Value> groupSizes, uint64_t domainId) {
   Value poolSize = groupSizes.front();
   for (Value groupSize : groupSizes.drop_front()) {
     poolSize = arith::AddIOp::create(builder, loc, poolSize, groupSize);
@@ -245,7 +245,6 @@ struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
       HipsrPoolAllocPass>::HipsrPoolAllocPassBase;
 
   void runOnOperation() override {
-    int64_t domainId = 0;
     getOperation().walk([&](PoolDomainOp domain) {
       Block &body = domain.getBody().front();
       llvm::DenseMap<Value, Lifetime> lifetimes = computeLiveness(body);
@@ -275,7 +274,7 @@ struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
         groupSizes.push_back(
             emitGroupSize(builder, domain.getLoc(), group, kPoolAlignment));
       }
-      emitPool(builder, domain.getLoc(), ctx, groupSizes, domainId++);
+      emitPool(builder, domain.getLoc(), ctx, groupSizes, domain.getDomainId());
     });
   }
 };

--- a/lib/Dialect/Hipsr/Transforms/PartitionPoolDomains.cpp
+++ b/lib/Dialect/Hipsr/Transforms/PartitionPoolDomains.cpp
@@ -422,15 +422,15 @@ static void materializeDomains(ArrayRef<Domain> domains, Value context) {
 
   IRRewriter rewriter(domains.front().operations.front()->getContext());
 
-  for (const Domain &domain : domains) {
+  for (auto [domainId, domain] : llvm::enumerate(domains)) {
     Operation *insertionPoint = domain.operations.front();
     rewriter.setInsertionPoint(insertionPoint);
 
     SmallVector<Type> resultTypes = llvm::map_to_vector(
         domain.results, [](Value result) { return result.getType(); });
 
-    auto domainOp = rewriter.create<PoolDomainOp>(insertionPoint->getLoc(),
-                                                  resultTypes, ValueRange{});
+    auto domainOp = rewriter.create<PoolDomainOp>(
+        insertionPoint->getLoc(), resultTypes, ValueRange{}, domainId);
     Region &bodyRegion = domainOp.getBody();
     Block *body = rewriter.createBlock(&bodyRegion);
     for (Operation *operation : domain.operations) {

--- a/test/lit/Conversion/hipsr-to-llvm/get_pool.mlir
+++ b/test/lit/Conversion/hipsr-to-llvm/get_pool.mlir
@@ -22,7 +22,8 @@
 // CHECK-NEXT:    llvm.return %[[D5]]
 func.func @get_pool(%ctx: !hipsr.context, %size: index)
     -> memref<?xi8, #hipsr.mem<device>> {
-  %pool = hipsr.get_pool(%ctx, %size) : memref<?xi8, #hipsr.mem<device>>
+  %pool = hipsr.get_pool(%ctx, %size) {domain_id = 0 : i64}
+      : memref<?xi8, #hipsr.mem<device>>
   return %pool : memref<?xi8, #hipsr.mem<device>>
 }
 

--- a/test/lit/Dialect/Hipsr/Transforms/MaterializeInitTensors/invalid.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/MaterializeInitTensors/invalid.mlir
@@ -26,7 +26,7 @@ func.func @unpopulated_shape_region(%ctx: !hipsr.context, %a: tensor<?x256xf16>,
         ins(%domain_a, %domain_b : tensor<?x256xf16>, tensor<256x512xf16>)
         outs(%init : tensor<?x512xf16>) : tensor<?x512xf16>
     hipsr.pool_domain_yield %matmul : tensor<?x512xf16>
-  } -> tensor<?x512xf16>
+  } -> tensor<?x512xf16> {domain_id = 0 : i64}
   return %0 : tensor<?x512xf16>
 }
 
@@ -63,6 +63,6 @@ func.func @barrier_placeholder(%ctx: !hipsr.context, %a: tensor<?x256xf16>,
         ins(%domain_a, %domain_b : tensor<?x256xf16>, tensor<256x512xf16>)
         outs(%init : tensor<?x512xf16>) : tensor<?x512xf16>
     hipsr.pool_domain_yield %matmul : tensor<?x512xf16>
-  } -> tensor<?x512xf16>
+  } -> tensor<?x512xf16> {domain_id = 0 : i64}
   return %0 : tensor<?x512xf16>
 }

--- a/test/lit/Dialect/Hipsr/Transforms/MaterializeInitTensors/materialize-init-tensors.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/MaterializeInitTensors/materialize-init-tensors.mlir
@@ -61,7 +61,7 @@
 // CHECK-NEXT:      %[[INIT:.+]] = tensor.empty(%[[DIM0]]) : tensor<?x512xf16>
 // CHECK-NEXT:      %[[MATMUL:.+]] = hipsr.matmul(%[[DCTX]]) ins(%[[DA]], %[[DB]] : tensor<?x256xf16>, tensor<256x512xf16>) outs(%[[INIT]] : tensor<?x512xf16>) : tensor<?x512xf16>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[MATMUL]] : tensor<?x512xf16>
-// CHECK-NEXT:    } -> tensor<?x512xf16>
+// CHECK-NEXT:    } -> tensor<?x512xf16> {domain_id = 0 : i64}
 // CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x512xf16>
 // CHECK-NEXT:  }
 func.func @matmul_domain(%ctx: !hipsr.context, %a: tensor<?x256xf16>,
@@ -88,7 +88,7 @@ func.func @matmul_domain(%ctx: !hipsr.context, %a: tensor<?x256xf16>,
         ins(%domain_a, %domain_b : tensor<?x256xf16>, tensor<256x512xf16>)
         outs(%init : tensor<?x512xf16>) : tensor<?x512xf16>
     hipsr.pool_domain_yield %matmul : tensor<?x512xf16>
-  } -> tensor<?x512xf16>
+  } -> tensor<?x512xf16> {domain_id = 0 : i64}
   return %0 : tensor<?x512xf16>
 }
 
@@ -116,7 +116,7 @@ func.func @matmul_domain(%ctx: !hipsr.context, %a: tensor<?x256xf16>,
 // CHECK-NEXT:      %[[INIT:.+]] = tensor.empty() : tensor<128x512xf16>
 // CHECK-NEXT:      %[[MATMUL:.+]] = hipsr.matmul(%[[DCTX]]) ins(%[[DA]], %[[DB]] : tensor<128x256xf16>, tensor<256x512xf16>) outs(%[[INIT]] : tensor<128x512xf16>) : tensor<128x512xf16>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[MATMUL]] : tensor<128x512xf16>
-// CHECK-NEXT:    } -> tensor<128x512xf16>
+// CHECK-NEXT:    } -> tensor<128x512xf16> {domain_id = 0 : i64}
 // CHECK-NEXT:    return %[[DOMAIN]] : tensor<128x512xf16>
 // CHECK-NEXT:  }
 func.func @static_shape(%ctx: !hipsr.context, %a: tensor<128x256xf16>,
@@ -143,7 +143,7 @@ func.func @static_shape(%ctx: !hipsr.context, %a: tensor<128x256xf16>,
         ins(%domain_a, %domain_b : tensor<128x256xf16>, tensor<256x512xf16>)
         outs(%init : tensor<128x512xf16>) : tensor<128x512xf16>
     hipsr.pool_domain_yield %matmul : tensor<128x512xf16>
-  } -> tensor<128x512xf16>
+  } -> tensor<128x512xf16> {domain_id = 0 : i64}
   return %0 : tensor<128x512xf16>
 }
 
@@ -173,7 +173,7 @@ func.func @static_shape(%ctx: !hipsr.context, %a: tensor<128x256xf16>,
 // CHECK-NEXT:      %[[INIT:.+]] = tensor.empty(%[[D0]], %[[D1]]) : tensor<?x?x64xf16>
 // CHECK-NEXT:      %[[ADD:.+]] = hipsr.add(%[[DCTX]]) ins(%[[DA]], %[[DB]] : tensor<?x?x64xf16>, tensor<?x?x64xf16>) outs(%[[INIT]] : tensor<?x?x64xf16>) : tensor<?x?x64xf16>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[ADD]] : tensor<?x?x64xf16>
-// CHECK-NEXT:    } -> tensor<?x?x64xf16>
+// CHECK-NEXT:    } -> tensor<?x?x64xf16> {domain_id = 0 : i64}
 // CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x?x64xf16>
 // CHECK-NEXT:  }
 func.func @multi_dynamic(%ctx: !hipsr.context, %a: tensor<?x?x64xf16>,
@@ -195,7 +195,7 @@ func.func @multi_dynamic(%ctx: !hipsr.context, %a: tensor<?x?x64xf16>,
         ins(%domain_a, %domain_b : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
         outs(%init : tensor<?x?x64xf16>) : tensor<?x?x64xf16>
     hipsr.pool_domain_yield %add : tensor<?x?x64xf16>
-  } -> tensor<?x?x64xf16>
+  } -> tensor<?x?x64xf16> {domain_id = 0 : i64}
   return %0 : tensor<?x?x64xf16>
 }
 
@@ -239,7 +239,7 @@ func.func @multi_dynamic(%ctx: !hipsr.context, %a: tensor<?x?x64xf16>,
 // CHECK-NEXT:      %[[MATMUL:.+]] = hipsr.matmul(%[[DCTX]]) ins(%[[DA]], %[[DB]] : tensor<?x256xf16>, tensor<256x512xf16>) outs(%[[MATMUL_INIT]] : tensor<?x512xf16>) : tensor<?x512xf16>
 // CHECK-NEXT:      %[[ADD:.+]] = hipsr.add(%[[DCTX]]) ins(%[[MATMUL]], %[[DC]] : tensor<?x512xf16>, tensor<?x512xf16>) outs(%[[ADD_INIT]] : tensor<?x512xf16>) : tensor<?x512xf16>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[ADD]] : tensor<?x512xf16>
-// CHECK-NEXT:    } -> tensor<?x512xf16>
+// CHECK-NEXT:    } -> tensor<?x512xf16> {domain_id = 0 : i64}
 // CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x512xf16>
 // CHECK-NEXT:  }
 func.func @interleaved(%ctx: !hipsr.context, %a: tensor<?x256xf16>,
@@ -280,7 +280,7 @@ func.func @interleaved(%ctx: !hipsr.context, %a: tensor<?x256xf16>,
         ins(%matmul, %domain_c : tensor<?x512xf16>, tensor<?x512xf16>)
         outs(%add_init : tensor<?x512xf16>) : tensor<?x512xf16>
     hipsr.pool_domain_yield %add : tensor<?x512xf16>
-  } -> tensor<?x512xf16>
+  } -> tensor<?x512xf16> {domain_id = 0 : i64}
   return %0 : tensor<?x512xf16>
 }
 
@@ -321,7 +321,7 @@ func.func @interleaved(%ctx: !hipsr.context, %a: tensor<?x256xf16>,
 // CHECK-NEXT:      %[[MATMUL:.+]] = hipsr.matmul(%[[DCTX]]) ins(%[[DA]], %[[DB]] : tensor<?x256xf16>, tensor<256x512xf16>) outs(%[[MATMUL_INIT]] : tensor<?x512xf16>) : tensor<?x512xf16>
 // CHECK-NEXT:      %[[ADD:.+]] = hipsr.add(%[[DCTX]]) ins(%[[MATMUL]], %[[DC]] : tensor<?x512xf16>, tensor<?x512xf16>) outs(%[[ADD_INIT]] : tensor<?x512xf16>) : tensor<?x512xf16>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[ADD]] : tensor<?x512xf16>
-// CHECK-NEXT:    } -> tensor<?x512xf16>
+// CHECK-NEXT:    } -> tensor<?x512xf16> {domain_id = 0 : i64}
 // CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x512xf16>
 // CHECK-NEXT:  }
 func.func @already_grouped(%ctx: !hipsr.context, %a: tensor<?x256xf16>,
@@ -362,7 +362,7 @@ func.func @already_grouped(%ctx: !hipsr.context, %a: tensor<?x256xf16>,
         ins(%matmul, %domain_c : tensor<?x512xf16>, tensor<?x512xf16>)
         outs(%add_init : tensor<?x512xf16>) : tensor<?x512xf16>
     hipsr.pool_domain_yield %add : tensor<?x512xf16>
-  } -> tensor<?x512xf16>
+  } -> tensor<?x512xf16> {domain_id = 0 : i64}
   return %0 : tensor<?x512xf16>
 }
 
@@ -378,7 +378,7 @@ func.func @already_grouped(%ctx: !hipsr.context, %a: tensor<?x256xf16>,
 // CHECK-NEXT:      %[[DIM:.+]] = tensor.dim %[[DIN]], %[[C1]] : tensor<3x4xf32>
 // CHECK-NEXT:      %[[BUFFER:.+]] = tensor.empty(%[[DIM]]) : tensor<2x?xi64>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[BUFFER]] : tensor<2x?xi64>
-// CHECK-NEXT:    } -> tensor<2x?xi64>
+// CHECK-NEXT:    } -> tensor<2x?xi64> {domain_id = 0 : i64}
 // CHECK-NEXT:    return %[[DOMAIN]] : tensor<2x?xi64>
 // CHECK-NEXT:  }
 func.func @no_placeholder(%in: tensor<3x4xf32>) -> tensor<2x?xi64> {
@@ -388,6 +388,6 @@ func.func @no_placeholder(%in: tensor<3x4xf32>) -> tensor<2x?xi64> {
     %n = tensor.dim %domain_in, %c1 : tensor<3x4xf32>
     %buffer = tensor.empty(%n) : tensor<2x?xi64>
     hipsr.pool_domain_yield %buffer : tensor<2x?xi64>
-  } -> tensor<2x?xi64>
+  } -> tensor<2x?xi64> {domain_id = 0 : i64}
   return %0 : tensor<2x?xi64>
 }

--- a/test/lit/Dialect/Hipsr/get_pool.mlir
+++ b/test/lit/Dialect/Hipsr/get_pool.mlir
@@ -5,12 +5,12 @@
 
 // RUN: hip-mlir-opt %s -split-input-file | FileCheck %s
 
-// CHECK-LABEL: func.func @get_pool_default
-func.func @get_pool_default(%ctx: !hipsr.context, %size: index)
+// CHECK-LABEL: func.func @get_pool_zero
+func.func @get_pool_zero(%ctx: !hipsr.context, %size: index)
     -> memref<?xi8, #hipsr.mem<device>> {
-  // CHECK: hipsr.get_pool(%{{.+}}, %{{.+}}) : memref<?xi8, #hipsr.mem<device>>
-  // CHECK-NOT: domain_id
-  %pool = hipsr.get_pool(%ctx, %size) : memref<?xi8, #hipsr.mem<device>>
+  // CHECK: hipsr.get_pool(%{{.+}}, %{{.+}}) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+  %pool = hipsr.get_pool(%ctx, %size) {domain_id = 0 : i64}
+      : memref<?xi8, #hipsr.mem<device>>
   return %pool : memref<?xi8, #hipsr.mem<device>>
 }
 

--- a/test/lit/Dialect/Hipsr/partition-pool-domains-invalid.mlir
+++ b/test/lit/Dialect/Hipsr/partition-pool-domains-invalid.mlir
@@ -21,7 +21,7 @@ func.func @existing_domain(%ctx: !hipsr.context, %arg: i32) -> i32 {
   %0 = hipsr.pool_domain(%ctx, %arg : !hipsr.context, i32) {
   ^bb0(%domain_ctx: !hipsr.context, %domain_arg: i32):
     hipsr.pool_domain_yield %domain_arg : i32
-  } -> i32
+  } -> i32 {domain_id = 0 : i64}
   return %0 : i32
 }
 
@@ -35,7 +35,7 @@ func.func @nested_existing_domain(
     %1 = hipsr.pool_domain(%ctx, %arg : !hipsr.context, i32) {
     ^bb0(%domain_ctx: !hipsr.context, %domain_arg: i32):
       hipsr.pool_domain_yield %domain_arg : i32
-    } -> i32
+    } -> i32 {domain_id = 0 : i64}
     scf.yield %1 : i32
   }
   return %0 : i32

--- a/test/lit/Dialect/Hipsr/partition-pool-domains.mlir
+++ b/test/lit/Dialect/Hipsr/partition-pool-domains.mlir
@@ -19,7 +19,7 @@
 // CHECK-NEXT: %[[SHAPE_ATTR_INIT:.*]] = hipsr.placeholder(%[[FIRST_CTX]]) ins(%[[FIRST_INPUT]] : tensor<?x4xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[SHAPE_ATTR_EXPANDED:.*]] = hipsr.expand(%[[FIRST_CTX]]) ins(%[[CAST]] : tensor<?x4xf16>) outs(%[[SHAPE_ATTR_INIT]] : tensor<?x4xf16>) {shape_attr = array<i64: 1, 4>} : tensor<?x4xf16>
 // CHECK-NEXT: hipsr.pool_domain_yield %[[SHAPE_ATTR_EXPANDED]] : tensor<?x4xf16>
-// CHECK-NEXT: } -> tensor<?x4xf16>
+// CHECK-NEXT: } -> tensor<?x4xf16> {domain_id = 0 : i64}
 // CHECK-NEXT: %[[EXPAND_DOMAIN:.*]] = hipsr.pool_domain(%[[CTX]], %[[INPUT]], %[[SHAPE]], %[[FIRST_DOMAIN]] : !hipsr.context, tensor<?x4xf32>, tensor<2xi64>, tensor<?x4xf16>) {
 // CHECK-NEXT: ^bb0(%[[EXPAND_CTX:.*]]: !hipsr.context, %[[SHAPE_ROOT:.*]]: tensor<?x4xf32>, %[[EXPAND_SHAPE:.*]]: tensor<2xi64>, %[[EXPAND_INPUT:.*]]: tensor<?x4xf16>):
 // CHECK-NEXT: %[[EXPAND_INIT:.*]] = hipsr.placeholder(%[[EXPAND_CTX]]) ins(%[[SHAPE_ROOT]], %[[EXPAND_SHAPE]] : tensor<?x4xf32>, tensor<2xi64>) {type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf16>
@@ -27,7 +27,7 @@
 // CHECK-NEXT: %[[ADD_INIT:.*]] = hipsr.placeholder(%[[EXPAND_CTX]]) ins(%[[SHAPE_ROOT]], %[[SHAPE_ROOT]] : tensor<?x4xf32>, tensor<?x4xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x4xf16>
 // CHECK-NEXT: %[[RESULT:.*]] = hipsr.add(%[[EXPAND_CTX]]) ins(%[[EXPANDED]], %[[EXPANDED]] : tensor<?x4xf16>, tensor<?x4xf16>) outs(%[[ADD_INIT]] : tensor<?x4xf16>) : tensor<?x4xf16>
 // CHECK-NEXT: hipsr.pool_domain_yield %[[RESULT]] : tensor<?x4xf16>
-// CHECK-NEXT: } -> tensor<?x4xf16>
+// CHECK-NEXT: } -> tensor<?x4xf16> {domain_id = 1 : i64}
 // CHECK-NEXT: return %[[EXPAND_DOMAIN]] : tensor<?x4xf16>
 // CHECK-NEXT: }
 func.func @expand_barrier_modes(
@@ -85,7 +85,7 @@ func.func @expand_barrier_modes(
 // CHECK-NEXT: hipsr.shape_yield (%[[D0]], %[[D1]]) : [f16]
 // CHECK-NEXT: }
 // CHECK-NEXT: hipsr.pool_domain_yield %[[REGION]], %[[CAST]] : i32, tensor<?x8xf16>
-// CHECK-NEXT: } -> i32, tensor<?x8xf16>
+// CHECK-NEXT: } -> i32, tensor<?x8xf16> {domain_id = 0 : i64}
 // CHECK-NEXT: return %[[DOMAIN]]#1, %[[DOMAIN]]#0 : tensor<?x8xf16>, i32
 // CHECK-NEXT: }
 func.func @nested_shape_region(%ctx: !hipsr.context,
@@ -121,7 +121,7 @@ func.func @nested_shape_region(%ctx: !hipsr.context,
 // CHECK-NEXT: hipsr.pool_domain(%[[CTX]], %[[VALUE]], %[[BUFFER]], %[[INDEX]] : !hipsr.context, i32, memref<4xi32>, index) {
 // CHECK-NEXT: ^bb0(%[[DCTX:.*]]: !hipsr.context, %[[DVALUE:.*]]: i32, %[[DBUFFER:.*]]: memref<4xi32>, %[[DINDEX:.*]]: index):
 // CHECK-NEXT: memref.store %[[DVALUE]], %[[DBUFFER]]{{\[}}%[[DINDEX]]] : memref<4xi32>
-// CHECK-NEXT: }
+// CHECK-NEXT: } {domain_id = 0 : i64}
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 func.func @zero_result_retained(

--- a/test/lit/Dialect/Hipsr/pool-domain-isolation.mlir
+++ b/test/lit/Dialect/Hipsr/pool-domain-isolation.mlir
@@ -16,7 +16,7 @@
 // CSE-NEXT: %[[INSIDE_C2:.+]] = arith.constant 2 : i32
 // CSE-NEXT: %[[SCALED:.+]] = arith.muli %[[DOMAIN_INPUT]], %[[INSIDE_C2]] : i32
 // CSE-NEXT: hipsr.pool_domain_yield %[[SCALED]] : i32
-// CSE-NEXT: } -> i32
+// CSE-NEXT: } -> i32 {domain_id = 0 : i64}
 // CSE-NEXT: %[[RESULT:.+]] = arith.addi %[[DOMAIN]], %[[OUTSIDE_C2]] : i32
 // CSE-NEXT: return %[[RESULT]] : i32
 // CSE-NEXT: }
@@ -27,7 +27,7 @@ func.func @cse_keeps_domain_isolated(%arg: i32) -> i32 {
     %inner_c2 = arith.constant 2 : i32
     %inner_scaled = arith.muli %domain_arg, %inner_c2 : i32
     hipsr.pool_domain_yield %inner_scaled : i32
-  } -> i32
+  } -> i32 {domain_id = 0 : i64}
   %result = arith.addi %scaled, %c2 : i32
   return %result : i32
 }
@@ -43,7 +43,7 @@ func.func @cse_keeps_domain_isolated(%arg: i32) -> i32 {
 // CANON-NEXT: %[[INSIDE_C2:.+]] = arith.constant 2 : i32
 // CANON-NEXT: %[[SCALED:.+]] = arith.muli %[[DOMAIN_INPUT]], %[[INSIDE_C2]] : i32
 // CANON-NEXT: hipsr.pool_domain_yield %[[SCALED]] : i32
-// CANON-NEXT: } -> i32
+// CANON-NEXT: } -> i32 {domain_id = 0 : i64}
 // CANON-NEXT: %[[RESULT:.+]] = arith.addi %[[DOMAIN]], %[[OUTSIDE_C2]] : i32
 // CANON-NEXT: return %[[RESULT]] : i32
 // CANON-NEXT: }
@@ -55,7 +55,7 @@ func.func @canonicalize_keeps_domain_isolated(%arg: i32) -> i32 {
     %inner_c2 = arith.addi %c1, %c1 : i32
     %inner_scaled = arith.muli %domain_arg, %inner_c2 : i32
     hipsr.pool_domain_yield %inner_scaled : i32
-  } -> i32
+  } -> i32 {domain_id = 0 : i64}
   %result = arith.addi %scaled, %c2 : i32
   return %result : i32
 }

--- a/test/lit/Dialect/Hipsr/pool-domain.mlir
+++ b/test/lit/Dialect/Hipsr/pool-domain.mlir
@@ -20,7 +20,7 @@
 // CHECK-NEXT: %[[INDEX_BUFFER:.+]] = tensor.empty(%[[DIM]]) : tensor<2x?xi64>
 // CHECK-NEXT: %[[COUNT_BUFFER:.+]] = tensor.empty() : tensor<i32>
 // CHECK-NEXT: hipsr.pool_domain_yield %[[INDEX_BUFFER]], %[[COUNT_BUFFER]] : tensor<2x?xi64>, tensor<i32>
-// CHECK-NEXT: } -> tensor<2x?xi64>, tensor<i32>
+// CHECK-NEXT: } -> tensor<2x?xi64>, tensor<i32> {domain_id = 0 : i64}
 // CHECK-NEXT: return %[[RESULTS]]#0, %[[RESULTS]]#1 : tensor<2x?xi64>, tensor<i32>
 // CHECK-NEXT: }
 func.func @roundtrip(%in: tensor<3x4xf32>) -> (tensor<2x?xi64>, tensor<i32>) {
@@ -31,7 +31,7 @@ func.func @roundtrip(%in: tensor<3x4xf32>) -> (tensor<2x?xi64>, tensor<i32>) {
     %idx = tensor.empty(%n) : tensor<2x?xi64>
     %cnt = tensor.empty() : tensor<i32>
     hipsr.pool_domain_yield %idx, %cnt : tensor<2x?xi64>, tensor<i32>
-  } -> tensor<2x?xi64>, tensor<i32>
+  } -> tensor<2x?xi64>, tensor<i32> {domain_id = 0 : i64}
   return %0#0, %0#1 : tensor<2x?xi64>, tensor<i32>
 }
 
@@ -44,7 +44,7 @@ func.func @roundtrip(%in: tensor<3x4xf32>) -> (tensor<2x?xi64>, tensor<i32>) {
 // CHECK-NEXT: %[[C1:.+]] = arith.constant 1 : index
 // CHECK-NEXT: %[[DIM:.+]] = memref.dim %[[DOMAIN_INPUT]], %[[C1]] : memref<2x?xi64>
 // CHECK-NEXT: hipsr.pool_domain_yield %[[DOMAIN_INPUT]], %[[DIM]] : memref<2x?xi64>, index
-// CHECK-NEXT: } -> memref<2x?xi64>, index
+// CHECK-NEXT: } -> memref<2x?xi64>, index {domain_id = 0 : i64}
 // CHECK-NEXT: return %[[RESULTS]]#0, %[[RESULTS]]#1 : memref<2x?xi64>, index
 // CHECK-NEXT: }
 func.func @memref_form(%in: memref<2x?xi64>) -> (memref<2x?xi64>, index) {
@@ -53,7 +53,7 @@ func.func @memref_form(%in: memref<2x?xi64>) -> (memref<2x?xi64>, index) {
     %c1 = arith.constant 1 : index
     %n = memref.dim %domain_in, %c1 : memref<2x?xi64>
     hipsr.pool_domain_yield %domain_in, %n : memref<2x?xi64>, index
-  } -> memref<2x?xi64>, index
+  } -> memref<2x?xi64>, index {domain_id = 0 : i64}
   return %0#0, %0#1 : memref<2x?xi64>, index
 }
 
@@ -61,13 +61,13 @@ func.func @memref_form(%in: memref<2x?xi64>) -> (memref<2x?xi64>, index) {
 // The printer omits the empty implicit yield.
 // CHECK-LABEL: func.func @empty_domain() {
 // CHECK-NEXT: hipsr.pool_domain() {
-// CHECK-NEXT: }
+// CHECK-NEXT: } {domain_id = 0 : i64}
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 func.func @empty_domain() {
   hipsr.pool_domain() {
     hipsr.pool_domain_yield
-  }
+  } {domain_id = 0 : i64}
   return
 }
 
@@ -76,7 +76,7 @@ func.func @empty_domain() {
 func.func @empty_body() {
   // expected-error @+1 {{failed to verify constraint: region with 1 blocks}}
   "hipsr.pool_domain"() ({
-  }) : () -> ()
+  }) {domain_id = 0 : i64} : () -> ()
   return
 }
 
@@ -88,7 +88,7 @@ func.func @missing_entry_argument(%in: tensor<3x4xf32>) -> tensor<3x4xf32> {
   %0 = hipsr.pool_domain(%in : tensor<3x4xf32>) {
     %local = tensor.empty() : tensor<3x4xf32>
     hipsr.pool_domain_yield %local : tensor<3x4xf32>
-  } -> tensor<3x4xf32>
+  } -> tensor<3x4xf32> {domain_id = 0 : i64}
   return %0 : tensor<3x4xf32>
 }
 
@@ -100,7 +100,7 @@ func.func @extra_entry_argument() -> tensor<3x4xf32> {
   %0 = hipsr.pool_domain() {
   ^bb0(%domain_in: tensor<3x4xf32>):
     hipsr.pool_domain_yield %domain_in : tensor<3x4xf32>
-  } -> tensor<3x4xf32>
+  } -> tensor<3x4xf32> {domain_id = 0 : i64}
   return %0 : tensor<3x4xf32>
 }
 
@@ -113,7 +113,7 @@ func.func @entry_argument_type_mismatch(%in: tensor<3x4xf32>)
   %0 = hipsr.pool_domain(%in : tensor<3x4xf32>) {
   ^bb0(%domain_in: tensor<3x4xi64>):
     hipsr.pool_domain_yield %domain_in : tensor<3x4xi64>
-  } -> tensor<3x4xi64>
+  } -> tensor<3x4xi64> {domain_id = 0 : i64}
   return %0 : tensor<3x4xi64>
 }
 
@@ -124,7 +124,7 @@ func.func @missing_yield_value() -> tensor<3x4xf32> {
   %0 = hipsr.pool_domain() {
     // expected-note @+1 {{region branch point}}
     hipsr.pool_domain_yield
-  } -> tensor<3x4xf32>
+  } -> tensor<3x4xf32> {domain_id = 0 : i64}
   return %0 : tensor<3x4xf32>
 }
 
@@ -136,7 +136,7 @@ func.func @extra_yield_value() {
     %local = tensor.empty() : tensor<3x4xf32>
     // expected-note @+1 {{region branch point}}
     hipsr.pool_domain_yield %local : tensor<3x4xf32>
-  }
+  } {domain_id = 0 : i64}
   return
 }
 
@@ -148,7 +148,7 @@ func.func @yield_type_mismatch() -> tensor<3x4xi64> {
     %local = tensor.empty() : tensor<3x4xf32>
     // expected-note @+1 {{region branch point}}
     hipsr.pool_domain_yield %local : tensor<3x4xf32>
-  } -> tensor<3x4xi64>
+  } -> tensor<3x4xi64> {domain_id = 0 : i64}
   return %0 : tensor<3x4xi64>
 }
 
@@ -161,7 +161,7 @@ func.func @body_uses_parent_value_directly(%in: tensor<3x4xf32>)
   ^bb0(%domain_in: tensor<3x4xf32>):
     // expected-error @+1 {{using value defined outside the region}}
     hipsr.pool_domain_yield %in : tensor<3x4xf32>
-  } -> tensor<3x4xf32>
+  } -> tensor<3x4xf32> {domain_id = 0 : i64}
   return %0 : tensor<3x4xf32>
 }
 
@@ -180,6 +180,6 @@ func.func @multi_block_body() {
     hipsr.pool_domain_yield
   ^bb1:
     hipsr.pool_domain_yield
-  }
+  } {domain_id = 0 : i64}
   return
 }

--- a/test/lit/Dialect/Hipsr/pool_alloc.mlir
+++ b/test/lit/Dialect/Hipsr/pool_alloc.mlir
@@ -9,7 +9,7 @@
 //   chi=1  single point : align_up_rounding, dynamic_size, dead_alloc_skipped
 //   chi=1  independent  : coalesce_static
 //   chi=2  staggered    : split_two_groups, split_two_groups_dynamic
-// two_domains covers the module-level domain_id counter.
+// two_domains covers the domain_id each pool_domain declares.
 
 // 3xf16 = 6 B is not a multiple of 256, so the alignUp chain must round up.
 // CHECK-LABEL: func.func @align_up_rounding
@@ -29,7 +29,7 @@ func.func @align_up_rounding(%ctx: !hipsr.context,
     hipsr.add(%dctx) ins(%d, %d : memref<3xf16, #hipsr.mem<device>>, memref<3xf16, #hipsr.mem<device>>)
                outs(%a1 : memref<3xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
-  }
+  } {domain_id = 0 : i64}
   return
 }
 
@@ -59,7 +59,7 @@ func.func @dynamic_size(%ctx: !hipsr.context,
     hipsr.add(%dctx) ins(%din, %din : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>)
                outs(%a1 : memref<?x512xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
-  }
+  } {domain_id = 0 : i64}
   return
 }
 
@@ -88,7 +88,7 @@ func.func @dead_alloc_skipped(%ctx: !hipsr.context,
     hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>)
                outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
-  }
+  } {domain_id = 0 : i64}
   return
 }
 
@@ -141,7 +141,7 @@ func.func @coalesce_static(%ctx: !hipsr.context,
     hipsr.add(%dctx) ins(%d4b, %d4b : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a4 : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.add(%dctx) ins(%a4, %a4 : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%d4b : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
-  }
+  } {domain_id = 0 : i64}
   return
 }
 
@@ -174,7 +174,7 @@ func.func @split_two_groups(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr
     hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.add(%dctx) ins(%a1, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a2 : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
-  }
+  } {domain_id = 0 : i64}
   return
 }
 
@@ -220,31 +220,32 @@ func.func @split_two_groups_dynamic(%ctx: !hipsr.context,
     hipsr.add(%dctx) ins(%a_dyn, %a_dyn : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>) outs(%din : memref<?x512xf16, #hipsr.mem<device>>)
     hipsr.add(%dctx) ins(%a_static, %a_static : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%dsin : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
-  }
+  } {domain_id = 0 : i64}
   return
 }
 
 // -----
 
-// domain_id counts up per pool_domain across the module. It equals the
-// default 0 in the first domain, which the printer elides.
+// Each get_pool carries the id its pool_domain declared. The ids are 0 and 7,
+// not 0 and 1, so a pass that numbered domains itself would not match. The
+// first one prints bare because get_pool defaults domain_id to 0.
 // CHECK-LABEL: func.func @two_domains
 // CHECK: %[[G0:.+]] = arith.muli %{{.+}}, %{{.+}} : index
 // CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) : memref<?xi8, #hipsr.mem<device>>
 // CHECK: %[[G1:.+]] = arith.muli %{{.+}}, %{{.+}} : index
-// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G1]]) {domain_id = 1 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G1]]) {domain_id = 7 : i64} : memref<?xi8, #hipsr.mem<device>>
 func.func @two_domains(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr.mem<device>>) {
   hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
   ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
     %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
     hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
-  }
+  } {domain_id = 0 : i64}
   hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
   ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
     %a2 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
     hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a2 : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
-  }
+  } {domain_id = 7 : i64}
   return
 }

--- a/test/lit/Dialect/Hipsr/pool_alloc.mlir
+++ b/test/lit/Dialect/Hipsr/pool_alloc.mlir
@@ -18,7 +18,7 @@
 // CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[C6]], %[[C255]] : index
 // CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
 // CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
-// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
 // CHECK-NOT: arith.maxui
 func.func @align_up_rounding(%ctx: !hipsr.context,
                         %in: memref<3xf16, #hipsr.mem<device>>) {
@@ -47,7 +47,7 @@ func.func @align_up_rounding(%ctx: !hipsr.context,
 // CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[BYTES]], %[[C255]] : index
 // CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
 // CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
-// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
 func.func @dynamic_size(%ctx: !hipsr.context,
                    %in: memref<?x512xf16, #hipsr.mem<device>>) {
   hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<?x512xf16, #hipsr.mem<device>>) {
@@ -75,7 +75,7 @@ func.func @dynamic_size(%ctx: !hipsr.context,
 // CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[C8192]], %[[C255]] : index
 // CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
 // CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
-// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
 // CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%[[LIVE]] : memref<4x1024xf16, #hipsr.mem<device>>)
 // CHECK-NOT: arith.maxui
 func.func @dead_alloc_skipped(%ctx: !hipsr.context,
@@ -109,7 +109,7 @@ func.func @dead_alloc_skipped(%ctx: !hipsr.context,
 // CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[M2]], %[[C255]] : index
 // CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
 // CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
-// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
 // CHECK-NOT: arith.divui
 func.func @coalesce_static(%ctx: !hipsr.context,
                                %in8: memref<8x1024xf16, #hipsr.mem<device>>,
@@ -162,7 +162,7 @@ func.func @coalesce_static(%ctx: !hipsr.context,
 // CHECK-NEXT: %[[D1:.+]] = arith.divui %[[N1]], %[[C256B]] : index
 // CHECK-NEXT: %[[G1:.+]] = arith.muli %[[D1]], %[[C256B]] : index
 // CHECK-NEXT: %[[POOLSZ:.+]] = arith.addi %[[G0]], %[[G1]] : index
-// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[POOLSZ]]) : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[POOLSZ]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
 // CHECK-NOT: arith.maxui
 func.func @split_two_groups(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr.mem<device>>) {
   hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
@@ -194,7 +194,7 @@ func.func @split_two_groups(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr
 // CHECK-NEXT: %[[D1:.+]] = arith.divui %[[N1]], %[[C256B]] : index
 // CHECK-NEXT: %[[G1:.+]] = arith.muli %[[D1]], %[[C256B]] : index
 // CHECK-NEXT: %[[POOLSZ:.+]] = arith.addi %[[G0]], %[[G1]] : index
-// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[POOLSZ]]) : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[POOLSZ]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
 // CHECK-NOT: arith.maxui
 func.func @split_two_groups_dynamic(%ctx: !hipsr.context,
                                     %inf16: memref<?x512xf16, #hipsr.mem<device>>,
@@ -223,7 +223,7 @@ func.func @split_two_groups_dynamic(%ctx: !hipsr.context,
 
 // CHECK-LABEL: func.func @two_domains
 // CHECK: %[[G0:.+]] = arith.muli %{{.+}}, %{{.+}} : index
-// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
 // CHECK: %[[G1:.+]] = arith.muli %{{.+}}, %{{.+}} : index
 // CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G1]]) {domain_id = 7 : i64} : memref<?xi8, #hipsr.mem<device>>
 func.func @two_domains(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr.mem<device>>) {

--- a/test/lit/Dialect/Hipsr/pool_alloc.mlir
+++ b/test/lit/Dialect/Hipsr/pool_alloc.mlir
@@ -2,14 +2,14 @@
 // Licensed under the MIT License.
 
 // RUN: hip-mlir-opt %s -split-input-file -hipsr-pool-alloc \
-// RUN:   | FileCheck %s --implicit-check-not=hipsr.get_pool \
-// RUN:       --implicit-check-not=memref.view
+// RUN:   | FileCheck %s --implicit-check-not=memref.view
 
 // Cases are ordered by lifetime-interval topology (interference-graph chromatic
 // number chi = group count), ascending:
 //   chi=1  single point : align_up_rounding, dynamic_size, dead_alloc_skipped
 //   chi=1  independent  : coalesce_static
-//   chi=2  staggered    : split_two_groups
+//   chi=2  staggered    : split_two_groups, split_two_groups_dynamic
+// two_domains covers the module-level domain_id counter.
 
 // 3xf16 = 6 B is not a multiple of 256, so the alignUp chain must round up.
 // CHECK-LABEL: func.func @align_up_rounding
@@ -18,7 +18,8 @@
 // CHECK-NEXT: %[[C255:.+]] = arith.constant 255 : index
 // CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[C6]], %[[C255]] : index
 // CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
-// CHECK-NEXT: arith.muli %[[DIV]], %[[C256]] : index
+// CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
+// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) : memref<?xi8, #hipsr.mem<device>>
 // CHECK-NOT: arith.maxui
 func.func @align_up_rounding(%ctx: !hipsr.context,
                         %in: memref<3xf16, #hipsr.mem<device>>) {
@@ -46,7 +47,8 @@ func.func @align_up_rounding(%ctx: !hipsr.context,
 // CHECK-NEXT: %[[C255:.+]] = arith.constant 255 : index
 // CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[BYTES]], %[[C255]] : index
 // CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
-// CHECK-NEXT: arith.muli %[[DIV]], %[[C256]] : index
+// CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
+// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) : memref<?xi8, #hipsr.mem<device>>
 func.func @dynamic_size(%ctx: !hipsr.context,
                    %in: memref<?x512xf16, #hipsr.mem<device>>) {
   hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<?x512xf16, #hipsr.mem<device>>) {
@@ -73,7 +75,8 @@ func.func @dynamic_size(%ctx: !hipsr.context,
 // CHECK-NEXT: %[[C255:.+]] = arith.constant 255 : index
 // CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[C8192]], %[[C255]] : index
 // CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
-// CHECK-NEXT: arith.muli %[[DIV]], %[[C256]] : index
+// CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
+// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) : memref<?xi8, #hipsr.mem<device>>
 // CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%[[LIVE]] : memref<4x1024xf16, #hipsr.mem<device>>)
 // CHECK-NOT: arith.maxui
 func.func @dead_alloc_skipped(%ctx: !hipsr.context,
@@ -106,7 +109,8 @@ func.func @dead_alloc_skipped(%ctx: !hipsr.context,
 // CHECK-NEXT: %[[C255:.+]] = arith.constant 255 : index
 // CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[M2]], %[[C255]] : index
 // CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
-// CHECK-NEXT: arith.muli %[[DIV]], %[[C256]] : index
+// CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
+// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) : memref<?xi8, #hipsr.mem<device>>
 // CHECK-NOT: arith.divui
 func.func @coalesce_static(%ctx: !hipsr.context,
                                %in8: memref<8x1024xf16, #hipsr.mem<device>>,
@@ -144,20 +148,23 @@ func.func @coalesce_static(%ctx: !hipsr.context,
 // -----
 
 // a1 is read while writing a2, so their lifetimes overlap and land in separate
-// groups: two independent size chains, each aligned on its own.
+// groups: two independent size chains, each aligned on its own, and the pool
+// size is their sum.
 // CHECK-LABEL: func.func @split_two_groups
 // CHECK: %[[C8192A:.+]] = arith.constant 8192 : index
 // CHECK-NEXT: %[[C256A:.+]] = arith.constant 256 : index
 // CHECK-NEXT: %[[C255A:.+]] = arith.constant 255 : index
 // CHECK-NEXT: %[[N0:.+]] = arith.addi %[[C8192A]], %[[C255A]] : index
 // CHECK-NEXT: %[[D0:.+]] = arith.divui %[[N0]], %[[C256A]] : index
-// CHECK-NEXT: arith.muli %[[D0]], %[[C256A]] : index
+// CHECK-NEXT: %[[G0:.+]] = arith.muli %[[D0]], %[[C256A]] : index
 // CHECK-NEXT: %[[C8192B:.+]] = arith.constant 8192 : index
 // CHECK-NEXT: %[[C256B:.+]] = arith.constant 256 : index
 // CHECK-NEXT: %[[C255B:.+]] = arith.constant 255 : index
 // CHECK-NEXT: %[[N1:.+]] = arith.addi %[[C8192B]], %[[C255B]] : index
 // CHECK-NEXT: %[[D1:.+]] = arith.divui %[[N1]], %[[C256B]] : index
-// CHECK-NEXT: arith.muli %[[D1]], %[[C256B]] : index
+// CHECK-NEXT: %[[G1:.+]] = arith.muli %[[D1]], %[[C256B]] : index
+// CHECK-NEXT: %[[POOLSZ:.+]] = arith.addi %[[G0]], %[[G1]] : index
+// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[POOLSZ]]) : memref<?xi8, #hipsr.mem<device>>
 // CHECK-NOT: arith.maxui
 func.func @split_two_groups(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr.mem<device>>) {
   hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
@@ -166,6 +173,77 @@ func.func @split_two_groups(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr
     %a2 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
     hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.add(%dctx) ins(%a1, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a2 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  }
+  return
+}
+
+// -----
+
+// Same staggered topology, but one group carries a dynamic batch dim: the
+// %dim factor flows through its align chain into the pool-size sum, so a
+// dynamic group is summed like any other.
+// CHECK-LABEL: func.func @split_two_groups_dynamic
+// CHECK: %[[DIM:.+]] = memref.dim %{{.+}} : memref<?x512xf16, #hipsr.mem<device>>
+// CHECK: %[[C1024:.+]] = arith.constant 1024 : index
+// CHECK-NEXT: %[[BYTES:.+]] = arith.muli %[[C1024]], %[[DIM]] : index
+// CHECK-NEXT: %[[C256A:.+]] = arith.constant 256 : index
+// CHECK-NEXT: %[[C255A:.+]] = arith.constant 255 : index
+// CHECK-NEXT: %[[N0:.+]] = arith.addi %[[BYTES]], %[[C255A]] : index
+// CHECK-NEXT: %[[D0:.+]] = arith.divui %[[N0]], %[[C256A]] : index
+// CHECK-NEXT: %[[G0:.+]] = arith.muli %[[D0]], %[[C256A]] : index
+// CHECK-NEXT: %[[C8192:.+]] = arith.constant 8192 : index
+// CHECK-NEXT: %[[C256B:.+]] = arith.constant 256 : index
+// CHECK-NEXT: %[[C255B:.+]] = arith.constant 255 : index
+// CHECK-NEXT: %[[N1:.+]] = arith.addi %[[C8192]], %[[C255B]] : index
+// CHECK-NEXT: %[[D1:.+]] = arith.divui %[[N1]], %[[C256B]] : index
+// CHECK-NEXT: %[[G1:.+]] = arith.muli %[[D1]], %[[C256B]] : index
+// CHECK-NEXT: %[[POOLSZ:.+]] = arith.addi %[[G0]], %[[G1]] : index
+// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[POOLSZ]]) : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NOT: arith.maxui
+func.func @split_two_groups_dynamic(%ctx: !hipsr.context,
+                                    %inf16: memref<?x512xf16, #hipsr.mem<device>>,
+                                    %sin: memref<4x1024xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %inf16, %sin :
+      !hipsr.context,
+      memref<?x512xf16, #hipsr.mem<device>>,
+      memref<4x1024xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context,
+       %din: memref<?x512xf16, #hipsr.mem<device>>,
+       %dsin: memref<4x1024xf16, #hipsr.mem<device>>):
+    %c0 = arith.constant 0 : index
+    %d = memref.dim %din, %c0 : memref<?x512xf16, #hipsr.mem<device>>
+    %a_dyn = memref.alloc(%d) : memref<?x512xf16, #hipsr.mem<device>>
+    %a_static = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%din, %din : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>) outs(%a_dyn : memref<?x512xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%dsin, %dsin : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a_static : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a_dyn, %a_dyn : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>) outs(%din : memref<?x512xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a_static, %a_static : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%dsin : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  }
+  return
+}
+
+// -----
+
+// domain_id counts up per pool_domain across the module. It equals the
+// default 0 in the first domain, which the printer elides.
+// CHECK-LABEL: func.func @two_domains
+// CHECK: %[[G0:.+]] = arith.muli %{{.+}}, %{{.+}} : index
+// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) : memref<?xi8, #hipsr.mem<device>>
+// CHECK: %[[G1:.+]] = arith.muli %{{.+}}, %{{.+}} : index
+// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G1]]) {domain_id = 1 : i64} : memref<?xi8, #hipsr.mem<device>>
+func.func @two_domains(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
+    %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  }
+  hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
+    %a2 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a2 : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
   }
   return

--- a/test/lit/Dialect/Hipsr/pool_alloc.mlir
+++ b/test/lit/Dialect/Hipsr/pool_alloc.mlir
@@ -9,7 +9,6 @@
 //   chi=1  single point : align_up_rounding, dynamic_size, dead_alloc_skipped
 //   chi=1  independent  : coalesce_static
 //   chi=2  staggered    : split_two_groups, split_two_groups_dynamic
-// two_domains covers the domain_id each pool_domain declares.
 
 // 3xf16 = 6 B is not a multiple of 256, so the alignUp chain must round up.
 // CHECK-LABEL: func.func @align_up_rounding
@@ -148,8 +147,7 @@ func.func @coalesce_static(%ctx: !hipsr.context,
 // -----
 
 // a1 is read while writing a2, so their lifetimes overlap and land in separate
-// groups: two independent size chains, each aligned on its own, and the pool
-// size is their sum.
+// groups: two independent size chains, each aligned on its own.
 // CHECK-LABEL: func.func @split_two_groups
 // CHECK: %[[C8192A:.+]] = arith.constant 8192 : index
 // CHECK-NEXT: %[[C256A:.+]] = arith.constant 256 : index
@@ -180,9 +178,6 @@ func.func @split_two_groups(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr
 
 // -----
 
-// Same staggered topology, but one group carries a dynamic batch dim: the
-// %dim factor flows through its align chain into the pool-size sum, so a
-// dynamic group is summed like any other.
 // CHECK-LABEL: func.func @split_two_groups_dynamic
 // CHECK: %[[DIM:.+]] = memref.dim %{{.+}} : memref<?x512xf16, #hipsr.mem<device>>
 // CHECK: %[[C1024:.+]] = arith.constant 1024 : index
@@ -226,9 +221,6 @@ func.func @split_two_groups_dynamic(%ctx: !hipsr.context,
 
 // -----
 
-// Each get_pool carries the id its pool_domain declared. The ids are 0 and 7,
-// not 0 and 1, so a pass that numbered domains itself would not match. The
-// first one prints bare because get_pool defaults domain_id to 0.
 // CHECK-LABEL: func.func @two_domains
 // CHECK: %[[G0:.+]] = arith.muli %{{.+}}, %{{.+}} : index
 // CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) : memref<?xi8, #hipsr.mem<device>>

--- a/test/lit/Dialect/Hipsr/pool_alloc_invalid.mlir
+++ b/test/lit/Dialect/Hipsr/pool_alloc_invalid.mlir
@@ -7,7 +7,7 @@ func.func @empty_domain() {
   // expected-error@+1 {{hipsr-pool-alloc: pool_domain has no poolable allocation}}
   hipsr.pool_domain() {
     hipsr.pool_domain_yield
-  }
+  } {domain_id = 0 : i64}
   return
 }
 
@@ -25,7 +25,7 @@ func.func @alloc_without_dps_write(%ctx: !hipsr.context,
                                memref<4x1024xf16, #hipsr.mem<device>>)
                outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
-  }
+  } {domain_id = 0 : i64}
   return
 }
 
@@ -44,6 +44,6 @@ func.func @no_context(%in: memref<4x1024xf16, #hipsr.mem<device>>) {
     linalg.copy ins(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
            outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
-  }
+  } {domain_id = 0 : i64}
   return
 }

--- a/test/lit/Dialect/Hipsr/pool_alloc_invalid.mlir
+++ b/test/lit/Dialect/Hipsr/pool_alloc_invalid.mlir
@@ -31,8 +31,6 @@ func.func @alloc_without_dps_write(%ctx: !hipsr.context,
 
 // -----
 
-// linalg.fill is a DPS write that takes no context, so the alloc is poolable
-// while the domain still has no context to hand to hipsr.get_pool.
 func.func @no_context(%in: memref<4x1024xf16, #hipsr.mem<device>>) {
   // expected-error@+1 {{hipsr-pool-alloc: pool_domain has no context}}
   hipsr.pool_domain(%in : memref<4x1024xf16, #hipsr.mem<device>>) {

--- a/test/lit/Dialect/Hipsr/pool_alloc_invalid.mlir
+++ b/test/lit/Dialect/Hipsr/pool_alloc_invalid.mlir
@@ -28,3 +28,22 @@ func.func @alloc_without_dps_write(%ctx: !hipsr.context,
   }
   return
 }
+
+// -----
+
+// linalg.fill is a DPS write that takes no context, so the alloc is poolable
+// while the domain still has no context to hand to hipsr.get_pool.
+func.func @no_context(%in: memref<4x1024xf16, #hipsr.mem<device>>) {
+  // expected-error@+1 {{hipsr-pool-alloc: pool_domain has no context}}
+  hipsr.pool_domain(%in : memref<4x1024xf16, #hipsr.mem<device>>) {
+  ^bb0(%din: memref<4x1024xf16, #hipsr.mem<device>>):
+    %cst = arith.constant 0.0 : f16
+    %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    linalg.fill ins(%cst : f16)
+           outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
+    linalg.copy ins(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
+           outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  }
+  return
+}

--- a/test/lit/Dialect/Hipsr/pool_alloc_invalid.mlir
+++ b/test/lit/Dialect/Hipsr/pool_alloc_invalid.mlir
@@ -28,20 +28,3 @@ func.func @alloc_without_dps_write(%ctx: !hipsr.context,
   } {domain_id = 0 : i64}
   return
 }
-
-// -----
-
-func.func @no_context(%in: memref<4x1024xf16, #hipsr.mem<device>>) {
-  // expected-error@+1 {{hipsr-pool-alloc: pool_domain has no context}}
-  hipsr.pool_domain(%in : memref<4x1024xf16, #hipsr.mem<device>>) {
-  ^bb0(%din: memref<4x1024xf16, #hipsr.mem<device>>):
-    %cst = arith.constant 0.0 : f16
-    %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
-    linalg.fill ins(%cst : f16)
-           outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
-    linalg.copy ins(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
-           outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
-    hipsr.pool_domain_yield
-  } {domain_id = 0 : i64}
-  return
-}

--- a/test/lit/Dialect/Hipsr/pool_alloc_report.mlir
+++ b/test/lit/Dialect/Hipsr/pool_alloc_report.mlir
@@ -3,8 +3,7 @@
 
 // RUN: hip-mlir-opt %s -split-input-file --verify-diagnostics \
 // RUN:   -hipsr-pool-alloc='emit-pool-report=true' \
-// RUN:   | FileCheck %s --implicit-check-not=hipsr.get_pool \
-// RUN:       --implicit-check-not=memref.view
+// RUN:   | FileCheck %s --implicit-check-not=memref.view
 
 // CHECK-LABEL: func.func @interleaved_allocs
 func.func @interleaved_allocs(%ctx: !hipsr.context,

--- a/test/lit/Dialect/Hipsr/pool_alloc_report.mlir
+++ b/test/lit/Dialect/Hipsr/pool_alloc_report.mlir
@@ -34,7 +34,7 @@ func.func @interleaved_allocs(%ctx: !hipsr.context,
                                     memref<4x1024xf16, #hipsr.mem<device>>)
                outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
-  }
+  } {domain_id = 0 : i64}
   return
 }
 
@@ -69,7 +69,7 @@ func.func @hoisted_allocs(%ctx: !hipsr.context,
                                     memref<4x1024xf16, #hipsr.mem<device>>)
                outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
-  }
+  } {domain_id = 0 : i64}
   return
 }
 
@@ -96,7 +96,7 @@ func.func @nested_region_user(%ctx: !hipsr.context,
       scf.yield
     }
     hipsr.pool_domain_yield
-  }
+  } {domain_id = 0 : i64}
   return
 }
 
@@ -137,7 +137,7 @@ func.func @coalesce_static(%ctx: !hipsr.context,
     hipsr.add(%dctx) ins(%d4b, %d4b : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a4 : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.add(%dctx) ins(%a4, %a4 : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%d4b : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
-  }
+  } {domain_id = 0 : i64}
   return
 }
 
@@ -161,7 +161,7 @@ func.func @split_three_groups(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hip
     hipsr.add(%dctx) ins(%a2, %a3 : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.add(%dctx) ins(%a1, %a3 : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
-  }
+  } {domain_id = 0 : i64}
   return
 }
 
@@ -180,7 +180,7 @@ func.func @dynamic_size(%ctx: !hipsr.context,
     hipsr.add(%dctx) ins(%din, %din : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>)
                outs(%a1 : memref<?x512xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
-  }
+  } {domain_id = 0 : i64}
   return
 }
 
@@ -209,7 +209,7 @@ func.func @coalesce_mixed(%ctx: !hipsr.context,
     hipsr.add(%dctx) ins(%sf16, %sf16 : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>)
                outs(%a2 : memref<?x512xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
-  }
+  } {domain_id = 0 : i64}
   return
 }
 
@@ -231,7 +231,7 @@ func.func @coalesce_dynamic(%ctx: !hipsr.context, %in: memref<?x1024xf16, #hipsr
     hipsr.add(%dctx) ins(%din, %din : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%a2 : memref<?x1024xf16, #hipsr.mem<device>>)
     hipsr.add(%dctx) ins(%a2, %din : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%din : memref<?x1024xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
-  }
+  } {domain_id = 0 : i64}
   return
 }
 
@@ -260,7 +260,7 @@ func.func @split_two_groups_dynamic(%ctx: !hipsr.context,
     hipsr.add(%dctx) ins(%a_dyn, %a_dyn : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>) outs(%din : memref<?x512xf16, #hipsr.mem<device>>)
     hipsr.add(%dctx) ins(%a_static, %a_static : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%dsin : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
-  }
+  } {domain_id = 0 : i64}
   return
 }
 
@@ -289,6 +289,6 @@ func.func @alloc_inside_region(%ctx: !hipsr.context,
       scf.yield
     }
     hipsr.pool_domain_yield
-  }
+  } {domain_id = 0 : i64}
   return
 }


### PR DESCRIPTION
## Summary

`hipsr-pool-alloc` now sums the per-group aligned sizes it already emits and hands the total to `hipsr.get_pool`, tagged with the `domain_id` its `pool_domain` declares.

## Related issue or design

wcy123/onnx-hipdnn-ep#114

## Why

- Group sizes are summed, not maxed: groups are disjoint in time within a domain, but they still need disjoint storage inside one pool, so the pool has to hold all of them at once. The `arith.maxui` inside a group covers members that reuse the same bytes.
- `domain_id` belongs to the domain, not to the pass. The runtime keys pools by id, so the id decides which domains share a buffer — that is the author's call, and a pass counting its way through a walk would tie it to traversal order and to how many domains were skipped. `pool_domain` declares it, `hipsr-pool-alloc` passes it through, and duplicates are allowed because repeating an id is how two domains ask for one pool.
- Every `hipsr.get_pool` prints its `domain_id`. It used to default to 0, so single-domain IR read as if the op had no pool selector at all, and which pool a call draws from is not something to infer from an absence.
- Single-group domains emit no `arith.addi` — the pool size is that group's size.
- A poolable alloc no longer implies a usable context: `linalg.fill` is a DPS write that takes no context, so a `pool_domain` without a context block argument can reach the emission point with a group to place and nothing to pass to `hipsr.get_pool`. That is a diagnostic now rather than a crash.

## What

- `Hipsr_PoolDomainOp` gains a required `I64Attr:$domain_id`, and `Hipsr_GetPoolOp`'s `domain_id` drops its `DefaultValuedAttr` wrapper. `assemblyFormat` is untouched on both — the existing `attr-dict` prints them, so a domain reads `} -> tensor<?x512xf16> {domain_id = 0 : i64}` and a pool reads `hipsr.get_pool(%ctx, %size) {domain_id = 0 : i64}`.
- `findContext` / `emitPool` in `HipsrPoolAllocPass.cpp`; `runOnOperation` collects the `emitGroupSize` results it previously discarded and reads `domain.getDomainId()` for the pool it emits.
- `materializeDomains` in `PartitionPoolDomains.cpp` numbers its domains by position. It is the only `PoolDomainOp` builder call in tree and is currently unreached, so this is the minimal change that keeps it compiling.
- Being required, both attributes are now part of the parse, so every hand-written `pool_domain` and `hipsr.get_pool` in the LIT suite carries one: the files that run today, plus the `UNSUPPORTED: true` ones so re-enabling them does not hit a parse error.
- `hip.get_pool` in the `hip` dialect keeps its default — this PR does not touch the `hip-pool-allocs` path.
- The pool still has no consumer; wcy123/onnx-hipdnn-ep#116 rewrites the allocs to `memref.view` over it. `GetPoolOp` carries `MemoryEffects::Allocate`, so DCE keeps it alive until then.
- `pool_alloc.mlir` and `pool_alloc_report.mlir` drop `--implicit-check-not=hipsr.get_pool` from their RUN lines; the `memref.view` guard stays for #116.

## Test plan

- [x] `pool_alloc.mlir`: the five existing cases check `hipsr.get_pool` at the end of their size chains, and `@split_two_groups` checks the `arith.addi` that sums the two groups.
- [x] New `@split_two_groups_dynamic` covers the dynamic batch dim requested on #671: the `memref.dim` factor flows through one group's align chain into the pool-size sum.
- [x] New `@two_domains` declares ids 0 and 7, so the CHECK for `domain_id = 7 : i64` fails against any pass that numbers domains itself, and the CHECK for `domain_id = 0 : i64` on the other pool fails against a printer that elides a zero.
- [x] Full `check-hip-mlir-lit`: 353 passed, 24 unsupported, 1 failure (`Conversion/onnx-to-hip/test_gather_block_quantized.mlir`) that reproduces on `main` without this change.

## Notes for reviewers

Stacked on #671. Offsets (#115) and the `memref.view` rewrite (#116) keep extending the same CHECK blocks in `pool_alloc.mlir`.

The context diagnostic has no LIT case: `-hipsr-pool-alloc` runs after bufferization, where a `pool_domain` always carries the context argument, so the case had to be hand-built. Say the word if you want it back.
