### PR TITLE
feat(hipsr): bufferize hipsr.cast through a general DPS model

### DIFF
--- a/lib/Dialect/Hipsr/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/lib/Dialect/Hipsr/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -15,7 +15,12 @@
 #include "hip/Dialect/Hipsr/IR/HipsrOps.h"
 
 #include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"
+#include "mlir/Dialect/Bufferization/IR/DstBufferizableOpInterfaceImpl.h"
 #include "mlir/IR/DialectRegistry.h"
+#include "mlir/IR/OperationSupport.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
+
+#include "llvm/ADT/STLExtras.h"
 
 using namespace mlir;
 using namespace mlir::bufferization;
@@ -62,6 +67,79 @@ struct PreserveShapeBufferizableModel
   }
 };
 
+// Bufferizes any hipsr destination-passing op, ported from upstream linalg's
+// bufferizeDestinationStyleOpInterface. A hipsr DPS op carries no region, so
+// the bufferized op is built in one step.
+LogicalResult bufferizeDpsOp(RewriterBase &rewriter,
+                             DestinationStyleOpInterface op,
+                             const BufferizationOptions &options,
+                             const BufferizationState &state) {
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPoint(op);
+
+  if (op.hasPureBufferSemantics()) {
+    return success();
+  }
+  if (!op.hasPureTensorSemantics()) {
+    return op->emitOpError("does not have pure tensor semantics");
+  }
+
+  // A DPS scalar has no buffer, so it is forwarded as it is. `!hipsr.context`
+  // is the one every hipsr DPS op carries.
+  SmallVector<Value> newOperands;
+  newOperands.reserve(op->getNumOperands());
+  for (OpOperand *input : op.getDpsInputOperands()) {
+    if (op.isScalar(input)) {
+      newOperands.push_back(input->get());
+      continue;
+    }
+    FailureOr<Value> buffer = getBuffer(rewriter, input->get(), options, state);
+    if (failed(buffer)) {
+      return failure();
+    }
+    newOperands.push_back(*buffer);
+  }
+
+  SmallVector<Value> initBuffers;
+  for (OpResult result : op->getOpResults()) {
+    OpOperand *init = op.getDpsInitOperand(result.getResultNumber());
+    FailureOr<Value> buffer = getBuffer(rewriter, init->get(), options, state);
+    if (failed(buffer)) {
+      return failure();
+    }
+    initBuffers.push_back(*buffer);
+  }
+  llvm::append_range(newOperands, initBuffers);
+
+  // Reading the buffers above may have inserted allocations.
+  rewriter.setInsertionPoint(op);
+
+  // Every Hipsr_DpsOp result is a tensor tied to an init, so the bufferized op
+  // writes through its init buffers and keeps no result. Each tensor result is
+  // therefore replaced by the buffer of its init instead of by a result of the
+  // new op, which is what rules out replaceOpWithNewBufferizedOp here.
+  OperationState newState(op->getLoc(), op->getName(), newOperands, TypeRange{},
+                          op->getAttrs());
+  rewriter.create(newState);
+  replaceOpWithBufferizedValues(rewriter, op, initBuffers);
+  return success();
+}
+
+// Binds the shared destination-passing rewrite to one op, the way upstream's
+// LinalgOpInterface does: the DPS base model answers the analysis queries and
+// bufferize() delegates to bufferizeDpsOp.
+template <typename OpTy>
+struct DpsBufferizableModel
+    : public DstBufferizableOpInterfaceExternalModel<DpsBufferizableModel<OpTy>,
+                                                     OpTy> {
+  LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
+                          const BufferizationOptions &options,
+                          BufferizationState &state) const {
+    return bufferizeDpsOp(rewriter, cast<DestinationStyleOpInterface>(op),
+                          options, state);
+  }
+};
+
 } // namespace
 } // namespace hipsr
 } // namespace mlir
@@ -70,5 +148,6 @@ void mlir::hipsr::registerBufferizableOpInterfaceExternalModels(
     DialectRegistry &registry) {
   registry.addExtension(+[](MLIRContext *ctx, HipsrDialect *) {
     PreserveShapeOp::attachInterface<PreserveShapeBufferizableModel>(*ctx);
+    CastOp::attachInterface<DpsBufferizableModel<CastOp>>(*ctx);
   });
 }

