### PR TITLE
fix(onnx-to-hip): take multi-dynamic expand_shape extents from the shape operand (-64% TTFT on Gemma-4 26B-A4B)

### DIFF
--- a/lib/Conversion/OnnxToHip/ReshapeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ReshapeConversion.cpp
@@ -51,51 +51,124 @@ validateSqueezeUnsqueezeOp(mlir::Operation *op, mlir::PatternRewriter &rewriter,
   return mlir::success();
 }
 
-/// Build output shape for expand_shape operations.
+/// Count the dynamic output dims a reassociation group covers.
+static int64_t countDynOutDims(mlir::RankedTensorType outputType,
+                               const mlir::ReassociationIndices &group) {
+  return llvm::count_if(
+      group, [&](int64_t idx) { return outputType.isDynamicDim(idx); });
+}
+
+/// Resolve output dim \p outDim's extent from a Reshape's `shape` operand.
+///
+/// Only a host-visible shape vector is honoured, i.e. the
+/// `tensor.from_elements` that ReshapeShapeFold leaves behind for the
+/// `Reshape(_, Shape(x))` idiom, whose elements are already host SSA values. A
+/// shape tensor that is still device-resident yields nullopt instead of paying
+/// for a readback; the caller then falls back to `tensor.reshape`, which
+/// consumes the runtime shape vector directly.
+///
+/// Resolution is per-dim rather than whole-vector because ONNX's `-1` ("infer")
+/// and `0` ("keep the input dim") are not usable as extents but normally sit on
+/// the feature dim -- a position the result type already pins as static, so the
+/// caller never asks about it. Resolving the whole vector up front would let a
+/// `-1` at such a position veto a split that is otherwise fully determined,
+/// which is the usual spelling of `[bs*ss, H] -> [bs, ss, -1]`.
+static std::optional<mlir::OpFoldResult>
+resolveShapeOperandExtent(mlir::PatternRewriter &rewriter, mlir::Location loc,
+                          mlir::Value shapeOperand, int64_t outDim,
+                          int64_t outputRank) {
+  if (!shapeOperand)
+    return std::nullopt;
+  // Shape-refining casts do not change the elements.
+  while (auto castOp = shapeOperand.getDefiningOp<mlir::tensor::CastOp>())
+    shapeOperand = castOp.getSource();
+
+  auto fromElements =
+      shapeOperand.getDefiningOp<mlir::tensor::FromElementsOp>();
+  if (!fromElements ||
+      static_cast<int64_t>(fromElements.getElements().size()) != outputRank)
+    return std::nullopt;
+
+  mlir::Value element = fromElements.getElements()[outDim];
+  // ReshapeShapeFold emits `arith.index_cast %tensor.dim`. Reusing the pre-cast
+  // index keeps the extent on the same SSA value the rest of the conversion
+  // derives dims from, instead of a round trip through i64.
+  if (auto castOp = element.getDefiningOp<mlir::arith::IndexCastOp>();
+      castOp && mlir::isa<mlir::IndexType>(castOp.getIn().getType()))
+    return mlir::OpFoldResult(castOp.getIn());
+  if (std::optional<int64_t> known = mlir::getConstantIntValue(element)) {
+    if (*known <= 0)
+      return std::nullopt;
+    return mlir::OpFoldResult(rewriter.getIndexAttr(*known));
+  }
+  return mlir::OpFoldResult(mlir::arith::IndexCastOp::create(
+      rewriter, loc, rewriter.getIndexType(), element));
+}
+
+/// Build the `output_shape` operand list for a `tensor.expand_shape`.
 /// Used by both Reshape and Unsqueeze when expanding dimensions.
 ///
