### PR TITLE
fix(pool-alloc): extend lifetimes through buffer aliases

### DIFF
--- a/lib/Dialect/Hipsr/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/Transforms/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(HipsrDialectTransforms PUBLIC
   HipsrDialectIR
   HipConstantsIO  # writeConstantsBinToFileSystem / ConstantEntry
   MLIRBufferizationDialect  # BufferizableOpInterface models
+  MLIRBufferizationTransforms  # BufferViewFlowAnalysis
   MLIRPass
   MLIRTransformUtils
   MLIRFuncDialect

--- a/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
@@ -120,10 +120,15 @@ computeLiveness(PoolDomainOp domain) {
 
   LLVM_DEBUG(DBGS() << "Computing liveness for " << idx << " operations\n");
 
+  struct FoldState {
+    std::optional<size_t> firstWrite;
+    std::optional<size_t> lastUse;
+  };
+
   auto processUser =
-      [&body, &opIndices](Operation *user, Value alias, memref::AllocOp allocOp,
-                          const FailureOr<std::optional<Lifetime>> &current)
-      -> FailureOr<std::optional<Lifetime>> {
+      [&body, &opIndices](
+          Operation *user, Value alias, memref::AllocOp allocOp,
+          const FailureOr<FoldState> &current) -> FailureOr<FoldState> {
     if (failed(current)) {
       return current;
     }
@@ -147,31 +152,37 @@ computeLiveness(PoolDomainOp domain) {
     bool isDpsWrite =
         llvm::is_contained(getHipsrDestinationOperands(user), alias);
 
-    if (current->has_value()) {
-      return std::optional<Lifetime>(Lifetime{
-          isDpsWrite ? std::min((*current)->start, userIdx) : (*current)->start,
-          std::max((*current)->end, userIdx)});
+    FoldState next = *current;
+    if (isDpsWrite) {
+      next.firstWrite = std::min(next.firstWrite.value_or(userIdx), userIdx);
     }
-    if (!isDpsWrite) {
-      allocOp.emitError("buffer used before written - invalid IR "
-                        "(first use is not a DPS destination)");
-      return failure();
-    }
-    return std::optional<Lifetime>(Lifetime{userIdx, userIdx});
+    next.lastUse = std::max(next.lastUse.value_or(userIdx), userIdx);
+    return next;
   };
 
   auto processAllocation =
       [&aliases, &processUser](
           memref::AllocOp allocOp) -> FailureOr<std::optional<Lifetime>> {
     Value buffer = allocOp.getResult();
-    FailureOr<std::optional<Lifetime>> lifetime =
-        std::optional<Lifetime>(std::nullopt);
+    FailureOr<FoldState> state = FoldState{};
     for (Value alias : aliases.resolve(buffer)) {
       for (Operation *user : alias.getUsers()) {
-        lifetime = processUser(user, alias, allocOp, lifetime);
+        state = processUser(user, alias, allocOp, state);
       }
     }
-    return lifetime;
+    if (failed(state)) {
+      return failure();
+    }
+    if (!state->lastUse) {
+      return std::optional<Lifetime>(std::nullopt);
+    }
+    if (!state->firstWrite) {
+      allocOp.emitError("allocation has users but no DPS write - invalid IR "
+                        "(buffer read before it is written)");
+      return failure();
+    }
+    return std::optional<Lifetime>(
+        Lifetime{*state->firstWrite, *state->lastUse});
   };
 
   llvm::DenseMap<Value, Lifetime> lifetimes;

--- a/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
@@ -12,6 +12,7 @@
 #include "mlir/Dialect/Bufferization/Transforms/BufferViewFlowAnalysis.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
@@ -120,19 +121,14 @@ computeLiveness(PoolDomainOp domain) {
 
   LLVM_DEBUG(DBGS() << "Computing liveness for " << idx << " operations\n");
 
-  struct FoldState {
-    std::optional<size_t> firstWrite;
-    std::optional<size_t> lastUse;
-  };
-
   auto processUser =
-      [&body, &opIndices](
-          Operation *user, Value alias, memref::AllocOp allocOp,
-          const FailureOr<FoldState> &current) -> FailureOr<FoldState> {
+      [&body, &opIndices](Operation *user, Value alias, memref::AllocOp allocOp,
+                          const FailureOr<std::optional<Lifetime>> &current)
+      -> FailureOr<std::optional<Lifetime>> {
     if (failed(current)) {
       return current;
     }
-    if (isa<memref::DeallocOp>(user)) {
+    if (isa<memref::DeallocOp, ViewLikeOpInterface>(user)) {
       return current;
     }
     Operation *blockLevelUser = body.findAncestorOpInBlock(*user);
@@ -152,37 +148,52 @@ computeLiveness(PoolDomainOp domain) {
     bool isDpsWrite =
         llvm::is_contained(getHipsrDestinationOperands(user), alias);
 
-    FoldState next = *current;
-    if (isDpsWrite) {
-      next.firstWrite = std::min(next.firstWrite.value_or(userIdx), userIdx);
+    if (current->has_value()) {
+      return std::optional<Lifetime>(Lifetime{
+          isDpsWrite ? std::min((*current)->start, userIdx) : (*current)->start,
+          std::max((*current)->end, userIdx)});
     }
-    next.lastUse = std::max(next.lastUse.value_or(userIdx), userIdx);
-    return next;
+    if (!isDpsWrite) {
+      allocOp.emitError("buffer used before written - invalid IR "
+                        "(first use is not a DPS destination)");
+      return failure();
+    }
+    return std::optional<Lifetime>(Lifetime{userIdx, userIdx});
+  };
+
+  auto blockLevelIndex =
+      [&body, &opIndices](Operation *user) -> std::optional<size_t> {
+    Operation *blockLevelUser = body.findAncestorOpInBlock(*user);
+    if (!blockLevelUser) {
+      return std::nullopt;
+    }
+    auto it = opIndices.find(blockLevelUser);
+    if (it == opIndices.end()) {
+      return std::nullopt;
+    }
+    return it->second;
   };
 
   auto processAllocation =
-      [&aliases, &processUser](
+      [&aliases, &processUser, &blockLevelIndex](
           memref::AllocOp allocOp) -> FailureOr<std::optional<Lifetime>> {
     Value buffer = allocOp.getResult();
-    FailureOr<FoldState> state = FoldState{};
+    llvm::SmallVector<std::pair<Value, Operation *>> users;
     for (Value alias : aliases.resolve(buffer)) {
       for (Operation *user : alias.getUsers()) {
-        state = processUser(user, alias, allocOp, state);
+        users.emplace_back(alias, user);
       }
     }
-    if (failed(state)) {
-      return failure();
+    llvm::stable_sort(
+        users, [&blockLevelIndex](const auto &lhs, const auto &rhs) {
+          return blockLevelIndex(lhs.second) < blockLevelIndex(rhs.second);
+        });
+    FailureOr<std::optional<Lifetime>> lifetime =
+        std::optional<Lifetime>(std::nullopt);
+    for (auto [alias, user] : users) {
+      lifetime = processUser(user, alias, allocOp, lifetime);
     }
-    if (!state->lastUse) {
-      return std::optional<Lifetime>(std::nullopt);
-    }
-    if (!state->firstWrite) {
-      allocOp.emitError("allocation has users but no DPS write - invalid IR "
-                        "(buffer read before it is written)");
-      return failure();
-    }
-    return std::optional<Lifetime>(
-        Lifetime{*state->firstWrite, *state->lastUse});
+    return lifetime;
   };
 
   llvm::DenseMap<Value, Lifetime> lifetimes;

--- a/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
@@ -9,6 +9,7 @@
 #include "hip/Dialect/Hipsr/IR/HipsrOps.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Bufferization/Transforms/BufferViewFlowAnalysis.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/BuiltinOps.h"
 
@@ -106,7 +107,10 @@ llvm::DenseMap<Value, size_t> mapAllocIndices(Block &body) {
   return indices;
 }
 
-llvm::DenseMap<Value, Lifetime> computeLiveness(Block &body) {
+llvm::DenseMap<Value, Lifetime> computeLiveness(PoolDomainOp domain) {
+  Block &body = domain.getBody().front();
+  BufferViewFlowAnalysis aliases(domain);
+
   llvm::DenseMap<Operation *, size_t> opIndices;
   size_t idx = 0;
   for (Operation &op : body) {
@@ -124,18 +128,23 @@ llvm::DenseMap<Value, Lifetime> computeLiveness(Block &body) {
     std::optional<size_t> end;
     Operation *firstWrite = nullptr;
     Operation *lastUse = nullptr;
-    for (Operation *user : buffer.getUsers()) {
-      Operation *blockLevelUser = body.findAncestorOpInBlock(*user);
-      assert(blockLevelUser && "alloc escapes its IsolatedFromAbove domain");
-      size_t userIdx = opIndices.lookup(blockLevelUser);
-      if (llvm::is_contained(getHipsrDestinationOperands(user), buffer) &&
-          (!start || userIdx < *start)) {
-        start = userIdx;
-        firstWrite = blockLevelUser;
-      }
-      if (!end || userIdx > *end) {
-        end = userIdx;
-        lastUse = blockLevelUser;
+    for (Value alias : aliases.resolve(buffer)) {
+      for (Operation *user : alias.getUsers()) {
+        if (isa<memref::DeallocOp>(user)) {
+          continue;
+        }
+        Operation *blockLevelUser = body.findAncestorOpInBlock(*user);
+        assert(blockLevelUser && "alloc escapes its IsolatedFromAbove domain");
+        size_t userIdx = opIndices.lookup(blockLevelUser);
+        if (llvm::is_contained(getHipsrDestinationOperands(user), alias) &&
+            (!start || userIdx < *start)) {
+          start = userIdx;
+          firstWrite = blockLevelUser;
+        }
+        if (!end || userIdx > *end) {
+          end = userIdx;
+          lastUse = blockLevelUser;
+        }
       }
     }
     if (start) {
@@ -385,7 +394,7 @@ struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
                         << domain.getDomainId() << ")\n");
       ++domainOrdinal;
       Block &body = domain.getBody().front();
-      llvm::DenseMap<Value, Lifetime> lifetimes = computeLiveness(body);
+      llvm::DenseMap<Value, Lifetime> lifetimes = computeLiveness(domain);
       Operation *insertionPoint = findInsertionPoint(body, lifetimes);
       if (!insertionPoint) {
         domain.emitError(

--- a/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
@@ -107,7 +107,8 @@ llvm::DenseMap<Value, size_t> mapAllocIndices(Block &body) {
   return indices;
 }
 
-llvm::DenseMap<Value, Lifetime> computeLiveness(PoolDomainOp domain) {
+FailureOr<llvm::DenseMap<Value, Lifetime>>
+computeLiveness(PoolDomainOp domain) {
   Block &body = domain.getBody().front();
   BufferViewFlowAnalysis aliases(domain);
 
@@ -117,44 +118,87 @@ llvm::DenseMap<Value, Lifetime> computeLiveness(PoolDomainOp domain) {
     opIndices[&op] = idx++;
   }
 
+  LLVM_DEBUG(DBGS() << "Computing liveness for " << idx << " operations\n");
+
+  auto processUser =
+      [&body, &opIndices](Operation *user, Value alias, memref::AllocOp allocOp,
+                          const FailureOr<std::optional<Lifetime>> &current)
+      -> FailureOr<std::optional<Lifetime>> {
+    if (failed(current)) {
+      return current;
+    }
+    if (isa<memref::DeallocOp>(user)) {
+      return current;
+    }
+    Operation *blockLevelUser = body.findAncestorOpInBlock(*user);
+    if (!blockLevelUser) {
+      allocOp.emitError("allocation escapes IsolatedFromAbove domain - "
+                        "user not in domain block");
+      return failure();
+    }
+    auto it = opIndices.find(blockLevelUser);
+    if (it == opIndices.end()) {
+      allocOp.emitError(
+          "internal error: block-level user not in opIndices map");
+      return failure();
+    }
+    size_t userIdx = it->second;
+
+    bool isDpsWrite =
+        llvm::is_contained(getHipsrDestinationOperands(user), alias);
+
+    if (current->has_value()) {
+      return std::optional<Lifetime>(Lifetime{
+          isDpsWrite ? std::min((*current)->start, userIdx) : (*current)->start,
+          std::max((*current)->end, userIdx)});
+    }
+    if (!isDpsWrite) {
+      allocOp.emitError("buffer used before written - invalid IR "
+                        "(first use is not a DPS destination)");
+      return failure();
+    }
+    return std::optional<Lifetime>(Lifetime{userIdx, userIdx});
+  };
+
+  auto processAllocation =
+      [&aliases, &processUser](
+          memref::AllocOp allocOp) -> FailureOr<std::optional<Lifetime>> {
+    Value buffer = allocOp.getResult();
+    FailureOr<std::optional<Lifetime>> lifetime =
+        std::optional<Lifetime>(std::nullopt);
+    for (Value alias : aliases.resolve(buffer)) {
+      for (Operation *user : alias.getUsers()) {
+        lifetime = processUser(user, alias, allocOp, lifetime);
+      }
+    }
+    return lifetime;
+  };
+
   llvm::DenseMap<Value, Lifetime> lifetimes;
+  size_t numAllocations = 0;
   for (Operation &op : body) {
     auto allocOp = dyn_cast<memref::AllocOp>(&op);
     if (!allocOp) {
       continue;
     }
-    Value buffer = allocOp.getResult();
-    std::optional<size_t> start;
-    std::optional<size_t> end;
-    Operation *firstWrite = nullptr;
-    Operation *lastUse = nullptr;
-    for (Value alias : aliases.resolve(buffer)) {
-      for (Operation *user : alias.getUsers()) {
-        if (isa<memref::DeallocOp>(user)) {
-          continue;
-        }
-        Operation *blockLevelUser = body.findAncestorOpInBlock(*user);
-        assert(blockLevelUser && "alloc escapes its IsolatedFromAbove domain");
-        size_t userIdx = opIndices.lookup(blockLevelUser);
-        if (llvm::is_contained(getHipsrDestinationOperands(user), alias) &&
-            (!start || userIdx < *start)) {
-          start = userIdx;
-          firstWrite = blockLevelUser;
-        }
-        if (!end || userIdx > *end) {
-          end = userIdx;
-          lastUse = blockLevelUser;
-        }
-      }
+    FailureOr<std::optional<Lifetime>> lifetimeOrErr =
+        processAllocation(allocOp);
+    if (failed(lifetimeOrErr)) {
+      return failure();
     }
-    if (start) {
-      lifetimes[buffer] = Lifetime{*start, *end};
-      LLVM_DEBUG(DBGS() << "alloc #" << opIndices.lookup(&op) << " lifetime ["
-                        << *start << "," << *end << "]: first write "
-                        << firstWrite->getName() << ", last use "
-                        << lastUse->getName() << "\n");
+    if (lifetimeOrErr->has_value()) {
+      Lifetime lifetime = **lifetimeOrErr;
+      lifetimes[allocOp.getResult()] = lifetime;
+      ++numAllocations;
+      LLVM_DEBUG(DBGS() << "  " << allocOp.getResult() << ": ["
+                        << lifetime.start << ", " << lifetime.end << "]\n");
+    } else {
+      allocOp.emitWarning("pool-allocs: allocation has no users (dead code?)");
     }
   }
+
+  LLVM_DEBUG(DBGS() << "Found " << numAllocations << " live allocations\n");
+
   return lifetimes;
 }
 
@@ -394,7 +438,13 @@ struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
                         << domain.getDomainId() << ")\n");
       ++domainOrdinal;
       Block &body = domain.getBody().front();
-      llvm::DenseMap<Value, Lifetime> lifetimes = computeLiveness(domain);
+      FailureOr<llvm::DenseMap<Value, Lifetime>> lifetimesOrErr =
+          computeLiveness(domain);
+      if (failed(lifetimesOrErr)) {
+        signalPassFailure();
+        return;
+      }
+      llvm::DenseMap<Value, Lifetime> lifetimes = std::move(*lifetimesOrErr);
       Operation *insertionPoint = findInsertionPoint(body, lifetimes);
       if (!insertionPoint) {
         domain.emitError(

--- a/test/lit/Dialect/Hipsr/Transforms/PoolAlloc/alias.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PoolAlloc/alias.mlir
@@ -1,0 +1,111 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s -split-input-file -hipsr-pool-alloc | FileCheck %s
+
+// CHECK-LABEL: func.func @subview_extends_lifetime
+// CHECK: %[[C8192A:.+]] = arith.constant 8192 : index
+// CHECK-NEXT: %[[C256A:.+]] = arith.constant 256 : index
+// CHECK-NEXT: %[[C255A:.+]] = arith.constant 255 : index
+// CHECK-NEXT: %[[N0:.+]] = arith.addi %[[C8192A]], %[[C255A]] : index
+// CHECK-NEXT: %[[D0:.+]] = arith.divui %[[N0]], %[[C256A]] : index
+// CHECK-NEXT: %[[G0:.+]] = arith.muli %[[D0]], %[[C256A]] : index
+// CHECK-NEXT: %[[C8192B:.+]] = arith.constant 8192 : index
+// CHECK-NEXT: %[[C256B:.+]] = arith.constant 256 : index
+// CHECK-NEXT: %[[C255B:.+]] = arith.constant 255 : index
+// CHECK-NEXT: %[[N1:.+]] = arith.addi %[[C8192B]], %[[C255B]] : index
+// CHECK-NEXT: %[[D1:.+]] = arith.divui %[[N1]], %[[C256B]] : index
+// CHECK-NEXT: %[[G1:.+]] = arith.muli %[[D1]], %[[C256B]] : index
+// CHECK-NEXT: %[[OFF0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[POOLSZ:.+]] = arith.addi %[[G0]], %[[G1]] : index
+// CHECK-NEXT: %[[POOL:.+]] = hipsr.get_pool(%{{.+}}, %[[POOLSZ]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V0:.+]] = memref.view %[[POOL]][%[[OFF0]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V1:.+]] = memref.view %[[POOL]][%[[G0]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[SUB:.+]] = memref.subview %[[V0]]
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} :{{.*}}) outs(%[[V0]] :{{.*}})
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} :{{.*}}) outs(%[[V1]] :{{.*}})
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%[[SUB]], %[[SUB]] :{{.*}}) outs(%{{.+}} :{{.*}})
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%[[V1]], %[[V1]] :{{.*}}) outs(%{{.+}} :{{.*}})
+// CHECK-NOT: memref.alloc
+func.func @subview_extends_lifetime(%ctx: !hipsr.context,
+                                    %in: memref<4x1024xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
+    %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    %a2 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    %v = memref.subview %a1[0, 0] [2, 1024] [1, 1] :
+        memref<4x1024xf16, #hipsr.mem<device>> to
+        memref<2x1024xf16, strided<[1024, 1]>, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a2 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%v, %v : memref<2x1024xf16, strided<[1024, 1]>, #hipsr.mem<device>>, memref<2x1024xf16, strided<[1024, 1]>, #hipsr.mem<device>>) outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a2, %a2 : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  } {domain_id = 0 : i64}
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @cast_extends_lifetime
+// CHECK: %[[G0:.+]] = arith.muli %{{.+}}, %{{.+}} : index
+// CHECK: %[[G1:.+]] = arith.muli %{{.+}}, %{{.+}} : index
+// CHECK-NEXT: %[[OFF0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[POOLSZ:.+]] = arith.addi %[[G0]], %[[G1]] : index
+// CHECK-NEXT: %[[POOL:.+]] = hipsr.get_pool(%{{.+}}, %[[POOLSZ]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V0:.+]] = memref.view %[[POOL]][%[[OFF0]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V1:.+]] = memref.view %[[POOL]][%[[G0]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[CAST:.+]] = memref.cast %[[V0]]
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} :{{.*}}) outs(%[[V0]] :{{.*}})
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} :{{.*}}) outs(%[[V1]] :{{.*}})
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%[[CAST]], %[[CAST]] :{{.*}}) outs(%{{.+}} :{{.*}})
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%[[V1]], %[[V1]] :{{.*}}) outs(%{{.+}} :{{.*}})
+// CHECK-NOT: memref.alloc
+func.func @cast_extends_lifetime(%ctx: !hipsr.context,
+                                 %in: memref<4x1024xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
+    %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    %a2 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    %c = memref.cast %a1 : memref<4x1024xf16, #hipsr.mem<device>> to memref<?x1024xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a2 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%c, %c : memref<?x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a2, %a2 : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  } {domain_id = 0 : i64}
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @collapse_shape_extends_lifetime
+// CHECK: %[[G0:.+]] = arith.muli %{{.+}}, %{{.+}} : index
+// CHECK: %[[G1:.+]] = arith.muli %{{.+}}, %{{.+}} : index
+// CHECK-NEXT: %[[OFF0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[POOLSZ:.+]] = arith.addi %[[G0]], %[[G1]] : index
+// CHECK-NEXT: %[[POOL:.+]] = hipsr.get_pool(%{{.+}}, %[[POOLSZ]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V0:.+]] = memref.view %[[POOL]][%[[OFF0]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[V1:.+]] = memref.view %[[POOL]][%[[G0]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[FLAT:.+]] = memref.collapse_shape %[[V0]]
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} :{{.*}}) outs(%[[V0]] :{{.*}})
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} :{{.*}}) outs(%[[V1]] :{{.*}})
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%[[FLAT]], %[[FLAT]] :{{.*}}) outs(%{{.+}} :{{.*}})
+// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%[[V1]], %[[V1]] :{{.*}}) outs(%{{.+}} :{{.*}})
+// CHECK-NOT: memref.alloc
+func.func @collapse_shape_extends_lifetime(%ctx: !hipsr.context,
+                                           %in: memref<4x1024xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
+    %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    %a2 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+    %f = memref.collapse_shape %a1 [[0, 1]] :
+        memref<4x1024xf16, #hipsr.mem<device>> into memref<4096xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a2 : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%f, %f : memref<4096xf16, #hipsr.mem<device>>, memref<4096xf16, #hipsr.mem<device>>) outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.add(%dctx) ins(%a2, %a2 : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  } {domain_id = 0 : i64}
+  return
+}

--- a/test/lit/Dialect/Hipsr/Transforms/PoolAlloc/invalid.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PoolAlloc/invalid.mlir
@@ -31,10 +31,10 @@ func.func @no_alloc(%ctx: !hipsr.context,
 
 func.func @alloc_without_dps_write(%ctx: !hipsr.context,
                                    %in: memref<4x1024xf16, #hipsr.mem<device>>) {
-  // expected-error@+1 {{hipsr-pool-alloc: pool_domain has no poolable allocation}}
   hipsr.pool_domain(%ctx, %in
       : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
   ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
+    // expected-error@+1 {{allocation has users but no DPS write}}
     %unwritten = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
     hipsr.add(%dctx) ins(%unwritten, %unwritten
                              : memref<4x1024xf16, #hipsr.mem<device>>,

--- a/test/lit/Dialect/Hipsr/Transforms/PoolAlloc/invalid.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PoolAlloc/invalid.mlir
@@ -34,7 +34,7 @@ func.func @alloc_without_dps_write(%ctx: !hipsr.context,
   hipsr.pool_domain(%ctx, %in
       : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
   ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
-    // expected-error@+1 {{allocation has users but no DPS write}}
+    // expected-error@+1 {{buffer used before written}}
     %unwritten = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
     hipsr.add(%dctx) ins(%unwritten, %unwritten
                              : memref<4x1024xf16, #hipsr.mem<device>>,


### PR DESCRIPTION
## Summary

`hipsr-pool-alloc` now follows buffer aliases when computing lifetimes, so two allocations that are simultaneously live through a view are no longer merged into the same pool slot.

## Related issue or design

[wcy123/onnx-hipdnn-ep#136](https://github.com/wcy123/onnx-hipdnn-ep/issues/136) — Step 1 of `doc/pass-09-pool-alloc.md`.

## Why

`computeLiveness` only inspected the direct users of each `memref.alloc` result. Once a buffer is wrapped in `memref.subview` / `memref.cast` / `memref.collapse_shape`, the real reads and writes behind the view are invisible and the lifetime ends early. That is a correctness problem rather than a missed optimization: two allocations that do overlap in time get judged disjoint and end up sharing the same pool bytes.

## What

- Build one `BufferViewFlowAnalysis` per `hipsr.pool_domain` and walk the users of every alias `resolve()` reports. `resolve()` includes the buffer itself, so the previously covered direct users stay covered.
- The DPS first-write probe compares against the alias instead of the original buffer, and `memref.dealloc` users no longer extend a lifetime.
- Link `MLIRBufferizationTransforms`, which is where `BufferViewFlowAnalysis` lives.

The analysis is rooted at the domain rather than the enclosing function: `Hipsr_PoolDomainOp` is `IsolatedFromAbove`, so aliases cannot escape it, and rebuilding per domain keeps the analysis valid across the alloc-to-view rewrite this pass performs on its way out.

Error handling and diagnostics are unchanged. An allocation with no DPS write is still excluded silently, because `memref.copy` writes fall into that bucket and `hip-promote-strided-operands` produces exactly that shape.

## Test plan

- [x] New `test/lit/Dialect/Hipsr/Transforms/PoolAlloc/alias.mlir`: in each of the `subview` / `cast` / `collapse_shape` cases the first buffer is read only through its alias, after the second buffer has been written. All three now produce two pool groups with distinct offsets and an `arith.addi` pool-size accumulation.
- [x] Reverting `computeLiveness` to the direct-users-only walk collapses all three cases into a single group sharing offset 0, which confirms the new tests catch the bug.
- [x] `ninja check-hip-mlir-lit`: 380 of 393 passed. The single failure, `Conversion/onnx-to-hip/test_gather_block_quantized.mlir`, reproduces on `main` without this change (assertion in `BuiltinAttributes.cpp:371`).
- [x] `pre-commit run --all-files` clean.

## Notes for reviewers

Scope is Step 1 of the design doc only; Steps 2-7 are already in tree and untouched.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
