### PR TITLE
refactor(hipsr): store constant bytes in DenseResourceElementsAttr

### DIFF
--- a/include/hip/Conversion/OnnxToHipsr/OnnxToHipsr.h
+++ b/include/hip/Conversion/OnnxToHipsr/OnnxToHipsr.h
@@ -22,10 +22,6 @@ namespace hipsr {
 #define GEN_PASS_DECL_CONVERTONNXTOHIPSRPASS
 #include "hip/Conversion/Passes.h.inc"
 
-// Populates patterns that convert `onnx.Constant` into `hipsr.constant`
-// (rank>=1 inline / mem_source / file_source) or `arith.constant` (rank-0
-// scalar). Pure IR rewrite -- no file I/O and no size-threshold policy (that
-// is layered on in the externalization pass).
 void populateOnnxToHipsrConstantPatterns(::mlir::RewritePatternSet &patterns);
 
 void populateCastConversionPatterns(::mlir::RewritePatternSet &patterns,

--- a/include/hip/Dialect/Hipsr/IR/HipsrAttrs.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrAttrs.td
@@ -31,24 +31,4 @@ def Hipsr_PlaceholderTypeAttr :
   let assemblyFormat = "`<` $value `>`";
 }
 
-// A constant whose bytes live in an external file: absolute path + byte offset
-// + byte size. Read on demand (streaming) via the dialect's file-map cache.
-def Hipsr_FileSourceAttr : AttrDef<Hipsr_Dialect, "FileSource"> {
-  let mnemonic = "file_source";
-  let summary = "File-backed constant source (path, offset, size)";
-  let parameters = (ins "::mlir::StringAttr":$path,
-                        "int64_t":$offset,
-                        "int64_t":$size);
-  let assemblyFormat = "`<` $path `,` $offset `,` $size `>`";
-}
-
-// A constant whose bytes live at a raw memory address (an ORT tensor pointer,
-// zero-copy). Valid only within the compiling process/session.
-def Hipsr_MemSourceAttr : AttrDef<Hipsr_Dialect, "MemSource"> {
-  let mnemonic = "mem_source";
-  let summary = "Memory-backed constant source (address, size)";
-  let parameters = (ins "int64_t":$address, "int64_t":$size);
-  let assemblyFormat = "`<` $address `,` $size `>`";
-}
-
 #endif // HIPSR_ATTRS

--- a/include/hip/Dialect/Hipsr/IR/HipsrConstantOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrConstantOp.td
@@ -2,57 +2,39 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 //
-// The hipsr.constant op: a constant tensor buffer. Holds its data in one of
-// three forms (inline / external source / externalized). Foundation only --
-// the onnx->hipsr conversion, externalization, and LLVM lowering that produce
-// and consume these forms live in later PRs.
-//
 
 //===----------------------------------------------------------------------===//
 // Hipsr_ConstantOp
 //===----------------------------------------------------------------------===//
 
-def Hipsr_ConstantOp : Hipsr_Op<"constant", [Pure]> {
-  let summary = "Constant tensor buffer (inline value or external source)";
+def Hipsr_ConstantOp : Hipsr_Op<"constant", [ConstantLike, Pure]> {
+  let summary = "Constant tensor buffer";
   let description = [{
     Produces a constant buffer.
 
-    - `value`  : inline `DenseElementsAttr` carrying the bytes.
-    - `source` : `#hipsr.file_source<...>` (on-disk file) or
-                 `#hipsr.mem_source<...>` (a raw ORT pointer).
+    - `value` : inline `DenseElementsAttr` carrying the bytes, or
+                `DenseResourceElementsAttr` naming a blob keyed
+                `file|<path>|<offset>` or `mem|<address-hex>`.
     - `offset`/`size`/`index` : offset+size = location in the constants file,
-                 index = ordinal in the runtime array.
-
-    Valid states: `{value}`, `{source}`, or either plus `{offset, size, index}`.
+                index = ordinal in the runtime array.
   }];
 
   let arguments = (ins
-    OptionalAttr<ElementsAttr>:$value,
-    OptionalAttr<AnyAttrOf<[Hipsr_FileSourceAttr, Hipsr_MemSourceAttr]>>:$source,
-    OptionalAttr<I64Attr>:$offset,
-    OptionalAttr<I64Attr>:$size,
-    OptionalAttr<I64Attr>:$index
+    ElementsAttr:$value,
+    OptionalAttr<I64Attr>:$index,   // Constant index (after externalization)
+    OptionalAttr<I64Attr>:$offset,  // Offset in constants.bin (after externalization)
+    OptionalAttr<I64Attr>:$size     // Size in bytes (after externalization)
   );
 
   let results = (outs Hipsr_TensorOrDeviceMemRef:$result);
 
   let assemblyFormat = "attr-dict `:` type($result)";
 
+  let hasFolder = 1;
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    /// True if the constant carries an inline dense value.
-    bool isInline() { return getValueAttr() != nullptr; }
-    /// True if the constant references an external file/memory source.
-    bool hasExternalSource() { return getSourceAttr() != nullptr; }
     /// True if the constant has been externalized (offset/size into constants file).
     bool isExternalized() { return getOffsetAttr() != nullptr; }
-
-    /// Returns a typed view of the constant data (inline dense / mem source /
-    /// file source via the dialect cache). MorphiZen-only contract; works both
-    /// pre- and post-externalization. See the CONTRACT comment on the
-    /// definition in HipsrOps.h. Defined out-of-line there.
-    template <typename T>
-    ::llvm::ArrayRef<T> getDataValues();
   }];
 }

--- a/include/hip/Dialect/Hipsr/IR/HipsrOps.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrOps.h
@@ -21,10 +21,7 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/Support/ErrorHandling.h"
-#include "llvm/Support/MemoryBuffer.h"
 
-#include <cassert>
 #include <cstdint>
 
 #define GET_OP_CLASSES