-/// For static dimensions: use compile-time size from outputType.
-/// For dynamic dimensions: extract from input via DimOp, dividing out any
-/// static dimensions in the same reassociation group.
-llvm::SmallVector<mlir::OpFoldResult> buildExpandShapeOutputShape(
-    mlir::PatternRewriter &rewriter, mlir::Location loc, mlir::Value data,
-    mlir::RankedTensorType outputType,
-    llvm::ArrayRef<mlir::ReassociationIndices> reassoc) {
+/// Extents that follow from the source type are computed by
+/// `tensor::ExpandShapeOp::inferOutputShape`: static dims come from
+/// \p outputType, and a group's single dynamic dim is the source extent divided
+/// by the group's static dims. That upstream helper is called rather than
+/// reimplemented because it also *declines* when a group covers more than one
+/// dynamic output dim -- the case with no solution in the source type, since
+/// the source dim holds only the PRODUCT of those dims. An in-tree copy of the
+/// derivation missing that bail-out is what turned
+/// `[bs*ss, 2816] -> [bs, ss, 2816]` into `[ss, ss, 2816]` and dispatched every
+/// Gemma-4 layer's input norm over ss^2 rows.
+///
+/// A multi-dynamic group's extents exist only in the Reshape's `shape` operand,
+/// so they are read from \p shapeOperand. Returns nullopt when that is not
+/// readable, letting the caller fall back to `tensor.reshape` instead of
+/// emitting an `output_shape` it cannot justify.
+std::optional<llvm::SmallVector<mlir::OpFoldResult>>
+buildExpandShapeOutputShape(mlir::PatternRewriter &rewriter, mlir::Location loc,
+                            mlir::Value data, mlir::RankedTensorType outputType,
+                            llvm::ArrayRef<mlir::ReassociationIndices> reassoc,
+                            mlir::Value shapeOperand = {}) {
+  auto inputType = mlir::cast<mlir::RankedTensorType>(data.getType());
+  bool hasMultiDynGroup =
+      llvm::any_of(reassoc, [&](const mlir::ReassociationIndices &group) {
+        return countDynOutDims(outputType, group) > 1;
+      });
+
+  if (!hasMultiDynGroup) {
+    // inferOutputShape reads a group's source extent as an SSA value, which
+    // holds whenever a group covering a dynamic output dim has a dynamic source
+    // dim. The opposite pairing describes an inconsistent source/result type
+    // pair; decline rather than trip the cast inside the helper.
+    for (auto [g, group] : llvm::enumerate(reassoc))
+      if (countDynOutDims(outputType, group) == 1 && !inputType.isDynamicDim(g))
+        return std::nullopt;
+    auto inferred = mlir::tensor::ExpandShapeOp::inferOutputShape(
+        rewriter, loc, outputType, reassoc,
+        mlir::tensor::getMixedSizes(rewriter, loc, data));
+    if (mlir::failed(inferred))
+      return std::nullopt;
+    return *inferred;
+  }
+
+  // Some group splits one dynamic source dim into several dynamic output dims.
+  // Statics still come from the result type, but every dynamic extent is taken
+  // from the shape operand: within such a group the source dim says nothing
+  // about the split, and sourcing the whole shape from one operand keeps the
+  // dynamic extents mutually consistent instead of mixing two derivations.
   int64_t outputRank = outputType.getRank();
-
-  llvm::SmallVector<int64_t> outDimToInDim(outputRank, -1);
-  for (auto [g, group] : llvm::enumerate(reassoc))
-    for (int64_t idx : group)
-      outDimToInDim[idx] = g;
-
   llvm::SmallVector<mlir::OpFoldResult> outputShape;
+  outputShape.reserve(outputRank);
   for (int64_t i : llvm::seq<int64_t>(outputRank)) {
     if (!outputType.isDynamicDim(i)) {
       outputShape.push_back(rewriter.getIndexAttr(outputType.getDimSize(i)));
       continue;
     }
-
-    int64_t srcDim = outDimToInDim[i];
-    const auto &group = reassoc[srcDim];
-
-    int64_t staticProduct = 1;
-    for (int64_t idx : group)
-      if (!outputType.isDynamicDim(idx))
-        staticProduct *= outputType.getDimSize(idx);
-
-    mlir::Value inputSize =
-        mlir::tensor::DimOp::create(rewriter, loc, data, srcDim);
-    if (staticProduct == 1) {
-      outputShape.push_back(inputSize);
-    } else {
-      mlir::Value divisor =
-          mlir::arith::ConstantIndexOp::create(rewriter, loc, staticProduct);
-      mlir::Value dynSize =
-          mlir::arith::DivUIOp::create(rewriter, loc, inputSize, divisor);
-      outputShape.push_back(dynSize);
-    }
+    auto extent =
+        resolveShapeOperandExtent(rewriter, loc, shapeOperand, i, outputRank);
+    if (!extent)
+      return std::nullopt;
+    outputShape.push_back(*extent);
   }
-
   return outputShape;
 }
 
@@ -194,17 +267,27 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
       if (auto reassocOpt =
               mlir::getReassociationIndicesForReshape(inputType, outputType)) {
         if (outputRank > inputRank) {
-          auto outputShape = buildExpandShapeOutputShape(
-              rewriter, loc, data, outputType, *reassocOpt);
-          auto expandOp = mlir::tensor::ExpandShapeOp::create(
-              rewriter, loc, outputType, data, *reassocOpt, outputShape);
-          rewriter.replaceOp(op, expandOp.getResult());
+          // The `shape` operand is the only place a multi-dynamic split's
+          // per-dim extents exist; ReshapeShapeFold has already folded
+          // `Shape(x)` into a host-visible tensor.from_elements for it.
+          mlir::Value shapeOperand =
+              op->getNumOperands() >= 2 ? op->getOperand(1) : mlir::Value();
+          if (auto outputShape = buildExpandShapeOutputShape(
+                  rewriter, loc, data, outputType, *reassocOpt, shapeOperand)) {
+            auto expandOp = mlir::tensor::ExpandShapeOp::create(
+                rewriter, loc, outputType, data, *reassocOpt, *outputShape);
+            rewriter.replaceOp(op, expandOp.getResult());
+            return mlir::success();
+          }
+          // Multi-dynamic split with an unreadable shape operand: fall through
+          // to the tensor.reshape fallback, which takes the runtime shape
+          // vector verbatim.
         } else {
           auto collapseOp = mlir::tensor::CollapseShapeOp::create(
               rewriter, loc, outputType, data, *reassocOpt);
           rewriter.replaceOp(op, collapseOp.getResult());
+          return mlir::success();
         }
-        return mlir::success();
       }
       // Fall through to tensor.reshape fallback (no structured reassoc).
     }
