### PR TITLE
feat(kernels): add GPU family fatbin support for custom_kernels

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -350,7 +350,7 @@ jobs:
           python build.py \
             --config Release \
             --cmake_generator Ninja \
-            --hip_arch gfx1151 \
+            --hip_arch gfx115X-all \
             --cmake_prefix_path "${{ runner.workspace }}/ort-install;${{ runner.workspace }}/llvm-install" \
             --cmake_extra_defines CMAKE_DISABLE_FIND_PACKAGE_OpenSSL=ON \
             --cmake_extra_defines "HIP_WHEEL_EXTRA_DLLS=$AMDGPU_EP;$HIP_BACKEND"
@@ -521,7 +521,7 @@ jobs:
           cp "$PREBUILT/bin/onnxruntime_providers_shared.dll" staging/bin/
           cp "$PREBUILT/bin/DirectML.dll" staging/bin/
 
-          # MorphiZen EP DLL + per-arch custom_kernels_gfx<arch>.dll + other
+          # MorphiZen EP DLL + family custom_kernels_gfx115X-all.dll + other
           # install DLLs/EXEs (kernel DLL must sit next to the EP DLL so
           # LlvmIrJit's GetModuleFileName-anchored Load finds it).
           cp "${{ runner.workspace }}/install/bin/"*.dll staging/bin/ 2>/dev/null || true
@@ -541,12 +541,12 @@ jobs:
           cp "$AMDGPU_EP" staging/bin/
           cp "$HIP_BACKEND" staging/bin/
 
-          # Smoke: the per-arch kernel DLL must be present in staging/bin/
+          # Smoke: the family kernel DLL must be present in staging/bin/
           # for the gpu-test job to load it. Failure here means the install
           # rule in lib/Runtime/Kernels/CMakeLists.txt regressed.
-          KERNEL_DLL="staging/bin/custom_kernels_gfx1151.dll"
+          KERNEL_DLL="staging/bin/custom_kernels_gfx115X-all.dll"
           if [ ! -f "$KERNEL_DLL" ]; then
-            echo "ERROR: $KERNEL_DLL missing from install (HIP_ARCHITECTURES=gfx1151)"
+            echo "ERROR: $KERNEL_DLL missing from install (HIP_ARCHITECTURES=gfx115X-all)"
             ls -1 "${{ runner.workspace }}/install/bin/" || true
             exit 1
           fi

--- a/backend-mlir-compiler/custom-op-mlir/src/LlvmIrJit.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/LlvmIrJit.cpp
@@ -32,6 +32,8 @@
 // this lib also links (see this dir's CMakeLists).
 #include "hip/Compiler/PluginRegistry.h"
 
+#include "hip/HipGpuFamilies.h"
+
 #include <glog/logging.h>
 
 // Per-OS runtime bitcode embedded as bytes; emitted by
@@ -318,30 +320,65 @@ bool installSearchGenerators(llvm::orc::LLJIT &jit) {
   }
 
 #ifdef HIPDNN_EP_LOAD_KERNEL_DLLS
