### PR TITLE
perf(slice): disable decomposition for memory experiment

### DIFF
--- a/lib/Conversion/OnnxToHip/SliceConversion.cpp
+++ b/lib/Conversion/OnnxToHip/SliceConversion.cpp
@@ -355,7 +355,7 @@ struct SliceToHip : public mlir::RewritePattern {
 
 void populateSliceConversionPatterns(RewritePatternSet &patterns,
                                      MLIRContext *ctx) {
-  patterns.add<SliceDecompose, SliceToHip>(ctx);
+  patterns.add<SliceToHip>(ctx);
 }
 
 } // namespace hip

--- a/lib/Conversion/OnnxToHip/SliceConversion.cpp
+++ b/lib/Conversion/OnnxToHip/SliceConversion.cpp
@@ -357,7 +357,9 @@ struct SliceToHip : public mlir::RewritePattern {
 
 void populateSliceConversionPatterns(RewritePatternSet &patterns,
                                      MLIRContext *ctx) {
-  if (hip_get_env("HIPDNN_EP_DISABLE_SLICE_DECOMPOSITION").empty())
+  const std::string enable =
+      hip_get_env("HIPDNN_EP_ENABLE_SLICE_DECOMPOSITION");
+  if (!enable.empty() && enable[0] >= '1')
     patterns.add<SliceDecompose>(ctx);
   patterns.add<SliceToHip>(ctx);
 }

--- a/lib/Conversion/OnnxToHip/SliceConversion.cpp
+++ b/lib/Conversion/OnnxToHip/SliceConversion.cpp
@@ -5,6 +5,8 @@
 
 #include "OnnxToHipUtils.h"
 
+#include "hip/debug_log.h"
+
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 
@@ -355,6 +357,8 @@ struct SliceToHip : public mlir::RewritePattern {
 
 void populateSliceConversionPatterns(RewritePatternSet &patterns,
                                      MLIRContext *ctx) {
+  if (hip_get_env("HIPDNN_EP_DISABLE_SLICE_DECOMPOSITION").empty())
+    patterns.add<SliceDecompose>(ctx);
   patterns.add<SliceToHip>(ctx);
 }
 

--- a/test/lit/Conversion/onnx-to-hip/test_slice.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_slice.mlir
@@ -44,6 +44,7 @@ module {
   // supports strides).
   func.func @test_slice_decompose_stride(%input: tensor<2x4xf32>) -> tensor<1x2xf32> {
     // CHECK-LABEL: func.func @test_slice_decompose_stride
+    // NO-DECOMPOSE-LABEL: func.func @test_slice_decompose_stride
     %starts = arith.constant dense<[1, 0]> : tensor<2xi64>
     %ends   = arith.constant dense<[2, 3]> : tensor<2xi64>
     %axes   = arith.constant dense<[0, 1]> : tensor<2xi64>
@@ -54,6 +55,8 @@ module {
 
     // CHECK-NOT: onnx.Slice
     // CHECK: tensor.extract_slice {{.*}}[1, 0] [1, 2] [1, 2]
+    // NO-DECOMPOSE-NOT: tensor.extract_slice
+    // NO-DECOMPOSE: hip.slice(
 
     return %r : tensor<1x2xf32>
   }
@@ -61,6 +64,7 @@ module {
   // Test 3: omitted axes / steps — default to all axes, unit stride.
   func.func @test_slice_decompose_default_axes(%input: tensor<4x6xf32>) -> tensor<2x3xf32> {
     // CHECK-LABEL: func.func @test_slice_decompose_default_axes
+    // NO-DECOMPOSE-LABEL: func.func @test_slice_decompose_default_axes
     %starts = arith.constant dense<[0, 0]> : tensor<2xi64>
     %ends   = arith.constant dense<[2, 3]> : tensor<2xi64>
     %r = "onnx.Slice"(%input, %starts, %ends)
@@ -68,6 +72,8 @@ module {
 
     // CHECK-NOT: onnx.Slice
     // CHECK: tensor.extract_slice {{.*}}[0, 0] [2, 3] [1, 1]
+    // NO-DECOMPOSE-NOT: tensor.extract_slice
+    // NO-DECOMPOSE: hip.slice(
 
     return %r : tensor<2x3xf32>
   }
@@ -112,6 +118,7 @@ module {
   // tensor.dim Value, not a constant).
   func.func @test_slice_decompose_dyn_untouched(%input: tensor<4x?xf32>) -> tensor<2x?xf32> {
     // CHECK-LABEL: func.func @test_slice_decompose_dyn_untouched
+    // NO-DECOMPOSE-LABEL: func.func @test_slice_decompose_dyn_untouched
     %starts = arith.constant dense<[1]> : tensor<1xi64>
     %ends   = arith.constant dense<[3]> : tensor<1xi64>
     %axes   = arith.constant dense<[0]> : tensor<1xi64>
@@ -127,6 +134,8 @@ module {
     // The first dim's slice is [start=1, size=2, step=1]; the second
     // dim is untouched and uses the runtime dim value.
     // CHECK: tensor.extract_slice %{{.*}}[1, 0] [2, %[[DIM]]] [1, 1]
+    // NO-DECOMPOSE-NOT: tensor.extract_slice
+    // NO-DECOMPOSE: hip.slice(
     return %r : tensor<2x?xf32>
   }
 

--- a/test/lit/Conversion/onnx-to-hip/test_slice.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_slice.mlir
@@ -9,8 +9,9 @@
 //   2. SliceToHip (fallback) — non-constant indices or negative steps fall
 //      through to a native hip.slice op whose runtime is a stub today.
 
-// RUN: env -u HIPDNN_EP_DISABLE_SLICE_DECOMPOSITION hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
-// RUN: env HIPDNN_EP_DISABLE_SLICE_DECOMPOSITION=1 hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s --check-prefix=NO-DECOMPOSE
+// RUN: env HIPDNN_EP_ENABLE_SLICE_DECOMPOSITION=1 hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+// RUN: env -u HIPDNN_EP_ENABLE_SLICE_DECOMPOSITION hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s --check-prefix=NO-DECOMPOSE
+// RUN: env HIPDNN_EP_ENABLE_SLICE_DECOMPOSITION=0 hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s --check-prefix=NO-DECOMPOSE
 
 module {
   func.func @main_graph(%arg0: tensor<4xf32>) -> tensor<4xf32> {

--- a/test/lit/Conversion/onnx-to-hip/test_slice.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_slice.mlir
@@ -9,7 +9,8 @@
 //   2. SliceToHip (fallback) — non-constant indices or negative steps fall
 //      through to a native hip.slice op whose runtime is a stub today.
 
-// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+// RUN: env -u HIPDNN_EP_DISABLE_SLICE_DECOMPOSITION hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+// RUN: env HIPDNN_EP_DISABLE_SLICE_DECOMPOSITION=1 hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s --check-prefix=NO-DECOMPOSE
 
 module {
   func.func @main_graph(%arg0: tensor<4xf32>) -> tensor<4xf32> {
@@ -20,6 +21,7 @@ module {
   // tensor.extract_slice.
   func.func @test_slice_decompose_simple(%input: tensor<4x6xf32>) -> tensor<2x6xf32> {
     // CHECK-LABEL: func.func @test_slice_decompose_simple
+    // NO-DECOMPOSE-LABEL: func.func @test_slice_decompose_simple
     %starts = arith.constant dense<[1]> : tensor<1xi64>
     %ends   = arith.constant dense<[3]> : tensor<1xi64>
     %axes   = arith.constant dense<[0]> : tensor<1xi64>
@@ -31,6 +33,9 @@ module {
     // CHECK-NOT: onnx.Slice
     // CHECK-NOT: hip.slice
     // CHECK: tensor.extract_slice {{.*}}[1, 0] [2, 6] [1, 1]
+    // NO-DECOMPOSE-NOT: onnx.Slice
+    // NO-DECOMPOSE-NOT: tensor.extract_slice
+    // NO-DECOMPOSE: hip.slice(
 
     return %r : tensor<2x6xf32>
   }

--- a/test/lit/Conversion/onnx-to-hip/test_slice_swinv2_window.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_slice_swinv2_window.mlir
@@ -8,7 +8,7 @@
 // Uses onnx.Constant operands (externalized by convert-onnx-to-hip) so the
 // SliceShapeFold -> SliceDecompose path is exercised end-to-end.
 
-// RUN: mkdir -p %t && hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip='externalize-min-num-elements=1 externalize-output-dir=%t' %s | FileCheck %s
+// RUN: mkdir -p %t && env -u HIPDNN_EP_DISABLE_SLICE_DECOMPOSITION hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip='externalize-min-num-elements=1 externalize-output-dir=%t' %s | FileCheck %s
 
 module {
   func.func @main_graph(%arg0: tensor<4xf32>) -> tensor<4xf32> {

--- a/test/lit/Conversion/onnx-to-hip/test_slice_swinv2_window.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_slice_swinv2_window.mlir
@@ -8,8 +8,9 @@
 // Uses onnx.Constant operands (externalized by convert-onnx-to-hip) so the
 // SliceShapeFold -> SliceDecompose path is exercised end-to-end.
 
-// RUN: mkdir -p %t && env -u HIPDNN_EP_DISABLE_SLICE_DECOMPOSITION hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip='externalize-min-num-elements=1 externalize-output-dir=%t' %s | FileCheck %s
-// RUN: mkdir -p %t && env HIPDNN_EP_DISABLE_SLICE_DECOMPOSITION=1 hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip='externalize-min-num-elements=1 externalize-output-dir=%t' %s | FileCheck %s --check-prefix=NO-DECOMPOSE
+// RUN: mkdir -p %t && env HIPDNN_EP_ENABLE_SLICE_DECOMPOSITION=1 hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip='externalize-min-num-elements=1 externalize-output-dir=%t' %s | FileCheck %s
+// RUN: mkdir -p %t && env -u HIPDNN_EP_ENABLE_SLICE_DECOMPOSITION hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip='externalize-min-num-elements=1 externalize-output-dir=%t' %s | FileCheck %s --check-prefix=NO-DECOMPOSE
+// RUN: mkdir -p %t && env HIPDNN_EP_ENABLE_SLICE_DECOMPOSITION=0 hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip='externalize-min-num-elements=1 externalize-output-dir=%t' %s | FileCheck %s --check-prefix=NO-DECOMPOSE
 
 module {
   func.func @main_graph(%arg0: tensor<4xf32>) -> tensor<4xf32> {

--- a/test/lit/Conversion/onnx-to-hip/test_slice_swinv2_window.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_slice_swinv2_window.mlir
@@ -9,6 +9,7 @@
 // SliceShapeFold -> SliceDecompose path is exercised end-to-end.
 
 // RUN: mkdir -p %t && env -u HIPDNN_EP_DISABLE_SLICE_DECOMPOSITION hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip='externalize-min-num-elements=1 externalize-output-dir=%t' %s | FileCheck %s
+// RUN: mkdir -p %t && env HIPDNN_EP_DISABLE_SLICE_DECOMPOSITION=1 hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip='externalize-min-num-elements=1 externalize-output-dir=%t' %s | FileCheck %s --check-prefix=NO-DECOMPOSE
 
 module {
   func.func @main_graph(%arg0: tensor<4xf32>) -> tensor<4xf32> {
@@ -18,6 +19,7 @@ module {
   func.func @test_swinv2_window_slice(%input: tensor<1x128x256x96xf16>)
       -> tensor<1x8x256x96xf16> {
     // CHECK-LABEL: func.func @test_swinv2_window_slice
+    // NO-DECOMPOSE-LABEL: func.func @test_swinv2_window_slice
     %starts = "onnx.Constant"() {value = dense<0> : tensor<1xi64>}
         : () -> tensor<1xi64>
     %ends = "onnx.Constant"() {value = dense<8> : tensor<1xi64>}
@@ -31,6 +33,8 @@ module {
     // CHECK-NOT: onnx.Slice
     // CHECK-NOT: hip.slice
     // CHECK: tensor.extract_slice {{.*}}[0, 0, 0, 0] [1, 8, 256, 96] [1, 1, 1, 1]
+    // NO-DECOMPOSE-NOT: tensor.extract_slice
+    // NO-DECOMPOSE: hip.slice(
 
     return %r : tensor<1x8x256x96xf16>
   }
@@ -40,6 +44,7 @@ module {
   func.func @test_swinv2_downsample_stride_slice(%input: tensor<1x128x256x96xf16>)
       -> tensor<1x64x256x96xf16> {
     // CHECK-LABEL: func.func @test_swinv2_downsample_stride_slice
+    // NO-DECOMPOSE-LABEL: func.func @test_swinv2_downsample_stride_slice
     %starts = "onnx.Constant"() {value = dense<1> : tensor<1xi64>}
         : () -> tensor<1xi64>
     %ends = "onnx.Constant"() {value = dense<9223372036854775807> : tensor<1xi64>}
@@ -54,6 +59,8 @@ module {
 
     // CHECK-NOT: hip.slice
     // CHECK: tensor.extract_slice {{.*}}[0, 1, 0, 0] [1, 64, 256, 96] [1, 2, 1, 1]
+    // NO-DECOMPOSE-NOT: tensor.extract_slice
+    // NO-DECOMPOSE: hip.slice(
 
     return %r : tensor<1x64x256x96xf16>
   }


### PR DESCRIPTION
Experimental-only PR that disables `SliceDecompose` registration to benchmark memory usage against `main`; this is not intended for merge.