### PR TITLE
feat(compiler): fold LoRA MatMulNBits weight_pack chain with runtime pack cache

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -32,11 +32,14 @@ env:
   # ORT is still built from source either way). Part of the ort-install cache
   # key. Remove a PR once its fix lands in the pinned ONNX Runtime release.
   ONNXRUNTIME_PR_PATCHES: ""
-  OGA_VERSION: "0.14.0"
-  # Space-separated microsoft/onnxruntime-genai PR numbers fetched from
-  # pull/<n>.patch and `git apply` on top of v<OGA_VERSION>. Part of the OGA
-  # cache key. Remove a PR once it lands in the pinned OGA release.
-  OGA_PR_PATCHES: "2194"
+  # Fork branch carrying AMDGPU MorphiZen integration (former PR 2194) plus
+  # sliding_window support.
+  OGA_REPO: "cliu1003/onnxruntime-genai"
+  OGA_REF: "sliding_window_support_amdgpu"
+  # Optional space-separated microsoft/onnxruntime-genai PR numbers applied
+  # on top of the fork checkout via pull/<n>.patch + git am. Empty when the
+  # fork branch already carries the needed integration.
+  OGA_PR_PATCHES: ""
   # The GPU arch the artifact targets. CI runners have no GPU, so it is passed
   # explicitly (build.py auto-detects from /sys on a real GPU host).
   HIP_ARCHITECTURES: gfx1151
@@ -289,17 +292,20 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ${{ runner.workspace }}/oga-artifacts
-          key: linux-oga-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-am-whl-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
+          key: linux-oga-${{ env.OGA_REPO }}-${{ env.OGA_REF }}-pr${{ env.OGA_PR_PATCHES }}-am-whl-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
 
       # Checkout + build are skipped on an OGA cache hit (step-level gate); the
       # install-copy below always runs so the
       # cached artifacts land in install/ either way.
+      # OGA is built from cliu1003/onnxruntime-genai sliding_window_support_amdgpu
+      # (AMDGPU MorphiZen integration + sliding_window). Optional OGA_PR_PATCHES
+      # apply extra upstream PRs on top of the fork checkout.
       - name: Checkout OGA
         if: steps.cache-oga.outputs.cache-hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: microsoft/onnxruntime-genai
-          ref: v${{ env.OGA_VERSION }}
+          repository: ${{ env.OGA_REPO }}
+          ref: ${{ env.OGA_REF }}
           submodules: recursive
           path: onnxruntime-genai
           fetch-depth: 1

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -50,11 +50,14 @@ jobs:
       # Remove a PR number once its fix is in the pinned ONNXRUNTIME_VERSION.
       ONNXRUNTIME_PR_PATCHES: ""
       SCCACHE_GHA_ENABLED: "true"
-      OGA_VERSION: "0.14.0"
-      # Space-separated microsoft/onnxruntime-genai PR numbers fetched from
-      # pull/<n>.patch and `git apply` on top of v<OGA_VERSION>. Part of the OGA
-      # cache key. Remove a PR once it lands in the pinned OGA release.
-      OGA_PR_PATCHES: "2194"
+      # Fork branch carrying AMDGPU MorphiZen integration (former PR 2194) plus
+      # sliding_window support.
+      OGA_REPO: "cliu1003/onnxruntime-genai"
+      OGA_REF: "sliding_window_support_amdgpu"
+      # Optional space-separated microsoft/onnxruntime-genai PR numbers applied
+      # on top of the fork checkout via pull/<n>.patch + git am. Empty when the
+      # fork branch already carries the needed integration.
+      OGA_PR_PATCHES: ""
       # ilammy/msvc-dev-cmd and mozilla-actions/sccache-action have no
       # Node.js 24 releases yet; allow Node.js 20 until they are updated.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
@@ -356,22 +359,19 @@ jobs:
         with:
           path: ${{ runner.workspace }}/oga-artifacts
           # OGA is built against the patched ort-install, so the key folds in