@@ -40,55 +37,6 @@ namespace hipsr {
 // compute: use is in Outputs
 // dps: use is in Init
 bool isHipsrDestinationOperand(::mlir::OpOperand &use);
-
-// CONTRACT: MorphiZen-generated constants only. Works both before and after
-// externalization (value/source are never removed -- offset/size only mark the
-// constants-file location). Fails fast on forms MorphiZen never emits
-// (splat-optimized DenseElementsAttr, DenseResourceElementsAttr); add real APIs
-// if that changes.
-template <typename T>::llvm::ArrayRef<T> ConstantOp::getDataValues() {
-  // Inline dense value. MorphiZen writes FULL tensor data
-  // (numElements * elemByteWidth), never splat-optimized.
-  if (auto dense =
-          ::llvm::dyn_cast_or_null<::mlir::DenseElementsAttr>(getValueAttr())) {
-    if (dense.isSplat()) {
-      llvm_unreachable("splat DenseElementsAttr not supported "
-                       "(MorphiZen never emits splat-optimized constants)");
-    }
-    ::llvm::ArrayRef<char> raw = dense.getRawData();
-    return ::llvm::ArrayRef<T>(reinterpret_cast<const T *>(raw.data()),
-                               raw.size() / sizeof(T));
-  }
-
-  // Resource-backed inline value: not emitted by MorphiZen.
-  if (::llvm::isa_and_nonnull<::mlir::DenseResourceElementsAttr>(
-          getValueAttr())) {
-    llvm_unreachable("DenseResourceElementsAttr not supported "
-                     "(MorphiZen never emits this)");
-  }
-
-  // External source: raw pointer (mem) or memory-mapped file (cached).
-  if (::mlir::Attribute src = getSourceAttr()) {
-    if (auto mem = ::llvm::dyn_cast<MemSourceAttr>(src)) {
-      const T *p =
-          reinterpret_cast<const T *>(static_cast<uintptr_t>(mem.getAddress()));
-      return ::llvm::ArrayRef<T>(p, mem.getSize() / sizeof(T));
-    }
-    if (auto file = ::llvm::dyn_cast<FileSourceAttr>(src)) {
-      auto *dialect = getContext()->getLoadedDialect<HipsrDialect>();
-      assert(dialect && "HipsrDialect not loaded");
-      ::llvm::MemoryBuffer *buf =
-          dialect->getOrLoadFileMap(file.getPath().getValue());
-      assert(buf && "failed to load file for FileSourceAttr");
-      const T *p =
-          reinterpret_cast<const T *>(buf->getBufferStart() + file.getOffset());
-      return ::llvm::ArrayRef<T>(p, file.getSize() / sizeof(T));
-    }
-  }
-
-  // The verifier guarantees value XOR source, so this is unreachable.
-  llvm_unreachable("ConstantOp has neither value nor source");
-}
 
 } // namespace hipsr
 } // namespace mlir

--- a/lib/Conversion/OnnxToHipsr/ConstantConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/ConstantConversion.cpp
@@ -2,31 +2,18 @@
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
  */
-//===- ConstantConversion.cpp - onnx.Constant -> hipsr.constant ----------===//
-//
-// Converts `onnx.Constant` into the hipsr constant forms. Matched by name via
-// the generic Operation API (no onnx-mlir headers), consistent with the rest
-// of convert-onnx-to-hipsr. Four branches, keyed only on the storage form of
-// the incoming onnx.Constant -- no size threshold (that policy is layered on
-// later, in externalization):
-//
-//   inline value + rank-0 scalar     -> arith.constant <scalar>
-//   inline value + rank>=1           -> hipsr.constant {value}      : tensor<>
-//   location == "*/_ORT_MEM_ADDR_/*" -> hipsr.constant {mem_source} : tensor<>
-//   location == <other path>         -> hipsr.constant {file_source}: tensor<>
-//
-// The result stays a ranked tensor (pre-bufferization); the broadened
-// hipsr.constant result type (Hipsr_TensorOrDeviceMemRef) means no
-// memref->tensor bridge is needed here.
-//
-//===----------------------------------------------------------------------===//
 
 #include "hip/Conversion/OnnxToHipsr/OnnxToHipsr.h"
 #include "hip/Dialect/Hipsr/IR/HipsrOps.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/AsmState.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/Support/MemoryBuffer.h"
 
 namespace mlir {
 namespace hipsr {
@@ -61,11 +48,10 @@ struct ConstantOpLowering : public ::mlir::RewritePattern {
         return ::mlir::success();
       }
 
-      // rank>=1 -> hipsr.constant {value}.
       rewriter.replaceOpWithNewOp<ConstantOp>(
           op, /*result=*/tensorType, /*value=*/valueAttr,
-          /*source=*/::mlir::Attribute(), /*offset=*/::mlir::IntegerAttr(),
-          /*size=*/::mlir::IntegerAttr(), /*index=*/::mlir::IntegerAttr());
+          /*index=*/IntegerAttr(), /*offset=*/IntegerAttr(),
+          /*size=*/IntegerAttr());
       return ::mlir::success();
     }
 
@@ -84,17 +70,30 @@ struct ConstantOpLowering : public ::mlir::RewritePattern {
     int64_t offset = offsetAttr.getInt();
     int64_t size = sizeAttr.getInt();
 
-    ::mlir::Attribute source;
+    std::string key;
+    ArrayRef<char> data;
     if (locAttr.getValue() == kOrtMemAddrTag) {
-      source = MemSourceAttr::get(op->getContext(), /*address=*/offset, size);
+      key = ("mem|0x" + llvm::utohexstr(static_cast<uint64_t>(offset),
+                                        /*LowerCase=*/true));
+      data = {reinterpret_cast<const char *>(static_cast<uintptr_t>(offset)),
+              static_cast<size_t>(size)};
     } else {
-      source = FileSourceAttr::get(op->getContext(), locAttr, offset, size);
+      auto *dialect = op->getContext()->getLoadedDialect<HipsrDialect>();
+      llvm::MemoryBuffer *buf = dialect->getOrLoadFileMap(locAttr.getValue());
+      if (!buf) {
+        return rewriter.notifyMatchFailure(
+            op, "cannot memory-map the external data file");
+      }
+      key = ("file|" + locAttr.getValue() + "|" + Twine(offset)).str();
+      data = {buf->getBufferStart() + offset, static_cast<size_t>(size)};
     }
 
+    auto value = DenseResourceElementsAttr::get(
+        tensorType, key, UnmanagedAsmResourceBlob::allocateInferAlign(data));
+
     rewriter.replaceOpWithNewOp<ConstantOp>(
-        op, /*result=*/tensorType, /*value=*/::mlir::ElementsAttr(), source,
-        /*offset=*/::mlir::IntegerAttr(), /*size=*/::mlir::IntegerAttr(),
-        /*index=*/::mlir::IntegerAttr());
+        op, /*result=*/tensorType, value, /*index=*/IntegerAttr(),
+        /*offset=*/IntegerAttr(), /*size=*/IntegerAttr());
     return ::mlir::success();
   }
 };

