### PR TITLE
fix(hipsr): install the ONNX conversion patterns

### DIFF
--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
@@ -71,6 +71,11 @@ struct ConvertOnnxToHipsrPass
     });
 
     RewritePatternSet patterns(&getContext());
+    populateOnnxToHipsrConstantPatterns(patterns);
+    populateCastConversionPatterns(patterns, &getContext());
+    populateMatMulConversionPatterns(patterns, &getContext());
+    populateExpandConversionPatterns(patterns, &getContext());
+
     if (failed(applyFullConversion(module, target, std::move(patterns)))) {
       signalPassFailure();
       return;

--- a/test/lit/Conversion/onnx-to-hipsr/cast.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/cast.mlir
@@ -1,8 +1,6 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// UNSUPPORTED: true
-//
 //===----------------------------------------------------------------------===//
 // Converts onnx.Cast to hipsr.cast, leaving the shape region empty (a later
 // pass populates it).
@@ -15,9 +13,9 @@
 // CHECK-LABEL: func.func @cast_chain(
 // CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:    %[[IN:.*]]: tensor<?x8xf32>) -> tensor<?x8xf32> {
-// CHECK-NEXT: %[[FIRST_INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[IN]] : tensor<?x8xf32>) {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
+// CHECK-NEXT: %[[FIRST_INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[IN]] : tensor<?x8xf32>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16>
 // CHECK-NEXT: %[[FIRST:.+]] = hipsr.cast(%[[CTX]]) ins(%[[IN]] : tensor<?x8xf32>) outs(%[[FIRST_INIT]] : tensor<?x8xf16>) : tensor<?x8xf16>
-// CHECK-NEXT: %[[SECOND_INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[FIRST_INIT]] : tensor<?x8xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x8xf32>
+// CHECK-NEXT: %[[SECOND_INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[FIRST_INIT]] : tensor<?x8xf16>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x8xf32>
 // CHECK-NEXT: %[[SECOND:.+]] = hipsr.cast(%[[CTX]]) ins(%[[FIRST]] : tensor<?x8xf16>) outs(%[[SECOND_INIT]] : tensor<?x8xf32>) : tensor<?x8xf32>
 // CHECK-NOT: shape_region
 func.func @cast_chain(

--- a/test/lit/Conversion/onnx-to-hipsr/constant.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/constant.mlir
@@ -1,8 +1,6 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// UNSUPPORTED: true
-//
 // convert-onnx-to-hipsr: onnx.Constant -> hipsr.constant / arith.constant.
 // Four branches keyed on storage form (no size threshold here):
 //   rank-0 scalar          -> arith.constant (compile-time)
@@ -11,7 +9,7 @@
 //   other location path    -> hipsr.constant {file_source}
 // onnx.Constant is written in generic form so no onnx dialect is required.
 
-// RUN: hip-mlir-opt --convert-onnx-to-hipsr %s | FileCheck %s
+// RUN: hip-mlir-opt --convert-onnx-to-hipsr --split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: func.func @scalar_const
 func.func @scalar_const() -> tensor<f32> {

--- a/test/lit/Conversion/onnx-to-hipsr/expand-invalid.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/expand-invalid.mlir
@@ -1,0 +1,85 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+//===----------------------------------------------------------------------===//
+// onnx.Expand forms the conversion rejects. A pattern that does not match
+// leaves the ONNX operation in place, and the strict conversion target then
+// fails the pass, so each case expects a legalization error.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --convert-onnx-to-hipsr --split-input-file --verify-diagnostics %s
+
+// The shape operand is an extent vector, so it must be rank 1.
+func.func @shape_rank(%ctx: !hipsr.context, %input: tensor<2x3xf16>,
+                      %shape: tensor<1x2xi64>) -> tensor<2x3xf16> {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Expand'}}
+  %0 = "onnx.Expand"(%input, %shape)
+      : (tensor<2x3xf16>, tensor<1x2xi64>) -> tensor<2x3xf16>
+  return %0 : tensor<2x3xf16>
+}
+
+// -----
+
+// ONNX shape extents are i64.
+func.func @shape_element_type(%ctx: !hipsr.context, %input: tensor<2x3xf16>,
+                              %shape: tensor<2xi32>) -> tensor<2x3xf16> {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Expand'}}
+  %0 = "onnx.Expand"(%input, %shape)
+      : (tensor<2x3xf16>, tensor<2xi32>) -> tensor<2x3xf16>
+  return %0 : tensor<2x3xf16>
+}
+
+// -----
+
+// The shape length fixes the output rank, so it cannot itself be dynamic.
+func.func @dynamic_shape_length(%ctx: !hipsr.context, %input: tensor<2x3xf16>,
+                                %shape: tensor<?xi64>) -> tensor<2x3xf16> {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Expand'}}
+  %0 = "onnx.Expand"(%input, %shape)
+      : (tensor<2x3xf16>, tensor<?xi64>) -> tensor<2x3xf16>
+  return %0 : tensor<2x3xf16>
+}
+
+// -----
+
+// An unranked input has no rank to broadcast against.
+func.func @unranked_input(%ctx: !hipsr.context, %input: tensor<*xf16>,
+                          %shape: tensor<2xi64>) -> tensor<2x3xf16> {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Expand'}}
+  %0 = "onnx.Expand"(%input, %shape)
+      : (tensor<*xf16>, tensor<2xi64>) -> tensor<2x3xf16>
+  return %0 : tensor<2x3xf16>
+}
+
+// -----
+
+// Expand only broadcasts, so it cannot change the element type.
+func.func @element_type_mismatch(%ctx: !hipsr.context, %input: tensor<2x3xf16>,
+                                 %shape: tensor<2xi64>) -> tensor<2x3xf32> {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Expand'}}
+  %0 = "onnx.Expand"(%input, %shape)
+      : (tensor<2x3xf16>, tensor<2xi64>) -> tensor<2x3xf32>
+  return %0 : tensor<2x3xf32>
+}
+
+// -----
+
+// The result rank must be max(input rank, shape length); 2 is neither here.
+func.func @result_rank(%ctx: !hipsr.context, %input: tensor<2x3xf16>,
+                       %shape: tensor<4xi64>) -> tensor<2x3xf16> {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Expand'}}
+  %0 = "onnx.Expand"(%input, %shape)
+      : (tensor<2x3xf16>, tensor<4xi64>) -> tensor<2x3xf16>
+  return %0 : tensor<2x3xf16>
+}
+
+// -----
+
+// Every hipsr op threads the context from function argument 0.
+func.func @missing_context(%input: tensor<2x3xf16>,
+                           %shape: tensor<2xi64>) -> tensor<2x3xf16> {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Expand'}}
+  %0 = "onnx.Expand"(%input, %shape)
+      : (tensor<2x3xf16>, tensor<2xi64>) -> tensor<2x3xf16>
+  return %0 : tensor<2x3xf16>
+}

--- a/test/lit/Conversion/onnx-to-hipsr/expand.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/expand.mlir
@@ -1,22 +1,26 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// UNSUPPORTED: true
-//
-// Converts supported onnx.Expand ops to placeholder-backed hipsr.expand ops.
-// Unsupported forms remain unchanged for another conversion path.
+//===----------------------------------------------------------------------===//
+// Converts onnx.Expand to a placeholder-backed hipsr.expand. Rejected forms
+// live in expand-invalid.mlir.
+//===----------------------------------------------------------------------===//
 
 // RUN: hip-mlir-opt %s --split-input-file -allow-unregistered-dialect -convert-onnx-to-hipsr | FileCheck %s
 
+// The requested extents are read at runtime, so the init is a barrier
+// placeholder over both the input and the shape operand.
 // CHECK-LABEL: func.func @expand(
 // CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:    %[[INPUT:.*]]: tensor<?x3xf16>,
 // CHECK-SAME:    %[[SHAPE:.*]]: tensor<2xi64>) -> tensor<?x?xf16> {
-// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]], %[[SHAPE]] : tensor<?x3xf16>, tensor<2xi64>) {type = #hipsr.placeholder_type<barrier>} : tensor<?x?xf16>
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]], %[[SHAPE]] : tensor<?x3xf16>, tensor<2xi64>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x?xf16>
 // CHECK-NEXT:    %[[RESULT:.*]] = hipsr.expand(%[[CTX]]) ins(%[[INPUT]], %[[SHAPE]] : tensor<?x3xf16>, tensor<2xi64>)
 // CHECK-SAME:      outs(%[[INIT]] : tensor<?x?xf16>) : tensor<?x?xf16>
-// CHECK-NOT:     shape_region
 // CHECK-NEXT:    return %[[RESULT]] : tensor<?x?xf16>
+//
+// The conversion leaves the region empty; hipsr-populate-shape-region fills it.
+// CHECK-NOT:     shape_region
 func.func @expand(%ctx: !hipsr.context, %input: tensor<?x3xf16>,
                   %shape: tensor<2xi64>) -> tensor<?x?xf16> {
   %0 = "onnx.Expand"(%input, %shape)
@@ -26,95 +30,20 @@ func.func @expand(%ctx: !hipsr.context, %input: tensor<?x3xf16>,
 
 // -----
 
-// Shape must be a rank-1 extent vector.
-// CHECK-LABEL: func.func @expand_shape_rank(
-// CHECK-SAME:    %{{.*}}: !hipsr.context,
+// A shape longer than the input rank raises the output rank, and the leading
+// extents come from the shape operand alone.
+// CHECK-LABEL: func.func @expand_broadcast_rank(
+// CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:    %[[INPUT:.*]]: tensor<2x3xf16>,
-// CHECK-SAME:    %[[SHAPE:.*]]: tensor<1x2xi64>) -> tensor<2x3xf16> {
-// CHECK-NOT:   hipsr.expand
-// CHECK-NEXT:  %[[RESULT:.*]] = "onnx.Expand"(%[[INPUT]], %[[SHAPE]]) : (tensor<2x3xf16>, tensor<1x2xi64>) -> tensor<2x3xf16>
-// CHECK-NEXT:  return %[[RESULT]] : tensor<2x3xf16>
-func.func @expand_shape_rank(%ctx: !hipsr.context,
-                             %input: tensor<2x3xf16>,
-                             %shape: tensor<1x2xi64>)
-    -> tensor<2x3xf16> {
+// CHECK-SAME:    %[[SHAPE:.*]]: tensor<4xi64>) -> tensor<?x?x?x?xf16> {
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]], %[[SHAPE]] : tensor<2x3xf16>, tensor<4xi64>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x?x?x?xf16>
+// CHECK-NEXT:    hipsr.expand(%[[CTX]]) ins(%[[INPUT]], %[[SHAPE]] : tensor<2x3xf16>, tensor<4xi64>)
+// CHECK-SAME:      outs(%[[INIT]] : tensor<?x?x?x?xf16>) : tensor<?x?x?x?xf16>
+func.func @expand_broadcast_rank(%ctx: !hipsr.context,
+                                 %input: tensor<2x3xf16>,
+                                 %shape: tensor<4xi64>)
+    -> tensor<?x?x?x?xf16> {
   %0 = "onnx.Expand"(%input, %shape)
-      : (tensor<2x3xf16>, tensor<1x2xi64>) -> tensor<2x3xf16>
-  return %0 : tensor<2x3xf16>
-}
-
-// -----
-
-// ONNX shape extents use i64 elements.
-// CHECK-LABEL: func.func @expand_shape_element_type(
-// CHECK-SAME:    %{{.*}}: !hipsr.context,
-// CHECK-SAME:    %[[INPUT:.*]]: tensor<2x3xf16>,
-// CHECK-SAME:    %[[SHAPE:.*]]: tensor<2xi32>) -> tensor<2x3xf16> {
-// CHECK-NOT:   hipsr.expand
-// CHECK-NEXT:  %[[RESULT:.*]] = "onnx.Expand"(%[[INPUT]], %[[SHAPE]]) : (tensor<2x3xf16>, tensor<2xi32>) -> tensor<2x3xf16>
-// CHECK-NEXT:  return %[[RESULT]] : tensor<2x3xf16>
-func.func @expand_shape_element_type(%ctx: !hipsr.context,
-                                     %input: tensor<2x3xf16>,
-                                     %shape: tensor<2xi32>)
-    -> tensor<2x3xf16> {
-  %0 = "onnx.Expand"(%input, %shape)
-      : (tensor<2x3xf16>, tensor<2xi32>) -> tensor<2x3xf16>
-  return %0 : tensor<2x3xf16>
-}
-
-// -----
-
-// The static shape length determines the output rank.
-// CHECK-LABEL: func.func @expand_dynamic_shape_length(
-// CHECK-SAME:    %{{.*}}: !hipsr.context,
-// CHECK-SAME:    %[[INPUT:.*]]: tensor<2x3xf16>,
-// CHECK-SAME:    %[[SHAPE:.*]]: tensor<?xi64>) -> tensor<2x3xf16> {
-// CHECK-NOT:   hipsr.expand
-// CHECK-NEXT:  %[[RESULT:.*]] = "onnx.Expand"(%[[INPUT]], %[[SHAPE]]) : (tensor<2x3xf16>, tensor<?xi64>) -> tensor<2x3xf16>
-// CHECK-NEXT:  return %[[RESULT]] : tensor<2x3xf16>
-func.func @expand_dynamic_shape_length(%ctx: !hipsr.context,
-                                       %input: tensor<2x3xf16>,
-                                       %shape: tensor<?xi64>)
-    -> tensor<2x3xf16> {
-  %0 = "onnx.Expand"(%input, %shape)
-      : (tensor<2x3xf16>, tensor<?xi64>) -> tensor<2x3xf16>
-  return %0 : tensor<2x3xf16>
-}
-
-// -----
-
-// Expand preserves the input element type.
-// CHECK-LABEL: func.func @expand_element_mismatch(
-// CHECK-SAME:    %{{.*}}: !hipsr.context,
-// CHECK-SAME:    %[[INPUT:.*]]: tensor<2x3xf16>,
-// CHECK-SAME:    %[[SHAPE:.*]]: tensor<2xi64>) -> tensor<2x3xf32> {
-// CHECK-NOT:   hipsr.expand
-// CHECK-NEXT:  %[[RESULT:.*]] = "onnx.Expand"(%[[INPUT]], %[[SHAPE]]) : (tensor<2x3xf16>, tensor<2xi64>) -> tensor<2x3xf32>
-// CHECK-NEXT:  return %[[RESULT]] : tensor<2x3xf32>
-func.func @expand_element_mismatch(%ctx: !hipsr.context,
-                                   %input: tensor<2x3xf16>,
-                                   %shape: tensor<2xi64>)
-    -> tensor<2x3xf32> {
-  %0 = "onnx.Expand"(%input, %shape)
-      : (tensor<2x3xf16>, tensor<2xi64>) -> tensor<2x3xf32>
-  return %0 : tensor<2x3xf32>
-}
-
-// -----
-
-// Output rank is max(input rank, requested shape length).
-// CHECK-LABEL: func.func @expand_output_rank(
-// CHECK-SAME:    %{{.*}}: !hipsr.context,
-// CHECK-SAME:    %[[INPUT:.*]]: tensor<2x3xf16>,
-// CHECK-SAME:    %[[SHAPE:.*]]: tensor<4xi64>) -> tensor<2x3xf16> {
-// CHECK-NOT:   hipsr.expand
-// CHECK-NEXT:  %[[RESULT:.*]] = "onnx.Expand"(%[[INPUT]], %[[SHAPE]]) : (tensor<2x3xf16>, tensor<4xi64>) -> tensor<2x3xf16>
-// CHECK-NEXT:  return %[[RESULT]] : tensor<2x3xf16>
-func.func @expand_output_rank(%ctx: !hipsr.context,
-                              %input: tensor<2x3xf16>,
-                              %shape: tensor<4xi64>)
-    -> tensor<2x3xf16> {
-  %0 = "onnx.Expand"(%input, %shape)
-      : (tensor<2x3xf16>, tensor<4xi64>) -> tensor<2x3xf16>
-  return %0 : tensor<2x3xf16>
+      : (tensor<2x3xf16>, tensor<4xi64>) -> tensor<?x?x?x?xf16>
+  return %0 : tensor<?x?x?x?xf16>
 }

--- a/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
@@ -1,8 +1,6 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// UNSUPPORTED: true
-//
 //===----------------------------------------------------------------------===//
 // Converts onnx.MatMul to hipsr.matmul (placeholder init, empty shape region).
 // Two cases: a plain 2-D matmul and a 1-D-operand matmul (the rank-reducing
@@ -16,7 +14,7 @@
 // CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:    %[[A:.*]]: tensor<?x4096xf16>,
 // CHECK-SAME:    %[[B:.*]]: tensor<4096x1024xf16>) -> tensor<?x1024xf16> {
-// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096x1024xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?x1024xf16>
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096x1024xf16>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x1024xf16>
 // CHECK-NEXT:    hipsr.matmul(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096x1024xf16>)
 // CHECK-SAME:      outs(%[[INIT]] : tensor<?x1024xf16>) : tensor<?x1024xf16>
 // CHECK-NOT:     shape_region
@@ -34,7 +32,7 @@ func.func @matmul_2d(%ctx: !hipsr.context, %a: tensor<?x4096xf16>,
 // CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:    %[[A:.*]]: tensor<?x4096xf16>,
 // CHECK-SAME:    %[[B:.*]]: tensor<4096xf16>) -> tensor<?xf16> {
-// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096xf16>) {type = #hipsr.placeholder_type<normal>} : tensor<?xf16>
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096xf16>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?xf16>
 // CHECK-NEXT:    hipsr.matmul(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x4096xf16>, tensor<4096xf16>)
 // CHECK-SAME:      outs(%[[INIT]] : tensor<?xf16>) : tensor<?xf16>
 // CHECK-NOT:     shape_region


### PR DESCRIPTION
## Summary

`convert-onnx-to-hipsr` built an empty pattern set, so every ONNX operation reached the strict conversion target unconverted. This adds the four `populate*` calls back and un-gates the four LIT tests that were supposed to catch this.

## Related issue or design

PR 2 of a 14-PR series adding the ONNX operations the hipsr embedding pipeline needs. Stacked on #702; see **Notes for reviewers**.

## Why

`ConvertOnnxToHipsrPass` marks the `onnx` dialect illegal and calls `applyFullConversion` with no patterns, so the pass only succeeded on IR that had no ONNX ops at all. Constant, Cast, MatMul and Expand each have a working pattern file, but nothing ever added them to the set, making all four dead code.

e48bfc6b (#628) dropped the calls when it swapped `applyPatternsGreedily` for `applyFullConversion`. Nothing caught it because #618 had already marked every test in `test/lit/Conversion/onnx-to-hipsr/` with `// UNSUPPORTED: true`, so the whole directory was gated at the time.

## What

`OnnxToHipsr.cpp` calls `populateOnnxToHipsrConstantPatterns`, `populateCastConversionPatterns`, `populateMatMulConversionPatterns` and `populateExpandConversionPatterns` before `applyFullConversion`.

The four tests come off `UNSUPPORTED` and are refreshed against what the conversion actually emits:

- The placeholder attribute is `placeholder_type`, not `type`. Both `cast.mlir` and `matmul.mlir` still expected the older spelling.
- `constant.mlir` gains `--split-input-file`. It already had `// -----` separators, but without the flag they were inert comments and all four cases parsed as one module.
- Expand's six negatives asserted that the ONNX op survived untouched. Under `applyFullConversion` an unmatched op fails the pass instead, so they move to `expand-invalid.mlir` as `failed to legalize operation 'onnx.Expand'` diagnostics, following `conversion-target-invalid.mlir`. That file now covers all seven rejection paths in the pattern: the three shape-operand guards, an unranked input, an element-type mismatch, a bad result rank, and a function whose argument 0 is not `!hipsr.context`.
- `expand.mlir` keeps the positive case and gains one for a shape longer than the input rank, which is the path that raises the output rank.

## Notes for reviewers

Stacked on #702, so the base is `test/hipsr-nested-test-layout` and the diff here is only this change's six files. GitHub retargets this PR to `main` when #702 merges. The dependency is one file: this PR edits `onnx-to-hipsr/constant.mlir`, which #702 creates by renaming `test_constant.mlir`. There is no textual conflict between the two.

`mlir::hip` declares identically named `populateCastConversionPatterns`, `populateMatMulConversionPatterns` and `populateExpandConversionPatterns` for the legacy pipeline. These calls resolve inside `mlir::hipsr` and the file includes only the hipsr header, so they reach the intended overloads.

The remaining 11 gated tests are outside this change: `hipsr-to-llvm` and the `Dialect/Hipsr/IR` files #618 disabled for other reasons.

## AI assistance

Cursor (Claude Opus 5) assisted with the root-cause analysis, the fix and the test refresh. I reviewed the result and understand it.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
