### PR TITLE
fix(shape): canonicalize host reshape provenance

### DIFF
--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -162,7 +162,53 @@ Frontend-neutral destination construction lives in
 lookup. `OnnxToHipUtils` retains only ONNX import semantics and wrappers, so a
 future frontend can target HIP without depending on the ONNX conversion layer.
 
-Pure descriptor transformations such as Reshape, Squeeze, and Unsqueeze generally lower to standard tensor operations rather than HIP DPS compute operations. Their shape inference and dim folding use MLIR's standard tensor interfaces and external models, not a second HIP-specific contract.
+Pure descriptor transformations such as Reshape, Squeeze, and Unsqueeze
+generally lower to standard tensor operations rather than HIP DPS compute
+operations. Their result-extent inference and dim folding use MLIR's standard
+tensor interfaces and external models, not a second HIP-specific contract.
+`ReifyRankedShapedTypeOpInterface` exposes shaped-result extents, and
+ValueBounds can reason about dimensions and scalar/index bounds; neither
+directly transports the integer payload of a rank-1 ONNX shape tensor. Typed
+ONNX operations and shape helpers could replace name-based transfer dispatch,
+while Shape-dialect integration would require representing the payload as
+explicit shape values.
+
+After pre-lowering ONNX rewrites reach their fixed point and before the first
+`onnx.Constant`-to-`hip.constant` carrier sweep, one function-level MLIR sparse
+forward dataflow solve computes Reshape target-payload provenance. Its monotonic
+lattice carries canonical tensor dimensions and an optional complete host
+payload through Shape, constant Gather/Slice, axis-zero Concat, Identity,
+Unsqueeze, scalar/vector Reshape, constants, and proven `tensor.from_elements`
+chains. Add, MatMul, and Cast transfer canonical dimension roots without
+claiming payload provenance. Joins keep a dimension fact only when incoming
+roots agree and keep a payload only when the complete vectors agree; there is
+no `hip.loop` dimension propagation.
+
+Literal target tensors do not require payload provenance. Conversion reads a
+dense `hip.constant` carrier directly, validates the ONNX Reshape rules, and
+materializes the target entries without consulting an externalized global or
+performing synchronized readback. Provenance is reserved for runtime-derived
+shape programs: a complete proof rebuilds their target from constants,
+canonical `tensor.dim` values, and proven host scalar SSA. Disagreement,
+unknown producers, partially-known payloads, and device-produced payloads leave
+the operand untouched. If no earlier shape-independent or static rewrite
+applies, the dynamic runtime-shaped fallback then uses synchronized readback.
+
+For `allowzero=1`, the provenance path accepts a target containing `-1` only
+when every other entry is proven strictly positive. A merely nonnegative entry
+could be zero, which ONNX forbids alongside `-1`, so it retains the unknown
+fallback. A target proven nonnegative throughout may bypass generic `-1`
+inference.
+
+Materialization stamps pass-internal markers for the dynamic runtime-shaped
+Reshape fallback. Before that fallback's first mutation, it revalidates the
+marker dependencies it consumes, target rank and length, host-safe scalar
+structure, nonnegative/no-`-1` claims, and mapped input-dimension identities.
+Earlier shape-independent or static Reshape rewrites do not consume marker
+claims and may bypass their validation. The fallback does not rerun the
+dataflow solver, so the markers are a handoff across this fixed pipeline
+boundary rather than durable proof after arbitrary IR mutation. The analysis is
+skipped for functions without an eligible dynamic Reshape.
 
 ## Static result typing
 
@@ -328,6 +374,7 @@ Primary regression coverage:
 | `test/lit/Dialect/hip-infer-loop-body-shapes.mlir` | Pre-conversion rank establishment |
 | `test/lit/Dialect/hip-dps-op-interface.mlir` | Shared `HipDpsOpInterface` reification |
 | `test/lit/Dialect/hip-broadcast-reify-shapes.mlir` | Shared broadcast reification and rank-zero success |
+| `test/lit/Conversion/onnx-to-hip/test_reshape_shape_provenance.mlir` | Proven host Reshape shapes, dataflow joins/shared producers, unknown-payload fallback, and `-1` handling |
 | `test/lit/Dialect/hip-matmul-reify-shapes.mlir` | Per-op reification through `--resolve-shaped-type-result-dims` |
 | `test/lit/Dialect/hip-matmul-shape-verifier.mlir` | Static MatMul shape validation |
 | `test/lit/Dialect/hip-loop-verifier.mlir` | Loop-carried type contract |

--- a/docs/design/pool-allocs-memory-planning.md
+++ b/docs/design/pool-allocs-memory-planning.md
@@ -82,6 +82,17 @@ the earliest used allocation when the complete operand cone can move safely.
 These preconditions preserve correctness when omitted, but omission may create
 more dominance domains and increase peak memory.
 
