### PR TITLE
build(therock): pin the self-built gfx115X-all SDK on Windows

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -100,23 +100,6 @@ jobs:
           path: ${{ runner.workspace }}/llvm-install
           key: dep-llvm-${{ env.LLVM_TAG }}
 
-      # protobuf / flatbuffers / gtest are NOT pre-built or cached here anymore:
-      # cmake/deps.cmake resolves them (find_package first, from-source
-      # FetchContent fallback) during the project build. With no prefix install
-      # they take the from-source path (sccache-accelerated). gtest is only
-      # pulled when unit tests are enabled (morphizen_ENABLE_UNIT_TEST=OFF here).
-
-      # -----------------------------------------------------------------------
-      # TheRock HIP SDK is NOT downloaded explicitly here: with no -DTHEROCK_DIST
-      # passed to Configure, cmake/deps.cmake auto-downloads + extracts it into
-      # the build tree (<build>/_therock) during configure. This exercises the
-      # default auto-download path in CI. (gpu-test downloads TheRock itself.)
-      # -----------------------------------------------------------------------
-
-      # -----------------------------------------------------------------------
-      # llvm-lit.py (from prebuilt) requires the lit pip package at runtime.
-      # Pin Python to avoid mismatch with find_package(Python3) in CMake.
-      # -----------------------------------------------------------------------
       - name: Setup Python 3.14
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
@@ -568,10 +551,18 @@ jobs:
           # without touching this workflow each time.
           cp "${{ runner.workspace }}/install/lib/"*.lib staging/lib/ 2>/dev/null || true
 
-          # amdhip64_7.dll – HIP runtime required at inference time. TheRock was
-          # auto-downloaded by cmake/deps.cmake into the build tree's _therock.
           THEROCK_DIR="../build/$(basename "$PWD")/_therock"
-          cp "$THEROCK_DIR/bin/amdhip64_7.dll" staging/bin/
+          for dll in amdhip64_7.dll MIOpen.dll amd_comgr0702.dll rocblas.dll \
+                     libhipblaslt.dll hiprtc0702.dll hiprtc-builtins0702.dll \
+                     hipdnn_backend.dll; do
+            cp "$THEROCK_DIR/bin/$dll" staging/bin/
+          done
+          for data in hipblaslt rocblas; do
+            cp -r "$THEROCK_DIR/bin/$data" staging/bin/
+          done
+          for lib in amdhip64.lib MIOpen.lib libhipblaslt.dll.a; do
+            cp "$THEROCK_DIR/lib/$lib" staging/lib/
+          done
 
           # MorphiZen EP config
           cp etc/morphizen_config.json staging/
@@ -693,7 +684,6 @@ jobs:
       pull-requests: write
 
     env:
-      THEROCK_VERSION: therock-dist-windows-gfx1151-7.11.0
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
 
     steps:
@@ -709,7 +699,6 @@ jobs:
           if exist oga-smoke-venv rd /s /q oga-smoke-venv
           if exist oga-smoke-results rd /s /q oga-smoke-results
           if exist wheelpkg rd /s /q wheelpkg
-          if exist therock-dist rd /s /q therock-dist
 
       - name: Download GPU test package
         uses: actions/download-artifact@v4
@@ -723,37 +712,10 @@ jobs:
           name: hip-python-package
           path: wheelpkg
 
-      # TheRock DLLs are required at runtime on the GPU machine.
-      # Download is fast enough that caching is not needed on the self-hosted runner.
-      - name: Download & extract TheRock
-        shell: pwsh
-        run: |
-          $dist = "$PWD\therock-dist"
-          New-Item -ItemType Directory -Force -Path $dist | Out-Null
-          curl.exe -fsSL `
-            "https://repo.amd.com/rocm/tarball/${{ env.THEROCK_VERSION }}.tar.gz" `
-            -o therock.tar.gz
-          tar -xzf therock.tar.gz -C $dist --strip-components=1
-          Remove-Item therock.tar.gz
-
-      # Run perf test against seq128 models via MorphiZen EP (models pre-placed
-      # at C:\actions-runner\_work\model\). Default bitcode (LLVM_IR) path only
-      # needs PATH -> ROCm runtime DLLs (therock-dist/bin) + co-located
-      # custom_kernels; the in-memory JIT reads neither THEROCK_DIST nor LIB
-      # (those are NATIVE-only, set in the native smoke steps below).
-      # Output is tee'd to results/ for QPS extraction. Non-zero exit code
-      # sets FAILED but continues so all models are tested.
-      #
-      # GPU-test asset dirs (model/, amdgpu-oga-models/, l2-test-models/) resolve
-      # under ${{ vars.GPU_TEST_ASSET_ROOT || runner.workspace }}: set the repo/org
-      # Actions variable GPU_TEST_ASSET_ROOT to a stable path (and stage the dirs
-      # there) so persistent assets need not live under the repo-name-derived
-      # _work/<repo>/, which strands them on a repo rename. Unset => runner.workspace
-      # (unchanged from today).
       - name: Run onnxruntime_perf_test (GPU)
         shell: cmd
         run: |
