### PR TITLE
feat(hipsr): add pipeline scaffolding for the hipsr dialect

### DIFF
--- a/include/hip/Dialect/Hipsr/Pipelines/Pipelines.h
+++ b/include/hip/Dialect/Hipsr/Pipelines/Pipelines.h
@@ -17,12 +17,7 @@ namespace hipsr {
 struct HipsrPipelineOptions : public PassPipelineOptions<HipsrPipelineOptions> {
 };
 
-/// Build the hipsr pipeline into `pm`. Adds no passes yet.
-///
-/// The passes it will add, in order: hipsr-populate-shape-region,
-/// hipsr-partition-pool-domains, hipsr-materialize-init-tensors,
-/// bufferization, hipsr-pool-alloc, hipsr-externalize-constants. See
-/// Dialect/Hipsr/Transforms/Passes.td for the order rules.
+/// Build the hipsr pipeline into `pm`.
 void buildHipsrPipeline(OpPassManager &pm,
                         const HipsrPipelineOptions &options = {});
 

--- a/include/hip/Dialect/Hipsr/Pipelines/Pipelines.h
+++ b/include/hip/Dialect/Hipsr/Pipelines/Pipelines.h
@@ -12,16 +12,12 @@
 namespace mlir {
 namespace hipsr {
 
-/// Options for `hipsr-pipeline`.
 struct HipsrPipelineOptions : public PassPipelineOptions<HipsrPipelineOptions> {
 };
 
-/// Build the hipsr pipeline into `pm`.
 void buildHipsrPipeline(OpPassManager &pm,
                         const HipsrPipelineOptions &options = {});
 
-/// Register the `hipsr-pipeline` name so it can be used in `hip-mlir-opt` and
-/// in pipeline strings.
 void registerHipsrPipelines();
 
 } // namespace hipsr

--- a/include/hip/Dialect/Hipsr/Pipelines/Pipelines.h
+++ b/include/hip/Dialect/Hipsr/Pipelines/Pipelines.h
@@ -12,8 +12,7 @@
 namespace mlir {
 namespace hipsr {
 
-/// Options for `hipsr-pipeline`. Empty for now. Add an option here together
-/// with the pass that reads it.
+/// Options for `hipsr-pipeline`.
 struct HipsrPipelineOptions : public PassPipelineOptions<HipsrPipelineOptions> {
 };
 

--- a/include/hip/Dialect/Hipsr/Pipelines/Pipelines.h
+++ b/include/hip/Dialect/Hipsr/Pipelines/Pipelines.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#ifndef HIP_DIALECT_HIPSR_PIPELINES_PIPELINES_H
+#define HIP_DIALECT_HIPSR_PIPELINES_PIPELINES_H
+
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Pass/PassOptions.h"
+
+namespace mlir {
+namespace hipsr {
+
+/// Options for `hipsr-pipeline`. Empty for now. Add an option here together
+/// with the pass that reads it.
+struct HipsrPipelineOptions
+    : public PassPipelineOptions<HipsrPipelineOptions> {};
+
+/// Build the hipsr pipeline into `pm`. Adds no passes yet.
+///
+/// The passes it will add, in order: hipsr-populate-shape-region,
+/// hipsr-partition-pool-domains, hipsr-materialize-init-tensors,
+/// bufferization, hipsr-pool-alloc, hipsr-externalize-constants. See
+/// Dialect/Hipsr/Transforms/Passes.td for the order rules.
+void buildHipsrPipeline(OpPassManager &pm,
+                        const HipsrPipelineOptions &options = {});
+
+/// Register the `hipsr-pipeline` name so it can be used in `hip-mlir-opt` and
+/// in pipeline strings.
+void registerHipsrPipelines();
+
+} // namespace hipsr
+} // namespace mlir
+
+#endif // HIP_DIALECT_HIPSR_PIPELINES_PIPELINES_H

--- a/include/hip/Dialect/Hipsr/Pipelines/Pipelines.h
+++ b/include/hip/Dialect/Hipsr/Pipelines/Pipelines.h
@@ -14,8 +14,8 @@ namespace hipsr {
 
 /// Options for `hipsr-pipeline`. Empty for now. Add an option here together
 /// with the pass that reads it.
-struct HipsrPipelineOptions
-    : public PassPipelineOptions<HipsrPipelineOptions> {};
+struct HipsrPipelineOptions : public PassPipelineOptions<HipsrPipelineOptions> {
+};
 
 /// Build the hipsr pipeline into `pm`. Adds no passes yet.
 ///

--- a/include/hip/InitAllPasses.h
+++ b/include/hip/InitAllPasses.h
@@ -11,6 +11,7 @@
 #include "hip/Conversion/OnnxToHip/Passes.h"
 #include "hip/Conversion/Passes.h"
 #include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
+#include "hip/Dialect/Hipsr/Pipelines/Pipelines.h"
 #include "hip/Dialect/Hipsr/Transforms/BufferizableOpInterfaceImpl.h"
 #include "hip/Dialect/Hipsr/Transforms/Passes.h"
 #include "hip/Dialect/IR/HipBufferize.h"
@@ -154,6 +155,7 @@ inline void registerAllPasses() {
     // hipsr dialect transform passes (TableGen GEN_PASS_REGISTRATION):
     // hipsr-populate-shape-region, hipsr-externalize-constants, ...
     mlir::hipsr::registerHipsrPasses();
+    mlir::hipsr::registerHipsrPipelines();
 
     // Conversion passes (convert-onnx-to-hip, outline-onnx-to-hipdnn,
     // convert-hip-to-llvm); onnx-loop-outline and its sibling onnx-if-outline

--- a/lib/Compiler/CMakeLists.txt
+++ b/lib/Compiler/CMakeLists.txt
@@ -27,6 +27,7 @@ target_link_libraries(LibHipCompiler PUBLIC
   HipDialectIR
   HipsrDialectIR
   HipsrDialectTransforms
+  HipsrDialectPipelines
   HipDialectTransforms
   HipTargetLLVM
   MLIRIR

--- a/lib/Dialect/Hipsr/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/CMakeLists.txt
@@ -5,3 +5,4 @@
 
 add_subdirectory(IR)
 add_subdirectory(Transforms)
+add_subdirectory(Pipelines)

--- a/lib/Dialect/Hipsr/Pipelines/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/Pipelines/CMakeLists.txt
@@ -1,0 +1,21 @@
+##
+# ** Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# ** Licensed under the MIT License.
+##
+
+add_library(HipsrDialectPipelines STATIC
+  Pipelines.cpp
+)
+
+# The pipeline will add the hipsr transform passes, so link them now. Adding
+# the first pass then only changes Pipelines.cpp.
+add_dependencies(HipsrDialectPipelines
+  HipsrTransformsPassIncGen
+)
+
+target_link_libraries(HipsrDialectPipelines PUBLIC
+  HipsrDialectTransforms
+  MLIRPass
+  MLIRIR
+  MLIRSupport
+)

--- a/lib/Dialect/Hipsr/Pipelines/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/Pipelines/CMakeLists.txt
@@ -7,12 +7,6 @@ add_library(HipsrDialectPipelines STATIC
   Pipelines.cpp
 )
 
-# The pipeline will add the hipsr transform passes, so link them now. Adding
-# the first pass then only changes Pipelines.cpp.
-add_dependencies(HipsrDialectPipelines
-  HipsrTransformsPassIncGen
-)
-
 target_link_libraries(HipsrDialectPipelines PUBLIC
   HipsrDialectTransforms
   MLIRPass

--- a/lib/Dialect/Hipsr/Pipelines/Pipelines.cpp
+++ b/lib/Dialect/Hipsr/Pipelines/Pipelines.cpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip/Dialect/Hipsr/Pipelines/Pipelines.h"
+
+#include "mlir/Pass/PassRegistry.h"
+
+void mlir::hipsr::buildHipsrPipeline(OpPassManager & /*pm*/,
+                                     const HipsrPipelineOptions & /*options*/) {
+}
+
+void mlir::hipsr::registerHipsrPipelines() {
+  PassPipelineRegistration<HipsrPipelineOptions>(
+      "hipsr-pipeline",
+      "Run the hipsr dialect lowering pipeline",
+      buildHipsrPipeline);
+}

--- a/lib/Dialect/Hipsr/Pipelines/Pipelines.cpp
+++ b/lib/Dialect/Hipsr/Pipelines/Pipelines.cpp
@@ -13,7 +13,6 @@ void mlir::hipsr::buildHipsrPipeline(OpPassManager & /*pm*/,
 
 void mlir::hipsr::registerHipsrPipelines() {
   PassPipelineRegistration<HipsrPipelineOptions>(
-      "hipsr-pipeline",
-      "Run the hipsr dialect lowering pipeline",
+      "hipsr-pipeline", "Run the hipsr dialect lowering pipeline",
       buildHipsrPipeline);
 }

--- a/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
@@ -10,9 +10,6 @@
 // pipeline must never freeze an extent to a constant. The embedding table is a
 // two-gigabyte external constant carried as an offset/size reference rather
 // than inline data.
-//
-// buildHipsrPipeline() currently adds no passes, so the graph must survive
-// unchanged.
 //===----------------------------------------------------------------------===//
 
 // RUN: hip-mlir-opt --hipsr-pipeline %s | FileCheck %s

--- a/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
@@ -1,0 +1,66 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Pipeline test: hipsr pipeline on a dynamically shaped embedding graph.
+//
+// The input is the ONNX-MLIR form of a text-embedding graph that scatters image
+// features into token embeddings. Every batch and sequence extent stays
+// symbolic, and NonZero makes the scatter index count data-dependent, so the
+// pipeline must never freeze an extent to a constant. The embedding table is a
+// two-gigabyte external constant carried as an offset/size reference rather
+// than inline data.
+//
+// buildHipsrPipeline() currently adds no passes, so the graph must survive
+// unchanged.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --hipsr-pipeline %s | FileCheck %s
+
+// CHECK-LABEL: func.func @main_graph(
+// CHECK-SAME:      %[[IDS:.*]]: tensor<?x?xi64> {onnx.name = "input_ids"},
+// CHECK-SAME:      %[[FEATURES:.*]]: tensor<?x4096xf16> {onnx.name = "image_features"})
+// CHECK-SAME:      -> (tensor<?x?x4096xf16> {onnx.name = "inputs_embeds"})
+
+// The embedding table stays a reference to external data.
+// CHECK: %[[TABLE:.*]] = "onnx.Constant"() {location = "embedding.onnx.data"
+// CHECK-SAME: offset = 0 : i64, size = 2034237440 : i64} : () -> tensor<248320x4096xf16>
+
+// CHECK: %[[FLAT:.*]] = "onnx.Reshape"(%[[FEATURES]], %{{.*}}) {{.*}} -> tensor<?xf16>
+// CHECK: %[[MASK:.*]] = "onnx.Equal"(%[[IDS]], %{{.*}}) {{.*}} -> tensor<?x?xui8>
+// CHECK: %[[EMBEDS:.*]] = "onnx.Gather"(%[[TABLE]], %[[IDS]]) {{.*}} -> tensor<?x?x4096xf16>
+// CHECK: %[[SHAPE:.*]] = "onnx.Shape"(%[[EMBEDS]]) {{.*}} -> tensor<3xi64>
+
+// NonZero yields a data-dependent trailing extent that feeds the scatter.
+// CHECK: %[[NONZERO:.*]] = "onnx.NonZero"(%{{.*}}) {{.*}} -> tensor<3x?xi64>
+// CHECK: %[[INDICES:.*]] = "onnx.Transpose"(%[[NONZERO]]) {{.*}} -> tensor<?x3xi64>
+// CHECK: %[[UPDATES:.*]] = "onnx.Slice"(%[[FLAT]], {{.*}}) {{.*}} -> tensor<?xf16>
+// CHECK: %[[OUT:.*]] = "onnx.ScatterND"(%[[EMBEDS]], %[[INDICES]], %[[UPDATES]])
+// CHECK-SAME: -> tensor<?x?x4096xf16>
+// CHECK: "onnx.Return"(%[[OUT]])
+
+module {
+  func.func @main_graph(%arg0: tensor<?x?xi64> {onnx.name = "input_ids"}, %arg1: tensor<?x4096xf16> {onnx.name = "image_features"}) -> (tensor<?x?x4096xf16> {onnx.name = "inputs_embeds"}) attributes {onnx.graph.name = "main_graph"} {
+    %0 = "onnx.NoValue"() {value} : () -> none
+    %1 = "onnx.Constant"() {location = "embedding.onnx.data", node.outputs = ["embed_tokens.weight"], offset = 0 : i64, size = 2034237440 : i64} : () -> tensor<248320x4096xf16>
+    %2 = "onnx.Constant"() {node.outputs = ["/Constant_output_0"], value = dense<248056> : tensor<i64>} : () -> tensor<i64>
+    %3 = "onnx.Constant"() {node.outputs = ["/Constant_1_output_0"], value = dense<-1> : tensor<1xi64>} : () -> tensor<1xi64>
+    %4 = "onnx.Constant"() {node.outputs = ["/Constant_3_output_0"], value = dense<0> : tensor<i64>} : () -> tensor<i64>
+    %5 = "onnx.Constant"() {node.outputs = ["/Constant_4_output_0"], value = dense<0> : tensor<1xi64>} : () -> tensor<1xi64>
+    %6 = "onnx.Reshape"(%arg1, %3) {allowzero = 0 : si64, node.outputs = ["/Reshape_output_0"], onnx_node_name = "/Reshape"} : (tensor<?x4096xf16>, tensor<1xi64>) -> tensor<?xf16>
+    %7 = "onnx.Equal"(%arg0, %2) {node.outputs = ["/Equal_output_0"], onnx_node_name = "/Equal"} : (tensor<?x?xi64>, tensor<i64>) -> tensor<?x?xui8>
+    %8 = "onnx.Unsqueeze"(%7, %3) {node.outputs = ["/Unsqueeze_output_0"], onnx_node_name = "/Unsqueeze"} : (tensor<?x?xui8>, tensor<1xi64>) -> tensor<?x?x1xui8>
+    %9 = "onnx.Gather"(%1, %arg0) {axis = 0 : si64, node.outputs = ["/embed_tokens/Gather_output_0"], onnx_node_name = "/embed_tokens/Gather"} : (tensor<248320x4096xf16>, tensor<?x?xi64>) -> tensor<?x?x4096xf16>
+    %10 = "onnx.Shape"(%9) {node.outputs = ["/Shape_1_output_0"], onnx_node_name = "/Shape_1", start = 0 : si64} : (tensor<?x?x4096xf16>) -> tensor<3xi64>
+    %11 = "onnx.Expand"(%8, %10) {node.outputs = ["/Expand_output_0"], onnx_node_name = "/Expand"} : (tensor<?x?x1xui8>, tensor<3xi64>) -> tensor<?x?x?xui8>
+    %12 = "onnx.Expand"(%11, %10) {node.outputs = ["/Expand_1_output_0"], onnx_node_name = "/Expand_1"} : (tensor<?x?x?xui8>, tensor<3xi64>) -> tensor<?x?x?xui8>
+    %13 = "onnx.NonZero"(%12) {node.outputs = ["/NonZero_output_0"], onnx_node_name = "/NonZero"} : (tensor<?x?x?xui8>) -> tensor<3x?xi64>
+    %14 = "onnx.Transpose"(%13) {node.outputs = ["/Transpose_output_0"], onnx_node_name = "/Transpose", perm = [1, 0]} : (tensor<3x?xi64>) -> tensor<?x3xi64>
+    %15 = "onnx.Shape"(%14) {node.outputs = ["/Shape_2_output_0"], onnx_node_name = "/Shape_2", start = 0 : si64} : (tensor<?x3xi64>) -> tensor<2xi64>
+    %16 = "onnx.Gather"(%15, %4) {axis = 0 : si64, node.outputs = ["/Gather_output_0"], onnx_node_name = "/Gather"} : (tensor<2xi64>, tensor<i64>) -> tensor<i64>
+    %17 = "onnx.Unsqueeze"(%16, %5) {node.outputs = ["/Unsqueeze_1_output_0"], onnx_node_name = "/Unsqueeze_1"} : (tensor<i64>, tensor<1xi64>) -> tensor<1xi64>
+    %18 = "onnx.Slice"(%6, %5, %17, %5) {node.outputs = ["/Slice_output_0"], onnx_node_name = "/Slice"} : (tensor<?xf16>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>) -> tensor<?xf16>
+    %19 = "onnx.ScatterND"(%9, %14, %18) {node.outputs = ["inputs_embeds"], onnx_node_name = "/ScatterND", reduction = "none"} : (tensor<?x?x4096xf16>, tensor<?x3xi64>, tensor<?xf16>) -> tensor<?x?x4096xf16>
+    "onnx.Return"(%19) : (tensor<?x?x4096xf16>) -> ()
+  }
+}

--- a/tools/hip-mlir-opt/CMakeLists.txt
+++ b/tools/hip-mlir-opt/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(hip-mlir-opt PRIVATE
   HipDialectIR
   HipsrDialectIR
   HipsrDialectTransforms
+  HipsrDialectPipelines
   HipDialectTransforms
   HipToLLVM
   OnnxToHip


### PR DESCRIPTION
## Summary

Adds a `Pipelines` component to the hipsr dialect and registers the `hipsr-pipeline` name.

## Why

The hipsr passes can only be named one at a time, so there is nowhere to record the order they must run in. This adds that place, following the layout upstream MLIR uses for `Dialect/Bufferization/Pipelines/`.

`convert-onnx-to-hipsr` is left out on purpose: it marks the `onnx` dialect illegal but calls `applyFullConversion` with no patterns, so it only succeeds on IR that has no ONNX ops.

## What

New:

- `include/hip/Dialect/Hipsr/Pipelines/Pipelines.h` — `HipsrPipelineOptions`, `buildHipsrPipeline`, `registerHipsrPipelines`.
- `lib/Dialect/Hipsr/Pipelines/Pipelines.cpp` — the builder and the `PassPipelineRegistration`.
- `lib/Dialect/Hipsr/Pipelines/CMakeLists.txt` — `HipsrDialectPipelines`.
- `test/lit/Dialect/Hipsr/Pipelines/embedding.mlir` — `--hipsr-pipeline` over a dynamically shaped graph.

Modified, one line each: `add_subdirectory(Pipelines)`, the `registerHipsrPipelines()` call in `registerAllPasses()`, and the library link in `LibHipCompiler` and `hip-mlir-opt`.

## Test

`embedding.mlir` is the ONNX-MLIR the EP emits for a text-embedding graph. Every batch and sequence extent stays symbolic, and `NonZero` makes the scatter index count data-dependent, so a pass that freezes an extent fails the checks.

## AI assistance

Cursor (Claude Opus 5) assisted with the design, the implementation and the test. I reviewed the result and understand it.
