### PR TITLE
feat(hipsr): assign pool offsets per group

### DIFF
--- a/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
@@ -21,6 +21,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <utility>
 
 namespace mlir {
 namespace hipsr {
@@ -227,12 +228,8 @@ Value findContext(Block &body) {
   return nullptr;
 }
 
-Value emitPool(OpBuilder &builder, Location loc, Value ctx,
-               llvm::ArrayRef<Value> groupSizes, uint64_t domainId) {
-  Value poolSize = groupSizes.front();
-  for (Value groupSize : groupSizes.drop_front()) {
-    poolSize = arith::AddIOp::create(builder, loc, poolSize, groupSize);
-  }
+Value emitPool(OpBuilder &builder, Location loc, Value ctx, Value poolSize,
+               uint64_t domainId) {
   auto deviceSpace =
       MemorySpaceAttr::get(builder.getContext(), MemorySpaceKind::Device);
   auto poolType = MemRefType::get({ShapedType::kDynamic}, builder.getI8Type(),
@@ -240,15 +237,17 @@ Value emitPool(OpBuilder &builder, Location loc, Value ctx,
   return GetPoolOp::create(builder, loc, poolType, ctx, poolSize, domainId);
 }
 
-llvm::SmallVector<Value> emitOffsets(OpBuilder &builder, Location loc,
-                                     llvm::ArrayRef<Value> groupSizes) {
+std::pair<llvm::SmallVector<Value>, Value>
+emitPoolLayout(OpBuilder &builder, Location loc,
+               llvm::ArrayRef<Value> groupSizes) {
   llvm::SmallVector<Value> offsets;
   offsets.push_back(arith::ConstantIndexOp::create(builder, loc, 0));
-  for (Value groupSize : groupSizes.drop_back()) {
-    offsets.push_back(
-        arith::AddIOp::create(builder, loc, offsets.back(), groupSize));
+  Value poolSize = groupSizes.front();
+  for (Value groupSize : groupSizes.drop_front()) {
+    offsets.push_back(poolSize);
+    poolSize = arith::AddIOp::create(builder, loc, poolSize, groupSize);
   }
-  return offsets;
+  return {offsets, poolSize};
 }
 
 struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
@@ -285,8 +284,9 @@ struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
         groupSizes.push_back(
             emitGroupSize(builder, domain.getLoc(), group, kPoolAlignment));
       }
-      emitPool(builder, domain.getLoc(), ctx, groupSizes, domain.getDomainId());
-      emitOffsets(builder, domain.getLoc(), groupSizes);
+      auto [offsets, poolSize] =
+          emitPoolLayout(builder, domain.getLoc(), groupSizes);
+      emitPool(builder, domain.getLoc(), ctx, poolSize, domain.getDomainId());
     });
   }
 };

--- a/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
@@ -240,6 +240,17 @@ Value emitPool(OpBuilder &builder, Location loc, Value ctx,
   return GetPoolOp::create(builder, loc, poolType, ctx, poolSize, domainId);
 }
 
+llvm::SmallVector<Value> emitOffsets(OpBuilder &builder, Location loc,
+                                     llvm::ArrayRef<Value> groupSizes) {
+  llvm::SmallVector<Value> offsets;
+  offsets.push_back(arith::ConstantIndexOp::create(builder, loc, 0));
+  for (Value groupSize : groupSizes.drop_back()) {
+    offsets.push_back(
+        arith::AddIOp::create(builder, loc, offsets.back(), groupSize));
+  }
+  return offsets;
+}
+
 struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
   using impl::HipsrPoolAllocPassBase<
       HipsrPoolAllocPass>::HipsrPoolAllocPassBase;
@@ -275,6 +286,7 @@ struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
             emitGroupSize(builder, domain.getLoc(), group, kPoolAlignment));
       }
       emitPool(builder, domain.getLoc(), ctx, groupSizes, domain.getDomainId());
+      emitOffsets(builder, domain.getLoc(), groupSizes);
     });
   }
 };

--- a/test/lit/Dialect/Hipsr/pool_alloc.mlir
+++ b/test/lit/Dialect/Hipsr/pool_alloc.mlir
@@ -19,8 +19,8 @@
 // CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[C6]], %[[C255]] : index
 // CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
 // CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
-// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
 // CHECK-NEXT: arith.constant 0 : index
+// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
 // CHECK-NOT: arith.maxui
 func.func @align_up_rounding(%ctx: !hipsr.context,
                         %in: memref<3xf16, #hipsr.mem<device>>) {
@@ -49,8 +49,8 @@ func.func @align_up_rounding(%ctx: !hipsr.context,
 // CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[BYTES]], %[[C255]] : index
 // CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
 // CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
-// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
 // CHECK-NEXT: arith.constant 0 : index
+// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
 func.func @dynamic_size(%ctx: !hipsr.context,
                    %in: memref<?x512xf16, #hipsr.mem<device>>) {
   hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<?x512xf16, #hipsr.mem<device>>) {
@@ -78,8 +78,8 @@ func.func @dynamic_size(%ctx: !hipsr.context,
 // CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[C8192]], %[[C255]] : index
 // CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
 // CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
-// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
 // CHECK-NEXT: arith.constant 0 : index
+// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
 // CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%[[LIVE]] : memref<4x1024xf16, #hipsr.mem<device>>)
 // CHECK-NOT: arith.maxui
 func.func @dead_alloc_skipped(%ctx: !hipsr.context,
@@ -113,8 +113,8 @@ func.func @dead_alloc_skipped(%ctx: !hipsr.context,
 // CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[M2]], %[[C255]] : index
 // CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
 // CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
-// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
 // CHECK-NEXT: arith.constant 0 : index
+// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
 // CHECK-NOT: arith.divui
 func.func @coalesce_static(%ctx: !hipsr.context,
                                %in8: memref<8x1024xf16, #hipsr.mem<device>>,
@@ -166,10 +166,9 @@ func.func @coalesce_static(%ctx: !hipsr.context,
 // CHECK-NEXT: %[[N1:.+]] = arith.addi %[[C8192B]], %[[C255B]] : index
 // CHECK-NEXT: %[[D1:.+]] = arith.divui %[[N1]], %[[C256B]] : index
 // CHECK-NEXT: %[[G1:.+]] = arith.muli %[[D1]], %[[C256B]] : index
+// CHECK-NEXT: arith.constant 0 : index
 // CHECK-NEXT: %[[POOLSZ:.+]] = arith.addi %[[G0]], %[[G1]] : index
 // CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[POOLSZ]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
-// CHECK-NEXT: %[[OFF0:.+]] = arith.constant 0 : index
-// CHECK-NEXT: arith.addi %[[OFF0]], %[[G0]] : index
 // CHECK-NOT: arith.maxui
 func.func @split_two_groups(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr.mem<device>>) {
   hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
@@ -200,10 +199,9 @@ func.func @split_two_groups(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr
 // CHECK-NEXT: %[[N1:.+]] = arith.addi %[[C8192]], %[[C255B]] : index
 // CHECK-NEXT: %[[D1:.+]] = arith.divui %[[N1]], %[[C256B]] : index
 // CHECK-NEXT: %[[G1:.+]] = arith.muli %[[D1]], %[[C256B]] : index
+// CHECK-NEXT: arith.constant 0 : index
 // CHECK-NEXT: %[[POOLSZ:.+]] = arith.addi %[[G0]], %[[G1]] : index
 // CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[POOLSZ]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
-// CHECK-NEXT: %[[OFF0:.+]] = arith.constant 0 : index
-// CHECK-NEXT: arith.addi %[[OFF0]], %[[G0]] : index
 // CHECK-NOT: arith.maxui
 func.func @split_two_groups_dynamic(%ctx: !hipsr.context,
                                     %inf16: memref<?x512xf16, #hipsr.mem<device>>,
@@ -249,12 +247,10 @@ func.func @split_two_groups_dynamic(%ctx: !hipsr.context,
 // CHECK-NEXT: %[[N2:.+]] = arith.addi %[[C8192C]], %[[C255C]] : index
 // CHECK-NEXT: %[[D2:.+]] = arith.divui %[[N2]], %[[C256C]] : index
 // CHECK-NEXT: %[[G2:.+]] = arith.muli %[[D2]], %[[C256C]] : index
+// CHECK-NEXT: arith.constant 0 : index
 // CHECK-NEXT: %[[SUM0:.+]] = arith.addi %[[G0]], %[[G1]] : index
 // CHECK-NEXT: %[[POOLSZ:.+]] = arith.addi %[[SUM0]], %[[G2]] : index
 // CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[POOLSZ]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
-// CHECK-NEXT: %[[OFF0:.+]] = arith.constant 0 : index
-// CHECK-NEXT: %[[OFF1:.+]] = arith.addi %[[OFF0]], %[[G0]] : index
-// CHECK-NEXT: arith.addi %[[OFF1]], %[[G1]] : index
 // CHECK-NOT: arith.maxui
 func.func @split_three_groups(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr.mem<device>>) {
   hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
@@ -277,11 +273,11 @@ func.func @split_three_groups(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hip
 
 // CHECK-LABEL: func.func @two_domains
 // CHECK: %[[G0:.+]] = arith.muli %{{.+}}, %{{.+}} : index
+// CHECK-NEXT: arith.constant 0 : index
 // CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
-// CHECK-NEXT: arith.constant 0 : index
 // CHECK: %[[G1:.+]] = arith.muli %{{.+}}, %{{.+}} : index
-// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G1]]) {domain_id = 7 : i64} : memref<?xi8, #hipsr.mem<device>>
 // CHECK-NEXT: arith.constant 0 : index
+// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G1]]) {domain_id = 7 : i64} : memref<?xi8, #hipsr.mem<device>>
 func.func @two_domains(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr.mem<device>>) {
   hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
   ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):

--- a/test/lit/Dialect/Hipsr/pool_alloc.mlir
+++ b/test/lit/Dialect/Hipsr/pool_alloc.mlir
@@ -9,6 +9,7 @@
 //   chi=1  single point : align_up_rounding, dynamic_size, dead_alloc_skipped
 //   chi=1  independent  : coalesce_static
 //   chi=2  staggered    : split_two_groups, split_two_groups_dynamic
+//   chi=3  clique K3    : split_three_groups
 
 // 3xf16 = 6 B is not a multiple of 256, so the alignUp chain must round up.
 // CHECK-LABEL: func.func @align_up_rounding
@@ -19,6 +20,7 @@
 // CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
 // CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
 // CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: arith.constant 0 : index
 // CHECK-NOT: arith.maxui
 func.func @align_up_rounding(%ctx: !hipsr.context,
                         %in: memref<3xf16, #hipsr.mem<device>>) {
@@ -48,6 +50,7 @@ func.func @align_up_rounding(%ctx: !hipsr.context,
 // CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
 // CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
 // CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: arith.constant 0 : index
 func.func @dynamic_size(%ctx: !hipsr.context,
                    %in: memref<?x512xf16, #hipsr.mem<device>>) {
   hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<?x512xf16, #hipsr.mem<device>>) {
@@ -76,6 +79,7 @@ func.func @dynamic_size(%ctx: !hipsr.context,
 // CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
 // CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
 // CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: arith.constant 0 : index
 // CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%[[LIVE]] : memref<4x1024xf16, #hipsr.mem<device>>)
 // CHECK-NOT: arith.maxui
 func.func @dead_alloc_skipped(%ctx: !hipsr.context,
@@ -110,6 +114,7 @@ func.func @dead_alloc_skipped(%ctx: !hipsr.context,
 // CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
 // CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
 // CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: arith.constant 0 : index
 // CHECK-NOT: arith.divui
 func.func @coalesce_static(%ctx: !hipsr.context,
                                %in8: memref<8x1024xf16, #hipsr.mem<device>>,
@@ -163,6 +168,8 @@ func.func @coalesce_static(%ctx: !hipsr.context,
 // CHECK-NEXT: %[[G1:.+]] = arith.muli %[[D1]], %[[C256B]] : index
 // CHECK-NEXT: %[[POOLSZ:.+]] = arith.addi %[[G0]], %[[G1]] : index
 // CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[POOLSZ]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[OFF0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: arith.addi %[[OFF0]], %[[G0]] : index
 // CHECK-NOT: arith.maxui
 func.func @split_two_groups(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr.mem<device>>) {
   hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
@@ -195,6 +202,8 @@ func.func @split_two_groups(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr
 // CHECK-NEXT: %[[G1:.+]] = arith.muli %[[D1]], %[[C256B]] : index
 // CHECK-NEXT: %[[POOLSZ:.+]] = arith.addi %[[G0]], %[[G1]] : index
 // CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[POOLSZ]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[OFF0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: arith.addi %[[OFF0]], %[[G0]] : index
 // CHECK-NOT: arith.maxui
 func.func @split_two_groups_dynamic(%ctx: !hipsr.context,
                                     %inf16: memref<?x512xf16, #hipsr.mem<device>>,
@@ -221,11 +230,58 @@ func.func @split_two_groups_dynamic(%ctx: !hipsr.context,
 
 // -----
 
+// CHECK-LABEL: func.func @split_three_groups
+// CHECK: %[[C8192A:.+]] = arith.constant 8192 : index
+// CHECK-NEXT: %[[C256A:.+]] = arith.constant 256 : index
+// CHECK-NEXT: %[[C255A:.+]] = arith.constant 255 : index
+// CHECK-NEXT: %[[N0:.+]] = arith.addi %[[C8192A]], %[[C255A]] : index
+// CHECK-NEXT: %[[D0:.+]] = arith.divui %[[N0]], %[[C256A]] : index
+// CHECK-NEXT: %[[G0:.+]] = arith.muli %[[D0]], %[[C256A]] : index
+// CHECK-NEXT: %[[C8192B:.+]] = arith.constant 8192 : index
+// CHECK-NEXT: %[[C256B:.+]] = arith.constant 256 : index
+// CHECK-NEXT: %[[C255B:.+]] = arith.constant 255 : index
+// CHECK-NEXT: %[[N1:.+]] = arith.addi %[[C8192B]], %[[C255B]] : index
+// CHECK-NEXT: %[[D1:.+]] = arith.divui %[[N1]], %[[C256B]] : index
+// CHECK-NEXT: %[[G1:.+]] = arith.muli %[[D1]], %[[C256B]] : index
+// CHECK-NEXT: %[[C8192C:.+]] = arith.constant 8192 : index
+// CHECK-NEXT: %[[C256C:.+]] = arith.constant 256 : index
+// CHECK-NEXT: %[[C255C:.+]] = arith.constant 255 : index
+// CHECK-NEXT: %[[N2:.+]] = arith.addi %[[C8192C]], %[[C255C]] : index
+// CHECK-NEXT: %[[D2:.+]] = arith.divui %[[N2]], %[[C256C]] : index
+// CHECK-NEXT: %[[G2:.+]] = arith.muli %[[D2]], %[[C256C]] : index
+// CHECK-NEXT: %[[SUM0:.+]] = arith.addi %[[G0]], %[[G1]] : index
+// CHECK-NEXT: %[[POOLSZ:.+]] = arith.addi %[[SUM0]], %[[G2]] : index
+// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[POOLSZ]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[OFF0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[OFF1:.+]] = arith.addi %[[OFF0]], %[[G0]] : index
+// CHECK-NEXT: arith.addi %[[OFF1]], %[[G1]] : index
+// CHECK-NOT: arith.maxui
+func.func @split_three_groups(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
+    %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    %a2 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    %a3 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a2 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a3 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a1, %a2 : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a2, %a3 : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a1, %a3 : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  } {domain_id = 0 : i64}
+  return
+}
+
+// -----
+
 // CHECK-LABEL: func.func @two_domains
 // CHECK: %[[G0:.+]] = arith.muli %{{.+}}, %{{.+}} : index
 // CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: arith.constant 0 : index
 // CHECK: %[[G1:.+]] = arith.muli %{{.+}}, %{{.+}} : index
 // CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G1]]) {domain_id = 7 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: arith.constant 0 : index
 func.func @two_domains(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr.mem<device>>) {
   hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
   ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):


### PR DESCRIPTION
## Summary

`hipsr-pool-alloc` now assigns each group a byte offset within the pool: the first group starts at a constant 0 and every later one starts at the running sum of the preceding group sizes.

## Related issue or design

wcy123/onnx-hipdnn-ep#115

## Why

- The offsets and the pool size are two points on one accumulation. Offsets are the exclusive prefix sums of the group sizes, the pool size is their total, so a single running chain yields both: each iteration records the accumulator as the next group's offset before adding the group size to it. Emitting them separately re-derived the same partial sums and opened with an add of zero.
- No alignment step of its own. #671 already rounds every group size up to the pool alignment, so summing aligned sizes yields aligned starts and consecutive groups land in non-overlapping intervals by construction.
- The offsets have no consumer yet. wcy123/onnx-hipdnn-ep#116 rewrites the allocs to `memref.view` over the pool and takes them then.

## What

- `emitPoolLayout` in `HipsrPoolAllocPass.cpp` builds that chain and returns the per-group offsets alongside the pool size. `emitPool` now takes the size as a `Value` instead of summing the group vector itself.
- Because the offsets are the chain's own partial sums, the only op this adds to the emitted IR is the `arith.constant 0` that starts group 0. The chain itself becomes observable in #116, where `memref.view %pool[%off]` binds each offset to the partial sum it reuses.
- `pool_alloc.mlir`: the existing cases expect that constant ahead of `hipsr.get_pool`, and `@two_domains` gets one per domain.
- New `@split_three_groups` covers a K3 interference clique, the smallest topology with more than one link in the chain.

## Test plan

- [x] `check-hip-mlir-lit`: 357 passed, 21 unsupported, and no failure that does not already reproduce on `main` without this change.
- [x] The three `pool_alloc*.mlir` files were confirmed green on `main` before this branch, since #674/#677/#679/#680 landed on top of #673.
- [x] `pre-commit run --all-files` converges in one pass.

## Notes for reviewers

Stacked on #673. #116 will extend these same CHECK blocks again and drop `--implicit-check-not=memref.view` from the RUN line.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