--- a/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/cast.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/cast.mlir
@@ -1,74 +1,62 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-//===----------------------------------------------------------------------===//
-// Positive coverage for one-shot-bufferize on hipsr.cast, the first hipsr DPS
-// op with a bufferization model.
-//
-// Both cases hand the pass device buffers through bufferization.to_tensor, so
-// the bufferized cast keeps the #hipsr.mem<device> space its operands require.
-// A tensor.empty init bufferizes to a space-less memref instead, which is an
-// error today and lives in invalid.mlir.
-//
-// Each case spells out its whole function, so the CHECK block reads as the
-// expected output and the absences are load bearing without a CHECK-NOT: an
-// inserted memref.copy, a surviving bufferization.to_tensor, or a result left
-// on the cast all break the CHECK-NEXT chain.
-//===----------------------------------------------------------------------===//
+// The #hipsr.mem<device> tensor encoding is what supplies the memory space that
+// hipsr operands require: use-encoding-for-memory-space carries the encoding of
+// a ranked tensor onto the memref it becomes, so a tensor.empty init allocates
+// in device space. Function boundaries use the identity layout map, as the
+// production pipeline does, because HIP runtime calls consume contiguous
+// buffers.
 
-// RUN: hip-mlir-opt --split-input-file --one-shot-bufferize %s | FileCheck %s
+// RUN: hip-mlir-opt --split-input-file --one-shot-bufferize="bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map use-encoding-for-memory-space" %s | FileCheck %s
 
-// The init buffer is writable, so the cast is rewritten in place: it takes the
-// buffers the to_tensor ops came from and keeps no result.
 // CHECK-LABEL: func.func @cast_static(
 // CHECK-SAME: %[[CTX:.+]]: !hipsr.context,
-// CHECK-SAME: %[[IN:.+]]: memref<4x8xf32, #hipsr.mem<device>>,
-// CHECK-SAME: %[[OUT:.+]]: memref<4x8xf16, #hipsr.mem<device>>) {
+// CHECK-SAME: %[[IN:.+]]: memref<4x8xf32, #hipsr.mem<device>>) -> memref<4x8xf16, #hipsr.mem<device>> {
+// CHECK-NEXT: %[[OUT:.+]] = memref.alloc() {{.*}}: memref<4x8xf16, #hipsr.mem<device>>
 // CHECK-NEXT: hipsr.cast(%[[CTX]]) ins(%[[IN]] : memref<4x8xf32, #hipsr.mem<device>>)
 // CHECK-SAME: outs(%[[OUT]] : memref<4x8xf16, #hipsr.mem<device>>)
