### PR TITLE
feat(hipsr): legalize onnx.Return and onnx.NoValue

### DIFF
--- a/include/hip/Conversion/OnnxToHipsr/OnnxToHipsr.h
+++ b/include/hip/Conversion/OnnxToHipsr/OnnxToHipsr.h
@@ -33,6 +33,9 @@ void populateMatMulConversionPatterns(::mlir::RewritePatternSet &patterns,
 void populateExpandConversionPatterns(::mlir::RewritePatternSet &patterns,
                                       ::mlir::MLIRContext *ctx);
 
+void populateReturnConversionPatterns(::mlir::RewritePatternSet &patterns,
+                                      ::mlir::MLIRContext *ctx);
+
 } // namespace hipsr
 } // namespace mlir
 

--- a/lib/Conversion/OnnxToHipsr/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHipsr/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(OnnxToHipsr STATIC
   CastConversion.cpp
   MatMulConversion.cpp
   ExpandConversion.cpp
+  ReturnConversion.cpp
 )
 
 add_dependencies(OnnxToHipsr

--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
@@ -47,6 +47,21 @@ Value resolveShapeGraphInput(Value input) {
   return destinations[result.getResultNumber()];
 }
 
+// onnx.NoValue stands in for an omitted optional operand, so it only becomes
+// dead once the conversion of its consumer drops that operand. Sweeping it up
+// therefore belongs after the conversion.
+void eraseDeadNoValue(ModuleOp module) {
+  SmallVector<Operation *> dead;
+  module.walk([&](Operation *op) {
+    if (op->getName().getStringRef() == "onnx.NoValue" && op->use_empty()) {
+      dead.push_back(op);
+    }
+  });
+  for (Operation *op : dead) {
+    op->erase();
+  }
+}
+
 // Placeholder inputs form the shape graph, not the data graph.
 // PlaceholderOp::verify reports any input this cannot fix.
 void rewirePlaceholderInputs(ModuleOp module) {
@@ -63,6 +78,9 @@ struct ConvertOnnxToHipsrPass
     ModuleOp module = getOperation();
     ConversionTarget target(getContext());
     target.addIllegalDialect("onnx");
+    // The consumer's conversion drops the operand this stands for, so the
+    // placeholder has to survive until then.
+    target.addLegalOp(OperationName("onnx.NoValue", &getContext()));
     target.addLegalDialect<HipsrDialect>();
     target.addLegalOp<ModuleOp, func::FuncOp, func::ReturnOp>();
     target.addLegalOp<arith::ConstantOp>();
@@ -75,11 +93,13 @@ struct ConvertOnnxToHipsrPass
     populateCastConversionPatterns(patterns, &getContext());
     populateMatMulConversionPatterns(patterns, &getContext());
     populateExpandConversionPatterns(patterns, &getContext());
+    populateReturnConversionPatterns(patterns, &getContext());
 
     if (failed(applyFullConversion(module, target, std::move(patterns)))) {
       signalPassFailure();
       return;
     }
+    eraseDeadNoValue(module);
     // Runs after conversion so every producer has its outs operand.
     rewirePlaceholderInputs(module);
   }

--- a/lib/Conversion/OnnxToHipsr/ReturnConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/ReturnConversion.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- ReturnConversion.cpp - Convert onnx.Return to func.return ----------===//
+//
+// onnx.Return carries graph structure rather than a computation, so it lowers
+// to func.return instead of to a hipsr operation.
+//
+//===----------------------------------------------------------------------===//
+
+#include "hip/Conversion/OnnxToHipsr/OnnxToHipsr.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir {
+namespace hipsr {
+namespace {
+
+struct ReturnToFunc : public ::mlir::RewritePattern {
+  ReturnToFunc(::mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Return", /*benefit=*/1, ctx) {}
+
+  ::mlir::LogicalResult
+  matchAndRewrite(::mlir::Operation *op,
+                  ::mlir::PatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<::mlir::func::ReturnOp>(op, op->getOperands());
+    return ::mlir::success();
+  }
+};
+
+} // namespace
+
+void populateReturnConversionPatterns(::mlir::RewritePatternSet &patterns,
+                                      ::mlir::MLIRContext *ctx) {
+  patterns.add<ReturnToFunc>(ctx);
+}
+
+} // namespace hipsr
+} // namespace mlir

--- a/test/lit/Conversion/onnx-to-hipsr/no-value.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/no-value.mlir
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+//===----------------------------------------------------------------------===//
+// onnx.NoValue stands in for an operand the exporter omitted. It stays legal
+// through the conversion so each consumer can drop it, and the pass erases the
+// placeholders left dead afterwards.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --convert-onnx-to-hipsr --split-input-file %s | FileCheck %s
+
+// An unused placeholder is erased. The return directly after the signature is
+// what proves it.
+// CHECK-LABEL: func.func @dead_placeholder(
+// CHECK-SAME:    %[[INPUT:.*]]: tensor<2x3xf16>) -> tensor<2x3xf16> {
+// CHECK-NEXT:    return %[[INPUT]] : tensor<2x3xf16>
+func.func @dead_placeholder(%input: tensor<2x3xf16>) -> tensor<2x3xf16> {
+  %none = "onnx.NoValue"() {value} : () -> none
+  return %input : tensor<2x3xf16>
+}

--- a/test/lit/Conversion/onnx-to-hipsr/return-invalid.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/return-invalid.mlir
@@ -1,0 +1,20 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+//===----------------------------------------------------------------------===//
+// onnx.Return forms that do not survive the conversion.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --convert-onnx-to-hipsr --split-input-file --verify-diagnostics %s
+
+// func.return carries HasParent<FuncOp>, so that trait is what rejects an
+// onnx.Return outside a function.
+func.func @return_outside_func(%ctx: !hipsr.context) {
+  hipsr.compute(%ctx) ins() outs() {
+  ^bb0(%body_ctx: !hipsr.context):
+    // expected-error @+1 {{'func.return' op expects parent op 'func.func'}}
+    "onnx.Return"() : () -> ()
+    hipsr.compute_yield
+  }
+  return
+}

--- a/test/lit/Conversion/onnx-to-hipsr/return.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/return.mlir
@@ -1,0 +1,28 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+//===----------------------------------------------------------------------===//
+// onnx.Return becomes func.return. Rejected forms live in return-invalid.mlir.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --convert-onnx-to-hipsr --split-input-file %s | FileCheck %s
+
+// The shape an ONNX importer produces, with the return carrying the graph's
+// result.
+// CHECK-LABEL: func.func @imported_graph(
+// CHECK-SAME:    %{{.*}}: !hipsr.context,
+// CHECK-SAME:    %[[INPUT:.*]]: tensor<?x4096xf16>) -> tensor<?x4096xf16> {
+// CHECK-NEXT:    return %[[INPUT]] : tensor<?x4096xf16>
+func.func @imported_graph(%ctx: !hipsr.context, %input: tensor<?x4096xf16>)
+    -> tensor<?x4096xf16> {
+  "onnx.Return"(%input) : (tensor<?x4096xf16>) -> ()
+}
+
+// -----
+
+// A graph with no results returns nothing.
+// CHECK-LABEL: func.func @return_no_operands(
+// CHECK-NEXT:    return
+func.func @return_no_operands(%ctx: !hipsr.context) {
+  "onnx.Return"() : () -> ()
+}


### PR DESCRIPTION
## Summary

Handles the two ONNX operations that carry graph structure rather than a computation, so `convert-onnx-to-hipsr` can run on IR as an importer actually emits it.

## Why

The target marks the whole `onnx` dialect illegal, so every ONNX operation needs handling, not just the compute ones. Every imported `func.func` ends in `onnx.Return`, and `onnx.NoValue` stands in wherever the exporter omitted an optional operand. Without both, the pass fails on any real graph before reaching a single compute operation.

## What

`ReturnConversion.cpp` rewrites `onnx.Return` to `func.return`. onnx-mlir does this in its own `StandardFuncReturnPass`, which is not in this pipeline. The rewrite is unconditional because `func.return` carries `HasParent<FuncOp>`, so that trait is what rejects an `onnx.Return` outside a function.

`onnx.NoValue` stays legal through the conversion so each consumer's conversion can drop the operand it stands for. `eraseDeadNoValue` then erases the placeholders left dead.

## Notes for reviewers

`onnx.NoValue` dominates its consumers, and `applyFullConversion` legalizes in dominance order and returns on the first failure. Making the placeholder illegal would therefore abort on it before reaching the consumer that drops the operand, which is why the erasure runs after the conversion instead of as a pattern.

DCE cannot take the sweep's place: an unregistered operation carries no effect information for `isMemoryEffectFree` to work with.

## AI assistance

Cursor (Claude Opus 5) assisted with the implementation and the tests. I reviewed the result and understand it.
