### PR TITLE
refactor(hipsr): simplify placeholder input rewiring

### DIFF
--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
@@ -34,7 +34,7 @@ namespace {
 
 // Conversion leaves each placeholder input pointing at a data result. Point it
 // at the outs operand its producer writes into, which has the same shape.
-static SmallVector<Value> resolveShapeGraphInputs(PlaceholderOp placeholder) {
+SmallVector<Value> resolveShapeGraphInputs(PlaceholderOp placeholder) {
   SmallVector<Value> resolved = llvm::to_vector(placeholder.getInputs());
   for (Value &input : resolved) {
     if (PlaceholderOp::isAllowedShapeGraphInput(input)) {
@@ -53,7 +53,7 @@ static SmallVector<Value> resolveShapeGraphInputs(PlaceholderOp placeholder) {
 
 // Placeholder inputs form the shape graph, not the data graph.
 // PlaceholderOp::verify reports any input this cannot fix.
-static void rewirePlaceholderInputs(ModuleOp module) {
+void rewirePlaceholderInputs(ModuleOp module) {
   module.walk([](PlaceholderOp placeholder) {
     SmallVector<Value> resolvedInputs = resolveShapeGraphInputs(placeholder);
     if (!llvm::equal(resolvedInputs, placeholder.getInputs())) {

--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
@@ -21,8 +21,8 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Transforms/DialectConversion.h"
 
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/SmallVectorExtras.h"
 
 namespace mlir {
 namespace hipsr {
@@ -32,33 +32,28 @@ namespace hipsr {
 
 namespace {
 
-// Conversion leaves each placeholder input pointing at a data result. Point it
-// at the outs operand its producer writes into, which has the same shape.
-SmallVector<Value> resolveShapeGraphInputs(PlaceholderOp placeholder) {
-  SmallVector<Value> resolved = llvm::to_vector(placeholder.getInputs());
-  for (Value &input : resolved) {
-    if (PlaceholderOp::isAllowedShapeGraphInput(input)) {
-      continue;
-    }
-    // Block arguments are allowed, so anything left is a result.
-    auto result = cast<OpResult>(input);
-    OperandRange destinations = getHipsrDestinationOperands(result.getOwner());
-    if (result.getResultNumber() >= destinations.size()) {
-      continue;
-    }
-    input = destinations[result.getResultNumber()];
+// Returns the shape-graph value for a placeholder input. A data result becomes
+// the outs operand its producer writes into, which has the same shape.
+Value resolveShapeGraphInput(Value input) {
+  if (PlaceholderOp::isAllowedShapeGraphInput(input)) {
+    return input;
   }
-  return resolved;
+  // Block arguments are allowed, so anything left is a result.
+  auto result = cast<OpResult>(input);
+  OperandRange destinations = getHipsrDestinationOperands(result.getOwner());
+  if (result.getResultNumber() >= destinations.size()) {
+    return input;
+  }
+  return destinations[result.getResultNumber()];
 }
 
 // Placeholder inputs form the shape graph, not the data graph.
 // PlaceholderOp::verify reports any input this cannot fix.
 void rewirePlaceholderInputs(ModuleOp module) {
   module.walk([](PlaceholderOp placeholder) {
-    SmallVector<Value> resolvedInputs = resolveShapeGraphInputs(placeholder);
-    if (!llvm::equal(resolvedInputs, placeholder.getInputs())) {
-      placeholder.getInputsMutable().assign(resolvedInputs);
-    }
+    SmallVector<Value> resolvedInputs =
+        llvm::map_to_vector(placeholder.getInputs(), resolveShapeGraphInput);
+    placeholder.getInputsMutable().assign(resolvedInputs);
   });
 }
 

--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
@@ -6,8 +6,8 @@
 //
 // Converts ONNX dialect IR into tensor-form hipsr dialect IR. The conversion
 // target keeps helper computations inside hipsr.compute while allowing scalar
-// constants as graph roots. After conversion, placeholder dependencies are
-// rewired into a parallel shape graph.
+// constants as graph roots. After conversion, placeholder inputs are moved onto
+// the shape graph.
 //
 //===----------------------------------------------------------------------===//
 
@@ -21,7 +21,6 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Transforms/DialectConversion.h"
 
-#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 
@@ -33,54 +32,34 @@ namespace hipsr {
 
 namespace {
 
-// Shape dependencies flow through placeholders instead of computed data.
-static LogicalResult finalizePlaceholderDependencies(ModuleOp module) {
-  llvm::DenseMap<Value, Value> placeholderForDataResult;
-  module.walk([&](Operation *op) {
-    ResultRange results = op->getResults();
-    OperandRange destinations = getHipsrDestinationOperands(op);
-    for (auto [result, destination] : llvm::zip(results, destinations)) {
-      if (!destination.getDefiningOp<PlaceholderOp>()) {
-        continue;
-      }
-      placeholderForDataResult.try_emplace(result, destination);
+// Conversion leaves each placeholder input pointing at a data result. Point it
+// at the outs operand its producer writes into, which has the same shape.
+static SmallVector<Value> resolveShapeGraphInputs(PlaceholderOp placeholder) {
+  SmallVector<Value> resolved = llvm::to_vector(placeholder.getInputs());
+  for (Value &input : resolved) {
+    if (PlaceholderOp::isAllowedShapeGraphInput(input)) {
+      continue;
+    }
+    // Block arguments are allowed, so anything left is a result.
+    auto result = cast<OpResult>(input);
+    OperandRange destinations = getHipsrDestinationOperands(result.getOwner());
+    if (result.getResultNumber() >= destinations.size()) {
+      continue;
+    }
+    input = destinations[result.getResultNumber()];
+  }
+  return resolved;
+}
+
+// Placeholder inputs form the shape graph, not the data graph.
+// PlaceholderOp::verify reports any input this cannot fix.
+static void rewirePlaceholderInputs(ModuleOp module) {
+  module.walk([](PlaceholderOp placeholder) {
+    SmallVector<Value> resolvedInputs = resolveShapeGraphInputs(placeholder);
+    if (!llvm::equal(resolvedInputs, placeholder.getInputs())) {
+      placeholder.getInputsMutable().assign(resolvedInputs);
     }
   });
-
-  llvm::SmallVector<std::pair<OpOperand *, Value>> replacements;
-  WalkResult walkResult =
-      module.walk([&](PlaceholderOp placeholder) -> WalkResult {
-        MutableOperandRange mutableInputs = placeholder.getInputsMutable();
-        for (auto [inputIndex, input] :
-             llvm::enumerate(placeholder.getInputs())) {
-          auto replacement = placeholderForDataResult.find(input);
-          Value resolvedInput = replacement == placeholderForDataResult.end()
-                                    ? input
-                                    : replacement->second;
-          if (!PlaceholderOp::isAllowedShapeGraphInput(resolvedInput)) {
-            placeholder.emitOpError("input ")
-                << inputIndex
-                << " must be a block argument or a result of "
-                   "hipsr.placeholder, arith.constant, or hipsr.constant; got "
-                   "result of '"
-                << resolvedInput.getDefiningOp()->getName() << "'";
-            return WalkResult::interrupt();
-          }
-          if (resolvedInput != input) {
-            replacements.emplace_back(&mutableInputs[inputIndex],
-                                      resolvedInput);
-          }
-        }
-        return WalkResult::advance();
-      });
-  if (walkResult.wasInterrupted()) {
-    return failure();
-  }
-
-  for (auto [operand, value] : replacements) {
-    operand->set(value);
-  }
-  return success();
 }
 
 struct ConvertOnnxToHipsrPass
@@ -101,10 +80,8 @@ struct ConvertOnnxToHipsrPass
       signalPassFailure();
       return;
     }
-    // Build the parallel shape graph after all data-graph rewrites finish.
-    if (failed(finalizePlaceholderDependencies(module))) {
-      signalPassFailure();
-    }
+    // Runs after conversion so every producer has its outs operand.
+    rewirePlaceholderInputs(module);
   }
 };
 


### PR DESCRIPTION
## Summary

`finalizePlaceholderDependencies` becomes a single walk over `hipsr.placeholder` ops that resolves one placeholder's inputs and writes them back with one `getInputsMutable().assign`. No behavior change for the IR the conversion produces.

## Related issue or design

None.

## Why

The old pass built two module-wide structures that never had to outlive a single placeholder: a `DenseMap` from every result to the outs operand it filled, and a vector of staged `OpOperand *` writes. `getHipsrDestinationOperands` does the same lookup on the spot, and rewiring a placeholder only reads other ops' operands.

It also carried a copy of `PlaceholderOp::verify()`'s diagnostic. The pass manager verifies after every pass, so a bad input still reports the same message at the same location. The resolver now starts from `isAllowedShapeGraphInput`, the verifier's own predicate, so the pass and the verifier cannot disagree about what a valid input is.

Dropping the trailing `destination.getDefiningOp<PlaceholderOp>()` check accepts more cases, not wrong ones. An outs operand that is a block argument or a constant has the same shape as the result and is a legal input. Anything else still fails verification.

The assign is unconditional. Comparing against the current inputs first would only avoid relinking unchanged operands in the use lists, which is O(1) per operand and order-insensitive, so it is not worth its own path.

## What

- `resolveShapeGraphInput(Value)` returns the shape-graph value for one input: an already-legal input comes back unchanged, a data result becomes the outs operand its producer writes into.
- `rewirePlaceholderInputs(ModuleOp)` maps it over each placeholder's inputs and assigns the result. It returns `void`, so `runOnOperation` loses its second failure branch.
- `llvm/ADT/DenseMap.h` and `llvm/ADT/STLExtras.h` are removed; `llvm/ADT/SmallVectorExtras.h` is added for `map_to_vector`.

## Compiler IR

<details>
<summary>Before / after</summary>

```mlir
// Before: the second placeholder's input points at the cast's data result.
%p0    = hipsr.placeholder(%ctx) ins(%in : tensor<?x8xf32>) ... : tensor<?x8xf16>
%cast0 = hipsr.cast(%ctx) ins(%in : tensor<?x8xf32>) outs(%p0 : tensor<?x8xf16>) : tensor<?x8xf16>
%p1    = hipsr.placeholder(%ctx) ins(%cast0 : tensor<?x8xf16>) ... : tensor<?x8xf32>
```

```mlir
// After: it points at the outs operand the cast writes into.
%p1    = hipsr.placeholder(%ctx) ins(%p0 : tensor<?x8xf16>) ... : tensor<?x8xf32>
```

</details>

## Notes for reviewers

`PlaceholderOp::verify()` is unchanged.

No test covers this transform yet, and none can: `--convert-onnx-to-hipsr` still passes an empty `RewritePatternSet` to `applyFullConversion`, and hand-written input whose placeholder points at a data result is rejected by the verifier before the pass runs. The only test that asserted the removed diagnostic is already `UNSUPPORTED: true`, like everything else in that directory.

## AI assistance

Cursor (Claude Opus 5) assisted with the refactor and the comment rewrites. Validated with a local incremental build, the MLIR LIT suite, and `pre-commit run --all-files`.