+Pre-conversion Reshape shape-provenance dataflow is an earlier pool-quality
+optimization for dynamic vision graphs. One function-level sparse analysis
+shares Shape/Gather/Slice/Concat payload facts across consumers and canonicalizes
+Add/MatMul/Cast dimension roots before ONNX constants become carriers. Dense
+carrier targets remain compile-time visible to Reshape conversion and bypass
+this runtime-payload provenance path. The analysis replaces fully proven
+runtime-derived target payloads with host scalar SSA, giving broadcast
+reification, CSE, and buffer reuse a canonical root dimension. Conflicting
+control-flow joins and unknown or device-produced target shapes deliberately
+keep the synchronized fallback.
+
 Pre-bufferization `hip-resolve-tensor-dims` serves a related purpose for tensor reshape chains. It lets upstream reification and canonicalization reduce `tensor.dim` queries before they become memref-level size arithmetic. Coverage of standard tensor reshape operations requires `tensor::registerInferTypeOpInterfaceExternalModels` on the dialect registry.
 
 ## PoolAllocs algorithm

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 add_library(OnnxToHip STATIC
   OnnxToHip.cpp
+  OnnxToHipUtils.cpp
   SimplifyOnnx.cpp
   MatMulConversion.cpp
   TransposeConversion.cpp
@@ -38,6 +39,7 @@ add_library(OnnxToHip STATIC
   OneHotConversion.cpp
   GatherShapeFold.cpp
   TransposeMatMulFold.cpp
+  ShapeProvenanceAnalysis.cpp
   ReshapeShapeFold.cpp
   PadShapeFold.cpp
   SliceShapeFold.cpp
@@ -120,6 +122,7 @@ target_link_libraries(OnnxToHip PUBLIC
   MLIRLinalgDialect
   MLIRMemRefDialect
   MLIRBufferizationDialect
+  MLIRAnalysis
   MLIRIR
   MLIRSupport
   MLIRTransforms

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "OnnxToHipUtils.h"
+#include "ShapeProvenanceAnalysis.h"
 
 #include "hip/debug_log.h"
 #include "hip/timing.h"
@@ -384,10 +385,9 @@ void ConvertOnnxToHipPass::runOnOperation() {
     // All patterns are value-based and require literal values to remain on
     // `onnx.Constant` until the first carrier sweep below.
     // ExistingOps strictness is sufficient: the patterns either rewrite to
-    // tensor.* (Gather) or emit `onnx.*` ops. FastGelu (-> onnx.Gelu) and
-    // ReshapeShapeFold (roots on onnx.Reshape, only swaps its shape operand
-    // in place; the re-visit fails the "operand1 is onnx.Shape" guard) are
-    // convergent. ProjectorOpsRewrites emits NEW `onnx.*` ops (Reshape, Gemm,
+    // tensor.* (Gather) or emit `onnx.*` ops. FastGelu (-> onnx.Gelu) is
+    // convergent.
+    // ProjectorOpsRewrites emits NEW `onnx.*` ops (Reshape, Gemm,
     // ReduceMean, ...) that a subsequent round must visit (e.g. the
     // AveragePool decomposition's emitted Reshape feeds the next round's
     // ReduceMean handling), so the set is applied in a fixed-point loop until
@@ -424,7 +424,6 @@ void ConvertOnnxToHipPass::runOnOperation() {
         populateGatherShapeFoldPatterns(preLoweringPatterns, ctx);
         populateTransposeMatMulFoldPatterns(preLoweringPatterns, ctx);
         populateGatherBlockQuantizedPreparePatterns(preLoweringPatterns, ctx);
-        populateReshapeShapeFoldPatterns(preLoweringPatterns, ctx);
         populatePadShapeFoldPatterns(preLoweringPatterns, ctx);
         populateSliceShapeFoldPatterns(preLoweringPatterns, ctx);
         populatePackBroadcastTo4DPatterns(preLoweringPatterns, ctx);
@@ -453,6 +452,18 @@ void ConvertOnnxToHipPass::runOnOperation() {
         funcOp.emitWarning()
             << "convert-onnx-to-hip: pre-lowering round loop hit kMaxRounds="
             << kMaxRounds << " without quiescence";
+    }
+    // Run one function-level solve over the quiesced generic ONNX IR while
+    // `onnx.Constant` values are still inline, before the first carrier sweep.
+    // Sparse dataflow shares producer facts across Reshapes and conservatively
+    // joins block arguments. Materialization stamps the proof contract consumed
+    // and revalidated if conversion reaches the dynamic runtime-shaped
+    // fallback.
+    if (hasEligibleReshapeShapeProvenanceCandidate(funcOp)) {
+      ShapeProvenanceAnalysis analysis(funcOp);
+      if (mlir::failed(analysis.run()) ||
+          mlir::failed(materializeReshapeShapeOperands(funcOp, analysis)))
+        return signalPassFailure();
     }
     // Run ConstantOfShape folding BEFORE `lowerOnnxConstants` so it can still
     // see the original `onnx.Constant` (or `onnx.Shape`) as the shape input.

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.cpp
@@ -22,11 +22,10 @@ DenseElementsAttr getCompileTimeConstantTensor(Value value) {
     return {};
   auto dense = defOp->getAttrOfType<DenseElementsAttr>("value");
   return dense && dense.getType() == value.getType() ? dense
-                                                      : DenseElementsAttr();
+                                                     : DenseElementsAttr();
 }
 
-bool extractConstantIntTensor(Value value,
-                              llvm::SmallVectorImpl<int64_t> &out,
+bool extractConstantIntTensor(Value value, llvm::SmallVectorImpl<int64_t> &out,
                               std::optional<int64_t> expectedRank) {
   return parseDenseIntElements(getCompileTimeConstantTensor(value), out,
                                expectedRank);

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- OnnxToHipUtils.cpp - ONNX-specific conversion helpers ------------===//
+
+#include "OnnxToHipUtils.h"
+
+namespace mlir::hip {
+
+DenseElementsAttr getCompileTimeConstantTensor(Value value) {
+  if (DenseElementsAttr dense = matchHipCompileTimeConstantTensor(value))
+    return dense;
+  if (!value)
+    return {};
+
+  Operation *defOp = value.getDefiningOp();
+  // Semantic pre-lowering rewrites intentionally run before hip.constant
+  // carrier creation. Recognize only the exact generic ONNX constant form.
+  if (!defOp || defOp->getName().getStringRef() != "onnx.Constant" ||
+      defOp->getNumResults() != 1 || defOp->getResult(0) != value)
+    return {};
+  auto dense = defOp->getAttrOfType<DenseElementsAttr>("value");
+  return dense && dense.getType() == value.getType() ? dense
+                                                      : DenseElementsAttr();
+}
+
+bool extractConstantIntTensor(Value value,
+                              llvm::SmallVectorImpl<int64_t> &out,
+                              std::optional<int64_t> expectedRank) {
+  return parseDenseIntElements(getCompileTimeConstantTensor(value), out,
+                               expectedRank);
+}
+
+bool extractConstantIntVector(Value value,
+                              llvm::SmallVectorImpl<int64_t> &out) {
+  return extractConstantIntTensor(value, out, /*expectedRank=*/1);
+}
+
+} // namespace mlir::hip

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -45,10 +45,15 @@
 
 #include <optional>
 
-#define DEBUG_TYPE "convert-onnx-to-hip"
-
 namespace mlir {
 namespace hip {
+
+inline constexpr llvm::StringLiteral kHostShapeOperandAttr =
+    "hip.host_shape_operand";
+inline constexpr llvm::StringLiteral kHostShapeNoMinusOneAttr =
+    "hip.host_shape_no_minus_one";
+inline constexpr llvm::StringLiteral kHostShapeInputDimMapAttr =
+    "hip.host_shape_input_dim_map";
 
 //===----------------------------------------------------------------------===//
 // Helpers
@@ -71,6 +76,20 @@ inline mlir::Value createEmptyTensor(mlir::OpBuilder &builder,
   return mlir::tensor::EmptyOp::create(builder, loc, resultType.getShape(),
                                        resultType.getElementType(), dynSizes);
 }
+
+/// Return the dense payload of a structurally known compile-time tensor
+/// constant: `arith.constant`, exact generic `onnx.Constant`, or inline
+/// `hip.constant`. The payload type must equal the SSA value type.
+mlir::DenseElementsAttr getCompileTimeConstantTensor(mlir::Value value);
+
+/// Recognize \p value as a compile-time rank-0/rank-1 integer tensor.
+bool extractConstantIntTensor(
+    mlir::Value value, llvm::SmallVectorImpl<int64_t> &out,
+    std::optional<int64_t> expectedRank = std::nullopt);
+
+/// Rank-1 convenience wrapper around `extractConstantIntTensor`.
+bool extractConstantIntVector(mlir::Value value,
+                              llvm::SmallVectorImpl<int64_t> &out);
 
 /// Resolve the ranked result type of an ONNX reduction op (ReduceMax / Sum /
 /// Mean / Prod / ...).
@@ -492,18 +511,6 @@ void populateTransposeMatMulFoldPatterns(RewritePatternSet &patterns,
 /// compute conversion. See GatherShapeFold.cpp for the dynseqlen rationale.
 void populateGatherShapeFoldPatterns(RewritePatternSet &patterns,
                                      MLIRContext *ctx);
-
-/// Pre-lowering pattern set: rewrite the `Reshape(data, Shape(src))` idiom
-/// so the shape operand becomes an explicit
-/// `tensor.from_elements(tensor.dim(src, *))`. This lets ReshapeConversion's
-/// `tensor.reshape` fallback recover per-output-dim sizes when the result has
-/// >1 dynamic dim in one reassociation group (otherwise ReshapeConversion
-/// ignores its second operand and emits the same SSA dim twice — the [N, N]
-/// bug). Sibling of GatherShapeFold; must run while the producer is still a
-/// generic ONNX op, before lowerOnnxConstants creates its carrier. See
-/// ReshapeShapeFold.cpp.
-void populateReshapeShapeFoldPatterns(RewritePatternSet &patterns,
-                                      MLIRContext *ctx);
 
 /// Pre-lowering pattern set: stamp `onnx.Pad`'s compile-time `pads` (and
 /// optional `axes`) constant onto the op as `hipdnn.pad_amounts` /

--- a/lib/Conversion/OnnxToHip/ReshapeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ReshapeConversion.cpp
@@ -5,9 +5,265 @@
 
 #include "OnnxToHipUtils.h"
 
+#include <algorithm>
+#include <optional>
+#include <utility>
+
 namespace mlir {
 namespace hip {
 namespace {
+
+bool isProvenHostShapeScalar(mlir::Value value) {
+  mlir::Operation *def = value.getDefiningOp();
+  if (!def)
+    return false;
+  if (mlir::isa<mlir::arith::ConstantOp, mlir::tensor::DimOp>(def))
+    return true;
+  if (mlir::isa<mlir::arith::IndexCastOp, mlir::arith::ExtSIOp,
+                mlir::arith::TruncIOp, mlir::arith::AddIOp, mlir::arith::SubIOp,
+                mlir::arith::MulIOp, mlir::arith::DivSIOp, mlir::arith::DivUIOp,
+                mlir::arith::CmpIOp, mlir::arith::SelectOp, mlir::arith::AndIOp,
+                mlir::arith::OrIOp>(def))
+    return llvm::all_of(def->getOperands(), isProvenHostShapeScalar);
+  return false;
+}
+
+bool isProvenNonNegativeShapeScalar(mlir::Value value) {
+  mlir::Operation *def = value.getDefiningOp();
+  if (!def)
+    return false;
+  if (auto constant = mlir::dyn_cast<mlir::arith::ConstantOp>(def)) {
+    auto integer = mlir::dyn_cast<mlir::IntegerAttr>(constant.getValue());
+    return integer && integer.getValue().isNonNegative();
+  }
+  if (mlir::isa<mlir::tensor::DimOp>(def))
+    return true;
+  if (auto indexCast = mlir::dyn_cast<mlir::arith::IndexCastOp>(def))
+    return isLosslessShapeIndexCast(indexCast) &&
+           isProvenNonNegativeShapeScalar(indexCast.getIn());
+  if (mlir::isa<mlir::arith::ExtSIOp>(def))
+    return isProvenNonNegativeShapeScalar(def->getOperand(0));
+  return false;
+}
+
+bool isProvenPositiveShapeScalar(mlir::Value value) {
+  mlir::Operation *def = value.getDefiningOp();
+  if (!def)
+    return false;
+  if (auto constant = mlir::dyn_cast<mlir::arith::ConstantOp>(def)) {
+    auto integer = mlir::dyn_cast<mlir::IntegerAttr>(constant.getValue());
+    return integer && integer.getValue().isStrictlyPositive();
+  }
+  if (auto indexCast = mlir::dyn_cast<mlir::arith::IndexCastOp>(def))
+    return isLosslessShapeIndexCast(indexCast) &&
+           isProvenPositiveShapeScalar(indexCast.getIn());
+  if (mlir::isa<mlir::arith::ExtSIOp>(def))
+    return isProvenPositiveShapeScalar(def->getOperand(0));
+  return false;
+}
+
+struct ValidatedDynamicReshapeShape {
+  bool hasProvenHostShape;
+  bool hasNoMinusOneProof;
+  mlir::DenseI64ArrayAttr inputDimMap;
+  int64_t allowzero;
+  std::optional<llvm::SmallVector<mlir::Value>> hostElements;
+  std::optional<llvm::SmallVector<int64_t>> constantElements;
+};
+
+mlir::FailureOr<ValidatedDynamicReshapeShape>
+validateDynamicReshapeShape(mlir::Operation *op, mlir::Value data,
+                            mlir::Value shapeOperand, int64_t inputRank,
+                            int64_t outputRank) {
+  bool hasProvenHostShape = op->hasAttr(kHostShapeOperandAttr);
+  bool hasNoMinusOneProof = op->hasAttr(kHostShapeNoMinusOneAttr);
+  auto inputDimMap =
+      op->getAttrOfType<mlir::DenseI64ArrayAttr>(kHostShapeInputDimMapAttr);
+  if (hasNoMinusOneProof && !hasProvenHostShape) {
+    op->emitError("nonnegative shape proof requires host shape proof");
+    return mlir::failure();
+  }
+  if (hasProvenHostShape &&
+      (!inputDimMap || inputDimMap.size() != static_cast<size_t>(outputRank))) {
+    op->emitError("host shape proof requires an input-dimension map");
+    return mlir::failure();
+  }
+
+  int64_t allowzero = 0;
+  if (auto attr = op->getAttrOfType<mlir::IntegerAttr>("allowzero"))
+    allowzero = attr.getSInt();
+  if (allowzero != 0 && allowzero != 1) {
+    op->emitError("Reshape allowzero must be 0 or 1");
+    return mlir::failure();
+  }
+
+  std::optional<llvm::SmallVector<mlir::Value>> hostElements;
+  std::optional<llvm::SmallVector<int64_t>> constantElements;
+  if (hasProvenHostShape) {
+    if (auto fromElements =
+            shapeOperand.getDefiningOp<mlir::tensor::FromElementsOp>()) {
+      if (fromElements.getElements().size() !=
+          static_cast<size_t>(outputRank)) {
+        op->emitError("malformed proven host shape operand");
+        return mlir::failure();
+      }
+      hostElements.emplace(fromElements.getElements().begin(),
+                           fromElements.getElements().end());
+      if (llvm::any_of(*hostElements, [](mlir::Value element) {
+            return !isProvenHostShapeScalar(element);
+          })) {
+        op->emitError("proven host shape contains unsafe scalar");
+        return mlir::failure();
+      }
+    } else {
+      llvm::SmallVector<int64_t> constants;
+      if (!extractConstantIntTensor(shapeOperand, constants,
+                                    /*expectedRank=*/1) ||
+          constants.size() != static_cast<size_t>(outputRank)) {
+        op->emitError("malformed proven host shape operand");
+        return mlir::failure();
+      }
+      constantElements = std::move(constants);
+    }
+  } else {
+    llvm::SmallVector<int64_t> constants;
+    if (extractConstantIntTensor(shapeOperand, constants, /*expectedRank=*/1) &&
+        constants.size() == static_cast<size_t>(outputRank))
+      constantElements = std::move(constants);
+  }
+
+  unsigned minusOneCount = 0;
+  auto validateConstant = [&](int64_t value) -> mlir::LogicalResult {
+    if (value < -1) {
+      op->emitError("Reshape target dimensions must be at least -1");
+      return mlir::failure();
+    }
+    minusOneCount += value == -1;
+    return mlir::success();
+  };
+  if (constantElements) {
+    for (int64_t value : *constantElements)
+      if (mlir::failed(validateConstant(value)))
+        return mlir::failure();
+  } else if (hostElements) {
+    for (mlir::Value element : *hostElements) {
+      mlir::IntegerAttr constant;
+      if (mlir::matchPattern(element, mlir::m_Constant(&constant))) {
+        if (mlir::failed(validateConstant(constant.getValue().getSExtValue())))
+          return mlir::failure();
+        continue;
+      }
+      if (!isProvenNonNegativeShapeScalar(element)) {
+        op->emitError("host shape proof contains an unproven runtime value");
+        return mlir::failure();
+      }
+    }
+  }
+  if (minusOneCount > 1) {
+    op->emitError(hasProvenHostShape
+                      ? "host shape proof contains multiple -1 entries"
+                      : "Reshape target may contain at most one -1");
+    return mlir::failure();
+  }
+  if (constantElements)
+    hasNoMinusOneProof = llvm::all_of(*constantElements,
+                                      [](int64_t value) { return value >= 0; });
+
+  auto isNonNegative = [](mlir::Value value) {
+    return isProvenNonNegativeShapeScalar(value);
+  };
+  if (hasNoMinusOneProof &&
+      ((constantElements &&
+        llvm::any_of(*constantElements,
+                     [](int64_t value) { return value < 0; })) ||
+       (hostElements && llvm::any_of(*hostElements, [&](mlir::Value value) {
+          return !isNonNegative(value);
+        })))) {
+    op->emitError("invalid nonnegative shape proof");
+    return mlir::failure();
+  }
+
+  if (allowzero == 1 && minusOneCount != 0) {
+    bool hasZero =
+        constantElements &&
+        llvm::is_contained(*constantElements, static_cast<int64_t>(0));
+    if (hostElements)
+      hasZero |= llvm::any_of(*hostElements, [](mlir::Value value) {
+        mlir::IntegerAttr constant;
+        return mlir::matchPattern(value, mlir::m_Constant(&constant)) &&
+               constant.getValue().isZero();
+      });
+    if (hasZero) {
+      op->emitError("Reshape cannot combine allowzero=1, zero, and -1");
+      return mlir::failure();
+    }
+    bool allOtherEntriesPositive =
+        (constantElements && llvm::all_of(*constantElements,
+                                          [](int64_t value) {
+                                            return value == -1 || value > 0;
+                                          })) ||
+        (hostElements && llvm::all_of(*hostElements, [](mlir::Value value) {
+           mlir::IntegerAttr constant;
+           return (mlir::matchPattern(value, mlir::m_Constant(&constant)) &&
+                   constant.getValue().getSExtValue() == -1) ||
+                  isProvenPositiveShapeScalar(value);
+         }));
+    if (hasProvenHostShape && !allOtherEntriesPositive) {
+      op->emitError(
+          "allowzero=1 with -1 requires positive proven target dimensions");
+      return mlir::failure();
+    }
+  }
+
+  auto getConstantAt = [&](int64_t index) -> std::optional<int64_t> {
+    if (constantElements)
+      return (*constantElements)[index];
+    if (!hostElements)
+      return std::nullopt;
+    mlir::IntegerAttr constant;
+    if (!mlir::matchPattern((*hostElements)[index],
+                            mlir::m_Constant(&constant)))
+      return std::nullopt;
+    return constant.getValue().getSExtValue();
+  };
+  if (allowzero == 0) {
+    for (int64_t index = inputRank; index < outputRank; ++index) {
+      std::optional<int64_t> constant = getConstantAt(index);
+      if (constant && *constant == 0) {
+        op->emitError("out-of-rank Reshape target entry cannot be zero");
+        return mlir::failure();
+      }
+      if (hasProvenHostShape && (!constant || *constant < 0)) {
+        op->emitError("out-of-rank proven Reshape target must be positive");
+        return mlir::failure();
+      }
+    }
+  }
+
+  if (hasProvenHostShape) {
+    for (int64_t index : llvm::seq<int64_t>(std::min(inputRank, outputRank))) {
+      if (inputDimMap[index] != index)
+        continue;
+      if (!hostElements) {
+        op->emitError("invalid input-dimension equivalence proof");
+        return mlir::failure();
+      }
+      mlir::Value dimValue = (*hostElements)[index];
+      if (auto cast = dimValue.getDefiningOp<mlir::arith::IndexCastOp>())
+        dimValue = cast.getIn();
+      auto dim = dimValue.getDefiningOp<mlir::tensor::DimOp>();
+      if (!dim || !dim.getConstantIndex() || dim.getSource() != data ||
+          *dim.getConstantIndex() != index) {
+        op->emitError("invalid input-dimension equivalence proof");
+        return mlir::failure();
+      }
+    }
+  }
+
+  return ValidatedDynamicReshapeShape{
+      hasProvenHostShape, hasNoMinusOneProof,      inputDimMap,
+      allowzero,          std::move(hostElements), std::move(constantElements)};
+}
 
 //===----------------------------------------------------------------------===//
 // Shape Operations Helpers (Reshape, Unsqueeze, Squeeze)
@@ -190,6 +446,10 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
   mlir::LogicalResult
   matchAndRewrite(mlir::Operation *op,
                   mlir::PatternRewriter &rewriter) const override {
+    if (op->getNumOperands() != 2 || op->getNumResults() != 1) {
+      op->emitError("onnx.Reshape expects exactly two operands and one result");
+      return mlir::failure();
+    }
     mlir::Value data = op->getOperand(0);
     auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(data.getType());
     auto outputType =
@@ -494,8 +754,21 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
       auto shapeTy =
           mlir::dyn_cast<mlir::RankedTensorType>(shapeOperand.getType());
       if (shapeTy && shapeTy.getRank() == 1 &&
-          shapeTy.getElementType().isInteger() &&
+          shapeTy.getElementType().isInteger(64) &&
           shapeTy.getDimSize(0) == outputRank) {
+        // Complete every fallible check, including proof-marker revalidation,
+        // before creating replacement IR. RewritePattern failure must leave the
+        // original IR unchanged, so this path's first rewriter mutation occurs
+        // only after validation succeeds.
+        mlir::FailureOr<ValidatedDynamicReshapeShape> validatedShape =
+            validateDynamicReshapeShape(op, data, shapeOperand, inputRank,
+                                        outputRank);
+        if (mlir::failed(validatedShape))
+          return mlir::failure();
+        bool hasProvenHostShape = validatedShape->hasProvenHostShape;
+        bool hasNoMinusOneProof = validatedShape->hasNoMinusOneProof;
+        mlir::DenseI64ArrayAttr inputDimMap = validatedShape->inputDimMap;
+        int64_t allowzero = validatedShape->allowzero;
         // ONNX `Reshape` permits one shape entry to be `-1`, meaning "infer
         // this dim so the total element count is preserved". `memref.reshape`
         // (the bufferization target of `tensor.reshape`) does NOT interpret
@@ -531,6 +804,8 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
                                                         /*isSigned=*/true)));
         mlir::Value cOne = mlir::arith::ConstantOp::create(
             rewriter, loc, rewriter.getIntegerAttr(elemTy, 1));
+        mlir::Value cZero = mlir::arith::ConstantOp::create(
+            rewriter, loc, rewriter.getIntegerAttr(elemTy, 0));
 
         // total = product of input dim sizes (as elemTy).
         mlir::Value total = cOne;
@@ -546,15 +821,61 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
         // negative / zero as 1 for the divisor) to find the inferred dim.
         llvm::SmallVector<mlir::Value> dims;
         dims.reserve(outputRank);
+        if (validatedShape->hostElements) {
+          llvm::append_range(dims, *validatedShape->hostElements);
+        } else if (validatedShape->constantElements) {
+          for (int64_t value : *validatedShape->constantElements)
+            dims.push_back(mlir::arith::ConstantOp::create(
+                rewriter, loc, rewriter.getI64IntegerAttr(value)));
+        } else {
+          for (int64_t i : llvm::seq<int64_t>(outputRank)) {
+            // Read each shape entry to the host with a stream sync (constants
+            // fold) instead of a bare host load of device memory. A bare
+            // tensor.extract here races a GPU-computed shape tensor and yields
+            // a garbage dim that collapses the reshape. See ReadbackScalar.h.
+            dims.push_back(readbackShapeEntryToHostOrExtract(rewriter, loc, op,
+                                                             shapeOperand, i));
+          }
+        }
+
+        if (allowzero == 0) {
+          for (int64_t i : llvm::seq<int64_t>(outputRank)) {
+            mlir::IntegerAttr constant;
+            bool isConstant =
+                mlir::matchPattern(dims[i], mlir::m_Constant(&constant));
+            if (i >= inputRank)
+              continue;
+            if (hasProvenHostShape && inputDimMap[i] == i)
+              continue;
+            mlir::Value inputDim =
+                mlir::tensor::DimOp::create(rewriter, loc, data, i);
+            mlir::Value inputDimI64 = mlir::arith::IndexCastOp::create(
+                rewriter, loc, elemTy, inputDim);
+            if (isConstant) {
+              if (constant.getValue().getSExtValue() == 0)
+                dims[i] = inputDimI64;
+              continue;
+            }
+            mlir::Value isZero = mlir::arith::CmpIOp::create(
+                rewriter, loc, mlir::arith::CmpIPredicate::eq, dims[i], cZero);
+            dims[i] = mlir::arith::SelectOp::create(rewriter, loc, isZero,
+                                                    inputDimI64, dims[i]);
+          }
+        }
+
+        if (hasNoMinusOneProof) {
+          auto newShapeTy =
+              mlir::RankedTensorType::get({(int64_t)outputRank}, elemTy);
+          mlir::Value newShape = mlir::tensor::FromElementsOp::create(
+              rewriter, loc, newShapeTy, dims);
+          auto reshapeOp = mlir::tensor::ReshapeOp::create(
+              rewriter, loc, outputType, data, newShape);
+          rewriter.replaceOp(op, reshapeOp.getResult());
+          return mlir::success();
+        }
+
         mlir::Value posProduct = cOne;
-        for (int64_t i : llvm::seq<int64_t>(outputRank)) {
-          // Read each shape entry to the host with a stream sync (constants
-          // fold) instead of a bare host load of device memory. A bare
-          // tensor.extract here races a GPU-computed shape tensor and yields a
-          // garbage dim that collapses the reshape. See ReadbackScalar.h.
-          mlir::Value v = readbackShapeEntryToHostOrExtract(rewriter, loc, op,
-                                                            shapeOperand, i);
-          dims.push_back(v);
+        for (mlir::Value v : dims) {
           mlir::Value isPositive = mlir::arith::CmpIOp::create(
               rewriter, loc, mlir::arith::CmpIPredicate::sgt, v, cOne);
           // sgt 1 catches >=2; combine with == 1 to keep 1 too.

--- a/lib/Conversion/OnnxToHip/ReshapeShapeFold.cpp
+++ b/lib/Conversion/OnnxToHip/ReshapeShapeFold.cpp
@@ -2,90 +2,19 @@
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
  */
-//===- ReshapeShapeFold.cpp - Pre-lowering Reshape(_, Shape) folding ------===//
+//===- ReshapeShapeFold.cpp - Materialize proven Reshape shapes -----------===//
 //
-// Sibling pass to GatherShapeFold.  Recognises the
-//
-//     %shape = onnx.Shape(%src)            : tensor<Nxi64>
-//     %out   = onnx.Reshape(%data, %shape) : tensor<...?...>
-//
-// idiom and rewrites the Reshape's shape operand into a
-//
-//     %d_i  = tensor.dim %src, i                            : index
-//     %s_i  = arith.index_cast %d_i : index to i64          ;; for dyn dims
-//     %s_j  = arith.constant <static_size> : i64            ;; for static dims
-//     %new  = tensor.from_elements %s_0, ..., %s_{N-1}      : tensor<Nxi64>
-//
-//     %out  = onnx.Reshape(%data, %new)
-//
-// so ReshapeConversion's `buildExpandShapeOutputShape` multi-dyn-per-group
-// branch (which already understands tensor.from_elements) can recover
-// per-output-dim sizes when the result has >1 dynamic dim in the same
-// reassociation group.
-//
-// Why this matters
-// ----------------
-// PR #212 GatherShapeFold rewrites Gather(Shape, idx) so the canonical
-// transformer-shape-arithmetic chain
-//
-//     bs   = Gather(Shape(input), 0)
-//     ss   = Gather(Shape(input), 1)
-//     mul  = bs * ss
-//     out  = Range(0, mul, 1)
-//
-// collapses to host arith over tensor.dim of input, avoiding the
-// SEGV-on-device-store-of-shape-vector issue on gfx1151.  But when the
-// SAME Shape(input) value is ALSO directly fed to Reshape (as in
-// Qwen3.5 mrope: `Reshape(Range_output, Shape(input))`), that use is
-// not a Gather — GatherShapeFold leaves it alone, and `onnx.Shape`
-// survives into ConvertOnnxToHip.  ReshapeConversion ignores its
-// second operand (it derives output shape from result type alone),
-// so for a `<?> -> <?, ?>` reshape with both output dims dynamic it
-// emits `output_shape [tensor.dim(out, 0), tensor.dim(out, 0)]` — the
-// SAME SSA value twice, semantically [N, N] backed by an N-element
-// buffer.  No downstream pass recovers the correct per-dim sizes once
-// the [N, N] expand_shape has been emitted.  Net effect: a 1×1 input
-// passes by coincidence (1×1 = 1²), every asymmetric shape silently
-// corrupts.
-//
-// This fold rewrites the shape operand BEFORE ConvertOnnxToHip so the
-// resulting `tensor.from_elements` is exactly what ReshapeConversion's
-// multi-dyn-per-group branch picks up.  That branch is the other half of
-// the fix and lives in `buildExpandShapeOutputShape`; without it this fold
-// has no effect, because the conversion otherwise never reads operand 1.
-//
-// Implementation notes
-// --------------------
-//   * Pattern roots on `onnx.Reshape` (greedy applier visits ops in
-//     post-order; we only need to fire once per Reshape).
-//   * Uses `modifyOpInPlace` to swap operand 1.  Under
-//     `GreedyRewriteStrictness::ExistingOps` (the OnnxToHipPass's
-//     pre-lowering set strictness) the modified op is re-considered
-//     but our match guard `operand(1).getDefiningOp() == onnx.Shape`
-//     fails on the second visit, so no infinite loop.
-//   * Honors `onnx.Shape`'s ONNX-15 `start`/`end` attributes (matches
-//     GatherShapeFold's normalization).  When the sub-range is empty
-//     we leave the op alone (a downstream verifier will reject it).
-//   * Leaves the original `onnx.Shape` op in place — it may have other
-//     uses (e.g. another Gather still pending fold).  DCE removes it
-//     later if it becomes unused.
-//   * Result-type check: the Reshape's existing result type is the
-//     ground truth ONNX shape inference computed; we don't touch it.
-//     The shape operand's RankedTensorType is `tensor<rangeLen x i64>`
-//     by construction.
-//
-// Non-goals
-// ---------
-//   * Folding `Reshape(_, Concat(Gather(Shape, 0), Gather(Shape, 1)))`:
-//     after GatherShapeFold each Gather becomes a 1-element
-//     tensor.from_elements, and ConcatConversion (or ReshapeConversion
-//     itself) handles the Concat case directly.  This fold only
-//     addresses the `Reshape(_, Shape)` direct-use case.
-//   * Folding `Range(_, Shape[*], _)` or `Slice(_, Shape, ...)`:
-//     analogous patterns; out of scope for this fix.  Add sibling
-//     folds when those uses arise.
+// Consume a completed function-level ShapeProvenanceAnalysis. Accepted payloads
+// are rebuilt from constants, canonical tensor dimensions, and proven host
+// scalar SSA values, then stamped for the dynamic runtime-shaped Reshape
+// fallback. That path revalidates every consumed marker claim before its first
+// mutation. Earlier shape-independent/static rewrites do not consume markers
+// and may bypass validation. Unknown or partially proven payloads remain
+// untouched; a dynamic fallback that needs them uses synchronized readback.
 //
 //===----------------------------------------------------------------------===//
+
+#include "ShapeProvenanceAnalysis.h"
 
 #include "OnnxToHipUtils.h"
 
@@ -95,121 +24,275 @@
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/Debug.h"
 
+#include <optional>
+#include <utility>
+
 #define DEBUG_TYPE "reshape-shape-fold"
 
 STATISTIC(NumReshapeShapeFolds,
-          "Number of Reshape(_, Shape(x)) idioms whose shape operand was "
-          "rewritten to tensor.from_elements(tensor.dim(x, *))");
+          "Number of Reshape target shapes proven to be host-side");
 
 namespace mlir {
 namespace hip {
 
 namespace {
 
-struct ReshapeOfShapeToFromElements : public mlir::RewritePattern {
-  ReshapeOfShapeToFromElements(mlir::MLIRContext *ctx)
-      : RewritePattern("onnx.Reshape", /*benefit=*/1, ctx) {}
+mlir::FailureOr<mlir::Value>
+materializeHostShape(mlir::IRRewriter &rewriter, mlir::Location loc,
+                     llvm::ArrayRef<ShapeProvenanceExpr> expressions,
+                     mlir::Type elementType) {
+  auto integerType = mlir::dyn_cast<mlir::IntegerType>(elementType);
+  if (!integerType)
+    return mlir::failure();
 
-  mlir::LogicalResult
-  matchAndRewrite(mlir::Operation *reshapeOp,
-                  mlir::PatternRewriter &rewriter) const override {
-    if (reshapeOp->getNumOperands() < 2)
-      return rewriter.notifyMatchFailure(reshapeOp, "reshape.arity");
-
-    mlir::Value shapeOperand = reshapeOp->getOperand(1);
-    mlir::Operation *shapeOp = shapeOperand.getDefiningOp();
-    if (!shapeOp || shapeOp->getName().getStringRef() != "onnx.Shape")
-      return rewriter.notifyMatchFailure(reshapeOp, "operand1.not_onnx_shape");
-
-    // onnx.Shape has a single operand (the input whose shape is being
-    // queried).  Defensive against malformed IR.
-    if (shapeOp->getNumOperands() != 1)
-      return rewriter.notifyMatchFailure(reshapeOp, "shape.arity");
-
-    mlir::Value src = shapeOp->getOperand(0);
-    auto srcType = mlir::dyn_cast<mlir::RankedTensorType>(src.getType());
-    if (!srcType)
-      return rewriter.notifyMatchFailure(reshapeOp, "shape.src_unranked");
-    int64_t rank = srcType.getRank();
-
-    // ONNX-15 Shape start/end attributes select a sub-range of the shape
-    // vector.  Normalize the same way GatherShapeFold does.
-    int64_t start = 0;
-    int64_t end = rank;
-    if (auto startAttr = shapeOp->getAttrOfType<mlir::IntegerAttr>("start"))
-      start = startAttr.getSInt();
-    if (auto endAttr = shapeOp->getAttrOfType<mlir::IntegerAttr>("end"))
-      end = endAttr.getSInt();
-    if (start < 0)
-      start += rank;
-    if (end < 0)
-      end += rank;
-    start = std::max(start, int64_t(0));
-    end = std::min(end, rank);
-    int64_t rangeLen = std::max(end - start, int64_t(0));
-    if (rangeLen == 0)
-      return rewriter.notifyMatchFailure(reshapeOp, "shape.empty_range");
-
-    // The shape operand's tensor type must be tensor<rangeLen x i64>.
-    // If the existing operand type disagrees the IR is malformed; bail.
-    auto shapeOperandType =
-        mlir::dyn_cast<mlir::RankedTensorType>(shapeOperand.getType());
-    if (!shapeOperandType || shapeOperandType.getRank() != 1 ||
-        !shapeOperandType.getElementType().isInteger(64) ||
-        (!shapeOperandType.isDynamicDim(0) &&
-         shapeOperandType.getDimSize(0) != rangeLen))
-      return rewriter.notifyMatchFailure(reshapeOp,
-                                         "shape.operand_type_mismatch");
-
-    mlir::Location loc = reshapeOp->getLoc();
-    auto i64Type = rewriter.getI64Type();
-
-    // Materialize per-dim i64 SSA values.  For dynamic dims emit
-    // `arith.index_cast %tensor.dim`, for static dims a plain
-    // `arith.constant` so canonicalization can fold downstream.
-    llvm::SmallVector<mlir::Value> elems;
-    elems.reserve(rangeLen);
-    for (int64_t i = 0; i < rangeLen; ++i) {
-      int64_t absDim = start + i;
-      mlir::Value elem;
-      if (srcType.isDynamicDim(absDim)) {
-        mlir::Value dimVal =
-            mlir::tensor::DimOp::create(rewriter, loc, src, absDim);
-        elem = mlir::arith::IndexCastOp::create(rewriter, loc, i64Type, dimVal);
-      } else {
-        elem = mlir::arith::ConstantOp::create(
-            rewriter, loc,
-            rewriter.getI64IntegerAttr(srcType.getDimSize(absDim)));
-      }
-      elems.push_back(elem);
+  // Validate the complete plan before creating IR. A failed materialization
+  // must not leave a partially constructed shape expression behind.
+  for (const ShapeProvenanceExpr &expression : expressions) {
+    if (expression.kind == ShapeProvenanceExpr::Kind::TensorDim) {
+      auto shapedType =
+          mlir::dyn_cast<mlir::ShapedType>(expression.value.getType());
+      if (!shapedType || !shapedType.hasRank() || expression.dimension < 0 ||
+          expression.dimension >= shapedType.getRank())
+        return mlir::failure();
     }
-
-    // Reconstruct the shape operand's tensor type with the now-static
-    // length (rangeLen).  Even if the original op carried tensor<?xi64>,
-    // tensor.from_elements demands a static rank-1 type with size ==
-    // elems.size().
-    auto newShapeType = mlir::RankedTensorType::get({rangeLen}, i64Type);
-    mlir::Value newShape =
-        mlir::tensor::FromElementsOp::create(rewriter, loc, newShapeType, elems)
-            .getResult();
-
-    LLVM_DEBUG(llvm::dbgs()
-               << "[" DEBUG_TYPE "] rewrote " << reshapeOp->getName()
-               << " shape operand from " << shapeOp->getName()
-               << " to from_elements over " << rangeLen << " dim(s) of src\n");
-
-    rewriter.modifyOpInPlace(reshapeOp,
-                             [&] { reshapeOp->setOperand(1, newShape); });
-    ++NumReshapeShapeFolds;
-    return mlir::success();
+    if (expression.kind == ShapeProvenanceExpr::Kind::HostScalar &&
+        !expression.value.getType().isIntOrIndex())
+      return mlir::failure();
   }
+
+  llvm::SmallVector<mlir::Value> elements;
+  elements.reserve(expressions.size());
+  for (const ShapeProvenanceExpr &expression : expressions) {
+    mlir::Value element;
+    switch (expression.kind) {
+    case ShapeProvenanceExpr::Kind::Constant:
+      element = mlir::arith::ConstantOp::create(
+          rewriter, loc,
+          rewriter.getIntegerAttr(integerType, expression.constant));
+      break;
+    case ShapeProvenanceExpr::Kind::TensorDim: {
+      mlir::Value dim = mlir::tensor::DimOp::create(
+          rewriter, loc, expression.value, expression.dimension);
+      element =
+          mlir::arith::IndexCastOp::create(rewriter, loc, integerType, dim);
+      break;
+    }
+    case ShapeProvenanceExpr::Kind::HostScalar:
+      element = expression.value;
+      if (element.getType() == integerType)
+        break;
+      if (element.getType().isIndex()) {
+        element = mlir::arith::IndexCastOp::create(rewriter, loc, integerType,
+                                                   element);
+        break;
+      }
+      auto sourceType = mlir::dyn_cast<mlir::IntegerType>(element.getType());
+      if (!sourceType)
+        return mlir::failure();
+      if (sourceType.getWidth() < integerType.getWidth())
+        element =
+            mlir::arith::ExtSIOp::create(rewriter, loc, integerType, element);
+      else if (sourceType.getWidth() > integerType.getWidth())
+        element =
+            mlir::arith::TruncIOp::create(rewriter, loc, integerType, element);
+      break;
+    }
+    elements.push_back(element);
+  }
+
+  auto shapeType = mlir::RankedTensorType::get(
+      {static_cast<int64_t>(elements.size())}, integerType);
+  return mlir::tensor::FromElementsOp::create(rewriter, loc, shapeType,
+                                              elements)
+      .getResult();
+}
+
+struct ReshapeMaterializationPlan {
+  mlir::Operation *reshapeOp;
+  mlir::Type shapeElementType;
+  llvm::SmallVector<ShapeProvenanceExpr> expressions;
+  llvm::SmallVector<int64_t> inputDimMap;
+  bool noMinusOne;
 };
+
+std::optional<ReshapeMaterializationPlan>
+buildMaterializationPlan(mlir::Operation *reshapeOp,
+                         const ShapeProvenanceAnalysis &analysis) {
+  if (reshapeOp->getNumOperands() != 2 || reshapeOp->getNumResults() != 1 ||
+      reshapeOp->hasAttr(kHostShapeOperandAttr))
+    return std::nullopt;
+
+  mlir::Value shapeOperand = reshapeOp->getOperand(1);
+  auto shapeOperandType =
+      mlir::dyn_cast<mlir::RankedTensorType>(shapeOperand.getType());
+  if (!shapeOperandType || shapeOperandType.getRank() != 1 ||
+      !shapeOperandType.getElementType().isInteger(64))
+    return std::nullopt;
+  // A literal target remains directly visible after the first lowering sweep
+  // as a dense hip.constant carrier. Leave it untouched so Reshape conversion
+  // can validate and materialize it without provenance markers.
+  llvm::SmallVector<int64_t> constantTarget;
+  if (extractConstantIntTensor(shapeOperand, constantTarget,
+                               /*expectedRank=*/1))
+    return std::nullopt;
+  auto resultType =
+      mlir::dyn_cast<mlir::RankedTensorType>(reshapeOp->getResult(0).getType());
+  if (!resultType)
+    return std::nullopt;
+
+  mlir::FailureOr<llvm::SmallVector<ShapeProvenanceExpr>> expressions =
+      analysis.getPayload(shapeOperand);
+  if (mlir::failed(expressions) ||
+      expressions->size() != static_cast<size_t>(resultType.getRank()))
+    return std::nullopt;
+
+  unsigned minusOneCount =
+      llvm::count_if(*expressions, [](const ShapeProvenanceExpr &expression) {
+        return expression.proof == ShapeValueProof::MinusOne;
+      });
+  if (llvm::any_of(*expressions,
+                   [](const ShapeProvenanceExpr &expression) {
+                     return expression.proof == ShapeValueProof::Invalid;
+                   }) ||
+      minusOneCount > 1)
+    return std::nullopt;
+  if (llvm::any_of(*expressions, [](const ShapeProvenanceExpr &expression) {
+        return expression.proof == ShapeValueProof::Unknown;
+      }))
+    return std::nullopt;
+
+  int64_t allowzero = 0;
+  if (auto attr = reshapeOp->getAttrOfType<mlir::IntegerAttr>("allowzero"))
+    allowzero = attr.getSInt();
+  if (allowzero != 0 && allowzero != 1)
+    return std::nullopt;
+  if (allowzero == 1 && minusOneCount != 0 &&
+      llvm::any_of(*expressions, [](const ShapeProvenanceExpr &expression) {
+        return expression.proof != ShapeValueProof::MinusOne &&
+               expression.proof != ShapeValueProof::Positive;
+      }))
+    return std::nullopt;
+
+  mlir::Value data = reshapeOp->getOperand(0);
+  auto dataType = mlir::dyn_cast<mlir::RankedTensorType>(data.getType());
+  if (!dataType)
+    return std::nullopt;
+  if (allowzero == 0) {
+    for (auto [index, expression] : llvm::enumerate(*expressions)) {
+      if (index < static_cast<size_t>(dataType.getRank()))
+        continue;
+      if (expression.kind != ShapeProvenanceExpr::Kind::Constant ||
+          expression.constant <= 0)
+        return std::nullopt;
+    }
+  }
+
+  // Rewrite every proven equivalent dimension onto the actual Reshape data
+  // operand. The marker's input-dimension map can then be revalidated
+  // structurally at the conversion boundary without retaining or rerunning the
+  // solver.
+  llvm::SmallVector<int64_t> inputDimMap(expressions->size(), -1);
+  for (auto [index, expression] : llvm::enumerate(*expressions)) {
+    if (index >= static_cast<size_t>(dataType.getRank()) ||
+        expression.kind != ShapeProvenanceExpr::Kind::TensorDim ||
+        !analysis.isEquivalentToDimension(expression, data,
+                                          static_cast<int64_t>(index)))
+      continue;
+    inputDimMap[index] = static_cast<int64_t>(index);
+    expression.value = data;
+    expression.dimension = static_cast<int64_t>(index);
+  }
+
+  bool noMinusOne =
+      llvm::all_of(*expressions, [](const ShapeProvenanceExpr &expression) {
+        return expression.proof == ShapeValueProof::Positive ||
+               expression.proof == ShapeValueProof::NonNegative;
+      });
+  return ReshapeMaterializationPlan{
+      reshapeOp, shapeOperandType.getElementType(), std::move(*expressions),
+      std::move(inputDimMap), noMinusOne};
+}
+
+bool applyMaterializationPlan(const ReshapeMaterializationPlan &plan,
+                              mlir::IRRewriter &rewriter) {
+  mlir::Operation *reshapeOp = plan.reshapeOp;
+  rewriter.setInsertionPoint(reshapeOp);
+  mlir::FailureOr<mlir::Value> newShape = materializeHostShape(
+      rewriter, reshapeOp->getLoc(), plan.expressions, plan.shapeElementType);
+  if (mlir::failed(newShape))
+    return false;
+
+  LLVM_DEBUG(llvm::dbgs() << "[" DEBUG_TYPE "] rewrote " << reshapeOp->getName()
+                          << " shape operand from function-level dataflow over "
+                          << plan.expressions.size() << " entries\n");
+
+  rewriter.modifyOpInPlace(reshapeOp, [&] {
+    reshapeOp->setOperand(1, *newShape);
+    reshapeOp->setAttr(kHostShapeOperandAttr, rewriter.getUnitAttr());
+    reshapeOp->setAttr(kHostShapeInputDimMapAttr,
+                       rewriter.getDenseI64ArrayAttr(plan.inputDimMap));
+    if (plan.noMinusOne)
+      reshapeOp->setAttr(kHostShapeNoMinusOneAttr, rewriter.getUnitAttr());
+  });
+  ++NumReshapeShapeFolds;
+  return true;
+}
 
 } // namespace
 
-void populateReshapeShapeFoldPatterns(mlir::RewritePatternSet &patterns,
-                                      mlir::MLIRContext *ctx) {
-  patterns.add<ReshapeOfShapeToFromElements>(ctx);
+bool hasEligibleReshapeShapeProvenanceCandidate(mlir::func::FuncOp funcOp) {
+  bool found = false;
+  funcOp.walk([&](mlir::Operation *op) {
+    if (found || op->getName().getStringRef() != "onnx.Reshape" ||
+        op->hasAttr(kHostShapeOperandAttr) || op->getNumOperands() != 2 ||
+        op->getNumResults() != 1)
+      return;
+
+    auto inputType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getOperand(0).getType());
+    auto outputType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    auto shapeType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getOperand(1).getType());
+    if (!inputType || !outputType || !shapeType || inputType == outputType ||
+        (inputType.hasStaticShape() && outputType.hasStaticShape()) ||
+        shapeType.getRank() != 1 || !shapeType.getElementType().isInteger(64))
+      return;
+    if (!shapeType.isDynamicDim(0) &&
+        shapeType.getDimSize(0) != outputType.getRank())
+      return;
+    found = true;
+  });
+  return found;
+}
+
+mlir::LogicalResult
+materializeReshapeShapeOperands(mlir::func::FuncOp funcOp,
+                                const ShapeProvenanceAnalysis &analysis) {
+  llvm::SmallVector<mlir::Operation *> reshapes;
+  funcOp.walk([&](mlir::Operation *op) {
+    if (op->getName().getStringRef() == "onnx.Reshape")
+      reshapes.push_back(op);
+  });
+
+  // Query the complete analysis before mutating any analyzed IR. Plans contain
+  // non-owning Value handles, but these mutations only insert scalar shape ops
+  // and update Reshape operands; they do not erase referenced values.
+  llvm::SmallVector<ReshapeMaterializationPlan> plans;
+  for (mlir::Operation *reshape : reshapes)
+    if (std::optional<ReshapeMaterializationPlan> plan =
+            buildMaterializationPlan(reshape, analysis))
+      plans.push_back(std::move(*plan));
+
+  mlir::IRRewriter rewriter(funcOp.getContext());
+  for (const ReshapeMaterializationPlan &plan : plans) {
+    if (!applyMaterializationPlan(plan, rewriter)) {
+      plan.reshapeOp->emitError(
+          "failed to materialize proven Reshape target shape");
+      return mlir::failure();
+    }
+  }
+  return mlir::success();
 }
 
 } // namespace hip

--- a/lib/Conversion/OnnxToHip/ShapeProvenanceAnalysis.cpp
+++ b/lib/Conversion/OnnxToHip/ShapeProvenanceAnalysis.cpp
@@ -1,0 +1,857 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- ShapeProvenanceAnalysis.cpp - Host shape dataflow ------------------===//
+
+#include "ShapeProvenanceAnalysis.h"
+
+#include "OnnxToHipUtils.h"
+
+#include "mlir/Analysis/DataFlow/SparseAnalysis.h"
+#include "mlir/Analysis/DataFlow/Utils.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "llvm/ADT/DenseMap.h"
+
+#include <algorithm>
+#include <cassert>
+#include <deque>
+#include <optional>
+#include <utility>
+
+namespace mlir {
+namespace hip {
+
+namespace {
+
+struct ShapeExprNode {
+  ShapeProvenanceExpr::Kind kind;
+  int64_t constant;
+  mlir::Value value;
+  int64_t dimension;
+  ShapeValueProof proof;
+};
+
+using Expr = const ShapeExprNode *;
+using ExprVector = llvm::SmallVector<Expr>;
+
+/// Monotonic sparse-dataflow fact for one SSA value.
+///
+/// `initialized == false` is lattice bottom. A missing optional is an unknown
+/// vector; a null entry in `dimensions` is one unknown axis after a CFG join.
+/// Payload proofs are intentionally all-or-nothing because partially reading a
+/// shape tensor would mix host SSA with synchronized device payload semantics.
+struct ShapeFact {
+  bool initialized = false;
+  std::optional<ExprVector> dimensions;
+  std::optional<ExprVector> payload;
+
+  static ShapeFact join(const ShapeFact &lhs, const ShapeFact &rhs) {
+    if (!lhs.initialized)
+      return rhs;
+    if (!rhs.initialized)
+      return lhs;
+
+    ShapeFact result;
+    result.initialized = true;
+    if (lhs.dimensions && rhs.dimensions &&
+        lhs.dimensions->size() == rhs.dimensions->size()) {
+      ExprVector dimensions;
+      dimensions.reserve(lhs.dimensions->size());
+      for (auto [lhsExpr, rhsExpr] :
+           llvm::zip(*lhs.dimensions, *rhs.dimensions))
+        dimensions.push_back(lhsExpr == rhsExpr ? lhsExpr : nullptr);
+      result.dimensions = std::move(dimensions);
+    }
+    if (lhs.payload && rhs.payload && *lhs.payload == *rhs.payload)
+      result.payload = lhs.payload;
+    return result;
+  }
+
+  bool operator==(const ShapeFact &other) const {
+    return initialized == other.initialized && dimensions == other.dimensions &&
+           payload == other.payload;
+  }
+
+  void print(llvm::raw_ostream &os) const {
+    if (!initialized) {
+      os << "uninitialized";
+      return;
+    }
+    os << "dims=";
+    printExprVector(os, dimensions);
+    os << ", payload=";
+    printExprVector(os, payload);
+  }
+
+private:
+  static void printExprVector(llvm::raw_ostream &os,
+                              const std::optional<ExprVector> &expressions) {
+    if (!expressions) {
+      os << "unknown";
+      return;
+    }
+    os << '[';
+    llvm::interleaveComma(*expressions, os, [&](Expr expr) {
+      if (!expr) {
+        os << '?';
+        return;
+      }
+      switch (expr->kind) {
+      case ShapeProvenanceExpr::Kind::Constant:
+        os << expr->constant;
+        break;
+      case ShapeProvenanceExpr::Kind::TensorDim:
+        os << "dim(" << expr->value << ", " << expr->dimension << ')';
+        break;
+      case ShapeProvenanceExpr::Kind::HostScalar:
+        os << "host(" << expr->value << ')';
+        break;
+      }
+    });
+    os << ']';
+  }
+};
+
+using ShapeLattice = mlir::dataflow::Lattice<ShapeFact>;
+
+enum class TransferKind {
+  Shape,
+  Gather,
+  Slice,
+  Concat,
+  Identity,
+  Unsqueeze,
+  Reshape,
+  Constant,
+  Add,
+  Cast,
+  MatMul,
+};
+
+struct TransferRegistration {
+  llvm::StringLiteral name;
+  TransferKind kind;
+};
+
+/// Keep generic ONNX operation-name dispatch in one table. Transfer functions
+/// remain separate below, so adding a producer cannot silently change the
+/// conservative fallback for unrelated operations.
+///
+/// TODO(shape-provenance): If the project adopts standard onnx-mlir, replace
+/// name-keyed dispatch with typed operations or external models and reuse ONNX
+/// shape helpers for rank-1 payload semantics. ReifyRankedShapedTypeOpInterface
+/// exposes shaped-result extents, while ValueBoundsOpInterface can reason about
+/// dimensions and scalar/index bounds; neither by itself transports the integer
+/// entries of a shape tensor. The Shape dialect can carry such payloads when
+/// they are represented as explicit shape values. Retire a local transfer only
+/// when one of those typed/helper or explicit-shape contracts represents the
+/// same payload fact.
+static constexpr TransferRegistration kTransferRegistry[] = {
+    {"onnx.Shape", TransferKind::Shape},
+    {"onnx.Gather", TransferKind::Gather},
+    {"onnx.Slice", TransferKind::Slice},
+    {"onnx.Concat", TransferKind::Concat},
+    {"onnx.Identity", TransferKind::Identity},
+    {"onnx.Unsqueeze", TransferKind::Unsqueeze},
+    {"onnx.Reshape", TransferKind::Reshape},
+    {"onnx.Constant", TransferKind::Constant},
+    {"onnx.Add", TransferKind::Add},
+    {"onnx.Cast", TransferKind::Cast},
+    {"onnx.CastLike", TransferKind::Cast},
+    {"onnx.MatMul", TransferKind::MatMul},
+};
+
+std::optional<TransferKind> lookupTransferKind(llvm::StringRef name) {
+  for (const TransferRegistration &registration : kTransferRegistry)
+    if (registration.name == name)
+      return registration.kind;
+  return std::nullopt;
+}
+
+ShapeValueProof getConstantProof(int64_t value) {
+  if (value > 0)
+    return ShapeValueProof::Positive;
+  if (value == 0)
+    return ShapeValueProof::NonNegative;
+  if (value == -1)
+    return ShapeValueProof::MinusOne;
+  return ShapeValueProof::Invalid;
+}
+
+int64_t normalizeAndClampIndex(int64_t index, int64_t length) {
+  assert(length >= 0 && "shape-vector length must be nonnegative");
+  if (index < 0) {
+    if (index < -length)
+      return 0;
+    index += length;
+  }
+  return std::clamp(index, int64_t(0), length);
+}
+
+bool isScalarIntegerOrIndex(mlir::Type type) {
+  return !mlir::isa<mlir::ShapedType>(type) && type.isIntOrIndex();
+}
+
+} // namespace
+
+class ShapeProvenanceAnalysis::Impl {
+public:
+  explicit Impl(mlir::func::FuncOp funcOp)
+      : funcOp(funcOp),
+        solver(mlir::DataFlowConfig().setInterprocedural(false)) {}
+
+  mlir::LogicalResult run() {
+    mlir::dataflow::loadBaselineAnalyses(solver);
+    solver.load<DataFlow>(*this);
+    return solver.initializeAndRun(funcOp);
+  }
+
+  mlir::FailureOr<llvm::SmallVector<ShapeProvenanceExpr>>
+  getPayload(mlir::Value value) const {
+    const ShapeFact *fact = lookupFact(value);
+    if (!fact || !fact->payload)
+      return mlir::failure();
+
+    llvm::SmallVector<ShapeProvenanceExpr> result;
+    result.reserve(fact->payload->size());
+    for (Expr expr : *fact->payload) {
+      if (!expr)
+        return mlir::failure();
+      result.push_back({expr->kind, expr->constant, expr->value,
+                        expr->dimension, expr->proof});
+    }
+    return result;
+  }
+
+  bool isEquivalentToDimension(const ShapeProvenanceExpr &expr,
+                               mlir::Value value, int64_t dimension) const {
+    if (expr.kind != ShapeProvenanceExpr::Kind::TensorDim)
+      return false;
+    Expr lhs = getDimensionExpr(expr.value, expr.dimension);
+    Expr rhs = getDimensionExpr(value, dimension);
+    return lhs && lhs == rhs;
+  }
+
+private:
+  class DataFlow final
+      : public mlir::dataflow::SparseForwardDataFlowAnalysis<ShapeLattice> {
+  public:
+    DataFlow(mlir::DataFlowSolver &solver, Impl &impl)
+        : SparseForwardDataFlowAnalysis(solver), impl(impl) {}
+
+    mlir::LogicalResult
+    visitOperation(mlir::Operation *op,
+                   llvm::ArrayRef<const ShapeLattice *> operands,
+                   llvm::ArrayRef<ShapeLattice *> results) override {
+      if (llvm::any_of(operands, [](const ShapeLattice *operand) {
+            return !operand->getValue().initialized;
+          }))
+        return mlir::success();
+
+      llvm::SmallVector<ShapeFact> resultFacts =
+          impl.transfer(op, operands, results.size());
+      assert(resultFacts.size() == results.size());
+      for (auto [result, fact] : llvm::zip(results, resultFacts))
+        propagateIfChanged(result, result->join(fact));
+      return mlir::success();
+    }
+
+    void setToEntryState(ShapeLattice *lattice) override {
+      propagateIfChanged(lattice, lattice->join(impl.getConservativeFact(
+                                      lattice->getAnchor())));
+    }
+
+  private:
+    Impl &impl;
+  };
+
+  Expr getConstant(int64_t value) {
+    auto key = std::make_pair(value, getConstantProof(value));
+    auto [it, inserted] = constants.try_emplace(key, nullptr);
+    if (inserted)
+      it->second = createExpr(ShapeProvenanceExpr::Kind::Constant, value, {}, 0,
+                              key.second);
+    return it->second;
+  }
+
+  Expr getTensorDim(mlir::Value value, int64_t dimension) {
+    auto key = std::make_pair(value, dimension);
+    auto [it, inserted] = tensorDims.try_emplace(key, nullptr);
+    if (inserted)
+      it->second = createExpr(ShapeProvenanceExpr::Kind::TensorDim, 0, value,
+                              dimension, ShapeValueProof::NonNegative);
+    return it->second;
+  }
+
+  Expr getHostScalar(mlir::Value value, ShapeValueProof proof) {
+    auto key = std::make_pair(value, proof);
+    auto [it, inserted] = hostScalars.try_emplace(key, nullptr);
+    if (inserted)
+      it->second =
+          createExpr(ShapeProvenanceExpr::Kind::HostScalar, 0, value, 0, proof);
+    return it->second;
+  }
+
+  Expr createExpr(ShapeProvenanceExpr::Kind kind, int64_t constant,
+                  mlir::Value value, int64_t dimension, ShapeValueProof proof) {
+    expressions.push_back({kind, constant, value, dimension, proof});
+    return &expressions.back();
+  }
+
+  ShapeFact getConservativeFact(mlir::Value value) {
+    ShapeFact fact;
+    fact.initialized = true;
+    auto type = mlir::dyn_cast<mlir::RankedTensorType>(value.getType());
+    if (!type)
+      return fact;
+
+    ExprVector dimensions;
+    dimensions.reserve(type.getRank());
+    for (int64_t dimension : llvm::seq<int64_t>(type.getRank())) {
+      dimensions.push_back(type.isDynamicDim(dimension)
+                               ? getTensorDim(value, dimension)
+                               : getConstant(type.getDimSize(dimension)));
+    }
+    fact.dimensions = std::move(dimensions);
+    return fact;
+  }
+
+  const ShapeFact *lookupFact(mlir::Value value) const {
+    const ShapeLattice *lattice = solver.lookupState<ShapeLattice>(value);
+    if (!lattice || !lattice->getValue().initialized)
+      return nullptr;
+    return &lattice->getValue();
+  }
+
+  Expr getDimensionExpr(mlir::Value value, int64_t dimension) const {
+    const ShapeFact *fact = lookupFact(value);
+    if (!fact || !fact->dimensions || dimension < 0 ||
+        dimension >= static_cast<int64_t>(fact->dimensions->size()))
+      return nullptr;
+    return (*fact->dimensions)[dimension];
+  }
+
+  static const ShapeFact &
+  getOperandFact(llvm::ArrayRef<const ShapeLattice *> operands,
+                 unsigned index) {
+    return operands[index]->getValue();
+  }
+
+  llvm::SmallVector<ShapeFact>
+  transfer(mlir::Operation *op, llvm::ArrayRef<const ShapeLattice *> operands,
+           size_t resultCount) {
+    llvm::SmallVector<ShapeFact> facts;
+    facts.reserve(resultCount);
+    for (mlir::Value result : op->getResults())
+      facts.push_back(getConservativeFact(result));
+    if (facts.empty())
+      return facts;
+
+    if (transferStandardTensorOperation(op, operands, facts))
+      return facts;
+    if (transferScalarOperation(op, operands, facts))
+      return facts;
+    if (mlir::isa<mlir::arith::ConstantOp>(op)) {
+      transferConstant(op, facts.front());
+      return facts;
+    }
+    if (auto fromElements = mlir::dyn_cast<mlir::tensor::FromElementsOp>(op)) {
+      transferFromElements(fromElements, operands, facts.front());
+      return facts;
+    }
+
+    std::optional<TransferKind> kind =
+        lookupTransferKind(op->getName().getStringRef());
+    if (!kind)
+      return facts;
+
+    switch (*kind) {
+    case TransferKind::Shape:
+      transferShape(op, operands, facts.front());
+      break;
+    case TransferKind::Gather:
+      transferGather(op, operands, facts.front());
+      break;
+    case TransferKind::Slice:
+      transferSlice(op, operands, facts.front());
+      break;
+    case TransferKind::Concat:
+      transferConcat(op, operands, facts.front());
+      break;
+    case TransferKind::Identity:
+      transferValuePreserving(op, operands, facts.front(),
+                              /*preservePayload=*/true,
+                              /*preserveDimensions=*/true);
+      break;
+    case TransferKind::Unsqueeze:
+    case TransferKind::Reshape:
+      transferValuePreserving(op, operands, facts.front(),
+                              /*preservePayload=*/true,
+                              /*preserveDimensions=*/false);
+      break;
+    case TransferKind::Constant:
+      transferConstant(op, facts.front());
+      break;
+    case TransferKind::Add:
+      transferAdd(op, operands, facts.front());
+      break;
+    case TransferKind::Cast:
+      transferValuePreserving(op, operands, facts.front(),
+                              /*preservePayload=*/false,
+                              /*preserveDimensions=*/true);
+      break;
+    case TransferKind::MatMul:
+      transferMatMul(op, operands, facts.front());
+      break;
+    }
+    return facts;
+  }
+
+  /// Propagate dimensions through standard tensor descriptor operations when
+  /// the mapping is exact. Collapse groups with multiple non-unit expressions
+  /// remain rooted at the result because representing products would require a
+  /// symbolic arithmetic expression, not a dimension identity.
+  bool
+  transferStandardTensorOperation(mlir::Operation *op,
+                                  llvm::ArrayRef<const ShapeLattice *> operands,
+                                  llvm::SmallVectorImpl<ShapeFact> &facts) {
+    if (mlir::isa<mlir::tensor::CastOp>(op)) {
+      transferValuePreserving(op, operands, facts.front(),
+                              /*preservePayload=*/false,
+                              /*preserveDimensions=*/true);
+      return true;
+    }
+
+    if (auto expand = mlir::dyn_cast<mlir::tensor::ExpandShapeOp>(op)) {
+      if (!facts.front().dimensions)
+        return true;
+      llvm::SmallVector<mlir::OpFoldResult> mixedShape =
+          expand.getMixedOutputShape();
+      for (auto [dimension, mixedSize] : llvm::enumerate(mixedShape)) {
+        if (std::optional<int64_t> constant =
+                mlir::getConstantIntValue(mixedSize)) {
+          (*facts.front().dimensions)[dimension] = getConstant(*constant);
+          continue;
+        }
+        mlir::Value value = llvm::cast<mlir::Value>(mixedSize);
+        auto operandIt = llvm::find(op->getOperands(), value);
+        if (operandIt == op->getOperands().end())
+          continue;
+        unsigned operandIndex =
+            static_cast<unsigned>(operandIt - op->getOperands().begin());
+        const auto &payload = getOperandFact(operands, operandIndex).payload;
+        if (payload && payload->size() == 1 && payload->front())
+          (*facts.front().dimensions)[dimension] = payload->front();
+      }
+      return true;
+    }
+
+    if (auto collapse = mlir::dyn_cast<mlir::tensor::CollapseShapeOp>(op)) {
+      const auto &sourceDimensions = getOperandFact(operands, 0).dimensions;
+      if (!sourceDimensions || !facts.front().dimensions)
+        return true;
+      for (auto [resultDim, group] :
+           llvm::enumerate(collapse.getReassociationIndices())) {
+        Expr source = nullptr;
+        bool exact = true;
+        for (int64_t sourceDim : group) {
+          Expr candidate = (*sourceDimensions)[sourceDim];
+          if (!candidate) {
+            exact = false;
+            break;
+          }
+          if (candidate->kind == ShapeProvenanceExpr::Kind::Constant &&
+              candidate->constant == 1)
+            continue;
+          if (source) {
+            exact = false;
+            break;
+          }
+          source = candidate;
+        }
+        if (exact && source)
+          (*facts.front().dimensions)[resultDim] = source;
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  bool transferScalarOperation(mlir::Operation *op,
+                               llvm::ArrayRef<const ShapeLattice *> operands,
+                               llvm::SmallVectorImpl<ShapeFact> &facts) {
+    if (op->getNumResults() != 1 ||
+        !isScalarIntegerOrIndex(op->getResult(0).getType()))
+      return false;
+
+    mlir::Value result = op->getResult(0);
+    if (auto constant = mlir::dyn_cast<mlir::arith::ConstantOp>(op)) {
+      auto integer = mlir::dyn_cast<mlir::IntegerAttr>(constant.getValue());
+      if (integer)
+        if (std::optional<int64_t> value = integer.getValue().trySExtValue())
+          facts.front().payload = ExprVector{getConstant(*value)};
+      return true;
+    }
+
+    if (auto dim = mlir::dyn_cast<mlir::tensor::DimOp>(op)) {
+      if (std::optional<int64_t> index = dim.getConstantIndex()) {
+        Expr expr = nullptr;
+        const ShapeFact &sourceFact = getOperandFact(operands, 0);
+        if (sourceFact.dimensions && *index >= 0 &&
+            *index < static_cast<int64_t>(sourceFact.dimensions->size()))
+          expr = (*sourceFact.dimensions)[*index];
+        if (expr)
+          facts.front().payload = ExprVector{expr};
+      } else {
+        facts.front().payload =
+            ExprVector{getHostScalar(result, ShapeValueProof::NonNegative)};
+      }
+      return true;
+    }
+
+    if (!mlir::isa<mlir::arith::IndexCastOp, mlir::arith::ExtSIOp,
+                   mlir::arith::TruncIOp, mlir::arith::AddIOp,
+                   mlir::arith::SubIOp, mlir::arith::MulIOp,
+                   mlir::arith::DivSIOp, mlir::arith::DivUIOp,
+                   mlir::arith::CmpIOp, mlir::arith::SelectOp,
+                   mlir::arith::AndIOp, mlir::arith::OrIOp>(op))
+      return false;
+
+    if (llvm::any_of(operands, [](const ShapeLattice *operand) {
+          const auto &payload = operand->getValue().payload;
+          return !payload || payload->size() != 1 || !payload->front();
+        }))
+      return true;
+
+    if (auto indexCast = mlir::dyn_cast<mlir::arith::IndexCastOp>(op)) {
+      if (isLosslessShapeIndexCast(indexCast))
+        facts.front().payload = getOperandFact(operands, 0).payload;
+      return true;
+    }
+
+    ShapeValueProof proof = ShapeValueProof::Unknown;
+    if (mlir::isa<mlir::arith::ExtSIOp>(op)) {
+      ShapeValueProof operandProof =
+          getOperandFact(operands, 0).payload->front()->proof;
+      if (operandProof == ShapeValueProof::Positive ||
+          operandProof == ShapeValueProof::NonNegative)
+        proof = operandProof;
+    }
+    facts.front().payload = ExprVector{getHostScalar(result, proof)};
+    return true;
+  }
+
+  void transferFromElements(mlir::tensor::FromElementsOp fromElements,
+                            llvm::ArrayRef<const ShapeLattice *> operands,
+                            ShapeFact &result) {
+    if (fromElements.getElements().size() != operands.size())
+      return;
+    ExprVector payload;
+    payload.reserve(operands.size());
+    for (const ShapeLattice *operand : operands) {
+      const auto &operandPayload = operand->getValue().payload;
+      if (!operandPayload || operandPayload->size() != 1 ||
+          !operandPayload->front())
+        return;
+      payload.push_back(operandPayload->front());
+    }
+    result.payload = std::move(payload);
+  }
+
+  void transferConstant(mlir::Operation *op, ShapeFact &result) {
+    llvm::SmallVector<int64_t> constants;
+    if (!extractConstantIntTensor(op->getResult(0), constants,
+                                  /*expectedRank=*/std::nullopt))
+      return;
+    ExprVector payload;
+    payload.reserve(constants.size());
+    for (int64_t constant : constants)
+      payload.push_back(getConstant(constant));
+    result.payload = std::move(payload);
+  }
+
+  void transferShape(mlir::Operation *op,
+                     llvm::ArrayRef<const ShapeLattice *> operands,
+                     ShapeFact &result) {
+    if (op->getNumOperands() != 1)
+      return;
+    const ShapeFact &source = getOperandFact(operands, 0);
+    if (!source.dimensions)
+      return;
+
+    int64_t rank = static_cast<int64_t>(source.dimensions->size());
+    int64_t start = 0;
+    int64_t end = rank;
+    if (auto attr = op->getAttrOfType<mlir::IntegerAttr>("start"))
+      start = attr.getSInt();
+    if (auto attr = op->getAttrOfType<mlir::IntegerAttr>("end"))
+      end = attr.getSInt();
+    start = normalizeAndClampIndex(start, rank);
+    end = normalizeAndClampIndex(end, rank);
+    if (start >= end)
+      return;
+
+    ExprVector payload(source.dimensions->begin() + start,
+                       source.dimensions->begin() + end);
+    if (llvm::is_contained(payload, nullptr))
+      return;
+    result.payload = std::move(payload);
+  }
+
+  void transferConcat(mlir::Operation *op,
+                      llvm::ArrayRef<const ShapeLattice *> operands,
+                      ShapeFact &result) {
+    int64_t axis = 0;
+    if (auto attr = op->getAttrOfType<mlir::IntegerAttr>("axis"))
+      axis = attr.getSInt();
+    if (axis != 0)
+      return;
+
+    ExprVector payload;
+    for (const ShapeLattice *operand : operands) {
+      const auto &operandPayload = operand->getValue().payload;
+      if (!operandPayload)
+        return;
+      llvm::append_range(payload, *operandPayload);
+    }
+    result.payload = std::move(payload);
+  }
+
+  void transferGather(mlir::Operation *op,
+                      llvm::ArrayRef<const ShapeLattice *> operands,
+                      ShapeFact &result) {
+    if (op->getNumOperands() != 2)
+      return;
+    auto dataType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getOperand(0).getType());
+    if (!dataType || dataType.getRank() != 1)
+      return;
+    int64_t axis = 0;
+    if (auto attr = op->getAttrOfType<mlir::IntegerAttr>("axis"))
+      axis = attr.getSInt();
+    if (axis != 0)
+      return;
+
+    llvm::SmallVector<int64_t> indices;
+    if (!extractConstantIntTensor(op->getOperand(1), indices,
+                                  /*expectedRank=*/std::nullopt) ||
+        indices.size() != 1)
+      return;
+    const auto &source = getOperandFact(operands, 0).payload;
+    if (!source || source->empty())
+      return;
+    int64_t index = indices.front();
+    if (index < 0)
+      index += static_cast<int64_t>(source->size());
+    if (index < 0 || index >= static_cast<int64_t>(source->size()))
+      return;
+    result.payload = ExprVector{(*source)[index]};
+  }
+
+  void transferSlice(mlir::Operation *op,
+                     llvm::ArrayRef<const ShapeLattice *> operands,
+                     ShapeFact &result) {
+    if (op->getNumOperands() < 3 || op->getNumOperands() > 5)
+      return;
+    auto dataType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getOperand(0).getType());
+    if (!dataType || dataType.getRank() != 1)
+      return;
+    const auto &source = getOperandFact(operands, 0).payload;
+    if (!source)
+      return;
+
+    llvm::SmallVector<int64_t> starts, ends, axes, steps;
+    if (!extractConstantIntTensor(op->getOperand(1), starts,
+                                  /*expectedRank=*/std::nullopt) ||
+        !extractConstantIntTensor(op->getOperand(2), ends,
+                                  /*expectedRank=*/std::nullopt) ||
+        starts.size() != 1 || ends.size() != 1)
+      return;
+    if (op->getNumOperands() >= 4 &&
+        !extractConstantIntTensor(op->getOperand(3), axes,
+                                  /*expectedRank=*/std::nullopt))
+      return;
+    if (op->getNumOperands() == 5 &&
+        !extractConstantIntTensor(op->getOperand(4), steps,
+                                  /*expectedRank=*/std::nullopt))
+      return;
+    if (axes.size() > 1 || steps.size() > 1)
+      return;
+    int64_t axis = axes.empty() ? 0 : axes.front();
+    int64_t step = steps.empty() ? 1 : steps.front();
+    if ((axis != 0 && axis != -1) || step != 1)
+      return;
+
+    int64_t length = static_cast<int64_t>(source->size());
+    int64_t start = starts.front();
+    int64_t end = ends.front();
+    start = normalizeAndClampIndex(start, length);
+    end = normalizeAndClampIndex(end, length);
+    if (end < start)
+      end = start;
+    result.payload = ExprVector(source->begin() + start, source->begin() + end);
+  }
+
+  void transferValuePreserving(mlir::Operation *op,
+                               llvm::ArrayRef<const ShapeLattice *> operands,
+                               ShapeFact &result, bool preservePayload,
+                               bool preserveDimensions) {
+    if (op->getNumOperands() < 1)
+      return;
+    const ShapeFact &source = getOperandFact(operands, 0);
+    if (preservePayload)
+      result.payload = source.payload;
+    if (preserveDimensions && source.dimensions && result.dimensions &&
+        source.dimensions->size() == result.dimensions->size())
+      result.dimensions = source.dimensions;
+  }
+
+  void transferAdd(mlir::Operation *op,
+                   llvm::ArrayRef<const ShapeLattice *> operands,
+                   ShapeFact &result) {
+    if (op->getNumOperands() != 2 || !result.dimensions)
+      return;
+    auto resultType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    if (!resultType)
+      return;
+
+    for (int64_t dimension : llvm::seq<int64_t>(resultType.getRank())) {
+      if (!resultType.isDynamicDim(dimension))
+        continue;
+      Expr source = nullptr;
+      bool ambiguous = false;
+      for (auto [operandIndex, operand] : llvm::enumerate(op->getOperands())) {
+        auto operandType =
+            mlir::dyn_cast<mlir::RankedTensorType>(operand.getType());
+        if (!operandType) {
+          ambiguous = true;
+          break;
+        }
+        int64_t pad = resultType.getRank() - operandType.getRank();
+        if (dimension < pad)
+          continue;
+        int64_t operandDim = dimension - pad;
+        if (operandType.getDimSize(operandDim) == 1)
+          continue;
+        const auto &operandDimensions =
+            getOperandFact(operands, operandIndex).dimensions;
+        Expr candidate =
+            operandDimensions ? (*operandDimensions)[operandDim] : nullptr;
+        if (!candidate || (source && source != candidate)) {
+          ambiguous = true;
+          break;
+        }
+        source = candidate;
+      }
+      if (source && !ambiguous)
+        (*result.dimensions)[dimension] = source;
+    }
+  }
+
+  void transferMatMul(mlir::Operation *op,
+                      llvm::ArrayRef<const ShapeLattice *> operands,
+                      ShapeFact &result) {
+    if (op->getNumOperands() != 2 || op->getNumResults() != 1 ||
+        operands.size() != 2 || !result.dimensions)
+      return;
+    auto resultType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    auto aType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getOperand(0).getType());
+    auto bType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getOperand(1).getType());
+    if (!resultType || !aType || !bType || resultType.getRank() < 2 ||
+        aType.getRank() < 2 || bType.getRank() < 2)
+      return;
+
+    int64_t resultRank = resultType.getRank();
+    int64_t resultBatchRank = resultRank - 2;
+    int64_t aBatchRank = aType.getRank() - 2;
+    int64_t bBatchRank = bType.getRank() - 2;
+    if (aBatchRank > resultBatchRank || bBatchRank > resultBatchRank ||
+        result.dimensions->size() != static_cast<size_t>(resultRank))
+      return;
+
+    auto getOperandDimension = [&](unsigned operandIndex,
+                                   int64_t operandDimension) -> Expr {
+      if (operandIndex >= operands.size() || operandDimension < 0)
+        return nullptr;
+      const auto &dimensions =
+          getOperandFact(operands, operandIndex).dimensions;
+      if (!dimensions ||
+          operandDimension >= static_cast<int64_t>(dimensions->size()))
+        return nullptr;
+      return (*dimensions)[operandDimension];
+    };
+
+    for (int64_t dimension : llvm::seq<int64_t>(resultRank)) {
+      if (!resultType.isDynamicDim(dimension))
+        continue;
+      Expr source = nullptr;
+      bool ambiguous = false;
+      if (dimension == resultRank - 2) {
+        source = getOperandDimension(0, aType.getRank() - 2);
+      } else if (dimension == resultRank - 1) {
+        source = getOperandDimension(1, bType.getRank() - 1);
+      } else {
+        auto mergeBatchDimension = [&](Expr candidate) {
+          if (!candidate || (source && source != candidate)) {
+            ambiguous = true;
+            return;
+          }
+          source = candidate;
+        };
+
+        int64_t aPad = resultBatchRank - aBatchRank;
+        int64_t bPad = resultBatchRank - bBatchRank;
+        if (dimension >= aPad) {
+          int64_t aDim = dimension - aPad;
+          if (aType.getDimSize(aDim) != 1)
+            mergeBatchDimension(getOperandDimension(0, aDim));
+        }
+        if (!ambiguous && dimension >= bPad) {
+          int64_t bDim = dimension - bPad;
+          if (bType.getDimSize(bDim) != 1)
+            mergeBatchDimension(getOperandDimension(1, bDim));
+        }
+      }
+      if (source && !ambiguous)
+        (*result.dimensions)[dimension] = source;
+    }
+  }
+
+  mlir::func::FuncOp funcOp;
+  mlir::DataFlowSolver solver;
+  // Lattice facts compare interned expression pointers. deque preserves their
+  // addresses as new expressions are discovered by the solver worklist.
+  std::deque<ShapeExprNode> expressions;
+  llvm::DenseMap<std::pair<int64_t, ShapeValueProof>, Expr> constants;
+  llvm::DenseMap<std::pair<mlir::Value, int64_t>, Expr> tensorDims;
+  llvm::DenseMap<std::pair<mlir::Value, ShapeValueProof>, Expr> hostScalars;
+};
+
+ShapeProvenanceAnalysis::ShapeProvenanceAnalysis(mlir::func::FuncOp funcOp)
+    : impl(std::make_unique<Impl>(funcOp)) {}
+
+ShapeProvenanceAnalysis::~ShapeProvenanceAnalysis() = default;
+
+mlir::LogicalResult ShapeProvenanceAnalysis::run() { return impl->run(); }
+
+mlir::FailureOr<llvm::SmallVector<ShapeProvenanceExpr>>
+ShapeProvenanceAnalysis::getPayload(mlir::Value value) const {
+  return impl->getPayload(value);
+}
+
+bool ShapeProvenanceAnalysis::isEquivalentToDimension(
+    const ShapeProvenanceExpr &expr, mlir::Value value,
+    int64_t dimension) const {
+  return impl->isEquivalentToDimension(expr, value, dimension);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/OnnxToHip/ShapeProvenanceAnalysis.h
+++ b/lib/Conversion/OnnxToHip/ShapeProvenanceAnalysis.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- ShapeProvenanceAnalysis.h - Host shape dataflow ----------*- C++ -*-===//
+//
+// Function-level sparse dataflow for host-side shape payloads and canonical
+// tensor dimensions used by Reshape shape materialization.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HIP_CONVERSION_ONNXTOHIP_SHAPEPROVENANCEANALYSIS_H
+#define HIP_CONVERSION_ONNXTOHIP_SHAPEPROVENANCEANALYSIS_H
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <cstdint>
+#include <memory>
+
+namespace mlir {
+namespace hip {
+
+enum class ShapeValueProof {
+  Positive,
+  NonNegative,
+  MinusOne,
+  Unknown,
+  Invalid,
+};
+
+struct ShapeProvenanceExpr {
+  enum class Kind {
+    Constant,
+    TensorDim,
+    HostScalar,
+  };
+
+  Kind kind;
+  int64_t constant = 0;
+  mlir::Value value;
+  int64_t dimension = 0;
+  ShapeValueProof proof = ShapeValueProof::Unknown;
+};
+
+/// Function-level analysis of shape payload and dimension provenance.
+///
+/// Each instance is intended for one successful solve over a stable function.
+/// Query before mutating the analyzed IR; copied descriptors contain non-owning
+/// `mlir::Value` handles and do not extend the lifetime of referenced IR.
+class ShapeProvenanceAnalysis {
+public:
+  explicit ShapeProvenanceAnalysis(mlir::func::FuncOp funcOp);
+  ~ShapeProvenanceAnalysis();
+
+  ShapeProvenanceAnalysis(const ShapeProvenanceAnalysis &) = delete;
+  ShapeProvenanceAnalysis &operator=(const ShapeProvenanceAnalysis &) = delete;
+
+  mlir::LogicalResult run();
+
+  mlir::FailureOr<llvm::SmallVector<ShapeProvenanceExpr>>
+  getPayload(mlir::Value value) const;
+
+  /// Return whether \p expr and the selected dimension of \p value have the
+  /// same canonical dimension root.
+  bool isEquivalentToDimension(const ShapeProvenanceExpr &expr,
+                               mlir::Value value, int64_t dimension) const;
+
+private:
+  class Impl;
+  std::unique_ptr<Impl> impl;
+};
+
+/// Return whether \p funcOp contains a dynamic onnx.Reshape whose rank-1 i64
+/// target operand could benefit from shape-provenance analysis.
+bool hasEligibleReshapeShapeProvenanceCandidate(mlir::func::FuncOp funcOp);
+
+/// Consume one completed analysis and materialize all provable onnx.Reshape
+/// target shapes. This preserves the proof-marker contract consumed by
+/// ReshapeConversion.
+mlir::LogicalResult
+materializeReshapeShapeOperands(mlir::func::FuncOp funcOp,
+                                const ShapeProvenanceAnalysis &analysis);
+
+} // namespace hip
+} // namespace mlir
+
+#endif // HIP_CONVERSION_ONNXTOHIP_SHAPEPROVENANCEANALYSIS_H

--- a/lib/Dialect/Transforms/ResolveTensorDims.cpp
+++ b/lib/Dialect/Transforms/ResolveTensorDims.cpp
@@ -59,6 +59,18 @@ namespace mlir::hip {
 
 namespace {
 
+struct FoldSelectOfSameValue final : public OpRewritePattern<arith::SelectOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(arith::SelectOp op,
+                                PatternRewriter &rewriter) const override {
+    if (op.getTrueValue() != op.getFalseValue())
+      return failure();
+    rewriter.replaceOp(op, op.getTrueValue());
+    return success();
+  }
+};
+
 struct ResolveTensorDimsPass final
     : public impl::ResolveTensorDimsPassBase<ResolveTensorDimsPass> {
   using Base::Base;
@@ -89,6 +101,7 @@ void ResolveTensorDimsPass::runOnOperation() {
   tensor::DimOp::getCanonicalizationPatterns(patterns, ctx);
   tensor::ExpandShapeOp::getCanonicalizationPatterns(patterns, ctx);
   tensor::CollapseShapeOp::getCanonicalizationPatterns(patterns, ctx);
+  patterns.add<FoldSelectOfSameValue>(ctx);
 
   if (failed(applyPatternsGreedily(funcOp, std::move(patterns))))
     return signalPassFailure();

--- a/test/lit/Conversion/onnx-to-hip/test_reshape_shape_provenance.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_reshape_shape_provenance.mlir
@@ -1,0 +1,830 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip \
+// RUN:   --canonicalize --cse --hip-resolve-tensor-dims | FileCheck %s
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip \
+// RUN:   | FileCheck %s --check-prefix=RAW
+
+module {
+  func.func @main_graph(%arg0: tensor<1xf16>) -> tensor<1xf16> {
+    return %arg0 : tensor<1xf16>
+  }
+
+  // Shape/Gather/Unsqueeze/Concat is proven while generic ONNX constants are
+  // still inline. Reshape consumes the scalar SSA directly and emits no
+  // synchronized payload readback.
+  // CHECK-LABEL: func.func @proven_shape_chain
+  // CHECK-SAME: %[[DATA:[A-Za-z0-9_]+]]: tensor<?x?x?xf16>
+  // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+  // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+  // CHECK: %[[D0:.*]] = tensor.dim %[[DATA]], %[[C0]]
+  // CHECK: %[[D0I:.*]] = arith.index_cast %[[D0]]
+  // CHECK: %[[D1:.*]] = tensor.dim %[[DATA]], %[[C1]]
+  // CHECK: %[[D1I:.*]] = arith.index_cast %[[D1]]
+  // CHECK: %[[TARGET:.*]] = tensor.from_elements %[[D0I]], %[[D1I]],
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK: tensor.reshape %[[DATA]](%[[TARGET]])
+  func.func @proven_shape_chain(
+      %data: tensor<?x?x?xf16>) -> tensor<?x?x?x?xf16> {
+    %idx0 = "onnx.Constant"() {value = dense<0> : tensor<i64>}
+      : () -> tensor<i64>
+    %idx1 = "onnx.Constant"() {value = dense<1> : tensor<i64>}
+      : () -> tensor<i64>
+    %axes = "onnx.Constant"() {value = dense<0> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %c16 = "onnx.Constant"() {value = dense<16> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %c72 = "onnx.Constant"() {value = dense<72> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %shape = "onnx.Shape"(%data)
+      : (tensor<?x?x?xf16>) -> tensor<3xi64>
+    %d0 = "onnx.Gather"(%shape, %idx0) {axis = 0 : si64}
+      : (tensor<3xi64>, tensor<i64>) -> tensor<i64>
+    %d1 = "onnx.Gather"(%shape, %idx1) {axis = 0 : si64}
+      : (tensor<3xi64>, tensor<i64>) -> tensor<i64>
+    %u0 = "onnx.Unsqueeze"(%d0, %axes)
+      : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
+    %u1 = "onnx.Unsqueeze"(%d1, %axes)
+      : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
+    %target = "onnx.Concat"(%u0, %u1, %c16, %c72) {axis = 0 : si64}
+      : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>)
+        -> tensor<4xi64>
+    %result = "onnx.Reshape"(%data, %target) {allowzero = 0 : si64}
+      : (tensor<?x?x?xf16>, tensor<4xi64>) -> tensor<?x?x?x?xf16>
+    return %result : tensor<?x?x?x?xf16>
+  }
+
+  // Reordered Gather inputs must remain reordered in the proven target.
+  // CHECK-LABEL: func.func @permuted_shape_chain
+  // CHECK-SAME: %[[PERM_DATA:[A-Za-z0-9_]+]]: tensor<?x?x?xf16>
+  // CHECK-DAG: %[[PERM_C0:.*]] = arith.constant 0 : index
+  // CHECK-DAG: %[[PERM_C1:.*]] = arith.constant 1 : index
+  // CHECK: %[[PERM_D1:.*]] = tensor.dim %[[PERM_DATA]], %[[PERM_C1]]
+  // CHECK: %[[PERM_D1I:.*]] = arith.index_cast %[[PERM_D1]]
+  // CHECK: %[[PERM_D0:.*]] = tensor.dim %[[PERM_DATA]], %[[PERM_C0]]
+  // CHECK: %[[PERM_D0I:.*]] = arith.index_cast %[[PERM_D0]]
+  // CHECK: tensor.from_elements %[[PERM_D1I]], %[[PERM_D0I]],
+  func.func @permuted_shape_chain(
+      %data: tensor<?x?x?xf16>) -> tensor<?x?x?x?xf16> {
+    %idx0 = "onnx.Constant"() {value = dense<0> : tensor<i64>}
+      : () -> tensor<i64>
+    %idx1 = "onnx.Constant"() {value = dense<1> : tensor<i64>}
+      : () -> tensor<i64>
+    %axes = "onnx.Constant"() {value = dense<0> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %c16 = "onnx.Constant"() {value = dense<16> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %c72 = "onnx.Constant"() {value = dense<72> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %shape = "onnx.Shape"(%data)
+      : (tensor<?x?x?xf16>) -> tensor<3xi64>
+    %d0 = "onnx.Gather"(%shape, %idx0) {axis = 0 : si64}
+      : (tensor<3xi64>, tensor<i64>) -> tensor<i64>
+    %d1 = "onnx.Gather"(%shape, %idx1) {axis = 0 : si64}
+      : (tensor<3xi64>, tensor<i64>) -> tensor<i64>
+    %u0 = "onnx.Unsqueeze"(%d0, %axes)
+      : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
+    %u1 = "onnx.Unsqueeze"(%d1, %axes)
+      : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
+    %target = "onnx.Concat"(%u1, %u0, %c16, %c72) {axis = 0 : si64}
+      : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>)
+        -> tensor<4xi64>
+    %result = "onnx.Reshape"(%data, %target) {allowzero = 1 : si64}
+      : (tensor<?x?x?xf16>, tensor<4xi64>) -> tensor<?x?x?x?xf16>
+    return %result : tensor<?x?x?x?xf16>
+  }
+
+  // An opaque shape tensor argument has no host-side provenance. The fallback
+  // retains one synchronized readback per output dimension.
+  // CHECK-LABEL: func.func @unknown_shape_argument
+  // CHECK-COUNT-4: hip.readback_scalar
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK: tensor.reshape
+  func.func @unknown_shape_argument(
+      %data: tensor<?x?x?xf16>,
+      %shape: tensor<4xi64>) -> tensor<?x?x?x?xf16> {
+    %result = "onnx.Reshape"(%data, %shape) {allowzero = 0 : si64}
+      : (tensor<?x?x?xf16>, tensor<4xi64>) -> tensor<?x?x?x?xf16>
+    return %result : tensor<?x?x?x?xf16>
+  }
+
+  // A dense carrier is a compile-time target at the Reshape conversion
+  // boundary. It bypasses both provenance materialization and synchronized
+  // payload readback; conversion never needs to inspect a memref global.
+  // RAW-LABEL: func.func @dense_carrier_target
+  // RAW-NOT: memref.get_global
+  // RAW-NOT: hip.readback_scalar
+  // RAW: %[[DENSE_TARGET:.*]] = tensor.from_elements
+  // RAW-NEXT: tensor.reshape %{{.*}}(%[[DENSE_TARGET]])
+  // CHECK-LABEL: func.func @dense_carrier_target
+  // CHECK-NOT: memref.get_global
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK: %[[DENSE_TARGET:.*]] = tensor.from_elements
+  // CHECK-NEXT: tensor.reshape %{{.*}}(%[[DENSE_TARGET]])
+  func.func @dense_carrier_target(
+      %data: tensor<?x?x?xf16>) -> tensor<?x?xf16> {
+    %target = hip.constant {
+      value = dense<[0, -1]> : tensor<2xi64>
+    } : tensor<2xi64>
+    %result = "onnx.Reshape"(%data, %target) {allowzero = 0 : si64}
+      : (tensor<?x?x?xf16>, tensor<2xi64>) -> tensor<?x?xf16>
+    return %result : tensor<?x?xf16>
+  }
+
+  // Provenance must not flatten a multidimensional Gather source. The outer
+  // Reshape therefore retains synchronized fallback reads for both target
+  // entries.
+  // CHECK-LABEL: func.func @multidimensional_gather_fallback
+  // CHECK-COUNT-2: hip.readback_scalar
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK: tensor.reshape
+  func.func @multidimensional_gather_fallback(
+      %data: tensor<?x?x?x?xf16>) -> tensor<?x?xf16> {
+    %shape = "onnx.Shape"(%data)
+      : (tensor<?x?x?x?xf16>) -> tensor<4xi64>
+    %shape2x2 = "onnx.Constant"() {
+      value = dense<[2, 2]> : tensor<2xi64>
+    } : () -> tensor<2xi64>
+    %matrix = "onnx.Reshape"(%shape, %shape2x2) {allowzero = 0 : si64}
+      : (tensor<4xi64>, tensor<2xi64>) -> tensor<2x2xi64>
+    %row = "onnx.Constant"() {value = dense<1> : tensor<i64>}
+      : () -> tensor<i64>
+    %target = "onnx.Gather"(%matrix, %row) {axis = 0 : si64}
+      : (tensor<2x2xi64>, tensor<i64>) -> tensor<2xi64>
+    %result = "onnx.Reshape"(%data, %target) {allowzero = 0 : si64}
+      : (tensor<?x?x?x?xf16>, tensor<2xi64>) -> tensor<?x?xf16>
+    return %result : tensor<?x?xf16>
+  }
+
+  // Rank-1 Slice preserves shape-vector order and remains provable.
+  // CHECK-LABEL: func.func @rank_one_slice_provenance
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK: tensor.from_elements
+  // CHECK: tensor.reshape
+  func.func @rank_one_slice_provenance(
+      %data: tensor<?x?x?x?xf16>) -> tensor<?x?x?xf16> {
+    %shape = "onnx.Shape"(%data)
+      : (tensor<?x?x?x?xf16>) -> tensor<4xi64>
+    %starts = "onnx.Constant"() {value = dense<0> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %ends = "onnx.Constant"() {value = dense<2> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %axes = "onnx.Constant"() {value = dense<0> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %one = "onnx.Constant"() {value = dense<1> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %slice = "onnx.Slice"(%shape, %starts, %ends, %axes)
+      : (tensor<4xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>)
+        -> tensor<2xi64>
+    %target = "onnx.Concat"(%slice, %one) {axis = 0 : si64}
+      : (tensor<2xi64>, tensor<1xi64>) -> tensor<3xi64>
+    %result = "onnx.Reshape"(%data, %target) {allowzero = 1 : si64}
+      : (tensor<?x?x?x?xf16>, tensor<3xi64>) -> tensor<?x?x?xf16>
+    return %result : tensor<?x?x?xf16>
+  }
+
+  // Slice of a rank-2 shape matrix is not flattened by provenance analysis.
+  // CHECK-LABEL: func.func @multidimensional_slice_fallback
+  // CHECK-COUNT-2: hip.readback_scalar
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK: tensor.reshape
+  func.func @multidimensional_slice_fallback(
+      %data: tensor<?x?x?x?xf16>) -> tensor<?x?xf16> {
+    %shape = "onnx.Shape"(%data)
+      : (tensor<?x?x?x?xf16>) -> tensor<4xi64>
+    %shape2x2 = "onnx.Constant"() {
+      value = dense<[2, 2]> : tensor<2xi64>
+    } : () -> tensor<2xi64>
+    %matrix = "onnx.Reshape"(%shape, %shape2x2) {allowzero = 0 : si64}
+      : (tensor<4xi64>, tensor<2xi64>) -> tensor<2x2xi64>
+    %starts = "onnx.Constant"() {value = dense<0> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %ends = "onnx.Constant"() {value = dense<1> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %axes = "onnx.Constant"() {value = dense<0> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %row = "onnx.Slice"(%matrix, %starts, %ends, %axes)
+      : (tensor<2x2xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>)
+        -> tensor<1x2xi64>
+    %vectorShape = "onnx.Constant"() {
+      value = dense<2> : tensor<1xi64>
+    } : () -> tensor<1xi64>
+    %target = "onnx.Reshape"(%row, %vectorShape) {allowzero = 0 : si64}
+      : (tensor<1x2xi64>, tensor<1xi64>) -> tensor<2xi64>
+    %result = "onnx.Reshape"(%data, %target) {allowzero = 0 : si64}
+      : (tensor<?x?x?x?xf16>, tensor<2xi64>) -> tensor<?x?xf16>
+    return %result : tensor<?x?xf16>
+  }
+
+  // Extreme negative/positive indices are clipped without signed overflow.
+  // CHECK-LABEL: func.func @extreme_shape_slice_indices
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK: tensor.reshape
+  func.func @extreme_shape_slice_indices(
+      %data: tensor<?x?x?xf16>) -> tensor<?x?x?x?xf16> {
+    %shape = "onnx.Shape"(%data) {
+      start = -9223372036854775808 : si64,
+      end = 9223372036854775807 : si64
+    } : (tensor<?x?x?xf16>) -> tensor<3xi64>
+    %starts = "onnx.Constant"() {
+      value = dense<-9223372036854775808> : tensor<1xi64>
+    } : () -> tensor<1xi64>
+    %ends = "onnx.Constant"() {
+      value = dense<9223372036854775807> : tensor<1xi64>
+    } : () -> tensor<1xi64>
+    %axes = "onnx.Constant"() {value = dense<0> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %slice = "onnx.Slice"(%shape, %starts, %ends, %axes)
+      : (tensor<3xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>)
+        -> tensor<3xi64>
+    %one = "onnx.Constant"() {value = dense<1> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %target = "onnx.Concat"(%slice, %one) {axis = 0 : si64}
+      : (tensor<3xi64>, tensor<1xi64>) -> tensor<4xi64>
+    %result = "onnx.Reshape"(%data, %target) {allowzero = 1 : si64}
+      : (tensor<?x?x?xf16>, tensor<4xi64>) -> tensor<?x?x?x?xf16>
+    return %result : tensor<?x?x?x?xf16>
+  }
+
+  // Plans for dependent Reshapes are all queried before the first
+  // materialization mutates IR.
+  // RAW-LABEL: func.func @dependent_reshapes
+  // RAW-NOT: hip.readback_scalar
+  // RAW-COUNT-2: tensor.expand_shape
+  func.func @dependent_reshapes(
+      %data: tensor<?x?xf16>) -> tensor<?x1x?x1xf16> {
+    %idx0 = "onnx.Constant"() {value = dense<0> : tensor<i64>}
+      : () -> tensor<i64>
+    %idx1 = "onnx.Constant"() {value = dense<1> : tensor<i64>}
+      : () -> tensor<i64>
+    %axes = "onnx.Constant"() {value = dense<0> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %one = "onnx.Constant"() {value = dense<1> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %sourceShape = "onnx.Shape"(%data)
+      : (tensor<?x?xf16>) -> tensor<2xi64>
+    %d0 = "onnx.Gather"(%sourceShape, %idx0) {axis = 0 : si64}
+      : (tensor<2xi64>, tensor<i64>) -> tensor<i64>
+    %d1 = "onnx.Gather"(%sourceShape, %idx1) {axis = 0 : si64}
+      : (tensor<2xi64>, tensor<i64>) -> tensor<i64>
+    %u0 = "onnx.Unsqueeze"(%d0, %axes)
+      : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
+    %u1 = "onnx.Unsqueeze"(%d1, %axes)
+      : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
+    %target0 = "onnx.Concat"(%u0, %one, %u1) {axis = 0 : si64}
+      : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<3xi64>
+    %first = "onnx.Reshape"(%data, %target0) {allowzero = 1 : si64}
+      : (tensor<?x?xf16>, tensor<3xi64>) -> tensor<?x1x?xf16>
+    %firstShape = "onnx.Shape"(%first)
+      : (tensor<?x1x?xf16>) -> tensor<3xi64>
+    %target1 = "onnx.Concat"(%firstShape, %one) {axis = 0 : si64}
+      : (tensor<3xi64>, tensor<1xi64>) -> tensor<4xi64>
+    %second = "onnx.Reshape"(%first, %target1) {allowzero = 1 : si64}
+      : (tensor<?x1x?xf16>, tensor<4xi64>) -> tensor<?x1x?x1xf16>
+    return %second : tensor<?x1x?x1xf16>
+  }
+
+  // Add(MatMul(x, W), bias) preserves x's leading dimensions. The proven
+  // input-dimension map removes allowzero's redundant zero-select.
+  // CHECK-LABEL: func.func @matmul_add_equivalence
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK-NOT: arith.select
+  // CHECK: tensor.reshape
+  func.func @matmul_add_equivalence(
+      %data: tensor<?x?x4xf16>,
+      %weight: tensor<4x4xf16>,
+      %bias: tensor<4xf16>) -> tensor<?x?x?x?xf16> {
+    %mm = "onnx.MatMul"(%data, %weight)
+      : (tensor<?x?x4xf16>, tensor<4x4xf16>) -> tensor<?x?x4xf16>
+    %sum = "onnx.Add"(%bias, %mm)
+      : (tensor<4xf16>, tensor<?x?x4xf16>) -> tensor<?x?x4xf16>
+    %shape = "onnx.Shape"(%data)
+      : (tensor<?x?x4xf16>) -> tensor<3xi64>
+    %idx0 = "onnx.Constant"() {value = dense<0> : tensor<i64>}
+      : () -> tensor<i64>
+    %axes = "onnx.Constant"() {value = dense<0> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %two = "onnx.Constant"() {value = dense<2> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %d0 = "onnx.Gather"(%shape, %idx0) {axis = 0 : si64}
+      : (tensor<3xi64>, tensor<i64>) -> tensor<i64>
+    %u0 = "onnx.Unsqueeze"(%d0, %axes)
+      : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
+    %target = "onnx.Concat"(%u0, %two, %two, %two) {axis = 0 : si64}
+      : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>)
+        -> tensor<4xi64>
+    %result = "onnx.Reshape"(%sum, %target) {allowzero = 0 : si64}
+      : (tensor<?x?x4xf16>, tensor<4xi64>) -> tensor<?x?x?x?xf16>
+    return %result : tensor<?x?x?x?xf16>
+  }
+
+  // A CFG join erases the first MatMul operand's batch-dimension root. The
+  // second operand's non-unit dynamic root must not overwrite that unknown:
+  // the original target is based on %rhs, not on the MatMul result.
+  // RAW-LABEL: func.func @matmul_unknown_batch_is_ambiguous
+  // RAW-SAME: %[[RHS:[A-Za-z0-9_]+]]: tensor<?x3x4xf16>
+  // RAW: %[[MM:.*]] = hip.matmul
+  // RAW-NEXT: %[[TARGET_DIM:.*]] = tensor.dim %[[RHS]],
+  // RAW-NEXT: %[[TARGET_DIM_I64:.*]] = arith.index_cast %[[TARGET_DIM]]
+  // RAW-NOT: hip.readback_scalar
+  // RAW: tensor.reshape %[[MM]]
+  func.func @matmul_unknown_batch_is_ambiguous(
+      %lhs0: tensor<?x2x3xf16>,
+      %lhs1: tensor<?x2x3xf16>,
+      %rhs: tensor<?x3x4xf16>,
+      %condition: i1) -> tensor<?x?xf16> {
+    cf.cond_br %condition, ^left(%lhs0 : tensor<?x2x3xf16>),
+      ^right(%lhs1 : tensor<?x2x3xf16>)
+  ^left(%leftValue: tensor<?x2x3xf16>):
+    cf.br ^join(%leftValue : tensor<?x2x3xf16>)
+  ^right(%rightValue: tensor<?x2x3xf16>):
+    cf.br ^join(%rightValue : tensor<?x2x3xf16>)
+  ^join(%lhs: tensor<?x2x3xf16>):
+    %mm = "onnx.MatMul"(%lhs, %rhs)
+      : (tensor<?x2x3xf16>, tensor<?x3x4xf16>) -> tensor<?x2x4xf16>
+    %c0 = arith.constant 0 : index
+    %rhsBatch = tensor.dim %rhs, %c0 : tensor<?x3x4xf16>
+    %rhsBatchI64 = arith.index_cast %rhsBatch : index to i64
+    %minusOne = arith.constant -1 : i64
+    %target = tensor.from_elements %rhsBatchI64, %minusOne : tensor<2xi64>
+    %result = "onnx.Reshape"(%mm, %target) {allowzero = 0 : si64}
+      : (tensor<?x2x4xf16>, tensor<2xi64>) -> tensor<?x?xf16>
+    return %result : tensor<?x?xf16>
+  }
+
+  // Cast preserves semantic dimensions. Canonicalizing those facts lets the
+  // materializer rewrite the proof onto the Reshape input itself.
+  // CHECK-LABEL: func.func @cast_dimension_equivalence
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK-NOT: arith.select
+  // CHECK: tensor.reshape
+  func.func @cast_dimension_equivalence(
+      %data: tensor<?x?xf16>) -> tensor<?x4xf32> {
+    %cast = "onnx.Cast"(%data) {to = f32}
+      : (tensor<?x?xf16>) -> tensor<?x?xf32>
+    %shape = "onnx.Shape"(%data)
+      : (tensor<?x?xf16>) -> tensor<2xi64>
+    %result = "onnx.Reshape"(%cast, %shape) {allowzero = 0 : si64}
+      : (tensor<?x?xf32>, tensor<2xi64>) -> tensor<?x4xf32>
+    return %result : tensor<?x4xf32>
+  }
+
+  // Two dynamic Add operands are ambiguous: the correct broadcast select must
+  // remain because neither dimension is proven to be the canonical source.
+  // CHECK-LABEL: func.func @ambiguous_add_keeps_select
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK: arith.select
+  // CHECK: tensor.reshape
+  func.func @ambiguous_add_keeps_select(
+      %lhs: tensor<?x?x4xf16>,
+      %rhs: tensor<?x?x4xf16>) -> tensor<?x?x?x?xf16> {
+    %sum = "onnx.Add"(%lhs, %rhs)
+      : (tensor<?x?x4xf16>, tensor<?x?x4xf16>) -> tensor<?x?x4xf16>
+    %shape = "onnx.Shape"(%lhs)
+      : (tensor<?x?x4xf16>) -> tensor<3xi64>
+    %idx0 = "onnx.Constant"() {value = dense<0> : tensor<i64>}
+      : () -> tensor<i64>
+    %axes = "onnx.Constant"() {value = dense<0> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %two = "onnx.Constant"() {value = dense<2> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %d0 = "onnx.Gather"(%shape, %idx0) {axis = 0 : si64}
+      : (tensor<3xi64>, tensor<i64>) -> tensor<i64>
+    %u0 = "onnx.Unsqueeze"(%d0, %axes)
+      : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
+    %target = "onnx.Concat"(%u0, %two, %two, %two) {axis = 0 : si64}
+      : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>)
+        -> tensor<4xi64>
+    %result = "onnx.Reshape"(%sum, %target) {allowzero = 0 : si64}
+      : (tensor<?x?x4xf16>, tensor<4xi64>) -> tensor<?x?x?x?xf16>
+    return %result : tensor<?x?x?x?xf16>
+  }
+
+  // Repeated SSA operands carry identical dimension facts and are not
+  // ambiguous dynamic broadcast sources.
+  // CHECK-LABEL: func.func @repeated_add_reuses_dimension
+  // CHECK-NOT: arith.select
+  // CHECK: tensor.reshape
+  func.func @repeated_add_reuses_dimension(
+      %data: tensor<?x?x4xf16>) -> tensor<?x?x?x?xf16> {
+    %sum = "onnx.Add"(%data, %data)
+      : (tensor<?x?x4xf16>, tensor<?x?x4xf16>) -> tensor<?x?x4xf16>
+    %shape = "onnx.Shape"(%data)
+      : (tensor<?x?x4xf16>) -> tensor<3xi64>
+    %idx0 = "onnx.Constant"() {value = dense<0> : tensor<i64>}
+      : () -> tensor<i64>
+    %axes = "onnx.Constant"() {value = dense<0> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %two = "onnx.Constant"() {value = dense<2> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %d0 = "onnx.Gather"(%shape, %idx0) {axis = 0 : si64}
+      : (tensor<3xi64>, tensor<i64>) -> tensor<i64>
+    %u0 = "onnx.Unsqueeze"(%d0, %axes)
+      : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
+    %target = "onnx.Concat"(%u0, %two, %two, %two) {axis = 0 : si64}
+      : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>)
+        -> tensor<4xi64>
+    %result = "onnx.Reshape"(%sum, %target) {allowzero = 0 : si64}
+      : (tensor<?x?x4xf16>, tensor<4xi64>) -> tensor<?x?x?x?xf16>
+    return %result : tensor<?x?x?x?xf16>
+  }
+
+  // allowzero=0 copies the corresponding input extent instead of preserving
+  // the literal zero.
+  // CHECK-LABEL: func.func @allowzero_zero_copies_input
+  // CHECK-SAME: %[[ZERO_DATA:[A-Za-z0-9_]+]]: tensor<?x?xf16>
+  // CHECK: %[[ZERO_D0:.*]] = tensor.dim %[[ZERO_DATA]]
+  // CHECK: %[[ZERO_D0I:.*]] = arith.index_cast %[[ZERO_D0]]
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK: tensor.from_elements %[[ZERO_D0I]],
+  // CHECK: tensor.reshape
+  func.func @allowzero_zero_copies_input(
+      %data: tensor<?x?xf16>) -> tensor<?x1xf16> {
+    %target = "onnx.Constant"() {
+      value = dense<[0, 1]> : tensor<2xi64>
+    } : () -> tensor<2xi64>
+    %result = "onnx.Reshape"(%data, %target) {allowzero = 0 : si64}
+      : (tensor<?x?xf16>, tensor<2xi64>) -> tensor<?x1xf16>
+    return %result : tensor<?x1xf16>
+  }
+
+  // allowzero=1 preserves a literal zero.
+  // CHECK-LABEL: func.func @allowzero_one_preserves_zero
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK: %[[ZERO_TARGET:.*]] = arith.constant dense<[0, 1]> : tensor<2xi64>
+  // CHECK: tensor.reshape %{{.*}}(%[[ZERO_TARGET]])
+  func.func @allowzero_one_preserves_zero(
+      %data: tensor<?x?xf16>) -> tensor<?x1xf16> {
+    %target = "onnx.Constant"() {
+      value = dense<[0, 1]> : tensor<2xi64>
+    } : () -> tensor<2xi64>
+    %result = "onnx.Reshape"(%data, %target) {allowzero = 1 : si64}
+      : (tensor<?x?xf16>, tensor<2xi64>) -> tensor<?x1xf16>
+    return %result : tensor<?x1xf16>
+  }
+
+  // Narrowing index casts can wrap a nonnegative dimension to -1. They must
+  // not receive the nonnegative fast-path proof, so generic -1 handling stays.
+  // CHECK-LABEL: func.func @narrowing_index_cast_keeps_inference
+  // CHECK: arith.cmpi eq
+  // CHECK: arith.select
+  // CHECK: tensor.reshape
+  func.func @narrowing_index_cast_keeps_inference(
+      %data: tensor<?x?xf16>) -> tensor<?x?x?xf16> {
+    %c0 = arith.constant 0 : index
+    %dim = tensor.dim %data, %c0 : tensor<?x?xf16>
+    %narrow = arith.index_cast %dim : index to i32
+    %wide = arith.extsi %narrow : i32 to i64
+    %c1 = arith.constant 1 : i64
+    %target = tensor.from_elements %wide, %c1, %c1 : tensor<3xi64>
+    %result = "onnx.Reshape"(%data, %target) {allowzero = 0 : si64}
+      : (tensor<?x?xf16>, tensor<3xi64>) -> tensor<?x?x?xf16>
+    return %result : tensor<?x?x?xf16>
+  }
+
+  // An ONNX literal becomes a dense carrier before Reshape conversion.
+  // Conversion rematerializes its entries without provenance or readback,
+  // including -1 inference and allowzero=0.
+  // CHECK-LABEL: func.func @onnx_literal_carrier_target
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK: arith.cmpi eq
+  // CHECK: arith.select
+  // CHECK: tensor.reshape
+  func.func @onnx_literal_carrier_target(
+      %data: tensor<?x?x?xf16>) -> tensor<?x3x?xf16> {
+    %target = "onnx.Constant"() {
+      value = dense<[0, 3, -1]> : tensor<3xi64>
+    } : () -> tensor<3xi64>
+    %result = "onnx.Reshape"(%data, %target) {allowzero = 0 : si64}
+      : (tensor<?x?x?xf16>, tensor<3xi64>) -> tensor<?x3x?xf16>
+    return %result : tensor<?x3x?xf16>
+  }
+
+  // A proven vector containing -1 bypasses payload readback but retains the
+  // existing inferred-dimension arithmetic.
+  // CHECK-LABEL: func.func @proven_minus_one
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK: arith.cmpi eq
+  // CHECK: arith.select
+  // CHECK: tensor.reshape
+  func.func @proven_minus_one(
+      %data: tensor<?x?x?xf16>) -> tensor<?x?x?x?xf16> {
+    %shape = "onnx.Shape"(%data)
+      : (tensor<?x?x?xf16>) -> tensor<3xi64>
+    %idx0 = "onnx.Constant"() {value = dense<0> : tensor<i64>}
+      : () -> tensor<i64>
+    %axes = "onnx.Constant"() {value = dense<0> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %minusOne = "onnx.Constant"() {value = dense<-1> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %c16 = "onnx.Constant"() {value = dense<16> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %c72 = "onnx.Constant"() {value = dense<72> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %d0 = "onnx.Gather"(%shape, %idx0) {axis = 0 : si64}
+      : (tensor<3xi64>, tensor<i64>) -> tensor<i64>
+    %u0 = "onnx.Unsqueeze"(%d0, %axes)
+      : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
+    %target = "onnx.Concat"(%u0, %minusOne, %c16, %c72) {axis = 0 : si64}
+      : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>)
+        -> tensor<4xi64>
+    %result = "onnx.Reshape"(%data, %target) {allowzero = 0 : si64}
+      : (tensor<?x?x?xf16>, tensor<4xi64>) -> tensor<?x?x?x?xf16>
+    return %result : tensor<?x?x?x?xf16>
+  }
+
+  // Identical positive constants reaching a CFG block argument retain their
+  // interned positive proof. The joined SSA value is not a compile-time tensor
+  // constant, so avoiding readback uniquely requires provenance.
+  // CHECK-LABEL: func.func @allowzero_minus_one_positive_join
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK: tensor.reshape
+  func.func @allowzero_minus_one_positive_join(
+      %data: tensor<?x?x?xf16>,
+      %condition: i1) -> tensor<2x?x3xf16> {
+    %two = arith.constant 2 : i64
+    cf.cond_br %condition, ^left(%two : i64), ^right(%two : i64)
+  ^left(%leftValue: i64):
+    cf.br ^join(%leftValue : i64)
+  ^right(%rightValue: i64):
+    cf.br ^join(%rightValue : i64)
+  ^join(%positive: i64):
+    %minusOne = arith.constant -1 : i64
+    %three = arith.constant 3 : i64
+    %target =
+      tensor.from_elements %positive, %minusOne, %three : tensor<3xi64>
+    %result = "onnx.Reshape"(%data, %target) {allowzero = 1 : si64}
+      : (tensor<?x?x?xf16>, tensor<3xi64>) -> tensor<2x?x3xf16>
+    return %result : tensor<2x?x3xf16>
+  }
+
+  // A tensor dimension is nonnegative but not strictly positive. Combined
+  // with allowzero=1 and -1, provenance must refuse the marker and retain the
+  // synchronized fallback.
+  // CHECK-LABEL: func.func @allowzero_minus_one_nonnegative_fallback
+  // CHECK-COUNT-3: hip.readback_scalar
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK: tensor.reshape
+  func.func @allowzero_minus_one_nonnegative_fallback(
+      %data: tensor<?x?x?xf16>) -> tensor<?x?x3xf16> {
+    %c0 = arith.constant 0 : index
+    %d0 = tensor.dim %data, %c0 : tensor<?x?x?xf16>
+    %d0i64 = arith.index_cast %d0 : index to i64
+    %minusOne = arith.constant -1 : i64
+    %three = arith.constant 3 : i64
+    %target = tensor.from_elements %d0i64, %minusOne, %three : tensor<3xi64>
+    %result = "onnx.Reshape"(%data, %target) {allowzero = 1 : si64}
+      : (tensor<?x?x?xf16>, tensor<3xi64>) -> tensor<?x?x3xf16>
+    return %result : tensor<?x?x3xf16>
+  }
+
+  // A scalar constant wider than i64 cannot be represented by a provenance
+  // constant. Joining it with an opaque scalar and narrowing it into a target
+  // shape must safely remain unknown instead of asserting in APInt accessors.
+  // CHECK-LABEL: func.func @wide_integer_constant_fallback
+  // CHECK: arith.constant 1208925819614629174706176 : i128
+  // CHECK-COUNT-3: hip.readback_scalar
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK: tensor.reshape
+  func.func @wide_integer_constant_fallback(
+      %data: tensor<?x?x?xf16>,
+      %opaque: i128,
+      %condition: i1) -> tensor<?x?x3xf16> {
+    %wide = arith.constant 1208925819614629174706176 : i128
+    cf.cond_br %condition, ^constant(%wide : i128), ^opaque(%opaque : i128)
+  ^constant(%constantValue: i128):
+    cf.br ^join(%constantValue : i128)
+  ^opaque(%opaqueValue: i128):
+    cf.br ^join(%opaqueValue : i128)
+  ^join(%joined: i128):
+    %narrow = arith.trunci %joined : i128 to i64
+    %one = arith.constant 1 : i64
+    %three = arith.constant 3 : i64
+    %target = tensor.from_elements %narrow, %one, %three : tensor<3xi64>
+    %result = "onnx.Reshape"(%data, %target) {allowzero = 0 : si64}
+      : (tensor<?x?x?xf16>, tensor<3xi64>) -> tensor<?x?x3xf16>
+    return %result : tensor<?x?x3xf16>
+  }
+
+  // Static reshapes cannot consume provenance and skip whole-function
+  // dataflow, even when the function contains other integer SSA.
+  // CHECK-LABEL: func.func @static_reshape_skips_provenance
+  // CHECK: arith.constant 1208925819614629174706176 : i128
+  // CHECK-NOT: hip.readback_scalar
+  func.func @static_reshape_skips_provenance(
+      %data: tensor<2x2xf16>) -> (tensor<4xf16>, i128) {
+    %wide = arith.constant 1208925819614629174706176 : i128
+    %target = "onnx.Constant"() {
+      value = dense<4> : tensor<1xi64>
+    } : () -> tensor<1xi64>
+    %result = "onnx.Reshape"(%data, %target) {allowzero = 0 : si64}
+      : (tensor<2x2xf16>, tensor<1xi64>) -> tensor<4xf16>
+    return %result, %wide : tensor<4xf16>, i128
+  }
+
+  // Materialization updates only the Reshape operand. The complete proven
+  // vector remains available to an unrelated non-Reshape consumer.
+  // RAW-LABEL: func.func @partial_shape_user
+  // RAW: %[[FULL:.*]] = tensor.from_elements
+  // RAW: %[[RESHAPE_SHAPE:.*]] = tensor.from_elements
+  // RAW: tensor.reshape %{{.*}}(%[[RESHAPE_SHAPE]])
+  // RAW: call @consume_shape(%{{.*}}, %[[FULL]])
+  func.func @partial_shape_user(
+      %data: tensor<?x?xf16>) -> tensor<?x1xf16> {
+    %c0 = arith.constant 0 : index
+    %d0 = tensor.dim %data, %c0 : tensor<?x?xf16>
+    %d0i64 = arith.index_cast %d0 : index to i64
+    %one = arith.constant 1 : i64
+    %seven = arith.constant 7 : i64
+    %full = tensor.from_elements %d0i64, %one, %seven : tensor<3xi64>
+    %starts = "onnx.Constant"() {value = dense<0> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %ends = "onnx.Constant"() {value = dense<2> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %axes = "onnx.Constant"() {value = dense<0> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %slice = "onnx.Slice"(%full, %starts, %ends, %axes)
+      : (tensor<3xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>)
+        -> tensor<2xi64>
+    %result = "onnx.Reshape"(%data, %slice) {allowzero = 1 : si64}
+      : (tensor<?x?xf16>, tensor<2xi64>) -> tensor<?x1xf16>
+    func.call @consume_shape(%full) : (tensor<3xi64>) -> ()
+    return %result : tensor<?x1xf16>
+  }
+
+  // A shared producer subgraph is analyzed once and both consumers receive
+  // the same payload fact without synchronized readback.
+  // CHECK-LABEL: func.func @shared_shape_subgraph
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK-COUNT-2: tensor.reshape
+  func.func @shared_shape_subgraph(
+      %lhs: tensor<?x?xf16>,
+      %rhs: tensor<?x?xf16>) -> (tensor<?x4xf16>, tensor<?x4xf16>) {
+    %shape = "onnx.Shape"(%lhs)
+      : (tensor<?x?xf16>) -> tensor<2xi64>
+    %lhsResult = "onnx.Reshape"(%lhs, %shape) {allowzero = 1 : si64}
+      : (tensor<?x?xf16>, tensor<2xi64>) -> tensor<?x4xf16>
+    %rhsResult = "onnx.Reshape"(%rhs, %shape) {allowzero = 1 : si64}
+      : (tensor<?x?xf16>, tensor<2xi64>) -> tensor<?x4xf16>
+    return %lhsResult, %rhsResult : tensor<?x4xf16>, tensor<?x4xf16>
+  }
+
+  // Identical payloads reaching a block argument from distinct CFG
+  // predecessors survive the lattice join.
+  // CHECK-LABEL: func.func @identical_dataflow_join
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK: tensor.reshape
+  func.func @identical_dataflow_join(
+      %data: tensor<?x?xf16>,
+      %condition: i1) -> tensor<?x4xf16> {
+    %shape = "onnx.Shape"(%data)
+      : (tensor<?x?xf16>) -> tensor<2xi64>
+    cf.cond_br %condition, ^left(%shape : tensor<2xi64>),
+      ^right(%shape : tensor<2xi64>)
+  ^left(%leftShape: tensor<2xi64>):
+    cf.br ^join(%leftShape : tensor<2xi64>)
+  ^right(%rightShape: tensor<2xi64>):
+    cf.br ^join(%rightShape : tensor<2xi64>)
+  ^join(%joinedShape: tensor<2xi64>):
+    %result = "onnx.Reshape"(%data, %joinedShape) {allowzero = 1 : si64}
+      : (tensor<?x?xf16>, tensor<2xi64>) -> tensor<?x4xf16>
+    return %result : tensor<?x4xf16>
+  }
+
+  // Divergent payloads conservatively join to unknown and retain synchronized
+  // fallback reads.
+  // CHECK-LABEL: func.func @divergent_dataflow_join
+  // CHECK-COUNT-2: hip.readback_scalar
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK: tensor.reshape
+  func.func @divergent_dataflow_join(
+      %data: tensor<?x?xf16>,
+      %condition: i1) -> tensor<?x4xf16> {
+    %shape = "onnx.Shape"(%data)
+      : (tensor<?x?xf16>) -> tensor<2xi64>
+    %ones = "onnx.Constant"() {
+      value = dense<1> : tensor<2xi64>
+    } : () -> tensor<2xi64>
+    cf.cond_br %condition, ^left(%shape : tensor<2xi64>),
+      ^right(%ones : tensor<2xi64>)
+  ^left(%leftShape: tensor<2xi64>):
+    cf.br ^join(%leftShape : tensor<2xi64>)
+  ^right(%rightShape: tensor<2xi64>):
+    cf.br ^join(%rightShape : tensor<2xi64>)
+  ^join(%joinedShape: tensor<2xi64>):
+    %result = "onnx.Reshape"(%data, %joinedShape) {allowzero = 1 : si64}
+      : (tensor<?x?xf16>, tensor<2xi64>) -> tensor<?x4xf16>
+    return %result : tensor<?x4xf16>
+  }
+
+  // One proven and one unknown incoming payload also joins to unknown.
+  // CHECK-LABEL: func.func @interesting_unknown_dataflow_join
+  // CHECK-COUNT-2: hip.readback_scalar
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK: tensor.reshape
+  func.func @interesting_unknown_dataflow_join(
+      %data: tensor<?x?xf16>,
+      %unknown: tensor<2xi64>,
+      %condition: i1) -> tensor<?x4xf16> {
+    %shape = "onnx.Shape"(%data)
+      : (tensor<?x?xf16>) -> tensor<2xi64>
+    cf.cond_br %condition, ^left(%shape : tensor<2xi64>),
+      ^right(%unknown : tensor<2xi64>)
+  ^left(%leftShape: tensor<2xi64>):
+    cf.br ^join(%leftShape : tensor<2xi64>)
+  ^right(%rightShape: tensor<2xi64>):
+    cf.br ^join(%rightShape : tensor<2xi64>)
+  ^join(%joinedShape: tensor<2xi64>):
+    %result = "onnx.Reshape"(%data, %joinedShape) {allowzero = 1 : si64}
+      : (tensor<?x?xf16>, tensor<2xi64>) -> tensor<?x4xf16>
+    return %result : tensor<?x4xf16>
+  }
+
+  // hip.loop has an outlined body whose result dimensions cannot be inferred
+  // from v_init alone. Keep the target rooted at %initial instead of claiming
+  // equivalence with the loop result.
+  // RAW-LABEL: func.func @direct_hip_loop_no_propagation
+  // RAW-SAME: %[[INITIAL:[A-Za-z0-9_]+]]: tensor<?x4xf16>
+  // RAW: %[[LOOP:.*]] = hip.loop
+  // RAW: %[[INITIAL_DIM:.*]] = tensor.dim %[[INITIAL]],
+  // RAW-NEXT: %[[INITIAL_DIM_I64:.*]] = arith.index_cast %[[INITIAL_DIM]]
+  // RAW-NEXT: %[[LOOP_TARGET:.*]] = tensor.from_elements %[[INITIAL_DIM_I64]],
+  // RAW: tensor.reshape %[[LOOP]](%[[LOOP_TARGET]])
+  func.func @direct_hip_loop_no_propagation(
+      %ctx: !hip.context,
+      %tripCount: index,
+      %condition: i1,
+      %initial: tensor<?x4xf16>) -> tensor<?x?xf16> {
+    %loop = hip.loop(%ctx, %tripCount, %condition)
+      iter_args(%initial : tensor<?x4xf16>)
+      -> (tensor<?x4xf16>)
+      body @direct_loop_body
+      {cond_is_passthrough, num_loop_carried = 1 : i32}
+    %c0 = arith.constant 0 : index
+    %d0 = tensor.dim %initial, %c0 : tensor<?x4xf16>
+    %d0i64 = arith.index_cast %d0 : index to i64
+    %c4 = arith.constant 4 : i64
+    %target = tensor.from_elements %d0i64, %c4 : tensor<2xi64>
+    %result = "onnx.Reshape"(%loop, %target) {allowzero = 1 : si64}
+      : (tensor<?x4xf16>, tensor<2xi64>) -> tensor<?x?xf16>
+    return %result : tensor<?x?xf16>
+  }
+
+  // A divergent loop backedge must widen the iter-arg payload to unknown.
+  // CHECK-LABEL: func.func @divergent_loop_backedge
+  // CHECK-COUNT-3: hip.readback_scalar
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK: tensor.reshape
+  func.func @divergent_loop_backedge(
+      %data: tensor<?x?xf16>,
+      %lb: index, %ub: index, %step: index) -> tensor<?x?x?xf16> {
+    %shape = "onnx.Shape"(%data)
+      : (tensor<?x?xf16>) -> tensor<2xi64>
+    %one = "onnx.Constant"() {value = dense<1> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %initial = "onnx.Concat"(%shape, %one) {axis = 0 : si64}
+      : (tensor<2xi64>, tensor<1xi64>) -> tensor<3xi64>
+    %other = "onnx.Constant"() {
+      value = dense<[1, 1, 1]> : tensor<3xi64>
+    } : () -> tensor<3xi64>
+    %joined = scf.for %iv = %lb to %ub step %step
+        iter_args(%carried = %initial) -> tensor<3xi64> {
+      scf.yield %other : tensor<3xi64>
+    }
+    %result = "onnx.Reshape"(%data, %joined) {allowzero = 1 : si64}
+      : (tensor<?x?xf16>, tensor<3xi64>) -> tensor<?x?x?xf16>
+    return %result : tensor<?x?x?xf16>
+  }
+
+  // Divergent RegionBranch results also join to unknown.
+  // CHECK-LABEL: func.func @divergent_region_result
+  // CHECK-COUNT-3: hip.readback_scalar
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK: tensor.reshape
+  func.func @divergent_region_result(
+      %data: tensor<?x?xf16>,
+      %condition: i1) -> tensor<?x?x?xf16> {
+    %shape = "onnx.Shape"(%data)
+      : (tensor<?x?xf16>) -> tensor<2xi64>
+    %one = "onnx.Constant"() {value = dense<1> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+    %proven = "onnx.Concat"(%shape, %one) {axis = 0 : si64}
+      : (tensor<2xi64>, tensor<1xi64>) -> tensor<3xi64>
+    %other = "onnx.Constant"() {
+      value = dense<[1, 1, 1]> : tensor<3xi64>
+    } : () -> tensor<3xi64>
+    %joined = scf.if %condition -> tensor<3xi64> {
+      scf.yield %proven : tensor<3xi64>
+    } else {
+      scf.yield %other : tensor<3xi64>
+    }
+    %result = "onnx.Reshape"(%data, %joined) {allowzero = 1 : si64}
+      : (tensor<?x?xf16>, tensor<3xi64>) -> tensor<?x?x?xf16>
+    return %result : tensor<?x?x?xf16>
+  }
+
+  func.func private @consume_shape(tensor<3xi64>)
+  func.func private @direct_loop_body(
+      !hip.context, index, i1, tensor<?x4xf16>) -> tensor<?x4xf16>
+}

--- a/test/lit/Conversion/onnx-to-hip/test_reshape_shape_provenance.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_reshape_shape_provenance.mlir
@@ -370,13 +370,14 @@ module {
     return %result : tensor<?x4xf32>
   }
 
-  // Two dynamic Add operands are ambiguous: the correct broadcast select must
-  // remain because neither dimension is proven to be the canonical source.
-  // CHECK-LABEL: func.func @ambiguous_add_keeps_select
+  // Two dynamic Add operands remain ambiguous to provenance. This stack layer
+  // still uses the foundation's deferred destination materialization policy;
+  // exact broadcast fallback is activated together with symbolic proofs later.
+  // CHECK-LABEL: func.func @ambiguous_add_defers_exact_materialization
   // CHECK-NOT: hip.readback_scalar
-  // CHECK: arith.select
+  // CHECK-NOT: arith.select
   // CHECK: tensor.reshape
-  func.func @ambiguous_add_keeps_select(
+  func.func @ambiguous_add_defers_exact_materialization(
       %lhs: tensor<?x?x4xf16>,
       %rhs: tensor<?x?x4xf16>) -> tensor<?x?x?x?xf16> {
     %sum = "onnx.Add"(%lhs, %rhs)

--- a/test/lit/Conversion/onnx-to-hip/test_reshape_shape_provenance_invalid.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_reshape_shape_provenance_invalid.mlir
@@ -1,0 +1,172 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip \
+// RUN:   --split-input-file --verify-diagnostics
+
+module {
+  func.func @main_graph(
+      %data: tensor<?x?xf16>,
+      %shape: tensor<3xi64>) -> tensor<?x?x?xf16> {
+    // expected-error@+1 {{nonnegative shape proof requires host shape proof}}
+    %result = "onnx.Reshape"(%data, %shape) {
+      allowzero = 0 : si64, hip.host_shape_no_minus_one
+    } : (tensor<?x?xf16>, tensor<3xi64>) -> tensor<?x?x?xf16>
+    return %result : tensor<?x?x?xf16>
+  }
+}
+
+// -----
+
+module {
+  func.func @main_graph(
+      %data: tensor<?xf16>,
+      %shape: tensor<1xi64>) {
+    // expected-error@+1 {{onnx.Reshape expects exactly two operands and one result}}
+    "onnx.Reshape"(%data, %shape)
+      : (tensor<?xf16>, tensor<1xi64>) -> ()
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @main_graph(
+      %data: tensor<?x?xf16>) -> tensor<?x?x?xf16> {
+    %c0 = arith.constant 0 : index
+    %d0 = tensor.dim %data, %c0 : tensor<?x?xf16>
+    %d0i64 = arith.index_cast %d0 : index to i64
+    %c1 = arith.constant 1 : i64
+    %target = tensor.from_elements %d0i64, %c1, %c1 : tensor<3xi64>
+    // expected-error@+1 {{host shape proof requires an input-dimension map}}
+    %result = "onnx.Reshape"(%data, %target) {
+      allowzero = 0 : si64, hip.host_shape_operand
+    } : (tensor<?x?xf16>, tensor<3xi64>) -> tensor<?x?x?xf16>
+    return %result : tensor<?x?x?xf16>
+  }
+}
+
+// -----
+
+module {
+  func.func @main_graph(
+      %data: tensor<?x?x?xf16>) -> tensor<?x?x3xf16> {
+    %c0 = arith.constant 0 : index
+    %d0 = tensor.dim %data, %c0 : tensor<?x?x?xf16>
+    %d0i64 = arith.index_cast %d0 : index to i64
+    %minusOne = arith.constant -1 : i64
+    %three = arith.constant 3 : i64
+    %target = tensor.from_elements %d0i64, %minusOne, %three : tensor<3xi64>
+    // expected-error@+1 {{allowzero=1 with -1 requires positive proven target dimensions}}
+    %result = "onnx.Reshape"(%data, %target) {
+      allowzero = 1 : si64,
+      hip.host_shape_input_dim_map = array<i64: -1, -1, -1>,
+      hip.host_shape_operand
+    } : (tensor<?x?x?xf16>, tensor<3xi64>) -> tensor<?x?x3xf16>
+    return %result : tensor<?x?x3xf16>
+  }
+}
+
+// -----
+
+module {
+  func.func @main_graph(
+      %data: tensor<?x?xf16>,
+      %other: tensor<?x?xf16>) -> tensor<?x?x?xf16> {
+    %c0 = arith.constant 0 : index
+    %otherD0 = tensor.dim %other, %c0 : tensor<?x?xf16>
+    %otherD0i64 = arith.index_cast %otherD0 : index to i64
+    %c1 = arith.constant 1 : i64
+    %target = tensor.from_elements %otherD0i64, %c1, %c1 : tensor<3xi64>
+    // expected-error@+1 {{invalid input-dimension equivalence proof}}
+    %result = "onnx.Reshape"(%data, %target) {
+      allowzero = 0 : si64,
+      hip.host_shape_input_dim_map = array<i64: 0, -1, -1>,
+      hip.host_shape_operand,
+      hip.host_shape_no_minus_one
+    } : (tensor<?x?xf16>, tensor<3xi64>) -> tensor<?x?x?xf16>
+    return %result : tensor<?x?x?xf16>
+  }
+}
+
+// -----
+
+module {
+  func.func @main_graph(
+      %data: tensor<?x?xf16>) -> tensor<?x?x?xf16> {
+    %target = "onnx.Constant"() {
+      value = dense<[1, 1, 0]> : tensor<3xi64>
+    } : () -> tensor<3xi64>
+    // expected-error@+1 {{out-of-rank Reshape target entry cannot be zero}}
+    %result = "onnx.Reshape"(%data, %target) {allowzero = 0 : si64}
+      : (tensor<?x?xf16>, tensor<3xi64>) -> tensor<?x?x?xf16>
+    return %result : tensor<?x?x?xf16>
+  }
+}
+
+// -----
+
+module {
+  func.func @main_graph(
+      %data: tensor<?x?xf16>,
+      %shape: tensor<2xi64>) -> tensor<?x?x?xf16> {
+    %c0 = arith.constant 0 : index
+    %unsafe = tensor.extract %shape[%c0] : tensor<2xi64>
+    %c1 = arith.constant 1 : i64
+    %target = tensor.from_elements %unsafe, %c1, %c1 : tensor<3xi64>
+    // expected-error@+1 {{proven host shape contains unsafe scalar}}
+    %result = "onnx.Reshape"(%data, %target) {
+      allowzero = 0 : si64,
+      hip.host_shape_input_dim_map = array<i64: -1, -1, -1>,
+      hip.host_shape_operand,
+      hip.host_shape_no_minus_one
+    } : (tensor<?x?xf16>, tensor<3xi64>) -> tensor<?x?x?xf16>
+    return %result : tensor<?x?x?xf16>
+  }
+}
+
+// -----
+
+module {
+  func.func @main_graph(
+      %data: tensor<?x?xf16>) -> tensor<?x?x?xf16> {
+    %target = "onnx.Constant"() {
+      value = dense<[-2, 1, 1]> : tensor<3xi64>
+    } : () -> tensor<3xi64>
+    // expected-error@+1 {{Reshape target dimensions must be at least -1}}
+    %result = "onnx.Reshape"(%data, %target) {allowzero = 0 : si64}
+      : (tensor<?x?xf16>, tensor<3xi64>) -> tensor<?x?x?xf16>
+    return %result : tensor<?x?x?xf16>
+  }
+}
+
+// -----
+
+module {
+  func.func @main_graph(
+      %data: tensor<?x?xf16>) -> tensor<?x?x?xf16> {
+    %target = "onnx.Constant"() {
+      value = dense<[-1, -1, 1]> : tensor<3xi64>
+    } : () -> tensor<3xi64>
+    // expected-error@+1 {{Reshape target may contain at most one -1}}
+    %result = "onnx.Reshape"(%data, %target) {allowzero = 0 : si64}
+      : (tensor<?x?xf16>, tensor<3xi64>) -> tensor<?x?x?xf16>
+    return %result : tensor<?x?x?xf16>
+  }
+}
+
+// -----
+
+module {
+  func.func @main_graph(
+      %data: tensor<?x?xf16>) -> tensor<?x?x?xf16> {
+    %target = "onnx.Constant"() {
+      value = dense<[0, -1, 1]> : tensor<3xi64>
+    } : () -> tensor<3xi64>
+    // expected-error@+1 {{Reshape cannot combine allowzero=1, zero, and -1}}
+    %result = "onnx.Reshape"(%data, %target) {allowzero = 1 : si64}
+      : (tensor<?x?xf16>, tensor<3xi64>) -> tensor<?x?x?xf16>
+    return %result : tensor<?x?x?xf16>
+  }
+}

--- a/test/lit/Dialect/hip-resolve-tensor-dims.mlir
+++ b/test/lit/Dialect/hip-resolve-tensor-dims.mlir
@@ -33,6 +33,16 @@
 
 // -----
 
+// CHECK-LABEL: @select_of_same_shape_value
+// CHECK-NOT: arith.select
+// CHECK: return %arg1
+func.func @select_of_same_shape_value(%condition: i1, %extent: i64) -> i64 {
+  %selected = arith.select %condition, %extent, %extent : i64
+  return %selected : i64
+}
+
+// -----
+
 // CHECK-LABEL: @dim_of_expand_static_slot
 func.func @dim_of_expand_static_slot(%arg0: tensor<?x4096xf16>) -> index {
   %c0 = arith.constant 0 : index

--- a/test/numeric/tests/test_shape_ops.py
+++ b/test/numeric/tests/test_shape_ops.py
@@ -3,10 +3,10 @@
 # Licensed under the MIT License.
 #
 
-"""Tests for data-rearrangement / shape ops: Tile, Expand, Pad, GatherND,
-Slice, ScatterND.
+"""Tests for data-rearrangement / shape ops: Reshape, Tile, Expand, Pad,
+GatherND, Slice, ScatterND.
 
-All six ops are added by the qwen-vision-kernels PR. They share a common
+The runtime-shaped operations share a common
 property: the **shape** of an output depends on a graph-time tensor (repeats
 for Tile, shape for Expand, pads for Pad, indices for GatherND, starts/ends
 for Slice, indices for ScatterND). The runtime D2H-reads these small tensors
@@ -33,6 +33,74 @@ from onnx import TensorProto, helper, numpy_helper
 
 from framework.comparator import compare_outputs
 from framework.onnx_utils import make_model_from_nodes, np_to_onnx_type
+
+
+# ---------------------------------------------------------------------------
+# Reshape
+# ---------------------------------------------------------------------------
+def _make_runtime_reshape_model(
+    dtype, input_rank: int, output_rank: int, allowzero: int
+):
+    tp = np_to_onnx_type(dtype)
+    X = helper.make_tensor_value_info("X", tp, [None] * input_rank)
+    shape = helper.make_tensor_value_info("shape", TensorProto.INT64, [output_rank])
+    Y = helper.make_tensor_value_info("Y", tp, [None] * output_rank)
+    reshape = helper.make_node(
+        "Reshape", ["X", "shape"], ["reshaped"], allowzero=allowzero
+    )
+    zero = numpy_helper.from_array(np.asarray(0, dtype=dtype), name="zero")
+    add = helper.make_node("Add", ["reshaped", "zero"], ["Y"])
+    return make_model_from_nodes([reshape, add], [X, shape], [Y], initializers=[zero])
+
+
+def _make_provenance_reshape_model(dtype):
+    """Build Shape->Gather->Unsqueeze->Concat->Reshape provenance."""
+    tp = np_to_onnx_type(dtype)
+    X = helper.make_tensor_value_info("X", tp, [None, None, None])
+    Y = helper.make_tensor_value_info("Y", tp, [None, None])
+    index = numpy_helper.from_array(np.asarray(1, dtype=np.int64), name="index")
+    axes = numpy_helper.from_array(np.asarray([0], dtype=np.int64), name="axes")
+    suffix = numpy_helper.from_array(np.asarray([8], dtype=np.int64), name="suffix")
+    zero = numpy_helper.from_array(np.asarray(0, dtype=dtype), name="zero")
+    nodes = [
+        helper.make_node("Shape", ["X"], ["input_shape"]),
+        helper.make_node("Gather", ["input_shape", "index"], ["middle_dim"], axis=0),
+        helper.make_node("Unsqueeze", ["middle_dim", "axes"], ["middle_dim_vec"]),
+        helper.make_node(
+            "Concat", ["middle_dim_vec", "suffix"], ["target_shape"], axis=0
+        ),
+        helper.make_node("Reshape", ["X", "target_shape"], ["reshaped"], allowzero=1),
+        helper.make_node("Add", ["reshaped", "zero"], ["Y"]),
+    ]
+    return make_model_from_nodes(
+        nodes, [X], [Y], initializers=[index, axes, suffix, zero]
+    )
+
+
+class TestRuntimeReshape:
+    @pytest.mark.parametrize(
+        "input_shape,target_shape,allowzero",
+        [
+            ((2, 3, 4), (6, 4), 0),
+            ((2, 6), (0, 3, 2), 0),
+            ((2, 6), (-1, 2, 2), 0),
+            ((0, 6), (0, 3, 2), 1),
+        ],
+    )
+    def test_runtime_reshape(self, model_runner, input_shape, target_shape, allowzero):
+        model = _make_runtime_reshape_model(
+            np.float32, len(input_shape), len(target_shape), allowzero
+        )
+        x = np.arange(np.prod(input_shape), dtype=np.float32).reshape(input_shape)
+        shape = np.asarray(target_shape, dtype=np.int64)
+        actual, expected = model_runner.run_sample(model, [x, shape])
+        compare_outputs(actual, expected, atol=0)
+
+    def test_shape_gather_concat_provenance(self, model_runner):
+        model = _make_provenance_reshape_model(np.float32)
+        x = np.arange(24, dtype=np.float32).reshape(2, 3, 4)
+        actual, expected = model_runner.run_sample(model, [x])
+        compare_outputs(actual, expected, atol=0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

ONNX Reshape targets are often assembled from values that already exist on the host, but the compiler could lose that provenance and treat the target as an arbitrary device payload. That forced a synchronized readback even when descriptor dimensions could have remained host SSA.

This affected Gemma reshape paths in particular. Recovering the complete host-derived target avoids unnecessary payload readback while preserving the synchronized fallback whenever the proof is incomplete or unsupported.

This PR fixes Reshape provenance only. It does not activate exact broadcast destination materialization; that production activation remains deferred to [#725](https://github.com/ROCm/hip-ep/pull/725).

## IR example

The main provenance test builds a Reshape target from Shape, Gather, Unsqueeze, and Concat:

```mlir
func.func @proven_shape_chain(
    %data: tensor<?x?x?xf16>) -> tensor<?x?x?x?xf16> {
  %idx0 = "onnx.Constant"() {value = dense<0> : tensor<i64>}
    : () -> tensor<i64>
  %idx1 = "onnx.Constant"() {value = dense<1> : tensor<i64>}
    : () -> tensor<i64>
  %axes = "onnx.Constant"() {value = dense<0> : tensor<1xi64>}
    : () -> tensor<1xi64>
  %c16 = "onnx.Constant"() {value = dense<16> : tensor<1xi64>}
    : () -> tensor<1xi64>
  %c72 = "onnx.Constant"() {value = dense<72> : tensor<1xi64>}
    : () -> tensor<1xi64>
  %shape = "onnx.Shape"(%data)
    : (tensor<?x?x?xf16>) -> tensor<3xi64>
  %d0 = "onnx.Gather"(%shape, %idx0) {axis = 0 : si64}
    : (tensor<3xi64>, tensor<i64>) -> tensor<i64>
  %d1 = "onnx.Gather"(%shape, %idx1) {axis = 0 : si64}
    : (tensor<3xi64>, tensor<i64>) -> tensor<i64>
  %u0 = "onnx.Unsqueeze"(%d0, %axes)
    : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
  %u1 = "onnx.Unsqueeze"(%d1, %axes)
    : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
  %target = "onnx.Concat"(%u0, %u1, %c16, %c72) {axis = 0 : si64}
    : (tensor<1xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>)
      -> tensor<4xi64>
  %result = "onnx.Reshape"(%data, %target) {allowzero = 0 : si64}
    : (tensor<?x?x?xf16>, tensor<4xi64>) -> tensor<?x?x?x?xf16>
  return %result : tensor<?x?x?x?xf16>
}
```

After conversion and provenance materialization, the target is rebuilt from host-visible descriptor dimensions and constants:

```mlir
%c0 = arith.constant 0 : index
%c1 = arith.constant 1 : index
%d0 = tensor.dim %data, %c0 : tensor<?x?x?xf16>
%d0_i64 = arith.index_cast %d0 : index to i64
%d1 = tensor.dim %data, %c1 : tensor<?x?x?xf16>
%d1_i64 = arith.index_cast %d1 : index to i64
%c16 = arith.constant 16 : i64
%c72 = arith.constant 72 : i64
%target = tensor.from_elements %d0_i64, %d1_i64, %c16, %c72 : tensor<4xi64>
%result = tensor.reshape %data(%target)
    : (tensor<?x?x?xf16>, tensor<4xi64>) -> tensor<?x?x?x?xf16>
```

No `hip.readback_scalar` is emitted for this proven chain. An opaque target tensor still takes the synchronized fallback.

## What changes

- Analyze supported shape-producing SSA once per function.
- Canonicalize complete host-derived ONNX Reshape targets into host SSA dimensions.
- Fix the provenance path used by Gemma reshapes without broadening the proof beyond supported producers.
- Materialize a recovered target only when every required value has a conservative proof.
- Preserve synchronized payload readback as the fallback for incomplete or unsupported provenance.
- Harden handling for `allowzero`, inferred `-1` dimensions, index-width conversion, control-flow boundaries, and malformed IR.
- Keep exact broadcast activation out of this layer; [#725](https://github.com/ROCm/hip-ep/pull/725) enables it after symbolic transport and provenance are in place.

## Stack

Merged prerequisite plus the 22 active shape PRs:

1. [#688 — refactor(hip): externalize constants after ONNX conversion](https://github.com/ROCm/hip-ep/pull/688)
2. [#724 — feat(shape): preserve symbolic compiler inputs](https://github.com/ROCm/hip-ep/pull/724)
3. [#639 — refactor(hip): establish shared shape-rule foundation](https://github.com/ROCm/hip-ep/pull/639)
4. [#681 — fix(shape): canonicalize host reshape provenance](https://github.com/ROCm/hip-ep/pull/681) ← this PR
5. [#725 — fix(shape): activate exact broadcasts with symbolic proofs](https://github.com/ROCm/hip-ep/pull/725)
6. [#734 — fix(shape): share MatMul and Gemm contracts](https://github.com/ROCm/hip-ep/pull/734)
7. [#641 — fix(shape): enforce shared broadcast contracts](https://github.com/ROCm/hip-ep/pull/641)
8. [#735 — refactor(conversion): share ONNX reduction conversion](https://github.com/ROCm/hip-ep/pull/735)
9. [#736 — fix(shape): normalize reduction contracts](https://github.com/ROCm/hip-ep/pull/736)
10. [#643 — fix(shape): share convolution contracts](https://github.com/ROCm/hip-ep/pull/643)
11. [#742 — fix(shape): share causal convolution contracts](https://github.com/ROCm/hip-ep/pull/742)
12. [#645 — fix(shape): share normalization contracts](https://github.com/ROCm/hip-ep/pull/645)
13. [#740 — fix(shape): share attention contracts](https://github.com/ROCm/hip-ep/pull/740)
14. [#741 — fix(shape): share GQA capacity contracts](https://github.com/ROCm/hip-ep/pull/741)
15. [#644 — fix(shape): share gather and tensor contracts](https://github.com/ROCm/hip-ep/pull/644)
16. [#727 — feat(shape): consume constant payload shapes directly](https://github.com/ROCm/hip-ep/pull/727)
17. [#728 — feat(shape): add exact Tile and Range destinations](https://github.com/ROCm/hip-ep/pull/728)
18. [#646 — refactor(hip): declare explicit DPS shape contracts](https://github.com/ROCm/hip-ep/pull/646)
19. [#730 — test(hip): audit explicit DPS contract inventory](https://github.com/ROCm/hip-ep/pull/730)
20. [#732 — test(hip): audit ONNX converter deduplication](https://github.com/ROCm/hip-ep/pull/732)
21. [#647 — fix(hip): harden shape refinement failure handling](https://github.com/ROCm/hip-ep/pull/647)
22. [#761 — refactor(hip): split shape utility headers by family](https://github.com/ROCm/hip-ep/pull/761)
23. [#764 — refactor(hip): clarify shape destination authority](https://github.com/ROCm/hip-ep/pull/764)

## AI assistance

AI tools assisted with the shape-provenance implementation, edge-case hardening, validation, and stack reconstruction. The contributor reviewed the resulting code and technical claims.

Made-with: Cursor

