### PR TITLE
refactor(hipsr): define the memory space with EnumAttr

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/HipsrAttrs.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrAttrs.td
@@ -10,9 +10,8 @@ include "hip/Dialect/Hipsr/IR/HipsrDialect.td"
 include "hip/Dialect/Hipsr/IR/HipsrEnums.td"
 include "mlir/IR/AttrTypeBase.td"
 
-def Hipsr_MemorySpaceAttr : AttrDef<Hipsr_Dialect, "MemorySpace"> {
-  let mnemonic = "mem";
-  let summary = "hipsr memory space attribute";
+def Hipsr_MemorySpaceAttr :
+    EnumAttr<Hipsr_Dialect, Hipsr_MemorySpace, "mem"> {
   let description = [{
     Says where a buffer lives, used as a `memref` memory space:
     `device` (VRAM), `host` (pageable), `pinned` (page-locked host),
@@ -20,10 +19,9 @@ def Hipsr_MemorySpaceAttr : AttrDef<Hipsr_Dialect, "MemorySpace"> {
 
     Every hipsr `memref` must have one of these memory spaces; a memref
     with no memory space is not allowed. The `Hipsr_*MemRef` type
-    constraints in `HipsrTypes.td` check this once ops start using them.
+    constraints in `HipsrTypes.td` enforce this on op operands and results.
   }];
-  let parameters = (ins EnumParameter<Hipsr_MemorySpaceKind>:$kind);
-  let assemblyFormat = "`<` $kind `>`";
+  let assemblyFormat = "`<` $value `>`";
 }
 
 def Hipsr_PlaceholderTypeAttr :

--- a/include/hip/Dialect/Hipsr/IR/HipsrDialect.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrDialect.h
@@ -27,7 +27,7 @@ class FileSystem;
 
 #include "hip/Dialect/Hipsr/IR/HipsrDialect.h.inc"
 
-// Enum header first: MemorySpaceAttr uses MemorySpaceKind.
+// Enum header first: MemorySpaceAttr uses MemorySpace.
 #include "hip/Dialect/Hipsr/IR/HipsrEnums.h.inc"
 
 #define GET_ATTRDEF_CLASSES
@@ -37,8 +37,7 @@ class FileSystem;
 #define GET_TYPEDEF_CLASSES
 #include "hip/Dialect/Hipsr/IR/HipsrTypes.h.inc"
 
-// Predicates for the Hipsr_*MemRef type constraints (used by op verifiers once
-// ops adopt them).
+// Predicates for the Hipsr_*MemRef type constraints used by op verifiers.
 #include "hip/Dialect/Hipsr/IR/HipsrTypes.h"
 
 namespace mlir {

--- a/include/hip/Dialect/Hipsr/IR/HipsrEnums.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrEnums.td
@@ -15,8 +15,8 @@ def Hipsr_Device  : I32EnumAttrCase<"Device",  1, "device">;
 def Hipsr_Pinned  : I32EnumAttrCase<"Pinned",  2, "pinned">;
 def Hipsr_Managed : I32EnumAttrCase<"Managed", 3, "managed">;
 
-def Hipsr_MemorySpaceKind : I32EnumAttr<"MemorySpaceKind",
-    "hipsr memory space kind",
+def Hipsr_MemorySpace : I32EnumAttr<"MemorySpace",
+    "hipsr memory space",
     [Hipsr_Host, Hipsr_Device, Hipsr_Pinned, Hipsr_Managed]> {
   let cppNamespace = "::mlir::hipsr";
   // The enum is wrapped by MemorySpaceAttr (HipsrAttrs.td), so the syntax

--- a/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrDialect.cpp
@@ -90,14 +90,14 @@ struct HipsrConvertToLLVMInterface : public ConvertToLLVMPatternInterface {
   void populateConvertToLLVMConversionPatterns(
       ConversionTarget &target, LLVMTypeConverter &typeConverter,
       RewritePatternSet &patterns) const final {
-    // #hipsr.mem<kind> -> integer address space. MemorySpaceKind's numeric
+    // #hipsr.mem<space> -> integer address space. MemorySpace's numeric
     // values already match the AMDGPU address spaces (host=0, device=1,
     // pinned=2, managed=3), so map the enum directly.
     typeConverter.addTypeAttributeConversion(
         [](BaseMemRefType,
            MemorySpaceAttr space) -> TypeConverter::AttributeConversionResult {
           return IntegerAttr::get(IntegerType::get(space.getContext(), 64),
-                                  static_cast<int64_t>(space.getKind()));
+                                  static_cast<int64_t>(space.getValue()));
         });
     typeConverter.addConversion([](ContextType type) -> Type {
       return LLVM::LLVMPointerType::get(type.getContext(), 0);

--- a/lib/Dialect/Hipsr/IR/HipsrTypes.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrTypes.cpp
@@ -5,7 +5,7 @@
 
 #include "hip/Dialect/Hipsr/IR/HipsrTypes.h"
 
-// Provides MemRefType plus the generated MemorySpaceAttr / MemorySpaceKind.
+// Provides MemRefType plus the generated MemorySpaceAttr / MemorySpace.
 #include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
 
 #include "mlir/IR/BuiltinTypes.h"
@@ -15,15 +15,16 @@ using namespace mlir::hipsr;
 
 namespace {
 
-// True only when the type is a memref whose space is a #hipsr.mem attribute of
-// this kind. A memref with no space, or a space set by some other attribute,
-// returns false -- hipsr requires every memref to name its space.
-bool memRefInSpace(Type type, MemorySpaceKind kind) {
+// True only when the type is a memref whose space is a #hipsr.mem attribute
+// naming this space. A memref with no space, or a space set by some other
+// attribute, returns false -- hipsr requires every memref to name its space.
+bool memRefInSpace(Type type, MemorySpace space) {
   auto memref = dyn_cast<MemRefType>(type);
-  if (!memref)
+  if (!memref) {
     return false;
-  auto space = dyn_cast_or_null<MemorySpaceAttr>(memref.getMemorySpace());
-  return space && space.getKind() == kind;
+  }
+  auto spaceAttr = dyn_cast_or_null<MemorySpaceAttr>(memref.getMemorySpace());
+  return spaceAttr && spaceAttr.getValue() == space;
 }
 
 } // namespace
@@ -31,17 +32,15 @@ bool memRefInSpace(Type type, MemorySpaceKind kind) {
 namespace mlir {
 namespace hipsr {
 
-bool isHostMemRef(Type type) {
-  return memRefInSpace(type, MemorySpaceKind::Host);
-}
+bool isHostMemRef(Type type) { return memRefInSpace(type, MemorySpace::Host); }
 bool isDeviceMemRef(Type type) {
-  return memRefInSpace(type, MemorySpaceKind::Device);
+  return memRefInSpace(type, MemorySpace::Device);
 }
 bool isPinnedMemRef(Type type) {
-  return memRefInSpace(type, MemorySpaceKind::Pinned);
+  return memRefInSpace(type, MemorySpace::Pinned);
 }
 bool isManagedMemRef(Type type) {
-  return memRefInSpace(type, MemorySpaceKind::Managed);
+  return memRefInSpace(type, MemorySpace::Managed);
 }
 
 } // namespace hipsr

--- a/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
@@ -343,7 +343,7 @@ Value findContext(Block &body) {
 Value emitPool(OpBuilder &builder, Location loc, Value ctx, Value poolSize,
                uint64_t domainId) {
   auto deviceSpace =
-      MemorySpaceAttr::get(builder.getContext(), MemorySpaceKind::Device);
+      MemorySpaceAttr::get(builder.getContext(), MemorySpace::Device);
   auto poolType = MemRefType::get({ShapedType::kDynamic}, builder.getI8Type(),
                                   MemRefLayoutAttrInterface{}, deviceSpace);
   return GetPoolOp::create(builder, loc, poolType, ctx, poolSize, domainId);

--- a/test/lit/Dialect/Hipsr/IR/memory_space_attr.mlir
+++ b/test/lit/Dialect/Hipsr/IR/memory_space_attr.mlir
@@ -9,7 +9,6 @@
 
 // RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s | FileCheck %s
 
-// -----
 // All four kinds print back unchanged as a memref memory space.
 // CHECK-LABEL: func.func @roundtrip_spaces
 // CHECK-SAME:    memref<4xf32, #hipsr.mem<device>>
@@ -34,7 +33,7 @@ func.func @attr_on_op() attributes {hipsr.space = #hipsr.mem<pinned>} {
 // -----
 // An unknown kind fails to parse.
 // expected-error @+2 {{to be one of: host, device, pinned, managed}}
-// expected-error @+1 {{failed to parse Hipsr_MemorySpaceAttr parameter 'kind'}}
+// expected-error @+1 {{failed to parse Hipsr_MemorySpaceAttr parameter 'value'}}
 func.func @bad_kind(%x: memref<4xf32, #hipsr.mem<bogus>>) {
   return
 }


### PR DESCRIPTION
## Summary

`Hipsr_MemorySpaceAttr` is now defined with `EnumAttr` instead of a hand-written `AttrDef`, matching `Hipsr_PlaceholderTypeAttr` beside it in the same file. The generated class is still `mlir::hipsr::MemorySpaceAttr` and the syntax is still `#hipsr.mem<device>`.

## Related issue or design

None.

## Why

`EnumAttr` is upstream's wrapper for an attribute holding one enum value. The old definition hand-rolled the same thing from `AttrDef` plus an explicit `EnumParameter`, spelling out `mnemonic`, `summary`, and `parameters` to arrive at what `EnumAttr` gives by default.

Renaming the enum from `MemorySpaceKind` to `MemorySpace` is what keeps the C++ name unchanged, rather than a cosmetic choice. `EnumAttr` derives from `AttrDef<dialect, enumInfo.className>`, and `AttrDef` sets `cppClassName = name # "Attr"`, so `MemorySpaceKind` would have produced `MemorySpaceKindAttr`. This mirrors upstream `gpu::AddressSpace` / `gpu::AddressSpaceAttr`.

## What

- `HipsrEnums.td`: enum renamed to `MemorySpace`. Cases and their AMDGPU address-space values are unchanged.
- `HipsrAttrs.td`: becomes `EnumAttr<Hipsr_Dialect, Hipsr_MemorySpace, "mem">`, keeping `assemblyFormat` so it still prints `#hipsr.mem<device>` rather than `EnumAttr`'s default bare `$value`.
- `getKind()` becomes `getValue()`; `MemorySpaceKind::Device` becomes `MemorySpace::Device`.
- Two comments claimed the `Hipsr_*MemRef` constraints apply "once ops start using them". Seven op definitions use them today, so both are corrected.

The one externally visible change is the parse diagnostic, `parameter 'kind'` to `parameter 'value'`, because `EnumAttr` names its parameter `$value`. `test/lit/Dialect/Hipsr/IR/memory_space_attr.mlir` is updated to match. That test is gated by `UNSUPPORTED: true` from #618, so it was checked by running `hip-mlir-opt --split-input-file --verify-diagnostics` on it directly, which exits 0.

## AI assistance

Cursor (Claude Opus 5) assisted with the conversion and the comment corrections. I reviewed the result and validated it with a local incremental build, the full MLIR LIT suite (373 passed, 0 failed), and `pre-commit run --all-files`.
