### PR TITLE
feat(hipsr): report pool-alloc effect per domain

### DIFF
--- a/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
@@ -16,11 +16,23 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/Debug.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <utility>
+
+#define DEBUG_TYPE "hipsr-pool-alloc"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "] ")
+
+STATISTIC(NumDomainsProcessed, "Number of pool domains processed");
+STATISTIC(NumAllocationsPooled, "Number of allocations backed by a pool view");
+STATISTIC(NumGroupsCreated, "Number of pool groups created");
+STATISTIC(NumAllocationsReused,
+          "Number of pool slots saved by reusing a group");
 
 namespace mlir {
 namespace hipsr {
@@ -57,6 +69,43 @@ AllocationSize computeAllocationSize(memref::AllocOp allocOp) {
           llvm::to_vector(allocOp.getDynamicSizes())};
 }
 
+struct MeasuredSizes {
+  int64_t maxBytes;
+  int64_t sumBytes;
+  size_t numDynamicDims;
+};
+
+std::optional<MeasuredSizes> measureSizes(llvm::ArrayRef<Value> allocs) {
+  AllocationSize first =
+      computeAllocationSize(allocs.front().getDefiningOp<memref::AllocOp>());
+  MeasuredSizes measured{first.staticBytes, first.staticBytes,
+                         first.dynamicDims.size()};
+  for (Value alloc : allocs.drop_front()) {
+    AllocationSize size =
+        computeAllocationSize(alloc.getDefiningOp<memref::AllocOp>());
+    if (size.dynamicDims != first.dynamicDims) {
+      return std::nullopt;
+    }
+    measured.maxBytes = std::max(measured.maxBytes, size.staticBytes);
+    measured.sumBytes += size.staticBytes;
+  }
+  return measured;
+}
+
+int64_t percentOf(int64_t part, int64_t whole) {
+  return whole == 0 ? 0 : part * 100 / whole;
+}
+
+llvm::DenseMap<Value, size_t> mapAllocIndices(Block &body) {
+  llvm::DenseMap<Value, size_t> indices;
+  for (auto [opIdx, op] : llvm::enumerate(body)) {
+    if (auto allocOp = dyn_cast<memref::AllocOp>(&op)) {
+      indices[allocOp.getResult()] = opIdx;
+    }
+  }
+  return indices;
+}
+
 llvm::DenseMap<Value, Lifetime> computeLiveness(Block &body) {
   llvm::DenseMap<Operation *, size_t> opIndices;
   size_t idx = 0;
@@ -73,6 +122,8 @@ llvm::DenseMap<Value, Lifetime> computeLiveness(Block &body) {
     Value buffer = allocOp.getResult();
     std::optional<size_t> start;
     std::optional<size_t> end;
+    Operation *firstWrite = nullptr;
+    Operation *lastUse = nullptr;
     for (Operation *user : buffer.getUsers()) {
       Operation *blockLevelUser = body.findAncestorOpInBlock(*user);
       assert(blockLevelUser && "alloc escapes its IsolatedFromAbove domain");
@@ -80,13 +131,19 @@ llvm::DenseMap<Value, Lifetime> computeLiveness(Block &body) {
       if (llvm::is_contained(getHipsrDestinationOperands(user), buffer) &&
           (!start || userIdx < *start)) {
         start = userIdx;
+        firstWrite = blockLevelUser;
       }
       if (!end || userIdx > *end) {
         end = userIdx;
+        lastUse = blockLevelUser;
       }
     }
     if (start) {
       lifetimes[buffer] = Lifetime{*start, *end};
+      LLVM_DEBUG(DBGS() << "alloc #" << opIndices.lookup(&op) << " lifetime ["
+                        << *start << "," << *end << "]: first write "
+                        << firstWrite->getName() << ", last use "
+                        << lastUse->getName() << "\n");
     }
   }
   return lifetimes;
@@ -112,14 +169,24 @@ greedyGrouping(Block &body, const llvm::DenseMap<Value, Lifetime> &lifetimes) {
     return !(a.end < b.start || b.end < a.start);
   };
 
+  llvm::DenseMap<Value, size_t> allocIndices = mapAllocIndices(body);
   llvm::SmallVector<llvm::SmallVector<Value>> groups;
   for (Value alloc : allocs) {
     Lifetime lifetime = lifetimes.lookup(alloc);
     bool placed = false;
-    for (llvm::SmallVector<Value> &group : groups) {
-      if (llvm::any_of(group, [&](Value member) {
-            return overlaps(lifetimes.lookup(member), lifetime);
-          })) {
+    for (auto [groupIdx, group] : llvm::enumerate(groups)) {
+      Value *conflict = llvm::find_if(group, [&](Value member) {
+        return overlaps(lifetimes.lookup(member), lifetime);
+      });
+      if (conflict != group.end()) {
+        LLVM_DEBUG({
+          Lifetime other = lifetimes.lookup(*conflict);
+          DBGS() << "alloc #" << allocIndices.lookup(alloc) << " ["
+                 << lifetime.start << "," << lifetime.end
+                 << "] conflicts with alloc #" << allocIndices.lookup(*conflict)
+                 << " [" << other.start << "," << other.end << "] in group "
+                 << groupIdx << "\n";
+        });
         continue;
       }
       group.push_back(alloc);
@@ -127,6 +194,8 @@ greedyGrouping(Block &body, const llvm::DenseMap<Value, Lifetime> &lifetimes) {
       break;
     }
     if (!placed) {
+      LLVM_DEBUG(DBGS() << "alloc #" << allocIndices.lookup(alloc)
+                        << " opens group " << groups.size() << "\n");
       groups.push_back({alloc});
     }
   }
@@ -146,45 +215,90 @@ findInsertionPoint(Block &body,
   return point;
 }
 
-void emitPoolingReport(Block &body,
-                       const llvm::DenseMap<Value, Lifetime> &lifetimes,
-                       llvm::ArrayRef<llvm::SmallVector<Value>> groups,
-                       Operation *insertionPoint) {
-  size_t insertionIdx = 0;
-  for (Operation &op : body) {
-    if (&op == insertionPoint) {
-      break;
-    }
-    ++insertionIdx;
-  }
-  body.getParentOp()->emitRemark()
-      << "hipsr-pool-alloc: insertion point after op " << insertionIdx;
-
-  llvm::DenseMap<Value, size_t> groupIndices;
+void logGroupSizes(Block &body,
+                   llvm::ArrayRef<llvm::SmallVector<Value>> groups) {
+  llvm::DenseMap<Value, size_t> allocIndices = mapAllocIndices(body);
   for (auto [groupIdx, group] : llvm::enumerate(groups)) {
+    std::optional<MeasuredSizes> measured = measureSizes(group);
+    if (!measured) {
+      DBGS() << "group " << groupIdx
+             << " max not comparable (mixed dynamic extents)\n";
+      for (Value member : group) {
+        AllocationSize size =
+            computeAllocationSize(member.getDefiningOp<memref::AllocOp>());
+        DBGS() << "  alloc #" << allocIndices.lookup(member) << " "
+               << size.staticBytes << " bytes x " << size.dynamicDims.size()
+               << " dyn\n";
+      }
+      continue;
+    }
+    DBGS() << "group " << groupIdx << " max " << measured->maxBytes << " bytes";
+    if (measured->numDynamicDims != 0) {
+      llvm::dbgs() << " x " << measured->numDynamicDims << " dyn";
+    }
+    llvm::dbgs() << "\n";
     for (Value member : group) {
-      groupIndices[member] = groupIdx;
+      int64_t bytes =
+          computeAllocationSize(member.getDefiningOp<memref::AllocOp>())
+              .staticBytes;
+      DBGS() << "  alloc #" << allocIndices.lookup(member) << " " << bytes
+             << " bytes, " << (measured->maxBytes - bytes) << " unused\n";
+    }
+  }
+}
+
+void emitPoolingReport(PoolDomainOp domain,
+                       llvm::ArrayRef<llvm::SmallVector<Value>> groups) {
+  llvm::SmallVector<Value> allocs;
+  for (llvm::ArrayRef<Value> group : groups) {
+    allocs.append(group.begin(), group.end());
+  }
+
+  auto remark = [&] {
+    InFlightDiagnostic diag = domain.emitRemark();
+    diag << "hipsr-pool-alloc: domain " << domain.getDomainId() << ": ";
+    return diag;
+  };
+
+  int64_t numAllocs = allocs.size();
+  int64_t numGroups = groups.size();
+  int64_t saved = numAllocs - numGroups;
+  remark() << numAllocs << " allocs in " << numGroups << " groups, " << saved
+           << " saved (" << percentOf(saved, numAllocs) << "%)";
+
+  std::optional<MeasuredSizes> domainSizes = measureSizes(allocs);
+  {
+    InFlightDiagnostic diag = remark();
+    diag << "before vs after: ";
+    if (!domainSizes) {
+      diag << "not comparable (mixed dynamic extents)";
+    } else {
+      int64_t after = 0;
+      for (llvm::ArrayRef<Value> group : groups) {
+        after += measureSizes(group)->maxBytes;
+      }
+      int64_t before = domainSizes->sumBytes;
+      if (domainSizes->numDynamicDims == 0) {
+        diag << before << " bytes vs " << after << " bytes, ";
+      }
+      diag << percentOf(before - after, before) << "% saved";
     }
   }
 
-  for (Operation &op : body) {
-    auto allocOp = dyn_cast<memref::AllocOp>(&op);
-    if (!allocOp) {
+  for (auto [groupIdx, group] : llvm::enumerate(groups)) {
+    InFlightDiagnostic diag = remark();
+    diag << "group " << groupIdx << ": " << group.size() << " allocs, ";
+    std::optional<MeasuredSizes> measured = measureSizes(group);
+    if (!measured) {
+      diag << "not comparable (mixed dynamic extents)";
       continue;
     }
-    auto it = lifetimes.find(allocOp.getResult());
-    if (it == lifetimes.end()) {
-      continue;
+    if (measured->numDynamicDims == 0) {
+      diag << "max " << measured->maxBytes << " bytes, ";
     }
-    AllocationSize size = computeAllocationSize(allocOp);
-    InFlightDiagnostic remark = allocOp.emitRemark();
-    remark << "hipsr-pool-alloc: lifetime [" << it->second.start << ","
-           << it->second.end << "] group "
-           << groupIndices.lookup(allocOp.getResult()) << " size "
-           << size.staticBytes;
-    if (!size.dynamicDims.empty()) {
-      remark << " x " << size.dynamicDims.size() << " dyn";
-    }
+    int64_t capacity = measured->maxBytes * group.size();
+    diag << percentOf(capacity - measured->sumBytes, capacity)
+         << "% avg unused";
   }
 }
 
@@ -265,7 +379,11 @@ struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
       HipsrPoolAllocPass>::HipsrPoolAllocPassBase;
 
   void runOnOperation() override {
+    size_t domainOrdinal = 0;
     getOperation().walk([&](PoolDomainOp domain) {
+      LLVM_DEBUG(DBGS() << "pool_domain #" << domainOrdinal << " (domain_id "
+                        << domain.getDomainId() << ")\n");
+      ++domainOrdinal;
       Block &body = domain.getBody().front();
       llvm::DenseMap<Value, Lifetime> lifetimes = computeLiveness(body);
       Operation *insertionPoint = findInsertionPoint(body, lifetimes);
@@ -275,6 +393,16 @@ struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
         signalPassFailure();
         return;
       }
+      LLVM_DEBUG({
+        size_t insertionIdx = 0;
+        for (Operation &op : body) {
+          if (&op == insertionPoint) {
+            break;
+          }
+          ++insertionIdx;
+        }
+        DBGS() << "insertion point after op #" << insertionIdx << "\n";
+      });
       Value ctx = findContext(body);
       if (!ctx) {
         domain.emitError("hipsr-pool-alloc: pool_domain has no context");
@@ -283,8 +411,13 @@ struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
       }
       llvm::SmallVector<llvm::SmallVector<Value>> groups =
           greedyGrouping(body, lifetimes);
+      LLVM_DEBUG(logGroupSizes(body, groups));
+      ++NumDomainsProcessed;
+      NumAllocationsPooled += lifetimes.size();
+      NumGroupsCreated += groups.size();
+      NumAllocationsReused += lifetimes.size() - groups.size();
       if (emitPoolReport) {
-        emitPoolingReport(body, lifetimes, groups, insertionPoint);
+        emitPoolingReport(domain, groups);
       }
 
       OpBuilder builder(&getContext());

--- a/test/lit/Dialect/Hipsr/Transforms/PoolAlloc/report.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PoolAlloc/report.mlir
@@ -4,33 +4,121 @@
 // RUN: hip-mlir-opt %s -split-input-file --verify-diagnostics \
 // RUN:   -hipsr-pool-alloc='emit-pool-report=true' | FileCheck %s
 
-// CHECK-LABEL: func.func @hoisted_allocs
-func.func @hoisted_allocs(%ctx: !hipsr.context,
-                          %in: memref<4x1024xf16, #hipsr.mem<device>>) {
-  // expected-remark@+1 {{hipsr-pool-alloc: insertion point after op 2}}
+// CHECK-LABEL: func.func @static_line
+func.func @static_line(%ctx: !hipsr.context,
+                       %in: memref<4x1024xf16, #hipsr.mem<device>>) {
+  // expected-remark@+4 {{hipsr-pool-alloc: domain 0: 5 allocs in 2 groups, 3 saved (60%)}}
+  // expected-remark@+3 {{hipsr-pool-alloc: domain 0: before vs after: 20992 bytes vs 12288 bytes, 41% saved}}
+  // expected-remark@+2 {{hipsr-pool-alloc: domain 0: group 0: 3 allocs, max 8192 bytes, 39% avg unused}}
+  // expected-remark@+1 {{hipsr-pool-alloc: domain 0: group 1: 2 allocs, max 4096 bytes, 25% avg unused}}
   hipsr.pool_domain(%ctx, %in
       : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
   ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [3,4] group 0 size 8192}}
-    %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [4,5] group 1 size 8192}}
-    %a2 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [5,6] group 0 size 8192}}
-    %a3 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
-    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>,
-                                      memref<4x1024xf16, #hipsr.mem<device>>)
-               outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
-    hipsr.add(%dctx) ins(%a1, %a1 : memref<4x1024xf16, #hipsr.mem<device>>,
-                                    memref<4x1024xf16, #hipsr.mem<device>>)
-               outs(%a2 : memref<4x1024xf16, #hipsr.mem<device>>)
-    hipsr.add(%dctx) ins(%a2, %a2 : memref<4x1024xf16, #hipsr.mem<device>>,
-                                    memref<4x1024xf16, #hipsr.mem<device>>)
-               outs(%a3 : memref<4x1024xf16, #hipsr.mem<device>>)
-    hipsr.add(%dctx) ins(%a3, %a3 : memref<4x1024xf16, #hipsr.mem<device>>,
-                                    memref<4x1024xf16, #hipsr.mem<device>>)
-               outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
+    %a0 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    %a1 = memref.alloc() : memref<2x1024xf16, #hipsr.mem<device>>
+    %a2 = memref.alloc() : memref<3x1024xf16, #hipsr.mem<device>>
+    %a3 = memref.alloc() : memref<1x1024xf16, #hipsr.mem<device>>
+    %a4 = memref.alloc() : memref<256xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a0 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a0, %a0 : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a1 : memref<2x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a1, %a1 : memref<2x1024xf16, #hipsr.mem<device>>, memref<2x1024xf16, #hipsr.mem<device>>) outs(%a2 : memref<3x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a2, %a2 : memref<3x1024xf16, #hipsr.mem<device>>, memref<3x1024xf16, #hipsr.mem<device>>) outs(%a3 : memref<1x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a3, %a3 : memref<1x1024xf16, #hipsr.mem<device>>, memref<1x1024xf16, #hipsr.mem<device>>) outs(%a4 : memref<256xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a4, %a4 : memref<256xf16, #hipsr.mem<device>>, memref<256xf16, #hipsr.mem<device>>) outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
   } {domain_id = 0 : i64}
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @dyn_common_factor
+func.func @dyn_common_factor(%ctx: !hipsr.context,
+                             %in: memref<?x1536xf16, #hipsr.mem<device>>) {
+  // expected-remark@+4 {{hipsr-pool-alloc: domain 1: 4 allocs in 2 groups, 2 saved (50%)}}
+  // expected-remark@+3 {{hipsr-pool-alloc: domain 1: before vs after: 28% saved}}
+  // expected-remark@+2 {{hipsr-pool-alloc: domain 1: group 0: 2 allocs, 33% avg unused}}
+  // expected-remark@+1 {{hipsr-pool-alloc: domain 1: group 1: 2 allocs, 25% avg unused}}
+  hipsr.pool_domain(%ctx, %in
+      : !hipsr.context, memref<?x1536xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context, %din: memref<?x1536xf16, #hipsr.mem<device>>):
+    %c0 = arith.constant 0 : index
+    %d = memref.dim %din, %c0 : memref<?x1536xf16, #hipsr.mem<device>>
+    %a0 = memref.alloc(%d) : memref<?x1536xf16, #hipsr.mem<device>>
+    %a1 = memref.alloc(%d) : memref<?x1024xf16, #hipsr.mem<device>>
+    %a2 = memref.alloc(%d) : memref<?x512xf16, #hipsr.mem<device>>
+    %a3 = memref.alloc(%d) : memref<?x512xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%din, %din : memref<?x1536xf16, #hipsr.mem<device>>, memref<?x1536xf16, #hipsr.mem<device>>) outs(%a0 : memref<?x1536xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a0, %a0 : memref<?x1536xf16, #hipsr.mem<device>>, memref<?x1536xf16, #hipsr.mem<device>>) outs(%a1 : memref<?x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a1, %a1 : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%a2 : memref<?x512xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a2, %a2 : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>) outs(%a3 : memref<?x512xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a3, %a3 : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>) outs(%din : memref<?x1536xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  } {domain_id = 1 : i64}
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @dyn_mixed_extents
+func.func @dyn_mixed_extents(%ctx: !hipsr.context,
+                             %ina: memref<?x512xf16, #hipsr.mem<device>>,
+                             %inb: memref<?x256xf16, #hipsr.mem<device>>) {
+  // expected-remark@+3 {{hipsr-pool-alloc: domain 2: 2 allocs in 1 groups, 1 saved (50%)}}
+  // expected-remark@+2 {{hipsr-pool-alloc: domain 2: before vs after: not comparable (mixed dynamic extents)}}
+  // expected-remark@+1 {{hipsr-pool-alloc: domain 2: group 0: 2 allocs, not comparable (mixed dynamic extents)}}
+  hipsr.pool_domain(%ctx, %ina, %inb :
+      !hipsr.context,
+      memref<?x512xf16, #hipsr.mem<device>>,
+      memref<?x256xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context,
+       %da: memref<?x512xf16, #hipsr.mem<device>>,
+       %db: memref<?x256xf16, #hipsr.mem<device>>):
+    %c0 = arith.constant 0 : index
+    %d0 = memref.dim %da, %c0 : memref<?x512xf16, #hipsr.mem<device>>
+    %d1 = memref.dim %db, %c0 : memref<?x256xf16, #hipsr.mem<device>>
+    %a0 = memref.alloc(%d0) : memref<?x512xf16, #hipsr.mem<device>>
+    %a1 = memref.alloc(%d1) : memref<?x256xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%da, %da : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>) outs(%a0 : memref<?x512xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a0, %a0 : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>) outs(%da : memref<?x512xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%db, %db : memref<?x256xf16, #hipsr.mem<device>>, memref<?x256xf16, #hipsr.mem<device>>) outs(%a1 : memref<?x256xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a1, %a1 : memref<?x256xf16, #hipsr.mem<device>>, memref<?x256xf16, #hipsr.mem<device>>) outs(%db : memref<?x256xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  } {domain_id = 2 : i64}
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @per_group_extents
+func.func @per_group_extents(%ctx: !hipsr.context,
+                             %ina: memref<?x1536xf16, #hipsr.mem<device>>,
+                             %inb: memref<?x1024xf16, #hipsr.mem<device>>) {
+  // expected-remark@+4 {{hipsr-pool-alloc: domain 3: 4 allocs in 2 groups, 2 saved (50%)}}
+  // expected-remark@+3 {{hipsr-pool-alloc: domain 3: before vs after: not comparable (mixed dynamic extents)}}
+  // expected-remark@+2 {{hipsr-pool-alloc: domain 3: group 0: 2 allocs, 33% avg unused}}
+  // expected-remark@+1 {{hipsr-pool-alloc: domain 3: group 1: 2 allocs, 25% avg unused}}
+  hipsr.pool_domain(%ctx, %ina, %inb :
+      !hipsr.context,
+      memref<?x1536xf16, #hipsr.mem<device>>,
+      memref<?x1024xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context,
+       %da: memref<?x1536xf16, #hipsr.mem<device>>,
+       %db: memref<?x1024xf16, #hipsr.mem<device>>):
+    %c0 = arith.constant 0 : index
+    %d0 = memref.dim %da, %c0 : memref<?x1536xf16, #hipsr.mem<device>>
+    %d1 = memref.dim %db, %c0 : memref<?x1024xf16, #hipsr.mem<device>>
+    %a0 = memref.alloc(%d0) : memref<?x1536xf16, #hipsr.mem<device>>
+    %a1 = memref.alloc(%d1) : memref<?x1024xf16, #hipsr.mem<device>>
+    %a2 = memref.alloc(%d0) : memref<?x512xf16, #hipsr.mem<device>>
+    %a3 = memref.alloc(%d1) : memref<?x512xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%da, %da : memref<?x1536xf16, #hipsr.mem<device>>, memref<?x1536xf16, #hipsr.mem<device>>) outs(%a0 : memref<?x1536xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a0, %a0 : memref<?x1536xf16, #hipsr.mem<device>>, memref<?x1536xf16, #hipsr.mem<device>>) outs(%a1 : memref<?x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a1, %a1 : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%a2 : memref<?x512xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a2, %a2 : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>) outs(%a3 : memref<?x512xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a3, %a3 : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>) outs(%da : memref<?x1536xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  } {domain_id = 3 : i64}
   return
 }
 
@@ -39,15 +127,24 @@ func.func @hoisted_allocs(%ctx: !hipsr.context,
 // CHECK-LABEL: func.func @nested_region_user
 func.func @nested_region_user(%ctx: !hipsr.context,
                               %in: memref<4x1024xf16, #hipsr.mem<device>>) {
-  // expected-remark@+1 {{hipsr-pool-alloc: insertion point after op 0}}
+  // expected-remark@+4 {{hipsr-pool-alloc: domain 4: 2 allocs in 2 groups, 0 saved (0%)}}
+  // expected-remark@+3 {{hipsr-pool-alloc: domain 4: before vs after: 12288 bytes vs 12288 bytes, 0% saved}}
+  // expected-remark@+2 {{hipsr-pool-alloc: domain 4: group 0: 1 allocs, max 8192 bytes, 0% avg unused}}
+  // expected-remark@+1 {{hipsr-pool-alloc: domain 4: group 1: 1 allocs, max 4096 bytes, 0% avg unused}}
   hipsr.pool_domain(%ctx, %in
       : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
   ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [1,2] group 0 size 8192}}
     %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    %a2 = memref.alloc() : memref<2x1024xf16, #hipsr.mem<device>>
     hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>,
                                       memref<4x1024xf16, #hipsr.mem<device>>)
                outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>,
+                                      memref<4x1024xf16, #hipsr.mem<device>>)
+               outs(%a2 : memref<2x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a2, %a2 : memref<2x1024xf16, #hipsr.mem<device>>,
+                                    memref<2x1024xf16, #hipsr.mem<device>>)
+               outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
     scf.execute_region {
       hipsr.add(%dctx) ins(%a1, %a1 : memref<4x1024xf16, #hipsr.mem<device>>,
                                       memref<4x1024xf16, #hipsr.mem<device>>)
@@ -55,20 +152,22 @@ func.func @nested_region_user(%ctx: !hipsr.context,
       scf.yield
     }
     hipsr.pool_domain_yield
-  } {domain_id = 0 : i64}
+  } {domain_id = 4 : i64}
   return
 }
 
 // -----
 
 // CHECK-LABEL: func.func @alloc_inside_region
+// CHECK: memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
 func.func @alloc_inside_region(%ctx: !hipsr.context,
                                %in: memref<4x1024xf16, #hipsr.mem<device>>) {
-  // expected-remark@+1 {{hipsr-pool-alloc: insertion point after op 0}}
+  // expected-remark@+3 {{hipsr-pool-alloc: domain 5: 1 allocs in 1 groups, 0 saved (0%)}}
+  // expected-remark@+2 {{hipsr-pool-alloc: domain 5: before vs after: 8192 bytes vs 8192 bytes, 0% saved}}
+  // expected-remark@+1 {{hipsr-pool-alloc: domain 5: group 0: 1 allocs, max 8192 bytes, 0% avg unused}}
   hipsr.pool_domain(%ctx, %in
       : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
   ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [1,2] group 0 size 8192}}
     %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
     hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>,
                                       memref<4x1024xf16, #hipsr.mem<device>>)
@@ -84,62 +183,6 @@ func.func @alloc_inside_region(%ctx: !hipsr.context,
       scf.yield
     }
     hipsr.pool_domain_yield
-  } {domain_id = 0 : i64}
-  return
-}
-
-// -----
-
-// CHECK-LABEL: func.func @mixed_dtypes
-func.func @mixed_dtypes(%ctx: !hipsr.context,
-                        %inf32: memref<4x256xf32, #hipsr.mem<device>>,
-                        %inf16: memref<?x512xf16, #hipsr.mem<device>>) {
-  // expected-remark@+1 {{hipsr-pool-alloc: insertion point after op 3}}
-  hipsr.pool_domain(%ctx, %inf32, %inf16 :
-      !hipsr.context,
-      memref<4x256xf32, #hipsr.mem<device>>,
-      memref<?x512xf16, #hipsr.mem<device>>) {
-  ^bb0(%dctx: !hipsr.context,
-       %sf32: memref<4x256xf32, #hipsr.mem<device>>,
-       %sf16: memref<?x512xf16, #hipsr.mem<device>>):
-    %c0 = arith.constant 0 : index
-    %d = memref.dim %sf16, %c0 : memref<?x512xf16, #hipsr.mem<device>>
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [4,4] group 0 size 4096}}
-    %a1 = memref.alloc() : memref<4x256xf32, #hipsr.mem<device>>
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [5,5] group 0 size 1024 x 1 dyn}}
-    %a2 = memref.alloc(%d) : memref<?x512xf16, #hipsr.mem<device>>
-    hipsr.add(%dctx) ins(%sf32, %sf32 : memref<4x256xf32, #hipsr.mem<device>>, memref<4x256xf32, #hipsr.mem<device>>)
-               outs(%a1 : memref<4x256xf32, #hipsr.mem<device>>)
-    hipsr.add(%dctx) ins(%sf16, %sf16 : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>)
-               outs(%a2 : memref<?x512xf16, #hipsr.mem<device>>)
-    hipsr.pool_domain_yield
-  } {domain_id = 0 : i64}
-  return
-}
-
-// -----
-
-// CHECK-LABEL: func.func @diamond
-func.func @diamond(%ctx: !hipsr.context, %in: memref<?x1024xf16, #hipsr.mem<device>>) {
-  // expected-remark@+1 {{hipsr-pool-alloc: insertion point after op 5}}
-  hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<?x1024xf16, #hipsr.mem<device>>) {
-  ^bb0(%dctx: !hipsr.context, %din: memref<?x1024xf16, #hipsr.mem<device>>):
-    %c0 = arith.constant 0 : index
-    %d = memref.dim %din, %c0 : memref<?x1024xf16, #hipsr.mem<device>>
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [6,8] group 0 size 2048 x 1 dyn}}
-    %a = memref.alloc(%d) : memref<?x1024xf16, #hipsr.mem<device>>
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [7,9] group 1 size 1024 x 1 dyn}}
-    %b = memref.alloc(%d) : memref<?x512xf16, #hipsr.mem<device>>
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [8,9] group 2 size 512 x 1 dyn}}
-    %c = memref.alloc(%d) : memref<?x256xf16, #hipsr.mem<device>>
-    // expected-remark@+1 {{hipsr-pool-alloc: lifetime [9,10] group 0 size 4096 x 1 dyn}}
-    %e = memref.alloc(%d) : memref<?x2048xf16, #hipsr.mem<device>>
-    hipsr.add(%dctx) ins(%din, %din : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%a : memref<?x1024xf16, #hipsr.mem<device>>)
-    hipsr.add(%dctx) ins(%a, %a : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%b : memref<?x512xf16, #hipsr.mem<device>>)
-    hipsr.add(%dctx) ins(%a, %a : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%c : memref<?x256xf16, #hipsr.mem<device>>)
-    hipsr.add(%dctx) ins(%b, %c : memref<?x512xf16, #hipsr.mem<device>>, memref<?x256xf16, #hipsr.mem<device>>) outs(%e : memref<?x2048xf16, #hipsr.mem<device>>)
-    hipsr.add(%dctx) ins(%e, %e : memref<?x2048xf16, #hipsr.mem<device>>, memref<?x2048xf16, #hipsr.mem<device>>) outs(%din : memref<?x1024xf16, #hipsr.mem<device>>)
-    hipsr.pool_domain_yield
-  } {domain_id = 0 : i64}
+  } {domain_id = 5 : i64}
   return
 }


### PR DESCRIPTION
## Summary

`hipsr-pool-alloc` now answers "how much did pooling save" instead of restating the grouping the IR already shows: `emit-pool-report` prints a per-domain summary (reuse ratio, before/after bytes, one row per group) and the pass gains statistics counters plus `LLVM_DEBUG` traces for the analysis. The transform itself is untouched.

## Related issue or design

wcy123/onnx-hipdnn-ep#118 (diagnostics for the rewritten pool-alloc pass).

## Why

The per-alloc remarks were scaffolding from the steps where the pass did not yet change IR, so printing was the only way to observe the analysis. Now that allocs become pool views, `line.mlir` and `diamond.mlir` assert the grouping directly through the view offsets, and `group N` / `size S` per alloc had become a second, weaker copy of that assertion.

What no remark answered is the question the option exists for: how much did pooling actually save, and where is the waste. That is a per-domain and per-group property, so the report is organized that way. The per-alloc detail is still worth having when a result looks wrong, but its audience is whoever is debugging the pass, which is what `LLVM_DEBUG` is for.

Two indicators are deliberately ratios rather than byte totals. Unused bytes per group grow with member count, so a 3-member group wasting 10 KB and a 10-member group wasting 10 KB read the same while the second is the better grouping; `avg unused = 1 - Σsize / (max × n)` normalizes that. Ratios also survive dynamic shapes, where the absolute numbers do not.

## What

- Four `STATISTIC` counters: `NumDomainsProcessed`, `NumAllocationsPooled`, `NumGroupsCreated`, `NumAllocationsReused` (pooled minus groups, i.e. the buffer slots reuse saved). Every number in the report maps onto one of them; the report is per domain, the counters accumulate per module.
- `DEBUG_TYPE` `hipsr-pool-alloc`, matching the pass registration name so one `--debug-only` does not also open the old `hip-pool-allocs` pass. Traces: each alloc's `[start, end]` with the ops selected as first write and last use, the grouping conflict pairs (which member's interval collided, in which group), each group's max with every member's slack against it, and the domain ordinal with the computed insertion point.
- A diagnostics-only size measurement over a set of allocs. Members are comparable when they multiply the same dynamic extents, in which case the common factor cancels out of every ratio; a set mixing extents reports `not comparable (mixed dynamic extents)` rather than inventing an order for symbolic products. Fully static sets report exact bytes, common-factor sets report ratios only since the absolute values depend on runtime extents. Comparability is decided per measured set, so a domain can be incomparable while each of its groups is fine.
- Byte figures exclude the 256-byte pool alignment: they measure what the grouping decision saves, while alignment is a fixed per-group allocator cost independent of who shares a group. Dropping the round-up also keeps the static and dynamic figures on one footing, since `alignUp` is not proportional to the dynamic factor. Reported bytes are therefore below the pool size `hipsr.get_pool` requests.

Report for the five allocations of `report.mlir`'s `@static_line`, sized 8192/4096/6144/2048/512:

```
hipsr-pool-alloc: domain 0: 5 allocs in 2 groups, 3 saved (60%)
hipsr-pool-alloc: domain 0: before vs after: 20992 bytes vs 12288 bytes, 41% saved
hipsr-pool-alloc: domain 0: group 0: 3 allocs, max 8192 bytes, 39% avg unused
hipsr-pool-alloc: domain 0: group 1: 2 allocs, max 4096 bytes, 25% avg unused
```

The three percentages measure different things (slots, bytes, per-use fill gap) and are normally unequal.

## Test plan

- [x] `ninja check-hip-mlir-lit`: 361 passed. The one failure, `Conversion/onnx-to-hip/test_gather_block_quantized.mlir`, reproduces on unmodified `main` in the same build (MLIR assertion `isSignedInteger()` in `BuiltinAttributes.cpp`) and is unrelated to this change.
- [x] `report.mlir` rewritten to assert the summary and group rows across all three size regimes: exact bytes when static, ratios only under a common dynamic factor, `not comparable` when extents differ, plus a domain that is incomparable while its groups are not.
- [x] `line.mlir`, `diamond.mlir`, `basic.mlir` and `invalid.mlir` unchanged, confirming the transform still emits identical IR and diagnostics.
- [x] Statistics and traces verified against a locally patched assertions build of the pass (see notes) and their numbers cross-checked against the report.
- [x] `pre-commit run --all-files` clean.

## Notes for reviewers

Empty domains still `emitError` and fail the pass, and dead allocs are still silently left in place. Turning either into a remark-and-skip changes behaviour, not diagnostics, so both stay out of this PR.

`STATISTIC` and `LLVM_DEBUG` are no-ops in a Release build, because both are gated on `NDEBUG` in the including translation unit and `CMAKE_BUILD_TYPE=Release` compiles the pass with `/DNDEBUG`. `--stats` and `--debug-only=hipsr-pool-alloc` therefore print nothing in the configuration CI and local builds use, which is also why no LIT test covers them and why none of the 20+ existing passes with these macros has such a test. I validated both layers by temporarily undefining `NDEBUG` for this translation unit and rebuilding. Worth deciding separately whether the tree wants an assertions build in CI, or `LLVM_FORCE_ENABLE_STATS` for the counters; either would make the second layer testable.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [ ] Substantial AI assistance is disclosed, and I reviewed and understand the result.