-// CHECK-NEXT: return
+// CHECK-NEXT: return %[[OUT]] : memref<4x8xf16, #hipsr.mem<device>>
 // CHECK-NEXT: }
 func.func @cast_static(%ctx: !hipsr.context,
-                       %in: memref<4x8xf32, #hipsr.mem<device>>,
-                       %out: memref<4x8xf16, #hipsr.mem<device>>) {
-  %input = bufferization.to_tensor %in restrict
-      : memref<4x8xf32, #hipsr.mem<device>> to tensor<4x8xf32>
-  %init = bufferization.to_tensor %out restrict writable
-      : memref<4x8xf16, #hipsr.mem<device>> to tensor<4x8xf16>
-  %0 = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
-      outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
-  return
+                       %in: tensor<4x8xf32, #hipsr.mem<device>>)
+    -> tensor<4x8xf16, #hipsr.mem<device>> {
+  %init = tensor.empty() : tensor<4x8xf16, #hipsr.mem<device>>
+  %0 = hipsr.cast(%ctx) ins(%in : tensor<4x8xf32, #hipsr.mem<device>>)
+      outs(%init : tensor<4x8xf16, #hipsr.mem<device>>)
+      : tensor<4x8xf16, #hipsr.mem<device>>
+  return %0 : tensor<4x8xf16, #hipsr.mem<device>>
 }
 
 // -----
 
-// The first cast's tensor result is replaced by the buffer of its init, so the
-// second cast reads %[[MID]] and the chain runs on the three device buffers.
-// The dynamic dimension needs nothing extra, since every buffer already exists.
+// The first cast's tensor result becomes the buffer of its init, so the second
+// cast reads %[[MID]].
 // CHECK-LABEL: func.func @cast_chain_dynamic(
 // CHECK-SAME: %[[CTX:.+]]: !hipsr.context,
-// CHECK-SAME: %[[IN:.+]]: memref<?x8xf16, #hipsr.mem<device>>,
-// CHECK-SAME: %[[MID:.+]]: memref<?x8xf32, #hipsr.mem<device>>,
-// CHECK-SAME: %[[OUT:.+]]: memref<?x8xi32, #hipsr.mem<device>>) {
+// CHECK-SAME: %[[IN:.+]]: memref<?x8xf16, #hipsr.mem<device>>) -> memref<?x8xi32, #hipsr.mem<device>> {
+// CHECK-NEXT: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[D0:.+]] = memref.dim %[[IN]], %[[C0]] : memref<?x8xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[MID:.+]] = memref.alloc(%[[D0]]) {{.*}}: memref<?x8xf32, #hipsr.mem<device>>
+// CHECK-NEXT: %[[OUT:.+]] = memref.alloc(%[[D0]]) {{.*}}: memref<?x8xi32, #hipsr.mem<device>>
 // CHECK-NEXT: hipsr.cast(%[[CTX]]) ins(%[[IN]] : memref<?x8xf16, #hipsr.mem<device>>)
 // CHECK-SAME: outs(%[[MID]] : memref<?x8xf32, #hipsr.mem<device>>)
 // CHECK-NEXT: hipsr.cast(%[[CTX]]) ins(%[[MID]] : memref<?x8xf32, #hipsr.mem<device>>)
 // CHECK-SAME: outs(%[[OUT]] : memref<?x8xi32, #hipsr.mem<device>>)
-// CHECK-NEXT: return
+// CHECK-NEXT: return %[[OUT]] : memref<?x8xi32, #hipsr.mem<device>>
 // CHECK-NEXT: }
 func.func @cast_chain_dynamic(%ctx: !hipsr.context,
-                              %in: memref<?x8xf16, #hipsr.mem<device>>,
-                              %mid: memref<?x8xf32, #hipsr.mem<device>>,
-                              %out: memref<?x8xi32, #hipsr.mem<device>>) {
-  %input = bufferization.to_tensor %in restrict
-      : memref<?x8xf16, #hipsr.mem<device>> to tensor<?x8xf16>
-  %mid_init = bufferization.to_tensor %mid restrict writable
-      : memref<?x8xf32, #hipsr.mem<device>> to tensor<?x8xf32>
-  %out_init = bufferization.to_tensor %out restrict writable
-      : memref<?x8xi32, #hipsr.mem<device>> to tensor<?x8xi32>
-  %0 = hipsr.cast(%ctx) ins(%input : tensor<?x8xf16>)
-      outs(%mid_init : tensor<?x8xf32>) : tensor<?x8xf32>
-  %1 = hipsr.cast(%ctx) ins(%0 : tensor<?x8xf32>)
-      outs(%out_init : tensor<?x8xi32>) : tensor<?x8xi32>
-  return
+                              %in: tensor<?x8xf16, #hipsr.mem<device>>)
+    -> tensor<?x8xi32, #hipsr.mem<device>> {
+  %c0 = arith.constant 0 : index
+  %d0 = tensor.dim %in, %c0 : tensor<?x8xf16, #hipsr.mem<device>>
+  %mid_init = tensor.empty(%d0) : tensor<?x8xf32, #hipsr.mem<device>>
+  %out_init = tensor.empty(%d0) : tensor<?x8xi32, #hipsr.mem<device>>
+  %0 = hipsr.cast(%ctx) ins(%in : tensor<?x8xf16, #hipsr.mem<device>>)
+      outs(%mid_init : tensor<?x8xf32, #hipsr.mem<device>>)
+      : tensor<?x8xf32, #hipsr.mem<device>>
+  %1 = hipsr.cast(%ctx) ins(%0 : tensor<?x8xf32, #hipsr.mem<device>>)
+      outs(%out_init : tensor<?x8xi32, #hipsr.mem<device>>)
+      : tensor<?x8xi32, #hipsr.mem<device>>
+  return %1 : tensor<?x8xi32, #hipsr.mem<device>>
 }

--- a/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/cast.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/cast.mlir
@@ -1,0 +1,74 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+//===----------------------------------------------------------------------===//
+// Positive coverage for one-shot-bufferize on hipsr.cast, the first hipsr DPS
+// op with a bufferization model.
+//
+// Both cases hand the pass device buffers through bufferization.to_tensor, so
+// the bufferized cast keeps the #hipsr.mem<device> space its operands require.
+// A tensor.empty init bufferizes to a space-less memref instead, which is an
+// error today and lives in invalid.mlir.
+//
+// Each case spells out its whole function, so the CHECK block reads as the
+// expected output and the absences are load bearing without a CHECK-NOT: an
+// inserted memref.copy, a surviving bufferization.to_tensor, or a result left
+// on the cast all break the CHECK-NEXT chain.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --split-input-file --one-shot-bufferize %s | FileCheck %s
+
+// The init buffer is writable, so the cast is rewritten in place: it takes the
+// buffers the to_tensor ops came from and keeps no result.
+// CHECK-LABEL: func.func @cast_static(
+// CHECK-SAME: %[[CTX:.+]]: !hipsr.context,
+// CHECK-SAME: %[[IN:.+]]: memref<4x8xf32, #hipsr.mem<device>>,
+// CHECK-SAME: %[[OUT:.+]]: memref<4x8xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT: hipsr.cast(%[[CTX]]) ins(%[[IN]] : memref<4x8xf32, #hipsr.mem<device>>)
+// CHECK-SAME: outs(%[[OUT]] : memref<4x8xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: return
+// CHECK-NEXT: }
+func.func @cast_static(%ctx: !hipsr.context,
+                       %in: memref<4x8xf32, #hipsr.mem<device>>,
+                       %out: memref<4x8xf16, #hipsr.mem<device>>) {
+  %input = bufferization.to_tensor %in restrict
+      : memref<4x8xf32, #hipsr.mem<device>> to tensor<4x8xf32>
+  %init = bufferization.to_tensor %out restrict writable
+      : memref<4x8xf16, #hipsr.mem<device>> to tensor<4x8xf16>
+  %0 = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32>)
+      outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
+  return
+}
+
+// -----
+
+// The first cast's tensor result is replaced by the buffer of its init, so the
+// second cast reads %[[MID]] and the chain runs on the three device buffers.
+// The dynamic dimension needs nothing extra, since every buffer already exists.
+// CHECK-LABEL: func.func @cast_chain_dynamic(
+// CHECK-SAME: %[[CTX:.+]]: !hipsr.context,
+// CHECK-SAME: %[[IN:.+]]: memref<?x8xf16, #hipsr.mem<device>>,
+// CHECK-SAME: %[[MID:.+]]: memref<?x8xf32, #hipsr.mem<device>>,
+// CHECK-SAME: %[[OUT:.+]]: memref<?x8xi32, #hipsr.mem<device>>) {
+// CHECK-NEXT: hipsr.cast(%[[CTX]]) ins(%[[IN]] : memref<?x8xf16, #hipsr.mem<device>>)
+// CHECK-SAME: outs(%[[MID]] : memref<?x8xf32, #hipsr.mem<device>>)
+// CHECK-NEXT: hipsr.cast(%[[CTX]]) ins(%[[MID]] : memref<?x8xf32, #hipsr.mem<device>>)
+// CHECK-SAME: outs(%[[OUT]] : memref<?x8xi32, #hipsr.mem<device>>)
+// CHECK-NEXT: return
+// CHECK-NEXT: }
+func.func @cast_chain_dynamic(%ctx: !hipsr.context,
+                              %in: memref<?x8xf16, #hipsr.mem<device>>,
+                              %mid: memref<?x8xf32, #hipsr.mem<device>>,
+                              %out: memref<?x8xi32, #hipsr.mem<device>>) {
+  %input = bufferization.to_tensor %in restrict
+      : memref<?x8xf16, #hipsr.mem<device>> to tensor<?x8xf16>
+  %mid_init = bufferization.to_tensor %mid restrict writable
+      : memref<?x8xf32, #hipsr.mem<device>> to tensor<?x8xf32>
+  %out_init = bufferization.to_tensor %out restrict writable
+      : memref<?x8xi32, #hipsr.mem<device>> to tensor<?x8xi32>
+  %0 = hipsr.cast(%ctx) ins(%input : tensor<?x8xf16>)
+      outs(%mid_init : tensor<?x8xf32>) : tensor<?x8xf32>
+  %1 = hipsr.cast(%ctx) ins(%0 : tensor<?x8xf32>)
+      outs(%out_init : tensor<?x8xi32>) : tensor<?x8xi32>
+  return
+}

--- a/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/invalid.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/invalid.mlir
@@ -1,0 +1,36 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+//===----------------------------------------------------------------------===//
+// Error paths of one-shot-bufferize on hipsr.cast. The rewrite itself is
+// covered in cast.mlir.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --split-input-file --verify-diagnostics --one-shot-bufferize %s
+
+// The DPS verifier accepts a buffer input next to a tensor init, but the
+// rewrite has no answer for it: the op is neither fully bufferized already nor
+// fully rewritable, so it refuses instead of dropping the tensor result.
+func.func @mixed_buffer_and_tensor(%ctx: !hipsr.context,
+                                   %in: memref<4x8xf32, #hipsr.mem<device>>) {
+  %init = tensor.empty() : tensor<4x8xf16>
+  // expected-error@+2 {{does not have pure tensor semantics}}
+  // expected-error@+1 {{failed to bufferize op}}
+  %0 = hipsr.cast(%ctx) ins(%in : memref<4x8xf32, #hipsr.mem<device>>)
+      outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
+  return
+}
+
+// -----
+
+// OPEN QUESTION: nothing tells one-shot-bufferize to allocate in
+// #hipsr.mem<device>, so a tensor init and a tensor input bufferize to
+// space-less memrefs that the operand constraint rejects. This case becomes a
+// positive test once we decide where the space comes from.
+func.func @no_memory_space(%ctx: !hipsr.context, %in: tensor<4x8xf32>) {
+  %init = tensor.empty() : tensor<4x8xf16>
+  // expected-error@+1 {{operand #1 must be ranked tensor or device memref}}
+  %0 = hipsr.cast(%ctx) ins(%in : tensor<4x8xf32>)
+      outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
+  return
+}

--- a/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/invalid.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/invalid.mlir
@@ -1,36 +1,45 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-//===----------------------------------------------------------------------===//
-// Error paths of one-shot-bufferize on hipsr.cast. The rewrite itself is
-// covered in cast.mlir.
-//===----------------------------------------------------------------------===//
+// Error paths under the same options as cast.mlir, which covers the rewrite
+// itself. A tensor without the #hipsr.mem<device> encoding bufferizes to a
+// space-less memref that the operand constraint rejects.
 
-// RUN: hip-mlir-opt --split-input-file --verify-diagnostics --one-shot-bufferize %s
+// RUN: hip-mlir-opt --split-input-file --verify-diagnostics --one-shot-bufferize="bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map use-encoding-for-memory-space" %s
 
-// The DPS verifier accepts a buffer input next to a tensor init, but the
-// rewrite has no answer for it: the op is neither fully bufferized already nor
-// fully rewritable, so it refuses instead of dropping the tensor result.
+// The DPS verifier accepts a buffer input next to a tensor init, which is
+// neither fully bufferized already nor fully rewritable.
 func.func @mixed_buffer_and_tensor(%ctx: !hipsr.context,
                                    %in: memref<4x8xf32, #hipsr.mem<device>>) {
-  %init = tensor.empty() : tensor<4x8xf16>
+  %init = tensor.empty() : tensor<4x8xf16, #hipsr.mem<device>>
   // expected-error@+2 {{does not have pure tensor semantics}}
   // expected-error@+1 {{failed to bufferize op}}
   %0 = hipsr.cast(%ctx) ins(%in : memref<4x8xf32, #hipsr.mem<device>>)
-      outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
+      outs(%init : tensor<4x8xf16, #hipsr.mem<device>>)
+      : tensor<4x8xf16, #hipsr.mem<device>>
   return
 }
 
 // -----
 
-// OPEN QUESTION: nothing tells one-shot-bufferize to allocate in
-// #hipsr.mem<device>, so a tensor init and a tensor input bufferize to
-// space-less memrefs that the operand constraint rejects. This case becomes a
-// positive test once we decide where the space comes from.
-func.func @no_memory_space(%ctx: !hipsr.context, %in: tensor<4x8xf32>) {
-  %init = tensor.empty() : tensor<4x8xf16>
-  // expected-error@+1 {{operand #1 must be ranked tensor or device memref}}
+// The input arrives space-less through the function boundary.
+func.func @input_without_encoding(%ctx: !hipsr.context, %in: tensor<4x8xf32>) {
+  %init = tensor.empty() : tensor<4x8xf16, #hipsr.mem<device>>
+  // expected-error@+1 {{operand #1 must be ranked tensor or device memref, but got 'memref<4x8xf32>'}}
   %0 = hipsr.cast(%ctx) ins(%in : tensor<4x8xf32>)
+      outs(%init : tensor<4x8xf16, #hipsr.mem<device>>)
+      : tensor<4x8xf16, #hipsr.mem<device>>
+  return
+}
+
+// -----
+
+// The init is space-less because its allocation has no encoding to follow.
+func.func @init_without_encoding(%ctx: !hipsr.context,
+                                 %in: tensor<4x8xf32, #hipsr.mem<device>>) {
+  %init = tensor.empty() : tensor<4x8xf16>
+  // expected-error@+1 {{operand #2 must be ranked tensor or device memref, but got 'memref<4x8xf16>'}}
+  %0 = hipsr.cast(%ctx) ins(%in : tensor<4x8xf32, #hipsr.mem<device>>)
       outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
   return
 }


### PR DESCRIPTION
## Summary

`hipsr.cast` now bufferizes, through a reusable `DpsBufferizableModel<OpTy>` that any hipsr destination-passing op can attach. `hipsr.cast` is the only op attached here.

## Related issue or design

None. Follows #693, which moved the hipsr bufferization models into `BufferizableOpInterfaceImpl.cpp` and deferred the generic DPS model.

## Why

`hipsr.cast` was the last hole between two neighbours that each assume the other side of bufferization: `hipsr-materialize-init-tensors` hands over `tensor.empty` inits, and `CastLowering` refuses tensors with "operands must be memrefs (run bufferization first)".

## What

Ported from upstream linalg's `bufferizeDestinationStyleOpInterface`, keeping its split: a file-local generic function that talks only to `DestinationStyleOpInterface`, plus a thin model over `DstBufferizableOpInterfaceExternalModel` that inherits the analysis answers and forwards `bufferize()`.

The only deliberate difference is dropping the region splice, since no `Hipsr_DpsOp` carries a region, which lets the bufferized op be built in one step. `replaceOpWithNewBufferizedOp` does not apply the way it does for the neighbouring `hipsr.preserve_shape` model: the tensor results become the init buffers, which are operands of the new op rather than results of it.

The device memory space comes from the `#hipsr.mem<device>` tensor encoding. `Hipsr_TensorOrDeviceMemRef` rejects any memref whose space is not `#hipsr.mem<device>` and stock One-Shot Bufferize allocates space-less memrefs, so `use-encoding-for-memory-space` carries the encoding onto every memref a tensor becomes and a `tensor.empty` init allocates in device space. No hipsr driver, `defaultMemorySpaceFn`, or post-bufferization rewrite of allocations is needed. Function boundaries use the identity layout map, as the production pipeline does, because HIP runtime calls consume contiguous buffers.

Before and after, from the static case of the new `cast.mlir`:

```mlir
// Before
%init = tensor.empty() : tensor<4x8xf16, #hipsr.mem<device>>
%0 = hipsr.cast(%ctx) ins(%in : tensor<4x8xf32, #hipsr.mem<device>>)
    outs(%init : tensor<4x8xf16, #hipsr.mem<device>>)
    : tensor<4x8xf16, #hipsr.mem<device>>

// After
%alloc = memref.alloc() {alignment = 64 : i64} : memref<4x8xf16, #hipsr.mem<device>>
hipsr.cast(%arg0) ins(%arg1 : memref<4x8xf32, #hipsr.mem<device>>)
    outs(%alloc : memref<4x8xf16, #hipsr.mem<device>>)
```

## Notes for reviewers

`invalid.mlir` pins the contract behind the encoding: a tensor without it bufferizes to a space-less memref that the operand constraint rejects, once on the input path through the function boundary and once on the init path through the allocation. The mixed buffer/tensor case is pinned there too, since the DPS verifier accepts an op the rewrite has no answer for.

The encoding has to be on the tensor types before bufferization runs, so `hipsr-materialize-init-tensors` will have to set it on the inits it creates, and `buildHipsrPipeline`, still an empty scaffold, will have to turn the switch on once it gains a bufferize step.

## AI assistance

Cursor (Claude Opus 5) assisted with the upstream port, the tests, and the memory-space investigation. I reviewed the result and validated it with a local incremental build, the MLIR LIT suite, and `pre-commit run --all-files`.
