### PR TITLE
feat(shape): preserve symbolic compiler inputs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,9 +72,9 @@ The default layout is:
 <workspace>/install/         install prefix
 ```
 
-`build.py` runs the LIT suite plus the GPU-free plugin and output-allocator
-unit tests by default. To run tests manually from Linux or Git Bash at the
-repository root:
+`build.py` runs the LIT suite plus the GPU-free plugin, output-allocator, and
+symbolic-metadata unit tests by default. To run tests manually from Linux or Git
+Bash at the repository root:
 
 ```bash
 BUILD_DIR=../build/$(basename "$PWD")

--- a/backend-mlir-compiler/level-1-pass/src/pass_main.cpp
+++ b/backend-mlir-compiler/level-1-pass/src/pass_main.cpp
@@ -7,6 +7,7 @@
 
 // Morphizen headers
 #include "hip/timing.h"
+#include "morphizen/cache_identity.hpp"
 #include "morphizen/env_config.hpp"
 #include "morphizen/morphizen.hpp"
 #include <cstdint>
@@ -109,6 +110,13 @@ static std::string get_mlir_bytecode(PassContext *ctx, Graph &graph) {
   }
 
   return std::string(bytecode->data(), bytecode->size());
+}
+
+static void verify_initializer_snapshot(Graph &graph, const char *phase) {
+  std::string error;
+  if (!verify_graph_initializer_digest(graph, error))
+    throw CacheIntegrityError(std::string("initializer verification failed ") +
+                              phase + ": " + error);
 }
 
 // Step 3: Compile MLIR bytecode to artifact
@@ -292,6 +300,8 @@ struct Level1MlirPass {
 
     TIMING_LOG("[Session] load_config: %.3fs\n", record_elapsed(t_prev));
 
+    verify_initializer_snapshot(graph, "before compiler consumption");
+
     // Step 2: Get MLIR bytecode from graph
     auto mlir_bytecode = get_mlir_bytecode(self.get_context().get(), graph);
     if (mlir_bytecode.empty()) {
@@ -310,6 +320,8 @@ struct Level1MlirPass {
       return;
     }
     CompilationArtifact artifact = *artifactOpt;
+
+    verify_initializer_snapshot(graph, "after compiler consumption");
 
     TIMING_LOG("[Session] MLIR compilation (CompilerDriver): %.3fs\n",
                record_elapsed(t_prev));

--- a/build.py
+++ b/build.py
@@ -348,7 +348,7 @@ def run_tests(args, build_dir):
             "-C",
             args.config,
             "-R",
-            "StaticPlugins|OutputAllocator|SymbolicDims",
+            "StaticPlugins|OutputAllocator|SymbolicDims|CacheIdentity",
             "--output-on-failure",
         ]
     )

