### PR TITLE
feat(hipsr): let compute hold buffers in any memory space

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/HipsrComputeOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrComputeOp.td
@@ -32,9 +32,10 @@ def Hipsr_ComputeOp : Hipsr_Op<"compute", [
     type need not match that result's, so the body may yield a reshaped or cast
     view of it.
 
-    Operands and results are tensors before bufferization and device memrefs
-    (`#hipsr.mem<device>`) after. A bufferized compute has no results and
-    yields nothing.
+    Operands and results are tensors before bufferization and memrefs after. A
+    memref may name any `#hipsr.mem` space, so a body that produces extents can
+    keep them in host memory while data stays on the device. A bufferized
+    compute has no results and yields nothing.
 
     Example, where the body fills its output and then flattens it, so the
     result type differs:
@@ -54,12 +55,12 @@ def Hipsr_ComputeOp : Hipsr_Op<"compute", [
 
   let arguments = (ins
     Hipsr_ContextType:$ctx,
-    Variadic<Hipsr_TensorOrDeviceMemRef>:$inputs,
-    Variadic<Hipsr_TensorOrDeviceMemRef>:$outputs
+    Variadic<Hipsr_TensorOrAnySpaceMemRef>:$inputs,
+    Variadic<Hipsr_TensorOrAnySpaceMemRef>:$outputs
   );
   // Named after linalg's $result_tensors, which is also the pre-bufferization
   // form; a bufferized compute holds memrefs here.
-  let results = (outs Variadic<Hipsr_TensorOrDeviceMemRef>:$result_tensors);
+  let results = (outs Variadic<Hipsr_TensorOrAnySpaceMemRef>:$result_tensors);
   let regions = (region SizedRegion<1>:$body);
 
   let assemblyFormat = [{

--- a/include/hip/Dialect/Hipsr/IR/HipsrComputeYieldOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrComputeYieldOp.td
@@ -16,9 +16,9 @@ def Hipsr_ComputeYieldOp : Hipsr_Op<"compute_yield",
   let description = [{
     Terminates a `hipsr.compute` body and gives that op its results.
 
-    Operands are tensors before bufferization and device memrefs
-    (`#hipsr.mem<device>`) after, and their types need not match the parent's
-    `outs` types. A bufferized compute has no results, so its yield carries no
+    Operands are tensors before bufferization and memrefs after, in any
+    `#hipsr.mem` space, and their types need not match the parent's `outs`
+    types. A bufferized compute has no results, so its yield carries no
     operands.
 
     Example:
@@ -27,7 +27,7 @@ def Hipsr_ComputeYieldOp : Hipsr_Op<"compute_yield",
     ```
   }];
 
-  let arguments = (ins Variadic<Hipsr_TensorOrDeviceMemRef>:$operands);
+  let arguments = (ins Variadic<Hipsr_TensorOrAnySpaceMemRef>:$operands);
 
   let assemblyFormat = "($operands^ `:` type($operands))? attr-dict";
 

--- a/include/hip/Dialect/Hipsr/IR/HipsrTypes.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrTypes.h
@@ -12,12 +12,14 @@ namespace mlir {
 namespace hipsr {
 
 // Predicates for the Hipsr_*MemRef type constraints in HipsrTypes.td. Each
-// returns true only when the type is a memref in that memory space; a memref
-// with no space (or a space set by some other attribute) returns false.
+// returns true only when the type is a memref in that memory space, or in any
+// of them for isAnySpaceMemRef; a memref with no space (or a space set by some
+// other attribute) returns false.
 bool isHostMemRef(::mlir::Type type);
 bool isDeviceMemRef(::mlir::Type type);
 bool isPinnedMemRef(::mlir::Type type);
 bool isManagedMemRef(::mlir::Type type);
+bool isAnySpaceMemRef(::mlir::Type type);
 
 } // namespace hipsr
 } // namespace mlir

--- a/include/hip/Dialect/Hipsr/IR/HipsrTypes.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrTypes.td
@@ -10,15 +10,16 @@ include "mlir/IR/OpBase.td"
 include "mlir/IR/AttrTypeBase.td"
 include "hip/Dialect/Hipsr/IR/HipsrDialect.td"
 
-// Type constraints for ops that need a memref in a specific memory space.
-//
-// One per memory space, in enum order (host, device, pinned, managed). A memref
-// with no space, or a space that is not a `#hipsr.mem<...>` attribute, does not
-// match (see the predicates in HipsrTypes.cpp).
+// Type constraints for ops that need a memref in a named memory space, one per
+// space in enum order (host, device, pinned, managed), plus one for an op that
+// takes any of them. A memref with no space, or a space that is not a
+// `#hipsr.mem<...>` attribute, matches none of them (see the predicates in
+// HipsrTypes.cpp).
 def Hipsr_HostMemRef    : Type<CPred<"::mlir::hipsr::isHostMemRef($_self)">,    "host memref">;
 def Hipsr_DeviceMemRef  : Type<CPred<"::mlir::hipsr::isDeviceMemRef($_self)">,  "device memref">;
 def Hipsr_PinnedMemRef  : Type<CPred<"::mlir::hipsr::isPinnedMemRef($_self)">,  "pinned memref">;
 def Hipsr_ManagedMemRef : Type<CPred<"::mlir::hipsr::isManagedMemRef($_self)">, "managed memref">;
+def Hipsr_AnySpaceMemRef : Type<CPred<"::mlir::hipsr::isAnySpaceMemRef($_self)">, "memref in a hipsr memory space">;
 
 // Matches a ranked tensor (which has no memory space) or a memref in the named
 // space. For ops that run both before and after bufferization.
@@ -27,6 +28,7 @@ def Hipsr_TensorOrDeviceMemRef  : AnyTypeOf<[AnyRankedTensor, Hipsr_DeviceMemRef
 def Hipsr_TensorOrPinnedMemRef  : AnyTypeOf<[AnyRankedTensor, Hipsr_PinnedMemRef],  "ranked tensor or pinned memref">;
 def Hipsr_TensorOrManagedMemRef : AnyTypeOf<[AnyRankedTensor, Hipsr_ManagedMemRef], "ranked tensor or managed memref">;
 def Hipsr_TensorOrMemRef : AnyTypeOf<[AnyRankedTensor, AnyMemRef], "ranked tensor or memref">;
+def Hipsr_TensorOrAnySpaceMemRef : AnyTypeOf<[AnyRankedTensor, Hipsr_AnySpaceMemRef], "ranked tensor or hipsr memref">;
 
 // Base class for hipsr types.
 class Hipsr_Type<string name, string typeMnemonic> : TypeDef<Hipsr_Dialect, name> {

--- a/lib/Dialect/Hipsr/IR/HipsrTypes.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrTypes.cpp
@@ -15,15 +15,19 @@ using namespace mlir::hipsr;
 
 namespace {
 
-// True only when the type is a memref whose space is a #hipsr.mem attribute
-// naming this space. A memref with no space, or a space set by some other
-// attribute, returns false -- hipsr requires every memref to name its space.
-bool memRefInSpace(Type type, MemorySpace space) {
+// The #hipsr.mem space a memref names, or null for any other type, for a memref
+// with no space, or for a space set by some other attribute -- hipsr requires
+// every memref to name its space.
+MemorySpaceAttr hipsrSpace(Type type) {
   auto memref = dyn_cast<MemRefType>(type);
   if (!memref) {
-    return false;
+    return {};
   }
-  auto spaceAttr = dyn_cast_or_null<MemorySpaceAttr>(memref.getMemorySpace());
+  return dyn_cast_or_null<MemorySpaceAttr>(memref.getMemorySpace());
+}
+
+bool memRefInSpace(Type type, MemorySpace space) {
+  MemorySpaceAttr spaceAttr = hipsrSpace(type);
   return spaceAttr && spaceAttr.getValue() == space;
 }
 
@@ -42,6 +46,8 @@ bool isPinnedMemRef(Type type) {
 bool isManagedMemRef(Type type) {
   return memRefInSpace(type, MemorySpace::Managed);
 }
+
+bool isAnySpaceMemRef(Type type) { return hipsrSpace(type) != nullptr; }
 
 } // namespace hipsr
 } // namespace mlir

--- a/test/lit/Dialect/Hipsr/IR/compute.mlir
+++ b/test/lit/Dialect/Hipsr/IR/compute.mlir
@@ -145,6 +145,42 @@ func.func @memref_form_with_result(%ctx: !hipsr.context,
 }
 
 // -----
+// Device is not the only space a bufferized compute may use: extents are read
+// on the host, so a compute that produces them holds its input, its output and
+// its result in host memory.
+// CHECK-LABEL: func.func @memref_form_host_space(
+// CHECK-SAME: %[[CTX:.+]]: !hipsr.context, %[[EXTENTS:.+]]: memref<2xi64, #hipsr.mem<host>>, %[[INIT:.+]]: memref<2xi64, #hipsr.mem<host>>) -> memref<2xi64, #hipsr.mem<host>> {
+// CHECK-NEXT: %[[RESULT:.+]] = hipsr.compute(%[[CTX]]) ins(%[[EXTENTS]] : memref<2xi64, #hipsr.mem<host>>) outs(%[[INIT]] : memref<2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT: ^bb0(%{{.+}}: !hipsr.context, %{{.+}}: memref<2xi64, #hipsr.mem<host>>, %[[DEST:.+]]: memref<2xi64, #hipsr.mem<host>>):
+// CHECK-NEXT: hipsr.compute_yield %[[DEST]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT: } : memref<2xi64, #hipsr.mem<host>>{{$}}
+// CHECK-NEXT: return %[[RESULT]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT: }
+func.func @memref_form_host_space(%ctx: !hipsr.context,
+                                  %extents: memref<2xi64, #hipsr.mem<host>>,
+                                  %init: memref<2xi64, #hipsr.mem<host>>)
+    -> memref<2xi64, #hipsr.mem<host>> {
+  %out = hipsr.compute(%ctx) ins(%extents : memref<2xi64, #hipsr.mem<host>>)
+                             outs(%init : memref<2xi64, #hipsr.mem<host>>) {
+  ^bb0(%body_ctx: !hipsr.context, %in: memref<2xi64, #hipsr.mem<host>>,
+       %dest: memref<2xi64, #hipsr.mem<host>>):
+    hipsr.compute_yield %dest : memref<2xi64, #hipsr.mem<host>>
+  } : memref<2xi64, #hipsr.mem<host>>
+  return %out : memref<2xi64, #hipsr.mem<host>>
+}
+
+// -----
+// Any space is accepted, but a buffer still has to name the one it lives in.
+func.func @memref_without_space(%ctx: !hipsr.context, %init: memref<6xf16>) {
+  // expected-error @+1 {{operand #1 must be variadic of ranked tensor or hipsr memref, but got 'memref<6xf16>'}}
+  hipsr.compute(%ctx) ins() outs(%init : memref<6xf16>) {
+  ^bb0(%body_ctx: !hipsr.context, %dest: memref<6xf16>):
+    hipsr.compute_yield
+  }
+  return
+}
+
+// -----
 // The generic form is invalid because the body has no block.
 func.func @empty_body(%ctx: !hipsr.context) {
   // expected-error @+1 {{failed to verify constraint: region with 1 blocks}}
@@ -243,7 +279,7 @@ func.func @body_uses_parent_value(%ctx: !hipsr.context, %init: tensor<6xf16>) {
 // -----
 // Inputs carry tensor data, so a scalar cannot cross the boundary.
 func.func @non_tensor_input(%ctx: !hipsr.context, %n: index) {
-  // expected-error @+1 {{operand #1 must be variadic of ranked tensor or device memref, but got 'index'}}
+  // expected-error @+1 {{operand #1 must be variadic of ranked tensor or hipsr memref, but got 'index'}}
   hipsr.compute(%ctx) ins(%n : index) outs() {
   ^bb0(%body_ctx: !hipsr.context, %extent: index):
     hipsr.compute_yield


### PR DESCRIPTION
## Summary

`hipsr.compute` and `hipsr.compute_yield` accepted only device memrefs, so a bufferized compute could not hold a buffer anywhere else. Both now accept a ranked tensor or a memref in any of the four `#hipsr.mem` spaces.

## Why

Not every value a compute produces belongs on the device. An extent vector is read on the host, which is where `hipsr.expand` already takes its `shape` operand from, so a compute that computes extents had nowhere to put them.

The looser constraint deliberately still requires a space to be named. `AnyMemRef` would also accept a memref with no space at all, and `OneShotBufferize/invalid.mlir` shows that rejection is load-bearing: a tensor that reaches bufferization without a `#hipsr.mem` encoding becomes a space-less memref, and the operand constraint is what reports it.

This only widens what verifies. No pass or conversion produces a non-device space yet.

## Notes for reviewers

`isAnySpaceMemRef` backs the new constraint. It and the four per-space predicates it generalizes now share one helper, so a single place decides which types name a hipsr space.

Cursor (Claude Opus 5) assisted with the constraint, the predicate and the tests; validated with the LIT suite. I reviewed the result and own every claim here.
