### PR TITLE
perf(causal_conv): absorb the Transpose pair into a channels-last convolution, -1.77 s TTFT at 16K

### DIFF
--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -2969,10 +2969,19 @@ def Hip_CausalConvWithStateOp : Hip_DpsOp<"causal_conv_with_state",
     the last spatial dimension) and depthwise (each channel is convolved
     independently with its own kernel).
 
-    Input layout is channels-first: (batch_size, channels, ...).
-    Weight layout: (channels, 1, k_1, ...) for depthwise convolution.
-    The carry state stores the last (k-1) positions along the causal axis
-    for incremental decode.
+    Input layout is channels-first, (batch_size, channels, ...), unless
+    `channels_last` is set, in which case 1D input is (batch_size, seq_len,
+    channels). Weight layout: (channels, 1, k_1, ...) for depthwise
+    convolution. The carry state stores the last (k-1) positions along the
+    causal axis for incremental decode, and is (batch, channels, k-1) in both
+    layouts -- only input and output are permuted, so a layout change never
+    invalidates a carried state.
+
+    `channels_last` exists because the surrounding graph is channels-last: a
+    channels-first convolution has to be bracketed by a Transpose pair, and at
+    the Qwen3.6 footprint that pair costs more than the convolution it serves.
+    The canonicalizer sets the attribute while absorbing both Transposes.
+    Only ndim=1 is supported channels-last.
 
     Example (1D):
     ```mlir
@@ -3003,7 +3012,8 @@ def Hip_CausalConvWithStateOp : Hip_DpsOp<"causal_conv_with_state",
 
     // Attributes
     DefaultValuedAttr<StrAttr, "\"none\"">:$activation,  // "none", "silu", "swish"
-    DefaultValuedAttr<I64Attr, "1">:$ndim                // 1, 2, or 3
+    DefaultValuedAttr<I64Attr, "1">:$ndim,               // 1, 2, or 3
+    DefaultValuedAttr<BoolAttr, "false">:$channels_last  // input/output (B, L, C)
   );
 
   let assemblyFormat = [{
@@ -3023,6 +3033,10 @@ def Hip_CausalConvWithStateOp : Hip_DpsOp<"causal_conv_with_state",
     `)`
     attr-dict (`:` type($result_tensors)^)?
   }];
+
+  // Absorbs a surrounding [0,2,1] Transpose pair into `channels_last`.
+  // See lib/Dialect/IR/HipCausalConvCanonicalize.cpp.
+  let hasCanonicalizer = 1;
 
   // OpStateOpInterface: construct this instance's per-session MIOpen
   // descriptor/algo cache (CausalConvState). No compile-time params — the

--- a/lib/Conversion/HipToLLVM/CausalConvWithStateLowering.cpp
+++ b/lib/Conversion/HipToLLVM/CausalConvWithStateLowering.cpp
@@ -17,7 +17,7 @@ namespace {
 //                                 output, present_state,
 //                                 batch_size, channels, seq_len,
 //                                 kernel_size, ndim, activation,
-//                                 element_size_bytes)
+//                                 element_size_bytes, channels_last)
 struct CausalConvWithStateOpLowering
     : public ConvertOpToLLVMPattern<CausalConvWithStateOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
@@ -59,25 +59,28 @@ struct CausalConvWithStateOpLowering
 
     // Extract shape info from input memref: (batch, channels, L) for ndim=1
     auto inputType = cast<MemRefType>(op.getInput().getType());
-    auto inputShape = inputType.getShape();
     int64_t rank = inputType.getRank();
+    bool channelsLast = op.getChannelsLast();
 
     // Input layout: (batch, channels, spatial_dims...)
     // For ndim=1: rank=3, shape = [batch, channels, L]
     // For ndim=2: rank=4, shape = [batch, channels, H, W]
     // For ndim=3: rank=5, shape = [batch, channels, D, H, W]
+    // Channels-last is 1D only: rank=3, shape = [batch, L, channels].
     if (rank < 3)
       return op.emitError("input must be at least rank-3");
+    if (channelsLast && rank != 3)
+      return op.emitError("channels_last requires a rank-3 input (ndim=1)");
 
     Value batchSize =
         getMemRefDimSize(inputType, 0, adaptor.getInput(), rewriter, loc);
-    Value channels =
-        getMemRefDimSize(inputType, 1, adaptor.getInput(), rewriter, loc);
+    Value channels = getMemRefDimSize(inputType, channelsLast ? 2 : 1,
+                                      adaptor.getInput(), rewriter, loc);
 
     // seq_len = product of spatial dimensions (last ndim dims)
-    // For ndim=1: just the last dim
-    Value seqLen =
-        getMemRefDimSize(inputType, 2, adaptor.getInput(), rewriter, loc);
+    // For ndim=1: just the last dim, or dim 1 when channels moved to the end
+    Value seqLen = getMemRefDimSize(inputType, channelsLast ? 1 : 2,
+                                    adaptor.getInput(), rewriter, loc);
     for (int64_t i = 3; i < rank; ++i) {
       Value dim =
           getMemRefDimSize(inputType, i, adaptor.getInput(), rewriter, loc);
@@ -113,8 +116,10 @@ struct CausalConvWithStateOpLowering
         inputType.getElementType().getIntOrFloatBitWidth() / 8;
     Value elemSizeVal = createI64Const(elemSizeBytes);
 
+    Value channelsLastVal = createI64Const(channelsLast ? 1 : 0);
+
     // Build function signature
-    SmallVector<Type, 15> paramTypes = {
+    SmallVector<Type, 16> paramTypes = {
         ptrType, // state
         i32Type, // op_state_slot
         ptrType, // input
@@ -129,7 +134,8 @@ struct CausalConvWithStateOpLowering
         i64Type, // kernel_size
         i64Type, // ndim
         i64Type, // activation
-        i64Type  // element_size_bytes
+        i64Type, // element_size_bytes
+        i64Type  // channels_last
     };
 
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
@@ -137,15 +143,15 @@ struct CausalConvWithStateOpLowering
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value, 15> args = {
-        statePtr,   getOpStateSlotValue(op, rewriter, loc),
-        inputPtr,   weightPtr,
-        biasPtr,    pastStatePtr,
-        outputPtr,  presentStatePtr,
-        batchSize,  channels,
-        seqLen,     kernelSizeVal,
-        ndimVal,    activationVal,
-        elemSizeVal};
+    SmallVector<Value, 16> args = {
+        statePtr,    getOpStateSlotValue(op, rewriter, loc),
+        inputPtr,    weightPtr,
+        biasPtr,     pastStatePtr,
+        outputPtr,   presentStatePtr,
+        batchSize,   channels,
+        seqLen,      kernelSizeVal,
+        ndimVal,     activationVal,
+        elemSizeVal, channelsLastVal};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
 

--- a/lib/Dialect/IR/CMakeLists.txt
+++ b/lib/Dialect/IR/CMakeLists.txt
@@ -4,6 +4,7 @@
 ##
 
 add_library(HipDialectIR STATIC
+  HipCausalConvCanonicalize.cpp
   HipDialect.cpp
   HipDpsOpInterface.cpp
   HipOpStateInterface.cpp

--- a/lib/Dialect/IR/HipCausalConvCanonicalize.cpp
+++ b/lib/Dialect/IR/HipCausalConvCanonicalize.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+//===----------------------------------------------------------------------===//
+// Absorb the Transpose pair around a channels-first causal convolution.
+//
+// ONNX Conv is channels-first, so an exporter whose surrounding graph is
+// channels-last has to bracket the convolution:
+//
+//   %t0 = hip.transpose(%x)  perm = [0, 2, 1]     // [B,L,C] -> [B,C,L]
+//   %y, %s = hip.causal_conv_with_state(%t0, ...)
+//   %t1 = hip.transpose(%y)  perm = [0, 2, 1]     // [B,C,L] -> [B,L,C]
+//
+// Both transposes are pure data movement in service of a layout the kernel does
+// not actually require. On Qwen3.6-35B-A3B each one moves 65 MB per layer and
+// the pair together costs more than the convolution between them, across all 30
+// linear-attention layers. This pattern rewrites the triple to a single
+// convolution with `channels_last` set, which reads and writes [B,L,C]
+// directly.
+//
+// Only input and output are permuted. The carry state is [B, C, k-1] under both
+// layouts, so past_state and present_state are forwarded untouched -- the fold
+// cannot invalidate a state buffer carried in from a previous step.
+//
+// The rewrite runs in the tensor domain, on the canonicalizer pass that
+// Pipelines.cpp schedules before bufferization. Afterwards there are no results
+// to trace a use-chain through, and the guards below fail closed.
+//===----------------------------------------------------------------------===//
+
+#include "hip/Dialect/IR/HipDialect.h"
+
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/PatternMatch.h"
+
+#include "llvm/ADT/Sequence.h"
+
+using namespace mlir;
+using namespace mlir::hip;
+
+namespace {
+
+/// The only permutation this fold understands: swap the trailing two axes of a
+/// rank-3 tensor, which is what converts between [B,L,C] and [B,C,L].
+bool isLastTwoAxisSwap(TransposeOp transpose) {
+  ArrayAttr perm = transpose.getPerm();
+  if (perm.size() != 3)
+    return false;
+  const int64_t expected[3] = {0, 2, 1};
+  for (int64_t i : llvm::seq<int64_t>(0, 3)) {
+    auto value = dyn_cast<IntegerAttr>(perm[i]);
+    if (!value || value.getInt() != expected[i])
+      return false;
+  }
+  return true;
+}
+
+/// Whether the channels-last custom kernel will actually accept this shape.
+///
+/// Only that kernel can read (B, L, C); the MIOpen fallback behind it is
+/// channels-first and refuses the attribute rather than misreading the buffer.
+/// So folding a shape outside the kernel's envelope would turn a working
+/// convolution into a hard runtime failure. Mirrors the envelope in
+/// wrap_causal_conv_with_state, and reads the kernel width the way
+/// CausalConvWithStateLowering does: the product of the weight dims from 2 on.
+bool fastPathAcceptsShape(CausalConvWithStateOp conv) {
+  auto weightType = dyn_cast<RankedTensorType>(conv.getWeight().getType());
+  if (!weightType || weightType.getRank() < 3)
+    return false;
+  int64_t kernelSize = 1;
+  for (int64_t i : llvm::seq<int64_t>(2, weightType.getRank())) {
+    if (weightType.isDynamicDim(i))
+      return false; // unknowable here, so leave the Transposes in place
+    kernelSize *= weightType.getDimSize(i);
+  }
+  if (kernelSize < 1 || kernelSize > 8)
+    return false;
+
+  auto inputType = dyn_cast<RankedTensorType>(conv.getInput().getType());
+  if (!inputType)
+    return false;
+  unsigned bytes = inputType.getElementType().getIntOrFloatBitWidth() / 8;
+  return bytes == 2 || bytes == 4;
+}
+
+/// tensor.empty for a DPS init, taking any dynamic extent from `source`. The
+/// caller guarantees `source` has the same shape as `type`, so extents align
+/// positionally.
+Value createEmptyLike(OpBuilder &builder, Location loc, RankedTensorType type,
+                      Value source) {
+  SmallVector<Value> dynSizes;
+  for (int64_t dim : llvm::seq<int64_t>(0, type.getRank()))
+    if (type.isDynamicDim(dim))
+      dynSizes.push_back(tensor::DimOp::create(builder, loc, source, dim));
+  return tensor::EmptyOp::create(builder, loc, type.getShape(),
+                                 type.getElementType(), dynSizes);
+}
+
+struct FoldTransposePairIntoChannelsLast
+    : public OpRewritePattern<CausalConvWithStateOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(CausalConvWithStateOp conv,
+                                PatternRewriter &rewriter) const override {
+    if (conv.getChannelsLast())
+      return rewriter.notifyMatchFailure(conv, "already channels-last");
+
+    // The channels-last kernel is 1D only, and only the 1D op has a single
+    // sequence axis for the permutation to be about.
+    if (conv.getNdim() != 1)
+      return rewriter.notifyMatchFailure(conv, "channels_last needs ndim=1");
+
+    // Tensor domain only: after bufferization the op has no results and the
+    // producer/consumer chain below is not expressible.
+    if (conv->getNumResults() != 2)
+      return rewriter.notifyMatchFailure(conv, "not in tensor form");
+
+    if (!fastPathAcceptsShape(conv))
+      return rewriter.notifyMatchFailure(
+          conv, "outside the channels-last kernel's supported envelope");
+
+    auto leading = conv.getInput().getDefiningOp<TransposeOp>();
+    if (!leading || !isLastTwoAxisSwap(leading))
+      return rewriter.notifyMatchFailure(conv,
+                                         "input is not a [0,2,1] transpose");
+
+    // The leading transpose must die with the fold. If its result is read
+    // anywhere else the transpose still runs, and rewriting the convolution
+    // then buys a layout change without removing the traffic that motivated it.
+    if (!leading->getResult(0).hasOneUse())
+      return rewriter.notifyMatchFailure(leading,
+                                         "transpose result has other readers");
+
+    // Same on the way out: the convolution's output must feed exactly one
+    // transpose back to channels-last, and feed it as data rather than as that
+    // transpose's own destination buffer.
+    Value convOutput = conv->getResult(0);
+    if (!convOutput.hasOneUse())
+      return rewriter.notifyMatchFailure(conv,
+                                         "output has more than one reader");
+    auto trailing = dyn_cast<TransposeOp>(*convOutput.getUsers().begin());
+    if (!trailing || !isLastTwoAxisSwap(trailing))
+      return rewriter.notifyMatchFailure(
+          conv, "output is not consumed by a [0,2,1] transpose");
+    if (trailing.getInput() != convOutput)
+      return rewriter.notifyMatchFailure(
+          trailing, "convolution output is the transpose destination");
+
+    Value nlcInput = leading.getInput();
+    auto nlcInputType = dyn_cast<RankedTensorType>(nlcInput.getType());
+    auto nlcOutputType =
+        dyn_cast<RankedTensorType>(trailing->getResult(0).getType());
+    if (!nlcInputType || !nlcOutputType)
+      return rewriter.notifyMatchFailure(conv, "unranked operands");
+
+    // Both transposes undo each other, so the convolution's channels-last input
+    // and output must agree in shape. Anything else means the perms did not
+    // compose the way the checks above assume, and the fold would silently
+    // reinterpret the buffer.
+    if (nlcInputType.getShape() != nlcOutputType.getShape() ||
+        nlcInputType.getElementType() != nlcOutputType.getElementType())
+      return rewriter.notifyMatchFailure(
+          conv, "transposes do not compose to the identity");
+
+    // A fresh init rather than the trailing transpose's: that one is defined
+    // after this convolution, so reusing it here would not dominate its use.
+    Value outputInit =
+        createEmptyLike(rewriter, conv.getLoc(), nlcOutputType, nlcInput);
+
+    auto folded = CausalConvWithStateOp::create(
+        rewriter, conv.getLoc(),
+        TypeRange{nlcOutputType, conv->getResult(1).getType()}, conv.getCtx(),
+        nlcInput, conv.getWeight(), conv.getBias(), conv.getPastState(),
+        outputInit, conv.getPresentState(), conv.getActivation(),
+        conv.getNdim(), /*channels_last=*/true);
+
+    rewriter.replaceOp(trailing, folded->getResult(0));
+    rewriter.replaceOp(conv, {folded->getResult(0), folded->getResult(1)});
+    // Guarded above as single-use, and that use was the convolution.
+    if (leading->getResult(0).use_empty())
+      rewriter.eraseOp(leading);
+    return success();
+  }
+};
+
+} // namespace
+
+void CausalConvWithStateOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
+  patterns.add<FoldTransposePairIntoChannelsLast>(context);
+}

--- a/lib/Runtime/Kernels/hip/causal_conv_step_kernel.hip
+++ b/lib/Runtime/Kernels/hip/causal_conv_step_kernel.hip
@@ -198,16 +198,38 @@ hipError_t launch_for_K(
 }
 
 // Prefill (seq_len > 1) fused causal depthwise 1D conv + bias + SiLU.
-// One thread per (b, c) plane slides a length-K window over the virtual
-// sequence [past_state[0..K-2], input[0..L-1]], writing L outputs and the
-// trailing K-1 present_state. fp32 accumulate -- numerically matches
-// causal_conv_step_kernel at L=1. Replaces the MIOpen prefill path (Find +
-// 3 pitched memcpys + conv + bias + activation + mul) with a single launch.
+// A thread slides a length-K window over its slice of the virtual sequence
+// [past_state[0..K-2], input[0..L-1]], writing that slice's outputs; the thread
+// holding the tail also writes the trailing K-1 present_state. fp32 accumulate
+// -- numerically matches causal_conv_step_kernel at L=1. Replaces the MIOpen
+// prefill path (Find + 3 pitched memcpys + conv + bias + activation + mul)
+// with a single launch. Layout matches wrap_causal_conv_with_state:
+//   input, output            flat [(b*C + c)*L + t]
+//   past_state, present_state flat [(b*C + c)*(K-1) + j]
+//   weight                    flat [c*K + j];   bias flat [c]
+//
+// One block owns one (b, c) plane and a TILE-long run of its outputs: lane i
+// produces output t0 + i, and the block stages virtual[t0 .. t0+TILE+K-2] in LDS
+// first so every global access is contiguous across the wave.
+//
+// Why it is shaped this way rather than one-thread-per-plane walking t. That
+// form fixes the grid at B*C, so a 4k-token prefill launches exactly as many
+// threads as a 40-token one -- 8192 threads, ~6 waves per CU, far too few to
+// cover DRAM latency, which is why it sat at 105 GB/s. But simply splitting t
+// across more blocks while keeping one thread per plane is *worse*, measured
+// 2.6x worse: each lane's addresses are seq_len apart, so a wave touches 32
+// different cache lines per load and only recovers the cost by consuming the
+// rest of each line on later iterations of its own serial walk. Multiply the
+// resident lane count and those lines no longer survive in cache between uses,
+// and the same traffic is refetched per element. Coalescing across lanes is what
+// actually removes the problem: consecutive lanes read consecutive t, so one
+// line serves the whole wave immediately and no cache retention is required.
+//
 // Layout matches wrap_causal_conv_with_state:
 //   input, output            flat [(b*C + c)*L + t]
 //   past_state, present_state flat [(b*C + c)*(K-1) + j]
 //   weight                    flat [c*K + j];   bias flat [c]
-template <typename T, int K, int HAS_BIAS, int ACT_SILU>
+template <typename T, int K, int HAS_BIAS, int ACT_SILU, int TILE>
 __global__ void causal_conv_prefill_kernel(
     const T* __restrict__ input,
     const T* __restrict__ weight,
@@ -219,15 +241,49 @@ __global__ void causal_conv_prefill_kernel(
     int channels,
     int seq_len) {
 
-    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const int plane = static_cast<int>(blockIdx.x);
     const int total = batch_size * channels;
-    if (idx >= total)
+    if (plane >= total)
         return;
 
-    const int c = idx % channels;
-    constexpr int STATE_LEN = K - 1;
+    const int t0 = static_cast<int>(blockIdx.y) * TILE;
+    if (t0 >= seq_len)
+        return;
 
-    // Per-channel weights (K taps) and optional bias.
+    const int c = plane % channels;
+    const int lane = static_cast<int>(threadIdx.x);
+    constexpr int STATE_LEN = K - 1;
+    constexpr int SMEM_LEN = TILE + K - 1;
+
+    const T* in_row = input + static_cast<int64_t>(plane) * seq_len;
+    T* out_row = output + static_cast<int64_t>(plane) * seq_len;
+
+    // smem[j] = virtual[t0 + j], where the virtual sequence is
+    //   virtual[i] = past_state[i]      for i < K-1
+    //                input[i - (K-1)]   otherwise,
+    // so output t reads virtual[t .. t+K-1] = smem[t-t0 .. t-t0+K-1]. Only the
+    // first tile of the first block touches past_state; every later tile reads
+    // its whole window from input.
+    __shared__ float smem[SMEM_LEN];
+    {
+        const T* ps = (STATE_LEN > 0 && past_state != nullptr)
+                          ? past_state + static_cast<int64_t>(plane) * STATE_LEN
+                          : nullptr;
+        for (int j = lane; j < SMEM_LEN; j += TILE) {
+            const int vi = t0 + j;
+            float v;
+            if (vi < STATE_LEN) {
+                v = ps ? to_f32<T>(ps[vi]) : 0.0f;
+            } else {
+                const int ii = vi - STATE_LEN;
+                v = (ii < seq_len) ? to_f32<T>(in_row[ii]) : 0.0f;
+            }
+            smem[j] = v;
+        }
+    }
+
+    // Per-channel weights (K taps) and optional bias: one channel per block, so
+    // every lane reads the same values and the load broadcasts.
     float w[K];
     {
         const T* wp = weight + static_cast<int64_t>(c) * K;
@@ -237,33 +293,14 @@ __global__ void causal_conv_prefill_kernel(
     }
     const float bias_v = HAS_BIAS ? to_f32<T>(bias[c]) : 0.0f;
 
-    // window[0..K-1] holds virtual[t .. t+K-1] for the current output t.
-    // Init for t=0: [past_state[0..K-2], input[0]].
-    float window[K];
-    {
-        const T* ps = (STATE_LEN > 0 && past_state != nullptr)
-                          ? past_state + static_cast<int64_t>(idx) * STATE_LEN
-                          : nullptr;
-        #pragma unroll
-        for (int j = 0; j < STATE_LEN; ++j)
-            window[j] = ps ? to_f32<T>(ps[j]) : 0.0f;
-    }
-    const T* in_row = input + static_cast<int64_t>(idx) * seq_len;
-    T* out_row = output + static_cast<int64_t>(idx) * seq_len;
-    window[K - 1] = to_f32<T>(in_row[0]);
+    __syncthreads();
 
-    for (int t = 0; t < seq_len; ++t) {
-        if (t > 0) {
-            // Slide the window: drop oldest, append virtual[t+K-1] = input[t].
-            #pragma unroll
-            for (int j = 0; j < K - 1; ++j)
-                window[j] = window[j + 1];
-            window[K - 1] = to_f32<T>(in_row[t]);
-        }
+    const int t = t0 + lane;
+    if (t < seq_len) {
         float y = 0.0f;
         #pragma unroll
         for (int j = 0; j < K; ++j)
-            y += w[j] * window[j];
+            y += w[j] * smem[lane + j];
         if (HAS_BIAS)
             y += bias_v;
         if (ACT_SILU) {
@@ -273,13 +310,174 @@ __global__ void causal_conv_prefill_kernel(
         out_row[t] = from_f32<T>(y);
     }
 
-    // present_state = last K-1 of virtual = window[1..K-1] after the last step.
-    if (STATE_LEN > 0) {
-        T* nps = present_state + static_cast<int64_t>(idx) * STATE_LEN;
+    // present_state[j] = virtual[L + j]: the trailing K-1 of the virtual
+    // sequence, owned by whichever block covers the final output.
+    if (STATE_LEN > 0 && t0 + TILE >= seq_len && lane < STATE_LEN) {
+        T* nps = present_state + static_cast<int64_t>(plane) * STATE_LEN;
+        nps[lane] = from_f32<T>(smem[seq_len - t0 + lane]);
+    }
+}
+
+// Channels-last prefill: input and output are [B, L, C] instead of [B, C, L].
+// The recurrent state keeps its native [B, C, K-1] layout either way.
+//
+// This exists because the ONNX export brackets the conv with a Transpose pair --
+// [B,L,C] -> [B,C,L] in, and back out -- purely because ONNX Conv wants its
+// channels first. Those two transposes move 65 MB each on Qwen3.6-35B-A3B and
+// together cost more than the convolution they surround. Nothing about the
+// arithmetic needs channels first, so the layout is a parameter here and the
+// transposes can be folded away by the caller.
+//
+// The shape falls out differently from the channels-first kernel. There, time is
+// the contiguous axis, so a wave must cover consecutive t and the K-deep window
+// overlaps between neighbouring lanes -- hence the LDS staging. Here channels are
+// contiguous, so a lane owns one channel and walks time by itself: the window
+// lives entirely in that lane's registers with no sharing, no LDS and no halo
+// staging, while each load still coalesces because neighbouring lanes read
+// neighbouring channels at the same t. A block covers CTILE channels x TTILE
+// timesteps and re-reads only the K-1 timesteps preceding its tile.
+template <typename T, int K, int HAS_BIAS, int ACT_SILU, int CTILE, int TTILE>
+__global__ void causal_conv_prefill_nlc_kernel(
+    const T* __restrict__ input,
+    const T* __restrict__ weight,
+    const T* __restrict__ bias,
+    const T* __restrict__ past_state,
+    T* __restrict__ output,
+    T* __restrict__ present_state,
+    int batch_size,
+    int channels,
+    int seq_len) {
+
+    const int c = static_cast<int>(blockIdx.x) * CTILE + static_cast<int>(threadIdx.x);
+    const int b = static_cast<int>(blockIdx.z);
+    const int t0 = static_cast<int>(blockIdx.y) * TTILE;
+    if (c >= channels || t0 >= seq_len || b >= batch_size)
+        return;
+
+    constexpr int STATE_LEN = K - 1;
+    const int64_t plane = static_cast<int64_t>(b) * channels + c;
+    const T* ps = (STATE_LEN > 0 && past_state != nullptr)
+                      ? past_state + plane * STATE_LEN
+                      : nullptr;
+    const T* in_b = input + static_cast<int64_t>(b) * seq_len * channels;
+    T* out_b = output + static_cast<int64_t>(b) * seq_len * channels;
+
+    // The virtual sequence the convolution slides over, same definition as the
+    // channels-first kernel: virtual[i] = past_state[i] for i < K-1, else
+    // input[i - (K-1)]. Output t reads virtual[t .. t+K-1].
+    auto virt = [&](int i) -> float {
+        if (i < STATE_LEN)
+            return ps ? to_f32<T>(ps[i]) : 0.0f;
+        const int ti = i - STATE_LEN;
+        return (ti < seq_len)
+                   ? to_f32<T>(in_b[static_cast<int64_t>(ti) * channels + c])
+                   : 0.0f;
+    };
+
+    // One channel per lane, so each lane reads its own K taps. Strided by K
+    // across the wave, but the whole filter bank is C*K elements and is reused
+    // by every timestep this lane walks.
+    float w[K];
+    {
+        const T* wp = weight + static_cast<int64_t>(c) * K;
+        #pragma unroll
+        for (int j = 0; j < K; ++j)
+            w[j] = to_f32<T>(wp[j]);
+    }
+    const float bias_v = HAS_BIAS ? to_f32<T>(bias[c]) : 0.0f;
+
+    // Seed with the K-1 virtual elements preceding this tile's first output.
+    float win[K];
+    #pragma unroll
+    for (int j = 0; j < STATE_LEN; ++j)
+        win[j] = virt(t0 + j);
+
+    const int tend = (t0 + TTILE < seq_len) ? t0 + TTILE : seq_len;
+    for (int t = t0; t < tend; ++t) {
+        win[K - 1] = to_f32<T>(in_b[static_cast<int64_t>(t) * channels + c]);
+        float y = 0.0f;
+        #pragma unroll
+        for (int j = 0; j < K; ++j)
+            y += w[j] * win[j];
+        if (HAS_BIAS)
+            y += bias_v;
+        if (ACT_SILU) {
+            const float s = 1.0f / (1.0f + expf(-y));
+            y *= s;
+        }
+        out_b[static_cast<int64_t>(t) * channels + c] = from_f32<T>(y);
+        #pragma unroll
+        for (int j = 0; j < K - 1; ++j)
+            win[j] = win[j + 1];
+    }
+
+    // present_state[j] = virtual[L + j], written by the tile holding the tail.
+    if (STATE_LEN > 0 && tend == seq_len) {
+        T* nps = present_state + plane * STATE_LEN;
         #pragma unroll
         for (int j = 0; j < STATE_LEN; ++j)
-            nps[j] = from_f32<T>(window[j + 1]);
+            nps[j] = from_f32<T>(virt(seq_len + j));
     }
+}
+
+template <typename T>
+hipError_t launch_prefill_nlc_for_K(
+    int K, hipStream_t stream,
+    const T* input, const T* weight, const T* bias, const T* past_state,
+    T* output, T* present_state,
+    int batch_size, int channels, int seq_len, int has_bias, int act_silu) {
+
+    // CTILE is the block size, so it sets the coalesced width; 256 covers four
+    // 64-lane waves of consecutive channels. TTILE trades halo re-reads against
+    // block count: at K=4 a 64-step tile re-reads 3 of every 64 timesteps, ~5%,
+    // while still giving 8192/256 x 3985/64 = 2016 blocks on this model.
+    constexpr int kCTile = 256;
+    constexpr int kTTile = 64;
+    const dim3 grid((channels + kCTile - 1) / kCTile,
+                    (seq_len + kTTile - 1) / kTTile,
+                    batch_size);
+
+    auto launch = [&](auto k_const, auto bias_const, auto act_const) {
+        constexpr int Kc = decltype(k_const)::value;
+        constexpr int Bc = decltype(bias_const)::value;
+        constexpr int Ac = decltype(act_const)::value;
+        hipLaunchKernelGGL(
+            (causal_conv_prefill_nlc_kernel<T, Kc, Bc, Ac, kCTile, kTTile>),
+            grid, dim3(kCTile), 0, stream,
+            input, weight, bias, past_state, output, present_state,
+            batch_size, channels, seq_len);
+        return hipGetLastError();
+    };
+
+#define DISPATCH_PREFILL_NLC_K(KVAL)                                          \
+    case KVAL: {                                                              \
+        using K_t = std::integral_constant<int, KVAL>;                        \
+        if (has_bias && act_silu)                                             \
+            return launch(K_t{}, std::integral_constant<int, 1>{},            \
+                          std::integral_constant<int, 1>{});                  \
+        if (has_bias)                                                         \
+            return launch(K_t{}, std::integral_constant<int, 1>{},            \
+                          std::integral_constant<int, 0>{});                  \
+        if (act_silu)                                                         \
+            return launch(K_t{}, std::integral_constant<int, 0>{},            \
+                          std::integral_constant<int, 1>{});                  \
+        return launch(K_t{}, std::integral_constant<int, 0>{},                \
+                      std::integral_constant<int, 0>{});                      \
+    }
+
+    switch (K) {
+        DISPATCH_PREFILL_NLC_K(1)
+        DISPATCH_PREFILL_NLC_K(2)
+        DISPATCH_PREFILL_NLC_K(3)
+        DISPATCH_PREFILL_NLC_K(4)
+        DISPATCH_PREFILL_NLC_K(5)
+        DISPATCH_PREFILL_NLC_K(6)
+        DISPATCH_PREFILL_NLC_K(7)
+        DISPATCH_PREFILL_NLC_K(8)
+        default:
+            return hipErrorInvalidValue;
+    }
+#undef DISPATCH_PREFILL_NLC_K
 }
 
 template <typename T>
@@ -289,17 +487,21 @@ hipError_t launch_prefill_for_K(
     T* output, T* present_state,
     int batch_size, int channels, int seq_len, int has_bias, int act_silu) {
 
-    const int total = batch_size * channels;
-    const int block = 256;
-    const int grid = (total + block - 1) / block;
+    // One block per (b, c) plane per kTile outputs. kTile is also the block
+    // size, so it sets the coalesced load width and the LDS staging buffer at
+    // once; 256 keeps that buffer near 1 KB and the halo re-read to K-1 elements
+    // per 256 outputs.
+    constexpr int kTile = 256;
+    const int planes = batch_size * channels;
+    const int tiles = (seq_len + kTile - 1) / kTile;
 
     auto launch = [&](auto k_const, auto bias_const, auto act_const) {
         constexpr int Kc = decltype(k_const)::value;
         constexpr int Bc = decltype(bias_const)::value;
         constexpr int Ac = decltype(act_const)::value;
         hipLaunchKernelGGL(
-            (causal_conv_prefill_kernel<T, Kc, Bc, Ac>),
-            dim3(grid), dim3(block), 0, stream,
+            (causal_conv_prefill_kernel<T, Kc, Bc, Ac, kTile>),
+            dim3(planes, tiles), dim3(kTile), 0, stream,
             input, weight, bias, past_state, output, present_state,
             batch_size, channels, seq_len);
         return hipGetLastError();
@@ -427,6 +629,68 @@ extern "C" int hip_causal_conv_step_decode(
     return 0;
 }
 
+namespace {
+
+// Shared body of the two prefill entry points: identical contract and
+// validation, differing only in which launcher (and so which activation layout)
+// they use. `who` names the caller in diagnostics.
+template <typename Launch>
+int prefill_common(
+    const char* who,
+    const void* input, const void* weight, const void* output,
+    const void* present_state,
+    int64_t batch_size, int64_t channels, int64_t seq_len,
+    int64_t kernel_size, int64_t activation, int64_t element_size_bytes,
+    Launch&& launch) {
+
+    if (!input || !weight || !output || !present_state) {
+        fprintf(stderr,
+                "[custom_kernels] %s: null required "
+                "pointer (input=%p weight=%p output=%p present_state=%p)\n",
+                who, input, weight, output, present_state);
+        return -1;
+    }
+    if (batch_size <= 0 || channels <= 0 || seq_len <= 0) {
+        fprintf(stderr,
+                "[custom_kernels] %s: invalid "
+                "batch=%lld channels=%lld seq_len=%lld\n",
+                who, (long long)batch_size, (long long)channels,
+                (long long)seq_len);
+        return -1;
+    }
+    if (kernel_size < 1 || kernel_size > 8) {
+        fprintf(stderr,
+                "[custom_kernels] %s: kernel_size=%lld "
+                "outside supported range [1,8]\n",
+                who, (long long)kernel_size);
+        return -1;
+    }
+    if (activation != 0 && activation != 1) {
+        fprintf(stderr,
+                "[custom_kernels] %s: unsupported "
+                "activation=%lld (0=none, 1=SiLU)\n",
+                who, (long long)activation);
+        return -1;
+    }
+    if (element_size_bytes != 2 && element_size_bytes != 4) {
+        fprintf(stderr,
+                "[custom_kernels] %s: unsupported "
+                "element_size_bytes=%lld (expect 2 or 4)\n",
+                who, (long long)element_size_bytes);
+        return -1;
+    }
+
+    const hipError_t err = launch(element_size_bytes == 4);
+    if (err != hipSuccess) {
+        fprintf(stderr, "[custom_kernels] %s: launch failed (%s)\n", who,
+                hipGetErrorString(err));
+        return static_cast<int>(err);
+    }
+    return 0;
+}
+
+} // namespace
+
 extern "C" int hip_causal_conv_prefill(
     void* stream,
     const void* input,
@@ -442,77 +706,85 @@ extern "C" int hip_causal_conv_prefill(
     int64_t activation,
     int64_t element_size_bytes) {
 
-    if (!input || !weight || !output || !present_state) {
-        fprintf(stderr,
-                "[custom_kernels] hip_causal_conv_prefill: null required "
-                "pointer (input=%p weight=%p output=%p present_state=%p)\n",
-                input, weight, output, present_state);
-        return -1;
-    }
-    if (batch_size <= 0 || channels <= 0 || seq_len <= 0) {
-        fprintf(stderr,
-                "[custom_kernels] hip_causal_conv_prefill: invalid "
-                "batch=%lld channels=%lld seq_len=%lld\n",
-                (long long)batch_size, (long long)channels, (long long)seq_len);
-        return -1;
-    }
-    if (kernel_size < 1 || kernel_size > 8) {
-        fprintf(stderr,
-                "[custom_kernels] hip_causal_conv_prefill: kernel_size=%lld "
-                "outside supported range [1,8]\n",
-                (long long)kernel_size);
-        return -1;
-    }
-    if (activation != 0 && activation != 1) {
-        fprintf(stderr,
-                "[custom_kernels] hip_causal_conv_prefill: unsupported "
-                "activation=%lld (0=none, 1=SiLU)\n",
-                (long long)activation);
-        return -1;
-    }
+    return prefill_common(
+        "hip_causal_conv_prefill", input, weight, output, present_state,
+        batch_size, channels, seq_len, kernel_size, activation,
+        element_size_bytes,
+        [&](bool is_f32) {
+            hipStream_t s = static_cast<hipStream_t>(stream);
+            const int K = static_cast<int>(kernel_size);
+            const int B = static_cast<int>(batch_size);
+            const int C = static_cast<int>(channels);
+            const int L = static_cast<int>(seq_len);
+            const int has_bias = bias ? 1 : 0;
+            const int act_silu = (activation == 1) ? 1 : 0;
+            if (is_f32)
+                return launch_prefill_for_K<float>(
+                    K, s,
+                    static_cast<const float*>(input),
+                    static_cast<const float*>(weight),
+                    static_cast<const float*>(bias),
+                    static_cast<const float*>(past_state),
+                    static_cast<float*>(output),
+                    static_cast<float*>(present_state),
+                    B, C, L, has_bias, act_silu);
+            return launch_prefill_for_K<__half>(
+                K, s,
+                static_cast<const __half*>(input),
+                static_cast<const __half*>(weight),
+                static_cast<const __half*>(bias),
+                static_cast<const __half*>(past_state),
+                static_cast<__half*>(output),
+                static_cast<__half*>(present_state),
+                B, C, L, has_bias, act_silu);
+        });
+}
 
-    hipStream_t s = static_cast<hipStream_t>(stream);
-    const int K = static_cast<int>(kernel_size);
-    const int B = static_cast<int>(batch_size);
-    const int C = static_cast<int>(channels);
-    const int L = static_cast<int>(seq_len);
-    const int has_bias = bias ? 1 : 0;
-    const int act_silu = (activation == 1) ? 1 : 0;
+extern "C" int hip_causal_conv_prefill_nlc(
+    void* stream,
+    const void* input,
+    const void* weight,
+    const void* bias,
+    const void* past_state,
+    void* output,
+    void* present_state,
+    int64_t batch_size,
+    int64_t channels,
+    int64_t seq_len,
+    int64_t kernel_size,
+    int64_t activation,
+    int64_t element_size_bytes) {
 
-    hipError_t err;
-    if (element_size_bytes == 4) {
-        err = launch_prefill_for_K<float>(
-            K, s,
-            static_cast<const float*>(input),
-            static_cast<const float*>(weight),
-            static_cast<const float*>(bias),
-            static_cast<const float*>(past_state),
-            static_cast<float*>(output),
-            static_cast<float*>(present_state),
-            B, C, L, has_bias, act_silu);
-    } else if (element_size_bytes == 2) {
-        err = launch_prefill_for_K<__half>(
-            K, s,
-            static_cast<const __half*>(input),
-            static_cast<const __half*>(weight),
-            static_cast<const __half*>(bias),
-            static_cast<const __half*>(past_state),
-            static_cast<__half*>(output),
-            static_cast<__half*>(present_state),
-            B, C, L, has_bias, act_silu);
-    } else {
-        fprintf(stderr,
-                "[custom_kernels] hip_causal_conv_prefill: unsupported "
-                "element_size_bytes=%lld (expect 2 or 4)\n",
-                (long long)element_size_bytes);
-        return -1;
-    }
-
-    if (err != hipSuccess) {
-        fprintf(stderr,
-                "[custom_kernels] hip_causal_conv_prefill: launch failed (%s)\n",
-                hipGetErrorString(err));
-        return static_cast<int>(err);
-    }
-    return 0;
+    return prefill_common(
+        "hip_causal_conv_prefill_nlc", input, weight, output, present_state,
+        batch_size, channels, seq_len, kernel_size, activation,
+        element_size_bytes,
+        [&](bool is_f32) {
+            hipStream_t s = static_cast<hipStream_t>(stream);
+            const int K = static_cast<int>(kernel_size);
+            const int B = static_cast<int>(batch_size);
+            const int C = static_cast<int>(channels);
+            const int L = static_cast<int>(seq_len);
+            const int has_bias = bias ? 1 : 0;
+            const int act_silu = (activation == 1) ? 1 : 0;
+            if (is_f32)
+                return launch_prefill_nlc_for_K<float>(
+                    K, s,
+                    static_cast<const float*>(input),
+                    static_cast<const float*>(weight),
+                    static_cast<const float*>(bias),
+                    static_cast<const float*>(past_state),
+                    static_cast<float*>(output),
+                    static_cast<float*>(present_state),
+                    B, C, L, has_bias, act_silu);
+            return launch_prefill_nlc_for_K<__half>(
+                K, s,
+                static_cast<const __half*>(input),
+                static_cast<const __half*>(weight),
+                static_cast<const __half*>(bias),
+                static_cast<const __half*>(past_state),
+                static_cast<__half*>(output),
+                static_cast<__half*>(present_state),
+                B, C, L, has_bias, act_silu);
+        });
 }

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -2197,6 +2197,30 @@ HIP_KERNEL_API int hip_causal_conv_prefill(
     int64_t activation,
     int64_t element_size_bytes);
 
+// Channels-last prefill: same contract as hip_causal_conv_prefill except that
+// input and output are [B, L, C]. The state keeps its [B, C, K-1] layout.
+//
+// The ONNX export wraps this convolution in a Transpose pair only because ONNX
+// Conv wants channels first; on Qwen3.6-35B-A3B those two transposes move 65 MB
+// apiece and together cost more than the convolution between them. A caller that
+// can fold the transposes away calls this instead, and pays neither. Results are
+// bit-identical to the channels-first kernel on the same data -- same fp32
+// accumulation of the same K taps in the same order.
+HIP_KERNEL_API int hip_causal_conv_prefill_nlc(
+    void* stream,
+    const void* input,
+    const void* weight,
+    const void* bias,
+    const void* past_state,
+    void* output,
+    void* present_state,
+    int64_t batch_size,
+    int64_t channels,
+    int64_t seq_len,
+    int64_t kernel_size,
+    int64_t activation,
+    int64_t element_size_bytes);
+
 /* =========================================================================
  * WMMA GEMM (Small-M Matrix Multiply via Wave Matrix Multiply-Accumulate)
  * =========================================================================

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -1304,25 +1304,31 @@ int wrap_qmoe(
 // Used by Gated DeltaNet (Qwen3.5) and Mamba models.
 // Performs causal depthwise convolution with carry state for incremental
 // decode. The convolution is causal (looks only at current and past positions)
-// and depthwise (each channel convolved independently). Input layout:
-// channels-first (batch, channels, seq_len). Weight layout: (channels, 1,
-// kernel_size) for 1D depthwise.
+// and depthwise (each channel convolved independently). Input layout is
+// channels-first (batch, channels, seq_len) unless channels_last is set, which
+// makes input and output (batch, seq_len, channels). Weight layout: (channels,
+// 1, kernel_size) for 1D depthwise.
 //   bias:       nullable - per-channel bias (channels)
 //   past_state: nullable - carry state from previous step (batch, channels,
 //   k-1) activation: 0=none, 1=silu/swish
 int wrap_causal_conv_with_state(
     RuntimeState *state,
     int op_state_slot,  // per-instance op-state slot (descriptor cache home)
-    const void *input,  // (batch, channels, seq_len)
+    const void *input,  // (batch, channels, seq_len), or (batch, seq_len,
+                        // channels) when channels_last
     const void *weight, // (channels, 1, kernel_size)
     const void *bias,   // nullable, (channels)
     const void *past_state, // nullable, (batch, channels, kernel_size - 1)
-    void *output,           // (batch, channels, seq_len)
+    void *output,           // same layout as input
     void *present_state,    // (batch, channels, kernel_size - 1)
     int64_t batch_size, int64_t channels, int64_t seq_len, int64_t kernel_size,
     int64_t ndim,
     int64_t activation, // 0=none, 1=silu/swish
-    int64_t element_size_bytes);
+    int64_t element_size_bytes,
+    // 0=channels-first, 1=channels-last. Permutes input and output only: the
+    // carry state is (batch, channels, k-1) either way. ndim=1 only, and only
+    // on the custom-kernel fast paths -- the MIOpen fallback is channels-first.
+    int64_t channels_last);
 
 //==============================================================================
 // ONNX Gemm via hipBLASLt

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -519,14 +519,12 @@ int wrap_miopenConvolutionTranspose(
   return 0;
 }
 
-int wrap_causal_conv_with_state(RuntimeState *state, int op_state_slot,
-                                const void *input, const void *weight,
-                                const void *bias, const void *past_state,
-                                void *output, void *present_state,
-                                int64_t batch_size, int64_t channels,
-                                int64_t seq_len, int64_t kernel_size,
-                                int64_t ndim, int64_t activation,
-                                int64_t element_size_bytes) {
+int wrap_causal_conv_with_state(
+    RuntimeState *state, int op_state_slot, const void *input,
+    const void *weight, const void *bias, const void *past_state, void *output,
+    void *present_state, int64_t batch_size, int64_t channels, int64_t seq_len,
+    int64_t kernel_size, int64_t ndim, int64_t activation,
+    int64_t element_size_bytes, int64_t channels_last) {
   (void)op_state_slot;
   if (!state || !input || !weight || !output || !present_state) {
     fprintf(stderr,
@@ -546,6 +544,8 @@ int wrap_causal_conv_with_state(RuntimeState *state, int op_state_slot,
   MOCK_PRINT("[MOCK]   ndim=%lld, activation=%s(%lld), elem_size=%lld,\n",
              (long long)ndim, act_name, (long long)activation,
              (long long)element_size_bytes);
+  MOCK_PRINT("[MOCK]   layout=%s,\n",
+             channels_last ? "channels_last(B,L,C)" : "channels_first(B,C,L)");
   MOCK_PRINT("[MOCK]   bias=%s, past_state=%s)\n", bias ? "yes" : "null",
              past_state ? "yes" : "null");
 

--- a/lib/Runtime/real/causal_conv_with_state.cpp
+++ b/lib/Runtime/real/causal_conv_with_state.cpp
@@ -202,14 +202,12 @@ template <typename T> static inline T silu(T x) {
   return x / (static_cast<T>(1) + std::exp(-x));
 }
 
-int wrap_causal_conv_with_state(RuntimeState *state, int op_state_slot,
-                                const void *input, const void *weight,
-                                const void *bias, const void *past_state,
-                                void *output, void *present_state,
-                                int64_t batch_size, int64_t channels,
-                                int64_t seq_len, int64_t kernel_size,
-                                int64_t ndim, int64_t activation,
-                                int64_t element_size_bytes) {
+int wrap_causal_conv_with_state(
+    RuntimeState *state, int op_state_slot, const void *input,
+    const void *weight, const void *bias, const void *past_state, void *output,
+    void *present_state, int64_t batch_size, int64_t channels, int64_t seq_len,
+    int64_t kernel_size, int64_t ndim, int64_t activation,
+    int64_t element_size_bytes, int64_t channels_last) {
   // ---- Cheap, configuration-level validation FIRST. None of these touch the
   // device, so do them before any allocation or descriptor work to avoid
   // ad-hoc cleanup paths (and to keep the OP_PROFILE scope tight around the
@@ -257,19 +255,20 @@ int wrap_causal_conv_with_state(RuntimeState *state, int op_state_slot,
       "causal_conv",
       [&] {
         char b[64];
-        snprintf(b, sizeof(b), "%lldx%lldx%lld,k=%lld", (long long)batch_size,
+        snprintf(b, sizeof(b), "%lldx%lldx%lld,k=%lld%s", (long long)batch_size,
                  (long long)channels, (long long)seq_len,
-                 (long long)kernel_size);
+                 (long long)kernel_size, channels_last ? ",nlc" : "");
         return std::string(b);
       },
       state);
 
   RUNTIME_DEBUG_LOG("[REAL] wrap_causal_conv_with_state: batch=%lld, "
                     "channels=%lld, seq_len=%lld, kernel=%lld, ndim=%lld, "
-                    "activation=%lld, elem_size=%lld\n",
+                    "activation=%lld, elem_size=%lld, channels_last=%lld\n",
                     (long long)batch_size, (long long)channels,
                     (long long)seq_len, (long long)kernel_size, (long long)ndim,
-                    (long long)activation, (long long)element_size_bytes);
+                    (long long)activation, (long long)element_size_bytes,
+                    (long long)channels_last);
 
   // ---- Fast path: single-step decode (seq_len==1, k<=8) -------------------
   // The MIOpen path requires building a "virtual" buffer of shape
@@ -289,6 +288,11 @@ int wrap_causal_conv_with_state(RuntimeState *state, int op_state_slot,
   // activation in {0=none, 1=SiLU}, fp16/fp32). Anything outside falls
   // through to the MIOpen path below, which handles prefill and any odd
   // hybrid shapes correctly.
+  //
+  // channels_last needs no separate kernel here: at seq_len==1 the flat index
+  // of element (b, c) is b*channels + c under both layouts, since the permuted
+  // axis has extent 1. The decode kernel is therefore layout-agnostic by
+  // construction rather than by accident.
   if (seq_len == 1 && kernel_size >= 1 && kernel_size <= 8 &&
       (activation == 0 || activation == 1) &&
       (element_size_bytes == 2 || element_size_bytes == 4)) {
@@ -313,23 +317,53 @@ int wrap_causal_conv_with_state(RuntimeState *state, int op_state_slot,
   // largest text-prefill op -- with one launch. Same supported envelope as
   // the decode fast path (k in [1,8], activation none/SiLU, fp16/fp32);
   // anything else falls through to MIOpen below.
+  //
+  // channels_last takes the _nlc kernel, which reads and writes (B, L, C)
+  // directly instead of paying the Transpose pair the channels-first kernel
+  // needs to be spliced into a channels-last graph.
   if (seq_len > 1 && kernel_size >= 1 && kernel_size <= 8 &&
       (activation == 0 || activation == 1) &&
       (element_size_bytes == 2 || element_size_bytes == 4)) {
-    int rc =
-        hip_causal_conv_prefill(stream, input, weight, bias, past_state, output,
-                                present_state, batch_size, channels, seq_len,
-                                kernel_size, activation, element_size_bytes);
+    int rc = channels_last
+                 ? hip_causal_conv_prefill_nlc(
+                       stream, input, weight, bias, past_state, output,
+                       present_state, batch_size, channels, seq_len,
+                       kernel_size, activation, element_size_bytes)
+                 : hip_causal_conv_prefill(
+                       stream, input, weight, bias, past_state, output,
+                       present_state, batch_size, channels, seq_len,
+                       kernel_size, activation, element_size_bytes);
     if (rc != 0) {
       fprintf(stderr,
-              "wrap_causal_conv_with_state: hip_causal_conv_prefill failed "
+              "wrap_causal_conv_with_state: hip_causal_conv_prefill%s failed "
               "(%d)\n",
-              rc);
+              channels_last ? "_nlc" : "", rc);
       return -1;
     }
     RUNTIME_DEBUG_LOG(
-        "[REAL] wrap_causal_conv_with_state: completed via fast prefill\n");
+        "[REAL] wrap_causal_conv_with_state: completed via fast prefill%s\n",
+        channels_last ? " (nlc)" : "");
     return 0;
+  }
+
+  // Everything below is MIOpen, and MIOpen is channels-first: the 4D tensor
+  // descriptors are (B, C, 1, virtual_len) and the pitched copies that build
+  // the virtual buffer assume each (b, c) plane is contiguous along the
+  // sequence axis. Reinterpreting a (B, L, C) buffer through them produces
+  // plausible-looking garbage rather than an error, so refuse instead. Reaching
+  // here with channels_last means the shape escaped the fast-path envelope
+  // above (k > 8, an activation other than none/SiLU, or an element size that
+  // is neither 2 nor 4 bytes); the fold that sets the attribute should not have
+  // fired on such a shape.
+  if (channels_last) {
+    fprintf(stderr,
+            "wrap_causal_conv_with_state: channels_last is only supported on "
+            "the custom-kernel fast paths, but this shape needs the "
+            "channels-first MIOpen path (k=%lld, activation=%lld, "
+            "elem_size=%lld)\n",
+            (long long)kernel_size, (long long)activation,
+            (long long)element_size_bytes);
+    return -1;
   }
 
   const int64_t state_len = kernel_size - 1; // k-1

--- a/test/lit/Conversion/hip-to-llvm/test_causal_conv_with_state.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_causal_conv_with_state.mlir
@@ -11,15 +11,17 @@
 // - Type conversion: !hip.context -> !llvm.ptr
 // - Optional inputs (bias, past_state) passed as pointers (null when absent)
 // - Two output buffers (output, present_state) forwarded
-// - Attributes (activation, ndim) converted to integer args
+// - Attributes (activation, ndim, channels_last) converted to integer args
 // - Shape info (batch, channels, seq_len, kernel_size) extracted:
 //     * static dims become llvm.mlir.constant
 //     * dynamic dims become llvm.extractvalue %desc[3, N] (+ llvm.mul for
 //       composite sizes like seq_len and kernel_size)
+//     * channels_last reads channels from dim 2 and seq_len from dim 1
 //
 // Expected: wrap_causal_conv_with_state(state, input, weight, bias,
 //           past_state, output, present_state, batch_size, channels,
-//           seq_len, kernel_size, ndim, activation, element_size_bytes)
+//           seq_len, kernel_size, ndim, activation, element_size_bytes,
+//           channels_last)
 //
 // Test cases:
 // 1. causal_conv_full                  — all static, bias + past_state, silu
@@ -28,6 +30,8 @@
 // 4. causal_conv_dynamic_activations   — dynamic input/output, static weight
 // 5. causal_conv_fully_dynamic         — dynamic input AND dynamic weight
 //                                         (validates kernel_size extraction)
+// 6. causal_conv_channels_last         — (B, L, C) input, static
+// 7. causal_conv_channels_last_dynamic — (B, L, C) input, dynamic L
 // ============================================================================
 
 // RUN: hip-mlir-opt %s --assign-op-state-slots --convert-hip-to-llvm | FileCheck %s
@@ -58,7 +62,7 @@ module {
              memref<1x64x128xf16, 1>, memref<1x64x3xf16, 1>)
         {activation = "silu", ndim = 1 : i64}
 
-    // CHECK: llvm.call @wrap_causal_conv_with_state({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_causal_conv_with_state({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
 
     return
   }
@@ -79,7 +83,7 @@ module {
              memref<1x64x128xf16, 1>, memref<1x64x3xf16, 1>)
         {ndim = 1 : i64}
 
-    // CHECK: llvm.call @wrap_causal_conv_with_state({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_causal_conv_with_state({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
 
     return
   }
@@ -103,7 +107,7 @@ module {
              memref<2x128x64xf16, 1>, memref<2x128x2xf16, 1>)
         {activation = "none", ndim = 1 : i64}
 
-    // CHECK: llvm.call @wrap_causal_conv_with_state({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_causal_conv_with_state({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
 
     return
   }
@@ -141,7 +145,7 @@ module {
     // CHECK: llvm.extractvalue {{.*}}[3, 2]
     // kernel_size = 4 remains a compile-time constant from static weight.
     // CHECK: llvm.mlir.constant(4 : i64)
-    // CHECK: llvm.call @wrap_causal_conv_with_state({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_causal_conv_with_state({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
 
     return
   }
@@ -174,7 +178,72 @@ module {
     // CHECK: llvm.mlir.constant(1 : i64)
     // CHECK: llvm.extractvalue {{.*}}[3, 2]
     // CHECK: llvm.mul
-    // CHECK: llvm.call @wrap_causal_conv_with_state({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64) -> i32
+    // CHECK: llvm.call @wrap_causal_conv_with_state({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
+
+    return
+  }
+
+  // --------------------------------------------------------------------------
+  // Test 6: channels_last. Input is (batch, seq_len, channels), so channels
+  // comes from dim 2 and seq_len from dim 1 -- the opposite of every case
+  // above. The two extents are deliberately different (L=128, C=64) so the
+  // emission order below distinguishes a correct swap from a no-op: the
+  // arguments are built batch, channels, seq_len, so the constants must appear
+  // as 2, 64, 128. Reading the dims channels-first would emit 2, 128, 64 and
+  // fail here rather than silently passing a transposed shape to the kernel.
+  // --------------------------------------------------------------------------
+  func.func @causal_conv_channels_last(
+      %ctx: !hip.context,
+      %input: memref<2x128x64xf16, 1>,
+      %weight: memref<64x1x4xf16, 1>,
+      %bias: memref<64xf16, 1>,
+      %past_state: memref<2x64x3xf16, 1>,
+      %output: memref<2x128x64xf16, 1>,
+      %present_state: memref<2x64x3xf16, 1>) {
+    // CHECK-LABEL: llvm.func @causal_conv_channels_last
+
+    hip.causal_conv_with_state(%ctx)
+        ins(%input, %weight, %bias, %past_state :
+            memref<2x128x64xf16, 1>, memref<64x1x4xf16, 1>,
+            memref<64xf16, 1>, memref<2x64x3xf16, 1>)
+        outs(%output, %present_state :
+             memref<2x128x64xf16, 1>, memref<2x64x3xf16, 1>)
+        {activation = "silu", ndim = 1 : i64, channels_last = true}
+
+    // batch = 2, then channels = 64 (dim 2), then seq_len = 128 (dim 1).
+    // CHECK: llvm.mlir.constant(2 : i64)
+    // CHECK: llvm.mlir.constant(64 : i64)
+    // CHECK: llvm.mlir.constant(128 : i64)
+    // CHECK: llvm.call @wrap_causal_conv_with_state({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
+
+    return
+  }
+
+  // --------------------------------------------------------------------------
+  // Test 7: channels_last with a dynamic sequence length, which is the shape
+  // the model actually presents (prompt length varies, channels does not).
+  // seq_len is extracted from descriptor index [3, 1] and channels stays a
+  // compile-time constant from dim 2.
+  // --------------------------------------------------------------------------
+  func.func @causal_conv_channels_last_dynamic(
+      %ctx: !hip.context,
+      %input: memref<1x?x64xf16, 1>,
+      %weight: memref<64x1x4xf16, 1>,
+      %output: memref<1x?x64xf16, 1>,
+      %present_state: memref<1x64x3xf16, 1>) {
+    // CHECK-LABEL: llvm.func @causal_conv_channels_last_dynamic
+
+    hip.causal_conv_with_state(%ctx)
+        ins(%input, %weight :
+            memref<1x?x64xf16, 1>, memref<64x1x4xf16, 1>)
+        outs(%output, %present_state :
+             memref<1x?x64xf16, 1>, memref<1x64x3xf16, 1>)
+        {activation = "silu", ndim = 1 : i64, channels_last = true}
+
+    // channels is static (dim 2); only seq_len (dim 1) is extracted.
+    // CHECK: llvm.mlir.constant(64 : i64)
+    // CHECK: llvm.extractvalue {{.*}}[3, 1]
+    // CHECK: llvm.call @wrap_causal_conv_with_state({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
 
     return
   }

--- a/test/lit/Dialect/hip-causal-conv-channels-last.mlir
+++ b/test/lit/Dialect/hip-causal-conv-channels-last.mlir
@@ -1,0 +1,236 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --canonicalize %s | FileCheck %s
+
+// What this file tests
+// --------------------
+// `CausalConvWithStateOp::getCanonicalizationPatterns` -- the fold that absorbs
+// a [0,2,1] Transpose pair around a causal convolution into its `channels_last`
+// attribute. See lib/Dialect/IR/HipCausalConvCanonicalize.cpp.
+//
+// The exporter emits Transpose/Conv/Transpose because ONNX Conv is
+// channels-first, not because the kernel needs that layout. Both transposes are
+// pure data movement, and on Qwen3.6-35B-A3B the pair costs more than the
+// convolution between them.
+//
+// The negative cases matter as much as the positive one: each guard exists
+// because folding without it produces IR that still verifies. A transpose with
+// a second reader keeps running, so folding buys the attribute without removing
+// the traffic; a permutation that is not the last-two-axis swap means the
+// buffer would be reinterpreted rather than relabelled.
+
+module {
+  // --------------------------------------------------------------------------
+  // Positive: the whole triple collapses to one convolution. Both transposes
+  // go away -- the leading one becomes dead, the trailing one is replaced by
+  // the convolution's own result.
+  // --------------------------------------------------------------------------
+  func.func @fold_transpose_pair(
+      %ctx: !hip.context,
+      %x: tensor<1x128x64xf16>,
+      %w: tensor<64x1x4xf16>,
+      %b: tensor<64xf16>,
+      %past: tensor<1x64x3xf16>)
+      -> (tensor<1x128x64xf16>, tensor<1x64x3xf16>) {
+    // CHECK-LABEL: func.func @fold_transpose_pair
+    // CHECK-NOT: hip.transpose
+    // CHECK: hip.causal_conv_with_state
+    // CHECK-SAME: channels_last = true
+    // CHECK-NOT: hip.transpose
+
+    %e0 = tensor.empty() : tensor<1x64x128xf16>
+    %t0 = hip.transpose(%ctx) ins(%x : tensor<1x128x64xf16>)
+        outs(%e0 : tensor<1x64x128xf16>) {perm = [0, 2, 1]}
+        : tensor<1x64x128xf16>
+
+    %e1 = tensor.empty() : tensor<1x64x128xf16>
+    %e2 = tensor.empty() : tensor<1x64x3xf16>
+    %y, %s = hip.causal_conv_with_state(%ctx)
+        ins(%t0, %w, %b, %past :
+            tensor<1x64x128xf16>, tensor<64x1x4xf16>,
+            tensor<64xf16>, tensor<1x64x3xf16>)
+        outs(%e1, %e2 : tensor<1x64x128xf16>, tensor<1x64x3xf16>)
+        {activation = "silu", ndim = 1 : i64}
+        : tensor<1x64x128xf16>, tensor<1x64x3xf16>
+
+    %e3 = tensor.empty() : tensor<1x128x64xf16>
+    %z = hip.transpose(%ctx) ins(%y : tensor<1x64x128xf16>)
+        outs(%e3 : tensor<1x128x64xf16>) {perm = [0, 2, 1]}
+        : tensor<1x128x64xf16>
+
+    return %z, %s : tensor<1x128x64xf16>, tensor<1x64x3xf16>
+  }
+
+  // --------------------------------------------------------------------------
+  // Negative: the convolution's output is not consumed by a transpose, so
+  // there is no channels-last output buffer to write into.
+  // --------------------------------------------------------------------------
+  func.func @no_fold_without_trailing_transpose(
+      %ctx: !hip.context,
+      %x: tensor<1x128x64xf16>,
+      %w: tensor<64x1x4xf16>)
+      -> (tensor<1x64x128xf16>, tensor<1x64x3xf16>) {
+    // CHECK-LABEL: func.func @no_fold_without_trailing_transpose
+    // CHECK: hip.transpose
+    // CHECK-NOT: channels_last
+
+    %e0 = tensor.empty() : tensor<1x64x128xf16>
+    %t0 = hip.transpose(%ctx) ins(%x : tensor<1x128x64xf16>)
+        outs(%e0 : tensor<1x64x128xf16>) {perm = [0, 2, 1]}
+        : tensor<1x64x128xf16>
+
+    %e1 = tensor.empty() : tensor<1x64x128xf16>
+    %e2 = tensor.empty() : tensor<1x64x3xf16>
+    %y, %s = hip.causal_conv_with_state(%ctx)
+        ins(%t0, %w : tensor<1x64x128xf16>, tensor<64x1x4xf16>)
+        outs(%e1, %e2 : tensor<1x64x128xf16>, tensor<1x64x3xf16>)
+        {ndim = 1 : i64}
+        : tensor<1x64x128xf16>, tensor<1x64x3xf16>
+
+    return %y, %s : tensor<1x64x128xf16>, tensor<1x64x3xf16>
+  }
+
+  // --------------------------------------------------------------------------
+  // Negative: the leading transpose has a second reader, so it survives the
+  // fold. Rewriting the convolution would leave both the transpose and a
+  // layout change, which is strictly worse than leaving it alone.
+  // --------------------------------------------------------------------------
+  func.func @no_fold_when_transpose_is_reused(
+      %ctx: !hip.context,
+      %x: tensor<1x128x64xf16>,
+      %w: tensor<64x1x4xf16>)
+      -> (tensor<1x128x64xf16>, tensor<1x64x3xf16>, tensor<1x64x128xf16>) {
+    // CHECK-LABEL: func.func @no_fold_when_transpose_is_reused
+    // CHECK: hip.transpose
+    // CHECK-NOT: channels_last
+
+    %e0 = tensor.empty() : tensor<1x64x128xf16>
+    %t0 = hip.transpose(%ctx) ins(%x : tensor<1x128x64xf16>)
+        outs(%e0 : tensor<1x64x128xf16>) {perm = [0, 2, 1]}
+        : tensor<1x64x128xf16>
+
+    %e1 = tensor.empty() : tensor<1x64x128xf16>
+    %e2 = tensor.empty() : tensor<1x64x3xf16>
+    %y, %s = hip.causal_conv_with_state(%ctx)
+        ins(%t0, %w : tensor<1x64x128xf16>, tensor<64x1x4xf16>)
+        outs(%e1, %e2 : tensor<1x64x128xf16>, tensor<1x64x3xf16>)
+        {ndim = 1 : i64}
+        : tensor<1x64x128xf16>, tensor<1x64x3xf16>
+
+    %e3 = tensor.empty() : tensor<1x128x64xf16>
+    %z = hip.transpose(%ctx) ins(%y : tensor<1x64x128xf16>)
+        outs(%e3 : tensor<1x128x64xf16>) {perm = [0, 2, 1]}
+        : tensor<1x128x64xf16>
+
+    return %z, %s, %t0
+        : tensor<1x128x64xf16>, tensor<1x64x3xf16>, tensor<1x64x128xf16>
+  }
+
+  // --------------------------------------------------------------------------
+  // Negative: a permutation that is not the last-two-axis swap. The pair still
+  // composes to the identity, but the convolution's channels axis is not where
+  // channels_last says it is.
+  // --------------------------------------------------------------------------
+  func.func @no_fold_wrong_permutation(
+      %ctx: !hip.context,
+      %x: tensor<128x1x64xf16>,
+      %w: tensor<1x1x4xf16>)
+      -> (tensor<128x1x64xf16>, tensor<1x128x3xf16>) {
+    // CHECK-LABEL: func.func @no_fold_wrong_permutation
+    // CHECK: hip.transpose
+    // CHECK-NOT: channels_last
+
+    %e0 = tensor.empty() : tensor<1x128x64xf16>
+    %t0 = hip.transpose(%ctx) ins(%x : tensor<128x1x64xf16>)
+        outs(%e0 : tensor<1x128x64xf16>) {perm = [1, 0, 2]}
+        : tensor<1x128x64xf16>
+
+    %e1 = tensor.empty() : tensor<1x128x64xf16>
+    %e2 = tensor.empty() : tensor<1x128x3xf16>
+    %y, %s = hip.causal_conv_with_state(%ctx)
+        ins(%t0, %w : tensor<1x128x64xf16>, tensor<1x1x4xf16>)
+        outs(%e1, %e2 : tensor<1x128x64xf16>, tensor<1x128x3xf16>)
+        {ndim = 1 : i64}
+        : tensor<1x128x64xf16>, tensor<1x128x3xf16>
+
+    %e3 = tensor.empty() : tensor<128x1x64xf16>
+    %z = hip.transpose(%ctx) ins(%y : tensor<1x128x64xf16>)
+        outs(%e3 : tensor<128x1x64xf16>) {perm = [1, 0, 2]}
+        : tensor<128x1x64xf16>
+
+    return %z, %s : tensor<128x1x64xf16>, tensor<1x128x3xf16>
+  }
+
+  // --------------------------------------------------------------------------
+  // Negative: k=12 is past the custom kernel's 8-tap limit, so this shape can
+  // only run on the channels-first MIOpen path. That path rejects
+  // channels_last outright rather than misreading the buffer, so folding here
+  // would convert a working convolution into a runtime failure.
+  // --------------------------------------------------------------------------
+  func.func @no_fold_when_kernel_too_wide(
+      %ctx: !hip.context,
+      %x: tensor<1x128x64xf16>,
+      %w: tensor<64x1x12xf16>)
+      -> (tensor<1x128x64xf16>, tensor<1x64x11xf16>) {
+    // CHECK-LABEL: func.func @no_fold_when_kernel_too_wide
+    // CHECK: hip.transpose
+    // CHECK-NOT: channels_last
+
+    %e0 = tensor.empty() : tensor<1x64x128xf16>
+    %t0 = hip.transpose(%ctx) ins(%x : tensor<1x128x64xf16>)
+        outs(%e0 : tensor<1x64x128xf16>) {perm = [0, 2, 1]}
+        : tensor<1x64x128xf16>
+
+    %e1 = tensor.empty() : tensor<1x64x128xf16>
+    %e2 = tensor.empty() : tensor<1x64x11xf16>
+    %y, %s = hip.causal_conv_with_state(%ctx)
+        ins(%t0, %w : tensor<1x64x128xf16>, tensor<64x1x12xf16>)
+        outs(%e1, %e2 : tensor<1x64x128xf16>, tensor<1x64x11xf16>)
+        {ndim = 1 : i64}
+        : tensor<1x64x128xf16>, tensor<1x64x11xf16>
+
+    %e3 = tensor.empty() : tensor<1x128x64xf16>
+    %z = hip.transpose(%ctx) ins(%y : tensor<1x64x128xf16>)
+        outs(%e3 : tensor<1x128x64xf16>) {perm = [0, 2, 1]}
+        : tensor<1x128x64xf16>
+
+    return %z, %s : tensor<1x128x64xf16>, tensor<1x64x11xf16>
+  }
+
+  // --------------------------------------------------------------------------
+  // Negative: already folded. A pattern that re-matched its own output would
+  // rewrite forever, so the canonicalizer completing at all is the assertion
+  // here. The transposes stay because this IR is deliberately inconsistent --
+  // a real graph has none left by this point.
+  // --------------------------------------------------------------------------
+  func.func @no_refold_when_already_channels_last(
+      %ctx: !hip.context,
+      %x: tensor<1x64x128xf16>,
+      %w: tensor<64x1x4xf16>)
+      -> (tensor<1x64x128xf16>, tensor<1x64x3xf16>) {
+    // CHECK-LABEL: func.func @no_refold_when_already_channels_last
+    // CHECK: hip.causal_conv_with_state
+    // CHECK-SAME: channels_last = true
+
+    %e0 = tensor.empty() : tensor<1x128x64xf16>
+    %t0 = hip.transpose(%ctx) ins(%x : tensor<1x64x128xf16>)
+        outs(%e0 : tensor<1x128x64xf16>) {perm = [0, 2, 1]}
+        : tensor<1x128x64xf16>
+
+    %e1 = tensor.empty() : tensor<1x128x64xf16>
+    %e2 = tensor.empty() : tensor<1x64x3xf16>
+    %y, %s = hip.causal_conv_with_state(%ctx)
+        ins(%t0, %w : tensor<1x128x64xf16>, tensor<64x1x4xf16>)
+        outs(%e1, %e2 : tensor<1x128x64xf16>, tensor<1x64x3xf16>)
+        {ndim = 1 : i64, channels_last = true}
+        : tensor<1x128x64xf16>, tensor<1x64x3xf16>
+
+    %e3 = tensor.empty() : tensor<1x64x128xf16>
+    %z = hip.transpose(%ctx) ins(%y : tensor<1x128x64xf16>)
+        outs(%e3 : tensor<1x64x128xf16>) {perm = [0, 2, 1]}
+        : tensor<1x64x128xf16>
+
+    return %z, %s : tensor<1x64x128xf16>, tensor<1x64x3xf16>
+  }
+}


### PR DESCRIPTION
## What

ONNX Conv is channels-first, so the exporter brackets every causal convolution
with a Transpose pair to reach `[B, C, L]`. Neither endpoint wants that layout:
the `in_proj` matmul upstream and linear attention downstream are both
token-major. The pair is pure data movement in service of an ABI.

Worse, `[B, C, L]` is also what held the convolution to ~8% of achievable
bandwidth. One thread owned each channel, so adjacent lanes read addresses
37,292 bytes apart and coalescing was impossible.

Four commits: parallelise the prefill across the sequence, add a channels-last
prefill kernel, fold the surrounding Transposes into a `channels_last`
attribute via a new canonicalization, and guard that fold to the shapes the
kernel actually accepts.

## Measured

Qwen3.6-35B-A3B VLM, 18,646 prompt tokens (16,823 text + 1,823 image),
gfx1151. Interleaved order-reversed A/B, 3 reps per run, no EP instrumentation:

| round | order | base | this branch | delta |
|---|---|---:|---:|---:|
| 1 | base first | 17,217 | 15,253 | -1,964 |
| 2 | base first | 17,221 | 15,495 | -1,726 |
| 4 | conv first | 16,959 | 15,341 | -1,618 |
| 5 | conv first | 17,118 | 15,337 | -1,781 |

**-1,772 ms (-10.35%), 95% CI [-2,002, -1,542].** Faster in all four rounds and
in both orderings. Confirmed at the op level too: the per-op profile goes from
100 `transpose` calls to 40, with `causal_conv` still at 30.

The absolute numbers here are ~19% above this box'\''s previously recorded clean
baseline of 14,455-14,610 ms. That shift is machine state, not this branch: it
appeared across an unrelated reboot, is present identically on both arms, and
also moves decode (19.70 -> 23.27 ms/token) and CPU-side preprocessing
(154 -> 191 ms). The paired A/B is what the delta rests on.

## Correctness

- `test/numeric` causal-conv suite: 18 passed, including
  `test_ccws_channels_last_bit_identical`, which asserts the channels-last path
  is byte-identical to channels-first, and
  `test_ccws_channels_last_matches_reference` at seq_len 1, 128 and 257.
- lit: 4 passed, including the new `hip-causal-conv-channels-last.mlir`.

Three things the fold has to get right, all covered by negative lit cases:

- **The MIOpen fallback is channels-first.** Its 4D descriptors are
  `(B, C, 1, virtual_len)` and the pitched copies assume each `(b, c)` plane is
  contiguous, so a `[B, L, C]` buffer read through them yields plausible
  garbage rather than an error. `wrap_causal_conv_with_state` now refuses
  `channels_last` on that path, and the fold only fires inside the custom
  kernel'\''s envelope (k in 1..8, fp16/fp32) so the refusal is unreachable.
  Without that guard a k > 8 model would have folded and then failed at
  runtime -- that is the last commit here.
- **Decode shares the graph.** At `seq_len == 1` the flat index of `(b, c)` is
  `b*channels + c` under both layouts, since the permuted axis has extent 1, so
  the decode kernel is layout-agnostic by construction rather than by accident.
- **Both Transposes must die.** If either has a second reader it still runs,
  and folding would buy a layout change without removing the traffic that
  motivated it. Both are checked single-use.

The carry state is `[B, C, k-1]` under both layouts and is forwarded untouched,
so the fold cannot invalidate a state buffer carried in from a previous step.