@@ -344,16 +427,22 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
             mlir::RankedTensorType::get(intShape, inputType.getElementType());
 
         // (d) Reuse the existing helper to compute output_shape values for the
-        // expand. It emits tensor.dim for dynamic dims and arith.divui when a
-        // dynamic input dim is split into (dyn, static_factor) — exactly the
-        // combine direction here. (PoolAllocs's hoistable whitelist must
-        // include arith.divui for the resulting dim arithmetic to survive
-        // pool-base hoisting.)
+        // expand. It emits tensor.dim for dynamic dims and an integer division
+        // when a dynamic input dim is split into (dyn, static_factor) — exactly
+        // the combine direction here. The divisor is a positive constant, so
+        // the division is speculatable and --hip-hoist-alloc-size-arith (which
+        // gates on mlir::isPure, not an op-name list) can still hoist the
+        // resulting dim arithmetic above the allocs --hip-pool-allocs absorbs.
+        //
+        // Each group here pairs one dynamic extent with the static factor K,
+        // so no group is multi-dynamic and the shape operand is never needed.
         auto intOutShape = buildExpandShapeOutputShape(rewriter, loc, data,
                                                        intType, expandReassoc);
+        if (!intOutShape)
+          break; // fall through to tensor.reshape fallback
 
         auto expanded = mlir::tensor::ExpandShapeOp::create(
-            rewriter, loc, intType, data, expandReassoc, intOutShape);
+            rewriter, loc, intType, data, expandReassoc, *intOutShape);
 
         // (e) Collapse: the OUTPUT dim that absorbs the factor pair maps to the
         // two intermediate dims; everything else is identity.
@@ -578,10 +667,15 @@ struct UnsqueezeToStdTensor : public mlir::RewritePattern {
           op, "cannot compute unsqueeze reassociation");
 
     mlir::Location loc = op->getLoc();
+    // Unsqueeze only inserts unit dims, so every group keeps at most one
+    // dynamic dim and no shape operand is needed.
     auto outputShape = buildExpandShapeOutputShape(rewriter, loc, data,
                                                    outputType, *reassocOpt);
+    if (!outputShape)
+      return rewriter.notifyMatchFailure(
+          op, "unsqueeze: multi-dynamic reassociation group");
     auto expandOp = mlir::tensor::ExpandShapeOp::create(
-        rewriter, loc, outputType, data, *reassocOpt, outputShape);
+        rewriter, loc, outputType, data, *reassocOpt, *outputShape);
     rewriter.replaceOp(op, expandOp.getResult());
     return mlir::success();
   }

