### PR TITLE
feat(hipsr): replace pooled allocs with views

### DIFF
--- a/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
@@ -248,6 +248,18 @@ emitPoolLayout(OpBuilder &builder, Location loc,
   return {offsets, poolSize};
 }
 
+void replaceAllocsWithViews(OpBuilder &builder, llvm::ArrayRef<Value> group,
+                            Value pool, Value offset) {
+  for (Value alloc : group) {
+    auto allocOp = alloc.getDefiningOp<memref::AllocOp>();
+    auto view =
+        memref::ViewOp::create(builder, allocOp.getLoc(), allocOp.getType(),
+                               pool, offset, allocOp.getDynamicSizes());
+    allocOp.getResult().replaceAllUsesWith(view.getResult());
+    allocOp.erase();
+  }
+}
+
 struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
   using impl::HipsrPoolAllocPassBase<
       HipsrPoolAllocPass>::HipsrPoolAllocPassBase;
@@ -284,7 +296,11 @@ struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
       }
       auto [offsets, poolSize] =
           emitPoolLayout(builder, domain.getLoc(), groupSizes);
-      emitPool(builder, domain.getLoc(), ctx, poolSize, domain.getDomainId());
+      Value pool = emitPool(builder, domain.getLoc(), ctx, poolSize,
+                            domain.getDomainId());
+      for (auto [group, offset] : llvm::zip_equal(groups, offsets)) {
+        replaceAllocsWithViews(builder, group, pool, offset);
+      }
     });
   }
 };

--- a/test/lit/Dialect/Hipsr/pool_alloc.mlir
+++ b/test/lit/Dialect/Hipsr/pool_alloc.mlir
@@ -6,8 +6,9 @@
 // Cases are ordered by lifetime-interval topology (interference-graph chromatic
 // number chi = group count), ascending:
 //   chi=1  single point : align_up_rounding, dynamic_size, dead_alloc_skipped
-//   chi=1  independent  : coalesce_static
+//   chi=1  independent  : coalesce_static, coalesce_dynamic, coalesce_mixed
 //   chi=2  staggered    : split_two_groups, split_two_groups_dynamic
+//   chi=2  one-over-many: split_with_coalesced_group
 //   chi=3  clique K3    : split_three_groups
 
 // 3xf16 = 6 B is not a multiple of 256, so the alignUp chain must round up.
