### PR TITLE
feat(hipsr): attach #hipsr.mem<device> encoding to materialized init tensors

### DIFF
--- a/lib/Dialect/Hipsr/Transforms/MaterializeInitTensorsPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/MaterializeInitTensorsPass.cpp
@@ -214,7 +214,7 @@ SmallVector<Value> extractDynamicDimensions(Value shapeValue,
 RankedTensorType getDeviceTensorType(RankedTensorType tensorType,
                                      OpBuilder &builder) {
   auto deviceSpace =
-      MemorySpaceAttr::get(builder.getContext(), MemorySpaceKind::Device);
+      MemorySpaceAttr::get(builder.getContext(), MemorySpace::Device);
   return RankedTensorType::get(tensorType.getShape(),
                                tensorType.getElementType(), deviceSpace);
 }

--- a/lib/Dialect/Hipsr/Transforms/MaterializeInitTensorsPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/MaterializeInitTensorsPass.cpp
@@ -16,7 +16,7 @@
 //   %0 = hipsr.matmul(%ctx) ins(%a, %b) outs(%init) : tensor<?x512xf16>
 // After:
 //   %shape = scf.execute_region -> !shape.shape { ... }
-//   %init = tensor.empty(%d0) : tensor<?x512xf16>
+//   %init = tensor.empty(%d0) : tensor<?x512xf16, #hipsr.mem<device>>
 //   %0 = hipsr.matmul(%ctx) ins(%a, %b) outs(%init) : tensor<?x512xf16>
 //
 // The phases run per domain: collect and group the placeholders, build the
@@ -211,12 +211,21 @@ SmallVector<Value> extractDynamicDimensions(Value shapeValue,
   return dynamicDimensions;
 }
 
+RankedTensorType getDeviceTensorType(RankedTensorType tensorType,
+                                     OpBuilder &builder) {
+  auto deviceSpace =
+      MemorySpaceAttr::get(builder.getContext(), MemorySpaceKind::Device);
+  return RankedTensorType::get(tensorType.getShape(),
+                               tensorType.getElementType(), deviceSpace);
+}
+
 Value createInitTensorFromShape(Value placeholderResult, Value shapeValue,
                                 Location loc, OpBuilder &builder) {
   auto tensorType = cast<RankedTensorType>(placeholderResult.getType());
   SmallVector<Value> dynamicDimensions =
       extractDynamicDimensions(shapeValue, tensorType, loc, builder);
-  return builder.create<tensor::EmptyOp>(loc, tensorType, dynamicDimensions);
+  return builder.create<tensor::EmptyOp>(
+      loc, getDeviceTensorType(tensorType, builder), dynamicDimensions);
 }
 
 // Materializes one tensor.empty per placeholder result. They all go after the

--- a/test/lit/Dialect/Hipsr/Transforms/MaterializeInitTensors/materialize-init-tensors.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/MaterializeInitTensors/materialize-init-tensors.mlir
@@ -13,9 +13,9 @@
 //   phase 2, shape computation -- each shape region body moves into an
 //   scf.execute_region yielding !shape.shape, with the region's block arguments
 //   replaced by the shapes of the placeholder inputs;
-//   phase 3, allocation -- one tensor.empty per placeholder result, its dynamic
-//   extents read out of the computed shape, all of them grouped after the last
-//   scf.execute_region;
+//   phase 3, allocation -- one tensor.empty per placeholder result, tagged
+//   #hipsr.mem<device>, its dynamic extents read out of the computed shape, all
+//   of them grouped after the last scf.execute_region;
 //   phase 4, cleanup -- every placeholder result use is rewired to its
 //   tensor.empty and the placeholders are erased.
 //
@@ -42,12 +42,12 @@
 // the shape and 512 stays in the tensor.empty type. The matmul ends up taking
 // that tensor.empty as its outs operand, with the placeholder gone.
 // CHECK-LABEL: func.func @matmul_domain(
-// CHECK-SAME:      %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<?x256xf16>, %[[B:.+]]: tensor<256x512xf16>) -> tensor<?x512xf16> {
-// CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]] : !hipsr.context, tensor<?x256xf16>, tensor<256x512xf16>) {
-// CHECK-NEXT:    ^bb0(%[[DCTX:.+]]: !hipsr.context, %[[DA:.+]]: tensor<?x256xf16>, %[[DB:.+]]: tensor<256x512xf16>):
+// CHECK-SAME:      %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<?x256xf16, #hipsr.mem<device>>, %[[B:.+]]: tensor<256x512xf16, #hipsr.mem<device>>) -> tensor<?x512xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]] : !hipsr.context, tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:    ^bb0(%[[DCTX:.+]]: !hipsr.context, %[[DA:.+]]: tensor<?x256xf16, #hipsr.mem<device>>, %[[DB:.+]]: tensor<256x512xf16, #hipsr.mem<device>>):
 // CHECK-NEXT:      %[[MATMUL_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[DA]] : tensor<?x256xf16> -> !shape.shape
-// CHECK-NEXT:        %[[B_SHAPE:.+]] = shape.shape_of %[[DB]] : tensor<256x512xf16> -> !shape.shape
+// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[DA]] : tensor<?x256xf16, #hipsr.mem<device>> -> !shape.shape
+// CHECK-NEXT:        %[[B_SHAPE:.+]] = shape.shape_of %[[DB]] : tensor<256x512xf16, #hipsr.mem<device>> -> !shape.shape
 // CHECK-NEXT:        %[[M_INDEX:.+]] = shape.const_size 0
 // CHECK-NEXT:        %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[M_INDEX]] : !shape.shape, !shape.size -> !shape.size
 // CHECK-NEXT:        %[[N_INDEX:.+]] = shape.const_size 1
@@ -58,22 +58,28 @@
 // CHECK-NEXT:      %[[DIM0_INDEX:.+]] = shape.const_size 0
 // CHECK-NEXT:      %[[DIM0_EXTENT:.+]] = shape.get_extent %[[MATMUL_SHAPE]], %[[DIM0_INDEX]] : !shape.shape, !shape.size -> !shape.size
 // CHECK-NEXT:      %[[DIM0:.+]] = shape.size_to_index %[[DIM0_EXTENT]] : !shape.size
-// CHECK-NEXT:      %[[INIT:.+]] = tensor.empty(%[[DIM0]]) : tensor<?x512xf16>
-// CHECK-NEXT:      %[[MATMUL:.+]] = hipsr.matmul(%[[DCTX]]) ins(%[[DA]], %[[DB]] : tensor<?x256xf16>, tensor<256x512xf16>) outs(%[[INIT]] : tensor<?x512xf16>) : tensor<?x512xf16>
-// CHECK-NEXT:      hipsr.pool_domain_yield %[[MATMUL]] : tensor<?x512xf16>
-// CHECK-NEXT:    } -> tensor<?x512xf16> {domain_id = 0 : i64}
-// CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x512xf16>
+// CHECK-NEXT:      %[[INIT:.+]] = tensor.empty(%[[DIM0]]) : tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[MATMUL:.+]] = hipsr.matmul(%[[DCTX]]) ins(%[[DA]], %[[DB]] : tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x512xf16, #hipsr.mem<device>>) : tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.pool_domain_yield %[[MATMUL]] : tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    } -> tensor<?x512xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x512xf16, #hipsr.mem<device>>
 // CHECK-NEXT:  }
-func.func @matmul_domain(%ctx: !hipsr.context, %a: tensor<?x256xf16>,
-                         %b: tensor<256x512xf16>) -> tensor<?x512xf16> {
+func.func @matmul_domain(%ctx: !hipsr.context,
+                         %a: tensor<?x256xf16, #hipsr.mem<device>>,
+                         %b: tensor<256x512xf16, #hipsr.mem<device>>)
+    -> tensor<?x512xf16, #hipsr.mem<device>> {
   %0 = hipsr.pool_domain(%ctx, %a, %b
-      : !hipsr.context, tensor<?x256xf16>, tensor<256x512xf16>) {
-  ^bb0(%domain_ctx: !hipsr.context, %domain_a: tensor<?x256xf16>,
-       %domain_b: tensor<256x512xf16>):
+      : !hipsr.context, tensor<?x256xf16, #hipsr.mem<device>>,
+        tensor<256x512xf16, #hipsr.mem<device>>) {
+  ^bb0(%domain_ctx: !hipsr.context,
+       %domain_a: tensor<?x256xf16, #hipsr.mem<device>>,
+       %domain_b: tensor<256x512xf16, #hipsr.mem<device>>):
     %init = hipsr.placeholder(%domain_ctx)
-        ins(%domain_a, %domain_b : tensor<?x256xf16>, tensor<256x512xf16>)
+        ins(%domain_a, %domain_b
+            : tensor<?x256xf16, #hipsr.mem<device>>,
+              tensor<256x512xf16, #hipsr.mem<device>>)
         {placeholder_type = #hipsr.placeholder_type<normal>}
-        : tensor<?x512xf16> shape_region {
+        : tensor<?x512xf16, #hipsr.mem<device>> shape_region {
     ^bb0(%a_shape: !shape.shape, %b_shape: !shape.shape):
       %m_index = shape.const_size 0
       %m = shape.get_extent %a_shape, %m_index
@@ -85,11 +91,14 @@ func.func @matmul_domain(%ctx: !hipsr.context, %a: tensor<?x256xf16>,
       hipsr.shape_yield %result_shape : !shape.shape
     }
     %matmul = hipsr.matmul(%domain_ctx)
-        ins(%domain_a, %domain_b : tensor<?x256xf16>, tensor<256x512xf16>)
-        outs(%init : tensor<?x512xf16>) : tensor<?x512xf16>
-    hipsr.pool_domain_yield %matmul : tensor<?x512xf16>
-  } -> tensor<?x512xf16> {domain_id = 0 : i64}
-  return %0 : tensor<?x512xf16>
+        ins(%domain_a, %domain_b
+            : tensor<?x256xf16, #hipsr.mem<device>>,
+              tensor<256x512xf16, #hipsr.mem<device>>)
+        outs(%init : tensor<?x512xf16, #hipsr.mem<device>>)
+        : tensor<?x512xf16, #hipsr.mem<device>>
+    hipsr.pool_domain_yield %matmul : tensor<?x512xf16, #hipsr.mem<device>>
+  } -> tensor<?x512xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+  return %0 : tensor<?x512xf16, #hipsr.mem<device>>
 }
 
 // -----
@@ -100,12 +109,12 @@ func.func @matmul_domain(%ctx: !hipsr.context, %a: tensor<?x256xf16>,
 // because the tensor.empty type already carries both extents. %[[SHAPE]] having
 // no reader below is the point of the case.
 // CHECK-LABEL: func.func @static_shape(
-// CHECK-SAME:      %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<128x256xf16>, %[[B:.+]]: tensor<256x512xf16>) -> tensor<128x512xf16> {
-// CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]] : !hipsr.context, tensor<128x256xf16>, tensor<256x512xf16>) {
-// CHECK-NEXT:    ^bb0(%[[DCTX:.+]]: !hipsr.context, %[[DA:.+]]: tensor<128x256xf16>, %[[DB:.+]]: tensor<256x512xf16>):
+// CHECK-SAME:      %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<128x256xf16, #hipsr.mem<device>>, %[[B:.+]]: tensor<256x512xf16, #hipsr.mem<device>>) -> tensor<128x512xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]] : !hipsr.context, tensor<128x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:    ^bb0(%[[DCTX:.+]]: !hipsr.context, %[[DA:.+]]: tensor<128x256xf16, #hipsr.mem<device>>, %[[DB:.+]]: tensor<256x512xf16, #hipsr.mem<device>>):
 // CHECK-NEXT:      %[[SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[DA]] : tensor<128x256xf16> -> !shape.shape
-// CHECK-NEXT:        %[[B_SHAPE:.+]] = shape.shape_of %[[DB]] : tensor<256x512xf16> -> !shape.shape
+// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[DA]] : tensor<128x256xf16, #hipsr.mem<device>> -> !shape.shape
+// CHECK-NEXT:        %[[B_SHAPE:.+]] = shape.shape_of %[[DB]] : tensor<256x512xf16, #hipsr.mem<device>> -> !shape.shape
 // CHECK-NEXT:        %[[M_INDEX:.+]] = shape.const_size 0
 // CHECK-NEXT:        %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[M_INDEX]] : !shape.shape, !shape.size -> !shape.size
 // CHECK-NEXT:        %[[N_INDEX:.+]] = shape.const_size 1
@@ -113,22 +122,28 @@ func.func @matmul_domain(%ctx: !hipsr.context, %a: tensor<?x256xf16>,
 // CHECK-NEXT:        %[[RESULT_SHAPE:.+]] = shape.from_extents %[[M]], %[[N]] : !shape.size, !shape.size
 // CHECK-NEXT:        scf.yield %[[RESULT_SHAPE]] : !shape.shape
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %[[INIT:.+]] = tensor.empty() : tensor<128x512xf16>
-// CHECK-NEXT:      %[[MATMUL:.+]] = hipsr.matmul(%[[DCTX]]) ins(%[[DA]], %[[DB]] : tensor<128x256xf16>, tensor<256x512xf16>) outs(%[[INIT]] : tensor<128x512xf16>) : tensor<128x512xf16>
-// CHECK-NEXT:      hipsr.pool_domain_yield %[[MATMUL]] : tensor<128x512xf16>
-// CHECK-NEXT:    } -> tensor<128x512xf16> {domain_id = 0 : i64}
-// CHECK-NEXT:    return %[[DOMAIN]] : tensor<128x512xf16>
+// CHECK-NEXT:      %[[INIT:.+]] = tensor.empty() : tensor<128x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[MATMUL:.+]] = hipsr.matmul(%[[DCTX]]) ins(%[[DA]], %[[DB]] : tensor<128x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<128x512xf16, #hipsr.mem<device>>) : tensor<128x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.pool_domain_yield %[[MATMUL]] : tensor<128x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    } -> tensor<128x512xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT:    return %[[DOMAIN]] : tensor<128x512xf16, #hipsr.mem<device>>
 // CHECK-NEXT:  }
-func.func @static_shape(%ctx: !hipsr.context, %a: tensor<128x256xf16>,
-                        %b: tensor<256x512xf16>) -> tensor<128x512xf16> {
+func.func @static_shape(%ctx: !hipsr.context,
+                        %a: tensor<128x256xf16, #hipsr.mem<device>>,
+                        %b: tensor<256x512xf16, #hipsr.mem<device>>)
+    -> tensor<128x512xf16, #hipsr.mem<device>> {
   %0 = hipsr.pool_domain(%ctx, %a, %b
-      : !hipsr.context, tensor<128x256xf16>, tensor<256x512xf16>) {
-  ^bb0(%domain_ctx: !hipsr.context, %domain_a: tensor<128x256xf16>,
-       %domain_b: tensor<256x512xf16>):
+      : !hipsr.context, tensor<128x256xf16, #hipsr.mem<device>>,
+        tensor<256x512xf16, #hipsr.mem<device>>) {
+  ^bb0(%domain_ctx: !hipsr.context,
+       %domain_a: tensor<128x256xf16, #hipsr.mem<device>>,
+       %domain_b: tensor<256x512xf16, #hipsr.mem<device>>):
     %init = hipsr.placeholder(%domain_ctx)
-        ins(%domain_a, %domain_b : tensor<128x256xf16>, tensor<256x512xf16>)
+        ins(%domain_a, %domain_b
+            : tensor<128x256xf16, #hipsr.mem<device>>,
+              tensor<256x512xf16, #hipsr.mem<device>>)
         {placeholder_type = #hipsr.placeholder_type<normal>}
-        : tensor<128x512xf16> shape_region {
+        : tensor<128x512xf16, #hipsr.mem<device>> shape_region {
     ^bb0(%a_shape: !shape.shape, %b_shape: !shape.shape):
       %m_index = shape.const_size 0
       %m = shape.get_extent %a_shape, %m_index
@@ -140,11 +155,14 @@ func.func @static_shape(%ctx: !hipsr.context, %a: tensor<128x256xf16>,
       hipsr.shape_yield %result_shape : !shape.shape
     }
     %matmul = hipsr.matmul(%domain_ctx)
-        ins(%domain_a, %domain_b : tensor<128x256xf16>, tensor<256x512xf16>)
-        outs(%init : tensor<128x512xf16>) : tensor<128x512xf16>
-    hipsr.pool_domain_yield %matmul : tensor<128x512xf16>
-  } -> tensor<128x512xf16> {domain_id = 0 : i64}
-  return %0 : tensor<128x512xf16>
+        ins(%domain_a, %domain_b
+            : tensor<128x256xf16, #hipsr.mem<device>>,
+              tensor<256x512xf16, #hipsr.mem<device>>)
+        outs(%init : tensor<128x512xf16, #hipsr.mem<device>>)
+        : tensor<128x512xf16, #hipsr.mem<device>>
+    hipsr.pool_domain_yield %matmul : tensor<128x512xf16, #hipsr.mem<device>>
+  } -> tensor<128x512xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+  return %0 : tensor<128x512xf16, #hipsr.mem<device>>
 }
 
 // -----
@@ -155,12 +173,12 @@ func.func @static_shape(%ctx: !hipsr.context, %a: tensor<128x256xf16>,
 // coming from a domain block argument is the only thing that gets a
 // shape.shape_of.
 // CHECK-LABEL: func.func @multi_dynamic(
-// CHECK-SAME:      %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<?x?x64xf16>, %[[B:.+]]: tensor<?x?x64xf16>) -> tensor<?x?x64xf16> {
-// CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]] : !hipsr.context, tensor<?x?x64xf16>, tensor<?x?x64xf16>) {
-// CHECK-NEXT:    ^bb0(%[[DCTX:.+]]: !hipsr.context, %[[DA:.+]]: tensor<?x?x64xf16>, %[[DB:.+]]: tensor<?x?x64xf16>):
+// CHECK-SAME:      %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<?x?x64xf16, #hipsr.mem<device>>, %[[B:.+]]: tensor<?x?x64xf16, #hipsr.mem<device>>) -> tensor<?x?x64xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]] : !hipsr.context, tensor<?x?x64xf16, #hipsr.mem<device>>, tensor<?x?x64xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:    ^bb0(%[[DCTX:.+]]: !hipsr.context, %[[DA:.+]]: tensor<?x?x64xf16, #hipsr.mem<device>>, %[[DB:.+]]: tensor<?x?x64xf16, #hipsr.mem<device>>):
 // CHECK-NEXT:      %[[SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[DA]] : tensor<?x?x64xf16> -> !shape.shape
-// CHECK-NEXT:        %[[B_SHAPE:.+]] = shape.shape_of %[[DB]] : tensor<?x?x64xf16> -> !shape.shape
+// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[DA]] : tensor<?x?x64xf16, #hipsr.mem<device>> -> !shape.shape
+// CHECK-NEXT:        %[[B_SHAPE:.+]] = shape.shape_of %[[DB]] : tensor<?x?x64xf16, #hipsr.mem<device>> -> !shape.shape
 // CHECK-NEXT:        %[[BROADCAST:.+]] = shape.broadcast %[[A_SHAPE]], %[[B_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
 // CHECK-NEXT:        scf.yield %[[BROADCAST]] : !shape.shape
 // CHECK-NEXT:      }
@@ -170,33 +188,42 @@ func.func @static_shape(%ctx: !hipsr.context, %a: tensor<128x256xf16>,
 // CHECK-NEXT:      %[[D1_INDEX:.+]] = shape.const_size 1
 // CHECK-NEXT:      %[[D1_EXTENT:.+]] = shape.get_extent %[[SHAPE]], %[[D1_INDEX]] : !shape.shape, !shape.size -> !shape.size
 // CHECK-NEXT:      %[[D1:.+]] = shape.size_to_index %[[D1_EXTENT]] : !shape.size
-// CHECK-NEXT:      %[[INIT:.+]] = tensor.empty(%[[D0]], %[[D1]]) : tensor<?x?x64xf16>
-// CHECK-NEXT:      %[[ADD:.+]] = hipsr.add(%[[DCTX]]) ins(%[[DA]], %[[DB]] : tensor<?x?x64xf16>, tensor<?x?x64xf16>) outs(%[[INIT]] : tensor<?x?x64xf16>) : tensor<?x?x64xf16>
-// CHECK-NEXT:      hipsr.pool_domain_yield %[[ADD]] : tensor<?x?x64xf16>
-// CHECK-NEXT:    } -> tensor<?x?x64xf16> {domain_id = 0 : i64}
-// CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x?x64xf16>
+// CHECK-NEXT:      %[[INIT:.+]] = tensor.empty(%[[D0]], %[[D1]]) : tensor<?x?x64xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[ADD:.+]] = hipsr.add(%[[DCTX]]) ins(%[[DA]], %[[DB]] : tensor<?x?x64xf16, #hipsr.mem<device>>, tensor<?x?x64xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x?x64xf16, #hipsr.mem<device>>) : tensor<?x?x64xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.pool_domain_yield %[[ADD]] : tensor<?x?x64xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    } -> tensor<?x?x64xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x?x64xf16, #hipsr.mem<device>>
 // CHECK-NEXT:  }
-func.func @multi_dynamic(%ctx: !hipsr.context, %a: tensor<?x?x64xf16>,
-                         %b: tensor<?x?x64xf16>) -> tensor<?x?x64xf16> {
+func.func @multi_dynamic(%ctx: !hipsr.context,
+                         %a: tensor<?x?x64xf16, #hipsr.mem<device>>,
+                         %b: tensor<?x?x64xf16, #hipsr.mem<device>>)
+    -> tensor<?x?x64xf16, #hipsr.mem<device>> {
   %0 = hipsr.pool_domain(%ctx, %a, %b
-      : !hipsr.context, tensor<?x?x64xf16>, tensor<?x?x64xf16>) {
-  ^bb0(%domain_ctx: !hipsr.context, %domain_a: tensor<?x?x64xf16>,
-       %domain_b: tensor<?x?x64xf16>):
+      : !hipsr.context, tensor<?x?x64xf16, #hipsr.mem<device>>,
+        tensor<?x?x64xf16, #hipsr.mem<device>>) {
+  ^bb0(%domain_ctx: !hipsr.context,
+       %domain_a: tensor<?x?x64xf16, #hipsr.mem<device>>,
+       %domain_b: tensor<?x?x64xf16, #hipsr.mem<device>>):
     %init = hipsr.placeholder(%domain_ctx)
-        ins(%domain_a, %domain_b : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
+        ins(%domain_a, %domain_b
+            : tensor<?x?x64xf16, #hipsr.mem<device>>,
+              tensor<?x?x64xf16, #hipsr.mem<device>>)
         {placeholder_type = #hipsr.placeholder_type<normal>}
-        : tensor<?x?x64xf16> shape_region {
+        : tensor<?x?x64xf16, #hipsr.mem<device>> shape_region {
     ^bb0(%lhs_shape: !shape.shape, %rhs_shape: !shape.shape):
       %result_shape = shape.broadcast %lhs_shape, %rhs_shape
           : !shape.shape, !shape.shape -> !shape.shape
       hipsr.shape_yield %result_shape : !shape.shape
     }
     %add = hipsr.add(%domain_ctx)
-        ins(%domain_a, %domain_b : tensor<?x?x64xf16>, tensor<?x?x64xf16>)
-        outs(%init : tensor<?x?x64xf16>) : tensor<?x?x64xf16>
-    hipsr.pool_domain_yield %add : tensor<?x?x64xf16>
-  } -> tensor<?x?x64xf16> {domain_id = 0 : i64}
-  return %0 : tensor<?x?x64xf16>
+        ins(%domain_a, %domain_b
+            : tensor<?x?x64xf16, #hipsr.mem<device>>,
+              tensor<?x?x64xf16, #hipsr.mem<device>>)
+        outs(%init : tensor<?x?x64xf16, #hipsr.mem<device>>)
+        : tensor<?x?x64xf16, #hipsr.mem<device>>
+    hipsr.pool_domain_yield %add : tensor<?x?x64xf16, #hipsr.mem<device>>
+  } -> tensor<?x?x64xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+  return %0 : tensor<?x?x64xf16, #hipsr.mem<device>>
 }
 
 // -----
@@ -210,12 +237,12 @@ func.func @multi_dynamic(%ctx: !hipsr.context, %a: tensor<?x?x64xf16>,
 // execute_region, so the domain reads as two shape computations, two
 // allocations, then the two data ops.
 // CHECK-LABEL: func.func @interleaved(
-// CHECK-SAME:      %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<?x256xf16>, %[[B:.+]]: tensor<256x512xf16>, %[[C:.+]]: tensor<?x512xf16>) -> tensor<?x512xf16> {
-// CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]], %[[C]] : !hipsr.context, tensor<?x256xf16>, tensor<256x512xf16>, tensor<?x512xf16>) {
-// CHECK-NEXT:    ^bb0(%[[DCTX:.+]]: !hipsr.context, %[[DA:.+]]: tensor<?x256xf16>, %[[DB:.+]]: tensor<256x512xf16>, %[[DC:.+]]: tensor<?x512xf16>):
+// CHECK-SAME:      %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<?x256xf16, #hipsr.mem<device>>, %[[B:.+]]: tensor<256x512xf16, #hipsr.mem<device>>, %[[C:.+]]: tensor<?x512xf16, #hipsr.mem<device>>) -> tensor<?x512xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]], %[[C]] : !hipsr.context, tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>, tensor<?x512xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:    ^bb0(%[[DCTX:.+]]: !hipsr.context, %[[DA:.+]]: tensor<?x256xf16, #hipsr.mem<device>>, %[[DB:.+]]: tensor<256x512xf16, #hipsr.mem<device>>, %[[DC:.+]]: tensor<?x512xf16, #hipsr.mem<device>>):
 // CHECK-NEXT:      %[[MATMUL_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[DA]] : tensor<?x256xf16> -> !shape.shape
-// CHECK-NEXT:        %[[B_SHAPE:.+]] = shape.shape_of %[[DB]] : tensor<256x512xf16> -> !shape.shape
+// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[DA]] : tensor<?x256xf16, #hipsr.mem<device>> -> !shape.shape
+// CHECK-NEXT:        %[[B_SHAPE:.+]] = shape.shape_of %[[DB]] : tensor<256x512xf16, #hipsr.mem<device>> -> !shape.shape
 // CHECK-NEXT:        %[[M_INDEX:.+]] = shape.const_size 0
 // CHECK-NEXT:        %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[M_INDEX]] : !shape.shape, !shape.size -> !shape.size
 // CHECK-NEXT:        %[[N_INDEX:.+]] = shape.const_size 1
@@ -224,36 +251,43 @@ func.func @multi_dynamic(%ctx: !hipsr.context, %a: tensor<?x?x64xf16>,
 // CHECK-NEXT:        scf.yield %[[FROM_EXTENTS]] : !shape.shape
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %[[ADD_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[C_SHAPE:.+]] = shape.shape_of %[[DC]] : tensor<?x512xf16> -> !shape.shape
+// CHECK-NEXT:        %[[C_SHAPE:.+]] = shape.shape_of %[[DC]] : tensor<?x512xf16, #hipsr.mem<device>> -> !shape.shape
 // CHECK-NEXT:        %[[BROADCAST:.+]] = shape.broadcast %[[MATMUL_SHAPE]], %[[C_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
 // CHECK-NEXT:        scf.yield %[[BROADCAST]] : !shape.shape
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %[[MATMUL_D0_INDEX:.+]] = shape.const_size 0
 // CHECK-NEXT:      %[[MATMUL_D0_EXTENT:.+]] = shape.get_extent %[[MATMUL_SHAPE]], %[[MATMUL_D0_INDEX]] : !shape.shape, !shape.size -> !shape.size
 // CHECK-NEXT:      %[[MATMUL_D0:.+]] = shape.size_to_index %[[MATMUL_D0_EXTENT]] : !shape.size
-// CHECK-NEXT:      %[[MATMUL_INIT:.+]] = tensor.empty(%[[MATMUL_D0]]) : tensor<?x512xf16>
+// CHECK-NEXT:      %[[MATMUL_INIT:.+]] = tensor.empty(%[[MATMUL_D0]]) : tensor<?x512xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[ADD_D0_INDEX:.+]] = shape.const_size 0
 // CHECK-NEXT:      %[[ADD_D0_EXTENT:.+]] = shape.get_extent %[[ADD_SHAPE]], %[[ADD_D0_INDEX]] : !shape.shape, !shape.size -> !shape.size
 // CHECK-NEXT:      %[[ADD_D0:.+]] = shape.size_to_index %[[ADD_D0_EXTENT]] : !shape.size
-// CHECK-NEXT:      %[[ADD_INIT:.+]] = tensor.empty(%[[ADD_D0]]) : tensor<?x512xf16>
-// CHECK-NEXT:      %[[MATMUL:.+]] = hipsr.matmul(%[[DCTX]]) ins(%[[DA]], %[[DB]] : tensor<?x256xf16>, tensor<256x512xf16>) outs(%[[MATMUL_INIT]] : tensor<?x512xf16>) : tensor<?x512xf16>
-// CHECK-NEXT:      %[[ADD:.+]] = hipsr.add(%[[DCTX]]) ins(%[[MATMUL]], %[[DC]] : tensor<?x512xf16>, tensor<?x512xf16>) outs(%[[ADD_INIT]] : tensor<?x512xf16>) : tensor<?x512xf16>
-// CHECK-NEXT:      hipsr.pool_domain_yield %[[ADD]] : tensor<?x512xf16>
-// CHECK-NEXT:    } -> tensor<?x512xf16> {domain_id = 0 : i64}
-// CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x512xf16>
+// CHECK-NEXT:      %[[ADD_INIT:.+]] = tensor.empty(%[[ADD_D0]]) : tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[MATMUL:.+]] = hipsr.matmul(%[[DCTX]]) ins(%[[DA]], %[[DB]] : tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>) outs(%[[MATMUL_INIT]] : tensor<?x512xf16, #hipsr.mem<device>>) : tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[ADD:.+]] = hipsr.add(%[[DCTX]]) ins(%[[MATMUL]], %[[DC]] : tensor<?x512xf16, #hipsr.mem<device>>, tensor<?x512xf16, #hipsr.mem<device>>) outs(%[[ADD_INIT]] : tensor<?x512xf16, #hipsr.mem<device>>) : tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.pool_domain_yield %[[ADD]] : tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    } -> tensor<?x512xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x512xf16, #hipsr.mem<device>>
 // CHECK-NEXT:  }
-func.func @interleaved(%ctx: !hipsr.context, %a: tensor<?x256xf16>,
-                       %b: tensor<256x512xf16>, %c: tensor<?x512xf16>)
-    -> tensor<?x512xf16> {
+func.func @interleaved(%ctx: !hipsr.context,
+                       %a: tensor<?x256xf16, #hipsr.mem<device>>,
+                       %b: tensor<256x512xf16, #hipsr.mem<device>>,
+                       %c: tensor<?x512xf16, #hipsr.mem<device>>)
+    -> tensor<?x512xf16, #hipsr.mem<device>> {
   %0 = hipsr.pool_domain(%ctx, %a, %b, %c
-      : !hipsr.context, tensor<?x256xf16>, tensor<256x512xf16>,
-        tensor<?x512xf16>) {
-  ^bb0(%domain_ctx: !hipsr.context, %domain_a: tensor<?x256xf16>,
-       %domain_b: tensor<256x512xf16>, %domain_c: tensor<?x512xf16>):
+      : !hipsr.context, tensor<?x256xf16, #hipsr.mem<device>>,
+        tensor<256x512xf16, #hipsr.mem<device>>,
+        tensor<?x512xf16, #hipsr.mem<device>>) {
+  ^bb0(%domain_ctx: !hipsr.context,
+       %domain_a: tensor<?x256xf16, #hipsr.mem<device>>,
+       %domain_b: tensor<256x512xf16, #hipsr.mem<device>>,
+       %domain_c: tensor<?x512xf16, #hipsr.mem<device>>):
     %matmul_init = hipsr.placeholder(%domain_ctx)
-        ins(%domain_a, %domain_b : tensor<?x256xf16>, tensor<256x512xf16>)
+        ins(%domain_a, %domain_b
+            : tensor<?x256xf16, #hipsr.mem<device>>,
+              tensor<256x512xf16, #hipsr.mem<device>>)
         {placeholder_type = #hipsr.placeholder_type<normal>}
-        : tensor<?x512xf16> shape_region {
+        : tensor<?x512xf16, #hipsr.mem<device>> shape_region {
     ^bb0(%a_shape: !shape.shape, %b_shape: !shape.shape):
       %m_index = shape.const_size 0
       %m = shape.get_extent %a_shape, %m_index
@@ -265,23 +299,31 @@ func.func @interleaved(%ctx: !hipsr.context, %a: tensor<?x256xf16>,
       hipsr.shape_yield %matmul_shape : !shape.shape
     }
     %matmul = hipsr.matmul(%domain_ctx)
-        ins(%domain_a, %domain_b : tensor<?x256xf16>, tensor<256x512xf16>)
-        outs(%matmul_init : tensor<?x512xf16>) : tensor<?x512xf16>
+        ins(%domain_a, %domain_b
+            : tensor<?x256xf16, #hipsr.mem<device>>,
+              tensor<256x512xf16, #hipsr.mem<device>>)
+        outs(%matmul_init : tensor<?x512xf16, #hipsr.mem<device>>)
+        : tensor<?x512xf16, #hipsr.mem<device>>
     %add_init = hipsr.placeholder(%domain_ctx)
-        ins(%matmul_init, %domain_c : tensor<?x512xf16>, tensor<?x512xf16>)
+        ins(%matmul_init, %domain_c
+            : tensor<?x512xf16, #hipsr.mem<device>>,
+              tensor<?x512xf16, #hipsr.mem<device>>)
         {placeholder_type = #hipsr.placeholder_type<normal>}
-        : tensor<?x512xf16> shape_region {
+        : tensor<?x512xf16, #hipsr.mem<device>> shape_region {
     ^bb0(%lhs_shape: !shape.shape, %rhs_shape: !shape.shape):
       %add_shape = shape.broadcast %lhs_shape, %rhs_shape
           : !shape.shape, !shape.shape -> !shape.shape
       hipsr.shape_yield %add_shape : !shape.shape
     }
     %add = hipsr.add(%domain_ctx)
-        ins(%matmul, %domain_c : tensor<?x512xf16>, tensor<?x512xf16>)
-        outs(%add_init : tensor<?x512xf16>) : tensor<?x512xf16>
-    hipsr.pool_domain_yield %add : tensor<?x512xf16>
-  } -> tensor<?x512xf16> {domain_id = 0 : i64}
-  return %0 : tensor<?x512xf16>
+        ins(%matmul, %domain_c
+            : tensor<?x512xf16, #hipsr.mem<device>>,
+              tensor<?x512xf16, #hipsr.mem<device>>)
+        outs(%add_init : tensor<?x512xf16, #hipsr.mem<device>>)
+        : tensor<?x512xf16, #hipsr.mem<device>>
+    hipsr.pool_domain_yield %add : tensor<?x512xf16, #hipsr.mem<device>>
+  } -> tensor<?x512xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+  return %0 : tensor<?x512xf16, #hipsr.mem<device>>
 }
 
 // -----
@@ -292,12 +334,12 @@ func.func @interleaved(%ctx: !hipsr.context, %a: tensor<?x256xf16>,
 // that keeps a placeholder from being moved before itself, which would
 // otherwise reverse their order.
 // CHECK-LABEL: func.func @already_grouped(
-// CHECK-SAME:      %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<?x256xf16>, %[[B:.+]]: tensor<256x512xf16>, %[[C:.+]]: tensor<?x512xf16>) -> tensor<?x512xf16> {
-// CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]], %[[C]] : !hipsr.context, tensor<?x256xf16>, tensor<256x512xf16>, tensor<?x512xf16>) {
-// CHECK-NEXT:    ^bb0(%[[DCTX:.+]]: !hipsr.context, %[[DA:.+]]: tensor<?x256xf16>, %[[DB:.+]]: tensor<256x512xf16>, %[[DC:.+]]: tensor<?x512xf16>):
+// CHECK-SAME:      %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<?x256xf16, #hipsr.mem<device>>, %[[B:.+]]: tensor<256x512xf16, #hipsr.mem<device>>, %[[C:.+]]: tensor<?x512xf16, #hipsr.mem<device>>) -> tensor<?x512xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]], %[[C]] : !hipsr.context, tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>, tensor<?x512xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:    ^bb0(%[[DCTX:.+]]: !hipsr.context, %[[DA:.+]]: tensor<?x256xf16, #hipsr.mem<device>>, %[[DB:.+]]: tensor<256x512xf16, #hipsr.mem<device>>, %[[DC:.+]]: tensor<?x512xf16, #hipsr.mem<device>>):
 // CHECK-NEXT:      %[[MATMUL_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[DA]] : tensor<?x256xf16> -> !shape.shape
-// CHECK-NEXT:        %[[B_SHAPE:.+]] = shape.shape_of %[[DB]] : tensor<256x512xf16> -> !shape.shape
+// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[DA]] : tensor<?x256xf16, #hipsr.mem<device>> -> !shape.shape
+// CHECK-NEXT:        %[[B_SHAPE:.+]] = shape.shape_of %[[DB]] : tensor<256x512xf16, #hipsr.mem<device>> -> !shape.shape
 // CHECK-NEXT:        %[[M_INDEX:.+]] = shape.const_size 0
 // CHECK-NEXT:        %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[M_INDEX]] : !shape.shape, !shape.size -> !shape.size
 // CHECK-NEXT:        %[[N_INDEX:.+]] = shape.const_size 1
@@ -306,36 +348,43 @@ func.func @interleaved(%ctx: !hipsr.context, %a: tensor<?x256xf16>,
 // CHECK-NEXT:        scf.yield %[[FROM_EXTENTS]] : !shape.shape
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %[[ADD_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[C_SHAPE:.+]] = shape.shape_of %[[DC]] : tensor<?x512xf16> -> !shape.shape
+// CHECK-NEXT:        %[[C_SHAPE:.+]] = shape.shape_of %[[DC]] : tensor<?x512xf16, #hipsr.mem<device>> -> !shape.shape
 // CHECK-NEXT:        %[[BROADCAST:.+]] = shape.broadcast %[[MATMUL_SHAPE]], %[[C_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
 // CHECK-NEXT:        scf.yield %[[BROADCAST]] : !shape.shape
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %[[MATMUL_D0_INDEX:.+]] = shape.const_size 0
 // CHECK-NEXT:      %[[MATMUL_D0_EXTENT:.+]] = shape.get_extent %[[MATMUL_SHAPE]], %[[MATMUL_D0_INDEX]] : !shape.shape, !shape.size -> !shape.size
 // CHECK-NEXT:      %[[MATMUL_D0:.+]] = shape.size_to_index %[[MATMUL_D0_EXTENT]] : !shape.size
-// CHECK-NEXT:      %[[MATMUL_INIT:.+]] = tensor.empty(%[[MATMUL_D0]]) : tensor<?x512xf16>
+// CHECK-NEXT:      %[[MATMUL_INIT:.+]] = tensor.empty(%[[MATMUL_D0]]) : tensor<?x512xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[ADD_D0_INDEX:.+]] = shape.const_size 0
 // CHECK-NEXT:      %[[ADD_D0_EXTENT:.+]] = shape.get_extent %[[ADD_SHAPE]], %[[ADD_D0_INDEX]] : !shape.shape, !shape.size -> !shape.size
 // CHECK-NEXT:      %[[ADD_D0:.+]] = shape.size_to_index %[[ADD_D0_EXTENT]] : !shape.size
-// CHECK-NEXT:      %[[ADD_INIT:.+]] = tensor.empty(%[[ADD_D0]]) : tensor<?x512xf16>
-// CHECK-NEXT:      %[[MATMUL:.+]] = hipsr.matmul(%[[DCTX]]) ins(%[[DA]], %[[DB]] : tensor<?x256xf16>, tensor<256x512xf16>) outs(%[[MATMUL_INIT]] : tensor<?x512xf16>) : tensor<?x512xf16>
-// CHECK-NEXT:      %[[ADD:.+]] = hipsr.add(%[[DCTX]]) ins(%[[MATMUL]], %[[DC]] : tensor<?x512xf16>, tensor<?x512xf16>) outs(%[[ADD_INIT]] : tensor<?x512xf16>) : tensor<?x512xf16>
-// CHECK-NEXT:      hipsr.pool_domain_yield %[[ADD]] : tensor<?x512xf16>
-// CHECK-NEXT:    } -> tensor<?x512xf16> {domain_id = 0 : i64}
-// CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x512xf16>
+// CHECK-NEXT:      %[[ADD_INIT:.+]] = tensor.empty(%[[ADD_D0]]) : tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[MATMUL:.+]] = hipsr.matmul(%[[DCTX]]) ins(%[[DA]], %[[DB]] : tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>) outs(%[[MATMUL_INIT]] : tensor<?x512xf16, #hipsr.mem<device>>) : tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[ADD:.+]] = hipsr.add(%[[DCTX]]) ins(%[[MATMUL]], %[[DC]] : tensor<?x512xf16, #hipsr.mem<device>>, tensor<?x512xf16, #hipsr.mem<device>>) outs(%[[ADD_INIT]] : tensor<?x512xf16, #hipsr.mem<device>>) : tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.pool_domain_yield %[[ADD]] : tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    } -> tensor<?x512xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x512xf16, #hipsr.mem<device>>
 // CHECK-NEXT:  }
-func.func @already_grouped(%ctx: !hipsr.context, %a: tensor<?x256xf16>,
-                           %b: tensor<256x512xf16>, %c: tensor<?x512xf16>)
-    -> tensor<?x512xf16> {
+func.func @already_grouped(%ctx: !hipsr.context,
+                           %a: tensor<?x256xf16, #hipsr.mem<device>>,
+                           %b: tensor<256x512xf16, #hipsr.mem<device>>,
+                           %c: tensor<?x512xf16, #hipsr.mem<device>>)
+    -> tensor<?x512xf16, #hipsr.mem<device>> {
   %0 = hipsr.pool_domain(%ctx, %a, %b, %c
-      : !hipsr.context, tensor<?x256xf16>, tensor<256x512xf16>,
-        tensor<?x512xf16>) {
-  ^bb0(%domain_ctx: !hipsr.context, %domain_a: tensor<?x256xf16>,
-       %domain_b: tensor<256x512xf16>, %domain_c: tensor<?x512xf16>):
+      : !hipsr.context, tensor<?x256xf16, #hipsr.mem<device>>,
+        tensor<256x512xf16, #hipsr.mem<device>>,
+        tensor<?x512xf16, #hipsr.mem<device>>) {
+  ^bb0(%domain_ctx: !hipsr.context,
+       %domain_a: tensor<?x256xf16, #hipsr.mem<device>>,
+       %domain_b: tensor<256x512xf16, #hipsr.mem<device>>,
+       %domain_c: tensor<?x512xf16, #hipsr.mem<device>>):
     %matmul_init = hipsr.placeholder(%domain_ctx)
-        ins(%domain_a, %domain_b : tensor<?x256xf16>, tensor<256x512xf16>)
+        ins(%domain_a, %domain_b
+            : tensor<?x256xf16, #hipsr.mem<device>>,
+              tensor<256x512xf16, #hipsr.mem<device>>)
         {placeholder_type = #hipsr.placeholder_type<normal>}
-        : tensor<?x512xf16> shape_region {
+        : tensor<?x512xf16, #hipsr.mem<device>> shape_region {
     ^bb0(%a_shape: !shape.shape, %b_shape: !shape.shape):
       %m_index = shape.const_size 0
       %m = shape.get_extent %a_shape, %m_index
@@ -347,45 +396,55 @@ func.func @already_grouped(%ctx: !hipsr.context, %a: tensor<?x256xf16>,
       hipsr.shape_yield %matmul_shape : !shape.shape
     }
     %add_init = hipsr.placeholder(%domain_ctx)
-        ins(%matmul_init, %domain_c : tensor<?x512xf16>, tensor<?x512xf16>)
+        ins(%matmul_init, %domain_c
+            : tensor<?x512xf16, #hipsr.mem<device>>,
+              tensor<?x512xf16, #hipsr.mem<device>>)
         {placeholder_type = #hipsr.placeholder_type<normal>}
-        : tensor<?x512xf16> shape_region {
+        : tensor<?x512xf16, #hipsr.mem<device>> shape_region {
     ^bb0(%lhs_shape: !shape.shape, %rhs_shape: !shape.shape):
       %add_shape = shape.broadcast %lhs_shape, %rhs_shape
           : !shape.shape, !shape.shape -> !shape.shape
       hipsr.shape_yield %add_shape : !shape.shape
     }
     %matmul = hipsr.matmul(%domain_ctx)
-        ins(%domain_a, %domain_b : tensor<?x256xf16>, tensor<256x512xf16>)
-        outs(%matmul_init : tensor<?x512xf16>) : tensor<?x512xf16>
+        ins(%domain_a, %domain_b
+            : tensor<?x256xf16, #hipsr.mem<device>>,
+              tensor<256x512xf16, #hipsr.mem<device>>)
+        outs(%matmul_init : tensor<?x512xf16, #hipsr.mem<device>>)
+        : tensor<?x512xf16, #hipsr.mem<device>>
     %add = hipsr.add(%domain_ctx)
-        ins(%matmul, %domain_c : tensor<?x512xf16>, tensor<?x512xf16>)
-        outs(%add_init : tensor<?x512xf16>) : tensor<?x512xf16>
-    hipsr.pool_domain_yield %add : tensor<?x512xf16>
-  } -> tensor<?x512xf16> {domain_id = 0 : i64}
-  return %0 : tensor<?x512xf16>
+        ins(%matmul, %domain_c
+            : tensor<?x512xf16, #hipsr.mem<device>>,
+              tensor<?x512xf16, #hipsr.mem<device>>)
+        outs(%add_init : tensor<?x512xf16, #hipsr.mem<device>>)
+        : tensor<?x512xf16, #hipsr.mem<device>>
+    hipsr.pool_domain_yield %add : tensor<?x512xf16, #hipsr.mem<device>>
+  } -> tensor<?x512xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+  return %0 : tensor<?x512xf16, #hipsr.mem<device>>
 }
 
 // -----
 
 // A domain without placeholders is left alone. The tensor.empty here is the one
-// the input already had, not one the pass built.
+// the input already had, not one the pass built, so it keeps the default memory
+// space: the pass only tags the allocations it materializes itself.
 // CHECK-LABEL: func.func @no_placeholder(
-// CHECK-SAME:      %[[IN:.+]]: tensor<3x4xf32>) -> tensor<2x?xi64> {
-// CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[IN]] : tensor<3x4xf32>) {
-// CHECK-NEXT:    ^bb0(%[[DIN:.+]]: tensor<3x4xf32>):
+// CHECK-SAME:      %[[IN:.+]]: tensor<3x4xf32, #hipsr.mem<device>>) -> tensor<2x?xi64> {
+// CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[IN]] : tensor<3x4xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT:    ^bb0(%[[DIN:.+]]: tensor<3x4xf32, #hipsr.mem<device>>):
 // CHECK-NEXT:      %[[C1:.+]] = arith.constant 1 : index
-// CHECK-NEXT:      %[[DIM:.+]] = tensor.dim %[[DIN]], %[[C1]] : tensor<3x4xf32>
+// CHECK-NEXT:      %[[DIM:.+]] = tensor.dim %[[DIN]], %[[C1]] : tensor<3x4xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[BUFFER:.+]] = tensor.empty(%[[DIM]]) : tensor<2x?xi64>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[BUFFER]] : tensor<2x?xi64>
 // CHECK-NEXT:    } -> tensor<2x?xi64> {domain_id = 0 : i64}
 // CHECK-NEXT:    return %[[DOMAIN]] : tensor<2x?xi64>
 // CHECK-NEXT:  }
-func.func @no_placeholder(%in: tensor<3x4xf32>) -> tensor<2x?xi64> {
-  %0 = hipsr.pool_domain(%in : tensor<3x4xf32>) {
-  ^bb0(%domain_in: tensor<3x4xf32>):
+func.func @no_placeholder(%in: tensor<3x4xf32, #hipsr.mem<device>>)
+    -> tensor<2x?xi64> {
+  %0 = hipsr.pool_domain(%in : tensor<3x4xf32, #hipsr.mem<device>>) {
+  ^bb0(%domain_in: tensor<3x4xf32, #hipsr.mem<device>>):
     %c1 = arith.constant 1 : index
-    %n = tensor.dim %domain_in, %c1 : tensor<3x4xf32>
+    %n = tensor.dim %domain_in, %c1 : tensor<3x4xf32, #hipsr.mem<device>>
     %buffer = tensor.empty(%n) : tensor<2x?xi64>
     hipsr.pool_domain_yield %buffer : tensor<2x?xi64>
   } -> tensor<2x?xi64> {domain_id = 0 : i64}


### PR DESCRIPTION
## Summary
`-hipsr-materialize-init-tensors` now tags every init `tensor.empty` it creates with the `#hipsr.mem<device>` memory-space encoding, so materialized allocations are pinned to device (VRAM) memory instead of the default space. The LIT coverage in `materialize-init-tensors.mlir` is updated to carry the encoding along the whole init/result chain.

## Why
The pass previously built init tensors straight from the placeholder result type, which had no memory space. Downstream bufferization has no way to infer that these buffers must live in device memory, and hipsr ops constrain their operands to device memrefs (`Hipsr_DeviceMemRef`). Recording the intended space on the tensor encoding lets it survive until bufferization turns the tensor into a `memref<..., #hipsr.mem<device>>`.

## What
- `MaterializeInitTensorsPass.cpp`: add `getDeviceTensorType` and build the init `tensor.empty` with a `#hipsr.mem<device>` encoding; dynamic-dim extraction is unchanged since the encoding does not affect the shape.
- `materialize-init-tensors.mlir`: spell out `#hipsr.mem<device>` across the init/result chain (placeholder, `outs`, result, `pool_domain_yield`, `pool_domain`, function result) so the DPS "outs type equals result type" verifier holds, and give the hipsr op inputs the same device space. `@no_placeholder` keeps its pre-existing default-space `tensor.empty`, which the pass does not touch.

Verified by running the pass and FileCheck against the updated LIT test with the prebuilt `hip-mlir-opt`.

## AI assist
Collaborative develop with Cursor.

Made with [Cursor](https://cursor.com)