--- a/lib/Conversion/OnnxToHip/ReshapeShapeFold.cpp
+++ b/lib/Conversion/OnnxToHip/ReshapeShapeFold.cpp
@@ -50,8 +50,9 @@
 //
 // This fold rewrites the shape operand BEFORE ConvertOnnxToHip so the
 // resulting `tensor.from_elements` is exactly what ReshapeConversion's
-// existing multi-dyn-per-group branch picks up.  Bug fix is structural
-// at the operand level; no change to ReshapeConversion required.
+// multi-dyn-per-group branch picks up.  That branch is the other half of
+// the fix and lives in `buildExpandShapeOutputShape`; without it this fold
+// has no effect, because the conversion otherwise never reads operand 1.
 //
 // Implementation notes
 // --------------------

--- a/test/lit/Conversion/onnx-to-hip/test_reshape.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_reshape.mlir
@@ -77,6 +77,45 @@ module {
     %result = "onnx.Reshape"(%data, %shape) {allowzero = 0 : si64} : (tensor<f16>, tensor<3xi64>) -> tensor<1x1x1xf16>
     return %result : tensor<1x1x1xf16>
   }
+
+  // --- Multi-dynamic expand: [bs*ss, H] -> [bs, ss, H] ---
+  // The source dim only holds the PRODUCT bs*ss, so the split has to come from
+  // the shape operand.  Deriving both extents positionally from the source
+  // yields [bs*ss, bs*ss, H], which is how every Gemma-4 decoder layer's input
+  // norm ended up dispatched over ss^2 rows.
+  func.func @test_reshape_expand_multi_dyn(%data: tensor<?x2816xf16>,
+                                           %ref: tensor<?x?x2816xf16>)
+      -> tensor<?x?x2816xf16> {
+    %shape = "onnx.Shape"(%ref) : (tensor<?x?x2816xf16>) -> tensor<3xi64>
+    %result = "onnx.Reshape"(%data, %shape) {allowzero = 0 : si64} : (tensor<?x2816xf16>, tensor<3xi64>) -> tensor<?x?x2816xf16>
+    return %result : tensor<?x?x2816xf16>
+  }
+
+  // --- Multi-dynamic expand, `-1` on the static output dim ---
+  // The most common ONNX spelling of this reshape. The `-1` ("infer") entry is
+  // not usable as an extent, but it sits on the dim the result type already
+  // pins as 2816, so it is never consulted: extents resolve per-dim, not
+  // whole-vector, and the split still comes from the shape operand.
+  func.func @test_reshape_expand_multi_dyn_infer_static_dim(
+      %data: tensor<?x2816xf16>, %bs: index, %ss: index)
+      -> tensor<?x?x2816xf16> {
+    %bs_i64 = arith.index_cast %bs : index to i64
+    %ss_i64 = arith.index_cast %ss : index to i64
+    %minus_one = arith.constant -1 : i64
+    %shape = tensor.from_elements %bs_i64, %ss_i64, %minus_one : tensor<3xi64>
+    %result = "onnx.Reshape"(%data, %shape) {allowzero = 0 : si64} : (tensor<?x2816xf16>, tensor<3xi64>) -> tensor<?x?x2816xf16>
+    return %result : tensor<?x?x2816xf16>
+  }
+
+  // --- Multi-dynamic expand with an opaque shape operand ---
+  // Nothing here reveals the split, so the conversion must decline to build an
+  // expand_shape and hand the runtime shape vector to tensor.reshape instead.
+  func.func @test_reshape_expand_multi_dyn_opaque(%data: tensor<?x2816xf16>,
+                                                  %shape: tensor<3xi64>)
+      -> tensor<?x?x2816xf16> {
+    %result = "onnx.Reshape"(%data, %shape) {allowzero = 0 : si64} : (tensor<?x2816xf16>, tensor<3xi64>) -> tensor<?x?x2816xf16>
+    return %result : tensor<?x?x2816xf16>
+  }
 }
 
 // CHECK-LABEL: func.func @test_reshape_expand