-          set PATH=%CD%\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
+          set PATH=%CD%\gpu-test-package\bin;%PATH%
           set MODEL_DIR=${{ vars.GPU_TEST_ASSET_ROOT || runner.workspace }}\model
           if not exist "%MODEL_DIR%" (
             echo [ERROR] MODEL_DIR not found: %MODEL_DIR%
@@ -795,9 +757,9 @@ jobs:
         if: always()
         shell: cmd
         run: |
-          set THEROCK_DIST=%CD%\therock-dist
-          set PATH=%CD%\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
-          set LIB=%CD%\gpu-test-package\lib;%CD%\therock-dist\lib
+          set THEROCK_DIST=%CD%\gpu-test-package
+          set PATH=%CD%\gpu-test-package\bin;%PATH%
+          set LIB=%CD%\gpu-test-package\lib
           set MODEL_DIR=${{ vars.GPU_TEST_ASSET_ROOT || runner.workspace }}\model
           if not exist "%MODEL_DIR%" (
             echo [SKIP] MODEL_DIR not found: %MODEL_DIR%
@@ -841,9 +803,9 @@ jobs:
         if: always()
         shell: cmd
         run: |
-          set THEROCK_DIST=%CD%\therock-dist
-          set PATH=%CD%\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
-          set LIB=%CD%\gpu-test-package\lib;%CD%\therock-dist\lib
+          set THEROCK_DIST=%CD%\gpu-test-package
+          set PATH=%CD%\gpu-test-package\bin;%PATH%
+          set LIB=%CD%\gpu-test-package\lib
           set MODEL_DIR=${{ vars.GPU_TEST_ASSET_ROOT || runner.workspace }}\model
           if not exist "%MODEL_DIR%" (
             echo [SKIP] MODEL_DIR not found: %MODEL_DIR%
@@ -884,7 +846,7 @@ jobs:
           $ErrorActionPreference = 'Continue'
           $PSNativeCommandUseErrorActionPreference = $false
           $pkgBin = Join-Path $PWD "gpu-test-package\bin"
-          $env:PATH = "$PWD\therock-dist\bin;$pkgBin;$env:PATH"
+          $env:PATH = "$pkgBin;$env:PATH"
 
           $modelDir = "${{ vars.GPU_TEST_ASSET_ROOT || runner.workspace }}\model"
           if (-not (Test-Path $modelDir)) {
@@ -960,7 +922,7 @@ jobs:
           $ErrorActionPreference = 'Continue'
           $PSNativeCommandUseErrorActionPreference = $false
           $pkgBin = Join-Path $PWD "gpu-test-package\bin"
-          $env:PATH = "$PWD\therock-dist\bin;$pkgBin;$env:PATH"
+          $env:PATH = "$pkgBin;$env:PATH"
 
           # amdgpu-oga-models holds AMDGPU-profile genai_config copies; it was
           # generated once on the GPU runner and persists across runs, so just
@@ -1105,7 +1067,7 @@ jobs:
         shell: cmd
         run: |
           setlocal enabledelayedexpansion
-          set PATH=%CD%\therock-dist\bin;%CD%\gpu-test-package\bin;%PATH%
+          set PATH=%CD%\gpu-test-package\bin;%PATH%
           rem The EP DLL is now hipgpu.dll; hip-onnx-runner's legacy default name
           rem is onnxruntime_morphizen_ep.dll, so point it at the new DLL.
           set MORPHIZEN_EP_LIB=%CD%\gpu-test-package\bin\hipgpu.dll

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -630,14 +630,10 @@ jobs:
           path: staging/
           retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 14 || 3 }}
 
-      # -----------------------------------------------------------------------
-      # Python wheel package: the three project wheels + run_onnx.py + OGA
-      # benchmark scripts. ROCm wheels are NOT bundled — they are installed
-      # from repo.amd.com at runtime (CI smoke) or downloaded by the local
-      # package_release.ps1 script when building the offline distribution.
-      # -----------------------------------------------------------------------
       - name: Stage Python wheel package
         shell: bash
+        env:
+          VLM_BENCHMARK_REF: f02a82c8312224ef3e2f673c4c6569d487d47e64
         run: |
           mkdir -p wheelpkg/wheels
           ORT_WHEEL=$(find "${{ runner.workspace }}/ort-install/wheels" \
@@ -654,6 +650,8 @@ jobs:
           cp "$ORT_WHEEL" "$OGA_WHEEL" "$EP_WHEEL" wheelpkg/wheels/
           cp python/examples/run_onnx.py wheelpkg/
           cp "${{ runner.workspace }}/oga-artifacts/benchmark-python/"*.py wheelpkg/
+          curl -fsSL --retry 3 -o wheelpkg/vlm_benchmark.py \
+            "https://raw.githubusercontent.com/amd/RyzenAI-SW/$VLM_BENCHMARK_REF/LLM-examples/VLM/vlm_benchmark.py"
           echo "=== Python wheel package layout ==="
           find wheelpkg/ -maxdepth 2 -mindepth 1 | sort
 

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -68,29 +68,33 @@ if(_HIPDNN_NEED_TOOLCHAIN)
       set(THEROCK_DIST "${_therock_dist_resolved}"
           CACHE PATH "TheRock ROCm SDK distribution path" FORCE)
     else()
-      # Auto-download: no SDK provided, so download the official tarball from the
-      # public AMD host and extract it under the build tree, so a fresh real
-      # build needs no manual SDK setup. The pin lives in cmake/deps.txt
-      # (therock;<base-url>;<rocm-version>); the full tarball basename is derived
-      # from the host OS + the first HIP_ARCHITECTURES entry.
       set(_therock_root "${CMAKE_BINARY_DIR}/_therock")
       if(NOT EXISTS "${_therock_root}/bin")
         if(WIN32)
-          set(_therock_os "windows")
+          set(_therock_windows_archs gfx1150 gfx1151 gfx1152 gfx1153)
+          foreach(_arch IN LISTS HIP_ARCHITECTURES)
+            if(NOT _arch IN_LIST _therock_windows_archs)
+              message(FATAL_ERROR
+                "HIP_ARCHITECTURES has '${_arch}', which the pinned TheRock "
+                "bundle (${_therock_windows_archs}) does not cover. Provide "
+                "your own SDK with -DTHEROCK_DIST=/path/to/therock.")
+            endif()
+          endforeach()
+          set(_therock_base "${DEP_HASH_therock_windows}")
+          set(_therock_url "${DEP_URL_therock_windows}/${_therock_base}.tar.gz")
         else()
-          set(_therock_os "linux")
+          set(_therock_arch "${HIP_ARCHITECTURES}")
+          if(_therock_arch MATCHES ";")
+            list(GET _therock_arch 0 _therock_arch)
+          endif()
+          if(NOT _therock_arch)
+            message(FATAL_ERROR
+              "Cannot derive the TheRock tarball: set -DHIP_ARCHITECTURES=<gfxNNNN> "
+              "(GPU arch), or provide -DTHEROCK_DIST=/path/to/therock.")
+          endif()
+          set(_therock_base "therock-dist-linux-${_therock_arch}-${DEP_HASH_therock_linux}")
+          set(_therock_url "${DEP_URL_therock_linux}/${_therock_base}.tar.gz")
         endif()
-        set(_therock_arch "${HIP_ARCHITECTURES}")
-        if(_therock_arch MATCHES ";")
-          list(GET _therock_arch 0 _therock_arch)
-        endif()
-        if(NOT _therock_arch)
-          message(FATAL_ERROR
-            "Cannot derive the TheRock tarball: set -DHIP_ARCHITECTURES=<gfxNNNN> "
-            "(GPU arch), or provide -DTHEROCK_DIST=/path/to/therock.")
-        endif()
-        set(_therock_base "therock-dist-${_therock_os}-${_therock_arch}-${DEP_HASH_therock}")
-        set(_therock_url "${DEP_URL_therock}/${_therock_base}.tar.gz")
         set(_therock_tgz "${CMAKE_BINARY_DIR}/${_therock_base}.tar.gz")
         if(NOT EXISTS "${_therock_tgz}")
           message(STATUS "THEROCK_DIST not provided; downloading ${_therock_url}")

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -2,18 +2,6 @@
 ## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 ## Licensed under the MIT License.
 ##
-## Dependency manifest read by cmake/deps.cmake.
-##
-## Format per line:  name;url;hash
-##   - hash is a version, git tag/commit, or SHA256 depending on the dep (see the
-##     per-row notes below); a SHA256 archive hash gets "SHA256=" prepended.
-##   - an empty hash column means the download is not yet pinned (unverified).
-##
-## Versions are pinned in the url/hash columns. CI builds LLVM and ONNX Runtime
-## into cached prefixes, so keep the CI workflows' LLVM_TAG / ONNXRUNTIME_VERSION
-## in sync with the llvm/onnxruntime rows below; the other deps are pinned here
-## only.
-##
 ## ONNX Runtime: official release archive. url = release base host; hash column =
 ## version. cmake/deps.cmake derives the per-OS archive basename
 ## (onnxruntime-win-x64-<ver>.zip / onnxruntime-linux-x64-<ver>.tgz). Resolved
@@ -29,7 +17,5 @@ flatbuffers;https://github.com/google/flatbuffers.git;v25.12.19
 ## Crash-backtrace helper (always FetchContent; no find_package path).
 cpptrace;https://github.com/jeremy-rifkin/cpptrace.git;v0.8.3
 ##
-## TheRock ROCm SDK. url = tarball base host; hash = pinned ROCm release. The
-## full tarball basename (therock-dist-<os>-<gfxArch>-<rocmVersion>) is derived
-## in cmake/deps.cmake from the host OS + HIP_ARCHITECTURES. Real builds only.
-therock;https://repo.amd.com/rocm/tarball;7.11.0
+therock_windows;https://github.com/ROCm/hip-ep/releases/download/v0.3.0;therock-dist-windows-gfx115X-all-7.11.0
+therock_linux;https://repo.amd.com/rocm/tarball;7.11.0


### PR DESCRIPTION
## Summary

Windows resolves TheRock from a self-built gfx115X bundle attached to this repo's v0.3.0 release instead of the official per-arch tarball, and gpu-test runs off the SDK already staged into the build artifact rather than downloading its own copy. The Python package also ships `vlm_benchmark.py`.

## Related issue or design

None

## Why

The official Windows tarballs are per-arch: covering gfx1150/1151/1152/1153 means four downloads, and the gfx1151 one alone unpacks to 2263 MB. One self-built bundle carries Tensile for all four in a 168 MB archive, so a single download serves every arch the Windows build targets.

gpu-test downloaded the official gfx1151 tarball on its own, so the SDK it ran against was not the one the build compiled with. Staging the runtime into the artifact build-windows already uploads makes them the same SDK by construction and removes a full-tarball download from every GPU run.

## What

- `deps.txt` gains one row per OS. Linux keeps the official tarball and its arch-derived basename; the Windows row pins the basename verbatim, since a release asset name is fixed once published.
- `deps.cmake` builds the URL per OS and rejects a `HIP_ARCHITECTURES` value the pinned bundle does not cover, instead of letting the download 404.
- build-windows copies the ROCm runtime DLLs, the hipblaslt/rocblas Tensile data, and the import libs into `staging/bin` and `staging/lib`. They merge into the existing directories rather than a subtree, so the package root works as `THEROCK_DIST` for the NATIVE linker while Tensile stays next to the DLLs that resolve it.
- gpu-test drops its download step; `PATH`, `THEROCK_DIST` and `LIB` point at `gpu-test-package`.
- The wheel package staging step fetches `vlm_benchmark.py` from `amd/RyzenAI-SW` at a pinned commit, since it lives neither here nor in the OGA tree the other benchmark scripts come from.

## Test plan

- [ ] build-windows green on a cold cache: configure downloads the release asset and the build completes
- [ ] gpu-test green with no TheRock download: perf test, NATIVE smoke, OGA wheel smoke and the L2 suite all run off `gpu-test-package`
- [ ] `hip-python-package` contains `vlm_benchmark.py` alongside `run_onnx.py` and `benchmark_e2e.py`
- [ ] Linux configure still resolves `therock-dist-linux-<arch>-7.11.0` from repo.amd.com

## Notes for reviewers

The bundle is attached to the existing v0.3.0 release rather than a new tag so users find every asset in one place. Its SHA256 is `570c5b5d469b7e009ca206d434e7774fc58989d89ffdd5cbb58629a71c974df7`.

Linux is untouched on purpose: it stays on the official tarball until an equivalent bundle is published for it. Making the wheels self-contained is likewise left out, because it would fork Windows from Linux before that happens. The `morphizen/` subtree workflows still fetch their own gfx1151 tarball; they pass `THEROCK_DIST` explicitly and do not go through `deps.cmake`, so they are out of scope here.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.

