### PR TITLE
perf(qmoe): bucket MoE tokens in chunks, -348 ms TTFT at 16K

### DIFF
--- a/lib/Runtime/Kernels/hip/qmoe_kernel.hip
+++ b/lib/Runtime/Kernels/hip/qmoe_kernel.hip
@@ -309,6 +309,140 @@ __global__ void bucket_tokens_kernel(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Chunked bucketing: the same three phases, but over ranges of (token, slot)
+// pairs so the work is spread across the machine instead of one workgroup.
+//
+// bucket_tokens_kernel above walks every pair in every thread, so its cost is
+// num_tokens*k long no matter how many CUs are idle. That is invisible at
+// decode (k pairs) and dominant at prefill: 3985 tokens x top-8 is 31,880 pairs
+// scanned twice by one workgroup, ~1.75 ms per layer on Qwen3.6-35B-A3B, 70 ms
+// across its 40 layers.
+//
+// Splitting it is a stable counting sort. Phase 1 histograms each chunk
+// independently. Phase 2 turns those per-chunk histograms into a per-(chunk,
+// expert) write base: expert_offsets[e] plus the counts of the same expert in
+// every earlier chunk. Phase 3 has each chunk write its own pairs from that
+// base, in ascending pair order.
+//
+// Ordering is what makes this safe to swap in. Pair index i == t*k + s, so
+// ascending i is exactly the (t, s) nesting of the serial version, chunks are
+// contiguous ascending ranges of i, and phase 2 hands out bases in chunk order.
+// Every expert's slice therefore comes out token-major, byte for byte what the
+// single-workgroup kernel produces -- which the downstream weighted scatter_add
+// depends on for reproducibility.
+// ---------------------------------------------------------------------------
+
+// Pairs per chunk. Small enough that a prefill splits into enough chunks to
+// fill the machine, large enough that the per-chunk histogram and the phase-2
+// scan over chunks stay cheap.
+#define QMOE_BUCKET_CHUNK 512
+// Chunk cap, which bounds the scratch matrix at nchunks*num_experts int32.
+#define QMOE_BUCKET_MAX_CHUNKS 256
+
+__global__ void bucket_count_chunks_kernel(
+    const int32_t* __restrict__ expert_indices,
+    int32_t* __restrict__ chunk_counts,   // [nchunks][num_experts]
+    int total_pairs,
+    int chunk_pairs,
+    int num_experts) {
+  extern __shared__ int32_t hist[];
+  const int chunk = static_cast<int>(blockIdx.x);
+  const int tid = static_cast<int>(threadIdx.x);
+  const int nthreads = static_cast<int>(blockDim.x);
+
+  for (int e = tid; e < num_experts; e += nthreads) hist[e] = 0;
+  __syncthreads();
+
+  const int begin = chunk * chunk_pairs;
+  const int end = min(begin + chunk_pairs, total_pairs);
+  for (int i = begin + tid; i < end; i += nthreads) {
+    const int e = expert_indices[i];
+    // topk_routing writes -1 for a token it could not route; the serial kernel
+    // drops those by never matching an eid, so they must not be counted here.
+    if (e >= 0 && e < num_experts) atomicAdd(&hist[e], 1);
+  }
+  __syncthreads();
+
+  for (int e = tid; e < num_experts; e += nthreads)
+    chunk_counts[(int64_t)chunk * num_experts + e] = hist[e];
+}
+
+// One block. Turns the per-chunk histograms into per-(chunk, expert) write
+// bases, and emits the same expert_counts / expert_offsets the serial kernel
+// does. Reads chunk_counts and overwrites it with the bases in place.
+__global__ void bucket_scan_chunks_kernel(
+    int32_t* __restrict__ chunk_counts,   // in: counts, out: write bases
+    int32_t* __restrict__ expert_counts,
+    int32_t* __restrict__ expert_offsets,
+    int nchunks,
+    int num_experts) {
+  extern __shared__ int32_t totals[];
+  const int e = static_cast<int>(threadIdx.x);
+
+  if (e < num_experts) {
+    int sum = 0;
+    for (int c = 0; c < nchunks; c++)
+      sum += chunk_counts[(int64_t)c * num_experts + e];
+    totals[e] = sum;
+    expert_counts[e] = sum;
+  }
+  __syncthreads();
+
+  // Exclusive prefix sum over experts. num_experts is <= 1024 and this runs
+  // once per layer, so a serial pass on one thread costs less than a Hillis-
+  // Steele scan's log2(n) barriers over the same LDS.
+  if (e == 0) {
+    int sum = 0;
+    expert_offsets[0] = 0;
+    for (int x = 0; x < num_experts; x++) {
+      const int c = totals[x];
+      totals[x] = sum;          // exclusive offset of expert x
+      sum += c;
+      expert_offsets[x + 1] = sum;
+    }
+  }
+  __syncthreads();
+
+  if (e < num_experts) {
+    int running = totals[e];
+    for (int c = 0; c < nchunks; c++) {
+      const int64_t idx = (int64_t)c * num_experts + e;
+      const int cnt = chunk_counts[idx];
+      chunk_counts[idx] = running;
+      running += cnt;
+    }
+  }
+}
+
+__global__ void bucket_scatter_chunks_kernel(
+    const int32_t* __restrict__ expert_indices,
+    const __half* __restrict__ expert_weights,
+    const int32_t* __restrict__ chunk_bases,   // [nchunks][num_experts]
+    int32_t* __restrict__ sorted_token_ids,
+    __half* __restrict__ sorted_weights,
+    int total_pairs,
+    int chunk_pairs,
+    int k,
+    int num_experts) {
+  const int chunk = static_cast<int>(blockIdx.x);
+  const int eid = static_cast<int>(threadIdx.x);
+  if (eid >= num_experts) return;
+
+  const int begin = chunk * chunk_pairs;
+  const int end = min(begin + chunk_pairs, total_pairs);
+  // Every thread reads the same pair index each step, so the load broadcasts
+  // out of one cache line rather than gathering per lane.
+  int write_pos = chunk_bases[(int64_t)chunk * num_experts + eid];
+  for (int i = begin; i < end; i++) {
+    if (expert_indices[i] == eid) {
+      sorted_token_ids[write_pos] = i / k;
+      sorted_weights[write_pos] = expert_weights[i];
+      write_pos++;
+    }
+  }
+}
+
 // ===== Host launchers (extern "C") — pure kernel launches, no alloc/sync ====
 
 extern "C" int hip_qmoe_topk_routing(
@@ -496,6 +630,16 @@ extern "C" int hip_qmoe_scatter_add(
   return static_cast<int>(err);
 }
 
+extern "C" size_t hip_qmoe_bucket_scratch_bytes(
+    int64_t num_tokens, int64_t num_experts, int64_t k) {
+  if (num_tokens <= 0 || num_experts <= 0 || k <= 0) return 0;
+  const int64_t total_pairs = num_tokens * k;
+  int64_t nchunks = (total_pairs + QMOE_BUCKET_CHUNK - 1) / QMOE_BUCKET_CHUNK;
+  if (nchunks > QMOE_BUCKET_MAX_CHUNKS) nchunks = QMOE_BUCKET_MAX_CHUNKS;
+  if (nchunks <= 1) return 0;   // single-workgroup path needs nothing
+  return (size_t)nchunks * (size_t)num_experts * sizeof(int32_t);
+}
+
 extern "C" int hip_qmoe_bucket_tokens(
     void* stream,
     const void* expert_indices,
@@ -507,7 +651,9 @@ extern "C" int hip_qmoe_bucket_tokens(
     int64_t num_tokens,
     int64_t num_experts,
     int64_t k,
-    int64_t element_size_bytes) {
+    int64_t element_size_bytes,
+    void* scratch,
+    size_t scratch_bytes) {
   if (num_tokens <= 0 || num_experts <= 0 || k <= 0) return 0;
 
   hipStream_t s = static_cast<hipStream_t>(stream);
@@ -531,6 +677,50 @@ extern "C" int hip_qmoe_bucket_tokens(
     return -1;
   }
   int block_dim = static_cast<int>(((num_experts + 31) / 32) * 32);
+
+  // Chunked path when there are enough pairs to be worth splitting and the
+  // caller supplied the scratch matrix. Decode (k pairs) keeps the single
+  // workgroup, where three launches would cost more than the scan they save.
+  const int64_t total_pairs = num_tokens * k;
+  int64_t nchunks = (total_pairs + QMOE_BUCKET_CHUNK - 1) / QMOE_BUCKET_CHUNK;
+  if (nchunks > QMOE_BUCKET_MAX_CHUNKS) nchunks = QMOE_BUCKET_MAX_CHUNKS;
+  const size_t need = (size_t)nchunks * num_experts * sizeof(int32_t);
+  if (nchunks > 1 && scratch && scratch_bytes >= need) {
+    // Chunks cover the pairs exactly, so the last one may be short.
+    const int chunk_pairs =
+        static_cast<int>((total_pairs + nchunks - 1) / nchunks);
+    const int64_t grid = (total_pairs + chunk_pairs - 1) / chunk_pairs;
+    int32_t* chunk_counts = static_cast<int32_t*>(scratch);
+    const size_t hist_bytes = num_experts * sizeof(int32_t);
+
+    hipLaunchKernelGGL(bucket_count_chunks_kernel, dim3((unsigned)grid),
+                       dim3(256), hist_bytes, s,
+                       static_cast<const int32_t*>(expert_indices),
+                       chunk_counts, static_cast<int>(total_pairs), chunk_pairs,
+                       static_cast<int>(num_experts));
+    hipLaunchKernelGGL(bucket_scan_chunks_kernel, dim3(1), dim3(block_dim),
+                       hist_bytes, s, chunk_counts,
+                       static_cast<int32_t*>(expert_counts),
+                       static_cast<int32_t*>(expert_offsets),
+                       static_cast<int>(grid),
+                       static_cast<int>(num_experts));
+    hipLaunchKernelGGL(bucket_scatter_chunks_kernel, dim3((unsigned)grid),
+                       dim3(block_dim), 0, s,
+                       static_cast<const int32_t*>(expert_indices),
+                       static_cast<const __half*>(expert_weights),
+                       chunk_counts,
+                       static_cast<int32_t*>(sorted_token_ids),
+                       static_cast<__half*>(sorted_weights),
+                       static_cast<int>(total_pairs), chunk_pairs,
+                       static_cast<int>(k), static_cast<int>(num_experts));
+
+    hipError_t cerr = hipGetLastError();
+    if (cerr != hipSuccess)
+      fprintf(stderr,
+              "[custom_kernels] hip_qmoe_bucket_tokens (chunked) failed: %s\n",
+              hipGetErrorString(cerr));
+    return static_cast<int>(cerr);
+  }
 
   hipLaunchKernelGGL(bucket_tokens_kernel, dim3(1), dim3(block_dim), 0, s,
                      static_cast<const int32_t*>(expert_indices),

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -2081,6 +2081,14 @@ HIP_KERNEL_API int hip_qmoe_scatter_add(
  *   sorted_token_ids - GPU [num_tokens * k]   int32 (output, grouped by eid)
  *   sorted_weights   - GPU [num_tokens * k]   fp16  (output, aligned w/ ids)
  *
+ *   scratch          - GPU scratch for the chunked path, or null
+ *   scratch_bytes    - bytes at scratch; size it with the helper below
+ *
+ * With scratch the bucketing runs as a chunked stable counting sort spread over
+ * the machine; without it (or for a single chunk's worth of pairs, i.e. decode)
+ * it runs as one workgroup. Both produce byte-identical output, token-major
+ * within each expert, which the downstream weighted scatter_add relies on.
+ *
  * Constraints: fp16 only; num_experts <= 1024.
  */
 HIP_KERNEL_API int hip_qmoe_bucket_tokens(
@@ -2094,7 +2102,15 @@ HIP_KERNEL_API int hip_qmoe_bucket_tokens(
     int64_t num_tokens,
     int64_t num_experts,
     int64_t k,
-    int64_t element_size_bytes);
+    int64_t element_size_bytes,
+    void* scratch,
+    size_t scratch_bytes);
+
+/* Scratch bytes hip_qmoe_bucket_tokens needs to take its chunked path for this
+ * shape. Returns 0 when the shape would use the single-workgroup path anyway.
+ */
+HIP_KERNEL_API size_t hip_qmoe_bucket_scratch_bytes(
+    int64_t num_tokens, int64_t num_experts, int64_t k);
 
 /* -------------------------------------------------------------------------
  * Fully fused MoE decode (num_tokens == 1).

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -272,11 +272,10 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
     // Bucket tokens on the device: count per expert (atomicAdd), exclusive
     // prefix sum into d_expert_offsets, scatter (token_id, weight) pairs
     // into d_sorted_token_ids / d_sorted_weights ordered by expert.
-    HIP_CHECK(hip_qmoe_bucket_tokens(stream, d_expert_indices, d_expert_weights,
-                                     d_expert_counts, d_expert_offsets,
-                                     d_sorted_token_ids, d_sorted_weights,
-                                     num_tokens, num_experts, k, elem_size,
-                                     d_bucket_scratch, sz_bucket_scratch));
+    HIP_CHECK(hip_qmoe_bucket_tokens(
+        stream, d_expert_indices, d_expert_weights, d_expert_counts,
+        d_expert_offsets, d_sorted_token_ids, d_sorted_weights, num_tokens,
+        num_experts, k, elem_size, d_bucket_scratch, sz_bucket_scratch));
 
     // Only readback the counts (num_experts * int32, e.g. 32*4 = 128 bytes)
     // to drive the host-side per-expert dispatch loop. Offsets are computed

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -145,6 +145,11 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
   size_t sz_a_scale_in = align_up_64(k_blocks_fc1 * sizeof(float));
   size_t sz_a_qb_mid = align_up_64(k * inter_size * sizeof(int8_t));
   size_t sz_a_scale_mid = align_up_64(k * k_blocks_fc2 * sizeof(float));
+  // Per-chunk histogram matrix for the chunked bucketing path. 0 for shapes
+  // that bucket in a single workgroup anyway (decode), so this costs nothing
+  // there; a prefill of this model asks for 256 chunks x 256 experts = 256 KB.
+  size_t sz_bucket_scratch =
+      align_up_64(hip_qmoe_bucket_scratch_bytes(num_tokens, num_experts, k));
 
   size_t off_expert_indices = 0;
   size_t off_expert_weights = off_expert_indices + sz_expert_indices;
@@ -160,7 +165,8 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
   size_t off_a_scale_in = off_a_qb_in + sz_a_qb_in;
   size_t off_a_qb_mid = off_a_scale_in + sz_a_scale_in;
   size_t off_a_scale_mid = off_a_qb_mid + sz_a_qb_mid;
-  size_t total_scratch = off_a_scale_mid + sz_a_scale_mid;
+  size_t off_bucket_scratch = off_a_scale_mid + sz_a_scale_mid;
+  size_t total_scratch = off_bucket_scratch + sz_bucket_scratch;
 
   if (hipdnn_ep_state_ensure_qmoe_scratch(state, total_scratch) != 0) {
     fprintf(stderr, "wrap_qmoe: ensure_qmoe_scratch(%zu) failed\n",
@@ -186,6 +192,8 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
   void *d_a_scale_in = scratch_base + off_a_scale_in;
   void *d_a_qb_mid = scratch_base + off_a_qb_mid;
   void *d_a_scale_mid = scratch_base + off_a_scale_mid;
+  void *d_bucket_scratch =
+      sz_bucket_scratch ? (scratch_base + off_bucket_scratch) : nullptr;
 
   RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: topk_routing(tokens=%lld, experts=%lld, "
                     "k=%lld, normalize=%lld)\n",
@@ -267,7 +275,8 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
     HIP_CHECK(hip_qmoe_bucket_tokens(stream, d_expert_indices, d_expert_weights,
                                      d_expert_counts, d_expert_offsets,
                                      d_sorted_token_ids, d_sorted_weights,
-                                     num_tokens, num_experts, k, elem_size));
+                                     num_tokens, num_experts, k, elem_size,
+                                     d_bucket_scratch, sz_bucket_scratch));
 
     // Only readback the counts (num_experts * int32, e.g. 32*4 = 128 bytes)
     // to drive the host-side per-expert dispatch loop. Offsets are computed


### PR DESCRIPTION
## What

`bucket_tokens_kernel` runs as a single workgroup with one thread per expert, and
every one of those threads walks every `(token, slot)` pair twice. Its cost is
therefore `num_tokens * k` long no matter how many CUs are idle: 1 of 40 CUs
busy, the rest stalled behind it.

That is invisible at decode, where there are only `k` pairs, and dominant at
prefill. This commit replaces it with a chunked stable counting sort -- histogram
each chunk of pairs, scan the per-chunk histograms into per-`(chunk, expert)`
write bases, then have each chunk write its own pairs.

## Measured

Entry-point microbenchmark, unchanged from the original commit:

| tokens | experts | k | serial | chunked | speedup |
|---:|---:|---:|---:|---:|---:|
| 3985 | 256 | 8 | 1.7738 ms | 0.0382 ms | 46.5x |
| 2048 | 256 | 8 | 0.9226 | 0.0371 | 24.9x |
| 512 | 256 | 8 | 0.2369 | 0.0273 | 8.7x |
| 3985 | 32 | 4 | 1.3145 | 0.0496 | 26.5x |

End-to-end at 16K, which the original commit expected to be unresolvable and is
not. Qwen3.6-35B-A3B VLM, 18,646 prompt tokens, gfx1151, interleaved
order-reversed A/B, 4 reps per run, no EP instrumentation:

| round | order | base | this branch | delta |
|---|---|---:|---:|---:|
| 1 | base first | 15,197 | 14,880 | -317 |
| 2 | base first | 15,266 | 14,874 | -392 |
| 3 | branch first | 15,451 | 15,097 | -354 |
| 4 | branch first | 15,417 | 15,087 | -330 |

**-348 ms (-2.27%), 95% CI [-401, -296]**, sd of paired differences 33 ms.
Faster in all four rounds and in both orderings.

The original commit measured at 3,985 tokens, where this defect costs ~71 ms
against a noise floor of roughly +-200 ms, and concluded correctly that no
end-to-end A/B could see it. At 18,646 tokens the same defect costs 353 ms by
RGP while the noise floor is unchanged, which is what makes it measurable. RGP
predicted 353 ms and the A/B returned 348 ms; the agreement is expected rather
than lucky, because this kernel was dispatch-limited rather than
bandwidth-limited and so had no clock-dependent floor to fall short of.

Baseline for this A/B is the channels-last causal convolution branch
(#722), since these stack.

## Correctness

The reason this is safe is ordering, not speed. The downstream weighted
`scatter_add` needs each expert'\''s slice to stay token-major for reproducibility.
Pair index `i == t*k + s`, so ascending `i` is exactly the `(t, s)` nesting the
serial kernel used; chunks are contiguous ascending ranges of `i`; and the scan
hands out bases in chunk order. All four outputs come back byte-identical to the
single-workgroup kernel at every shape in the table, including the `-1` slots
`topk_routing` emits for an unroutable token, which both paths must drop rather
than count.

Shapes that would not benefit keep the old path: below one chunk'\''s worth of
pairs (decode, and anything under 512) three launches would cost more than the
scan they save, so the launcher falls through to the single workgroup. Same when
the caller passes no scratch, so callers without an arena keep working.

`test/numeric/tests/test_qmoe.py`: 3 passed, `test_qmoe_gpt_oss_shape[1]` failed.
That failure is pre-existing and not from here -- verified by running the same
test against the parent build, which fails with bit-identical numbers
(`max_diff=6.152344e-01`, `cosine=0.999961`). It is also a decode shape, which
takes the single-workgroup fallback, so the chunked path is not even reached.

## Not addressed

The D2H of the counts plus `hipStreamSynchronize` right after this call. It sizes
a host loop that issues gather/fc1/swiglu/fc2/scatter per active expert, and at
prefill essentially all 256 experts are active every layer -- on the order of
1,500 launches per layer. That launch count, not the sync, is the remaining cost
here, and it wants its own change.