@@ -163,6 +164,88 @@ func.func @coalesce_static(%ctx: !hipsr.context,
 
 // -----
 
+// CHECK-LABEL: func.func @coalesce_dynamic
+// CHECK: %[[DIM:.+]] = memref.dim %{{.+}}, %{{.+}} : memref<?x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[C2048A:.+]] = arith.constant 2048 : index
+// CHECK-NEXT: %[[S0:.+]] = arith.muli %[[C2048A]], %[[DIM]] : index
+// CHECK-NEXT: %[[C2048B:.+]] = arith.constant 2048 : index
+// CHECK-NEXT: %[[S1:.+]] = arith.muli %[[C2048B]], %[[DIM]] : index
+// CHECK-NEXT: %[[MAX:.+]] = arith.maxui %[[S0]], %[[S1]] : index
+// CHECK-NEXT: %[[C256:.+]] = arith.constant 256 : index
+// CHECK-NEXT: %[[C255:.+]] = arith.constant 255 : index
+// CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[MAX]], %[[C255]] : index
+// CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
+// CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
+// CHECK-NEXT: %[[OFF:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[POOL:.+]] = hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V0:.+]] = memref.view %[[POOL]][%[[OFF]]][%[[DIM]]] : memref<?xi8, #hipsr.mem<device>> to memref<?x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V1:.+]] = memref.view %[[POOL]][%[[OFF]]][%[[DIM]]] : memref<?xi8, #hipsr.mem<device>> to memref<?x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%[[V0]] : memref<?x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%[[V0]], %{{.+}} : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%{{.+}} : memref<?x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%[[V1]] : memref<?x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%[[V1]], %{{.+}} : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%{{.+}} : memref<?x1024xf16, #hipsr.mem<device>>)
+// CHECK-NOT: memref.alloc
+func.func @coalesce_dynamic(%ctx: !hipsr.context, %in: memref<?x1024xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<?x1024xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context, %din: memref<?x1024xf16, #hipsr.mem<device>>):
+    %c0 = arith.constant 0 : index
+    %d = memref.dim %din, %c0 : memref<?x1024xf16, #hipsr.mem<device>>
+    %a1 = memref.alloc(%d) : memref<?x1024xf16, #hipsr.mem<device>>
+    %a2 = memref.alloc(%d) : memref<?x1024xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%din, %din : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%a1 : memref<?x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a1, %din : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%din : memref<?x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%din, %din : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%a2 : memref<?x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a2, %din : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%din : memref<?x1024xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  } {domain_id = 0 : i64}
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @coalesce_mixed
+// CHECK: %[[DIM:.+]] = memref.dim %{{.+}}, %{{.+}} : memref<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[C4096:.+]] = arith.constant 4096 : index
+// CHECK-NEXT: %[[C1024:.+]] = arith.constant 1024 : index
+// CHECK-NEXT: %[[BYTES:.+]] = arith.muli %[[C1024]], %[[DIM]] : index
+// CHECK-NEXT: %[[MAX:.+]] = arith.maxui %[[C4096]], %[[BYTES]] : index
+// CHECK-NEXT: %[[C256:.+]] = arith.constant 256 : index
+// CHECK-NEXT: %[[C255:.+]] = arith.constant 255 : index
+// CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[MAX]], %[[C255]] : index
+// CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
+// CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
+// CHECK-NEXT: %[[OFF:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[POOL:.+]] = hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V0:.+]] = memref.view %[[POOL]][%[[OFF]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x256xf32, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V1:.+]] = memref.view %[[POOL]][%[[OFF]]][%[[DIM]]] : memref<?xi8, #hipsr.mem<device>> to memref<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<4x256xf32, #hipsr.mem<device>>, memref<4x256xf32, #hipsr.mem<device>>) outs(%[[V0]] : memref<4x256xf32, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>) outs(%[[V1]] : memref<?x512xf16, #hipsr.mem<device>>)
+// CHECK-NOT: memref.alloc
+func.func @coalesce_mixed(%ctx: !hipsr.context,
+                          %inf32: memref<4x256xf32, #hipsr.mem<device>>,
+                          %inf16: memref<?x512xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %inf32, %inf16 :
+      !hipsr.context,
+      memref<4x256xf32, #hipsr.mem<device>>,
+      memref<?x512xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context,
+       %sf32: memref<4x256xf32, #hipsr.mem<device>>,
+       %sf16: memref<?x512xf16, #hipsr.mem<device>>):
+    %c0 = arith.constant 0 : index
+    %d = memref.dim %sf16, %c0 : memref<?x512xf16, #hipsr.mem<device>>
+    %a1 = memref.alloc() : memref<4x256xf32, #hipsr.mem<device>>
+    %a2 = memref.alloc(%d) : memref<?x512xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%sf32, %sf32 : memref<4x256xf32, #hipsr.mem<device>>, memref<4x256xf32, #hipsr.mem<device>>)
+               outs(%a1 : memref<4x256xf32, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%sf16, %sf16 : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>)
+               outs(%a2 : memref<?x512xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  } {domain_id = 0 : i64}
+  return
+}
+
+// -----
+
 // CHECK-LABEL: func.func @split_two_groups
 // CHECK: %[[C8192A:.+]] = arith.constant 8192 : index
 // CHECK-NEXT: %[[C256A:.+]] = arith.constant 256 : index
@@ -243,6 +326,78 @@ func.func @split_two_groups_dynamic(%ctx: !hipsr.context,
     hipsr.add(%dctx) ins(%dsin, %dsin : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a_static : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.add(%dctx) ins(%a_dyn, %a_dyn : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>) outs(%din : memref<?x512xf16, #hipsr.mem<device>>)
     hipsr.add(%dctx) ins(%a_static, %a_static : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%dsin : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  } {domain_id = 0 : i64}
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @split_with_coalesced_group
+// CHECK: %[[DIM:.+]] = memref.dim %{{.+}}, %{{.+}} : memref<?x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[C16384:.+]] = arith.constant 16384 : index
+// CHECK-NEXT: %[[C4096:.+]] = arith.constant 4096 : index
+// CHECK-NEXT: %[[C2048:.+]] = arith.constant 2048 : index
+// CHECK-NEXT: %[[S2:.+]] = arith.muli %[[C2048]], %[[DIM]] : index
+// CHECK-NEXT: %[[M0:.+]] = arith.maxui %[[C16384]], %[[C4096]] : index
+// CHECK-NEXT: %[[M1:.+]] = arith.maxui %[[M0]], %[[S2]] : index
+// CHECK-NEXT: %[[C256A:.+]] = arith.constant 256 : index
+// CHECK-NEXT: %[[C255A:.+]] = arith.constant 255 : index
+// CHECK-NEXT: %[[N0:.+]] = arith.addi %[[M1]], %[[C255A]] : index
+// CHECK-NEXT: %[[D0:.+]] = arith.divui %[[N0]], %[[C256A]] : index
+// CHECK-NEXT: %[[G0:.+]] = arith.muli %[[D0]], %[[C256A]] : index
+// CHECK-NEXT: %[[C8192:.+]] = arith.constant 8192 : index
+// CHECK-NEXT: %[[C256B:.+]] = arith.constant 256 : index
+// CHECK-NEXT: %[[C255B:.+]] = arith.constant 255 : index
+// CHECK-NEXT: %[[N1:.+]] = arith.addi %[[C8192]], %[[C255B]] : index
+// CHECK-NEXT: %[[D1:.+]] = arith.divui %[[N1]], %[[C256B]] : index
+// CHECK-NEXT: %[[G1:.+]] = arith.muli %[[D1]], %[[C256B]] : index
+// CHECK-NEXT: %[[OFF0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[POOLSZ:.+]] = arith.addi %[[G0]], %[[G1]] : index
+// CHECK-NEXT: %[[POOL:.+]] = hipsr.get_pool(%{{.+}}, %[[POOLSZ]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V0:.+]] = memref.view %[[POOL]][%[[OFF0]]][] : memref<?xi8, #hipsr.mem<device>> to memref<8x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V1:.+]] = memref.view %[[POOL]][%[[OFF0]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x256xf32, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V2:.+]] = memref.view %[[POOL]][%[[OFF0]]][%[[DIM]]] : memref<?xi8, #hipsr.mem<device>> to memref<?x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V3:.+]] = memref.view %[[POOL]][%[[G0]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<8x1024xf16, #hipsr.mem<device>>, memref<8x1024xf16, #hipsr.mem<device>>) outs(%[[V0]] : memref<8x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%[[V3]] : memref<4x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%[[V0]], %[[V0]] : memref<8x1024xf16, #hipsr.mem<device>>, memref<8x1024xf16, #hipsr.mem<device>>) outs(%{{.+}} : memref<8x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<4x256xf32, #hipsr.mem<device>>, memref<4x256xf32, #hipsr.mem<device>>) outs(%[[V1]] : memref<4x256xf32, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%[[V1]], %[[V1]] : memref<4x256xf32, #hipsr.mem<device>>, memref<4x256xf32, #hipsr.mem<device>>) outs(%{{.+}} : memref<4x256xf32, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%[[V2]] : memref<?x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%[[V2]], %[[V2]] : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%{{.+}} : memref<?x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%[[V3]], %[[V3]] : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>)
+// CHECK-NOT: memref.alloc
+func.func @split_with_coalesced_group(%ctx: !hipsr.context,
+                               %in16: memref<8x1024xf16, #hipsr.mem<device>>,
+                               %inf32: memref<4x256xf32, #hipsr.mem<device>>,
+                               %in2: memref<?x1024xf16, #hipsr.mem<device>>,
+                               %in4: memref<4x1024xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %in16, %inf32, %in2, %in4 :
+      !hipsr.context,
+      memref<8x1024xf16, #hipsr.mem<device>>,
+      memref<4x256xf32, #hipsr.mem<device>>,
+      memref<?x1024xf16, #hipsr.mem<device>>,
+      memref<4x1024xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context,
+       %d16: memref<8x1024xf16, #hipsr.mem<device>>,
+       %df32: memref<4x256xf32, #hipsr.mem<device>>,
+       %d2: memref<?x1024xf16, #hipsr.mem<device>>,
+       %d4: memref<4x1024xf16, #hipsr.mem<device>>):
+    %c0 = arith.constant 0 : index
+    %d = memref.dim %d2, %c0 : memref<?x1024xf16, #hipsr.mem<device>>
+    %a1 = memref.alloc() : memref<8x1024xf16, #hipsr.mem<device>>
+    %a2 = memref.alloc() : memref<4x256xf32, #hipsr.mem<device>>
+    %a3 = memref.alloc(%d) : memref<?x1024xf16, #hipsr.mem<device>>
+    %a4 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%d16, %d16 : memref<8x1024xf16, #hipsr.mem<device>>, memref<8x1024xf16, #hipsr.mem<device>>) outs(%a1 : memref<8x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%d4, %d4 : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a4 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a1, %a1 : memref<8x1024xf16, #hipsr.mem<device>>, memref<8x1024xf16, #hipsr.mem<device>>) outs(%d16 : memref<8x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%df32, %df32 : memref<4x256xf32, #hipsr.mem<device>>, memref<4x256xf32, #hipsr.mem<device>>) outs(%a2 : memref<4x256xf32, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a2, %a2 : memref<4x256xf32, #hipsr.mem<device>>, memref<4x256xf32, #hipsr.mem<device>>) outs(%df32 : memref<4x256xf32, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%d2, %d2 : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%a3 : memref<?x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a3, %a3 : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%d2 : memref<?x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a4, %a4 : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%d4 : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
   } {domain_id = 0 : i64}
   return

--- a/test/lit/Dialect/Hipsr/pool_alloc.mlir
+++ b/test/lit/Dialect/Hipsr/pool_alloc.mlir
@@ -1,8 +1,7 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// RUN: hip-mlir-opt %s -split-input-file -hipsr-pool-alloc \
-// RUN:   | FileCheck %s --implicit-check-not=memref.view
+// RUN: hip-mlir-opt %s -split-input-file -hipsr-pool-alloc | FileCheck %s
 
 // Cases are ordered by lifetime-interval topology (interference-graph chromatic
 // number chi = group count), ascending:
@@ -19,9 +18,12 @@
 // CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[C6]], %[[C255]] : index
 // CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
 // CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
-// CHECK-NEXT: arith.constant 0 : index
-// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[OFF:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[POOL:.+]] = hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V0:.+]] = memref.view %[[POOL]][%[[OFF]]][] : memref<?xi8, #hipsr.mem<device>> to memref<3xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<3xf16, #hipsr.mem<device>>, memref<3xf16, #hipsr.mem<device>>) outs(%[[V0]] : memref<3xf16, #hipsr.mem<device>>)
 // CHECK-NOT: arith.maxui
+// CHECK-NOT: memref.alloc
 func.func @align_up_rounding(%ctx: !hipsr.context,
                         %in: memref<3xf16, #hipsr.mem<device>>) {
   hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<3xf16, #hipsr.mem<device>>) {
@@ -41,7 +43,6 @@ func.func @align_up_rounding(%ctx: !hipsr.context,
 // CHECK-LABEL: func.func @dynamic_size
 // CHECK: %[[C0:.+]] = arith.constant 0 : index
 // CHECK-NEXT: %[[DIM:.+]] = memref.dim %{{.+}}, %[[C0]] : memref<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT: memref.alloc(%[[DIM]]) : memref<?x512xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[C1024:.+]] = arith.constant 1024 : index
 // CHECK-NEXT: %[[BYTES:.+]] = arith.muli %[[C1024]], %[[DIM]] : index
 // CHECK-NEXT: %[[C256:.+]] = arith.constant 256 : index
@@ -49,8 +50,11 @@ func.func @align_up_rounding(%ctx: !hipsr.context,
 // CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[BYTES]], %[[C255]] : index
 // CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
 // CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
-// CHECK-NEXT: arith.constant 0 : index
-// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[OFF:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[POOL:.+]] = hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V0:.+]] = memref.view %[[POOL]][%[[OFF]]][%[[DIM]]] : memref<?xi8, #hipsr.mem<device>> to memref<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>) outs(%[[V0]] : memref<?x512xf16, #hipsr.mem<device>>)
+// CHECK-NOT: memref.alloc
 func.func @dynamic_size(%ctx: !hipsr.context,
                    %in: memref<?x512xf16, #hipsr.mem<device>>) {
   hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<?x512xf16, #hipsr.mem<device>>) {
@@ -67,20 +71,18 @@ func.func @dynamic_size(%ctx: !hipsr.context,
 
 // -----
 
-// An alloc with no DPS write has no interval to place, so it joins no group and
-// the size chain covers the live alloc alone (8192, no maxui).
 // CHECK-LABEL: func.func @dead_alloc_skipped
 // CHECK: memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[LIVE:.+]] = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[C8192:.+]] = arith.constant 8192 : index
 // CHECK-NEXT: %[[C256:.+]] = arith.constant 256 : index
 // CHECK-NEXT: %[[C255:.+]] = arith.constant 255 : index
 // CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[C8192]], %[[C255]] : index
 // CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
 // CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
-// CHECK-NEXT: arith.constant 0 : index
-// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%[[LIVE]] : memref<4x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: %[[OFF:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[POOL:.+]] = hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V0:.+]] = memref.view %[[POOL]][%[[OFF]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%[[V0]] : memref<4x1024xf16, #hipsr.mem<device>>)
 // CHECK-NOT: arith.maxui
 func.func @dead_alloc_skipped(%ctx: !hipsr.context,
                         %in: memref<4x1024xf16, #hipsr.mem<device>>) {
@@ -97,9 +99,6 @@ func.func @dead_alloc_skipped(%ctx: !hipsr.context,
 
 // -----
 
-// Four disjoint allocs of differing sizes coalesce into one group: three
-// arith.maxui fold the sizes and the align chain runs once for the whole group
-// (the trailing CHECK-NOT rules out a second group).
 // CHECK-LABEL: func.func @coalesce_static
 // CHECK: %[[C16384:.+]] = arith.constant 16384 : index
 // CHECK-NEXT: %[[C8192A:.+]] = arith.constant 8192 : index
@@ -113,9 +112,22 @@ func.func @dead_alloc_skipped(%ctx: !hipsr.context,
 // CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[M2]], %[[C255]] : index
 // CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
 // CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
-// CHECK-NEXT: arith.constant 0 : index
-// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[OFF:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[POOL:.+]] = hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V0:.+]] = memref.view %[[POOL]][%[[OFF]]][] : memref<?xi8, #hipsr.mem<device>> to memref<8x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V1:.+]] = memref.view %[[POOL]][%[[OFF]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V2:.+]] = memref.view %[[POOL]][%[[OFF]]][] : memref<?xi8, #hipsr.mem<device>> to memref<2x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V3:.+]] = memref.view %[[POOL]][%[[OFF]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<8x1024xf16, #hipsr.mem<device>>, memref<8x1024xf16, #hipsr.mem<device>>) outs(%[[V0]] : memref<8x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%[[V0]], %[[V0]] : memref<8x1024xf16, #hipsr.mem<device>>, memref<8x1024xf16, #hipsr.mem<device>>) outs(%{{.+}} : memref<8x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%[[V1]] : memref<4x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%[[V1]], %[[V1]] : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<2x1024xf16, #hipsr.mem<device>>, memref<2x1024xf16, #hipsr.mem<device>>) outs(%[[V2]] : memref<2x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%[[V2]], %[[V2]] : memref<2x1024xf16, #hipsr.mem<device>>, memref<2x1024xf16, #hipsr.mem<device>>) outs(%{{.+}} : memref<2x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%[[V3]] : memref<4x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%[[V3]], %[[V3]] : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>)
 // CHECK-NOT: arith.divui
+// CHECK-NOT: memref.alloc
 func.func @coalesce_static(%ctx: !hipsr.context,
                                %in8: memref<8x1024xf16, #hipsr.mem<device>>,
                                %in4a: memref<4x1024xf16, #hipsr.mem<device>>,
@@ -151,8 +163,6 @@ func.func @coalesce_static(%ctx: !hipsr.context,
 
 // -----
 
-// a1 is read while writing a2, so their lifetimes overlap and land in separate
-// groups: two independent size chains, each aligned on its own.
 // CHECK-LABEL: func.func @split_two_groups
 // CHECK: %[[C8192A:.+]] = arith.constant 8192 : index
 // CHECK-NEXT: %[[C256A:.+]] = arith.constant 256 : index
@@ -166,10 +176,15 @@ func.func @coalesce_static(%ctx: !hipsr.context,
 // CHECK-NEXT: %[[N1:.+]] = arith.addi %[[C8192B]], %[[C255B]] : index
 // CHECK-NEXT: %[[D1:.+]] = arith.divui %[[N1]], %[[C256B]] : index
 // CHECK-NEXT: %[[G1:.+]] = arith.muli %[[D1]], %[[C256B]] : index
-// CHECK-NEXT: arith.constant 0 : index
+// CHECK-NEXT: %[[OFF0:.+]] = arith.constant 0 : index
 // CHECK-NEXT: %[[POOLSZ:.+]] = arith.addi %[[G0]], %[[G1]] : index
-// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[POOLSZ]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[POOL:.+]] = hipsr.get_pool(%{{.+}}, %[[POOLSZ]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V0:.+]] = memref.view %[[POOL]][%[[OFF0]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V1:.+]] = memref.view %[[POOL]][%[[G0]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%[[V0]] : memref<4x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%[[V0]], %{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%[[V1]] : memref<4x1024xf16, #hipsr.mem<device>>)
 // CHECK-NOT: arith.maxui
+// CHECK-NOT: memref.alloc
 func.func @split_two_groups(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr.mem<device>>) {
   hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
   ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
@@ -199,10 +214,17 @@ func.func @split_two_groups(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr
 // CHECK-NEXT: %[[N1:.+]] = arith.addi %[[C8192]], %[[C255B]] : index
 // CHECK-NEXT: %[[D1:.+]] = arith.divui %[[N1]], %[[C256B]] : index
 // CHECK-NEXT: %[[G1:.+]] = arith.muli %[[D1]], %[[C256B]] : index
-// CHECK-NEXT: arith.constant 0 : index
+// CHECK-NEXT: %[[OFF0:.+]] = arith.constant 0 : index
 // CHECK-NEXT: %[[POOLSZ:.+]] = arith.addi %[[G0]], %[[G1]] : index
-// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[POOLSZ]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[POOL:.+]] = hipsr.get_pool(%{{.+}}, %[[POOLSZ]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V0:.+]] = memref.view %[[POOL]][%[[OFF0]]][%[[DIM]]] : memref<?xi8, #hipsr.mem<device>> to memref<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V1:.+]] = memref.view %[[POOL]][%[[G0]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>) outs(%[[V0]] : memref<?x512xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%[[V1]] : memref<4x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%[[V0]], %[[V0]] : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>) outs(%{{.+}} : memref<?x512xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%[[V1]], %[[V1]] : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>)
 // CHECK-NOT: arith.maxui
+// CHECK-NOT: memref.alloc
 func.func @split_two_groups_dynamic(%ctx: !hipsr.context,
                                     %inf16: memref<?x512xf16, #hipsr.mem<device>>,
                                     %sin: memref<4x1024xf16, #hipsr.mem<device>>) {
@@ -247,11 +269,21 @@ func.func @split_two_groups_dynamic(%ctx: !hipsr.context,
 // CHECK-NEXT: %[[N2:.+]] = arith.addi %[[C8192C]], %[[C255C]] : index
 // CHECK-NEXT: %[[D2:.+]] = arith.divui %[[N2]], %[[C256C]] : index
 // CHECK-NEXT: %[[G2:.+]] = arith.muli %[[D2]], %[[C256C]] : index
-// CHECK-NEXT: arith.constant 0 : index
+// CHECK-NEXT: %[[OFF0:.+]] = arith.constant 0 : index
 // CHECK-NEXT: %[[SUM0:.+]] = arith.addi %[[G0]], %[[G1]] : index
 // CHECK-NEXT: %[[POOLSZ:.+]] = arith.addi %[[SUM0]], %[[G2]] : index
-// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[POOLSZ]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[POOL:.+]] = hipsr.get_pool(%{{.+}}, %[[POOLSZ]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V0:.+]] = memref.view %[[POOL]][%[[OFF0]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V1:.+]] = memref.view %[[POOL]][%[[G0]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V2:.+]] = memref.view %[[POOL]][%[[SUM0]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%[[V0]] : memref<4x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%[[V1]] : memref<4x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%[[V2]] : memref<4x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%[[V0]], %[[V1]] : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%[[V1]], %[[V2]] : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%[[V0]], %[[V2]] : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>)
 // CHECK-NOT: arith.maxui
+// CHECK-NOT: memref.alloc
 func.func @split_three_groups(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr.mem<device>>) {
   hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
   ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
@@ -273,11 +305,16 @@ func.func @split_three_groups(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hip
 
 // CHECK-LABEL: func.func @two_domains
 // CHECK: %[[G0:.+]] = arith.muli %{{.+}}, %{{.+}} : index
-// CHECK-NEXT: arith.constant 0 : index
-// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[OFF0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[POOL0:.+]] = hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V0:.+]] = memref.view %[[POOL0]][%[[OFF0]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%[[V0]] : memref<4x1024xf16, #hipsr.mem<device>>)
 // CHECK: %[[G1:.+]] = arith.muli %{{.+}}, %{{.+}} : index
-// CHECK-NEXT: arith.constant 0 : index
-// CHECK-NEXT: hipsr.get_pool(%{{.+}}, %[[G1]]) {domain_id = 7 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[OFF1:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[POOL1:.+]] = hipsr.get_pool(%{{.+}}, %[[G1]]) {domain_id = 7 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V1:.+]] = memref.view %[[POOL1]][%[[OFF1]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%[[V1]] : memref<4x1024xf16, #hipsr.mem<device>>)
+// CHECK-NOT: memref.alloc
 func.func @two_domains(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr.mem<device>>) {
   hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
   ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):

--- a/test/lit/Dialect/Hipsr/pool_alloc_report.mlir
+++ b/test/lit/Dialect/Hipsr/pool_alloc_report.mlir
@@ -2,43 +2,7 @@
 // Licensed under the MIT License.
 
 // RUN: hip-mlir-opt %s -split-input-file --verify-diagnostics \
-// RUN:   -hipsr-pool-alloc='emit-pool-report=true' \
-// RUN:   | FileCheck %s --implicit-check-not=memref.view
-
-// CHECK-LABEL: func.func @interleaved_allocs
-func.func @interleaved_allocs(%ctx: !hipsr.context,
-                              %in: memref<4x1024xf16, #hipsr.mem<device>>) {
-  // expected-remark@+1 {{hipsr-pool-alloc: insertion point after op 4}}
-  hipsr.pool_domain(%ctx, %in
-      : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
-  ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [1,3] group 0 size 8192}}
-    %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
-    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>,
-                                      memref<4x1024xf16, #hipsr.mem<device>>)
-               outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [3,5] group 1 size 8192}}
-    %a2 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
-    hipsr.add(%dctx) ins(%a1, %a1 : memref<4x1024xf16, #hipsr.mem<device>>,
-                                    memref<4x1024xf16, #hipsr.mem<device>>)
-               outs(%a2 : memref<4x1024xf16, #hipsr.mem<device>>)
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [5,7] group 0 size 8192}}
-    %a3 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
-    hipsr.add(%dctx) ins(%a2, %a2 : memref<4x1024xf16, #hipsr.mem<device>>,
-                                    memref<4x1024xf16, #hipsr.mem<device>>)
-               outs(%a3 : memref<4x1024xf16, #hipsr.mem<device>>)
-    // No DPS write, so no live range: a remark here would be unexpected and
-    // fail the run.
-    %unwritten = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
-    hipsr.add(%dctx) ins(%a3, %a3 : memref<4x1024xf16, #hipsr.mem<device>>,
-                                    memref<4x1024xf16, #hipsr.mem<device>>)
-               outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
-    hipsr.pool_domain_yield
-  } {domain_id = 0 : i64}
-  return
-}
-
-// -----
+// RUN:   -hipsr-pool-alloc='emit-pool-report=true' | FileCheck %s
 
 // Hoisted allocs are the form materialize-init-tensors produces. Ranges start
 // at the DPS write, so a1 and a3 stay disjoint; indexing the allocs themselves


### PR DESCRIPTION
## Summary

Every poolable `memref.alloc` in a `hipsr.pool_domain` is now rewritten into a `memref.view` into the pool at its group's offset. This is the last piece of the transform: the group sizes, `hipsr.get_pool` and offsets emitted by the earlier patches in this series finally have a consumer.

## Related issue or design

Related issue: wcy123/onnx-hipdnn-ep#116

## Why

All members of a group share a single offset. Grouping already guarantees their lifetimes do not overlap, so they take turns on the same bytes — that reuse is the point of the pass.

Views are built at the pass insertion point, right after the pool, rather than in place at each alloc. The pool is anchored after the last poolable alloc, so a view built in place would precede the pool it reads.

## What

- `replaceAllocsWithViews` creates one `memref.view` per group member (original memref type, dynamic sizes forwarded from the alloc), replaces the alloc's uses, and erases it.
- `pool_alloc.mlir` drops `--implicit-check-not=memref.view` and each case now checks the views and the data ops that consume them, plus `CHECK-NOT: memref.alloc`. `@dead_alloc_skipped` is the exception: its alloc has no DPS write, is not pooled, and stays in place.
- `pool_alloc.mlir` also gains the three cases it was still missing relative to the reference fixture. `@coalesce_dynamic` and `@coalesce_mixed` previously had only remark coverage in the report test; `@split_with_coalesced_group` was not covered anywhere and is the widest topology in the set — three allocs of mixed element type and shape coalesced into one group folded by two `arith.maxui`, plus a fourth that overlaps all three and takes its own group.
- `pool_alloc_report.mlir` drops `@interleaved_allocs`. Allocations interleaved with data ops cannot be pooled under this anchor; `@hoisted_allocs` already covers the same lifetime topology, including a third alloc reusing the first group.

## Test plan

- [x] `check-hip-mlir-lit` green: 358 passed, and the single failure (`Conversion/onnx-to-hip/test_gather_block_quantized.mlir`) is unchanged from `main`
- [x] `pool_alloc.mlir`, `pool_alloc_report.mlir` and `pool_alloc_invalid.mlir` pass
- [x] Transformed report IR round-trips through `hip-mlir-opt --verify-each`, so views dominate their users — including the nested-region cases `@nested_region_user` and `@alloc_inside_region`
- [x] `pre-commit run --all-files` converges

## Notes for reviewers

The offsets consumed here are the ones from #683: the first group takes the constant 0 and later groups reuse the running pool-size sum, so a group's view is offset by the total size of the groups before it.

Next in the series: wiring the pass into the pipeline, which is the first time it sees real input.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