--- a/lib/Dialect/Hipsr/IR/HipsrConstantOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrConstantOp.cpp
@@ -16,22 +16,20 @@ using namespace mlir;
 using namespace mlir::hipsr;
 
 LogicalResult ConstantOp::verify() {
-  bool hasValue = getValueAttr() != nullptr;
-  bool hasSource = getSourceAttr() != nullptr;
-  bool hasOffset = getOffsetAttr() != nullptr;
-  bool hasSize = getSizeAttr() != nullptr;
-  bool hasIndex = getIndexAttr() != nullptr;
-
-  if (hasValue == hasSource) {
-    return emitOpError("expected exactly one of {value} or {source}");
+  ElementsAttr value = getValue();
+  if (auto dense = dyn_cast<DenseElementsAttr>(value)) {
+    if (dense.isSplat() && dense.getNumElements() > 1) {
+      return emitOpError("splat value is not supported.");
+    }
+    return success();
   }
-
-  if (hasOffset != hasSize || hasOffset != hasIndex) {
-    return emitOpError("`offset`, `size` and `index` must be set together");
+  if (!isa<DenseResourceElementsAttr>(value)) {
+    return emitOpError("value must be dense<...> or dense_resource<...>");
   }
-
   return success();
 }
+
+OpFoldResult ConstantOp::fold(FoldAdaptor) { return getValue(); }
 
 namespace {
 

--- a/lib/Dialect/Hipsr/Transforms/ExternalizeConstants.cpp
+++ b/lib/Dialect/Hipsr/Transforms/ExternalizeConstants.cpp
@@ -4,18 +4,6 @@
  */
 //===- ExternalizeConstants.cpp - hipsr.constant -> constants file -------===//
 //
-// Phase 2 of the hipsr constant subsystem. Two stages inside one pass:
-//
-//   Phase 1 (always): walk each opted-in hipsr.constant, assign a 64-byte
-//     aligned cumulative offset, and stamp offset/size on the op (append-only
-//     -- value/source are kept). Builds one hip::ConstantEntry per constant.
-//   Phase 2 (only when a FileSystem is injected on the dialect): write the
-//     entries to the constants file via writeConstantsBinToFileSystem.
-//
-// file_source entries carry their file_path/offset only (data = nullptr) so
-// this pass does not read the weight file; inline / mem_source entries carry a
-// byte view (getDataValues). See Passes.td.
-//
 //===----------------------------------------------------------------------===//
 
 #include "hip/Dialect/Hipsr/Transforms/Passes.h"
@@ -25,6 +13,7 @@
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/DialectResourceBlobManager.h"
 
 #include "llvm/Support/MathExtras.h"
 
@@ -42,6 +31,8 @@ namespace {
 // Constants-file alignment: every constant starts on a 64-byte boundary (GPU
 // alignment; matches the hip.* constants-file layout).
 constexpr int64_t kConstantAlignment = 64;
+
+constexpr llvm::StringLiteral kFileKeyPrefix = "file|";
 
 struct HipsrExternalizeConstantsPass
     : impl::HipsrExternalizeConstantsPassBase<HipsrExternalizeConstantsPass> {
@@ -62,23 +53,26 @@ struct HipsrExternalizeConstantsPass
     int64_t constantIndex = 0;
     module.walk([&](ConstantOp c) {
       hip::ConstantEntry entry;
-      int64_t size = 0;
-      if (auto fileSrc =
-              llvm::dyn_cast_or_null<FileSourceAttr>(c.getSourceAttr())) {
-        // File-ref: keep the on-disk reference (path/offset); this pass does
-        // not read the (possibly multi-GB) weight file.
-        entry.file_path = fileSrc.getPath().getValue().str();
-        entry.file_offset = fileSrc.getOffset();
-        size = fileSrc.getSize();
+      ElementsAttr value = c.getValue();
+      llvm::ArrayRef<char> bytes;
+      if (auto resource = dyn_cast<DenseResourceElementsAttr>(value)) {
+        bytes = resource.getData();
+        StringRef key = resource.getRawHandle().getKey();
+        if (key.consume_front(kFileKeyPrefix)) {
+          // File-ref: keep the on-disk reference (path/offset); this pass does
+          // not read the (possibly multi-GB) weight file.
+          auto [path, offsetText] = key.rsplit('|');
+          entry.file_path = path.str();
+          offsetText.getAsInteger(10, entry.file_offset);
+        } else {
+          entry.data = bytes.data();
+        }
       } else {
-        // inline value or mem_source: a byte view. getDataValues does not read
-        // the bytes here (it only forms the pointer/size); the writer reads
-        // them in Phase 2.
-        llvm::ArrayRef<uint8_t> bytes = c.getDataValues<uint8_t>();
+        bytes = cast<DenseElementsAttr>(value).getRawData();
         entry.data = bytes.data();
-        size = static_cast<int64_t>(bytes.size());
       }
 
+      int64_t size = static_cast<int64_t>(bytes.size());
       int64_t offset = llvm::alignTo(filePos, kConstantAlignment);
       entry.offset = offset;
       entry.size = size;

--- a/test/lit/Conversion/hipsr-to-llvm/constant.mlir
+++ b/test/lit/Conversion/hipsr-to-llvm/constant.mlir
@@ -1,8 +1,6 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// UNSUPPORTED: true
-
 // RUN: hip-mlir-opt %s --convert-to-llvm | FileCheck %s
 
 // CHECK-LABEL: llvm.func @single_constant
@@ -11,7 +9,7 @@ func.func @single_constant(%ctx: !llvm.ptr)
     -> memref<3x4xf32, #hipsr.mem<device>> {
   // CHECK:   %[[IDX:.*]] = llvm.mlir.constant(0 : i64) : i64
   // CHECK:   %[[PTR:.*]] = llvm.call @hipdnn_ep_constant_get(%[[CTX]], %[[IDX]]) : (!llvm.ptr, i64) -> !llvm.ptr<1>
-  %c = hipsr.constant {value = dense<1.0> : tensor<3x4xf32>, offset = 0 : i64, size = 48 : i64, index = 0 : i64}
+  %c = hipsr.constant {value = dense_resource<"mem|0x7ff620910000"> : tensor<3x4xf32>, offset = 0 : i64, size = 48 : i64, index = 0 : i64}
      : memref<3x4xf32, #hipsr.mem<device>>
   return %c : memref<3x4xf32, #hipsr.mem<device>>
 }
@@ -22,12 +20,12 @@ func.func @two_constants(%ctx: !llvm.ptr, %n: i64)
     -> (memref<64xf32, #hipsr.mem<device>>, memref<8xf32, #hipsr.mem<device>>) {
   // CHECK:   %[[IDX0:.*]] = llvm.mlir.constant(0 : i64) : i64
   // CHECK:   %[[P0:.*]] = llvm.call @hipdnn_ep_constant_get(%[[CTX2]], %[[IDX0]]) : (!llvm.ptr, i64) -> !llvm.ptr<1>
-  %w = hipsr.constant {value = dense<1.0> : tensor<64xf32>, offset = 0 : i64, size = 256 : i64, index = 0 : i64}
+  %w = hipsr.constant {value = dense_resource<"mem|0x7ff620920000"> : tensor<64xf32>, offset = 0 : i64, size = 256 : i64, index = 0 : i64}
      : memref<64xf32, #hipsr.mem<device>>
   // CHECK:   llvm.insertvalue {{.*}}[4, 0]
   // CHECK:   %[[IDX1:.*]] = llvm.mlir.constant(1 : i64) : i64
   // CHECK:   %[[P1:.*]] = llvm.call @hipdnn_ep_constant_get(%[[CTX2]], %[[IDX1]]) : (!llvm.ptr, i64) -> !llvm.ptr<1>
-  %b = hipsr.constant {value = dense<2.0> : tensor<8xf32>, offset = 256 : i64, size = 32 : i64, index = 1 : i64}
+  %b = hipsr.constant {value = dense_resource<"mem|0x7ff620930000"> : tensor<8xf32>, offset = 256 : i64, size = 32 : i64, index = 1 : i64}
      : memref<8xf32, #hipsr.mem<device>>
   return %w, %b : memref<64xf32, #hipsr.mem<device>>, memref<8xf32, #hipsr.mem<device>>
 }

--- a/test/lit/Conversion/onnx-to-hipsr/constant.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/constant.mlir
@@ -22,8 +22,8 @@ func.func @inline_const() -> tensor<4xf32> {
 
 // -----
 
-// CHECK-LABEL: func.func @mem_source_const
-func.func @mem_source_const() -> tensor<2x4xf32> {
+// CHECK-LABEL: func.func @mem_resource_const
+func.func @mem_resource_const() -> tensor<2x4xf32> {
   // CHECK: hipsr.constant {value = dense_resource<"mem|0x7ff620910000"> : tensor<2x4xf32>} : tensor<2x4xf32>
   %0 = "onnx.Constant"() {location = "*/_ORT_MEM_ADDR_/*", offset = 140695085056000 : i64, size = 32 : i64} : () -> tensor<2x4xf32>
   return %0 : tensor<2x4xf32>
@@ -31,8 +31,8 @@ func.func @mem_source_const() -> tensor<2x4xf32> {
 
 // -----
 
-// CHECK-LABEL: func.func @file_source_const
-func.func @file_source_const() -> tensor<4xi8> {
+// CHECK-LABEL: func.func @file_resource_const
+func.func @file_resource_const() -> tensor<4xi8> {
   // CHECK: hipsr.constant {value = dense_resource<"file|w.bin|4"> : tensor<4xi8>} : tensor<4xi8>
   %0 = "onnx.Constant"() {location = "w.bin", offset = 4 : i64, size = 4 : i64} : () -> tensor<4xi8>
   return %0 : tensor<4xi8>

--- a/test/lit/Conversion/onnx-to-hipsr/constant.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/constant.mlir
@@ -1,15 +1,7 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// convert-onnx-to-hipsr: onnx.Constant -> hipsr.constant / arith.constant.
-// Four branches keyed on storage form (no size threshold here):
-//   rank-0 scalar          -> arith.constant (compile-time)
-//   rank>=1 inline value   -> hipsr.constant {value}
-//   "*/_ORT_MEM_ADDR_/*"   -> hipsr.constant {mem_source}
-//   other location path    -> hipsr.constant {file_source}
-// onnx.Constant is written in generic form so no onnx dialect is required.
-
-// RUN: hip-mlir-opt --convert-onnx-to-hipsr --split-input-file %s | FileCheck %s
+// RUN: rm -rf %t && mkdir -p %t && cd %t && echo 0123456789abcdef > w.bin && hip-mlir-opt --convert-onnx-to-hipsr --split-input-file --mlir-elide-resource-strings-if-larger=0 %s | FileCheck %s
 
 // CHECK-LABEL: func.func @scalar_const
 func.func @scalar_const() -> tensor<f32> {
@@ -32,7 +24,7 @@ func.func @inline_const() -> tensor<4xf32> {
 
 // CHECK-LABEL: func.func @mem_source_const
 func.func @mem_source_const() -> tensor<2x4xf32> {
-  // CHECK: hipsr.constant {source = #hipsr.mem_source<140695085056000, 32>} : tensor<2x4xf32>
+  // CHECK: hipsr.constant {value = dense_resource<"mem|0x7ff620910000"> : tensor<2x4xf32>} : tensor<2x4xf32>
   %0 = "onnx.Constant"() {location = "*/_ORT_MEM_ADDR_/*", offset = 140695085056000 : i64, size = 32 : i64} : () -> tensor<2x4xf32>
   return %0 : tensor<2x4xf32>
 }
@@ -40,8 +32,8 @@ func.func @mem_source_const() -> tensor<2x4xf32> {
 // -----
 
 // CHECK-LABEL: func.func @file_source_const
-func.func @file_source_const() -> tensor<100xf32> {
-  // CHECK: hipsr.constant {source = #hipsr.file_source<"weights.bin", 1048576, 400>} : tensor<100xf32>
-  %0 = "onnx.Constant"() {location = "weights.bin", offset = 1048576 : i64, size = 400 : i64} : () -> tensor<100xf32>
-  return %0 : tensor<100xf32>
+func.func @file_source_const() -> tensor<4xi8> {
+  // CHECK: hipsr.constant {value = dense_resource<"file|w.bin|4"> : tensor<4xi8>} : tensor<4xi8>
+  %0 = "onnx.Constant"() {location = "w.bin", offset = 4 : i64, size = 4 : i64} : () -> tensor<4xi8>
+  return %0 : tensor<4xi8>
 }

--- a/test/lit/Dialect/Hipsr/IR/constant.mlir
+++ b/test/lit/Dialect/Hipsr/IR/constant.mlir
@@ -1,13 +1,11 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// UNSUPPORTED: true
-
 // RUN: hip-mlir-opt %s -split-input-file -verify-diagnostics | FileCheck %s
 
-// CHECK-LABEL: func.func @inline_const
+// CHECK-LABEL: func.func @inline_const(
+// CHECK-NEXT: hipsr.constant {value = dense<{{.*}}> : tensor<4xf16>} : memref<4xf16, #hipsr.mem<device>>
 func.func @inline_const() -> memref<4xf16, #hipsr.mem<device>> {
-  // CHECK: hipsr.constant {value = dense<{{.*}}> : tensor<4xf16>} : memref<4xf16, #hipsr.mem<device>>
   %c = hipsr.constant {value = dense<[1.0, 2.0, 3.0, 4.0]> : tensor<4xf16>}
      : memref<4xf16, #hipsr.mem<device>>
   return %c : memref<4xf16, #hipsr.mem<device>>
@@ -15,9 +13,9 @@ func.func @inline_const() -> memref<4xf16, #hipsr.mem<device>> {
 
 // -----
 
-// CHECK-LABEL: func.func @inline_const_tensor
+// CHECK-LABEL: func.func @inline_const_tensor(
+// CHECK-NEXT: hipsr.constant {value = dense<{{.*}}> : tensor<4xf16>} : tensor<4xf16>
 func.func @inline_const_tensor() -> tensor<4xf16> {
-  // CHECK: hipsr.constant {value = dense<{{.*}}> : tensor<4xf16>} : tensor<4xf16>
   %c = hipsr.constant {value = dense<[1.0, 2.0, 3.0, 4.0]> : tensor<4xf16>}
      : tensor<4xf16>
   return %c : tensor<4xf16>
@@ -25,50 +23,69 @@ func.func @inline_const_tensor() -> tensor<4xf16> {
 
 // -----
 
-// CHECK-LABEL: func.func @file_source_const
-func.func @file_source_const() -> memref<100xf32, #hipsr.mem<device>> {
-  // CHECK: hipsr.constant {source = #hipsr.file_source<"w.bin", 0, 1000>} : memref<100xf32, #hipsr.mem<device>>
-  %c = hipsr.constant {source = #hipsr.file_source<"w.bin", 0, 1000>}
+// CHECK-LABEL: func.func @file_resource_const(
+// CHECK-NEXT: hipsr.constant {value = dense_resource<"file|w.bin|1024"> : tensor<100xf32>} : memref<100xf32, #hipsr.mem<device>>
+func.func @file_resource_const() -> memref<100xf32, #hipsr.mem<device>> {
+  %c = hipsr.constant {value = dense_resource<"file|w.bin|1024"> : tensor<100xf32>}
      : memref<100xf32, #hipsr.mem<device>>
   return %c : memref<100xf32, #hipsr.mem<device>>
 }
 
 // -----
 
-// CHECK-LABEL: func.func @mem_source_const
-func.func @mem_source_const() -> memref<2x4xf32, #hipsr.mem<device>> {
-  // CHECK: hipsr.constant {source = #hipsr.mem_source<140695085056000, 32>} : memref<2x4xf32, #hipsr.mem<device>>
-  %c = hipsr.constant {source = #hipsr.mem_source<140695085056000, 32>}
+// CHECK-LABEL: func.func @mem_resource_const(
+// CHECK-NEXT: hipsr.constant {value = dense_resource<"mem|0x7ff620910000"> : tensor<2x4xf32>} : memref<2x4xf32, #hipsr.mem<device>>
+func.func @mem_resource_const() -> memref<2x4xf32, #hipsr.mem<device>> {
+  %c = hipsr.constant {value = dense_resource<"mem|0x7ff620910000"> : tensor<2x4xf32>}
      : memref<2x4xf32, #hipsr.mem<device>>
   return %c : memref<2x4xf32, #hipsr.mem<device>>
 }
 
 // -----
 
-// CHECK-LABEL: func.func @externalized_const
+// CHECK-LABEL: func.func @externalized_const(
+// CHECK-NEXT: hipsr.constant {index = 0 : i64, offset = 0 : i64, size = 524288 : i64, value = dense_resource<"mem|0x7ff620910000"> : tensor<512x512xf16>} : memref<512x512xf16, #hipsr.mem<device>>
 func.func @externalized_const() -> memref<512x512xf16, #hipsr.mem<device>> {
-  // CHECK: hipsr.constant {index = 0 : i64, offset = 0 : i64, size = 524288 : i64, value = dense<{{.*}}> : tensor<512x512xf16>} : memref<512x512xf16, #hipsr.mem<device>>
-  %c = hipsr.constant {value = dense<1.0> : tensor<512x512xf16>, offset = 0 : i64, size = 524288 : i64, index = 0 : i64}
+  %c = hipsr.constant {value = dense_resource<"mem|0x7ff620910000"> : tensor<512x512xf16>, offset = 0 : i64, size = 524288 : i64, index = 0 : i64}
      : memref<512x512xf16, #hipsr.mem<device>>
   return %c : memref<512x512xf16, #hipsr.mem<device>>
 }
 
 // -----
 
-func.func @both_value_and_source_rejected() -> memref<4xf16, #hipsr.mem<device>> {
-  // expected-error @+1 {{expected exactly one of {value} or {source}}}
-  %c = hipsr.constant {value = dense<1.0> : tensor<4xf16>, source = #hipsr.mem_source<140695085056000, 8>}
+func.func @missing_value_rejected() -> memref<4xf16, #hipsr.mem<device>> {
+  // expected-error @+1 {{requires attribute 'value'}}
+  %c = hipsr.constant {} : memref<4xf16, #hipsr.mem<device>>
+  return %c : memref<4xf16, #hipsr.mem<device>>
+}
+
+// -----
+
+func.func @sparse_value_rejected() -> memref<3x4xi32, #hipsr.mem<device>> {
+  // expected-error @+1 {{value must be dense<...> or dense_resource<...>}}
+  %c = hipsr.constant {value = sparse<[[0, 0], [1, 2]], [1, 5]> : tensor<3x4xi32>}
+     : memref<3x4xi32, #hipsr.mem<device>>
+  return %c : memref<3x4xi32, #hipsr.mem<device>>
+}
+
+// -----
+
+func.func @splat_value_rejected() -> memref<4xf16, #hipsr.mem<device>> {
+  // expected-error @+1 {{splat value is not supported.}}
+  %c = hipsr.constant {value = dense<1.0> : tensor<4xf16>}
      : memref<4xf16, #hipsr.mem<device>>
   return %c : memref<4xf16, #hipsr.mem<device>>
 }
 
 // -----
 
-func.func @offset_without_size_rejected() -> memref<4xf16, #hipsr.mem<device>> {
-  // expected-error @+1 {{`offset`, `size` and `index` must be set together}}
-  %c = hipsr.constant {value = dense<1.0> : tensor<4xf16>, offset = 0 : i64}
-     : memref<4xf16, #hipsr.mem<device>>
-  return %c : memref<4xf16, #hipsr.mem<device>>
+// A single-element tensor is stored splat but its raw data is already complete.
+// CHECK-LABEL: func.func @single_element_const(
+// CHECK-NEXT: hipsr.constant {value = dense<{{.*}}> : tensor<1xf16>} : memref<1xf16, #hipsr.mem<device>>
+func.func @single_element_const() -> memref<1xf16, #hipsr.mem<device>> {
+  %c = hipsr.constant {value = dense<1.0> : tensor<1xf16>}
+     : memref<1xf16, #hipsr.mem<device>>
+  return %c : memref<1xf16, #hipsr.mem<device>>
 }
 
 // -----
@@ -77,6 +94,7 @@ func.func @offset_without_size_rejected() -> memref<4xf16, #hipsr.mem<device>> {
 // (Hipsr_TensorOrDeviceMemRef), not by the verifier.
 func.func @non_device_space_rejected() -> memref<4xf16> {
   // expected-error @+1 {{result #0 must be ranked tensor or device memref}}
-  %c = hipsr.constant {value = dense<1.0> : tensor<4xf16>} : memref<4xf16>
+  %c = hipsr.constant {value = dense<[1.0, 2.0, 3.0, 4.0]> : tensor<4xf16>}
+     : memref<4xf16>
   return %c : memref<4xf16>
 }

--- a/test/lit/Dialect/Hipsr/Transforms/ExternalizeConstants/externalize-constants.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/ExternalizeConstants/externalize-constants.mlir
@@ -1,8 +1,6 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// UNSUPPORTED: true
-
 // RUN: hip-mlir-opt --hipsr-externalize-constants %s -split-input-file | FileCheck %s
 
 // -----
@@ -16,23 +14,39 @@ func.func @inline_value() -> tensor<4xf32> {
 
 // -----
 
-// CHECK-LABEL: func.func @file_source
-// CHECK: hipsr.constant {index = 0 : i64, offset = 0 : i64, size = 1000 : i64, source = #hipsr.file_source<"w.bin", 100, 1000>} : tensor<100xf32>
-func.func @file_source() -> tensor<100xf32> {
-  %0 = hipsr.constant {source = #hipsr.file_source<"w.bin", 100, 1000>} : tensor<100xf32>
-  return %0 : tensor<100xf32>
+// CHECK-LABEL: func.func @file_resource
+// CHECK: hipsr.constant {index = 0 : i64, offset = 0 : i64, size = 16 : i64, value = dense_resource<"file|w.bin|100"> : tensor<2xi64>} : tensor<2xi64>
+func.func @file_resource() -> tensor<2xi64> {
+  %0 = hipsr.constant {value = dense_resource<"file|w.bin|100"> : tensor<2xi64>} : tensor<2xi64>
+  return %0 : tensor<2xi64>
 }
+
+{-#
+  dialect_resources: {
+    builtin: {
+      "file|w.bin|100": "0x0100000001000000000000000200000000000000"
+    }
+  }
+#-}
 
 // -----
 
 // CHECK-LABEL: func.func @cumulative_alignment
-// CHECK: hipsr.constant {index = 0 : i64, offset = 0 : i64, size = 1000 : i64, source = #hipsr.file_source<"w.bin", 0, 1000>} : tensor<250xf32>
-// CHECK: hipsr.constant {index = 1 : i64, offset = 1024 : i64, size = 8 : i64, value = dense<[5.000000e+00, 6.000000e+00]> : tensor<2xf32>} : tensor<2xf32>
-func.func @cumulative_alignment() -> (tensor<250xf32>, tensor<2xf32>) {
-  %0 = hipsr.constant {source = #hipsr.file_source<"w.bin", 0, 1000>} : tensor<250xf32>
+// CHECK: hipsr.constant {index = 0 : i64, offset = 0 : i64, size = 16 : i64, value = dense_resource<"file|w.bin|0"> : tensor<2xi64>} : tensor<2xi64>
+// CHECK: hipsr.constant {index = 1 : i64, offset = 64 : i64, size = 8 : i64, value = dense<[5.000000e+00, 6.000000e+00]> : tensor<2xf32>} : tensor<2xf32>
+func.func @cumulative_alignment() -> (tensor<2xi64>, tensor<2xf32>) {
+  %0 = hipsr.constant {value = dense_resource<"file|w.bin|0"> : tensor<2xi64>} : tensor<2xi64>
   %1 = hipsr.constant {value = dense<[5.0, 6.0]> : tensor<2xf32>} : tensor<2xf32>
-  return %0, %1 : tensor<250xf32>, tensor<2xf32>
+  return %0, %1 : tensor<2xi64>, tensor<2xf32>
 }
+
+{-#
+  dialect_resources: {
+    builtin: {
+      "file|w.bin|0": "0x0100000001000000000000000200000000000000"
+    }
+  }
+#-}
 
 // -----
 // Module-scoped: the pass runs on the whole module, so offsets accumulate
@@ -40,12 +54,12 @@ func.func @cumulative_alignment() -> (tensor<250xf32>, tensor<2xf32>) {
 // rather than restarting at 0 per function.
 
 // CHECK-LABEL: func.func @first
-// CHECK: hipsr.constant {index = 0 : i64, offset = 0 : i64, size = 1000 : i64, source = #hipsr.file_source<"w.bin", 0, 1000>} : tensor<250xf32>
+// CHECK: hipsr.constant {index = 0 : i64, offset = 0 : i64, size = 16 : i64, value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00]> : tensor<4xf32>} : tensor<4xf32>
 // CHECK-LABEL: func.func @second
-// CHECK: hipsr.constant {index = 1 : i64, offset = 1024 : i64, size = 8 : i64, value = dense<[7.000000e+00, 8.000000e+00]> : tensor<2xf32>} : tensor<2xf32>
-func.func @first() -> tensor<250xf32> {
-  %0 = hipsr.constant {source = #hipsr.file_source<"w.bin", 0, 1000>} : tensor<250xf32>
-  return %0 : tensor<250xf32>
+// CHECK: hipsr.constant {index = 1 : i64, offset = 64 : i64, size = 8 : i64, value = dense<[7.000000e+00, 8.000000e+00]> : tensor<2xf32>} : tensor<2xf32>
+func.func @first() -> tensor<4xf32> {
+  %0 = hipsr.constant {value = dense<[1.0, 2.0, 3.0, 4.0]> : tensor<4xf32>} : tensor<4xf32>
+  return %0 : tensor<4xf32>
 }
 func.func @second() -> tensor<2xf32> {
   %0 = hipsr.constant {value = dense<[7.0, 8.0]> : tensor<2xf32>} : tensor<2xf32>

--- a/test/unit/test_externalize_constants.cpp
+++ b/test/unit/test_externalize_constants.cpp
@@ -3,17 +3,6 @@
  * Licensed under the MIT License.
  */
 
-// Unit test for -hipsr-externalize-constants that exercises Phase 2 (the
-// constants-file write), which the LIT tests cannot: LIT runs hip-mlir-opt with
-// no injected FileSystem, so it only sees the Phase 1 IR mutation
-// (offset/size). Here we inject an in-memory FileSystem and assert the actual
-// bytes written -- the only way to catch entry-field bugs (e.g. file_source vs
-// inline routing) that are invisible in the IR because they produce identical
-// offset/size.
-//
-// Plain main() (no GTest): matches the other MLIR-side unit tests and avoids a
-// GTest dependency that is not present in the compiler build.
-
 #include "hip/Dialect/Hipsr/IR/HipsrOps.h"
 #include "hip/Dialect/Hipsr/Transforms/Passes.h"
 #include "hip/Support/DiskFileSystem.h"
@@ -21,12 +10,15 @@
 #include "morphizen-foundation/file_io.hpp"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinDialect.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/DialectResourceBlobManager.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Pass/PassManager.h"
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -35,6 +27,7 @@
 #include <fstream>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -129,10 +122,6 @@ void verifyLayout(const std::vector<char> &blob,
         label + ": blob length == aligned total");
 }
 
-// FileSystem that captures every write into an in-memory buffer per filename,
-// so a test can inspect the exact constants-file bytes. create_reader is unused
-// -- writeConstantsBinToFileSystem reads file_source data via std::fopen on the
-// file path directly, not through the FileSystem.
 class CapturingFileSystem : public morphizen::FileSystem {
 public:
   class Writer : public morphizen::FileWriter {
@@ -173,9 +162,9 @@ public:
   void destroy_writer(morphizen::FileWriter *) override {}
 };
 
-// Loads the parsed dialects, injects `fs`, runs the pass. Returns the module
-// and sets `ok` to whether the pass succeeded.
 struct Harness {
+  using Blobs = std::vector<std::pair<std::string, llvm::ArrayRef<char>>>;
+
   mlir::MLIRContext ctx;
 
   Harness() {
@@ -183,12 +172,19 @@ struct Harness {
   }
 
   mlir::OwningOpRef<mlir::ModuleOp> run(const std::string &ir,
-                                        morphizen::FileSystem *fs, bool &ok) {
+                                        morphizen::FileSystem *fs, bool &ok,
+                                        const Blobs &blobs = {}) {
     auto module = mlir::parseSourceString<mlir::ModuleOp>(ir, &ctx);
     if (!module) {
       llvm::errs() << "failed to parse IR\n";
       ok = false;
       return module;
+    }
+    auto &manager =
+        mlir::DenseResourceElementsHandle::getManagerInterface(&ctx);
+    for (const auto &[key, bytes] : blobs) {
+      manager.update(key,
+                     mlir::UnmanagedAsmResourceBlob::allocateInferAlign(bytes));
     }
     ctx.getLoadedDialect<mlir::hipsr::HipsrDialect>()->setFileSystem(fs);
 
@@ -234,37 +230,32 @@ void testInlineValueBytesWritten() {
         "inline: blob bytes match dense value, rest zero");
 }
 
-// mem_source: the writer must copy the bytes at the raw address (entry.data),
-// not treat it as a file. Covers the getDataValues mem-pointer branch.
-void testMemSourceBytesWritten() {
-  std::vector<uint8_t> host = {50, 60, 70};
-  auto addr = reinterpret_cast<uintptr_t>(host.data());
+void testMemResourceBytesWritten() {
+  std::vector<char> host = {50, 60, 70};
 
   Harness h;
   CapturingFileSystem fs;
   bool ok = false;
-  auto module = h.run("func.func @f() -> tensor<3xi8> {\n"
-                      "  %0 = hipsr.constant {source = #hipsr.mem_source<" +
-                          std::to_string(addr) +
-                          ", 3>} : tensor<3xi8>\n"
-                          "  return %0 : tensor<3xi8>\n"
-                          "}\n",
-                      &fs, ok);
-  check(ok, "mem_source: pass succeeds");
+  auto module = h.run(R"mlir(
+    func.func @f() -> tensor<3xi8> {
+      %0 = hipsr.constant {value = dense_resource<"mem|0x1"> : tensor<3xi8>} : tensor<3xi8>
+      return %0 : tensor<3xi8>
+    }
+  )mlir",
+                      &fs, ok, {{"mem|0x1", host}});
+  check(ok, "mem resource: pass succeeds");
   if (!ok) {
     return;
   }
 
   const std::vector<char> &blob = fs.files["constants.bin"];
-  check(blob.size() == 64, "mem_source: blob padded to 64");
+  check(blob.size() == 64, "mem resource: blob padded to 64");
   check(blob.size() == 64 && static_cast<uint8_t>(blob[0]) == 50 &&
             static_cast<uint8_t>(blob[2]) == 70,
-        "mem_source: blob bytes copied from address");
+        "mem resource: blob bytes copied from the pointed-at memory");
 }
 
-// file_source: the constants-file bytes come from the referenced file at the
-// given offset. Covers the file-ref branch.
-void testFileSourceBytesStreamed() {
+void testFileResourceBytesStreamed() {
   auto path = std::filesystem::temp_directory_path() /
               "hipsr_externalize_test_weights.bin";
   {
@@ -276,20 +267,22 @@ void testFileSourceBytesStreamed() {
   Harness h;
   CapturingFileSystem fs;
   bool ok = false;
+  std::string key = "file|" + path.generic_string() + "|0";
+  std::vector<char> window(5);
   auto module = h.run("func.func @f() -> tensor<5xi8> {\n"
-                      "  %0 = hipsr.constant {source = #hipsr.file_source<\"" +
-                          path.generic_string() +
-                          "\", 0, 5>} : tensor<5xi8>\n"
+                      "  %0 = hipsr.constant {value = dense_resource<\"" +
+                          key +
+                          "\"> : tensor<5xi8>} : tensor<5xi8>\n"
                           "  return %0 : tensor<5xi8>\n"
                           "}\n",
-                      &fs, ok);
-  check(ok, "file_source: pass succeeds");
+                      &fs, ok, {{key, window}});
+  check(ok, "file resource: pass succeeds");
 
   const std::vector<char> &blob = fs.files["constants.bin"];
-  check(blob.size() == 64, "file_source: blob padded to 64");
+  check(blob.size() == 64, "file resource: blob padded to 64");
   check(blob.size() == 64 && static_cast<uint8_t>(blob[0]) == 1 &&
             static_cast<uint8_t>(blob[4]) == 5,
-        "file_source: blob bytes streamed from file");
+        "file resource: blob bytes streamed from file");
 
   std::filesystem::remove(path);
 }
@@ -301,8 +294,6 @@ void testCumulativeAlignmentAndPadding() {
   Harness h;
   CapturingFileSystem fs;
   bool ok = false;
-  // Non-splat values: getDataValues is a MorphiZen-only contract that does not
-  // support splat-optimized DenseElementsAttr, so use distinct bytes.
   auto module = h.run(R"mlir(
     func.func @f() -> (tensor<4xi8>, tensor<8xi8>) {
       %0 = hipsr.constant {value = dense<[1, 2, 3, 4]> : tensor<4xi8>} : tensor<4xi8>
@@ -382,9 +373,6 @@ void testOffsetDrivenReadBack() {
   fs::remove_all(dir, ec);
   fs::create_directories(dir, ec);
 
-  // Source file for the file_source constant: 200 bytes, src[i] == i, so the
-  // window [50, 150) is bytes 50..149. A nonzero file_offset also checks that
-  // the writer reads from the right place in the source.
   fs::path srcFile = dir / "weights.bin";
   {
     std::ofstream ofs(srcFile, std::ios::binary);
@@ -394,12 +382,10 @@ void testOffsetDrivenReadBack() {
     }
   }
 
-  // Live host buffer for the mem_source constant.
-  std::vector<uint8_t> memHost(7);
+  std::vector<char> memHost(7);
   for (int i = 0; i < 7; ++i) {
-    memHost[i] = static_cast<uint8_t>(200 + i);
+    memHost[i] = static_cast<char>(200 + i);
   }
-  auto addr = reinterpret_cast<uintptr_t>(memHost.data());
 
   // Expected bytes, in declaration order (== module walk order).
   std::vector<std::vector<char>> expected;
@@ -411,11 +397,10 @@ void testOffsetDrivenReadBack() {
   }
   expected.push_back(std::move(e1));
   expected.push_back({91, 92, 93}); // c2
-  std::vector<char> e3;             // c3 mem buffer
-  for (int i = 0; i < 7; ++i) {
-    e3.push_back(static_cast<char>(memHost[i]));
-  }
-  expected.push_back(std::move(e3));
+  expected.push_back(memHost);      // c3 mem buffer
+
+  std::string fileKey = "file|" + srcFile.generic_string() + "|50";
+  std::vector<char> fileWindow(100);
 
   // c0's i32 values whose little-endian bytes are {1..4} and {5..8}.
   std::string ir =
@@ -423,14 +408,13 @@ void testOffsetDrivenReadBack() {
       "tensor<7xi8>) {\n"
       "  %0 = hipsr.constant {value = dense<[67305985, 134678021]> : "
       "tensor<2xi32>} : tensor<2xi32>\n"
-      "  %1 = hipsr.constant {source = #hipsr.file_source<\"" +
-      srcFile.generic_string() +
-      "\", 50, 100>} : tensor<100xi8>\n"
+      "  %1 = hipsr.constant {value = dense_resource<\"" +
+      fileKey +
+      "\"> : tensor<100xi8>} : tensor<100xi8>\n"
       "  %2 = hipsr.constant {value = dense<[91, 92, 93]> : tensor<3xi8>} : "
       "tensor<3xi8>\n"
-      "  %3 = hipsr.constant {source = #hipsr.mem_source<" +
-      std::to_string(addr) +
-      ", 7>} : tensor<7xi8>\n"
+      "  %3 = hipsr.constant {value = dense_resource<\"mem|0x1\"> : "
+      "tensor<7xi8>} : tensor<7xi8>\n"
       "  return %0, %1, %2, %3 : tensor<2xi32>, tensor<100xi8>, tensor<3xi8>, "
       "tensor<7xi8>\n"
       "}\n";
@@ -438,7 +422,8 @@ void testOffsetDrivenReadBack() {
   Harness h;
   mlir::hip::DiskFileSystem diskFs(dir.string().c_str());
   bool ok = false;
-  auto module = h.run(ir, &diskFs, ok);
+  auto module =
+      h.run(ir, &diskFs, ok, {{fileKey, fileWindow}, {"mem|0x1", memHost}});
   check(ok, "readback: pass succeeds");
   if (!ok || !module) {
     fs::remove_all(dir, ec);
@@ -520,8 +505,8 @@ void testWriteFailureFailsPass() {
 
 int main() {
   testInlineValueBytesWritten();
-  testMemSourceBytesWritten();
-  testFileSourceBytesStreamed();
+  testMemResourceBytesWritten();
+  testFileResourceBytesStreamed();
   testCumulativeAlignmentAndPadding();
   testMultiFunctionSharesOneConstantsFile();
   testOffsetDrivenReadBack();


### PR DESCRIPTION
## Summary

`hipsr.constant` now stores its bytes in MLIR's `DenseResourceElementsAttr` instead of the custom `#hipsr.file_source` / `#hipsr.mem_source` attributes. The op has a single required `value` attribute in one of two forms: an inline `DenseElementsAttr`, or a resource blob keyed `file|<path>|<offset>` (on-disk weights) / `mem|<address-hex>` (an ORT tensor pointer).

## Related issue or design

None.

## Why

Carrying `value` and `source` as two mutually exclusive optional attributes forced every consumer through a three-way dispatch and forced the verifier to police a value-XOR-source state machine. `DenseResourceElementsAttr` is the upstream mechanism for exactly this — an `ElementsAttr` whose bytes live outside the attribute — so the blob manager owns the pointer/length bookkeeping and the op keeps one attribute with one meaning.

Both external forms are non-owning `UnmanagedAsmResourceBlob`s: the `mem|` blob points at the ORT tensor and the `file|` blob at the dialect's memory-mapped weight file, so building the attribute copies no weight bytes.

## What

- `HipsrConstantOp.td`: `value` becomes a required `ElementsAttr`; `source` is dropped; the op gains `ConstantLike` and a folder. `isInline()` / `hasExternalSource()` are gone.
- `HipsrAttrs.td`: `Hipsr_FileSourceAttr` / `Hipsr_MemSourceAttr` deleted.
- `HipsrOps.h`: `ConstantOp::getDataValues<T>()` deleted — the blob manager already exposes the bytes.
- `ConstantConversion.cpp`: both branches build a key plus an `ArrayRef<char>` view and share one `DenseResourceElementsAttr::get`.
- `ExternalizeConstants.cpp`: dispatches on the attribute kind and, for resources, on the `file|` key prefix; file-backed entries still record path/offset only so the pass never reads the weight file.
- Verifier rejects a splat with more than one element and anything that is neither `dense<...>` nor `dense_resource<...>`.

## Test plan

- [x] `llvm-lit test/lit/Dialect/Hipsr test/lit/Conversion/onnx-to-hipsr test/lit/Conversion/hipsr-to-llvm test/lit/Pipeline` — 49 passed, 8 unsupported (all pre-existing).
- [x] `test-hipsr-externalize-constants` — all checks pass, covering the bytes actually written for both blob kinds.
- [x] `pre-commit run --all-files` — clean.

Coverage, all three files enabled by this PR or by its base:

- `Conversion/onnx-to-hipsr/constant.mlir` runs the conversion end to end now that #703 installed the patterns, so the emitted resource keys are checked against a real weight file the `RUN` line creates.
- `Dialect/Hipsr/IR/constant.mlir` round-trips all four value forms and pins every verifier rejection.
- `Dialect/Hipsr/Transforms/ExternalizeConstants/externalize-constants.mlir` pins the module-scoped cumulative offsets for inline and file-backed constants.

## Notes for reviewers

Rebased onto #703, which installed the ONNX conversion patterns. That is what makes `onnx-to-hipsr/constant.mlir` live coverage for `ConstantConversion.cpp` rather than a gated file; its `RUN` line gains `--split-input-file` from #703 plus `--mlir-elide-resource-strings-if-larger=0` so the blob keys print without their bytes.

The second commit renames that file's `mem_source_const` / `file_source_const` cases, which named the attribute this PR deletes.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