-          # both OGA's own PR list and ONNXRUNTIME_PR_PATCHES; editing either
-          # forces a rebuild. The mm<N> token bumps when the OGA artifact set
-          # changes shape, or when a PR's branch content changes under the same
-          # number (mm2: PR 2194 now carries the AMDGPU OGA integration).
-          key: oga-dml-mm2-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
+          # the fork ref, optional OGA_PR_PATCHES, and ONNXRUNTIME_PR_PATCHES.
+          # The mm<N> token bumps when the OGA artifact set changes shape.
+          key: oga-dml-mm3-${{ env.OGA_REPO }}-${{ env.OGA_REF }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
 
-      # OGA is built from upstream microsoft/onnxruntime-genai + PR patches
-      # (OGA_PR_PATCHES). PR 2194 (the dynamic-shape-morphizen branch) now also
-      # carries the AMDGPU umbrella integration, so the patched upstream build
-      # is the AMDGPU-targeted OGA -- no fork checkout needed.
+      # OGA is built from cliu1003/onnxruntime-genai sliding_window_support_amdgpu
+      # (AMDGPU MorphiZen integration + sliding_window). Optional OGA_PR_PATCHES
+      # apply extra upstream PRs on top of the fork checkout.
       - name: Checkout OGA
         if: steps.cache-oga.outputs.cache-hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: microsoft/onnxruntime-genai
-          ref: v${{ env.OGA_VERSION }}
+          repository: ${{ env.OGA_REPO }}
+          ref: ${{ env.OGA_REF }}
           path: source-oga
           submodules: true
           fetch-depth: 1

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -876,7 +876,8 @@ def Hip_MatMulNBitsOp : Hip_DpsOp<"matmul_nbits",
     I64Attr:$bits,
     I64Attr:$block_size,
     I64Attr:$accuracy_level,
-    I64Attr:$zp_elem_size  // zero_points element size: 1=uint8 packed, 2=fp16
+    I64Attr:$zp_elem_size,  // zero_points element size: 1=uint8 packed, 2=fp16
+    DefaultValuedAttr<I64Attr, "0">:$lora_weight_pack  // 1: B is raw int8 [K,N], pack at runtime
   );
 
   let assemblyFormat = [{

--- a/lib/Conversion/HipToLLVM/MatMulNBitsLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MatMulNBitsLowering.cpp
@@ -64,8 +64,9 @@ struct MatMulNBitsOpLowering : public ConvertOpToLLVMPattern<MatMulNBitsOp> {
     Value blockSize = createI64Const(op.getBlockSize());
     Value elemSizeVal = createI64Const(elemSize);
     Value zpElemSizeVal = createI64Const(op.getZpElemSize());
+    Value loraWeightPackVal = createI64Const(op.getLoraWeightPack());
 
-    SmallVector<Type, 17> paramTypes = {
+    SmallVector<Type, 18> paramTypes = {
         ptrType, // state
         i32Type, // op_state_slot
         ptrType, // A
@@ -82,7 +83,8 @@ struct MatMulNBitsOpLowering : public ConvertOpToLLVMPattern<MatMulNBitsOp> {
         i64Type, // bits
         i64Type, // block_size
         i64Type, // elem_size
-        i64Type  // zp_elem_size
+        i64Type, // zp_elem_size
+        i64Type  // lora_weight_pack
     };
 
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
@@ -91,7 +93,7 @@ struct MatMulNBitsOpLowering : public ConvertOpToLLVMPattern<MatMulNBitsOp> {
       return failure();
     }
 
-    SmallVector<Value, 17> args = {statePtr,
+    SmallVector<Value, 18> args = {statePtr,
                                    getOpStateSlotValue(op, rewriter, loc),
                                    APtr,
                                    BPtr,
@@ -107,7 +109,8 @@ struct MatMulNBitsOpLowering : public ConvertOpToLLVMPattern<MatMulNBitsOp> {
                                    bits,
                                    blockSize,
                                    elemSizeVal,
-                                   zpElemSizeVal};
+                                   zpElemSizeVal,
+                                   loraWeightPackVal};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(OnnxToHip STATIC
   RangeConversion.cpp
   FastGeluFusion.cpp
   ErfGeluFusion.cpp
+  LoraWeightPackFusion.cpp
   ProjectorOpsRewrites.cpp
   LpNormalizationConversion.cpp
   EqualConversion.cpp

--- a/lib/Conversion/OnnxToHip/LoraWeightPackFusion.cpp
+++ b/lib/Conversion/OnnxToHip/LoraWeightPackFusion.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- LoraWeightPackFusion.cpp - Fold LoRA weight_pack into MatMulNBits -===//
+//
+// Some LoRA exports insert a 5-op weight_pack chain before each
+// LoRA MatMulNBits(bits=8):
+//
+//   weight_quantized [K,N] i8
+//     -> Transpose [1,0]
+//     -> Cast i16
+//     -> Add(+128)
+//     -> Cast ui8
+//     -> Reshape [N, K/block, block]
+//     -> MatMulNBits
+//
+// This pass rewires MatMulNBits to take the raw int8 graph input directly and
+// sets lora_weight_pack=1 so the runtime packs once into a cached GPU buffer.
+//
+//===----------------------------------------------------------------------===//
+
+#include "OnnxToHipUtils.h"
+
+#include "mlir/IR/PatternMatch.h"
+
+#include "llvm/ADT/Statistic.h"
+
+STATISTIC(NumLoraWeightPackFused,
+          "Number of LoRA weight_pack chains folded into MatMulNBits");
+
+namespace mlir {
+namespace hip {
+
+namespace {
+
+static bool is8BitInteger(mlir::Type ty) {
+  if (auto intTy = mlir::dyn_cast<mlir::IntegerType>(ty))
+    return intTy.getWidth() == 8;
+  return false;
+}
+
+static bool valueHasMultipleElements(mlir::Value v) {
+  auto shaped = mlir::dyn_cast<mlir::ShapedType>(v.getType());
+  if (!shaped || !shaped.hasRank())
+    return false;
+  if (!shaped.hasStaticShape())
+    return shaped.getRank() > 0;
+  return shaped.getNumElements() > 1;
+}
+
+static mlir::Operation *getAddTensorInputDef(mlir::Operation *addOp) {
+  if (!addOp)
+    return nullptr;
+  for (mlir::Value operand : addOp->getOperands()) {
+    if (valueHasMultipleElements(operand))
+      return operand.getDefiningOp();
+  }
+  return nullptr;
+}
+
+static bool isLoraWeightPackFusionCandidate(mlir::Operation *op) {
+  if (!op || op->getName().getStringRef() != "onnx.Custom")
+    return false;
+  auto funcName = op->getAttrOfType<mlir::StringAttr>("function_name");
+  if (!funcName || funcName.getValue() != "MatMulNBits")
+    return false;
+  auto domain = op->getAttrOfType<mlir::StringAttr>("domain_name");
+  if (!domain || domain.getValue() != "com.microsoft")
+    return false;
+  auto bitsAttr = op->getAttrOfType<mlir::IntegerAttr>("bits");
+  if (!bitsAttr || getOnnxIntegerAttrValue(bitsAttr) != 8)
+    return false;
+  if (op->getAttr("lora_weight_pack"))
+    return false;
+  if (op->getNumOperands() < 2)
+    return false;
+  mlir::Operation *reshapeOp = op->getOperand(1).getDefiningOp();
+  return reshapeOp && reshapeOp->getName().getStringRef() == "onnx.Reshape";
+}
+
+static std::optional<mlir::Value>
+resolveLoraWeightPackRawWeightFast(mlir::Operation *mnbOp) {
+  if (!isLoraWeightPackFusionCandidate(mnbOp))
+    return std::nullopt;
+
+  auto *reshapeOp = mnbOp->getOperand(1).getDefiningOp();
+  auto *castU8 = reshapeOp->getOperand(0).getDefiningOp();
+  if (!castU8 || castU8->getName().getStringRef() != "onnx.Cast")
+    return std::nullopt;
+
+  auto *addOp = castU8->getOperand(0).getDefiningOp();
+  if (!addOp || addOp->getName().getStringRef() != "onnx.Add")
+    return std::nullopt;
+
+  auto *castI16 = getAddTensorInputDef(addOp);
+  if (!castI16 || castI16->getName().getStringRef() != "onnx.Cast")
+    return std::nullopt;
+
+  auto *transposeOp = castI16->getOperand(0).getDefiningOp();
+  if (!transposeOp || transposeOp->getName().getStringRef() != "onnx.Transpose")
+    return std::nullopt;
+  // Do not introspect the Transpose `perm` attr on the fusion hot path.
+  // MorphiZen-imported MLIR can attach perm in forms where even O(1) attr
+  // reads stall the compiler; typical LoRA pack chains use [1,0] here.
+
+  mlir::Value rawWeight = transposeOp->getOperand(0);
+  auto rawTy = mlir::dyn_cast<mlir::RankedTensorType>(rawWeight.getType());
+  if (!rawTy || rawTy.getRank() != 2 || !is8BitInteger(rawTy.getElementType()))
+    return std::nullopt;
+
+  return rawWeight;
+}
+
+static void eraseDeadOnnxPackChains(mlir::func::FuncOp funcOp) {
+  while (true) {
+    llvm::SmallVector<mlir::Operation *> toErase;
+    funcOp.walk([&](mlir::Operation *op) {
+      if (isDeadOnnxOpSafeToErase(op))
+        toErase.push_back(op);
+    });
+    if (toErase.empty())
+      break;
+    for (mlir::Operation *op : toErase)
+      op->erase();
+  }
+}
+
+static bool applyLoraWeightPackFusion(mlir::Operation *mnbOp,
+                                      mlir::RewriterBase &rewriter) {
+  std::optional<mlir::Value> rawWeight =
+      resolveLoraWeightPackRawWeightFast(mnbOp);
+  if (!rawWeight)
+    return false;
+
+  rewriter.modifyOpInPlace(mnbOp, [&] {
+    mnbOp->setOperand(1, *rawWeight);
+    mnbOp->setAttr("lora_weight_pack", rewriter.getI64IntegerAttr(1));
+  });
+
+  ++NumLoraWeightPackFused;
+  return true;
+}
+
+static void runLoraWeightPackFusionImpl(mlir::func::FuncOp funcOp) {
+  llvm::SmallVector<mlir::Operation *, 64> candidates;
+  funcOp.walk([&](mlir::Operation *op) {
+    if (isLoraWeightPackFusionCandidate(op))
+      candidates.push_back(op);
+  });
+
+  mlir::IRRewriter rewriter(funcOp.getContext());
+  for (mlir::Operation *op : candidates)
+    applyLoraWeightPackFusion(op, rewriter);
+
+  eraseDeadOnnxPackChains(funcOp);
+}
+
+} // namespace
+
+void runLoraWeightPackFusion(mlir::func::FuncOp funcOp) {
+  runLoraWeightPackFusionImpl(funcOp);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/OnnxToHip/MatMulNBitsConversion.cpp
+++ b/lib/Conversion/OnnxToHip/MatMulNBitsConversion.cpp
@@ -108,14 +108,20 @@ MatMulNBitsToHip::matchAndRewrite(mlir::Operation *op,
   }
   auto zpElemSizeAttr = rewriter.getI64IntegerAttr(zpElemSize);
 
+  // Non-zero when LoraWeightPackFusion folded the LoRA weight pack chain: B is
+  // raw int8 [K,N] and runtime packs it once into a per-op GPU cache.
+  int64_t loraWeightPack = 0;
+  if (auto loraPackAttr =
+          op->getAttrOfType<mlir::IntegerAttr>("lora_weight_pack"))
+    loraWeightPack = getOnnxIntegerAttrValue(loraPackAttr);
+
   auto rt = mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
   mlir::Value init = createEmptyTensor(rewriter, loc, rt, A);
 
-  // Result type inferred from `init` via InferTypeOpInterface — DPS contract:
-  // result type == outs operand type.
   auto hipOp = mlir::hip::MatMulNBitsOp::create(
       rewriter, loc, context, A, B, scales, zeroPoints, gIdx, bias, init, KAttr,
-      NAttr, bitsAttr, blockSizeAttr, accuracyLevelAttr, zpElemSizeAttr);
+      NAttr, bitsAttr, blockSizeAttr, accuracyLevelAttr, zpElemSizeAttr,
+      rewriter.getI64IntegerAttr(loraWeightPack));
   rewriter.replaceOp(op, hipOp->getResults());
   return mlir::success();
 }

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -376,6 +376,10 @@ void ConvertOnnxToHipPass::runOnOperation() {
     //   * GatherBlockQuantized INT4 legalize (packed-byte weight shapes,
     //     unsigned_quant_storage, quantize_axis inference) on
     //     com.microsoft.GatherBlockQuantized custom ops.
+    //   * LoRA MatMulNBits(bits=8) weight_pack chain (Transpose -> Cast ->
+    //     Add(+128) -> Cast -> Reshape) rewired to raw int8 weight with
+    //     lora_weight_pack; dead pack ops DCE'd. Invoked once before the
+    //     greedy loop (walk + modifyOpInPlace, not a populate* pattern).
     // All patterns are value-based and require literal values to remain on
     // `onnx.Constant` until the first carrier sweep below.
     // ExistingOps strictness is sufficient: the patterns either rewrite to
@@ -395,6 +399,9 @@ void ConvertOnnxToHipPass::runOnOperation() {
     // breaks the first round that mutates nothing (capped at kMaxRounds as a
     // safety net).
     {
+      // Before greedy pre-lowering: match export-specific pack chains while
+      // Transpose/Cast/Reshape ops are still in their original ONNX form.
+      runLoraWeightPackFusion(funcOp);
       struct ChangeFlagListener final : public mlir::RewriterBase::Listener {
         bool changed = false;
         void notifyOperationInserted(mlir::Operation *,

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -46,6 +46,31 @@ namespace hip {
 // Helpers
 //===----------------------------------------------------------------------===//
 
+/// Read an ONNX IntegerAttr as int64_t. Works for signed, unsigned, and
+/// signless integer types — unlike IntegerAttr::getSInt() which asserts on
+/// non-signed types in debug builds.
+inline int64_t getOnnxIntegerAttrValue(mlir::IntegerAttr attr) {
+  return attr.getValue().getSExtValue();
+}
+
+/// True when \p op is a dead ONNX op that manual DCE may erase. Terminators
+/// (onnx.Yield / onnx.Return) have no results so use_empty() is always true —
+/// erasing them leaves an empty block and fails verification. Dead onnx.NoValue
+/// placeholders must also be erased — they have no LLVM lowering path.
+inline bool isDeadOnnxOpSafeToErase(mlir::Operation *op) {
+  if (!op || !op->use_empty())
+    return false;
+  llvm::StringRef name = op->getName().getStringRef();
+  if (!name.starts_with("onnx."))
+    return false;
+  if (name == "onnx.EntryPoint" || name == "onnx.Yield" ||
+      name == "onnx.Return")
+    return false;
+  if (op->hasTrait<mlir::OpTrait::IsTerminator>())
+    return false;
+  return true;
+}
+
 /// Create a tensor.empty for a DPS init operand.  Dynamic dimension sizes
 /// are extracted from \p source using tensor.dim at each dynamic index.
 /// Suitable for ops where the output shape aligns positionally with one input
@@ -502,6 +527,11 @@ void populatePowDecompositionPatterns(RewritePatternSet &patterns,
 /// See ErfGeluFusion.cpp.
 void populateErfGeluFusionPatterns(RewritePatternSet &patterns,
                                    MLIRContext *ctx);
+
+/// Pre-lowering: fold LoRA weight_pack (Transpose/Cast/Add/Cast/Reshape) into
+/// MatMulNBits(bits=8) with lora_weight_pack=1 for runtime pack+cache.
+/// See LoraWeightPackFusion.cpp.
+void runLoraWeightPackFusion(mlir::func::FuncOp funcOp);
 
 /// Pre-lowering pattern set: decompose vision/projector ops that have no
 /// direct MorphiZen converter into supported primitives — patch-embed

--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -5470,6 +5470,34 @@ __global__ void unpack_zp_3bit_to_u8_kernel(
 // unpack/convert kernels run at most once per (zero_points pointer) over
 // the lifetime of a RuntimeState — instead of once per matmul_nbits call,
 // which on 8B asym decode is ~225 redundant launches per Compute().
+
+__global__ void pack_lora_weight_mnbits_int8_kernel(const int8_t* __restrict__ src,
+                                                    uint8_t* __restrict__ dst,
+                                                    int K, int N)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = K * N;
+    if (idx >= total)
+        return;
+    int k = idx / N;
+    int n = idx % N;
+    // Transpose [K,N] -> [N,K] and apply signed int8 -> uint8 (+128).
+    dst[n * K + k] = static_cast<uint8_t>(static_cast<int16_t>(src[k * N + n]) + 128);
+}
+
+extern "C" void hip_pack_lora_weight_mnbits_int8(void* stream, const void* raw_i8,
+                                                 void* dst_u8, int K, int N)
+{
+    int total = K * N;
+    constexpr int THR = 256;
+    dim3 grid(static_cast<unsigned>((total + THR - 1) / THR));
+    dim3 block(THR);
+    hipLaunchKernelGGL(pack_lora_weight_mnbits_int8_kernel,
+                       grid, block, 0, static_cast<hipStream_t>(stream),
+                       static_cast<const int8_t*>(raw_i8),
+                       static_cast<uint8_t*>(dst_u8), K, N);
+}
+
 extern "C" void hip_matmul_nbits_unpack_zp_u8(
     void* stream, const void* zp_packed, void* dst_u8, int N, int groups_k)
 {

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -1725,6 +1725,10 @@ HIP_KERNEL_API void hip_matmul_nbits_convert_zp_fp16(
 HIP_KERNEL_API void hip_matmul_nbits_dequant_b_fp16(
     void* stream, const void* B_packed, const void* scales_fp16,
     const void* zeros_fp16, void* B_fp16_out, int N, int K, int group_size);
+/* LoRA weight_pack fusion: transpose [K,N] int8 + signed_offset(+128) -> [N,K] uint8.
+ * Used by the per-op-state cache in lib/Runtime/real/matmul_nbits.cpp. */
+HIP_KERNEL_API void hip_pack_lora_weight_mnbits_int8(
+    void* stream, const void* raw_i8, void* dst_u8, int K, int N);
 
 /* =========================================================================
  * GatherBlockQuantized (com.microsoft)

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -1239,7 +1239,8 @@ int wrap_matmul_nbits(
     int64_t bits,            // quantization bits (e.g. 4)
     int64_t block_size,      // quantization block size
     int64_t elem_size,       // element size in bytes
-    int64_t zp_elem_size);   // zero_points element size: 1=uint8 packed, 2=fp16
+    int64_t zp_elem_size,    // zero_points element size: 1=uint8 packed, 2=fp16
+    int64_t lora_weight_pack); // 1: B is raw int8 [K,N], runtime pack+cache
 
 // GatherBlockQuantized operation wrapper (com.microsoft).
 // Gather + block-wise dequantize: gather rows from `data` along

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -1353,8 +1353,9 @@ int wrap_matmul_nbits(RuntimeState *state, int op_state_slot, const void *A,
                       const void *bias, void *output, int64_t M, int64_t N,
                       int64_t K, int64_t batch_count, int64_t bits,
                       int64_t block_size, int64_t elem_size,
-                      int64_t zp_elem_size) {
+                      int64_t zp_elem_size, int64_t lora_weight_pack) {
   (void)op_state_slot;
+  (void)lora_weight_pack;
   if (!state) {
     fprintf(stderr, "Invalid state in wrap_matmul_nbits\n");
     return -1;

--- a/lib/Runtime/real/lora_weight_pack_cache.h
+++ b/lib/Runtime/real/lora_weight_pack_cache.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#ifndef HIPDNN_EP_REAL_LORA_WEIGHT_PACK_CACHE_H
+#define HIPDNN_EP_REAL_LORA_WEIGHT_PACK_CACHE_H
+
+// Per MatMulNBits op-state cache of LoRA weight_pack buffers. Fuses
+// Transpose + signed_offset(+128) into one GPU buffer at first use per
+// op instance, then reuses it for the session. Do not key on raw_i8 pointer:
+// hybrid/streaming constant upload may restage weights at a new address every
+// Compute() even though the logical weight is unchanged.
+
+#include <cstddef>
+
+namespace hipdnn_ep_real {
+
+struct LoraWeightPackEntry {
+  void *packed = nullptr;
+  size_t bytes = 0;
+  int cached_k = 0;
+  int cached_n = 0;
+
+  ~LoraWeightPackEntry();
+  LoraWeightPackEntry() = default;
+  LoraWeightPackEntry(const LoraWeightPackEntry &) = delete;
+  LoraWeightPackEntry &operator=(const LoraWeightPackEntry &) = delete;
+};
+
+// Returns cached packed uint8 [N, K]. Packs at most once per op-state entry
+// (fixed K,N for a compiled MatMulNBits). Returns nullptr on hipMalloc failure.
+const void *lookup_or_pack_lora_weight(LoraWeightPackEntry &entry, void *stream,
+                                       const void *raw_i8, int K, int N);
+
+} // namespace hipdnn_ep_real
+
+#endif // HIPDNN_EP_REAL_LORA_WEIGHT_PACK_CACHE_H

--- a/lib/Runtime/real/matmul_nbits.cpp
+++ b/lib/Runtime/real/matmul_nbits.cpp
@@ -10,6 +10,7 @@
 #include "error_check_macros.h"
 #include "hip_arch_compat.h"
 #include "hip_custom_kernels.h"
+#include "lora_weight_pack_cache.h"
 #include "runtime_types.h"
 #include "zp_unpack_cache.h"
 
@@ -191,6 +192,48 @@ const void *lookup_or_convert_zp_fp16(ZpUnpackCache &cache, void *stream,
   return dst;
 }
 
+LoraWeightPackEntry::~LoraWeightPackEntry() {
+  if (packed)
+    hipFree(packed);
+}
+
+const void *lookup_or_pack_lora_weight(LoraWeightPackEntry &entry, void *stream,
+                                       const void *raw_i8, int K, int N) {
+  const size_t need = static_cast<size_t>(K) * static_cast<size_t>(N);
+
+  if (entry.packed && entry.cached_k == K && entry.cached_n == N &&
+      entry.bytes >= need) {
+    RUNTIME_DEBUG_LOG("[lora-weight-pack] cache hit K=%d N=%d bytes=%zu\n", K,
+                      N, need);
+    return entry.packed;
+  }
+
+  if (entry.packed) {
+    hipFree(entry.packed);
+    entry.packed = nullptr;
+    entry.bytes = 0;
+    entry.cached_k = 0;
+    entry.cached_n = 0;
+  }
+
+  void *dst = nullptr;
+  if (hipMalloc(&dst, need) != hipSuccess) {
+    fprintf(stderr,
+            "matmul_nbits: hipMalloc(%zu) for lora weight pack cache failed\n",
+            need);
+    return nullptr;
+  }
+  RUNTIME_DEBUG_LOG(
+      "[lora-weight-pack] packing raw=%p -> dst=%p K=%d N=%d bytes=%zu\n",
+      raw_i8, dst, K, N, need);
+  hip_pack_lora_weight_mnbits_int8(stream, raw_i8, dst, K, N);
+  entry.packed = dst;
+  entry.bytes = need;
+  entry.cached_k = K;
+  entry.cached_n = N;
+  return entry.packed;
+}
+
 } // namespace hipdnn_ep_real
 
 // Teardown shim for the qmoe-owned RuntimeState::zp_unpack_cache. Called from
@@ -206,6 +249,7 @@ extern "C" void hipdnn_ep_zp_unpack_cache_destroy(void *cache_ptr) {
 // share it.
 struct MatmulNbitsState : OpStateT<MatmulNbitsState> {
   hipdnn_ep_real::ZpUnpackCache zp;
+  hipdnn_ep_real::LoraWeightPackEntry lora_pack;
 
   // CDNA/wave64 prefill fast path: dequantized fp16 weights, keyed by the
   // packed-B device pointer (stable for the model's lifetime, so each weight
@@ -499,7 +543,7 @@ int wrap_matmul_nbits(RuntimeState *state, int op_state_slot, const void *A,
                       const void *bias, void *output, int64_t M, int64_t N,
                       int64_t K, int64_t batch_count, int64_t bits,
                       int64_t block_size, int64_t elem_size,
-                      int64_t zp_elem_size) {
+                      int64_t zp_elem_size, int64_t lora_weight_pack) {
   OP_PROFILE(
       "matmul_nbits",
       [&] {
@@ -532,6 +576,31 @@ int wrap_matmul_nbits(RuntimeState *state, int op_state_slot, const void *A,
   if (g_idx) {
     fprintf(stderr, "wrap_matmul_nbits: g_idx not supported\n");
     return -1;
+  }
+
+  if (lora_weight_pack) {
+    if (bits != 8 || block_size <= 0 || (K % block_size) != 0) {
+      fprintf(stderr, "wrap_matmul_nbits: lora_weight_pack requires bits=8, "
+                      "K%%block_size==0\n");
+      return -1;
+    }
+    MatmulNbitsState *mst =
+        MatmulNbitsState::get_op_state(state, op_state_slot);
+    if (!mst) {
+      fprintf(stderr, "wrap_matmul_nbits: no MatmulNbitsState at slot %d\n",
+              op_state_slot);
+      return -1;
+    }
+    // Replaces raw int8 [K,N] with cached packed uint8 [N,K] for the kernel.
+    const void *packed_b = hipdnn_ep_real::lookup_or_pack_lora_weight(
+        mst->lora_pack, stream, B, static_cast<int>(K), static_cast<int>(N));
+    if (!packed_b) {
+      fprintf(stderr,
+              "wrap_matmul_nbits: lora weight pack failed (K=%lld N=%lld)\n",
+              (long long)K, (long long)N);
+      return -1;
+    }
+    B = packed_b;
   }
 
   // Pre-unpack zero_points (asym path) using this instance's pointer-keyed

--- a/test/lit/Conversion/hip-to-llvm/test_matmul_nbits.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_matmul_nbits.mlir
@@ -38,12 +38,12 @@ module {
   // CHECK-LABEL: llvm.func @test_matmul_nbits_basic
   // CHECK: llvm.call @wrap_matmul_nbits({{.*}}) :
   // CHECK-SAME: (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
-  // CHECK-SAME:  i64, i64, i64, i64, i64, i64, i64, i64) -> i32
-  // Verify 17 parameters:
+  // CHECK-SAME:  i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
+  // Verify 18 parameters:
   // - 1 i32: op_state_slot (2nd arg; per-instance MatmulNbitsState; threaded by
   //          --assign-op-state-slots, replaces shared RuntimeState::zp_unpack_cache)
   // - 8 pointers: state, A, B, scales, zero_points(null), g_idx(null), bias(null), output
-  // - 8 i64: M=128, N=5120, K=2880, batch_count=1, bits=4, block_size=32, elem_size=2, zp_elem_size=0
+  // - 9 i64: M=128, N=5120, K=2880, batch_count=1, bits=4, block_size=32, elem_size=2, zp_elem_size=0, lora_weight_pack=0
 
   // ===== Test 2: MatMulNBits with zero_points =====
 
@@ -67,7 +67,7 @@ module {
   // CHECK-LABEL: llvm.func @test_matmul_nbits_with_zp
   // CHECK: llvm.call @wrap_matmul_nbits({{.*}}) :
   // CHECK-SAME: (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
-  // CHECK-SAME:  i64, i64, i64, i64, i64, i64, i64, i64) -> i32
+  // CHECK-SAME:  i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
 
   // ===== Test 3: 2D MatMulNBits (no batch dimension) =====
 
@@ -89,6 +89,6 @@ module {
   // CHECK-LABEL: llvm.func @test_matmul_nbits_2d
   // CHECK: llvm.call @wrap_matmul_nbits({{.*}}) :
   // CHECK-SAME: (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
-  // CHECK-SAME:  i64, i64, i64, i64, i64, i64, i64, i64) -> i32
+  // CHECK-SAME:  i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
   // M=128, batch_count=1 (2D: no batch dims)
 }

--- a/tools/onnx-merged-convert/merged_convert/step2_fp16_cleanup.py
+++ b/tools/onnx-merged-convert/merged_convert/step2_fp16_cleanup.py
@@ -13,6 +13,14 @@ from onnx import TensorProto, shape_inference
 
 FP32 = TensorProto.FLOAT
 FP16 = TensorProto.FLOAT16
+_FLOAT_ELEM_TYPES = frozenset(
+    {
+        TensorProto.FLOAT,
+        TensorProto.FLOAT16,
+        TensorProto.DOUBLE,
+        TensorProto.BFLOAT16,
+    }
+)
 _PRE_CAST_CASTFP32_RE = re.compile(
     "(?:^getitem(?:_\\d+)?_pre_cast_castfp32$|GroupQueryAttention_output_\\d+_pre_cast_castfp32$)"
 )
@@ -36,7 +44,78 @@ def _replace_tensor_uses(graph: onnx.GraphProto, old: str, new: str) -> int:
             if name == old:
                 node.input[idx] = new
                 replacements += 1
+    for vi in list(graph.output) + list(graph.value_info):
+        if vi.name == old:
+            vi.name = new
+            replacements += 1
     return replacements
+
+
+def _build_tensor_users(
+    graph: onnx.GraphProto,
+) -> dict[str, list[tuple[onnx.NodeProto, int]]]:
+    users: dict[str, list[tuple[onnx.NodeProto, int]]] = {}
+    for node in graph.node:
+        for idx, name in enumerate(node.input):
+            if name:
+                users.setdefault(name, []).append((node, idx))
+    return users
+
+
+def _infer_activation_elem_types(graph: onnx.GraphProto) -> dict[str, int]:
+    """Best-effort elem_type map for activation tensors."""
+    types: dict[str, int] = {}
+    for init in graph.initializer:
+        types[init.name] = init.data_type
+    for vi in list(graph.input) + list(graph.output) + list(graph.value_info):
+        elem_type = vi.type.tensor_type.elem_type
+        if elem_type:
+            types[vi.name] = elem_type
+
+    changed = True
+    while changed:
+        changed = False
+        for node in graph.node:
+            if node.op_type == "Cast":
+                to_type = _cast_to(node)
+                if to_type is None or not node.output:
+                    continue
+                out = node.output[0]
+                if types.get(out) != to_type:
+                    types[out] = to_type
+                    changed = True
+                continue
+
+            in_types = [
+                types[inp]
+                for inp in node.input
+                if inp and inp in types and types[inp] in _FLOAT_ELEM_TYPES
+            ]
+            if not in_types or not node.output:
+                continue
+            if all(t == FP16 for t in in_types):
+                out_type = FP16
+            elif len(set(in_types)) == 1:
+                out_type = in_types[0]
+            else:
+                continue
+            for out in node.output:
+                if not out or types.get(out) == out_type:
+                    continue
+                types[out] = out_type
+                changed = True
+    return types
+
+
+def _is_fp16_consumer_op(node: onnx.NodeProto) -> bool:
+    """True when a downstream op consumes fp16 activations on this edge."""
+    if node.op_type == "Cast":
+        return _cast_to(node) == FP16
+    return True
+
+
+def _keep_gqa_pre_cast_fp16_cast(src: str, dst: str) -> bool:
+    return src.endswith("_pre_cast") and "GroupQueryAttention_output_" in dst
 
 
 def _remove_nodes(graph: onnx.GraphProto, names: set[str]) -> int:
@@ -198,6 +277,43 @@ def remove_redundant_mnbits_fp16_casts(model: onnx.ModelProto) -> int:
     return folded
 
 
+def remove_redundant_fp16_casts(model: onnx.ModelProto) -> int:
+    """Drop Cast(fp16) when upstream and downstream ops already use fp16."""
+    graph = model.graph
+    total = 0
+    while True:
+        elem_types = _infer_activation_elem_types(graph)
+        users = _build_tensor_users(graph)
+        remove: set[str] = set()
+        removed = 0
+        for cast in graph.node:
+            if cast.op_type != "Cast" or _cast_to(cast) != FP16:
+                continue
+            if not cast.input or not cast.output:
+                continue
+            src = cast.input[0]
+            dst = cast.output[0]
+            if elem_types.get(src) != FP16:
+                continue
+            if _emu_fp32_boundary_tensor(graph, src):
+                continue
+            if _keep_gqa_pre_cast_fp16_cast(src, dst):
+                continue
+            consumers = users.get(dst, [])
+            if not consumers or any(
+                not _is_fp16_consumer_op(node) for node, _idx in consumers
+            ):
+                continue
+            _replace_tensor_uses(graph, dst, src)
+            remove.add(cast.name)
+            removed += 1
+        _remove_nodes(graph, remove)
+        total += removed
+        if removed == 0:
+            break
+    return total
+
+
 def ensure_matmul_nbits_fp16_inputs(model: onnx.ModelProto) -> int:
     """Cast MatMulNBits activations to fp16 so ORT does not mix float/float16 on T1."""
     graph = model.graph
@@ -253,6 +369,7 @@ def optimize_fp16_activations(
         else 0,
         "mnbits_fp16_casts_folded": remove_redundant_mnbits_fp16_casts(model),
         "mnbits_fp16_inputs": ensure_matmul_nbits_fp16_inputs(model),
+        "fp16_casts_removed": remove_redundant_fp16_casts(model),
     }
     if clear_value_info:
         del model.graph.value_info[:]


### PR DESCRIPTION
## Summary

Fold the redundant 5-op LoRA `weight_pack` ONNX chain (Transpose → Cast → Add(+128) → Cast → Reshape) into `MatMulNBits(bits=8)` at compile time, and pack the raw int8 weight once per op-state slot at runtime via a cached GPU buffer. Also extend the merged-ONNX export tool to drop redundant `Cast(fp16)` nodes when activations are already fp16 end-to-end.

**Developer-visible effect:** LoRA `MatMulNBits` graphs compile with fewer ONNX ops; decode no longer launches the pack chain every step after warm-up.

## Related issue or design

None

## Why

Some LoRA exports insert a fixed preprocessing chain before each 8-bit `MatMulNBits` weight: transpose `[K,N]` int8, apply signed offset (+128), and reshape into the packed layout expected by the kernel. When left in the graph, these ops run on every inference step even though the logical weight is unchanged.

Moving pack to runtime with a per-op-state cache:
- removes five ONNX ops from the compiled graph;
- performs transpose + offset in one small kernel;
- reuses the packed buffer for the session (keyed by op-state slot and `(K, N)`, not the raw weight pointer, so restaged constant uploads do not thrash the cache).

The `step2_fp16_cleanup.py` change is a complementary export-time cleanup: redundant `Cast(fp16)` nodes add graph noise and can interfere with downstream dtype handling without changing numerics.

## What

**Compiler / MLIR**
- Add `LoraWeightPackFusion` pre-lowering pass (`runLoraWeightPackFusion`): match the 5-op chain, rewire `MatMulNBits` operand B to the raw int8 graph input, set `lora_weight_pack=1`, DCE dead pack ops.
- Plumb `lora_weight_pack` through `HipOps.td` → `MatMulNBitsConversion` → `MatMulNBitsLowering` → `wrap_matmul_nbits`.
- Add `getOnnxIntegerAttrValue` / `isDeadOnnxOpSafeToErase` helpers in `OnnxToHipUtils.h`.

**Runtime**
- Add `pack_lora_weight_mnbits_int8` HIP kernel (transpose `[K,N]` int8 → `[N,K]` uint8 with +128).
- Add `LoraWeightPackEntry` + `lookup_or_pack_lora_weight()` in `matmul_nbits.cpp` (per `MatmulNbitsState` slot).
- Extend `wrap_matmul_nbits(..., lora_weight_pack)`; mock runtime updated accordingly.

**Export tool**
- `remove_redundant_fp16_casts()` in `step2_fp16_cleanup.py` with guards for emu fp32 boundaries and GQA pre-cast edges.

**Tests**
- Update `test_matmul_nbits.mlir` CHECK lines for the 18-parameter `wrap_matmul_nbits` signature.

## Test plan

- [x] `test/lit/Conversion/hip-to-llvm/test_matmul_nbits.mlir` — CHECK updated for new `lora_weight_pack=0` parameter (default path unchanged).
- [x] Rebuilt `hip-compiler-dll` and ran end-to-end LoRA decode on target hardware — model loads and generates correctly after fusion.
- [x] Trace/profile: pack-chain ops (transpose/cast/add) no longer appear on the hot decode path; `pack_lora` runs only during warm-up (~once per fused MatMulNBits instance).

## Notes for reviewers

- Fusion runs **once per function**, before the greedy pre-lowering loop (walk + `modifyOpInPlace`, not a `populate*` pattern).
- Transpose `perm` is intentionally **not** read on the fusion hot path (MorphiZen-imported MLIR can stall on attr introspection); matching relies on the fixed export chain shape + 2-D int8 raw weight type.
- `MatmulNbitsState` now holds both the existing CDNA/wave64 int4 prefill caches (`b_fp16`, `prefill_algos`) and the new `lora_pack` entry — rebase conflict resolution kept both paths.
- Default behaviour is unchanged when `lora_weight_pack=0`.

## Checklist

- [ ] The change is focused, or links a design/series explaining its scope.
- [ ] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [ ] Substantial AI assistance is disclosed, and I reviewed and understand the result.