-  // Per-arch GPU kernel DLL/SO, dlopen'd from the EP binary's own directory.
+  // Per-arch or family GPU kernel DLL/SO, dlopen'd from the EP directory.
+  // Try custom_kernels_<gcnArchName> first, then a family fatbin (e.g.
+  // custom_kernels_gfx115X-all) when the per-arch variant is not installed.
   {
     const std::string arch = detectCustomKernelArch();
+    const char sep =
 #ifdef _WIN32
-    const std::string basename = "custom_kernels_" + arch + ".dll";
-    const char sep = '\\';
+        '\\';
 #else
-    const std::string basename = "libcustom_kernels_" + arch + ".so";
-    const char sep = '/';
+        '/';
 #endif
-    std::string kernel_lib = thisModuleDirectory();
-    if (!kernel_lib.empty())
-      kernel_lib.push_back(sep);
-    kernel_lib += basename;
+    std::string kernel_dir = thisModuleDirectory();
+    const auto basenames = hip_ep::customKernelLibraryBasenames(arch);
 
-    auto gen = llvm::orc::DynamicLibrarySearchGenerator::Load(
-        kernel_lib.c_str(), global_prefix);
-    if (!gen) {
-      LOG(ERROR) << "LlvmIrJit: Load(" << kernel_lib << ") for arch=" << arch
-                 << " failed: " << llvm::toString(gen.takeError())
-                 << ". Install " << basename << " next to the EP DLL/SO.";
+    bool loaded = false;
+    for (const std::string &basename : basenames) {
+#ifdef _WIN32
+      const std::string filename = basename + ".dll";
+#else
+      const std::string filename = "lib" + basename + ".so";
+#endif
+      std::string kernel_lib = kernel_dir;
+      if (!kernel_lib.empty())
+        kernel_lib.push_back(sep);
+      kernel_lib += filename;
+
+      if (!llvm::sys::fs::exists(kernel_lib)) {
+        LOG(INFO) << "LlvmIrJit: " << kernel_lib << " not found; trying next "
+                  << "custom-kernels candidate.";
+        continue;
+      }
+
+      auto gen = llvm::orc::DynamicLibrarySearchGenerator::Load(
+          kernel_lib.c_str(), global_prefix);
+      if (!gen) {
+        LOG(WARNING) << "LlvmIrJit: Load(" << kernel_lib
+                     << ") failed: " << llvm::toString(gen.takeError());
+        continue;
+      }
+      jd.addGenerator(std::move(*gen));
+      LOG(INFO) << "LlvmIrJit: loaded custom kernels from " << kernel_lib
+                << " (device arch=" << arch << ")";
+      loaded = true;
+      break;
+    }
+
+    if (!loaded) {
+      LOG(ERROR) << "LlvmIrJit: no custom-kernels library found for arch="
+                 << arch << ". Tried:";
+      for (const std::string &basename : basenames) {
+#ifdef _WIN32
+        LOG(ERROR) << "  custom_kernels candidate: " << basename << ".dll";
+#else
+        LOG(ERROR) << "  custom_kernels candidate: lib" << basename << ".so";
+#endif
+      }
+      LOG(ERROR) << "Install one next to the EP DLL/SO.";
       return false;
     }
-    jd.addGenerator(std::move(*gen));
   }
 #endif // HIPDNN_EP_LOAD_KERNEL_DLLS
 

--- a/build.py
+++ b/build.py
@@ -402,7 +402,8 @@ def parse_arguments():
     p.add_argument(
         "--hip_arch",
         default="",
-        help="GPU arch (e.g. gfx1151); auto-detected on Linux if unset",
+        help="GPU arch (e.g. gfx1151) or family (e.g. gfx115X-all); "
+        "auto-detected on Linux if unset",
     )
     p.add_argument(
         "--mock", action="store_true", help="mock runtime (no GPU/HIP/TheRock)"

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -84,7 +84,7 @@ if(_HIPDNN_NEED_TOOLCHAIN)
         if(_therock_arch MATCHES ";")
           list(GET _therock_arch 0 _therock_arch)
         endif()
-        include(${CMAKE_CURRENT_SOURCE_DIR}/hip_families.cmake)
+        include(${CMAKE_CURRENT_LIST_DIR}/hip_families.cmake)
         hip_first_concrete_gpu_arch("${_therock_arch}" _therock_arch)
         if(NOT _therock_arch)
           message(FATAL_ERROR

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -84,6 +84,8 @@ if(_HIPDNN_NEED_TOOLCHAIN)
         if(_therock_arch MATCHES ";")
           list(GET _therock_arch 0 _therock_arch)
         endif()
+        include(${CMAKE_CURRENT_SOURCE_DIR}/hip_families.cmake)
+        hip_first_concrete_gpu_arch("${_therock_arch}" _therock_arch)
         if(NOT _therock_arch)
           message(FATAL_ERROR
             "Cannot derive the TheRock tarball: set -DHIP_ARCHITECTURES=<gfxNNNN> "

--- a/cmake/hip_families.cmake
+++ b/cmake/hip_families.cmake
@@ -1,0 +1,40 @@
+##
+# ** Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# ** Licensed under the MIT License.
+##
+
+set(_HIP_FAMILY_gfx115X_members gfx1150 gfx1151 gfx1152 gfx1153)
+set(HIP_GPU_FAMILY_gfx115X-all ${_HIP_FAMILY_gfx115X_members})
+unset(_HIP_FAMILY_gfx115X_members)
+
+# True when NAME is a registered family (not a concrete gfxNNNN arch).
+function(hip_is_gpu_family NAME OUT_VAR)
+    if(DEFINED HIP_GPU_FAMILY_${NAME})
+        set(${OUT_VAR} TRUE PARENT_SCOPE)
+    else()
+        set(${OUT_VAR} FALSE PARENT_SCOPE)
+    endif()
+endfunction()
+
+# Member arch list for a family; empty when NAME is not a family.
+function(hip_expand_gpu_family NAME OUT_VAR)
+    if(DEFINED HIP_GPU_FAMILY_${NAME})
+        set(${OUT_VAR} ${HIP_GPU_FAMILY_${NAME}} PARENT_SCOPE)
+    else()
+        set(${OUT_VAR} "" PARENT_SCOPE)
+    endif()
+endfunction()
+
+# First concrete gfx arch for TheRock tarball selection / defaults.
+function(hip_first_concrete_gpu_arch ENTRY OUT_VAR)
+    hip_is_gpu_family("${ENTRY}" _is_family)
+    if(_is_family)
+        hip_expand_gpu_family("${ENTRY}" _members)
+        if(_members)
+            list(GET _members 0 _first)
+            set(${OUT_VAR} "${_first}" PARENT_SCOPE)
+            return()
+        endif()
+    endif()
+    set(${OUT_VAR} "${ENTRY}" PARENT_SCOPE)
+endfunction()

--- a/docs/design/custom_kernel_design.md
+++ b/docs/design/custom_kernel_design.md
@@ -139,7 +139,12 @@ Implements GQA as a multi-step operation:
 
 ### 5. `lib/Runtime/Kernels/CMakeLists.txt`
 
-Build one SHARED library per arch in `HIP_ARCHITECTURES`, each carrying a single fatbin slice for that arch. Install side-by-side with the EP binary so `LlvmIrJit` finds it via `GetModuleFileName` / `dladdr` anchoring. No static archive is produced.
+Build one SHARED library per `HIP_ARCHITECTURES` entry. Concrete arch names
+(e.g. `gfx1151`) produce a single-slice fatbin; family names (e.g.
+`gfx115X-all`, see `cmake/hip_families.cmake`) produce one multi-slice fatbin
+with native code objects for every member arch. Install side-by-side with the EP
+binary so `LlvmIrJit` finds it via `GetModuleFileName` / `dladdr` anchoring.
+No static archive is produced.
 
 ```cmake
 cmake_minimum_required(VERSION 3.18)
@@ -277,7 +282,14 @@ Four execution paths, auto-dispatched by shape:
 
 ## Key Design Decisions
 
-- **Per-arch SHARED library, not static lib**: One `custom_kernels_<arch>.{dll,so}` per arch in `HIP_ARCHITECTURES`, each with a single fatbin slice. Co-located with the EP binary; `LlvmIrJit::create` `dlopen`s the matching variant at JIT init based on `gcnArchName`. Per-model bitcode stays free of GPU code, which is what keeps it OS-portable and bytewise-stable across model recompiles when only the host CRT changes.
+- **Per-arch or per-family SHARED library, not static lib**: Each concrete entry
+  in `HIP_ARCHITECTURES` becomes `custom_kernels_<name>.{dll,so}`. Concrete
+  arches carry one native fatbin slice; family names (e.g. `gfx115X-all`) carry
+  one multi-slice native fatbin. Co-located with the EP binary; `LlvmIrJit`
+  dlopens `custom_kernels_<gcnArchName>` first, then falls back to a family DLL
+  when the per-arch variant is absent (`include/hip/HipGpuFamilies.h`). Per-model
+  bitcode stays free of GPU code, which is what keeps it OS-portable and
+  bytewise-stable across model recompiles when only the host CRT changes.
 - **Pure C header interface**: The header uses only C types (`void`*, `int64_t`, `float`) so it can be included by Clang during bitcode compilation AND by MSVC if needed.
 - **Separation of concerns**: `.hip` files contain device code (compiled by hipcc); `.cpp` runtime wrappers contain host logic (compiled by Clang to bitcode and embedded as `runtime.bc` inside the EP DLL). They communicate through the C header.
-- **`hip_utils.cmake` reuse**: Proven approach for Windows hipcc compilation, multi-config generators, architecture flags. The `OFFLOAD_ARCHS` arg overrides the global `HIP_ARCHITECTURES` so each per-arch target builds a single-slice fatbin instead of a multi-slice bloated one.
+- **`hip_utils.cmake` reuse**: Proven approach for Windows hipcc compilation, multi-config generators, architecture flags. The `OFFLOAD_ARCHS` arg overrides the global `HIP_ARCHITECTURES`. Per-arch targets pass a single arch; family targets pass every member arch so hipcc emits one native slice per member in the same shared library.

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -174,9 +174,10 @@ unset HIP_PATH
 
 python build.py --install_dir "$LOCAL_DIR" --cmake_prefix_path "$LOCAL_DIR"
 #   --mock                    mock runtime (no GPU/HIP/TheRock)
-#   --hip_arch gfx1151        target GPU; auto-detected by default. Set it for a
-#                             cross-machine build+run -- the *target* GPU's arch
-#                             (e.g. from `offload-arch.exe` on that machine)
+#   --hip_arch gfx1151        concrete GPU arch (single-slice custom_kernels DLL)
+#   --hip_arch gfx115X-all    family fatbin (multi-slice; covers gfx1150-1153)
+#                             cross-machine builds: use the target GPU's arch or
+#                             a family that includes it (offload-arch / hipInfo)
 #   --therock_dist <path>     reuse a local TheRock SDK (else auto-downloaded)
 #   --cmake_generator Ninja   use Ninja (run from an x64 Native Tools prompt)
 #   --config RelWithDebInfo   build type (default Release)

--- a/include/hip/HipGpuFamilies.h
+++ b/include/hip/HipGpuFamilies.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace hip_ep {
+
+// Member-to-family map. Keep in sync with cmake/hip_families.cmake.
+inline std::optional<std::string_view> familyForGpuArch(std::string_view arch) {
+  static constexpr struct {
+    std::string_view family;
+    std::string_view member;
+  } kMembers[] = {
+      {"gfx115X-all", "gfx1150"},
+      {"gfx115X-all", "gfx1151"},
+      {"gfx115X-all", "gfx1152"},
+      {"gfx115X-all", "gfx1153"},
+  };
+  for (const auto &entry : kMembers) {
+    if (entry.member == arch)
+      return entry.family;
+  }
+  return std::nullopt;
+}
+
+// Basenames to try when dlopen'ing custom kernels (no directory/extension).
+// Per-arch DLL first, then the family fatbin if the arch belongs to one.
+inline std::vector<std::string>
+customKernelLibraryBasenames(std::string_view arch) {
+  std::vector<std::string> names;
+  names.emplace_back(std::string("custom_kernels_") + std::string(arch));
+  if (auto family = familyForGpuArch(arch))
+    names.emplace_back(std::string("custom_kernels_") + std::string(*family));
+  return names;
+}
+
+} // namespace hip_ep

--- a/lib/Runtime/Kernels/CMakeLists.txt
+++ b/lib/Runtime/Kernels/CMakeLists.txt
@@ -13,10 +13,11 @@
 # filename, so the output names are decoupled from the directory name -- do not
 # rename the targets to match the folder.
 #
-# Per-arch shared libraries: one SHARED library per arch in HIP_ARCHITECTURES,
-# each carrying a single fatbin slice. The EP DLL dlopens the matching variant
-# at JIT init via gcnArchName probing. No static archive is produced; the EP
-# DLL no longer carries hip_* launcher symbols.
+# Per-arch or per-family shared libraries driven by HIP_ARCHITECTURES:
+#   * concrete arch (gfx1151): one SHARED lib, single native fatbin slice
+#   * family name (gfx115X-all): one SHARED lib, multi-slice native fatbin
+#   * semicolon list (gfx1150;gfx1151): one single-slice lib per entry
+# LlvmIrJit dlopens custom_kernels_<gcnArchName> first, then the family DLL.
 #
 # Build flow (per arch):
 #   .hip files -> hipcc -c --offload-arch=<arch> -> .obj
@@ -24,13 +25,16 @@
 
 cmake_minimum_required(VERSION 3.18)
 
+include(${CMAKE_SOURCE_DIR}/cmake/hip_families.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/hip_utils.cmake)
 
 # Require HIP_ARCHITECTURES to be set (no silent defaults that may not match hardware)
 if(NOT HIP_ARCHITECTURES)
     message(FATAL_ERROR
         "[custom_kernels] HIP_ARCHITECTURES is not set.\n"
-        "Pass -DHIP_ARCHITECTURES=<arch>[;<arch>...] to cmake (e.g. gfx1100;gfx1151).\n"
+        "Pass -DHIP_ARCHITECTURES=<arch>[;<arch>...] or a family (e.g. gfx115X-all).\n"
+        "Examples: gfx1151 (single arch), gfx115X-all (family fatbin), "
+        "gfx1100;gfx1151 (multiple single-slice libs).\n"
         "Run 'rocminfo | grep gfx' or 'hipInfo' to find your GPU architecture.")
 endif()
 message(STATUS "[custom_kernels] Using HIP_ARCHITECTURES: ${HIP_ARCHITECTURES}")
@@ -81,19 +85,31 @@ set(_kernel_sources
     hip/strided_copy_kernel.hip
 )
 
-# One SHARED target per arch. Each builds a fatbin with that single slice;
-# OFFLOAD_ARCHS narrows the global list to one element so the resulting
-# DLL/SO is not bloated with code for archs the consumer won't load.
-foreach(_arch IN LISTS HIP_ARCHITECTURES)
-    set(_target custom_kernels_${_arch})
+# One SHARED target per HIP_ARCHITECTURES entry. Families compile all member
+# arches into one multi-slice fatbin; concrete entries get a single slice.
+foreach(_entry IN LISTS HIP_ARCHITECTURES)
+    set(_target custom_kernels_${_entry})
+    hip_is_gpu_family("${_entry}" _is_family)
+    if(_is_family)
+        hip_expand_gpu_family("${_entry}" _offload_archs)
+        if(NOT _offload_archs)
+            message(FATAL_ERROR
+                "[custom_kernels] family '${_entry}' has no member arches.")
+        endif()
+        message(STATUS
+            "[custom_kernels] family '${_entry}' -> offload: ${_offload_archs}")
+    else()
+        set(_offload_archs ${_entry})
+    endif()
+
     hip_add_library(${_target} SHARED ${_kernel_sources}
         INCLUDE_DIRECTORIES
             ${CMAKE_CURRENT_SOURCE_DIR}/include
         OFFLOAD_ARCHS
-            ${_arch}
+            ${_offload_archs}
     )
     set_target_properties(${_target} PROPERTIES
-        OUTPUT_NAME custom_kernels_${_arch}
+        OUTPUT_NAME custom_kernels_${_entry}
         FOLDER "custom_kernels"
     )
     install(TARGETS ${_target}
@@ -101,7 +117,11 @@ foreach(_arch IN LISTS HIP_ARCHITECTURES)
         LIBRARY DESTINATION lib   # Linux .so co-located with EP .so
         ARCHIVE DESTINATION lib   # Windows import lib; unused by the EP but harmless
     )
-    message(STATUS "[custom_kernels] Adding per-arch SHARED target: ${_target}")
+    if(_is_family)
+        message(STATUS "[custom_kernels] Adding family SHARED target: ${_target}")
+    else()
+        message(STATUS "[custom_kernels] Adding per-arch SHARED target: ${_target}")
+    endif()
 endforeach()
 
 # Export include directory for Runtime bitcode compilation


### PR DESCRIPTION
Support gfx115X-all as a multi-slice HIP_ARCHITECTURES family, with LlvmIrJit falling back from per-arch to family DLLs at runtime. Update Windows CI to build with --hip_arch gfx115X-all.