--- a/build.py
+++ b/build.py
@@ -322,7 +322,8 @@ def build_targets(args, build_dir):
 def run_tests(args, build_dir):
     """Run the GPU-free test suites (no device needed, so they run on the build
     machine in every CI job): the MLIR LIT pass-verification suite plus the
-    compiler-plugin registrar and output-allocator ctest unit tests."""
+    compiler-plugin registrar, output-allocator, and symbolic-metadata ctest
+    unit tests."""
     step("Test (check-hip-mlir-lit)")
     run_subprocess(
         [
@@ -347,7 +348,7 @@ def run_tests(args, build_dir):
             "-C",
             args.config,
             "-R",
-            "StaticPlugins|OutputAllocator",
+            "StaticPlugins|OutputAllocator|SymbolicDims",
             "--output-on-failure",
         ]
     )

--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -48,7 +48,16 @@ initializer bytes for persistent artifacts, canonical symbolic metadata, and
 the resolved compiler contract. Process-local initializer addresses are
 normalized out of graph identity. Prebuilt artifacts without finalized
 initializer identity are ignored, and restored cache metadata must match the
-already-finalized key.
+already-finalized key. A prebuilt mismatch is a cache miss and triggers fresh
+compilation; an EPContext mismatch is reported to ORT because its source graph
+is unavailable for recompilation.
+
+External initializer paths are resolved against the model directory and
+lexically normalized without resolving symlinks. For persistent artifacts, the
+compiler verifies initializer bytes immediately before and after consuming the
+compiler graph and rejects a mutation. This closes the hash-to-compile window;
+it does not make later changes to a streaming source file safe after
+compilation.
 
 ## DPS shape contract
 

--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -30,6 +30,26 @@ Shape ownership is intentionally split:
 
 ONNX-level shape inference remains upstream's responsibility. `--hip-infer-shapes` does not convert `UnrankedTensorType` into a ranked type; see [unranked-tensor-handling.md](unranked-tensor-handling.md).
 
+## Symbolic metadata transport
+
+ONNX `dim_param` names are authoritative frontend identities, but ranked MLIR
+tensor types retain only static integers and dynamic markers. MorphiZen
+therefore records each named tensor's symbolic dimensions in the deterministic
+`HSDI1` metadata format. The ORT bridge reserves the metadata key, MLIR model
+serialization projects it temporarily onto the module, and loading imports it
+back into model metadata.
+
+The transport alone does not change destination construction or HIP shape
+semantics. A later conversion layer may consume the metadata conservatively; a
+missing identity always means no proof.
+
+Compiled artifacts are keyed by the source or canonical compiler graph,
+initializer bytes for persistent artifacts, canonical symbolic metadata, and
+the resolved compiler contract. Process-local initializer addresses are
+normalized out of graph identity. Prebuilt artifacts without finalized
+initializer identity are ignored, and restored cache metadata must match the
+already-finalized key.
+
 ## DPS shape contract
 
 In tensor mode, each HIP DPS tensor result must equal the corresponding `outs` operand type. In memref mode, the operation has no tensor result; it writes directly through the destination memref.

--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -39,6 +39,13 @@ therefore records each named tensor's symbolic dimensions in the deterministic
 serialization projects it temporarily onto the module, and loading imports it
 back into model metadata.
 
+The normative wire grammar, canonical ordering, bounds, empty/missing
+semantics, and versioning rule are defined beside the public encoder and
+decoder in
+[`symbolic_dims.hpp`](../../morphizen/morphizen-graph/include/morphizen/symbolic_dims.hpp).
+The encoder emits only that canonical form, and the decoder rejects malformed,
+non-canonical, or unknown-version input.
+
 The transport alone does not change destination construction or HIP shape
 semantics. A later conversion layer may consume the metadata conservatively; a
 missing identity always means no proof.

--- a/morphizen/mlir-imp/CMakeLists.txt
+++ b/morphizen/mlir-imp/CMakeLists.txt
@@ -75,6 +75,7 @@ target_link_libraries(${LIB_NAME}
   PRIVATE
   morphizen-utils
   morphizen-ort-api-ext
+  morphizen-graph
   Microsoft.GSL::GSL
   # OMBuilder
   MLIRIR

--- a/morphizen/mlir-imp/src/mlir-graph.cpp
+++ b/morphizen/mlir-imp/src/mlir-graph.cpp
@@ -22,7 +22,9 @@
 #include "mlir/IR/Verifier.h"
 #include "mlir/Transforms/RegionUtils.h" // for getUsedValuesDefinedAbove
 #include "morphizen-foundation/env_config.hpp"
-#include "llvm/ADT/STLExtras.h"       // for map_range, to_vector
+#include "morphizen/symbolic_dims.hpp"
+#include "llvm/ADT/STLExtras.h" // for map_range, to_vector
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SetVector.h"       // for SetVector
 #include "llvm/ADT/SmallPtrSet.h"     // for SmallPtrSet
 #include "llvm/ADT/SmallSet.h"        // for SmallSet
@@ -1214,6 +1216,21 @@ std::string MLIRGraph::save_string() const {
       MLIRNode(op).restoreMorphizenAttrs(snapshot);
     }
   };
+  bool projected = false;
+  llvm::scope_exit restore_state([&]() {
+    if (projected)
+      module->removeAttr(kOnnxDimParamsModuleAttr);
+    restore_backups();
+  });
+
+  if (module->hasAttr(kOnnxDimParamsModuleAttr)) {
+    throw std::runtime_error(
+        "live module contains conflicting symbolic dimension metadata");
+  }
+  const MLIRModel &model = get_model();
+  projected = model.has_metadata_prop(kOnnxDimParamsMetadataKey);
+  if (projected)
+    module->setAttr(kOnnxDimParamsModuleAttr, model.get_symbolic_dim_attr());
 
   // Serialize the MLIR module (text or bytecode based on env var)
   std::string result;
@@ -1227,13 +1244,10 @@ std::string MLIRGraph::save_string() const {
     mlir::BytecodeWriterConfig config;
     if (failed(mlir::writeBytecodeToFile(module, stream, config))) {
       LOG(ERROR) << "Failed to write MLIR bytecode";
-      restore_backups();
       return "";
     }
   }
   stream.flush();
-
-  restore_backups();
 
   MY_LOG(1) << "Successfully serialized MLIR graph to string ("
             << backups.size() << " ops snapshotted, format="

--- a/morphizen/mlir-imp/src/mlir-model.cpp
+++ b/morphizen/mlir-imp/src/mlir-model.cpp
@@ -12,6 +12,11 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/Parser/Parser.h"
 #include "morphizen-foundation/env_config.hpp"
+#include "morphizen/symbolic_dims.hpp"
+#include "llvm/ADT/ScopeExit.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/SHA256.h"
 #include "llvm/Support/raw_ostream.h"
 #include <filesystem>
 #include <fstream>
@@ -22,9 +27,74 @@ DEF_ENV_PARAM(MORPHIZEN_MLIR_SAVE_WITH_DEBUG_INFO, "0")
 #define MY_LOG(n) LOG_IF(INFO, ENV_PARAM(MORPHIZEN_DEBUG_MLIR_MODEL) >= n)
 namespace morphizen {
 namespace mlir_impl {
+namespace {
+
+std::vector<SymbolicDimRecord>
+parse_symbolic_dim_attr(mlir::ArrayAttr records_attr) {
+  std::vector<SymbolicDimRecord> records;
+  records.reserve(records_attr.size());
+  for (mlir::Attribute attr : records_attr) {
+    auto dictionary = mlir::dyn_cast<mlir::DictionaryAttr>(attr);
+    if (!dictionary)
+      throw std::runtime_error(
+          "symbolic dimension record must be a dictionary");
+    auto scope = dictionary.getAs<mlir::StringAttr>("scope");
+    auto value_name = dictionary.getAs<mlir::StringAttr>("value_name");
+    auto dimensions = dictionary.getAs<mlir::ArrayAttr>("dimensions");
+    if (!scope || !value_name || !dimensions)
+      throw std::runtime_error(
+          "symbolic dimension record is missing required fields");
+
+    SymbolicDimRecord record{
+        scope.getValue().str(), value_name.getValue().str(), {}};
+    record.dimensions.reserve(dimensions.size());
+    for (mlir::Attribute dimension_attr : dimensions) {
+      auto dimension = mlir::dyn_cast<mlir::StringAttr>(dimension_attr);
+      if (!dimension)
+        throw std::runtime_error("symbolic dimension entry must be a string");
+      record.dimensions.push_back(dimension.getValue().str());
+    }
+    records.push_back(std::move(record));
+  }
+  return records;
+}
+
+std::string compute_compiler_graph_digest(mlir::ModuleOp module) {
+  mlir::OwningOpRef<mlir::ModuleOp> clone(
+      mlir::cast<mlir::ModuleOp>(module->clone()));
+  clone->walk([&](mlir::Operation *op) {
+    if (op->getName().getStringRef() != "onnx.Constant")
+      return;
+    auto location = op->getAttrOfType<mlir::StringAttr>("location");
+    if (!location || location.getValue() != "*/_ORT_MEM_ADDR_/*")
+      return;
+    if (auto offset = op->getAttrOfType<mlir::IntegerAttr>("offset"))
+      op->setAttr("offset",
+                  mlir::IntegerAttr::get(offset.getType(), /*value=*/0));
+  });
+
+  std::string canonical;
+  llvm::raw_string_ostream stream(canonical);
+  mlir::OpPrintingFlags flags;
+  flags.printGenericOpForm();
+  clone->print(stream, flags);
+  llvm::SHA256 sha256;
+  sha256.update(canonical);
+  return llvm::toHex(sha256.final(), /*LowerCase=*/true);
+}
+
+} // namespace
 
 MLIRModel::MLIRModel(PrivateTag, mlir::OwningOpRef<mlir::ModuleOp> module)
     : module_(std::move(module)) {
+  mlir::ModuleOp moduleOp = *module_;
+  if (auto attr =
+          moduleOp->getAttrOfType<mlir::ArrayAttr>(kOnnxDimParamsModuleAttr)) {
+    metadata_[std::string(kOnnxDimParamsMetadataKey)] =
+        encode_symbolic_dim_records(parse_symbolic_dim_attr(attr));
+    moduleOp->removeAttr(kOnnxDimParamsModuleAttr);
+  }
+
   // get the function with sym_name = "main_graph" from the module.
   mlir::func::FuncOp mainFunc = nullptr;
   auto ops = module_->getOps<mlir::func::FuncOp>();
@@ -129,7 +199,20 @@ MLIRGraph &MLIRModel::main_graph() const { return *main_graph_; }
 
 void MLIRModel::set_metadata_prop(const std::string &key,
                                   const std::string &value) {
+  if ((key == kOnnxDimParamsMetadataKey ||
+       key == kInitializerDataDigestMetadataKey ||
+       key == kCompilerGraphDigestMetadataKey) &&
+      metadata_.count(key))
+    throw std::runtime_error(
+        "reserved compiler metadata cannot be overwritten");
+  if (key == kInitializerDataDigestMetadataKey &&
+      metadata_.count(kCompilerGraphDigestMetadataKey))
+    throw std::runtime_error(
+        "reserved compiler graph metadata cannot be overwritten");
   metadata_[key] = value;
+  if (key == kInitializerDataDigestMetadataKey)
+    metadata_[kCompilerGraphDigestMetadataKey] =
+        compute_compiler_graph_digest(getModule());
 }
 
 std::string MLIRModel::get_metadata_prop(const std::string &key) const {
@@ -142,6 +225,34 @@ bool MLIRModel::has_metadata_prop(const std::string &key) const {
 }
 
 mlir::ModuleOp MLIRModel::getModule() const { return *module_; }
+
+mlir::ArrayAttr MLIRModel::get_symbolic_dim_attr() const {
+  if (!has_metadata_prop(kOnnxDimParamsMetadataKey))
+    return {};
+  std::string error;
+  auto records = decode_symbolic_dim_records(
+      get_metadata_prop(kOnnxDimParamsMetadataKey), error);
+  if (!records)
+    throw std::runtime_error("invalid symbolic dimension model metadata: " +
+                             error);
+
+  mlir::Builder builder(getModule().getContext());
+  llvm::SmallVector<mlir::Attribute> record_attrs;
+  record_attrs.reserve(records->size());
+  for (const SymbolicDimRecord &record : *records) {
+    llvm::SmallVector<mlir::Attribute> dimensions;
+    dimensions.reserve(record.dimensions.size());
+    for (const std::string &dimension : record.dimensions)
+      dimensions.push_back(builder.getStringAttr(dimension));
+    record_attrs.push_back(builder.getDictionaryAttr({
+        builder.getNamedAttr("scope", builder.getStringAttr(record.scope)),
+        builder.getNamedAttr("value_name",
+                             builder.getStringAttr(record.value_name)),
+        builder.getNamedAttr("dimensions", builder.getArrayAttr(dimensions)),
+    }));
+  }
+  return builder.getArrayAttr(record_attrs);
+}
 
 void MLIRModel::maybe_dump_mlir(const std::filesystem::path &path) const {
   if (ENV_PARAM(MORPHIZEN_DEBUG_MLIR_MODEL) > 5) {
@@ -209,6 +320,18 @@ MLIRModel::create_main_graph(MLIRModel &model, mlir::OpBuilder &builder,
 }
 
 std::string MLIRModel::serialize_as_string() const {
+  mlir::ModuleOp module = getModule();
+  if (module->hasAttr(kOnnxDimParamsModuleAttr))
+    throw std::runtime_error(
+        "live module contains conflicting symbolic dimension metadata");
+  bool projected = has_metadata_prop(kOnnxDimParamsMetadataKey);
+  if (projected)
+    module->setAttr(kOnnxDimParamsModuleAttr, get_symbolic_dim_attr());
+  llvm::scope_exit restore([&]() {
+    if (projected)
+      module->removeAttr(kOnnxDimParamsModuleAttr);
+  });
+
   std::string result;
   llvm::raw_string_ostream stream(result);
   mlir::OpPrintingFlags flags;
@@ -220,7 +343,7 @@ std::string MLIRModel::serialize_as_string() const {
     flags.printValueUsers();
   }
 
-  getModule().print(stream, flags);
+  module.print(stream, flags);
   return result;
 }
 

--- a/morphizen/mlir-imp/src/mlir-model.hpp
+++ b/morphizen/mlir-imp/src/mlir-model.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include <filesystem>
 #include <map>
@@ -50,6 +51,10 @@ public:
   bool has_metadata_prop(const std::string &key) const;
 
   mlir::ModuleOp getModule() const;
+
+  /// Build the compiler-facing structured symbolic-dimension attribute from
+  /// authoritative model metadata. Returns null when metadata is absent.
+  mlir::ArrayAttr get_symbolic_dim_attr() const;
 
   std::string serialize_as_string() const;
 

--- a/morphizen/morphizen-core/cmake/morphizen-core-static.cmake
+++ b/morphizen/morphizen-core/cmake/morphizen-core-static.cmake
@@ -23,6 +23,8 @@ add_library(${LIB_NAME} STATIC
   include/morphizen/plugin.hpp
   include/morphizen/morphizen.hpp
   include/morphizen/_sanity_check.hpp
+  include/morphizen/cache_identity.hpp
+  src/cache_identity.cpp
   src/ort_api_impl.cpp
   include/morphizen/pass_context.hpp
   src/pass_context_imp.hpp

--- a/morphizen/morphizen-core/include/morphizen/cache_identity.hpp
+++ b/morphizen/morphizen-core/include/morphizen/cache_identity.hpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#pragma once
+
+#include "morphizen/export.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace google {
+namespace protobuf {
+class MessageLite;
+} // namespace protobuf
+} // namespace google
+
+namespace onnxruntime {
+class Graph;
+} // namespace onnxruntime
+
+namespace morphizen {
+
+struct CacheKeyInputs {
+  std::string_view base_key;
+  std::string_view graph_digest;
+  std::string_view compiler_contract;
+  std::string_view symbolic_metadata;
+  std::string_view initializer_digest;
+  std::string_view compiler_graph_digest;
+};
+
+enum class CacheLoadKind {
+  Fresh,
+  Prebuilt,
+  EpContext,
+};
+
+enum class CacheLoadAction {
+  Use,
+  Recompile,
+  Reject,
+};
+
+struct InitializerDigest {
+  std::string name;
+  std::string sha256;
+};
+
+struct ExternalInitializerSlice {
+  std::filesystem::path path;
+  int64_t offset = 0;
+  size_t size = 0;
+  std::string sha256;
+};
+
+class MORPHIZEN_DLL_SPEC CacheIntegrityError : public std::runtime_error {
+public:
+  using std::runtime_error::runtime_error;
+};
+
+MORPHIZEN_DLL_SPEC bool is_lowercase_sha256(std::string_view value);
+
+MORPHIZEN_DLL_SPEC std::string
+compute_framed_sha256(const std::vector<std::string> &fields);
+
+MORPHIZEN_DLL_SPEC std::string finalize_cache_key(const CacheKeyInputs &inputs);
+
+MORPHIZEN_DLL_SPEC bool is_finalized_cache_key(std::string_view key);
+
+MORPHIZEN_DLL_SPEC CacheLoadAction select_cache_load_action(
+    CacheLoadKind kind, bool initializer_digest_finalized, bool cache_available,
+    std::string_view expected_key, std::string_view loaded_key);
+
+MORPHIZEN_DLL_SPEC std::string
+serialize_deterministically(const google::protobuf::MessageLite &message);
+
+MORPHIZEN_DLL_SPEC std::string
+combine_initializer_digests(std::vector<InitializerDigest> digests);
+
+MORPHIZEN_DLL_SPEC std::filesystem::path
+normalize_external_initializer_path(const std::filesystem::path &model_path,
+                                    const std::filesystem::path &external_path);
+
+MORPHIZEN_DLL_SPEC bool
+verify_external_initializer_slice(const ExternalInitializerSlice &slice,
+                                  std::string &error);
+
+MORPHIZEN_DLL_SPEC std::string
+compute_graph_initializer_digest(const onnxruntime::Graph &graph);
+
+MORPHIZEN_DLL_SPEC bool
+verify_graph_initializer_digest(const onnxruntime::Graph &graph,
+                                std::string &error);
+
+} // namespace morphizen

--- a/morphizen/morphizen-core/include/morphizen/cache_identity.hpp
+++ b/morphizen/morphizen-core/include/morphizen/cache_identity.hpp
@@ -21,7 +21,7 @@ class MessageLite;
 } // namespace google
 
 namespace onnxruntime {
-class Graph;
+struct Graph;
 } // namespace onnxruntime
 
 namespace morphizen {

--- a/morphizen/morphizen-core/include/morphizen/util.hpp
+++ b/morphizen/morphizen-core/include/morphizen/util.hpp
@@ -166,4 +166,9 @@ MORPHIZEN_DLL_SPEC std::string
 get_md5_of_file(const std::filesystem::path &path);
 MORPHIZEN_DLL_SPEC std::string get_md5_of_buffer(const char *buffer,
                                                  size_t size);
+MORPHIZEN_DLL_SPEC std::string get_sha256_of_buffer(const void *buffer,
+                                                    size_t size);
+MORPHIZEN_DLL_SPEC std::string
+get_sha256_of_file_slice(const std::filesystem::path &path, int64_t offset,
+                         size_t size);
 } // namespace morphizen

--- a/morphizen/morphizen-core/src/cache_identity.cpp
+++ b/morphizen/morphizen-core/src/cache_identity.cpp
@@ -1,0 +1,221 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#include "morphizen/cache_identity.hpp"
+
+#include "morphizen/graph.hpp"
+#include "morphizen/model.hpp"
+#include "morphizen/morphizen_ort_api.h"
+#include "morphizen/symbolic_dims.hpp"
+#include "morphizen/util.hpp"
+#include "sha256.h"
+
+#include <algorithm>
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
+#include <google/protobuf/message_lite.h>
+#include <sstream>
+
+namespace morphizen {
+namespace {
+
+constexpr std::string_view kFinalizedCacheKeyPrefix = "hsdi1-";
+constexpr std::string_view kOrtMemoryAddressLocation = "*/_ORT_MEM_ADDR_/*";
+
+void add_framed(SHA256 &sha256, std::string_view value) {
+  uint64_t size = value.size();
+  unsigned char big_endian_size[sizeof(size)];
+  for (size_t i = 0; i < sizeof(size); ++i) {
+    unsigned shift = static_cast<unsigned>((sizeof(size) - i - 1) * 8);
+    big_endian_size[i] = static_cast<unsigned char>((size >> shift) & 0xff);
+  }
+  sha256.add(big_endian_size, sizeof(big_endian_size));
+  if (!value.empty())
+    sha256.add(value.data(), value.size());
+}
+
+InitializerDigest
+digest_initializer(const Graph &graph,
+                   morphizen_cxx::NodeArgConstRef initializer) {
+  std::string location;
+  size_t offset = 0;
+  size_t size = 0;
+  size_t checksum = 0;
+  (void)MORPHIZEN_ORT_API(node_arg_external_location)(
+      graph, *initializer.ptr(), location, offset, size, checksum);
+
+  std::string digest;
+  if (location == kOrtMemoryAddressLocation) {
+    digest = get_sha256_of_buffer(
+        reinterpret_cast<const void *>(static_cast<uintptr_t>(offset)), size);
+  } else if (!location.empty() && location.front() != '<') {
+    digest =
+        get_sha256_of_file_slice(location, static_cast<int64_t>(offset), size);
+  } else {
+    gsl::span<const char> data = initializer.const_data_as_raw();
+    digest = get_sha256_of_buffer(data.data(), data.size());
+  }
+  return {initializer.name(), std::move(digest)};
+}
+
+} // namespace
+
+bool is_lowercase_sha256(std::string_view value) {
+  return value.size() == 64 &&
+         std::all_of(value.begin(), value.end(), [](unsigned char c) {
+           return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
+         });
+}
+
+std::string compute_framed_sha256(const std::vector<std::string> &fields) {
+  SHA256 sha256;
+  for (const std::string &field : fields)
+    add_framed(sha256, field);
+  return sha256.getHash();
+}
+
+std::string finalize_cache_key(const CacheKeyInputs &inputs) {
+  std::string symbolic_error;
+  if (!decode_symbolic_dim_records(inputs.symbolic_metadata, symbolic_error))
+    throw std::invalid_argument("invalid symbolic dimension metadata: " +
+                                symbolic_error);
+  if (!inputs.initializer_digest.empty() &&
+      !is_lowercase_sha256(inputs.initializer_digest))
+    throw std::invalid_argument("invalid initializer data SHA-256 metadata");
+  if (!inputs.compiler_graph_digest.empty() &&
+      !is_lowercase_sha256(inputs.compiler_graph_digest))
+    throw std::invalid_argument("invalid compiler graph SHA-256 metadata");
+
+  SHA256 sha256;
+  add_framed(sha256, "hipdnn.symbolic.extent.cache.v1");
+  add_framed(sha256, inputs.graph_digest);
+  add_framed(sha256, inputs.base_key);
+  add_framed(sha256, inputs.compiler_contract);
+  add_framed(sha256, inputs.symbolic_metadata);
+  add_framed(sha256, inputs.initializer_digest);
+  add_framed(sha256, inputs.compiler_graph_digest);
+  add_framed(sha256, kOnnxDimParamsEncodingVersion);
+  add_framed(sha256, kOnnxDimParamsResolverPolicyVersion);
+  return std::string(kFinalizedCacheKeyPrefix) + sha256.getHash();
+}
+
+bool is_finalized_cache_key(std::string_view key) {
+  return key.size() == kFinalizedCacheKeyPrefix.size() + 64 &&
+         key.substr(0, kFinalizedCacheKeyPrefix.size()) ==
+             kFinalizedCacheKeyPrefix &&
+         is_lowercase_sha256(key.substr(kFinalizedCacheKeyPrefix.size()));
+}
+
+CacheLoadAction select_cache_load_action(CacheLoadKind kind,
+                                         bool initializer_digest_finalized,
+                                         bool cache_available,
+                                         std::string_view expected_key,
+                                         std::string_view loaded_key) {
+  if (kind == CacheLoadKind::Prebuilt &&
+      (!initializer_digest_finalized || !cache_available))
+    return CacheLoadAction::Recompile;
+  if (!loaded_key.empty() && loaded_key == expected_key)
+    return CacheLoadAction::Use;
+  return kind == CacheLoadKind::Prebuilt ? CacheLoadAction::Recompile
+                                         : CacheLoadAction::Reject;
+}
+
+std::string
+serialize_deterministically(const google::protobuf::MessageLite &message) {
+  std::string result;
+  bool success = false;
+  {
+    google::protobuf::io::StringOutputStream output(&result);
+    google::protobuf::io::CodedOutputStream coded(&output);
+    coded.SetSerializationDeterministic(true);
+    success = message.SerializeToCodedStream(&coded) && !coded.HadError();
+  }
+  if (!success)
+    throw std::runtime_error(
+        "cannot serialize compiler contract for cache identity");
+  return result;
+}
+
+std::string
+combine_initializer_digests(std::vector<InitializerDigest> digests) {
+  std::sort(digests.begin(), digests.end(),
+            [](const InitializerDigest &lhs, const InitializerDigest &rhs) {
+              return lhs.name < rhs.name;
+            });
+  std::string framed = "HIDI1\n";
+  for (const InitializerDigest &digest : digests) {
+    if (!is_lowercase_sha256(digest.sha256))
+      throw std::invalid_argument("invalid initializer SHA-256 digest");
+    framed += std::to_string(digest.name.size()) + ":" + digest.name;
+    framed += std::to_string(digest.sha256.size()) + ":" + digest.sha256;
+  }
+  return get_sha256_of_buffer(framed.data(), framed.size());
+}
+
+std::filesystem::path normalize_external_initializer_path(
+    const std::filesystem::path &model_path,
+    const std::filesystem::path &external_path) {
+  std::filesystem::path resolved = external_path;
+  if (!external_path.is_absolute()) {
+    std::filesystem::path model_dir = model_path.has_parent_path()
+                                          ? model_path.parent_path()
+                                          : std::filesystem::path();
+    resolved = model_dir / external_path;
+  }
+  return std::filesystem::absolute(resolved).lexically_normal();
+}
+
+bool verify_external_initializer_slice(const ExternalInitializerSlice &slice,
+                                       std::string &error) {
+  error.clear();
+  if (!is_lowercase_sha256(slice.sha256)) {
+    error = "invalid expected initializer SHA-256";
+    return false;
+  }
+  try {
+    std::string actual =
+        get_sha256_of_file_slice(slice.path, slice.offset, slice.size);
+    if (actual != slice.sha256) {
+      error = "external initializer changed: " + slice.path.string();
+      return false;
+    }
+  } catch (const std::exception &exception) {
+    error = exception.what();
+    return false;
+  }
+  return true;
+}
+
+std::string compute_graph_initializer_digest(const Graph &graph) {
+  std::vector<InitializerDigest> digests;
+  for (morphizen_cxx::NodeArgConstRef initializer :
+       morphizen_cxx::GraphConstRef(graph).constant_initializers())
+    digests.push_back(digest_initializer(graph, initializer));
+  return combine_initializer_digests(std::move(digests));
+}
+
+bool verify_graph_initializer_digest(const Graph &graph, std::string &error) {
+  error.clear();
+  auto graph_ref = morphizen_cxx::GraphConstRef(graph);
+  const auto &model = graph_ref.model();
+  auto model_ref = morphizen_cxx::ModelConstRef(model);
+  if (!model_ref.has_metadata(kInitializerDataDigestMetadataKey))
+    return true;
+
+  std::string expected =
+      model_ref.get_metadata(kInitializerDataDigestMetadataKey);
+  try {
+    std::string actual = compute_graph_initializer_digest(graph);
+    if (actual != expected) {
+      error = "initializer data changed after cache identity finalization";
+      return false;
+    }
+  } catch (const std::exception &exception) {
+    error = exception.what();
+    return false;
+  }
+  return true;
+}
+
+} // namespace morphizen

--- a/morphizen/morphizen-core/src/morphizen_compile_model.cpp
+++ b/morphizen/morphizen-core/src/morphizen_compile_model.cpp
@@ -9,6 +9,7 @@
 #include <glog/logging.h>
 
 #include "md5.h"
+#include "sha256.h"
 #include "./config.hpp"
 #include "./file_lock.hpp"
 #include "./logger_adapter.hpp"
@@ -16,11 +17,15 @@
 #include "./version_info.hpp"
 #include "profile_utils.hpp"
 #include "morphizen/morphizen.hpp"
+#include "morphizen/symbolic_dims.hpp"
 #include "morphizen/util.hpp"
 #include "morphizen-foundation/env_config.hpp"
+#include <cctype>
 #include <codecvt>
 #include <errno.h>
 #include <functional>
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 #include <google/protobuf/util/json_util.h>
 #include <ios>
 #include <limits>
@@ -30,6 +35,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
+#include <string_view>
 #include <sstream>
 #include <set>
 #include "morphizen-foundation/encryption.hpp"
@@ -140,6 +146,11 @@ bool check_cache_hit(PassContextImp &context) {
   auto prebuild_cache_context_name =
       context.get_provider_option("prebuild_cache_context");
   if (prebuild_cache_context_name) {
+    if (!context.initializer_digest_finalized) {
+      LOG(WARNING) << "ignoring prebuild cache because initializer bytes were "
+                      "not included in the finalized key";
+      return false;
+    }
     MY_LOG(1) << "==== prebuild_cache_context hit ====";
     if (!has_mem_binary(prebuild_cache_context_name.value())) {
       LOG(ERROR) << " " << prebuild_cache_context_name.value()
@@ -303,6 +314,120 @@ static std::string get_signature(const std::string &model_path,
   return md5_in_memory_a;
 }
 
+static void add_framed(SHA256 &sha256, std::string_view value) {
+  uint64_t size = value.size();
+  unsigned char big_endian_size[sizeof(size)];
+  for (size_t i = 0; i < sizeof(size); ++i)
+    big_endian_size[sizeof(size) - i - 1] =
+        static_cast<unsigned char>((size >> (i * 8)) & 0xff);
+  sha256.add(big_endian_size, sizeof(big_endian_size));
+  if (!value.empty())
+    sha256.add(value.data(), value.size());
+}
+
+static std::string
+serialize_deterministically(const google::protobuf::MessageLite &message) {
+  std::string result;
+  google::protobuf::io::StringOutputStream output(&result);
+  google::protobuf::io::CodedOutputStream coded(&output);
+  coded.SetSerializationDeterministic(true);
+  if (!message.SerializeToCodedStream(&coded) || coded.HadError())
+    throw std::runtime_error(
+        "cannot serialize compiler contract for cache identity");
+  return result;
+}
+
+static std::string
+get_complete_graph_digest(const std::filesystem::path &model_path,
+                          const Graph &graph, const Model &model) {
+  if (!model_path.empty()) {
+    std::ifstream input(model_path, std::ios::binary);
+    if (!input)
+      throw std::runtime_error("cannot open model for cache identity: " +
+                               model_path.string());
+    SHA256 sha256;
+    char buffer[64 * 1024];
+    while (input) {
+      input.read(buffer, sizeof(buffer));
+      sha256.add(buffer, static_cast<size_t>(input.gcount()));
+    }
+    if (!input.eof())
+      throw std::runtime_error("cannot read model for cache identity: " +
+                               model_path.string());
+    return sha256.getHash();
+  }
+
+  if (morphizen_cxx::ModelConstRef(model).has_metadata(
+          kCompilerGraphDigestMetadataKey))
+    return morphizen_cxx::ModelConstRef(model).get_metadata(
+        kCompilerGraphDigestMetadataKey);
+
+  auto serialized = morphizen_cxx::GraphConstRef(graph).save_string();
+  if (!serialized.get() || serialized->empty())
+    throw std::runtime_error(
+        "cannot serialize graph for cache identity finalization");
+  return SHA256()(*serialized);
+}
+
+static std::string finalize_cache_key(const std::string &base_key,
+                                      const std::string &graph_digest,
+                                      const std::string &compiler_contract,
+                                      const Model &model) {
+  std::string symbolic_bytes =
+      std::string(kOnnxDimParamsEncodingVersion) + "\n0\n";
+  auto model_ref = morphizen_cxx::ModelConstRef(model);
+  if (model_ref.has_metadata(kOnnxDimParamsMetadataKey))
+    symbolic_bytes = model_ref.get_metadata(kOnnxDimParamsMetadataKey);
+
+  std::string error;
+  if (!decode_symbolic_dim_records(symbolic_bytes, error))
+    throw std::runtime_error("invalid symbolic dimension metadata: " + error);
+  std::string initializer_digest;
+  if (model_ref.has_metadata(kInitializerDataDigestMetadataKey))
+    initializer_digest =
+        model_ref.get_metadata(kInitializerDataDigestMetadataKey);
+  if (!initializer_digest.empty() &&
+      (initializer_digest.size() != 64 ||
+       !std::all_of(initializer_digest.begin(), initializer_digest.end(),
+                    [](unsigned char c) {
+                      return std::isdigit(c) || (c >= 'a' && c <= 'f');
+                    })))
+    throw std::runtime_error("invalid initializer data SHA-256 metadata");
+  std::string compiler_graph_digest;
+  if (model_ref.has_metadata(kCompilerGraphDigestMetadataKey))
+    compiler_graph_digest =
+        model_ref.get_metadata(kCompilerGraphDigestMetadataKey);
+  if (!compiler_graph_digest.empty() &&
+      (compiler_graph_digest.size() != 64 ||
+       !std::all_of(compiler_graph_digest.begin(), compiler_graph_digest.end(),
+                    [](unsigned char c) {
+                      return std::isdigit(c) || (c >= 'a' && c <= 'f');
+                    })))
+    throw std::runtime_error("invalid compiler graph SHA-256 metadata");
+
+  SHA256 sha256;
+  add_framed(sha256, "hipdnn.symbolic.extent.cache.v1");
+  add_framed(sha256, graph_digest);
+  add_framed(sha256, base_key);
+  add_framed(sha256, compiler_contract);
+  add_framed(sha256, symbolic_bytes);
+  add_framed(sha256, initializer_digest);
+  add_framed(sha256, compiler_graph_digest);
+  add_framed(sha256, kOnnxDimParamsEncodingVersion);
+  add_framed(sha256, kOnnxDimParamsResolverPolicyVersion);
+  return "hsdi1-" + sha256.getHash();
+}
+
+static bool is_finalized_cache_key(std::string_view key) {
+  constexpr std::string_view prefix = "hsdi1-";
+  return key.size() == prefix.size() + 64 &&
+         key.substr(0, prefix.size()) == prefix &&
+         std::all_of(key.begin() + prefix.size(), key.end(),
+                     [](unsigned char c) {
+                       return std::isdigit(c) || (c >= 'a' && c <= 'f');
+                     });
+}
+
 std::shared_ptr<PassContextImp> initialize_context(
     const std::string &model_path, const Graph &onnx_graph,
     const std::vector<morphizen_cxx::NodeConstRef> &ep_context_nodes,
@@ -328,6 +453,37 @@ std::shared_ptr<PassContextImp> initialize_context(
   auto &model = morphizen_cxx::GraphConstRef(onnx_graph).model();
   auto md5 =
       get_signature(context->model_path.string(), onnx_graph, context->config_);
+  std::string complete_graph_digest;
+  if (!context->is_ep_context_model)
+    complete_graph_digest =
+        get_complete_graph_digest(context->model_path, onnx_graph, model);
+
+  // Target selection and effective pass configuration are compiler inputs, so
+  // resolve them before freezing the cache identity.
+  context->target_auto_discovery(model);
+  std::string compiler_contract;
+  if (!context->is_ep_context_model) {
+    SHA256 contract;
+    add_framed(contract, serialize_deterministically(context->config_));
+    if (context->target_proto_)
+      add_framed(contract,
+                 serialize_deterministically(*context->target_proto_));
+    add_framed(contract,
+               serialize_deterministically(context->context_proto.version()));
+    for (const PassProto &pass : context->compute_effective_passes())
+      add_framed(contract, serialize_deterministically(pass));
+    static const std::set<std::string> non_compiler_options = {
+        "cache_key",      "cacheKey", "config_file",
+        "encryption_key", "target",   "prebuild_cache_context",
+    };
+    for (const auto &[key, value] : context->get_all_provider_options()) {
+      if (non_compiler_options.count(key))
+        continue;
+      add_framed(contract, key);
+      add_framed(contract, value);
+    }
+    compiler_contract = contract.getHash();
+  }
 
   if (!context->context_proto.cache_key().empty()) {
     MY_LOG(1) << "use cache key specified by user "
@@ -349,13 +505,17 @@ std::shared_ptr<PassContextImp> initialize_context(
     LOG_VERBOSE(1) << "use cache key in memory signature " << new_cache_key;
     *context->context_proto.mutable_cache_key() = new_cache_key;
   }
-  // Algorithm-A : based on names of node-args tensor0-names of
-  // topologically ordered model-graph Algorithm-B : based on
-  // input/output-tensor names overall auto-mapping mechanism will be to use
-  // Algorithm-A first, if that fails then use Algorithm-B to identify the
-  // model/target
-  context->target_auto_discovery(model);
-
+  if (!context->is_ep_context_model) {
+    auto finalized =
+        finalize_cache_key(context->context_proto.cache_key(),
+                           complete_graph_digest, compiler_contract, model);
+    MY_LOG(1) << "finalized symbolic-aware cache key " << finalized;
+    *context->context_proto.mutable_cache_key() = std::move(finalized);
+    context->cache_key_finalized = true;
+    context->initializer_digest_finalized =
+        morphizen_cxx::ModelConstRef(model).has_metadata(
+            kInitializerDataDigestMetadataKey);
+  }
   // log version of binary
   context->print_version_info("EXEC VERSION: ");
   if (!context->is_ep_context_model) {
@@ -776,6 +936,7 @@ store_cache_directory_from_main_node(PassContextImp &context,
   CHECK(!loaded_cache_key.empty())
       << "EP context node must have non-empty cache_file_prefix attribute";
   *context.context_proto.mutable_cache_key() = loaded_cache_key;
+  context.cache_key_finalized = true;
 #if MORPHIZEN_ORT_API_MAJOR >= 12
   auto ep_cache_context = main_node.release_attr_string("ep_cache_context");
 #else
@@ -903,11 +1064,12 @@ restore_execution_providers_from_ep_context_model(
   store_cache_directory_from_main_node(*context, main_node.value());
 
   auto ep_context_cache_key = context->context_proto.cache_key();
-  bool user_provided_different_cache_key =
+  bool user_provided_different_final_cache_key =
       user_cache_key.has_value() && !user_cache_key->empty() &&
+      is_finalized_cache_key(*user_cache_key) &&
       user_cache_key.value() != ep_context_cache_key;
 
-  if (user_provided_different_cache_key) {
+  if (user_provided_different_final_cache_key) {
     LOG(ERROR) << "When using EP context model, your cache key '"
                << user_cache_key.value()
                << "' is different from the one in the EP context model '"

--- a/morphizen/morphizen-core/src/morphizen_compile_model.cpp
+++ b/morphizen/morphizen-core/src/morphizen_compile_model.cpp
@@ -16,6 +16,7 @@
 #include "./pass_imp.hpp"
 #include "./version_info.hpp"
 #include "profile_utils.hpp"
+#include "morphizen/cache_identity.hpp"
 #include "morphizen/morphizen.hpp"
 #include "morphizen/symbolic_dims.hpp"
 #include "morphizen/util.hpp"
@@ -24,8 +25,6 @@
 #include <codecvt>
 #include <errno.h>
 #include <functional>
-#include <google/protobuf/io/coded_stream.h>
-#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 #include <google/protobuf/util/json_util.h>
 #include <ios>
 #include <limits>
@@ -146,23 +145,35 @@ bool check_cache_hit(PassContextImp &context) {
   auto prebuild_cache_context_name =
       context.get_provider_option("prebuild_cache_context");
   if (prebuild_cache_context_name) {
-    if (!context.initializer_digest_finalized) {
-      LOG(WARNING) << "ignoring prebuild cache because initializer bytes were "
-                      "not included in the finalized key";
+    bool available = has_mem_binary(prebuild_cache_context_name.value());
+    std::string_view expected_key = context.context_proto.cache_key();
+    CacheLoadAction action = select_cache_load_action(
+        CacheLoadKind::Prebuilt, context.initializer_digest_finalized,
+        available, expected_key, expected_key);
+    if (action == CacheLoadAction::Recompile) {
+      if (!context.initializer_digest_finalized) {
+        LOG(WARNING)
+            << "ignoring prebuilt cache because initializer bytes were "
+               "not included in the finalized key";
+      } else {
+        LOG(WARNING) << "prebuilt cache '"
+                     << prebuild_cache_context_name.value()
+                     << "' is unavailable; compiling a fresh artifact";
+      }
       return false;
     }
-    MY_LOG(1) << "==== prebuild_cache_context hit ====";
-    if (!has_mem_binary(prebuild_cache_context_name.value())) {
-      LOG(ERROR) << " " << prebuild_cache_context_name.value()
-                 << " does not in mem please check morphizen_config.json";
-
-      std::abort();
+    try {
+      auto prebuild_ep_context_in_mem =
+          get_mem_binary(prebuild_cache_context_name.value());
+      context.create_tar_file_for_prebuild_cache(
+          std::move(prebuild_ep_context_in_mem));
+      MY_LOG(1) << "==== prebuild_cache_context candidate ====";
+      return true;
+    } catch (const CacheIntegrityError &error) {
+      LOG(WARNING) << "prebuilt cache rejected: " << error.what();
+      context.maybe_create_tar_file_for_write();
+      return false;
     }
-    auto prebuild_ep_context_in_mem =
-        get_mem_binary(prebuild_cache_context_name.value());
-    context.create_tar_file_for_prebuild_cache(
-        std::move(prebuild_ep_context_in_mem));
-    return true;
   }
   // No file-based cache - always miss for non-prebuild scenarios
   return false;
@@ -192,16 +203,30 @@ static int64_t compute_model_clone_threshold(const ConfigProto &config_proto,
 void compile_onnx_model_2(std::shared_ptr<PassContextImp> context,
                           const Graph &onnx_graph) {
   bool cache_hit = check_cache_hit(*context);
-  if (!cache_hit) {
-    auto &model = morphizen_cxx::GraphConstRef(onnx_graph).model();
-    int64_t threshold = compute_model_clone_threshold(
-        context->get_config_proto(), context.get());
-    auto cloned_model = morphizen::model_clone(model, threshold);
-    auto &cloned_graph = morphizen::model_main_graph(*cloned_model);
-    update_cache(context, cloned_graph);
-  } else {
-    MY_LOG(1) << "==== cache hit ====";
+  if (cache_hit) {
+    try {
+      read_cache(context);
+      MY_LOG(1) << "==== cache hit ====";
+      return;
+    } catch (const CacheIntegrityError &error) {
+      CacheLoadAction action = select_cache_load_action(
+          CacheLoadKind::Prebuilt, context->initializer_digest_finalized,
+          /*cache_available=*/true, context->context_proto.cache_key(),
+          /*loaded_key=*/{});
+      if (action != CacheLoadAction::Recompile)
+        throw;
+      LOG(WARNING) << "prebuilt cache rejected: " << error.what()
+                   << "; compiling a fresh artifact";
+      context->maybe_create_tar_file_for_write();
+    }
   }
+
+  auto &model = morphizen_cxx::GraphConstRef(onnx_graph).model();
+  int64_t threshold =
+      compute_model_clone_threshold(context->get_config_proto(), context.get());
+  auto cloned_model = morphizen::model_clone(model, threshold);
+  auto &cloned_graph = morphizen::model_main_graph(*cloned_model);
+  update_cache(context, cloned_graph);
   auto encryption_key = context->get_provider_option("encryption_key", "");
   read_cache(context);
 }
@@ -314,29 +339,6 @@ static std::string get_signature(const std::string &model_path,
   return md5_in_memory_a;
 }
 
-static void add_framed(SHA256 &sha256, std::string_view value) {
-  uint64_t size = value.size();
-  unsigned char big_endian_size[sizeof(size)];
-  for (size_t i = 0; i < sizeof(size); ++i)
-    big_endian_size[sizeof(size) - i - 1] =
-        static_cast<unsigned char>((size >> (i * 8)) & 0xff);
-  sha256.add(big_endian_size, sizeof(big_endian_size));
-  if (!value.empty())
-    sha256.add(value.data(), value.size());
-}
-
-static std::string
-serialize_deterministically(const google::protobuf::MessageLite &message) {
-  std::string result;
-  google::protobuf::io::StringOutputStream output(&result);
-  google::protobuf::io::CodedOutputStream coded(&output);
-  coded.SetSerializationDeterministic(true);
-  if (!message.SerializeToCodedStream(&coded) || coded.HadError())
-    throw std::runtime_error(
-        "cannot serialize compiler contract for cache identity");
-  return result;
-}
-
 static std::string
 get_complete_graph_digest(const std::filesystem::path &model_path,
                           const Graph &graph, const Model &model) {
@@ -369,63 +371,28 @@ get_complete_graph_digest(const std::filesystem::path &model_path,
   return SHA256()(*serialized);
 }
 
-static std::string finalize_cache_key(const std::string &base_key,
-                                      const std::string &graph_digest,
-                                      const std::string &compiler_contract,
-                                      const Model &model) {
-  std::string symbolic_bytes =
-      std::string(kOnnxDimParamsEncodingVersion) + "\n0\n";
+static CacheKeyInputs get_cache_key_inputs(const std::string &base_key,
+                                           const std::string &graph_digest,
+                                           const std::string &compiler_contract,
+                                           const Model &model,
+                                           std::string &symbolic_bytes,
+                                           std::string &initializer_digest,
+                                           std::string &compiler_graph_digest) {
+  symbolic_bytes = std::string(kOnnxDimParamsEncodingVersion) + "\n0\n";
   auto model_ref = morphizen_cxx::ModelConstRef(model);
   if (model_ref.has_metadata(kOnnxDimParamsMetadataKey))
     symbolic_bytes = model_ref.get_metadata(kOnnxDimParamsMetadataKey);
 
-  std::string error;
-  if (!decode_symbolic_dim_records(symbolic_bytes, error))
-    throw std::runtime_error("invalid symbolic dimension metadata: " + error);
-  std::string initializer_digest;
   if (model_ref.has_metadata(kInitializerDataDigestMetadataKey))
     initializer_digest =
         model_ref.get_metadata(kInitializerDataDigestMetadataKey);
-  if (!initializer_digest.empty() &&
-      (initializer_digest.size() != 64 ||
-       !std::all_of(initializer_digest.begin(), initializer_digest.end(),
-                    [](unsigned char c) {
-                      return std::isdigit(c) || (c >= 'a' && c <= 'f');
-                    })))
-    throw std::runtime_error("invalid initializer data SHA-256 metadata");
-  std::string compiler_graph_digest;
   if (model_ref.has_metadata(kCompilerGraphDigestMetadataKey))
     compiler_graph_digest =
         model_ref.get_metadata(kCompilerGraphDigestMetadataKey);
-  if (!compiler_graph_digest.empty() &&
-      (compiler_graph_digest.size() != 64 ||
-       !std::all_of(compiler_graph_digest.begin(), compiler_graph_digest.end(),
-                    [](unsigned char c) {
-                      return std::isdigit(c) || (c >= 'a' && c <= 'f');
-                    })))
-    throw std::runtime_error("invalid compiler graph SHA-256 metadata");
-
-  SHA256 sha256;
-  add_framed(sha256, "hipdnn.symbolic.extent.cache.v1");
-  add_framed(sha256, graph_digest);
-  add_framed(sha256, base_key);
-  add_framed(sha256, compiler_contract);
-  add_framed(sha256, symbolic_bytes);
-  add_framed(sha256, initializer_digest);
-  add_framed(sha256, compiler_graph_digest);
-  add_framed(sha256, kOnnxDimParamsEncodingVersion);
-  add_framed(sha256, kOnnxDimParamsResolverPolicyVersion);
-  return "hsdi1-" + sha256.getHash();
-}
-
-static bool is_finalized_cache_key(std::string_view key) {
-  constexpr std::string_view prefix = "hsdi1-";
-  return key.size() == prefix.size() + 64 &&
-         key.substr(0, prefix.size()) == prefix &&
-         std::all_of(key.begin() + prefix.size(), key.end(),
-                     [](unsigned char c) {
-                       return std::isdigit(c) || (c >= 'a' && c <= 'f');
-                     });
+  return {
+      base_key,       graph_digest,       compiler_contract,
+      symbolic_bytes, initializer_digest, compiler_graph_digest,
+  };
 }
 
 std::shared_ptr<PassContextImp> initialize_context(
@@ -463,15 +430,15 @@ std::shared_ptr<PassContextImp> initialize_context(
   context->target_auto_discovery(model);
   std::string compiler_contract;
   if (!context->is_ep_context_model) {
-    SHA256 contract;
-    add_framed(contract, serialize_deterministically(context->config_));
+    std::vector<std::string> contract_fields;
+    contract_fields.push_back(serialize_deterministically(context->config_));
     if (context->target_proto_)
-      add_framed(contract,
-                 serialize_deterministically(*context->target_proto_));
-    add_framed(contract,
-               serialize_deterministically(context->context_proto.version()));
+      contract_fields.push_back(
+          serialize_deterministically(*context->target_proto_));
+    contract_fields.push_back(
+        serialize_deterministically(context->context_proto.version()));
     for (const PassProto &pass : context->compute_effective_passes())
-      add_framed(contract, serialize_deterministically(pass));
+      contract_fields.push_back(serialize_deterministically(pass));
     static const std::set<std::string> non_compiler_options = {
         "cache_key",      "cacheKey", "config_file",
         "encryption_key", "target",   "prebuild_cache_context",
@@ -479,10 +446,10 @@ std::shared_ptr<PassContextImp> initialize_context(
     for (const auto &[key, value] : context->get_all_provider_options()) {
       if (non_compiler_options.count(key))
         continue;
-      add_framed(contract, key);
-      add_framed(contract, value);
+      contract_fields.push_back(key);
+      contract_fields.push_back(value);
     }
-    compiler_contract = contract.getHash();
+    compiler_contract = compute_framed_sha256(contract_fields);
   }
 
   if (!context->context_proto.cache_key().empty()) {
@@ -506,9 +473,14 @@ std::shared_ptr<PassContextImp> initialize_context(
     *context->context_proto.mutable_cache_key() = new_cache_key;
   }
   if (!context->is_ep_context_model) {
-    auto finalized =
-        finalize_cache_key(context->context_proto.cache_key(),
-                           complete_graph_digest, compiler_contract, model);
+    std::string symbolic_bytes;
+    std::string initializer_digest;
+    std::string compiler_graph_digest;
+    CacheKeyInputs inputs = get_cache_key_inputs(
+        context->context_proto.cache_key(), complete_graph_digest,
+        compiler_contract, model, symbolic_bytes, initializer_digest,
+        compiler_graph_digest);
+    auto finalized = finalize_cache_key(inputs);
     MY_LOG(1) << "finalized symbolic-aware cache key " << finalized;
     *context->context_proto.mutable_cache_key() = std::move(finalized);
     context->cache_key_finalized = true;
@@ -918,11 +890,9 @@ static std::optional<morphizen_cxx::NodeConstRef> get_main_ep_context_node(
       ret = node;
     }
   }
-  CHECK_EQ(count_main_context, 1)
-      << "There must be exactly one main EPContext node. The EP context "
-         "model "
-         "have "
-      << count_main_context << " main EPContext nodes.";
+  if (count_main_context != 1)
+    throw CacheIntegrityError(
+        "EPContext model must contain exactly one main context node");
   return ret;
 }
 
@@ -933,8 +903,9 @@ store_cache_directory_from_main_node(PassContextImp &context,
   int64_t ep_embed_mode = main_node.get_attr_int("embed_mode", 1);
   // Always use cache_key prefix - validate it exists
   auto loaded_cache_key = main_node.get_attr_string("cache_file_prefix", "");
-  CHECK(!loaded_cache_key.empty())
-      << "EP context node must have non-empty cache_file_prefix attribute";
+  if (!is_finalized_cache_key(loaded_cache_key))
+    throw CacheIntegrityError(
+        "EPContext node has an invalid finalized cache_file_prefix");
   *context.context_proto.mutable_cache_key() = loaded_cache_key;
   context.cache_key_finalized = true;
 #if MORPHIZEN_ORT_API_MAJOR >= 12
@@ -991,8 +962,8 @@ store_cache_directory_from_main_node(PassContextImp &context,
 }
 
 static int64_t get_ep_context_index(const morphizen_cxx::NodeConstRef &node) {
-  CHECK(node.has_attr("index"))
-      << "EPContext Node has no index attr, EPContext node : " << node;
+  if (!node.has_attr("index"))
+    throw CacheIntegrityError("EPContext node has no index attribute");
   return node.get_attr_int("index");
 }
 
@@ -1000,7 +971,10 @@ static std::vector<std::unique_ptr<ExecutionProvider>>
 create_execution_providers_from_ep_context_nodes(
     std::shared_ptr<PassContextImp> context,
     std::vector<morphizen_cxx::NodeConstRef> ep_context_nodes) {
-  CHECK_EQ(ep_context_nodes.size(), context->context_proto.meta_def_size());
+  if (ep_context_nodes.size() !=
+      static_cast<size_t>(context->context_proto.meta_def_size()))
+    throw CacheIntegrityError(
+        "EPContext node count does not match cached metadata");
   auto size = ep_context_nodes.size();
   auto ret = std::vector<std::unique_ptr<ExecutionProvider>>();
   ret.reserve(size);
@@ -1013,8 +987,8 @@ create_execution_providers_from_ep_context_nodes(
   for (auto idx = 0u; idx < size; ++idx) {
     auto node = ep_context_nodes[idx];
     auto index = get_ep_context_index(node);
-    CHECK_EQ(index, idx) << "EPContext Node index mismatch, EPContext node : "
-                         << node;
+    if (index != static_cast<int64_t>(idx))
+      throw CacheIntegrityError("EPContext node index mismatch");
     auto meta_def_index = idx;
     auto &meta_def = *context->context_proto.mutable_meta_def(meta_def_index);
     update_meta_def_from_ep_node(node, meta_def);
@@ -1048,7 +1022,8 @@ restore_execution_providers_from_ep_context_model(
       }
     }
   }
-  CHECK(main_node) << " no main EPContext node";
+  if (!main_node)
+    throw CacheIntegrityError("EPContext model has no main context node");
 
   auto user_cache_key = context->get_provider_option("cache_key");
   if (!user_cache_key.has_value()) {
@@ -1064,19 +1039,15 @@ restore_execution_providers_from_ep_context_model(
   store_cache_directory_from_main_node(*context, main_node.value());
 
   auto ep_context_cache_key = context->context_proto.cache_key();
-  bool user_provided_different_final_cache_key =
-      user_cache_key.has_value() && !user_cache_key->empty() &&
+  if (user_cache_key.has_value() && !user_cache_key->empty() &&
       is_finalized_cache_key(*user_cache_key) &&
-      user_cache_key.value() != ep_context_cache_key;
-
-  if (user_provided_different_final_cache_key) {
-    LOG(ERROR) << "When using EP context model, your cache key '"
-               << user_cache_key.value()
-               << "' is different from the one in the EP context model '"
-               << ep_context_cache_key
-               << "'. This is not allowed. Please remove the cache key from "
-                  "provider options ";
-    abort();
+      select_cache_load_action(CacheLoadKind::EpContext,
+                               /*initializer_digest_finalized=*/true,
+                               /*cache_available=*/true, *user_cache_key,
+                               ep_context_cache_key) ==
+          CacheLoadAction::Reject) {
+    throw CacheIntegrityError(
+        "provider cache key does not match the EPContext cache key");
   }
 
   context->update_pass_context_from_context_json_in_cache();
@@ -1247,7 +1218,11 @@ std::vector<std::unique_ptr<ExecutionProvider>> compile_onnx_model_3_internal(
     }
   }
 #endif
-  catch (const morphizen_encryption::EncryptionError &e) {
+  catch (const CacheIntegrityError &e) {
+    if (set_ort_status)
+      set_ort_status(ORT_FAIL, e.what());
+    return {};
+  } catch (const morphizen_encryption::EncryptionError &e) {
     if (set_ort_status) {
       set_ort_status(1, e.what());
     }

--- a/morphizen/morphizen-core/src/pass_context_imp.cpp
+++ b/morphizen/morphizen-core/src/pass_context_imp.cpp
@@ -21,6 +21,7 @@
 #include "mem_stream_buffer.hpp"
 #include "morphizen-foundation/env_config.hpp"
 #include "morphizen-foundation/mem_binary.hpp"
+#include "morphizen/cache_identity.hpp"
 #include "morphizen/config_reader.hpp"
 #include "morphizen/util.hpp"
 #include "morphizen/weak.hpp"
@@ -986,23 +987,26 @@ void PassContextImp::create_tar_file_for_prebuild_cache(
     // when ep.context is not enabled, we don't need to worry to much about
     // how to save tar_file_
     tar_file_ = TarFile::create_from_buffer(std::move(buffer));
-    CHECK(tar_file_ != nullptr) << " create a tar file from memory ";
+    if (!tar_file_)
+      throw CacheIntegrityError("cannot open prebuilt cache from memory");
   } else {
     if (is_ep_context_embed_mode) {
       // for embeded mode, it works similar to is_ep_context_enable = false;
       tar_file_ = TarFile::create_from_buffer(std::move(buffer));
-      CHECK(tar_file_ != nullptr) << " create a tar file from memory ";
+      if (!tar_file_)
+        throw CacheIntegrityError("cannot open embedded prebuilt cache");
     } else {
       auto binary_file_path = get_dir_of_ep_context_model() /
                               get_basename_of_ep_context_binary_file();
       auto open_mode =
           std::ios::binary | std::ios::in | std::ios::out | std::ios::trunc;
-      auto stream = std::unique_ptr<std::fstream>();
-      stream = std::make_unique<std::fstream>(binary_file_path, open_mode);
-      CHECK(stream->is_open())
-          << "failed to open ep context file " << binary_file_path;
-      CHECK(stream->write(buffer.data(), buffer.size()).good())
-          << "fail to write to " << binary_file_path;
+      auto stream = std::make_unique<std::fstream>(binary_file_path, open_mode);
+      if (!stream->is_open())
+        throw CacheIntegrityError("cannot open prebuilt EP context file: " +
+                                  binary_file_path.string());
+      if (!stream->write(buffer.data(), buffer.size()).good())
+        throw CacheIntegrityError("cannot write prebuilt EP context file: " +
+                                  binary_file_path.string());
       stream->seekg(0);
       stream->seekp(0);
       stream->flush();
@@ -1012,10 +1016,11 @@ void PassContextImp::create_tar_file_for_prebuild_cache(
   }
   // Always use cache_key prefix - verify context.json exists with prefix
   auto prefix = get_context_proto().cache_key();
-  CHECK(!prefix.empty()) << "cache_key required for prebuild cache";
-  CHECK(tar_file_->has_file(prefix + "/context.json"))
-      << "tar file does not have " << prefix << "/context.json, "
-      << "please check prebuild ep context generation";
+  if (prefix.empty())
+    throw CacheIntegrityError("cache key required for prebuilt cache");
+  if (!tar_file_ || !tar_file_->has_file(prefix + "/context.json"))
+    throw CacheIntegrityError("prebuilt cache does not contain " + prefix +
+                              "/context.json");
 }
 void PassContextImp::print_version_info(const char *prefix) {
   auto &context = get_context_proto();
@@ -1070,12 +1075,13 @@ void PassContextImp::pass_context_update_context_json(
   auto status = google::protobuf::util::JsonStringToMessage(
       &json_str[0], &context_proto_in_cache, options);
 
-  CHECK(status.ok()) << "cannot parse json string:" << status.message()
-                     << &json_str[0];
-  if (cache_key_finalized) {
-    CHECK_EQ(context_proto_in_cache.cache_key(), context_proto.cache_key())
-        << "cached context key does not match the finalized graph cache key";
-  }
+  if (!status.ok())
+    throw CacheIntegrityError("cannot parse cached context JSON: " +
+                              std::string(status.message()));
+  if (cache_key_finalized &&
+      context_proto_in_cache.cache_key() != context_proto.cache_key())
+    throw CacheIntegrityError(
+        "cached context key does not match the finalized graph cache key");
   // Note: Old cache files with config field in ContextProto are not supported
   // after this refactoring (breaking change). The config field is now
   // runtime-only.
@@ -1087,8 +1093,8 @@ void PassContextImp::pass_context_update_context_json(
 
 void PassContextImp::update_pass_context_from_context_json_in_cache() {
   auto context_context_json = read_file_c8("context.json");
-  CHECK(context_context_json.has_value())
-      << "cannot read context.json from ep context";
+  if (!context_context_json)
+    throw CacheIntegrityError("cannot read context.json from cache context");
   auto context_context_json_text = dos2unix(*context_context_json);
   pass_context_update_context_json(context_context_json_text);
 }

--- a/morphizen/morphizen-core/src/pass_context_imp.cpp
+++ b/morphizen/morphizen-core/src/pass_context_imp.cpp
@@ -1072,6 +1072,10 @@ void PassContextImp::pass_context_update_context_json(
 
   CHECK(status.ok()) << "cannot parse json string:" << status.message()
                      << &json_str[0];
+  if (cache_key_finalized) {
+    CHECK_EQ(context_proto_in_cache.cache_key(), context_proto.cache_key())
+        << "cached context key does not match the finalized graph cache key";
+  }
   // Note: Old cache files with config field in ContextProto are not supported
   // after this refactoring (breaking change). The config field is now
   // runtime-only.
@@ -1100,9 +1104,9 @@ void PassContextImp::update_config_proto_root_field() {
     auto ret = std::optional<std::string>();
     return this->get_provider_option_with_priority(names);
   };
-  if (auto cache_key = get_provider_option_local({"cache_key", "cacheKey"})) {
-    context_proto.set_cache_key(*cache_key);
-  }
+  if (!cache_key_finalized)
+    if (auto cache_key = get_provider_option_local({"cache_key", "cacheKey"}))
+      context_proto.set_cache_key(*cache_key);
   // cache_dir removed by Issue #006 (PR #80)
   // encryption_key removed - now read from provider_options directly (Issue
   // #004)

--- a/morphizen/morphizen-core/src/pass_context_imp.hpp
+++ b/morphizen/morphizen-core/src/pass_context_imp.hpp
@@ -201,6 +201,8 @@ public:
   ContextProto context_proto;
   const ConfigProto config_; // Runtime-only INPUT (never serialized, immutable)
   bool is_ep_context_model = false;
+  bool cache_key_finalized = false;
+  bool initializer_digest_finalized = false;
   std::filesystem::path model_path;
   std::unique_ptr<morphizen_cxx::Model> ep_context_model_;
   std::chrono::time_point<std::chrono::steady_clock> start_ =

--- a/morphizen/morphizen-core/src/pass_context_imp.hpp
+++ b/morphizen/morphizen-core/src/pass_context_imp.hpp
@@ -376,6 +376,8 @@ private:
       const std::vector<std::unique_ptr<morphizen::ExecutionProvider>> &eps,
       const char *const *keys, const char *const *values, size_t kv_len);
   friend bool check_cache_hit(PassContextImp &context);
+  friend void compile_onnx_model_2(std::shared_ptr<PassContextImp> context,
+                                   const Graph &onnx_graph);
   std::map<std::string, std::string> ep_dynamic_options;
   mutable std::mutex ep_dynamic_options_lock;
   // for share context, many context may be same. may need to change container

--- a/morphizen/morphizen-core/src/util.cpp
+++ b/morphizen/morphizen-core/src/util.cpp
@@ -4,6 +4,7 @@
  */
 #include "morphizen/util.hpp"
 #include "md5.h"
+#include "sha256.h"
 #include <cstdio>
 
 #include <glog/logging.h>
@@ -247,5 +248,37 @@ std::string get_md5_of_file(const std::filesystem::path &path) {
   }
   file.close();
   return MD5_computer.getHash();
+}
+
+std::string get_sha256_of_buffer(const void *buffer, size_t size) {
+  return SHA256()(buffer, size);
+}
+
+std::string get_sha256_of_file_slice(const std::filesystem::path &path,
+                                     int64_t offset, size_t size) {
+  if (offset < 0)
+    throw std::invalid_argument("negative external initializer offset");
+  std::ifstream file(path, std::ios::binary);
+  if (!file)
+    throw std::runtime_error("cannot open external initializer: " +
+                             path.string());
+  file.seekg(offset);
+  if (!file)
+    throw std::runtime_error("cannot seek external initializer: " +
+                             path.string());
+
+  SHA256 sha256;
+  char buffer[64 * 1024];
+  size_t remaining = size;
+  while (remaining != 0) {
+    size_t chunk = std::min(remaining, sizeof(buffer));
+    file.read(buffer, static_cast<std::streamsize>(chunk));
+    if (static_cast<size_t>(file.gcount()) != chunk)
+      throw std::runtime_error("cannot read external initializer: " +
+                               path.string());
+    sha256.add(buffer, chunk);
+    remaining -= chunk;
+  }
+  return sha256.getHash();
 }
 } // namespace morphizen

--- a/morphizen/morphizen-graph/CMakeLists.txt
+++ b/morphizen/morphizen-graph/CMakeLists.txt
@@ -17,6 +17,7 @@ set(MORPHIZEN_GRAPH_SOURCES
     src/node_arg.cpp
     src/node_input.cpp
     src/node_attr.cpp
+    src/symbolic_dims.cpp
 )
 
 # Header files
@@ -26,6 +27,7 @@ set(MORPHIZEN_GRAPH_HEADERS
     include/morphizen/node_arg.hpp
     include/morphizen/node_input.hpp
     include/morphizen/node_attr.hpp
+    include/morphizen/symbolic_dims.hpp
     include/morphizen/_sanity_check.hpp
 )
 

--- a/morphizen/morphizen-graph/include/morphizen/symbolic_dims.hpp
+++ b/morphizen/morphizen-graph/include/morphizen/symbolic_dims.hpp
@@ -11,6 +11,31 @@
 
 namespace morphizen {
 
+/// Normative HSDI1 symbolic-dimension metadata contract.
+///
+/// The wire grammar is ASCII framing around opaque byte strings:
+///
+///   file     := "HSDI1\n" record-count "\n" record*
+///   record   := bytes(scope) bytes(value-name) rank ":" bytes(dimension)* "\n"
+///   bytes(x) := byte-count ":" lowercase-hex(x)
+///
+/// Decimal counts contain no leading zero unless the value is zero. A bytes
+/// field has exactly twice `byte-count` hexadecimal characters. Records are
+/// strictly sorted by the bytewise lexicographic `(scope, value-name)` pair;
+/// duplicate pairs, trailing bytes, and non-canonical spellings are invalid.
+///
+/// HSDI1 permits at most 1,000,000 records, 1,024 dimensions per record,
+/// 16 MiB of decoded bytes per scope, value name, or dimension, and 64 MiB in
+/// the complete encoding. Scope and value name are non-empty. An empty
+/// dimension (`0:`) means that axis has no symbolic identity. A missing
+/// metadata property and the canonical zero-record value `HSDI1\n0\n` both
+/// provide no symbolic proofs; cache identity normalizes missing metadata to
+/// that zero-record value.
+///
+/// HSDI1 is immutable. An incompatible grammar, field meaning, ordering, or
+/// bound requires a new encoding magic and new versioned metadata key/module
+/// attribute. A resolver-only semantic change instead updates
+/// kOnnxDimParamsResolverPolicyVersion. Decoders reject unknown magic.
 inline constexpr char kOnnxDimParamsMetadataKey[] =
     "com.amd.morphizen.onnx_dim_params.v1";
 inline constexpr char kOnnxDimParamsModuleAttr[] = "hipdnn.onnx_dim_params_v1";

--- a/morphizen/morphizen-graph/include/morphizen/symbolic_dims.hpp
+++ b/morphizen/morphizen-graph/include/morphizen/symbolic_dims.hpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace morphizen {
+
+inline constexpr char kOnnxDimParamsMetadataKey[] =
+    "com.amd.morphizen.onnx_dim_params.v1";
+inline constexpr char kOnnxDimParamsModuleAttr[] = "hipdnn.onnx_dim_params_v1";
+inline constexpr char kOnnxDimParamsEncodingVersion[] = "HSDI1";
+inline constexpr char kOnnxDimParamsResolverPolicyVersion[] =
+    "onnx-symbolic-extent-v1-main-graph-single-input-binding";
+inline constexpr char kInitializerDataDigestMetadataKey[] =
+    "com.amd.morphizen.initializer_data_sha256.v1";
+inline constexpr char kCompilerGraphDigestMetadataKey[] =
+    "com.amd.morphizen.compiler_graph_sha256.v1";
+
+struct SymbolicDimRecord {
+  std::string scope;
+  std::string value_name;
+  std::vector<std::string> dimensions;
+};
+
+/// Encode records using the deterministic HSDI1 wire format.
+/// Throws std::invalid_argument for malformed or duplicate input records.
+std::string encode_symbolic_dim_records(std::vector<SymbolicDimRecord> records);
+
+/// Decode and validate canonical HSDI1 bytes.
+/// Returns nullopt and fills `error` when the input is malformed or
+/// non-canonical.
+std::optional<std::vector<SymbolicDimRecord>>
+decode_symbolic_dim_records(std::string_view encoded, std::string &error);
+
+} // namespace morphizen

--- a/morphizen/morphizen-graph/src/symbolic_dims.cpp
+++ b/morphizen/morphizen-graph/src/symbolic_dims.cpp
@@ -1,0 +1,242 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#include "morphizen/symbolic_dims.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <limits>
+#include <set>
+#include <stdexcept>
+
+namespace morphizen {
+namespace {
+
+constexpr size_t kMaxRecords = 1'000'000;
+constexpr size_t kMaxRank = 1'024;
+constexpr size_t kMaxFieldBytes = 16 * 1024 * 1024;
+constexpr size_t kMaxEncodedBytes = 64 * 1024 * 1024;
+
+char hex_digit(unsigned value) {
+  return value < 10 ? static_cast<char>('0' + value)
+                    : static_cast<char>('a' + value - 10);
+}
+
+std::string hex_encode(std::string_view value) {
+  std::string result;
+  result.reserve(value.size() * 2);
+  for (unsigned char byte : value) {
+    result.push_back(hex_digit(byte >> 4));
+    result.push_back(hex_digit(byte & 0x0f));
+  }
+  return result;
+}
+
+std::optional<unsigned> hex_value(char value) {
+  if (value >= '0' && value <= '9')
+    return static_cast<unsigned>(value - '0');
+  if (value >= 'a' && value <= 'f')
+    return static_cast<unsigned>(value - 'a' + 10);
+  return std::nullopt;
+}
+
+bool record_less(const SymbolicDimRecord &lhs, const SymbolicDimRecord &rhs) {
+  if (lhs.scope != rhs.scope)
+    return lhs.scope < rhs.scope;
+  return lhs.value_name < rhs.value_name;
+}
+
+void append_bytes(std::string &out, std::string_view value) {
+  if (value.size() > kMaxFieldBytes)
+    throw std::invalid_argument("symbolic dimension field exceeds limit");
+  out += std::to_string(value.size());
+  out.push_back(':');
+  out += hex_encode(value);
+}
+
+class Decoder {
+public:
+  explicit Decoder(std::string_view input) : input(input) {}
+
+  std::optional<size_t> decimal(char terminator, size_t maximum,
+                                std::string_view field) {
+    if (position >= input.size() ||
+        !std::isdigit(static_cast<unsigned char>(input[position]))) {
+      fail(std::string(field) + " has no decimal value");
+      return std::nullopt;
+    }
+    size_t value = 0;
+    while (position < input.size() &&
+           std::isdigit(static_cast<unsigned char>(input[position]))) {
+      unsigned digit = static_cast<unsigned>(input[position++] - '0');
+      if (value > (maximum - digit) / 10) {
+        fail(std::string(field) + " exceeds limit");
+        return std::nullopt;
+      }
+      value = value * 10 + digit;
+    }
+    if (!consume(terminator)) {
+      fail(std::string(field) + " is not terminated");
+      return std::nullopt;
+    }
+    return value;
+  }
+
+  std::optional<std::string> bytes(std::string_view field) {
+    auto size = decimal(':', kMaxFieldBytes, field);
+    if (!size)
+      return std::nullopt;
+    if (*size > (input.size() - position) / 2) {
+      fail(std::string(field) + " is truncated");
+      return std::nullopt;
+    }
+    std::string result;
+    result.reserve(*size);
+    for (size_t i = 0; i < *size; ++i) {
+      auto high = hex_value(input[position++]);
+      auto low = hex_value(input[position++]);
+      if (!high || !low) {
+        fail(std::string(field) + " contains non-lowercase hex");
+        return std::nullopt;
+      }
+      result.push_back(static_cast<char>((*high << 4) | *low));
+    }
+    return result;
+  }
+
+  bool consume(char expected) {
+    if (position >= input.size() || input[position] != expected)
+      return false;
+    ++position;
+    return true;
+  }
+
+  bool consume(std::string_view expected) {
+    if (input.substr(position, expected.size()) != expected)
+      return false;
+    position += expected.size();
+    return true;
+  }
+
+  bool done() const { return position == input.size(); }
+  const std::string &error_message() const { return error; }
+
+  void fail(std::string message) {
+    if (error.empty())
+      error = std::move(message);
+  }
+
+private:
+  std::string_view input;
+  size_t position = 0;
+  std::string error;
+};
+
+} // namespace
+
+std::string
+encode_symbolic_dim_records(std::vector<SymbolicDimRecord> records) {
+  if (records.size() > kMaxRecords)
+    throw std::invalid_argument("too many symbolic dimension records");
+  std::sort(records.begin(), records.end(), record_less);
+
+  std::set<std::pair<std::string, std::string>> keys;
+  std::string result = std::string(kOnnxDimParamsEncodingVersion) + "\n";
+  result += std::to_string(records.size());
+  result.push_back('\n');
+  for (const SymbolicDimRecord &record : records) {
+    if (record.scope.empty() || record.value_name.empty())
+      throw std::invalid_argument(
+          "symbolic dimension record has empty scope or value name");
+    if (record.dimensions.size() > kMaxRank)
+      throw std::invalid_argument(
+          "symbolic dimension record rank exceeds limit");
+    if (!keys.emplace(record.scope, record.value_name).second)
+      throw std::invalid_argument("duplicate symbolic dimension record");
+
+    append_bytes(result, record.scope);
+    append_bytes(result, record.value_name);
+    result += std::to_string(record.dimensions.size());
+    result.push_back(':');
+    for (const std::string &dimension : record.dimensions)
+      append_bytes(result, dimension);
+    result.push_back('\n');
+    if (result.size() > kMaxEncodedBytes)
+      throw std::invalid_argument("symbolic dimension encoding exceeds limit");
+  }
+  return result;
+}
+
+std::optional<std::vector<SymbolicDimRecord>>
+decode_symbolic_dim_records(std::string_view encoded, std::string &error) {
+  error.clear();
+  if (encoded.size() > kMaxEncodedBytes) {
+    error = "symbolic dimension encoding exceeds limit";
+    return std::nullopt;
+  }
+
+  Decoder decoder(encoded);
+  if (!decoder.consume(kOnnxDimParamsEncodingVersion) ||
+      !decoder.consume('\n')) {
+    error = "unsupported symbolic dimension encoding version";
+    return std::nullopt;
+  }
+  auto record_count = decoder.decimal('\n', kMaxRecords, "record count");
+  if (!record_count) {
+    error = decoder.error_message();
+    return std::nullopt;
+  }
+
+  std::vector<SymbolicDimRecord> records;
+  records.reserve(*record_count);
+  std::pair<std::string, std::string> previous;
+  bool have_previous = false;
+  for (size_t record_index = 0; record_index < *record_count; ++record_index) {
+    auto scope = decoder.bytes("scope");
+    auto value_name = decoder.bytes("value name");
+    auto rank = decoder.decimal(':', kMaxRank, "rank");
+    if (!scope || !value_name || !rank || scope->empty() ||
+        value_name->empty()) {
+      error = decoder.error_message().empty()
+                  ? "record has empty scope or value name"
+                  : decoder.error_message();
+      return std::nullopt;
+    }
+    SymbolicDimRecord record{std::move(*scope), std::move(*value_name), {}};
+    record.dimensions.reserve(*rank);
+    for (size_t axis = 0; axis < *rank; ++axis) {
+      auto dimension = decoder.bytes("dimension");
+      if (!dimension) {
+        error = decoder.error_message();
+        return std::nullopt;
+      }
+      record.dimensions.push_back(std::move(*dimension));
+    }
+    if (!decoder.consume('\n')) {
+      error = "record is not newline terminated";
+      return std::nullopt;
+    }
+
+    std::pair<std::string, std::string> key{record.scope, record.value_name};
+    if (have_previous && !(previous < key)) {
+      error = "records are duplicate or not canonically sorted";
+      return std::nullopt;
+    }
+    previous = std::move(key);
+    have_previous = true;
+    records.push_back(std::move(record));
+  }
+  if (!decoder.done()) {
+    error = "trailing bytes after symbolic dimension records";
+    return std::nullopt;
+  }
+  if (encode_symbolic_dim_records(records) != encoded) {
+    error = "symbolic dimension encoding is not canonical";
+    return std::nullopt;
+  }
+  return records;
+}
+
+} // namespace morphizen

--- a/morphizen/ort-bridge/src/ir-converter-imp.cpp
+++ b/morphizen/ort-bridge/src/ir-converter-imp.cpp
@@ -5,6 +5,7 @@
 #define MORPHIZEN_USER 1
 #include "./ir-converter-imp.hpp"
 #include "./ort-graph-wrapper.hpp"
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <glog/logging.h>
@@ -13,6 +14,8 @@
 #include <morphizen/graph.hpp>
 #include <morphizen/morphizen-ort-api-ext.hpp>
 #include <morphizen/node_attr.hpp>
+#include <morphizen/symbolic_dims.hpp>
+#include <morphizen/util.hpp>
 #include <unordered_set>
 DEF_ENV_PARAM(MORPHIZEN_DEBUG_IR_CONVERTER, "0")
 DEF_ENV_PARAM_2(MORPHIZEN_DEBUG_IR_CONVERTER_OUTPUT_FILE,
@@ -56,27 +59,47 @@ OrtStatus *IRConverterImp::convert_to_model(morphizen::Model &model) const {
   auto &main_graph = MORPHIZEN_ORT_API(model_main_graph)(model);
 
   throw_if_error(convert_metadata(main_graph, model));
+  if (MORPHIZEN_ORT_API(model_has_meta_data)(
+          model, std::string(kOnnxDimParamsMetadataKey)) ||
+      MORPHIZEN_ORT_API(model_has_meta_data)(
+          model, std::string(kInitializerDataDigestMetadataKey)) ||
+      MORPHIZEN_ORT_API(model_has_meta_data)(
+          model, std::string(kCompilerGraphDigestMetadataKey))) {
+    return ort_api.CreateStatus(ORT_INVALID_ARGUMENT,
+                                "input model uses a reserved compiler metadata "
+                                "key");
+  }
   throw_if_error(convert_graph(main_graph));
   // Top-level graph drives its own resolve(true); sub graphs are
   // resolved by the backend when graph_add_node consumes their
   // attr_proto_new_graph attribute.
   morphizen_cxx::GraphRef(main_graph).resolve(true);
 
-  // Serialize dim_params as model metadata for the level-1 pass.
-  // Format: "name1:p0,p1;name2:p0,p1,p2;..." (parsed by parse_dim_params_map)
-  if (!dim_params_map_.empty()) {
-    std::string encoded;
-    for (const auto &[name, params] : dim_params_map_) {
-      if (!encoded.empty())
-        encoded += ';';
-      encoded += name + ':';
-      for (size_t i = 0; i < params.size(); ++i) {
-        if (i > 0)
-          encoded += ',';
-        encoded += params[i];
+  // Preserve authoritative ONNX dimension-variable identity for compiler
+  // shape reasoning. The encoder sorts records and validates a deterministic,
+  // delimiter-safe representation. Empty maps have a canonical encoding so
+  // cache salting is stable for models without symbolic dimensions.
+  try {
+    std::vector<SymbolicDimRecord> records;
+    records.reserve(dim_params_map_.size());
+    for (const auto &[name, params] : dim_params_map_)
+      records.push_back({"main_graph", name, params});
+    MORPHIZEN_ORT_API(model_set_meta_data)
+    (model, std::string(kOnnxDimParamsMetadataKey),
+     encode_symbolic_dim_records(std::move(records)));
+    if (config_.hash_initializer_data) {
+      std::sort(initializer_digests_.begin(), initializer_digests_.end());
+      std::string framed = "HIDI1\n";
+      for (const auto &[name, digest] : initializer_digests_) {
+        framed += std::to_string(name.size()) + ":" + name;
+        framed += std::to_string(digest.size()) + ":" + digest;
       }
+      MORPHIZEN_ORT_API(model_set_meta_data)
+      (model, std::string(kInitializerDataDigestMetadataKey),
+       get_sha256_of_buffer(framed.data(), framed.size()));
     }
-    MORPHIZEN_ORT_API(model_set_meta_data)(model, "dim_params_map", encoded);
+  } catch (const std::exception &error) {
+    return ort_api.CreateStatus(ORT_INVALID_ARGUMENT, error.what());
   }
 
   // Save converted model to file for debugging if enabled
@@ -284,6 +307,7 @@ IRConverterImp::convert_graph_initializers(morphizen::Graph &graph) const {
     // Create ValueInfo wrapper for the initializer
     auto value_info =
         Ort::ConstValueInfo(initializer); // Create ONNX ValueInfoProto
+    std::string initializer_name = value_info.GetName();
 
     // Try the file-reference path first: ValueInfo_GetExternalInitializerInfo
     // returns the {file_path, offset, byte_size} triple WITHOUT triggering
@@ -314,6 +338,10 @@ IRConverterImp::convert_graph_initializers(morphizen::Graph &graph) const {
       std::string abs_path_str = abs_path.u8string();
       int64_t file_offset = ext_info.GetFileOffset();
       size_t byte_size = ext_info.GetByteSize();
+      if (config_.hash_initializer_data)
+        initializer_digests_.emplace_back(
+            initializer_name,
+            get_sha256_of_file_slice(abs_path, file_offset, byte_size));
 
       // Need shape + element type, which require the OrtValue. ORT will
       // construct a stub tensor descriptor without materializing the data
@@ -372,6 +400,9 @@ IRConverterImp::convert_graph_initializers(morphizen::Graph &graph) const {
       auto shape = tensor_info.GetShape();
       const void *tensor_data = tensor_value.GetTensorRawData();
       size_t data_size = tensor_value.GetTensorSizeInBytes();
+      if (config_.hash_initializer_data)
+        initializer_digests_.emplace_back(
+            initializer_name, get_sha256_of_buffer(tensor_data, data_size));
 
       if (data_size > config_.external_data_threshold) {
         // Large tensor: use the no-copy memory-address mechanism. Encode the
@@ -435,9 +466,6 @@ IRConverterImp::convert_value_info_proto(const Ort::ConstValueInfo &value_info,
   }
 
   // Collect ONNX symbolic dimension names (dim_param) for each tensor.
-  // Data flow: ORT GetSymbolicDimensions → dim_params_map_ → model metadata
-  // "dim_params_map" → level-1 pass builds DimSource entries → custom op
-  // resolves dynamic output shapes at runtime from input tensor shapes.
   auto onnx_type = type_info.GetONNXType();
   if (onnx_type == ONNX_TYPE_TENSOR) {
     auto tensor_info = type_info.GetTensorTypeAndShapeInfo();

--- a/morphizen/ort-bridge/src/ir-converter-imp.cpp
+++ b/morphizen/ort-bridge/src/ir-converter-imp.cpp
@@ -11,6 +11,7 @@
 #include <glog/logging.h>
 #include <limits>
 #include <morphizen-utils/morphizen-utils.hpp>
+#include <morphizen/cache_identity.hpp>
 #include <morphizen/graph.hpp>
 #include <morphizen/morphizen-ort-api-ext.hpp>
 #include <morphizen/node_attr.hpp>
@@ -88,15 +89,9 @@ OrtStatus *IRConverterImp::convert_to_model(morphizen::Model &model) const {
     (model, std::string(kOnnxDimParamsMetadataKey),
      encode_symbolic_dim_records(std::move(records)));
     if (config_.hash_initializer_data) {
-      std::sort(initializer_digests_.begin(), initializer_digests_.end());
-      std::string framed = "HIDI1\n";
-      for (const auto &[name, digest] : initializer_digests_) {
-        framed += std::to_string(name.size()) + ":" + name;
-        framed += std::to_string(digest.size()) + ":" + digest;
-      }
       MORPHIZEN_ORT_API(model_set_meta_data)
       (model, std::string(kInitializerDataDigestMetadataKey),
-       get_sha256_of_buffer(framed.data(), framed.size()));
+       compute_graph_initializer_digest(main_graph));
     }
   } catch (const std::exception &error) {
     return ort_api.CreateStatus(ORT_INVALID_ARGUMENT, error.what());
@@ -298,8 +293,6 @@ IRConverterImp::convert_graph_initializers(morphizen::Graph &graph) const {
   std::filesystem::path model_path = api_model_path
                                          ? std::filesystem::path(api_model_path)
                                          : std::filesystem::path();
-  std::filesystem::path model_dir =
-      model_path.has_parent_path() ? model_path.parent_path() : model_path;
 
   // Get initializers from the ORT graph
   auto initializers = graph_.initializers();
@@ -307,7 +300,6 @@ IRConverterImp::convert_graph_initializers(morphizen::Graph &graph) const {
     // Create ValueInfo wrapper for the initializer
     auto value_info =
         Ort::ConstValueInfo(initializer); // Create ONNX ValueInfoProto
-    std::string initializer_name = value_info.GetName();
 
     // Try the file-reference path first: ValueInfo_GetExternalInitializerInfo
     // returns the {file_path, offset, byte_size} triple WITHOUT triggering
@@ -334,14 +326,10 @@ IRConverterImp::convert_graph_initializers(morphizen::Graph &graph) const {
       // directory to get an absolute path the runtime can fopen without
       // needing to know the model location.
       std::filesystem::path abs_path =
-          rel_path.is_absolute() ? rel_path : (model_dir / rel_path);
+          normalize_external_initializer_path(model_path, rel_path);
       std::string abs_path_str = abs_path.u8string();
       int64_t file_offset = ext_info.GetFileOffset();
       size_t byte_size = ext_info.GetByteSize();
-      if (config_.hash_initializer_data)
-        initializer_digests_.emplace_back(
-            initializer_name,
-            get_sha256_of_file_slice(abs_path, file_offset, byte_size));
 
       // Need shape + element type, which require the OrtValue. ORT will
       // construct a stub tensor descriptor without materializing the data
@@ -400,9 +388,6 @@ IRConverterImp::convert_graph_initializers(morphizen::Graph &graph) const {
       auto shape = tensor_info.GetShape();
       const void *tensor_data = tensor_value.GetTensorRawData();
       size_t data_size = tensor_value.GetTensorSizeInBytes();
-      if (config_.hash_initializer_data)
-        initializer_digests_.emplace_back(
-            initializer_name, get_sha256_of_buffer(tensor_data, data_size));
 
       if (data_size > config_.external_data_threshold) {
         // Large tensor: use the no-copy memory-address mechanism. Encode the

--- a/morphizen/ort-bridge/src/ir-converter-imp.hpp
+++ b/morphizen/ort-bridge/src/ir-converter-imp.hpp
@@ -51,9 +51,10 @@ private:
   OrtGraphWrapper graph_;
   IRConverterConfig config_;
   // Symbolic dimension names keyed by tensor name (e.g. "input_ids" →
-  // ["batch_size", "sequence_length"]). Serialized as model metadata
-  // "dim_params_map" so the level-1 pass can build DimSource entries.
+  // ["batch_size", "sequence_length"]). Serialized through the reserved,
+  // deterministic HSDI1 model metadata record for compiler shape reasoning.
   mutable std::unordered_map<std::string, std::vector<std::string>>
       dim_params_map_;
+  mutable std::vector<std::pair<std::string, std::string>> initializer_digests_;
 };
 } // namespace morphizen

--- a/morphizen/ort-bridge/src/ir-converter-imp.hpp
+++ b/morphizen/ort-bridge/src/ir-converter-imp.hpp
@@ -55,6 +55,5 @@ private:
   // deterministic HSDI1 model metadata record for compiler shape reasoning.
   mutable std::unordered_map<std::string, std::vector<std::string>>
       dim_params_map_;
-  mutable std::vector<std::pair<std::string, std::string>> initializer_digests_;
 };
 } // namespace morphizen

--- a/morphizen/ort-bridge/src/ir-converter.hpp
+++ b/morphizen/ort-bridge/src/ir-converter.hpp
@@ -19,6 +19,9 @@ struct IRConverterConfig {
   // external data mechanism (mirrors ORT kSmallTensorExternalDataThreshold).
   // Set to SIZE_MAX to disable the optimisation entirely.
   size_t external_data_threshold = 127;
+  // Persistent/prebuilt artifacts embed initializer bytes. Bind those bytes
+  // into cache identity only for paths that can reuse such an artifact.
+  bool hash_initializer_data = false;
 };
 
 class IRConverter {

--- a/morphizen/ort-bridge/src/morphizen-ep.cpp
+++ b/morphizen/ort-bridge/src/morphizen-ep.cpp
@@ -262,10 +262,17 @@ OrtStatus *ORT_API_CALL MorphiZenEP::GetCapabilityImpl(
     MY_LOG(1) << " no available IR converter.";
     return nullptr;
   }
-  // Use the OrtGraphWrapper class instead of manual API calls
-  auto graph_wrapper = morphizen::OrtGraphWrapper(*self, *graph);
-  self->GetCapability(graph_wrapper, *graph_support_info);
-  return nullptr;
+  try {
+    // Use the OrtGraphWrapper class instead of manual API calls.
+    auto graph_wrapper = morphizen::OrtGraphWrapper(*self, *graph);
+    self->GetCapability(graph_wrapper, *graph_support_info);
+    return nullptr;
+  } catch (const std::exception &error) {
+    return Ort::GetApi().CreateStatus(ORT_FAIL, error.what());
+  } catch (...) {
+    return Ort::GetApi().CreateStatus(
+        ORT_FAIL, "GetCapability failed with unknown exception");
+  }
 }
 
 OrtStatus *ORT_API_CALL MorphiZenEP::CompileImpl(
@@ -354,6 +361,11 @@ MorphiZenEP::GetCapability(OrtGraphWrapper &graph_viewer,
     ir_config.external_data_threshold = static_cast<size_t>(std::stoull(
         provider_options_.at("XLNX_model_clone_external_data_threshold")));
   }
+  ir_config.hash_initializer_data =
+      enable_ep_context_ ||
+      provider_options_.count("prebuild_cache_context") != 0 ||
+      provider_options_.count("config_file") != 0 ||
+      provider_options_.count("target") != 0;
   MY_LOG(2) << "IRConverter external_data_threshold: "
             << ir_config.external_data_threshold;
   auto ir_model = ir_converter(*this, graph_viewer.get(), ir_config);

--- a/morphizen/ort-bridge/src/morphizen-ep.cpp
+++ b/morphizen/ort-bridge/src/morphizen-ep.cpp
@@ -383,6 +383,10 @@ MorphiZenEP::GetCapability(OrtGraphWrapper &graph_viewer,
           },
           &logger_));
 
+  if (status != nullptr) {
+    execution_providers_.reset();
+    return status;
+  }
   if (!execution_providers_) {
     MY_LOG(1) << "Failed to compile ONNX model to MorphiZen EP.";
     return nullptr;

--- a/test/runtime/CMakeLists.txt
+++ b/test/runtime/CMakeLists.txt
@@ -60,3 +60,24 @@ target_link_libraries(test-gqa-autotune PRIVATE HipSchemasLib)
 
 add_test(NAME GqaAutotuneUnitTest COMMAND test-gqa-autotune)
 set_target_properties(test-gqa-autotune PROPERTIES FOLDER "runtime-tests")
+add_executable(test-symbolic-dims test_symbolic_dims.cpp)
+target_compile_features(test-symbolic-dims PRIVATE cxx_std_17)
+target_link_libraries(test-symbolic-dims PRIVATE morphizen-graph)
+add_test(NAME SymbolicDimsUnitTest COMMAND test-symbolic-dims)
+set_target_properties(test-symbolic-dims PROPERTIES FOLDER "runtime-tests")
+
+add_executable(test-symbolic-dims-mlir test_symbolic_dims_mlir.cpp)
+target_compile_features(test-symbolic-dims-mlir PRIVATE cxx_std_17)
+target_include_directories(test-symbolic-dims-mlir PRIVATE
+    ${CMAKE_SOURCE_DIR}/morphizen/mlir-imp/src
+)
+target_include_directories(test-symbolic-dims-mlir SYSTEM PRIVATE
+    ${LLVM_INCLUDE_DIRS}
+    ${MLIR_INCLUDE_DIRS}
+)
+target_link_libraries(test-symbolic-dims-mlir PRIVATE
+    mlir-imp
+    morphizen-graph
+)
+add_test(NAME SymbolicDimsMLIRUnitTest COMMAND test-symbolic-dims-mlir)
+set_target_properties(test-symbolic-dims-mlir PROPERTIES FOLDER "runtime-tests")

--- a/test/runtime/CMakeLists.txt
+++ b/test/runtime/CMakeLists.txt
@@ -81,3 +81,11 @@ target_link_libraries(test-symbolic-dims-mlir PRIVATE
 )
 add_test(NAME SymbolicDimsMLIRUnitTest COMMAND test-symbolic-dims-mlir)
 set_target_properties(test-symbolic-dims-mlir PROPERTIES FOLDER "runtime-tests")
+
+add_executable(test-cache-identity test_cache_identity.cpp)
+target_compile_features(test-cache-identity PRIVATE cxx_std_17)
+target_link_libraries(test-cache-identity PRIVATE
+    morphizen-core-static
+)
+add_test(NAME CacheIdentityUnitTest COMMAND test-cache-identity)
+set_target_properties(test-cache-identity PROPERTIES FOLDER "runtime-tests")

--- a/test/runtime/test_cache_identity.cpp
+++ b/test/runtime/test_cache_identity.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#include "morphizen/cache_identity.hpp"
+#include "morphizen/config.pb.h"
+#include "morphizen/morphizen.hpp"
+#include "morphizen/symbolic_dims.hpp"
+#include "morphizen/util.hpp"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace {
+
+bool check(bool condition, const char *message) {
+  if (!condition)
+    std::cerr << "FAILED: " << message << "\n";
+  return condition;
+}
+
+} // namespace
+
+int main() {
+  using morphizen::CacheKeyInputs;
+  using morphizen::CacheLoadAction;
+  using morphizen::CacheLoadKind;
+
+  const std::string empty_symbols = morphizen::encode_symbolic_dim_records({});
+  const std::string partition_a = morphizen::encode_symbolic_dim_records(
+      {{"main_graph", "lhs", {"N"}}, {"main_graph", "rhs", {"N"}}});
+  const std::string partition_b = morphizen::encode_symbolic_dim_records(
+      {{"main_graph", "lhs", {"N"}}, {"main_graph", "rhs", {"M"}}});
+  const std::string digest_a(64, 'a');
+  const std::string digest_b(64, 'b');
+
+  CacheKeyInputs inputs{"base",        "graph",  "contract-a",
+                        empty_symbols, digest_a, digest_b};
+  const std::string first = morphizen::finalize_cache_key(inputs);
+  bool ok = check(first == morphizen::finalize_cache_key(inputs),
+                  "cache key must be deterministic");
+  ok &= check(morphizen::is_finalized_cache_key(first),
+              "final key must use canonical lowercase SHA-256 form");
+
+  inputs.symbolic_metadata = partition_a;
+  const std::string symbolic_a = morphizen::finalize_cache_key(inputs);
+  inputs.symbolic_metadata = partition_b;
+  ok &= check(symbolic_a != morphizen::finalize_cache_key(inputs),
+              "symbolic partition must change the cache key");
+  inputs.symbolic_metadata = partition_a;
+  inputs.compiler_contract = "contract-b";
+  ok &= check(symbolic_a != morphizen::finalize_cache_key(inputs),
+              "compiler contract must change the cache key");
+
+  ok &= check(morphizen::select_cache_load_action(CacheLoadKind::Fresh, true,
+                                                  true, first, first) ==
+                  CacheLoadAction::Use,
+              "matching fresh context must be accepted");
+  ok &= check(morphizen::select_cache_load_action(CacheLoadKind::Fresh, true,
+                                                  true, first, symbolic_a) ==
+                  CacheLoadAction::Reject,
+              "fresh context mismatch must be rejected");
+  ok &= check(morphizen::select_cache_load_action(CacheLoadKind::Prebuilt, true,
+                                                  true, first, symbolic_a) ==
+                  CacheLoadAction::Recompile,
+              "prebuilt mismatch must trigger a fresh compile");
+  ok &= check(morphizen::select_cache_load_action(CacheLoadKind::Prebuilt,
+                                                  false, true, first, first) ==
+                  CacheLoadAction::Recompile,
+              "prebuilt cache without initializer identity must be bypassed");
+  ok &= check(morphizen::select_cache_load_action(CacheLoadKind::Prebuilt, true,
+                                                  false, first, first) ==
+                  CacheLoadAction::Recompile,
+              "unavailable prebuilt cache must be bypassed");
+  ok &= check(morphizen::select_cache_load_action(
+                  CacheLoadKind::EpContext, true, true, first, symbolic_a) ==
+                  CacheLoadAction::Reject,
+              "EPContext mismatch must be rejected");
+
+  morphizen::ConfigProto config;
+  (*config.mutable_provider_options())["z"] = "last";
+  (*config.mutable_provider_options())["a"] = "first";
+  const std::string serialized = morphizen::serialize_deterministically(config);
+  morphizen::ConfigProto parsed;
+  ok &= check(!serialized.empty() && parsed.ParseFromString(serialized),
+              "deterministic protobuf bytes must be finalized before return");
+  ok &= check(serialized == morphizen::serialize_deterministically(config),
+              "protobuf serialization must be deterministic");
+
+  std::vector<morphizen::InitializerDigest> digests{{"z", digest_a},
+                                                    {"a", digest_b}};
+  std::vector<morphizen::InitializerDigest> reversed{{"a", digest_b},
+                                                     {"z", digest_a}};
+  ok &= check(morphizen::combine_initializer_digests(digests) ==
+                  morphizen::combine_initializer_digests(reversed),
+              "initializer digest must not depend on traversal order");
+
+  const auto nonce =
+      std::chrono::steady_clock::now().time_since_epoch().count();
+  const std::filesystem::path path =
+      std::filesystem::temp_directory_path() /
+      ("hipdnn_initializer_snapshot_" + std::to_string(nonce) + ".bin");
+  {
+    std::ofstream output(path, std::ios::binary);
+    output << "abcdef";
+  }
+  morphizen::ExternalInitializerSlice slice{
+      path, 1, 3, morphizen::get_sha256_of_buffer("bcd", 3)};
+  std::string error;
+  ok &= check(morphizen::verify_external_initializer_slice(slice, error),
+              "unchanged external initializer slice must verify");
+  {
+    std::fstream output(path, std::ios::binary | std::ios::in | std::ios::out);
+    output.seekp(2);
+    output.put('X');
+  }
+  ok &= check(!morphizen::verify_external_initializer_slice(slice, error),
+              "initializer mutation must be rejected");
+  std::error_code ignored;
+  std::filesystem::remove(path, ignored);
+
+  const std::filesystem::path normalized =
+      morphizen::normalize_external_initializer_path(
+          std::filesystem::temp_directory_path() / "model" / "." /
+              "network.onnx",
+          "weights/../weights.bin");
+  ok &= check(normalized == (std::filesystem::temp_directory_path() / "model" /
+                             "weights.bin")
+                                .lexically_normal(),
+              "equivalent logical initializer paths must normalize");
+
+  return ok ? 0 : 1;
+}

--- a/test/runtime/test_symbolic_dims.cpp
+++ b/test/runtime/test_symbolic_dims.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#include "morphizen/symbolic_dims.hpp"
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+bool check(bool condition, const char *message) {
+  if (!condition)
+    std::cerr << "FAILED: " << message << "\n";
+  return condition;
+}
+
+} // namespace
+
+int main() {
+  using morphizen::SymbolicDimRecord;
+
+  std::vector<SymbolicDimRecord> unsorted{
+      {"main_graph", "z:value;with,delimiters", {"", "u1*u2"}},
+      {"main_graph", "pixel_values", {"num_patches", ""}},
+      {"main_graph", "unicode", {u8"序列", ""}},
+  };
+  std::vector<SymbolicDimRecord> sorted{unsorted[1], unsorted[2], unsorted[0]};
+  std::string encoded = morphizen::encode_symbolic_dim_records(unsorted);
+  std::string sortedEncoded = morphizen::encode_symbolic_dim_records(sorted);
+  bool ok = check(encoded == sortedEncoded,
+                  "encoding must not depend on insertion order");
+
+  std::string error;
+  auto decoded = morphizen::decode_symbolic_dim_records(encoded, error);
+  ok &= check(decoded.has_value(), "canonical encoding must decode");
+  ok &= check(error.empty(), "successful decode must not report an error");
+  ok &= check(decoded && decoded->size() == 3, "decoded record count");
+  ok &= check(decoded && (*decoded)[0].value_name == "pixel_values",
+              "records must be canonically sorted");
+  ok &= check(decoded && (*decoded)[0].dimensions[0] == "num_patches",
+              "symbolic dimension must round-trip");
+  ok &= check(decoded && (*decoded)[1].dimensions[0] == u8"序列",
+              "UTF-8 dimension must round-trip");
+  ok &= check(decoded && (*decoded)[2].dimensions[1] == "u1*u2",
+              "expression-like dimension must remain opaque");
+  ok &= check(decoded &&
+                  morphizen::encode_symbolic_dim_records(*decoded) == encoded,
+              "decode/re-encode must preserve canonical cache bytes");
+
+  std::string zero =
+      morphizen::encode_symbolic_dim_records(std::vector<SymbolicDimRecord>{});
+  ok &= check(zero == "HSDI1\n0\n", "empty map has canonical encoding");
+  ok &= check(morphizen::encode_symbolic_dim_records({{"g", "x", {"N", ""}}}) ==
+                  "HSDI1\n1\n1:671:782:1:4e0:\n",
+              "non-empty encoding must match the HSDI1 golden bytes");
+
+  for (const std::string &bad : {
+           std::string("HSDI2\n0\n"),
+           std::string("HSDI1\n1\n4:6D61696E0:0:\n"),
+           std::string("HSDI1\n00\n"),
+           std::string("HSDI1\n1\n1:6"),
+           std::string("HSDI1\n1\n1:zz1:781:1:4e\n"),
+           std::string("HSDI1\n1\n0:1:781:1:4e\n"),
+           std::string("HSDI1\n1\n1:671:781025:\n"),
+           std::string("HSDI1\n2\n1:671:7a0:\n1:671:610:\n"),
+           encoded + "trailing",
+       }) {
+    error.clear();
+    ok &= check(!morphizen::decode_symbolic_dim_records(bad, error),
+                "malformed encoding must fail");
+    ok &= check(!error.empty(), "malformed encoding must report an error");
+  }
+
+  try {
+    (void)morphizen::encode_symbolic_dim_records(
+        {{"main_graph", "x", {"N"}}, {"main_graph", "x", {"N"}}});
+    ok &= check(false, "duplicate records must be rejected");
+  } catch (const std::invalid_argument &) {
+  }
+
+  return ok ? 0 : 1;
+}

--- a/test/runtime/test_symbolic_dims_mlir.cpp
+++ b/test/runtime/test_symbolic_dims_mlir.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#include "mlir-graph.hpp"
+#include "mlir-model.hpp"
+#include "morphizen/symbolic_dims.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+bool check(bool condition, const char *message) {
+  if (!condition)
+    std::cerr << "FAILED: " << message << "\n";
+  return condition;
+}
+
+} // namespace
+
+int main() {
+  using morphizen::mlir_impl::MLIRModel;
+
+  const std::string metadata = morphizen::encode_symbolic_dim_records(
+      {{"main_graph", "input", {"N", "D"}},
+       {"main_graph", "output", {"N", "D"}}});
+  auto model = MLIRModel::create_empty();
+  model->set_metadata_prop(std::string(morphizen::kOnnxDimParamsMetadataKey),
+                           metadata);
+  model->set_metadata_prop(
+      std::string(morphizen::kInitializerDataDigestMetadataKey),
+      std::string(64, 'a'));
+  bool ok = check(
+      model->has_metadata_prop(morphizen::kCompilerGraphDigestMetadataKey),
+      "initializer digest must finalize compiler graph identity");
+  ok &=
+      check(model->get_metadata_prop(morphizen::kCompilerGraphDigestMetadataKey)
+                    .size() == 64,
+            "compiler graph identity must be SHA-256");
+
+  const std::string first = model->main_graph().save_string();
+  ok &= check(!first.empty(), "first serialization must produce bytecode");
+  ok &= check(model->main_graph().save_string() == first,
+              "repeated serialization must restore temporary module metadata");
+
+  const std::filesystem::path path = std::filesystem::temp_directory_path() /
+                                     "hipdnn_symbolic_dims_roundtrip.mlirbc";
+  {
+    std::ofstream output(path, std::ios::binary);
+    output.write(first.data(), static_cast<std::streamsize>(first.size()));
+    ok &= check(static_cast<bool>(output), "bytecode write must succeed");
+  }
+
+  auto loaded = MLIRModel::load(path.string());
+  std::error_code ignored;
+  std::filesystem::remove(path, ignored);
+  ok &= check(loaded != nullptr, "serialized bytecode must load");
+  if (!loaded)
+    return 1;
+  ok &= check(loaded->has_metadata_prop(morphizen::kOnnxDimParamsMetadataKey),
+              "loaded model must import symbolic metadata");
+  ok &= check(loaded->get_metadata_prop(morphizen::kOnnxDimParamsMetadataKey) ==
+                  metadata,
+              "loaded model must preserve canonical metadata bytes");
+  ok &= check(!loaded->has_metadata_prop(
+                  morphizen::kInitializerDataDigestMetadataKey) &&
+                  !loaded->has_metadata_prop(
+                      morphizen::kCompilerGraphDigestMetadataKey),
+              "cache-only digests must not become serialized model authority");
+  ok &= check(loaded->main_graph().save_string() == first,
+              "load/re-serialize must be byte-identical");
+
+  loaded->getModule()->setAttr(morphizen::kOnnxDimParamsModuleAttr,
+                               loaded->get_symbolic_dim_attr());
+  try {
+    (void)loaded->main_graph().save_string();
+    ok &= check(false, "conflicting live module metadata must be rejected");
+  } catch (const std::runtime_error &) {
+  }
+
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Why

ONNX models already carry symbolic dimension identities through `dim_param`, but those identities disappeared when ORT graphs became ranked MLIR tensors. Once two equal dynamic dimensions became unrelated SSA values, exact broadcast sizing had to materialize runtime merge expressions that later fragmented allocation domains.

Compilation behavior also depends on the symbolic partition. Reusing an artifact compiled for a different partition, graph, initializer payload, target, pass set, or effective compiler option can select shape logic that does not belong to the current model. The cache path must distinguish a recoverable prebuilt mismatch, which can compile from the source graph, from an unrecoverable EPContext mismatch, which must be reported to ORT because no source graph is available.

Cache identity also has two lifetime boundaries to defend. Deterministic protobuf bytes must be finalized before the serialization streams die, and initializer bytes must still match the finalized digest immediately before and after compiler consumption. This PR adds that transport and cache authority only; the later activation PR consumes the symbolic facts for destination construction.

## IR example

The runtime round-trip test supplies `N` and `D` records for `input` and `output`. During MLIR serialization they are projected into the transient module attribute built by this PR:

```mlir
module attributes {
  hipdnn.onnx_dim_params_v1 = [
    {scope = "main_graph", value_name = "input", dimensions = ["N", "D"]},
    {scope = "main_graph", value_name = "output", dimensions = ["N", "D"]}
  ]
} {
  func.func @main_graph(
      %input: tensor<?x?xf32> {onnx.name = "input"}) -> tensor<?x?xf32> {
    return %input : tensor<?x?xf32>
  }
}
```

The attribute is imported back into canonical `HSDI1` model metadata when MLIR is loaded and removed from the live module. `HSDI1` now has a normative byte-counted, lowercase-hex grammar, canonical record ordering, explicit bounds, and versioning rules beside the public encoder/decoder. Repeated serialization restores the same temporary attribute without leaving it behind.

The cache decision is intentionally outside the IR: malformed, unavailable, or key-mismatched prebuilt state is treated as a recoverable miss and recompiles, while an EPContext key mismatch is returned as an ORT failure. Compiler-contract protobuf serialization is completed before returning its bytes, and initializer snapshots are verified on both sides of compiler graph consumption.

## What changes

- Encode symbolic dimension records in the versioned, canonical `HSDI1` format and document its normative grammar, ordering, limits, empty semantics, and compatibility boundary.
- Reserve compiler-owned metadata keys at the ORT bridge boundary.
- Preserve `dim_param` identities for named top-level tensor values.
- Project symbolic records only while serializing MLIR and restore the live module on every exit path.
- Import and validate the module attribute when loading MLIR.
- Finalize cache keys with domain-separated SHA-256 framing over graph, initializer, symbolic, compiler-graph, and compiler-contract identities.
- Deterministically serialize compiler-contract protobufs with stream lifetimes scoped so all buffered bytes are finalized before return.
- Normalize process-local initializer addresses out of compiler graph identity.
- Hash actual initializer bytes for persistent/prebuilt artifacts and fail closed when that identity is unavailable.
- Verify initializer snapshots immediately before and after compiler consumption, rejecting mutation across the hash-to-compile window.
- Recover from unavailable, malformed, or mismatched prebuilt caches by compiling fresh; reject EPContext mismatches through ORT because recompilation is impossible.
- Prevent provider options or cached `context.json` from replacing an already-finalized key.
- Add direct GPU-free cache-policy, protobuf-lifetime, initializer-mutation, canonical-encoding, malformed-input, repeated-save, and MLIR bytecode round-trip tests.
- Make no shape-materialization, runtime ABI, or kernel changes.

## Stack

Merged prerequisite plus the 22 active shape PRs:

1. [#688 — refactor(hip): externalize constants after ONNX conversion](https://github.com/ROCm/hip-ep/pull/688)
2. [#724 — feat(shape): preserve symbolic compiler inputs](https://github.com/ROCm/hip-ep/pull/724) ← this PR
3. [#639 — refactor(hip): establish shared shape-rule foundation](https://github.com/ROCm/hip-ep/pull/639)
4. [#681 — fix(shape): canonicalize host reshape provenance](https://github.com/ROCm/hip-ep/pull/681)
5. [#725 — fix(shape): activate exact broadcasts with symbolic proofs](https://github.com/ROCm/hip-ep/pull/725)
6. [#734 — fix(shape): share MatMul and Gemm contracts](https://github.com/ROCm/hip-ep/pull/734)
7. [#641 — fix(shape): enforce shared broadcast contracts](https://github.com/ROCm/hip-ep/pull/641)
8. [#735 — refactor(conversion): share ONNX reduction conversion](https://github.com/ROCm/hip-ep/pull/735)
9. [#736 — fix(shape): normalize reduction contracts](https://github.com/ROCm/hip-ep/pull/736)
10. [#643 — fix(shape): share convolution contracts](https://github.com/ROCm/hip-ep/pull/643)
11. [#742 — fix(shape): share causal convolution contracts](https://github.com/ROCm/hip-ep/pull/742)
12. [#645 — fix(shape): share normalization contracts](https://github.com/ROCm/hip-ep/pull/645)
13. [#740 — fix(shape): share attention contracts](https://github.com/ROCm/hip-ep/pull/740)
14. [#741 — fix(shape): share GQA capacity contracts](https://github.com/ROCm/hip-ep/pull/741)
15. [#644 — fix(shape): share gather and tensor contracts](https://github.com/ROCm/hip-ep/pull/644)
16. [#727 — feat(shape): consume constant payload shapes directly](https://github.com/ROCm/hip-ep/pull/727)
17. [#728 — feat(shape): add exact Tile and Range destinations](https://github.com/ROCm/hip-ep/pull/728)
18. [#646 — refactor(hip): declare explicit DPS shape contracts](https://github.com/ROCm/hip-ep/pull/646)
19. [#730 — test(hip): audit explicit DPS contract inventory](https://github.com/ROCm/hip-ep/pull/730)
20. [#732 — test(hip): audit ONNX converter deduplication](https://github.com/ROCm/hip-ep/pull/732)
21. [#647 — fix(hip): harden shape refinement failure handling](https://github.com/ROCm/hip-ep/pull/647)
22. [#761 — refactor(hip): split shape utility headers by family](https://github.com/ROCm/hip-ep/pull/761)
23. [#764 — refactor(hip): clarify shape destination authority](https://github.com/ROCm/hip-ep/pull/764)

## AI assistance

AI tools assisted with the metadata design, cache-authority hardening, test construction, review-feedback fixes, and stack reconstruction. The contributor reviewed and validated the resulting code.

Made-with: Cursor