@@ -118,4 +157,27 @@ module {
 // CHECK: hip.readback_scalar
 // CHECK: tensor.from_elements
 // CHECK: tensor.expand_shape
+// CHECK-NOT: onnx.Reshape
+
+// The two dynamic output extents must be DISTINCT dims of the rank-3 reference,
+// never the same source dim twice.
+// CHECK-LABEL: func.func @test_reshape_expand_multi_dyn
+// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+// CHECK: %[[BS:.*]] = tensor.dim %[[REF:.*]], %[[C0]] : tensor<?x?x2816xf16>
+// CHECK: %[[SS:.*]] = tensor.dim %[[REF]], %[[C1]] : tensor<?x?x2816xf16>
+// CHECK: tensor.expand_shape %{{.*}} {{\[\[}}0, 1], [2]] output_shape [%[[BS]], %[[SS]], 2816]
+// CHECK-NOT: onnx.Reshape
+
+// A `-1` on an output dim the result type pins as static must not block the
+// expand: the split still comes from the two resolvable entries.
+// CHECK-LABEL: func.func @test_reshape_expand_multi_dyn_infer_static_dim
+// CHECK-SAME: %[[BS:[^:]*]]: index, %[[SS:[^:]*]]: index
+// CHECK: tensor.expand_shape %{{.*}} {{\[\[}}0, 1], [2]] output_shape [%[[BS]], %[[SS]], 2816]
+// CHECK-NOT: tensor.reshape
+// CHECK-NOT: onnx.Reshape
+
+// CHECK-LABEL: func.func @test_reshape_expand_multi_dyn_opaque
+// CHECK-NOT: tensor.expand_shape
+// CHECK: tensor.reshape
 // CHECK-NOT: onnx.Reshape


### PR DESCRIPTION
## Summary

`buildExpandShapeOutputShape` derived every dynamic output dimension of a `tensor.expand_shape` from the source dimension it came from. That is correct only while a reassociation group covers at most one dynamic dimension. When a `Reshape` splits one dynamic source dimension into several dynamic output dimensions, the source extent is their *product*, so each of those output dimensions was assigned the whole product.

This makes the split silently wrong for any `[bs*ss, H] -> [bs, ss, H]` reshape, and every consumer inherits the inflated shape. On Gemma-4 26B-A4B it cost 78% of decoder prefill and made 4K prompts unrunnable.

## Related issue or design

None.

## Why

The per-layer `Reshape([bs*ss, 2816] -> [bs, ss, 2816])` in Gemma-4 26B-A4B lowered to

```mlir
%dim_289 = tensor.dim %2525, %c0 : tensor<?x2816xf16>
%dim_290 = tensor.dim %2525, %c0 : tensor<?x2816xf16>   // same dim, twice
%expanded_291 = tensor.expand_shape %2525 [[0, 1], [2]]
    output_shape [%dim_289, %dim_290, 2816] : tensor<?x2816xf16> into tensor<?x?x2816xf16>
```

With `bs = 1` the source dimension already equals `ss`, so the expansion claimed `[ss, ss, 2816]` rather than `[1, ss, 2816]`. The 30 layer input norms consuming it ran over `ss^2` rows.

Two things kept it silent. The wrong shape is numerically equal to the right one at `bs = 1`, which is the batch size everything is tested at. And the norm runtime ABI passes element counts rather than shapes: `simplified_layer_norm` recovers `num_rows` as `input_num_elements / scale_num_elements`, which divides evenly for any `ss`, so an `ss`-times-too-large buffer is indistinguishable from a well-formed larger batch. At 2,049 tokens that was 5,036 ms of the 6,486 ms decoder prefill; at 4,097 tokens the N-squared tensor needed 88 GB against 63.6 GB of shared APU memory, and the host rebooted.

`ReshapeShapeFold` already rewrites `Reshape(_, Shape(x))` into a host-visible `tensor.from_elements` carrying the correct per-dimension values, and its comment said this was so the conversion could consume them — but the consuming branch was never written and the conversion never read operand 1. The fix is to finish that path rather than add a new mechanism.

## What

- `ReshapeConversion.cpp`: `buildExpandShapeOutputShape` now detects reassociation groups with more than one dynamic output dimension and takes those extents from the shape operand, walking `tensor.from_elements` through `arith.index_cast`, `tensor.cast`, and constants. Extents are resolved lazily per dimension, so an unresolvable entry elsewhere in the operand — an ONNX `-1` placeholder at a statically known position, say — no longer sinks the whole expansion.
- Groups without a multi-dynamic split are delegated to upstream `tensor::ExpandShapeOp::inferOutputShape` instead of being re-derived here. Upstream declines the multi-dynamic case by design; the in-tree copy had dropped that bail-out, which is what let this through in the first place.
- The helper returns `std::nullopt` when a multi-dynamic group's extents are not host-readable, and all three call sites (`Reshape` expand, same-rank split/combine, `Unsqueeze`) fall back to `tensor.reshape` rather than emit an `expand_shape` whose `output_shape` cannot be justified.
- `ReshapeShapeFold.cpp`: correct the stale comment that claimed the operand was already consumed and that no change to `ReshapeConversion` was required. The fold is inert without the consuming branch, so the two halves need to describe each other.

No verifier or shape assertion is added. `[ss, ss, 2816]` is a legal shape and only the value is wrong, so nothing downstream can distinguish it; the fix has to be at the point the shape is constructed.

## Test plan

`test/lit/Conversion/onnx-to-hip/test_reshape.mlir`:

- `test_reshape_expand_multi_dyn` pins the `[?, 2816] -> [?, ?, 2816]` split to two *distinct* extents read from the shape operand, at dimension indices 0 and 1. Before the fix both came from index 0.
- `test_reshape_expand_multi_dyn_infer_static_dim` pins the lazy per-dimension resolution: a `-1` placeholder at a static position still permits the expansion.
- `test_reshape_expand_multi_dyn_opaque` pins the `tensor.reshape` fallback when the shape operand is opaque.

388 lit tests pass, 12 unsupported (pre-existing Morphizen plugin tests), 0 failures. The norm e2e tests (`test_simplified_layer_norm_model.mlir`, `test_skip_simplified_layer_norm_model.mlir`, `test_rms_normalization_model.mlir`) pass unchanged. 21 numeric layer-norm tests pass on gfx1151.

Correctness on Gemma-4 26B-A4B FP16W4-qmoe: generated text at 513 and 2,049 tokens matches the pre-fix build, and `HIPDNN_EP_DEBUG` confirms all 181 rank-3 norms report `2049x2816` with no remaining `4198401`.

## Performance

Gemma-4 26B-A4B FP16W4-qmoe, gfx1151 (Strix Halo, 63.6 GB shared), Release build, 2,049-token prompt, median of 5 after warmup.

| Metric | Before | After |
|---|---:|---:|
| TTFT | 7,865 ms | 2,859 ms |
| Decoder prefill | 6,486 ms | 1,520 ms |
| Layernorm within prefill | 5,036 ms | 50 ms |
| Norm rows dispatched | 4,198,401 | 2,049 |

TTFT at other lengths: 1,905 ms at 513, 2,183 ms at 1,025, and 4,983 ms at 4,097. Prefill is now near-linear in prompt length; 4,097 tokens previously exhausted shared memory and rebooted the host.

## Notes for reviewers

- Scope was narrowed after the first revision. An earlier push also added a conversion-time norm axis verifier, divisibility guards in two runtime norm wrappers, and a `hip-to-llvm` norm test. None of them could catch this bug — `4198401 * 2816` is exactly divisible by 2816 — and none are needed for the result above, so they were dropped to keep the change to one mechanism. The numbers were measured on a build that still carried them; they are assertions and preconditions only and do not affect generated code.
- The vision encoder path is unaffected; its 1,446 ms is now the largest fixed component of VLM TTFT.
- Worth confirming the fallback direction is the one you want: an unreadable shape operand on a multi-dynamic group now yields `tensor.reshape`, which is correct but blocks fusion. I found no such case in the models tested, so the branch is exercised only by the lit test.
- Routing single-dynamic groups through upstream `inferOutputShape` is the one change that touches existing expand-shape sites. The lit suite pins their IR and is unchanged, but it is the part worth a second look.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.

AI assistance: the diagnosis (IR dumps, roofline check confirming the kernel was at 91% of achievable bandwidth and so not the problem), the patch, the tests, and the benchmark runs were produced with Cursor. All measurements above are from real runs on the machine named, and I reviewed the change.
