### PR TITLE
perf(gqa): fold the attention bias into the softmax's score read, -11.7% TTFT at 16K

### DIFF
--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -1168,16 +1168,65 @@ extern "C" int hip_gqa_add_attention_bias_f32(
 // Output-type-templated: reads fp32 scores, writes TOut ∈ {__half, float}.
 // fp16 output (TOut=__half) feeds the fp16 Value GEMM; fp32 output (TOut=float)
 // feeds the fp32 Value GEMM on the Whisper no_causal fp32 decomposed path.
-template <typename TOut>
+//
+// HAS_BIAS folds the external additive mask in here instead of running
+// add_attention_bias_kernel first. That kernel was a full read-modify-write
+// over the score buffer -- 2.14 GB per head at a 16K prompt -- purely to hand
+// this kernel a value it is about to read anyway. A block owns one query row,
+// and the bias runs along the key axis in the same order the reduction below
+// does, so the fold is one extra contiguous stream to read. The three passes
+// re-read it, but a row is 32-64 KB and stays resident across them, so the cost
+// is one stream from memory against the two the separate pass spent on the
+// scores alone.
+//
+// The bias is indexed on its own full extents rather than through a bumped
+// pointer, for the reason add_attention_bias_kernel gives at length: `input`
+// can be a sub-block of the logical [bias_sq, bias_total_seq] matrix -- `cols`
+// query rows from bias_row_offset when the caller tiles the prefill, and `rows`
+// key columns from bias_col_offset when it narrows to a sliding window -- while
+// the bias always describes the whole thing. Folding either offset into the
+// pointer would mis-stride every batch/head plane after the first.
+//
+// The bias is added to the score BEFORE the max is taken, which is required
+// rather than incidental: taking the max of unbiased scores and then adding the
+// bias could leave a masked entry (bias -65504) as the column max and put every
+// exponent off scale.
+template <typename TOut, bool HAS_BIAS = false, typename TBias = __half>
 __global__ void softmax_f32_to_out_kernel(
     const float* input, TOut* output,
     int rows, int cols, int input_batch_stride, int output_batch_stride,
-    const __half* head_sink, int num_heads, int use_smooth_softmax) {
+    const __half* head_sink, int num_heads, int use_smooth_softmax,
+    const TBias* __restrict__ bias, int bias_batch, int bias_heads,
+    int bias_sq, int bias_row_offset, int bias_total_seq, int bias_col_offset) {
   const int linear = __builtin_amdgcn_readfirstlane(blockIdx.x);
   const int head = __builtin_amdgcn_readfirstlane(linear / cols);
   const int col  = __builtin_amdgcn_readfirstlane(linear % cols);
   const float* in_col = input + (size_t)head * input_batch_stride + (size_t)col * rows;
   TOut* out_col = output + (size_t)head * output_batch_stride + (size_t)col * rows;
+
+  // Start of this query row inside the bias, resolved exactly as
+  // add_attention_bias_kernel resolves it. `col` is the query row (this kernel
+  // reduces along `rows`, the key axis), so it indexes the bias's row axis.
+  const TBias* bias_row = nullptr;
+  if (HAS_BIAS) {
+    const int b = head / num_heads;
+    const int h = head % num_heads;
+    const int bias_b = (bias_batch == 1) ? 0 : b;
+    const int bias_h = (bias_heads == 1) ? 0 : h;
+    const size_t bias_plane = (size_t)bias_sq * bias_total_seq;
+    bias_row = bias + (size_t)bias_b * bias_heads * bias_plane +
+               (size_t)bias_h * bias_plane +
+               (size_t)(bias_row_offset + col) * bias_total_seq +
+               bias_col_offset;
+  }
+
+  // Score with the bias already folded in, or the raw score when there is none.
+  auto score_at = [&](int i) -> float {
+    float s = in_col[i];
+    if (HAS_BIAS)
+      s += static_cast<float>(bias_row[i]);
+    return s;
+  };
 
   const int tid = threadIdx.x;
   const int wave_id = tid / WAVE_SIZE;
@@ -1188,7 +1237,7 @@ __global__ void softmax_f32_to_out_kernel(
   // Pass 1: find max (fp32, no overflow risk)
   float local_max = -INFINITY;
   for (int i = tid; i < rows; i += blockDim.x)
-    local_max = fmaxf(local_max, in_col[i]);
+    local_max = fmaxf(local_max, score_at(i));
 
   local_max = warp_reduce_max(local_max);
   if (tid % WAVE_SIZE == 0)
@@ -1206,7 +1255,7 @@ __global__ void softmax_f32_to_out_kernel(
   // Pass 2: exp2f + sum (fp32 throughout, values recomputed in Pass 3)
   float local_sum = 0.0f;
   for (int i = tid; i < rows; i += blockDim.x)
-    local_sum += exp2f((in_col[i] - max_val) * LOG2E);
+    local_sum += exp2f((score_at(i) - max_val) * LOG2E);
 
   local_sum = warp_reduce_sum(local_sum);
   if (tid % WAVE_SIZE == 0)
@@ -1232,17 +1281,19 @@ __global__ void softmax_f32_to_out_kernel(
   // Pass 3: normalize and write output (fp16 or fp32 per TOut).
   float inv_sum = 1.0f / sum_val;
   for (int i = tid; i < rows; i += blockDim.x) {
-    float e = exp2f((in_col[i] - max_val) * LOG2E);
+    float e = exp2f((score_at(i) - max_val) * LOG2E);
     out_col[i] = gqa_from_float<TOut>(e * inv_sum);
   }
 }
 
-template <typename TOut>
+template <typename TOut, bool HAS_BIAS, typename TBias>
 static void launch_softmax_f32_to_out(
     hipStream_t stream, const void* input_f32, void* output,
     int total_head_queries, int rows, int cols,
     int input_batch_stride, int output_batch_stride,
-    const void* head_sink, int num_heads, int use_smooth_softmax) {
+    const void* head_sink, int num_heads, int use_smooth_softmax,
+    const void* bias, int bias_batch, int bias_heads,
+    int bias_sq, int bias_row_offset, int bias_total_seq, int bias_col_offset) {
   // The block must be a whole multiple of the hardware wave, else the tail of a
   // partial wave is inactive and the __shfl_xor reduction folds in its lanes.
   // The floor is therefore the device wave size: 32 on wave32 (RDNA, unchanged
@@ -1254,11 +1305,27 @@ static void launch_softmax_f32_to_out(
   while (threads < std::min(rows, 256)) threads *= 2;
   if (threads > 256) threads = 256;
   int num_waves = threads / wave;
-  softmax_f32_to_out_kernel<TOut><<<total_head_queries, threads,
-                                    num_waves * sizeof(float), stream>>>(
-      static_cast<const float*>(input_f32), static_cast<TOut*>(output),
-      rows, cols, input_batch_stride, output_batch_stride,
-      static_cast<const __half*>(head_sink), num_heads, use_smooth_softmax);
+  softmax_f32_to_out_kernel<TOut, HAS_BIAS, TBias>
+      <<<total_head_queries, threads, num_waves * sizeof(float), stream>>>(
+          static_cast<const float*>(input_f32), static_cast<TOut*>(output),
+          rows, cols, input_batch_stride, output_batch_stride,
+          static_cast<const __half*>(head_sink), num_heads, use_smooth_softmax,
+          static_cast<const TBias*>(bias), bias_batch, bias_heads, bias_sq,
+          bias_row_offset, bias_total_seq, bias_col_offset);
+}
+
+// Selects the no-bias instantiation, so the existing callers stay on exactly
+// the code they had.
+template <typename TOut>
+static void launch_softmax_f32_to_out(
+    hipStream_t stream, const void* input_f32, void* output,
+    int total_head_queries, int rows, int cols,
+    int input_batch_stride, int output_batch_stride,
+    const void* head_sink, int num_heads, int use_smooth_softmax) {
+  launch_softmax_f32_to_out<TOut, false, __half>(
+      stream, input_f32, output, total_head_queries, rows, cols,
+      input_batch_stride, output_batch_stride, head_sink, num_heads,
+      use_smooth_softmax, nullptr, 1, 1, 0, 0, 0, 0);
 }
 
 extern "C" int hip_gqa_softmax_f32_to_f16(
@@ -1289,6 +1356,58 @@ extern "C" int hip_gqa_softmax_f32_to_f32(
       stream, input_f32, output_f32, total_head_queries, rows, cols,
       input_batch_stride, output_batch_stride, head_sink, num_heads,
       use_smooth_softmax);
+  GQA_RETURN_LAUNCH_STATUS();
+}
+
+// Bias-folding variant: adds the external additive mask while reading the score
+// column, replacing a separate hip_gqa_add_attention_bias_f32 pass over the
+// same buffer. bias_element_size_bytes selects the mask dtype (2 = fp16, the
+// usual ONNX Attention export; 4 = fp32). output_fp32 picks the probability
+// dtype, matching the two entries above. The bias extents follow
+// hip_gqa_add_attention_bias_f32, including its convention that a
+// non-positive bias_sq / bias_total_seq means the bias covers exactly the block
+// passed in; note this kernel's `cols` is the query count and `rows` the key
+// extent, the transpose of the names that entry uses.
+extern "C" int hip_gqa_softmax_f32_to_out_biased(
+    void* stream_ptr, const void* input_f32, void* output,
+    int total_head_queries, int rows, int cols,
+    int input_batch_stride, int output_batch_stride,
+    const void* head_sink, int num_heads, int use_smooth_softmax,
+    const void* bias, int bias_batch, int bias_heads,
+    int bias_element_size_bytes, int output_fp32,
+    int bias_sq, int bias_row_offset, int bias_total_seq, int bias_col_offset) {
+  if (!bias)
+    return -1;
+  hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
+  (void)hipGetLastError();  // clear stale error for correct attribution
+  if (bias_element_size_bytes != 2 && bias_element_size_bytes != 4) {
+    fprintf(stderr,
+            "hip_gqa_softmax_f32_to_out_biased: unsupported bias elem size %d\n",
+            bias_element_size_bytes);
+    return -1;
+  }
+  if (bias_sq <= 0)
+    bias_sq = cols;
+  if (bias_total_seq <= 0)
+    bias_total_seq = rows;
+#define GQA_SOFTMAX_BIASED(TOUT, TBIAS)                                        \
+  launch_softmax_f32_to_out<TOUT, true, TBIAS>(                                \
+      stream, input_f32, output, total_head_queries, rows, cols,               \
+      input_batch_stride, output_batch_stride, head_sink, num_heads,           \
+      use_smooth_softmax, bias, bias_batch, bias_heads, bias_sq,               \
+      bias_row_offset, bias_total_seq, bias_col_offset)
+  if (output_fp32) {
+    if (bias_element_size_bytes == 2)
+      GQA_SOFTMAX_BIASED(float, __half);
+    else
+      GQA_SOFTMAX_BIASED(float, float);
+  } else {
+    if (bias_element_size_bytes == 2)
+      GQA_SOFTMAX_BIASED(__half, __half);
+    else
+      GQA_SOFTMAX_BIASED(__half, float);
+  }
+#undef GQA_SOFTMAX_BIASED
   GQA_RETURN_LAUNCH_STATUS();
 }
 

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -805,6 +805,29 @@ HIP_KERNEL_API int hip_gqa_softmax_f32_to_f32(
     int input_batch_stride, int output_batch_stride,
     const void* head_sink, int num_heads, int use_smooth_softmax);
 
+/* Same as hip_gqa_softmax_f32_to_f32 / _f16, with the external additive mask
+ * folded into the score read so a preceding hip_gqa_add_attention_bias_f32 pass
+ * over the same buffer is not needed. output_fp32 picks the probability dtype
+ * (0 = fp16, feeding the fp16 Value GEMM; 1 = fp32) and
+ * bias_element_size_bytes the mask dtype (2 = fp16, 4 = fp32). The bias is
+ * added before the column max is taken.
+ *
+ * The bias is indexed on its own full extents, exactly as
+ * hip_gqa_add_attention_bias_f32 does, because the score buffer can be a
+ * sub-block of the logical [bias_sq, bias_total_seq] matrix: `cols` query rows
+ * starting at bias_row_offset, and `rows` key columns starting at
+ * bias_col_offset. Mind the axis names -- this kernel reduces along `rows`, so
+ * its `rows` is the key extent and its `cols` the query count, which is the
+ * transpose of the naming hip_gqa_add_attention_bias_f32 uses. */
+HIP_KERNEL_API int hip_gqa_softmax_f32_to_out_biased(
+    void* stream, const void* input_f32, void* output,
+    int total_head_queries, int rows, int cols,
+    int input_batch_stride, int output_batch_stride,
+    const void* head_sink, int num_heads, int use_smooth_softmax,
+    const void* bias, int bias_batch, int bias_heads,
+    int bias_element_size_bytes, int output_fp32,
+    int bias_sq, int bias_row_offset, int bias_total_seq, int bias_col_offset);
+
 /* Legacy fast-path decode kernel (folded into gqa_kernel.hip with a legacy_*
  * device kernel). The production decode path uses hip_gqa_flash_decode above
  * for EVERY fp16 causal GQA/MHA decode (window + sink folded in, split count

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -2088,22 +2088,11 @@ static int gqa_forward_hipblaslt(
           sSt->layB, &beta, d_S_f32, sSt->layC, d_S_f32, sSt->layD, &sAlgo,
           gemm_ws_ptr, gemm_ws_bytes, stream));
 
-      // ---- Step 8b: Add external attention bias (onnx.Attention attn_mask) --
-      // The bias is indexed over the full query and key ranges, so the chunk's
-      // row offset and the window's key offset are passed through rather than
-      // folded into the pointer: with bias_batch or bias_heads > 1 the plane
-      // stride still spans all sq rows and all total_seq columns.
-      if (attention_bias) {
-        HIP_CHECK(hip_gqa_add_attention_bias_f32(
-            stream, d_S_f32, const_cast<void *>(attention_bias),
-            static_cast<int>(B * H), static_cast<int>(H),
-            static_cast<int>(attn_bias_batch),
-            static_cast<int>(attn_bias_num_heads), static_cast<int>(c),
-            static_cast<int>(kv_span), scoreBatchStride,
-            static_cast<int>(elem_sz), static_cast<int>(sq),
-            static_cast<int>(q0), static_cast<int>(total_seq),
-            static_cast<int>(kv_lo)));
-      }
+      // ---- Step 8b: external attention bias (onnx.Attention attn_mask) ----
+      // Folded into the softmax's own score read below rather than added by a
+      // pass of its own. hip_gqa_add_attention_bias_f32 was a full
+      // read-modify-write over this buffer -- 2.14 GB per head at a 16K prompt
+      // -- to deliver a value the softmax was about to read anyway.
 
       // ---- Step 9: Causal Mask (fp32) + Softmax (fp32 -> fp16/fp32) ----
       // S is treated as [B*H, c, kv_span] (head stride c*kv_span) by both
@@ -2143,7 +2132,31 @@ static int gqa_forward_hipblaslt(
       // fp32 Value GEMM. d_S_fp16 is the probabilities buffer either way (sized
       // by elem_sz above), so the name is fp16-specific but holds fp32 when
       // gemm_fp32.
-      if (gemm_fp32) {
+      //
+      // With a bias, the biased entry folds it in while reading the score. It
+      // takes the bias's own extents and the chunk's / window's offsets into
+      // them, for the same reason hip_gqa_add_attention_bias_f32 did: the score
+      // block is a sub-block of the logical [sq, total_seq] matrix, and with
+      // attn_bias_batch or attn_bias_num_heads > 1 a bumped pointer would
+      // mis-stride every plane after the first.
+      //
+      // Folding here applies the bias AFTER the causal triangle above, which
+      // inverts the order documented at Step 8b. That is safe only because the
+      // triangle writes -INFINITY: adding any finite bias to it leaves
+      // -INFINITY, and where the triangle wrote nothing the sum is the same
+      // either way.
+      if (attention_bias) {
+        HIP_CHECK(hip_gqa_softmax_f32_to_out_biased(
+            stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * c),
+            static_cast<int>(kv_span), static_cast<int>(c), scoreBatchStride,
+            scoreBatchStride, head_sink, static_cast<int>(H),
+            static_cast<int>(use_smooth_softmax), attention_bias,
+            static_cast<int>(attn_bias_batch),
+            static_cast<int>(attn_bias_num_heads), static_cast<int>(elem_sz),
+            static_cast<int>(gemm_fp32), static_cast<int>(sq),
+            static_cast<int>(q0), static_cast<int>(total_seq),
+            static_cast<int>(kv_lo)));
+      } else if (gemm_fp32) {
         HIP_CHECK(hip_gqa_softmax_f32_to_f32(
             stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * c),
             static_cast<int>(kv_span), static_cast<int>(c), scoreBatchStride,


### PR DESCRIPTION
## What

`add_attention_bias_kernel` was a full read-modify-write pass over the fp32 score buffer -- 17.2 GB per layer at a 16K prompt -- immediately followed by `softmax_f32_to_out_kernel` reading the same buffer again. The bias pass existed only to hand the softmax a value the softmax was about to read anyway.

This adds a `HAS_BIAS` template parameter to the softmax kernel and reads the bias through a `score_at()` accessor, deleting the separate pass. A block owns one query row and the bias runs along the key axis in the same order the softmax reduces, so the fold is one extra contiguous stream. The kernel's three passes re-read it, but a row is 32-64 KB and stays resident, so the cost is one stream from memory against the two the separate pass spent on the scores alone.

Two details that are load-bearing rather than incidental:

**The bias is added before the column max is taken.** Taking the max of unbiased scores and then adding the bias could leave a masked entry (bias `-65504`) as the column max and put every exponent off scale.

**The bias is indexed on its own full extents**, carrying the same four arguments `hip_gqa_add_attention_bias_f32` takes for it (`bias_sq`, `bias_row_offset`, `bias_total_seq`, `bias_col_offset`). The score buffer is a sub-block of the logical `[sq, total_seq]` matrix -- a chunk of query rows since #787 tiled the prefill, and a narrowed key range since #795 recovered the sliding window -- while the bias always describes the whole thing. Folding either offset into the pointer would mis-stride every batch/head plane after the first.

This also inverts the documented order of the causal triangle and the bias, which is safe only because the triangle writes `-INFINITY`: adding any finite bias to it leaves `-INFINITY`, and elsewhere the sum is the same either way. Called out in a comment at the site.

## Related issue or design

Rebased onto `main` and retargeted from `feat/rgp-capture-fence`, which is not going to land. The branch is now one commit on top of `main`.

Worth knowing for review: this is a **port, not a replay**. The original was written against that base branch's head-grouping of the score buffers, which `main` never took -- `main` solved the same allocation problem with #787's query-row chunking and then narrowed the key range in #795. Every line the original commit touched in `gqa.cpp` had changed shape, and the bias indexing genuinely had to be reworked rather than re-applied: the old kernel resolved the bias plane as `cols * rows` and offset it by `col * rows`, which is only correct when the score block *is* the whole matrix. Under chunking and narrowing it is not, so the plane is now `bias_sq * bias_total_seq` with the two offsets applied inside it.

## What is not here

There is **no environment variable**. The fold is unconditional: with a bias it is taken, and with none the softmax runs the instantiation it always did. The previous revision of this PR carried `HIPDNN_EP_GQA_FUSE_BIAS_SOFTMAX=0` to restore the separate pass from one binary, which is measurement scaffolding rather than something a merged kernel should ship.

One consequence to flag: with the switch gone, nothing calls `hip_gqa_add_attention_bias_f32` any more. The entry and its kernel are left in place -- they are an exported `HIP_KERNEL_API` symbol and still correct -- but a reviewer who wants them deleted should say so, since that is a separate change to the kernel library's surface rather than part of this one.

## Measurement

**Re-measured on `main`, on the model's published config.** Two earlier revisions of this section have been superseded. The first carried a 40,716 -> 33,981 ms (-16.6%) result taken on the pre-rebase branch, whose baseline predated #787 and #795. The second was taken on `main` but against a **stale `genai_config.json`** belonging to an older revision of the Gemma-4 export, and it claimed a config workaround was needed to run the model at all; both of those points were wrong and are corrected below. The numbers here are `f1a82124` against `f1a82124` + this commit, differing only by this commit, with both `hipgpu.dll` and `custom_kernels_gfx1151.dll` swapped together, on the export's `genai_config.json` exactly as published.

### TTFT, Gemma-4 26B-A4B 16K VLM prefill, gfx1151

`vlm_benchmark.py`, 16,241 prompt tokens (15,987 text + 254 image), 3 reps + 1 warmup per block, blocks run base/cand then cand/base so drift cannot pass for an arm effect:

| arm | block 1 | block 2 | mean p50 |
|---|---|---|---|
| `main` | 46,647.8 ms | 46,766.4 ms | 46,707.1 ms |
| `main` + this commit | 41,166.8 ms | 41,276.9 ms | 41,221.8 ms |

**-5,485 ms (-11.7%).** Each arm's two blocks land within 119 ms of each other against a 5,485 ms arm separation -- about 46x the largest within-arm spread -- and reversing the block order did not move the result.

### Per-op GPU time at the same operating point

`HIPDNN_EP_PERF` on the decoder graph at `sq=16384`, mean of two warm reps per arm (within-arm spread under 0.15%). These run the ONNX graph directly through `hip-onnx-runner` rather than through genai, so they are unaffected by the config correction above:

| op | `main` | + this commit | delta |
|---|---|---|---|
| `gqa` (30 layers) | 29,857.6 ms | 25,087.7 ms | **-4,769.9 ms (-16.0%)** |
| -- 25 local-attention layers (d=256) | 22,977.1 ms | 19,012.9 ms | -3,964.2 ms |
| -- 5 global layers (d=512) | 6,880.6 ms | 6,074.7 ms | -805.9 ms |
| `qmoe` (control) | 3,948.7 ms | 3,940.9 ms | -0.2% |
| `matmul_nbits` (control) | 1,646.5 ms | 1,627.2 ms | -1.2% |
| total GPU | 36,934.8 ms | 32,112.7 ms | -4,822.1 ms (-13.1%) |

The controls sit inside run-to-run spread while `gqa` moves 16%, and the whole-graph saving is accounted for by `gqa` on its own, so the effect is isolated to the op this commit changes.

### The saving is the whole cost of the deleted pass

The pass moved `2 x 17.2 GB` of fp32 scores plus `0.54 GB` of fp16 bias per layer, or 34.9 GB. Dividing that by the measured per-layer saving gives **220 GB/s** on the local-attention layers and **217 GB/s** on the global ones -- 86% and 85% of this part's 256 GB/s roofline.

Those two groups differ in `head_dim`, KV head count and absolute cost, so their agreeing to within 2% is what identifies the mechanism as "one fewer full stream over the score buffer" rather than something incidental. A pass running that close to bandwidth is almost entirely irreducible traffic, and this commit recovers it in full. It also means the three passes' bias re-reads cost nothing measurable, which is the residency assumption the kernel comment makes.

### On the #795 caveat

An earlier revision warned that #795's window narrowing might have cut the win substantially, on the reasoning that 25 of 30 layers would attend only 1024 keys. A later revision claimed to have disproved that from `skv=16385` on all 30 layers. **Both statements should be disregarded**; the second was measured on a config with the `sliding_window` block deleted, so it could not have observed narrowing either way.

What is actually true is simpler: **this export ships no `sliding_window` block at all**, so #795's narrowing is not active for it, and the measurement above is at full key width on every layer. Whether #795 reduces this commit's win for an export that does configure a window is **unmeasured** and remains an open question for review.

The gap between the original -16.6% and this -11.7% is largely denominator: the absolute saving is 5,485 ms against the original 6,735 ms, while this baseline is 46.7 s rather than 40.7 s -- a different code base (post-#787, post-#795) as well as a different config.

## Verification

Real-model output was **token-for-token identical** between the two arms over a 32-token greedy decode. That is the expected result rather than a lucky one: both paths add the bias to the score in fp32, so they evaluate the same rounding, and the separate pass merely stored the sum to memory in between. This was measured pre-rebase, using the switch, and **has not been re-run on the rebased branch** -- it is the main thing still outstanding here. The 16K runs above completed and generated tokens on both arms, which is a liveness check, not an equivalence check.

`custom_kernels_gfx1151.dll` and `hipgpu.dll` both build clean for gfx1151 with no new warnings, and `pre-commit` passes.

### Retracted: the "config workaround" caveat

A previous revision of this section reported that Gemma-4 could not run through genai on `main` at all, quoting an output-allocator failure on `present.0.key` (`{1,8,1024,256}` vs `{1,8,3264,256}`), attributing it to the EP not honouring `past_present_share_buffer`, stating it reproduced across five commits, and proposing it deserved its own issue.

**That was an artifact of a stale `genai_config.json`, not an EP defect.** The config in use belonged to an older revision of the export and set `past_present_share_buffer: true` with a `sliding_window` block; the published config sets it `false` and ships no window block, and the model runs unmodified. There is no bug here to file, and the earlier claim that the workaround "inflates absolute TTFT, which is why the baseline reads 46.5 s" was also wrong -- re-measuring on the published config moved the baseline by 0.4%, from 46,514.7 ms to 46,707.1 ms.

### RGP capture

Still not possible, for an unrelated reason: `model_benchmark` rejects Gemma-4's mixed KV geometry, and while `hip-onnx-runner` does reach GQA, it runs one inference and exits, so only 1.8 MB of a 142.6 MB trace streamed out before the process died. The bias/softmax split above is therefore byte accounting against op-level timing, not SPM counters.

## What is left after this

`gqa` is still 78% of a 16K prefill. The score buffer costs about 86 GB per layer once the bias pass is gone, and almost 60% of that is the softmax streaming the score matrix three times -- max, then exp+sum, then exp+normalise. Collapsing that to a single online pass is worth roughly 4.7 s, about as much again as this commit wins.

That is out of scope here and not small: two independent gates in `gqa.cpp` force this model onto the decomposed pipeline that materialises scores at all -- an additive attention bias forces it (lines 35-37), and windowed flash prefill is implemented only for `head_dim == 64` (line 25) while Gemma-4 is d=256.

## Notes for reviewers

- New entry `hip_gqa_softmax_f32_to_out_biased` dispatches the `(TOut, TBias)` instantiation from the output and bias dtypes; the existing callers select `HAS_BIAS=false` through an overload and are unchanged.
- Mind the axis naming when checking the indexing: the softmax kernel reduces along `rows`, so its `rows` is the key extent and its `cols` the query count -- the transpose of the names `hip_gqa_add_attention_bias_f32` uses for the same buffer. Both the header and the entry comment say so.
- `bias_element_size_bytes` is passed `elem_sz`, i.e. the GEMM/cache element size, exactly as the bias-add call did. That equates the mask dtype with the GEMM dtype; it is pre-existing behaviour carried over unchanged, not a new assumption.

Made with [Cursor](https://cursor.com)
