### PR TITLE
fix(shape): activate exact broadcasts with symbolic proofs

### DIFF
--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -82,6 +82,25 @@ before introducing another feature-specific symbolic analysis. Frontend payload
 provenance, such as reconstructing a shape tensor's values, is a separate
 problem from proving affine equality between dimensions.
 
+ONNX also carries authoritative dimension-variable identity (`dim_param`).
+MorphiZen preserves that frontend fact as compile-time-only module metadata.
+Immediately before ONNX compute conversion, a bounded operation-local plan may
+reuse one operand extent when every dynamic non-unit broadcast contributor has
+the same eligible non-empty identity. Missing, different, malformed, unnamed,
+multi-bound, nested-subgraph, and post-rewrite values retain the exact runtime
+broadcast expression. Pre-existing operation-local plan attributes are rejected
+rather than trusted. The metadata and generated plan are consumed during ONNX
+conversion and do not survive into HIP IR; `ReifyRankedShapedTypeOpInterface`
+and `--hip-infer-shapes` remain frontend-neutral and callback-free.
+
+MorphiZen's finalized cache key includes the immutable source model (or
+canonical in-memory compiler graph), persistent-artifact initializer bytes,
+canonical symbolic metadata, resolved compiler contract, encoding version, and
+resolver-policy version in domain-separated SHA-256 fields. Process-local
+initializer addresses are normalized out of graph identity. A prebuilt artifact
+without finalized initializer identity is ignored, and a restored cache context
+must contain the same finalized key; cache metadata cannot replace it.
+
 Phase 1 of `--hip-infer-shapes` is intentionally local rather than a global
 fixpoint: each operation is refined once in producer-before-consumer order, and
 cast barriers preserve existing consumer signatures instead of propagating

--- a/docs/design/pool-allocs-memory-planning.md
+++ b/docs/design/pool-allocs-memory-planning.md
@@ -93,6 +93,14 @@ reification, CSE, and buffer reuse a canonical root dimension. Conflicting
 control-flow joins and unknown or device-produced target shapes deliberately
 keep the synchronized fallback.
 
+ONNX symbolic dimension identity is another pre-conversion pool-quality input.
+When every dynamic non-unit contributor to one broadcast result axis carries
+the same eligible non-empty `dim_param`, destination construction reuses one
+operand dimension instead of materializing a redundant runtime merge. The
+exact runtime broadcast remains for missing, unequal, malformed, or
+independently bound identities. This avoids late duplicate size cones without
+changing PoolAllocs, HIP reification, or runtime allocation semantics.
+
 Pre-bufferization `hip-resolve-tensor-dims` serves a related purpose for tensor reshape chains. It lets upstream reification and canonicalization reduce `tensor.dim` queries before they become memref-level size arithmetic. Coverage of standard tensor reshape operations requires `tensor::registerInferTypeOpInterfaceExternalModels` on the dialect registry.
 
 ## PoolAllocs algorithm

--- a/include/hip/Conversion/HipConversionUtils.h
+++ b/include/hip/Conversion/HipConversionUtils.h
@@ -39,13 +39,12 @@ createEmptyTensorFromReifiedShape(OpBuilder &builder, Location loc,
                                   RankedTensorType resultType,
                                   llvm::ArrayRef<OpFoldResult> reifiedShape);
 
-/// Validate against the shared NumPy broadcast shape rule, then build a
-/// tensor.empty using the established conversion-time extent source policy.
-/// Exact dynamic merge materialization is activated with frontend proofs in a
-/// later stack layer.
-FailureOr<Value> createBroadcastEmptyTensor(OpBuilder &builder, Location loc,
-                                            RankedTensorType resultType,
-                                            ValueRange operands);
+/// Build a tensor.empty from the shared NumPy broadcast shape rule. Pure shape
+/// and imported-result checks complete before shape SSA emits.
+FailureOr<Value>
+createBroadcastEmptyTensor(OpBuilder &builder, Location loc,
+                           RankedTensorType resultType, ValueRange operands,
+                           ArrayRef<int64_t> canonicalOperandForResultDim = {});
 
 /// Return !hip.context from function argument 0.
 FailureOr<Value> getContextArg(Operation *op, PatternRewriter &rewriter);

--- a/include/hip/Dialect/IR/HipShapeUtils.h
+++ b/include/hip/Dialect/IR/HipShapeUtils.h
@@ -124,7 +124,8 @@ reifyElementwiseSameShapeFor(OpBuilder &b, Location loc, Value source,
 /// emitted.
 FailureOr<SmallVector<OpFoldResult>>
 reifyBroadcastResultShape(OpBuilder &b, Location loc, ValueRange operands,
-                          function_ref<InFlightDiagnostic()> emitError);
+                          function_ref<InFlightDiagnostic()> emitError,
+                          ArrayRef<int64_t> canonicalOperandForResultDim = {});
 
 /// Reify the result shape of a transpose op as `output[i] = input[perm[i]]`.
 /// `perm` must be a permutation of `[0, rank-1)` and have the same length

--- a/lib/Conversion/HipConversionUtils.cpp
+++ b/lib/Conversion/HipConversionUtils.cpp
@@ -92,9 +92,10 @@ createEmptyTensorFromReifiedShape(OpBuilder &builder, Location loc,
   return Value(tensor::EmptyOp::create(builder, loc, resultType, dynSizes));
 }
 
-FailureOr<Value> createBroadcastEmptyTensor(OpBuilder &builder, Location loc,
-                                            RankedTensorType resultType,
-                                            ValueRange operands) {
+FailureOr<Value>
+createBroadcastEmptyTensor(OpBuilder &builder, Location loc,
+                           RankedTensorType resultType, ValueRange operands,
+                           ArrayRef<int64_t> canonicalOperandForResultDim) {
   llvm::SmallVector<llvm::ArrayRef<int64_t>> staticShapes;
   staticShapes.reserve(operands.size());
   for (Value operand : operands) {
@@ -110,45 +111,12 @@ FailureOr<Value> createBroadcastEmptyTensor(OpBuilder &builder, Location loc,
       !isResultTypeCompatibleWithInferredShape(resultType, *inferredShape))
     return failure();
 
-  // The foundation deliberately keeps the established conversion-time
-  // materialization policy. Exact dynamic broadcast reification remains
-  // available to shape interfaces, but activating it for destination sizing
-  // is deferred until frontend identity proofs can fold redundant merges.
-  int64_t resultRank = resultType.getRank();
-  llvm::SmallVector<Value> dynSizes;
-  for (int64_t dimIdx : llvm::seq<int64_t>(resultRank)) {
-    if (!resultType.isDynamicDim(dimIdx))
-      continue;
-
-    Value chosen;
-    int64_t chosenDim = -1;
-    Value fallback;
-    int64_t fallbackDim = -1;
-    for (Value operand : operands) {
-      auto type = dyn_cast<RankedTensorType>(operand.getType());
-      int64_t offset = resultRank - type.getRank();
-      if (dimIdx < offset)
-        continue;
-      int64_t operandDim = dimIdx - offset;
-      if (!fallback) {
-        fallback = operand;
-        fallbackDim = operandDim;
-      }
-      if (!type.isDynamicDim(operandDim) && type.getDimSize(operandDim) == 1)
-        continue;
-      chosen = operand;
-      chosenDim = operandDim;
-      break;
-    }
-    if (!chosen) {
-      chosen = fallback;
-      chosenDim = fallbackDim;
-    }
-    if (!chosen)
-      return failure();
-    dynSizes.push_back(tensor::DimOp::create(builder, loc, chosen, chosenDim));
-  }
-  return Value(tensor::EmptyOp::create(builder, loc, resultType, dynSizes));
+  FailureOr<llvm::SmallVector<OpFoldResult>> shape = reifyBroadcastResultShape(
+      builder, loc, operands, [&] { return emitError(loc); },
+      canonicalOperandForResultDim);
+  if (failed(shape))
+    return failure();
+  return createEmptyTensorFromReifiedShape(builder, loc, resultType, *shape);
 }
 
 FailureOr<Value> getContextArg(Operation *op, PatternRewriter &rewriter) {

--- a/lib/Conversion/OnnxToHip/AndConversion.cpp
+++ b/lib/Conversion/OnnxToHip/AndConversion.cpp
@@ -44,7 +44,7 @@ struct AndToHip : public mlir::RewritePattern {
       return rewriter.notifyMatchFailure(op, "expected ranked tensor inputs");
 
     mlir::FailureOr<mlir::Value> initOrFailure =
-        createBroadcastEmptyTensor(rewriter, loc, resultType, {a, b});
+        createOnnxBroadcastEmptyTensor(rewriter, loc, resultType, {a, b}, op);
     if (mlir::failed(initOrFailure))
       return rewriter.notifyMatchFailure(
           op, "And: no ranked operand spans dynamic result dim");

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 add_library(OnnxToHip STATIC
   OnnxToHip.cpp
+  OnnxDimParams.cpp
   OnnxToHipUtils.cpp
   SimplifyOnnx.cpp
   MatMulConversion.cpp

--- a/lib/Conversion/OnnxToHip/DivConversion.cpp
+++ b/lib/Conversion/OnnxToHip/DivConversion.cpp
@@ -29,7 +29,7 @@ struct DivToHip : public mlir::RewritePattern {
         mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
 
     mlir::FailureOr<mlir::Value> initOrFailure =
-        createBroadcastEmptyTensor(rewriter, loc, resultType, {a, b});
+        createOnnxBroadcastEmptyTensor(rewriter, loc, resultType, {a, b}, op);
     if (mlir::failed(initOrFailure))
       return rewriter.notifyMatchFailure(
           op, "Div: no ranked operand spans dynamic result dim");

--- a/lib/Conversion/OnnxToHip/ElementwiseConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ElementwiseConversion.cpp
@@ -54,7 +54,7 @@ AddToHip::matchAndRewrite(mlir::Operation *op,
       mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
 
   mlir::FailureOr<mlir::Value> initOrFailure =
-      createBroadcastEmptyTensor(rewriter, loc, resultType, {a, b});
+      createOnnxBroadcastEmptyTensor(rewriter, loc, resultType, {a, b}, op);
   if (mlir::failed(initOrFailure))
     return rewriter.notifyMatchFailure(
         op, "Add: no ranked operand spans dynamic result dim");
@@ -80,7 +80,7 @@ MulToHip::matchAndRewrite(mlir::Operation *op,
       mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
 
   mlir::FailureOr<mlir::Value> initOrFailure =
-      createBroadcastEmptyTensor(rewriter, loc, resultType, {a, b});
+      createOnnxBroadcastEmptyTensor(rewriter, loc, resultType, {a, b}, op);
   if (mlir::failed(initOrFailure))
     return rewriter.notifyMatchFailure(
         op, "Mul: no ranked operand spans dynamic result dim");
@@ -105,7 +105,7 @@ SubToHip::matchAndRewrite(mlir::Operation *op,
   auto resultType =
       mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
   mlir::FailureOr<mlir::Value> initOrFailure =
-      createBroadcastEmptyTensor(rewriter, loc, resultType, {lhs, rhs});
+      createOnnxBroadcastEmptyTensor(rewriter, loc, resultType, {lhs, rhs}, op);
   if (mlir::failed(initOrFailure))
     return rewriter.notifyMatchFailure(
         op, "Sub: no ranked operand spans dynamic result dim");

--- a/lib/Conversion/OnnxToHip/EqualConversion.cpp
+++ b/lib/Conversion/OnnxToHip/EqualConversion.cpp
@@ -29,7 +29,7 @@ struct EqualToHip : public mlir::RewritePattern {
         mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
 
     mlir::FailureOr<mlir::Value> initOrFailure =
-        createBroadcastEmptyTensor(rewriter, loc, resultType, {a, b});
+        createOnnxBroadcastEmptyTensor(rewriter, loc, resultType, {a, b}, op);
     if (mlir::failed(initOrFailure))
       return rewriter.notifyMatchFailure(
           op, "Equal: no ranked operand spans dynamic result dim");

--- a/lib/Conversion/OnnxToHip/GreaterConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GreaterConversion.cpp
@@ -49,7 +49,7 @@ struct GreaterDecompose : public mlir::RewritePattern {
           op, "onnx.Greater decompose expects a ranked tensor result");
 
     mlir::FailureOr<mlir::Value> initOrFailure =
-        createBroadcastEmptyTensor(rewriter, loc, resultType, {b, a});
+        createOnnxBroadcastEmptyTensor(rewriter, loc, resultType, {b, a}, op);
     if (mlir::failed(initOrFailure))
       return rewriter.notifyMatchFailure(
           op, "Greater: cannot infer dynamic result dimensions from "

--- a/lib/Conversion/OnnxToHip/GreaterOrEqualConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GreaterOrEqualConversion.cpp
@@ -53,7 +53,7 @@ struct GreaterOrEqualDecompose : public mlir::RewritePattern {
 
     // less = (A < B); same (boolean, broadcasted) type as the final result.
     mlir::FailureOr<mlir::Value> lessInit =
-        createBroadcastEmptyTensor(rewriter, loc, resultType, {a, b});
+        createOnnxBroadcastEmptyTensor(rewriter, loc, resultType, {a, b}, op);
     if (mlir::failed(lessInit))
       return rewriter.notifyMatchFailure(
           op, "GreaterOrEqual: cannot infer dynamic result dimensions from "

--- a/lib/Conversion/OnnxToHip/LessConversion.cpp
+++ b/lib/Conversion/OnnxToHip/LessConversion.cpp
@@ -29,7 +29,7 @@ struct LessToHip : public mlir::RewritePattern {
         mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
 
     mlir::FailureOr<mlir::Value> initOrFailure =
-        createBroadcastEmptyTensor(rewriter, loc, resultType, {a, b});
+        createOnnxBroadcastEmptyTensor(rewriter, loc, resultType, {a, b}, op);
     if (mlir::failed(initOrFailure))
       return rewriter.notifyMatchFailure(
           op, "Less: no ranked operand spans dynamic result dim");

--- a/lib/Conversion/OnnxToHip/LessOrEqualConversion.cpp
+++ b/lib/Conversion/OnnxToHip/LessOrEqualConversion.cpp
@@ -54,7 +54,7 @@ struct LessOrEqualDecompose : public mlir::RewritePattern {
 
     // less = (B < A); same (boolean, broadcasted) type as the final result.
     mlir::FailureOr<mlir::Value> lessInit =
-        createBroadcastEmptyTensor(rewriter, loc, resultType, {b, a});
+        createOnnxBroadcastEmptyTensor(rewriter, loc, resultType, {b, a}, op);
     if (mlir::failed(lessInit))
       return rewriter.notifyMatchFailure(
           op, "LessOrEqual: cannot infer dynamic result dimensions from "

--- a/lib/Conversion/OnnxToHip/ModConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ModConversion.cpp
@@ -29,7 +29,7 @@ struct ModToHip : public mlir::RewritePattern {
         mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
 
     mlir::FailureOr<mlir::Value> initOrFailure =
-        createBroadcastEmptyTensor(rewriter, loc, resultType, {a, b});
+        createOnnxBroadcastEmptyTensor(rewriter, loc, resultType, {a, b}, op);
     if (mlir::failed(initOrFailure))
       return rewriter.notifyMatchFailure(
           op, "Mod: no ranked operand spans dynamic result dim");

--- a/lib/Conversion/OnnxToHip/OnnxDimParams.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxDimParams.cpp
@@ -1,0 +1,256 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#include "OnnxDimParams.h"
+
+#include "hip/Dialect/IR/HipDialect.h"
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Value.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringSet.h"
+
+namespace mlir::hip {
+namespace {
+
+bool isBroadcastOp(Operation *op) {
+  llvm::StringRef name = op->getName().getStringRef();
+  return llvm::is_contained({"onnx.Add", "onnx.And", "onnx.Div", "onnx.Equal",
+                             "onnx.Greater", "onnx.GreaterOrEqual", "onnx.Less",
+                             "onnx.LessOrEqual", "onnx.Mod", "onnx.Mul",
+                             "onnx.Or", "onnx.Sub", "onnx.Where"},
+                            name);
+}
+
+std::optional<std::string> getValueName(Value value) {
+  if (auto argument = dyn_cast<BlockArgument>(value)) {
+    auto funcOp =
+        dyn_cast_or_null<func::FuncOp>(argument.getOwner()->getParentOp());
+    if (!funcOp || argument.getOwner() != &funcOp.getBody().front())
+      return std::nullopt;
+    auto name = funcOp.getArgAttrOfType<StringAttr>(argument.getArgNumber(),
+                                                    "onnx.name");
+    if (!name)
+      return std::nullopt;
+    return name.getValue().str();
+  }
+
+  auto result = dyn_cast<OpResult>(value);
+  if (!result)
+    return std::nullopt;
+  auto outputs =
+      result.getDefiningOp()->getAttrOfType<ArrayAttr>("node.outputs");
+  if (!outputs || result.getResultNumber() >= outputs.size())
+    return std::nullopt;
+  auto name = dyn_cast<StringAttr>(outputs[result.getResultNumber()]);
+  if (!name || name.getValue().empty())
+    return std::nullopt;
+  return name.getValue().str();
+}
+
+bool isFunctionArgument(Value value) {
+  auto argument = dyn_cast<BlockArgument>(value);
+  if (!argument)
+    return false;
+  auto funcOp =
+      dyn_cast_or_null<func::FuncOp>(argument.getOwner()->getParentOp());
+  return funcOp && argument.getOwner() == &funcOp.getBody().front();
+}
+
+} // namespace
+
+FailureOr<OnnxDimParams> OnnxDimParams::parse(ModuleOp module) {
+  auto records = module->getAttrOfType<ArrayAttr>(kOnnxDimParamsModuleAttr);
+  if (!records)
+    return failure();
+
+  OnnxDimParams result;
+  llvm::StringSet<> seen;
+  for (Attribute recordAttr : records) {
+    auto record = dyn_cast<DictionaryAttr>(recordAttr);
+    if (!record) {
+      module.emitError("symbolic dimension record must be a dictionary");
+      return failure();
+    }
+    auto scope = record.getAs<StringAttr>("scope");
+    auto valueName = record.getAs<StringAttr>("value_name");
+    auto dimensions = record.getAs<ArrayAttr>("dimensions");
+    if (!scope || !valueName || !dimensions) {
+      module.emitError("symbolic dimension record is missing required fields");
+      return failure();
+    }
+    if (scope.getValue() != "main_graph")
+      continue;
+    if (valueName.getValue().empty()) {
+      module.emitError("symbolic dimension value name is empty");
+      return failure();
+    }
+    if (!seen.insert(valueName.getValue()).second) {
+      module.emitError("duplicate symbolic dimension value record: ")
+          << valueName.getValue();
+      return failure();
+    }
+
+    llvm::SmallVector<std::string> params;
+    params.reserve(dimensions.size());
+    for (Attribute dimensionAttr : dimensions) {
+      auto dimension = dyn_cast<StringAttr>(dimensionAttr);
+      if (!dimension) {
+        module.emitError("symbolic dimension entry must be a string");
+        return failure();
+      }
+      params.push_back(dimension.getValue().str());
+    }
+    result.byValueName[valueName.getValue()] = std::move(params);
+  }
+  return result;
+}
+
+LogicalResult
+OnnxDimParams::annotateBroadcastDimSources(func::FuncOp funcOp) const {
+  llvm::StringMap<unsigned> inputBindings;
+  llvm::StringSet<> liveNames;
+
+  auto validateValue = [&](Value value) -> LogicalResult {
+    auto name = getValueName(value);
+    if (!name)
+      return success();
+    if (!liveNames.insert(*name).second)
+      return funcOp.emitError("duplicate live ONNX value name: ") << *name;
+    auto found = byValueName.find(*name);
+    if (found == byValueName.end())
+      return success();
+    auto tensorType = dyn_cast<RankedTensorType>(value.getType());
+    if (!tensorType)
+      return funcOp.emitError("symbolic dimension metadata names a non-ranked "
+                              "tensor value: ")
+             << *name;
+    if (static_cast<int64_t>(found->second.size()) != tensorType.getRank())
+      return funcOp.emitError("symbolic dimension rank mismatch for ") << *name;
+    return success();
+  };
+
+  for (BlockArgument argument : funcOp.getArguments()) {
+    if (isa<hip::ContextType>(argument.getType()))
+      continue;
+    if (failed(validateValue(argument)))
+      return failure();
+    auto name = getValueName(argument);
+    if (!name)
+      continue;
+    auto found = byValueName.find(*name);
+    if (found == byValueName.end())
+      continue;
+    for (const std::string &symbol : found->second)
+      if (!symbol.empty())
+        ++inputBindings[symbol];
+  }
+
+  WalkResult validation = funcOp.walk([&](Operation *op) {
+    if (op->getParentOp() != funcOp)
+      return WalkResult::advance();
+    for (Value result : op->getResults())
+      if (failed(validateValue(result)))
+        return WalkResult::interrupt();
+    return WalkResult::advance();
+  });
+  if (validation.wasInterrupted())
+    return failure();
+
+  WalkResult annotation = funcOp.walk([&](Operation *op) {
+    if (op->getParentOp() != funcOp)
+      return WalkResult::advance();
+    if (!isBroadcastOp(op) || op->getNumResults() != 1)
+      return WalkResult::advance();
+    if (op->hasAttr(kBroadcastDimSourcesAttr)) {
+      op->emitError("broadcast operation already has a dimension-source plan");
+      return WalkResult::interrupt();
+    }
+    auto resultType = dyn_cast<RankedTensorType>(op->getResult(0).getType());
+    if (!resultType)
+      return WalkResult::advance();
+
+    llvm::SmallVector<int64_t> sources(resultType.getRank(), -1);
+    bool hasSource = false;
+    for (int64_t outputAxis : llvm::seq<int64_t>(resultType.getRank())) {
+      if (!resultType.isDynamicDim(outputAxis))
+        continue;
+
+      llvm::SmallVector<std::pair<unsigned, std::string>> contributors;
+      bool hasStaticNonUnit = false;
+      bool complete = true;
+      for (auto [operandIndex, operand] : llvm::enumerate(op->getOperands())) {
+        auto operandType = dyn_cast<RankedTensorType>(operand.getType());
+        if (!operandType) {
+          complete = false;
+          break;
+        }
+        int64_t padding = resultType.getRank() - operandType.getRank();
+        if (padding < 0) {
+          complete = false;
+          break;
+        }
+        if (outputAxis < padding)
+          continue;
+        int64_t operandAxis = outputAxis - padding;
+        int64_t extent = operandType.getDimSize(operandAxis);
+        if (extent == 1)
+          continue;
+        if (!ShapedType::isDynamic(extent)) {
+          hasStaticNonUnit = true;
+          continue;
+        }
+
+        auto name = getValueName(operand);
+        if (!name) {
+          complete = false;
+          break;
+        }
+        auto found = byValueName.find(*name);
+        if (found == byValueName.end() ||
+            operandAxis >= static_cast<int64_t>(found->second.size()) ||
+            found->second[operandAxis].empty()) {
+          complete = false;
+          break;
+        }
+        contributors.emplace_back(static_cast<unsigned>(operandIndex),
+                                  found->second[operandAxis]);
+      }
+      if (!complete || hasStaticNonUnit || contributors.size() < 2)
+        continue;
+      llvm::StringRef symbol = contributors.front().second;
+      if (!llvm::all_of(contributors, [&](const auto &contributor) {
+            return contributor.second == symbol;
+          }))
+        continue;
+      if (inputBindings.lookup(symbol) > 1)
+        continue;
+
+      unsigned canonical = contributors.front().first;
+      for (const auto &[operandIndex, ignored] : contributors)
+        if (isFunctionArgument(op->getOperand(operandIndex))) {
+          canonical = operandIndex;
+          break;
+        }
+      sources[outputAxis] = canonical;
+      hasSource = true;
+    }
+    if (hasSource)
+      op->setAttr(kBroadcastDimSourcesAttr,
+                  DenseI64ArrayAttr::get(funcOp.getContext(), sources));
+    return WalkResult::advance();
+  });
+  return annotation.wasInterrupted() ? failure() : success();
+}
+
+llvm::SmallVector<int64_t> getBroadcastDimSources(Operation *onnxOp) {
+  auto sources =
+      onnxOp->getAttrOfType<DenseI64ArrayAttr>(kBroadcastDimSourcesAttr);
+  if (!sources)
+    return {};
+  return llvm::to_vector(sources.asArrayRef());
+}
+
+} // namespace mlir::hip

--- a/lib/Conversion/OnnxToHip/OnnxDimParams.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxDimParams.cpp
@@ -122,6 +122,12 @@ OnnxDimParams::annotateBroadcastDimSources(func::FuncOp funcOp) const {
     auto found = byValueName.find(*name);
     if (found == byValueName.end())
       return success();
+    // ORT may retain tensor ValueInfo for an omitted optional output even
+    // though the importer represents that result position as NoneType. Such a
+    // value is an absence marker, not a live tensor, and cannot contribute a
+    // symbolic broadcast proof.
+    if (isa<NoneType>(value.getType()))
+      return success();
     auto tensorType = dyn_cast<RankedTensorType>(value.getType());
     if (!tensorType)
       return funcOp.emitError("symbolic dimension metadata names a non-ranked "

--- a/lib/Conversion/OnnxToHip/OnnxDimParams.h
+++ b/lib/Conversion/OnnxToHip/OnnxDimParams.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#ifndef HIP_CONVERSION_ONNXTOHIP_ONNXDIMPARAMS_H
+#define HIP_CONVERSION_ONNXTOHIP_ONNXDIMPARAMS_H
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
+
+#include <string>
+
+namespace mlir::hip {
+
+inline constexpr llvm::StringLiteral kOnnxDimParamsModuleAttr =
+    "hipdnn.onnx_dim_params_v1";
+inline constexpr llvm::StringLiteral kBroadcastDimSourcesAttr =
+    "hipdnn.broadcast_dim_sources";
+
+class OnnxDimParams {
+public:
+  static FailureOr<OnnxDimParams> parse(ModuleOp module);
+
+  LogicalResult annotateBroadcastDimSources(func::FuncOp funcOp) const;
+
+private:
+  llvm::StringMap<llvm::SmallVector<std::string>> byValueName;
+};
+
+/// Return one canonical operand index per result axis. `-1` means that the
+/// exact runtime broadcast merge remains required.
+llvm::SmallVector<int64_t> getBroadcastDimSources(Operation *onnxOp);
+
+} // namespace mlir::hip
+
+#endif // HIP_CONVERSION_ONNXTOHIP_ONNXDIMPARAMS_H

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -11,12 +11,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "OnnxDimParams.h"
 #include "OnnxToHipUtils.h"
 #include "ShapeProvenanceAnalysis.h"
 
 #include "hip/debug_log.h"
 #include "hip/timing.h"
 
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/FormatVariadic.h"
@@ -24,6 +26,7 @@
 
 #include <limits>
 #include <map>
+#include <optional>
 
 #define DEBUG_TYPE "convert-onnx-to-hip"
 
@@ -332,6 +335,30 @@ void ConvertOnnxToHipPass::runOnOperation() {
   mlir::MLIRContext *ctx = module.getContext();
   const bool timing = hipdnn_ep_timing_enabled();
 
+  bool hasUntrustedPlan = false;
+  module.walk([&](Operation *op) {
+    if (op->hasAttr(kBroadcastDimSourcesAttr)) {
+      op->emitError("pre-existing broadcast dimension-source plan is not "
+                    "trusted compiler metadata");
+      hasUntrustedPlan = true;
+    }
+  });
+  if (hasUntrustedPlan)
+    return signalPassFailure();
+  llvm::scope_exit clearPlans([&]() {
+    module.walk(
+        [&](Operation *op) { op->removeAttr(kBroadcastDimSourcesAttr); });
+  });
+
+  std::optional<OnnxDimParams> dimParams;
+  if (module->hasAttr(kOnnxDimParamsModuleAttr)) {
+    auto parsed = OnnxDimParams::parse(module);
+    if (failed(parsed))
+      return signalPassFailure();
+    dimParams.emplace(std::move(*parsed));
+    module->removeAttr(kOnnxDimParamsModuleAttr);
+  }
+
   auto passStart = timing_now();
   auto phaseStart = passStart;
 
@@ -479,6 +506,9 @@ void ConvertOnnxToHipPass::runOnOperation() {
               funcOp, std::move(preFoldPatterns), cfg)))
         return signalPassFailure();
     }
+    if (dimParams && funcOp.getSymName() == "main_graph")
+      if (failed(dimParams->annotateBroadcastDimSources(funcOp)))
+        return signalPassFailure();
     if (mlir::failed(lowerOnnxConstants(funcOp, constantOrder)))
       return signalPassFailure();
     lowerOnnxReturns(funcOp);

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -12,6 +12,7 @@
 #ifndef HIP_CONVERSION_ONNXTOHIP_UTILS_H
 #define HIP_CONVERSION_ONNXTOHIP_UTILS_H
 
+#include "OnnxDimParams.h"
 #include "ReadbackScalar.h"
 
 #include "hip/Conversion/HipConversionUtils.h"
@@ -75,6 +76,27 @@ inline mlir::Value createEmptyTensor(mlir::OpBuilder &builder,
   }
   return mlir::tensor::EmptyOp::create(builder, loc, resultType.getShape(),
                                        resultType.getElementType(), dynSizes);
+}
+
+inline mlir::FailureOr<mlir::Value>
+createOnnxBroadcastEmptyTensor(mlir::OpBuilder &builder, mlir::Location loc,
+                               mlir::RankedTensorType resultType,
+                               mlir::ValueRange operands,
+                               mlir::Operation *onnxOp) {
+  llvm::SmallVector<int64_t> sources = getBroadcastDimSources(onnxOp);
+  for (int64_t &source : sources) {
+    if (source < 0)
+      continue;
+    if (source >= static_cast<int64_t>(onnxOp->getNumOperands()))
+      return mlir::failure();
+    mlir::Value plannedOperand = onnxOp->getOperand(source);
+    auto found = llvm::find(operands, plannedOperand);
+    if (found == operands.end())
+      return mlir::failure();
+    source = static_cast<int64_t>(found - operands.begin());
+  }
+  return mlir::hip::createBroadcastEmptyTensor(builder, loc, resultType,
+                                               operands, sources);
 }
 
 /// Return the dense payload of a structurally known compile-time tensor
@@ -240,14 +262,19 @@ lowerVariadicBroadcastChain(mlir::Operation *op,
   mlir::Value accumulate = op->getOperand(0);
   for (unsigned i : llvm::seq<unsigned>(1, numInputs)) {
     mlir::Value rhs = op->getOperand(i);
+    auto stepShape = mlir::hip::reifyBroadcastResultShape(
+        rewriter, loc, {accumulate, rhs}, [&]() { return op->emitError(); });
+    if (mlir::failed(stepShape))
+      return mlir::failure();
+
     bool isFinal = i == numInputs - 1;
     mlir::RankedTensorType stepResultType =
         isFinal ? resultType
                 : mlir::RankedTensorType::get(stepStaticShapes[i - 1],
                                               resultType.getElementType(),
                                               resultType.getEncoding());
-    auto init = createBroadcastEmptyTensor(rewriter, loc, stepResultType,
-                                           {accumulate, rhs});
+    auto init = createEmptyTensorFromReifiedShape(rewriter, loc, stepResultType,
+                                                  *stepShape);
     if (mlir::failed(init))
       return rewriter.notifyMatchFailure(
           op, llvm::Twine(opName) +

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -84,16 +84,33 @@ createOnnxBroadcastEmptyTensor(mlir::OpBuilder &builder, mlir::Location loc,
                                mlir::ValueRange operands,
                                mlir::Operation *onnxOp) {
   llvm::SmallVector<int64_t> sources = getBroadcastDimSources(onnxOp);
-  for (int64_t &source : sources) {
-    if (source < 0)
+  if (!sources.empty())
+    sources.resize(resultType.getRank(), -1);
+  for (auto [axis, source] : llvm::enumerate(sources)) {
+    if (source < 0) {
+      sources[axis] = -1;
       continue;
-    if (source >= static_cast<int64_t>(onnxOp->getNumOperands()))
-      return mlir::failure();
+    }
+    if (source >= static_cast<int64_t>(onnxOp->getNumOperands())) {
+      sources[axis] = -1;
+      continue;
+    }
     mlir::Value plannedOperand = onnxOp->getOperand(source);
     auto found = llvm::find(operands, plannedOperand);
-    if (found == operands.end())
-      return mlir::failure();
-    source = static_cast<int64_t>(found - operands.begin());
+    auto plannedType =
+        mlir::dyn_cast<mlir::RankedTensorType>(plannedOperand.getType());
+    int64_t padding =
+        plannedType ? resultType.getRank() - plannedType.getRank() : -1;
+    if (found == operands.end() || padding < 0 ||
+        static_cast<int64_t>(axis) < padding ||
+        !mlir::ShapedType::isDynamic(
+            plannedType.getDimSize(static_cast<int64_t>(axis) - padding))) {
+      // Symbolic sources are optional proofs. A stale operation-local plan
+      // must degrade only this axis to the exact runtime broadcast merge.
+      sources[axis] = -1;
+      continue;
+    }
+    sources[axis] = static_cast<int64_t>(found - operands.begin());
   }
   return mlir::hip::createBroadcastEmptyTensor(builder, loc, resultType,
                                                operands, sources);

--- a/lib/Conversion/OnnxToHip/OrConversion.cpp
+++ b/lib/Conversion/OnnxToHip/OrConversion.cpp
@@ -44,7 +44,7 @@ struct OrToHip : public mlir::RewritePattern {
       return rewriter.notifyMatchFailure(op, "expected ranked tensor inputs");
 
     mlir::FailureOr<mlir::Value> initOrFailure =
-        createBroadcastEmptyTensor(rewriter, loc, resultType, {a, b});
+        createOnnxBroadcastEmptyTensor(rewriter, loc, resultType, {a, b}, op);
     if (mlir::failed(initOrFailure))
       return rewriter.notifyMatchFailure(
           op, "Or: no ranked operand spans dynamic result dim");

--- a/lib/Conversion/OnnxToHip/WhereConversion.cpp
+++ b/lib/Conversion/OnnxToHip/WhereConversion.cpp
@@ -48,8 +48,8 @@ WhereToHip::matchAndRewrite(mlir::Operation *op,
 
   // Use the same NumPy broadcast rule as hip.where reification, including the
   // runtime case where an earlier dynamic operand resolves to one.
-  mlir::FailureOr<mlir::Value> initOrFailure =
-      createBroadcastEmptyTensor(rewriter, loc, resultType, {condition, x, y});
+  mlir::FailureOr<mlir::Value> initOrFailure = createOnnxBroadcastEmptyTensor(
+      rewriter, loc, resultType, {condition, x, y}, op);
   if (mlir::failed(initOrFailure))
     return rewriter.notifyMatchFailure(
         op, "onnx.Where: no ranked operand spans dynamic result dim");

--- a/lib/Dialect/IR/HipShapeUtils.cpp
+++ b/lib/Dialect/IR/HipShapeUtils.cpp
@@ -133,7 +133,8 @@ namespace mlir::hip::detail {
 FailureOr<SmallVector<OpFoldResult>>
 reifyBroadcastShape(OpBuilder &b, Location loc,
                     ArrayRef<SmallVector<OpFoldResult>> inputShapes,
-                    function_ref<InFlightDiagnostic()> emitError) {
+                    function_ref<InFlightDiagnostic()> emitError,
+                    ArrayRef<int64_t> canonicalOperandForResultDim) {
   if (inputShapes.empty()) {
     emitError() << "broadcast requires at least one input shape";
     return failure();
@@ -142,11 +143,39 @@ reifyBroadcastShape(OpBuilder &b, Location loc,
   size_t resultRank = 0;
   for (const SmallVector<OpFoldResult> &shape : inputShapes)
     resultRank = std::max(resultRank, shape.size());
+  if (!canonicalOperandForResultDim.empty() &&
+      canonicalOperandForResultDim.size() != resultRank) {
+    emitError() << "broadcast dimension-source plan has rank "
+                << canonicalOperandForResultDim.size() << ", expected "
+                << resultRank;
+    return failure();
+  }
 
   SmallVector<OpFoldResult> result(resultRank, b.getIndexAttr(1));
+  for (size_t axis : llvm::seq<size_t>(0, resultRank)) {
+    if (canonicalOperandForResultDim.empty() ||
+        canonicalOperandForResultDim[axis] < 0)
+      continue;
+    int64_t source = canonicalOperandForResultDim[axis];
+    if (source >= static_cast<int64_t>(inputShapes.size())) {
+      emitError() << "broadcast dimension-source operand " << source
+                  << " is out of range";
+      return failure();
+    }
+    size_t padding = resultRank - inputShapes[source].size();
+    if (axis < padding) {
+      emitError() << "broadcast dimension-source operand " << source
+                  << " does not span result axis " << axis;
+      return failure();
+    }
+    result[axis] = inputShapes[source][axis - padding];
+  }
   for (const SmallVector<OpFoldResult> &shape : inputShapes) {
     size_t pad = resultRank - shape.size();
     for (size_t i : llvm::seq<size_t>(0, resultRank)) {
+      if (!canonicalOperandForResultDim.empty() &&
+          canonicalOperandForResultDim[i] >= 0)
+        continue;
       OpFoldResult inputDim =
           i < pad ? OpFoldResult(b.getIndexAttr(1)) : shape[i - pad];
       FailureOr<OpFoldResult> merged =
@@ -296,7 +325,8 @@ mlir::hip::reifyElementwiseSameShapeFor(OpBuilder &b, Location loc,
 
 FailureOr<SmallVector<OpFoldResult>> mlir::hip::reifyBroadcastResultShape(
     OpBuilder &b, Location loc, ValueRange operands,
-    function_ref<InFlightDiagnostic()> emitError) {
+    function_ref<InFlightDiagnostic()> emitError,
+    ArrayRef<int64_t> canonicalOperandForResultDim) {
   if (operands.empty()) {
     emitError() << "broadcast requires at least one operand";
     return failure();
@@ -337,7 +367,8 @@ FailureOr<SmallVector<OpFoldResult>> mlir::hip::reifyBroadcastResultShape(
       continue;
     shapes.push_back(tensor::getMixedSizes(b, loc, operand));
   }
-  return detail::reifyBroadcastShape(b, loc, shapes, emitError);
+  return detail::reifyBroadcastShape(b, loc, shapes, emitError,
+                                     canonicalOperandForResultDim);
 }
 
 bool mlir::hip::parseDenseIntElements(DenseElementsAttr dense,

--- a/lib/Dialect/IR/HipShapeUtilsInternal.h
+++ b/lib/Dialect/IR/HipShapeUtilsInternal.h
@@ -23,7 +23,8 @@ std::string formatShape(ArrayRef<int64_t> shape);
 FailureOr<SmallVector<OpFoldResult>>
 reifyBroadcastShape(OpBuilder &b, Location loc,
                     ArrayRef<SmallVector<OpFoldResult>> inputShapes,
-                    function_ref<InFlightDiagnostic()> emitError);
+                    function_ref<InFlightDiagnostic()> emitError,
+                    ArrayRef<int64_t> canonicalOperandForResultDim = {});
 
 } // namespace mlir::hip::detail
 

--- a/test/lit/Conversion/onnx-to-hip/test_dim_params_broadcast.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_dim_params_broadcast.mlir
@@ -129,6 +129,88 @@ module attributes {
 
 // -----
 
+// A stale proof can name an original operand that a conversion does not
+// consume. Greater intentionally consumes its first two operands in reverse;
+// the extra operand models an operation-local plan invalidated after planning.
+// Losing that optional proof must retain the exact runtime broadcast and must
+// neither leave the plan behind nor prevent conversion.
+module attributes {
+  hipdnn.onnx_dim_params_v1 = [
+    {scope = "main_graph", value_name = "canonical", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "b", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "c", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "out", dimensions = ["N"]}
+  ]
+} {
+  // CHECK-LABEL: func.func @main_graph
+  // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+  // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+  // CHECK: %[[B:.*]] = hip.cast
+  // CHECK: %[[C:.*]] = hip.cast
+  // CHECK-DAG: %[[CD:.*]] = tensor.dim %[[C]], %[[C0]]
+  // CHECK-DAG: %[[BD:.*]] = tensor.dim %[[B]], %[[C0]]
+  // CHECK: %[[IS_ONE:.*]] = arith.cmpi eq, %[[CD]], %[[C1]] : index
+  // CHECK: %[[DIM:.*]] = arith.select %[[IS_ONE]], %[[BD]], %[[CD]] : index
+  // CHECK: tensor.empty(%[[DIM]])
+  // CHECK: hip.less{{.*}}ins(%[[C]], %[[B]]
+  // CHECK-NOT: hipdnn.broadcast_dim_sources
+  func.func @main_graph(
+      %seed: tensor<?xf16>,
+      %canonical: tensor<?xf32> {onnx.name = "canonical"}) -> tensor<?xi1> {
+    %b = "onnx.Cast"(%seed) {node.outputs = ["b"], to = 1 : i64}
+        : (tensor<?xf16>) -> tensor<?xf32>
+    %c = "onnx.Cast"(%seed) {node.outputs = ["c"], to = 1 : i64}
+        : (tensor<?xf16>) -> tensor<?xf32>
+    %out = "onnx.Greater"(%b, %c, %canonical) {node.outputs = ["out"]}
+        : (tensor<?xf32>, tensor<?xf32>, tensor<?xf32>) -> tensor<?xi1>
+    "onnx.Return"(%out) : (tensor<?xi1>) -> ()
+  }
+}
+
+// -----
+
+// Preserve a valid remapped source on the leading axis while a missing
+// lower-rank canonical operand degrades only the trailing axis. The trailing
+// extent still uses select(lhs == 1, rhs, lhs).
+module attributes {
+  hipdnn.onnx_dim_params_v1 = [
+    {scope = "main_graph", value_name = "canonical", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "b", dimensions = ["M", "N"]},
+    {scope = "main_graph", value_name = "c", dimensions = ["M", "N"]},
+    {scope = "main_graph", value_name = "out", dimensions = ["M", "N"]}
+  ]
+} {
+  // CHECK-LABEL: func.func @main_graph
+  // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+  // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+  // CHECK: %[[B:.*]] = hip.cast
+  // CHECK: %[[C:.*]] = hip.cast
+  // CHECK-NOT: tensor.dim %[[C]], %[[C0]]
+  // CHECK: %[[C1D:.*]] = tensor.dim %[[C]], %[[C1]]
+  // CHECK: %[[B0:.*]] = tensor.dim %[[B]], %[[C0]]
+  // CHECK: %[[B1:.*]] = tensor.dim %[[B]], %[[C1]]
+  // CHECK: %[[IS_ONE:.*]] = arith.cmpi eq, %[[C1D]], %[[C1]] : index
+  // CHECK: %[[D1:.*]] = arith.select %[[IS_ONE]], %[[B1]], %[[C1D]] : index
+  // CHECK: tensor.empty(%[[B0]], %[[D1]])
+  // CHECK: hip.less{{.*}}ins(%[[C]], %[[B]]
+  // CHECK-NOT: hipdnn.broadcast_dim_sources
+  func.func @main_graph(
+      %seed: tensor<?x?xf16>,
+      %canonical: tensor<?xf32> {onnx.name = "canonical"})
+      -> tensor<?x?xi1> {
+    %b = "onnx.Cast"(%seed) {node.outputs = ["b"], to = 1 : i64}
+        : (tensor<?x?xf16>) -> tensor<?x?xf32>
+    %c = "onnx.Cast"(%seed) {node.outputs = ["c"], to = 1 : i64}
+        : (tensor<?x?xf16>) -> tensor<?x?xf32>
+    %out = "onnx.Greater"(%b, %c, %canonical) {node.outputs = ["out"]}
+        : (tensor<?x?xf32>, tensor<?x?xf32>, tensor<?xf32>)
+          -> tensor<?x?xi1>
+    "onnx.Return"(%out) : (tensor<?x?xi1>) -> ()
+  }
+}
+
+// -----
+
 // Where consumes all three original contributors. One graph-input binding for
 // N makes the complete contributor class eligible.
 module attributes {

--- a/test/lit/Conversion/onnx-to-hip/test_dim_params_broadcast.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_dim_params_broadcast.mlir
@@ -1,0 +1,264 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --split-input-file --hip-add-context-arg \
+// RUN:   --convert-onnx-to-hip %s | FileCheck %s
+
+// One caller-controlled binding for N. Both internal Cast results carry N, so
+// Add destination construction reuses one contributor without a runtime merge.
+module attributes {
+  hipdnn.onnx_dim_params_v1 = [
+    {scope = "main_graph", value_name = "a", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "b", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "c", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "out", dimensions = ["N"]}
+  ]
+} {
+  // CHECK-LABEL: func.func @main_graph
+  // CHECK-NOT: hipdnn.onnx_dim_params_v1
+  // CHECK-NOT: arith.select
+  // CHECK: hip.cast
+  // CHECK: hip.cast
+  // CHECK: %[[INIT:.*]] = tensor.empty
+  // CHECK: hip.add{{.*}}outs(%[[INIT]] :
+  func.func @main_graph(
+      %a: tensor<?xf16> {onnx.name = "a"}) -> tensor<?xf32> {
+    %b = "onnx.Cast"(%a) {node.outputs = ["b"], to = 1 : i64}
+        : (tensor<?xf16>) -> tensor<?xf32>
+    %c = "onnx.Cast"(%a) {node.outputs = ["c"], to = 1 : i64}
+        : (tensor<?xf16>) -> tensor<?xf32>
+    %out = "onnx.Add"(%b, %c) {node.outputs = ["out"]}
+        : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+    "onnx.Return"(%out) : (tensor<?xf32>) -> ()
+  }
+}
+
+// -----
+
+// A successor-block argument is not a function argument. Its local argument
+// number must not inherit onnx.name from the function entry block.
+module attributes {
+  hipdnn.onnx_dim_params_v1 = [
+    {scope = "main_graph", value_name = "a", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "c", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "cfg_out", dimensions = ["N"]}
+  ]
+} {
+  // CHECK-LABEL: func.func @main_graph
+  // CHECK: ^bb1
+  // CHECK: arith.select
+  // CHECK: hip.add
+  func.func @main_graph(
+      %a: tensor<?xf16> {onnx.name = "a"}, %independent: tensor<?xf32>)
+      -> tensor<?xf32> {
+    cf.br ^bb1(%independent : tensor<?xf32>)
+  ^bb1(%block_arg: tensor<?xf32>):
+    %c = "onnx.Cast"(%a) {node.outputs = ["c"], to = 1 : i64}
+        : (tensor<?xf16>) -> tensor<?xf32>
+    %cfg_out = "onnx.Add"(%block_arg, %c) {node.outputs = ["cfg_out"]}
+        : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+    "onnx.Return"(%cfg_out) : (tensor<?xf32>) -> ()
+  }
+}
+
+// -----
+
+// V1 metadata is scoped to operations directly in main_graph. Values inside a
+// nested region cannot borrow main-graph names to prove independent extents.
+module attributes {
+  hipdnn.onnx_dim_params_v1 = [
+    {scope = "main_graph", value_name = "x", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "y", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "nested_out", dimensions = ["N"]}
+  ]
+} {
+  // CHECK-LABEL: func.func @main_graph
+  // CHECK: scf.if
+  // CHECK: arith.select
+  // CHECK: hip.add
+  func.func @main_graph(
+      %p: tensor<?xf16>, %q: tensor<?xf16>) -> tensor<?xf32> {
+    %condition = arith.constant true
+    %result = scf.if %condition -> tensor<?xf32> {
+      %x = "onnx.Cast"(%p) {node.outputs = ["x"], to = 1 : i64}
+          : (tensor<?xf16>) -> tensor<?xf32>
+      %y = "onnx.Cast"(%q) {node.outputs = ["y"], to = 1 : i64}
+          : (tensor<?xf16>) -> tensor<?xf32>
+      %nested_out = "onnx.Add"(%x, %y) {node.outputs = ["nested_out"]}
+          : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+      scf.yield %nested_out : tensor<?xf32>
+    } else {
+      %fallback = "onnx.Cast"(%p) {to = 1 : i64}
+          : (tensor<?xf16>) -> tensor<?xf32>
+      scf.yield %fallback : tensor<?xf32>
+    }
+    "onnx.Return"(%result) : (tensor<?xf32>) -> ()
+  }
+}
+
+// -----
+
+// Greater lowers with reversed HIP operands. The positional plan is remapped
+// through actual operand Values, so equal symbols still avoid the merge.
+module attributes {
+  hipdnn.onnx_dim_params_v1 = [
+    {scope = "main_graph", value_name = "a", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "b", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "c", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "out", dimensions = ["N"]}
+  ]
+} {
+  // CHECK-LABEL: func.func @main_graph
+  // CHECK: %[[B:.*]] = hip.cast
+  // CHECK: %[[C:.*]] = hip.cast
+  // CHECK: tensor.dim %[[B]]
+  // CHECK-NOT: tensor.dim %[[C]]
+  // CHECK-NOT: arith.select
+  // CHECK: hip.less{{.*}}ins(%[[C]], %[[B]]
+  func.func @main_graph(
+      %a: tensor<?xf16> {onnx.name = "a"}) -> tensor<?xi1> {
+    %b = "onnx.Cast"(%a) {node.outputs = ["b"], to = 1 : i64}
+        : (tensor<?xf16>) -> tensor<?xf32>
+    %c = "onnx.Cast"(%a) {node.outputs = ["c"], to = 1 : i64}
+        : (tensor<?xf16>) -> tensor<?xf32>
+    %out = "onnx.Greater"(%b, %c) {node.outputs = ["out"]}
+        : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xi1>
+    "onnx.Return"(%out) : (tensor<?xi1>) -> ()
+  }
+}
+
+// -----
+
+// Where consumes all three original contributors. One graph-input binding for
+// N makes the complete contributor class eligible.
+module attributes {
+  hipdnn.onnx_dim_params_v1 = [
+    {scope = "main_graph", value_name = "a", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "cond", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "x", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "y", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "out", dimensions = ["N"]}
+  ]
+} {
+  // CHECK-LABEL: func.func @main_graph
+  // CHECK-NOT: arith.select
+  // CHECK: hip.where
+  func.func @main_graph(
+      %a: tensor<?xf16> {onnx.name = "a"}) -> tensor<?xf32> {
+    %cond = "onnx.Cast"(%a) {node.outputs = ["cond"], to = 9 : i64}
+        : (tensor<?xf16>) -> tensor<?xi1>
+    %x = "onnx.Cast"(%a) {node.outputs = ["x"], to = 1 : i64}
+        : (tensor<?xf16>) -> tensor<?xf32>
+    %y = "onnx.Cast"(%a) {node.outputs = ["y"], to = 1 : i64}
+        : (tensor<?xf16>) -> tensor<?xf32>
+    %out = "onnx.Where"(%cond, %x, %y) {node.outputs = ["out"]}
+        : (tensor<?xi1>, tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+    "onnx.Return"(%out) : (tensor<?xf32>) -> ()
+  }
+}
+
+// -----
+
+// Where requires one complete equality class across condition, X, and Y.
+// A different condition symbol retains exact three-way broadcast.
+module attributes {
+  hipdnn.onnx_dim_params_v1 = [
+    {scope = "main_graph", value_name = "a", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "cond", dimensions = ["M"]},
+    {scope = "main_graph", value_name = "x", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "y", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "out", dimensions = ["N"]}
+  ]
+} {
+  // CHECK-LABEL: func.func @main_graph
+  // CHECK: arith.select
+  // CHECK: hip.where
+  func.func @main_graph(
+      %a: tensor<?xf16> {onnx.name = "a"}) -> tensor<?xf32> {
+    %cond = "onnx.Cast"(%a) {node.outputs = ["cond"], to = 9 : i64}
+        : (tensor<?xf16>) -> tensor<?xi1>
+    %x = "onnx.Cast"(%a) {node.outputs = ["x"], to = 1 : i64}
+        : (tensor<?xf16>) -> tensor<?xf32>
+    %y = "onnx.Cast"(%a) {node.outputs = ["y"], to = 1 : i64}
+        : (tensor<?xf16>) -> tensor<?xf32>
+    %out = "onnx.Where"(%cond, %x, %y) {node.outputs = ["out"]}
+        : (tensor<?xi1>, tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+    "onnx.Return"(%out) : (tensor<?xf32>) -> ()
+  }
+}
+
+// -----
+
+// Variadic Max uses a pairwise HIP chain. Intermediate accumulators have no
+// ONNX tensor identity, so v1 deliberately keeps exact runtime selects.
+module attributes {
+  hipdnn.onnx_dim_params_v1 = [
+    {scope = "main_graph", value_name = "a", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "b", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "c", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "d", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "out", dimensions = ["N"]}
+  ]
+} {
+  // CHECK-LABEL: func.func @main_graph
+  // CHECK: arith.select
+  // CHECK: hip.max
+  func.func @main_graph(
+      %a: tensor<?xf16> {onnx.name = "a"}) -> tensor<?xf32> {
+    %b = "onnx.Cast"(%a) {node.outputs = ["b"], to = 1 : i64}
+        : (tensor<?xf16>) -> tensor<?xf32>
+    %c = "onnx.Cast"(%a) {node.outputs = ["c"], to = 1 : i64}
+        : (tensor<?xf16>) -> tensor<?xf32>
+    %d = "onnx.Cast"(%a) {node.outputs = ["d"], to = 1 : i64}
+        : (tensor<?xf16>) -> tensor<?xf32>
+    %out = "onnx.Max"(%b, %c, %d) {node.outputs = ["out"]}
+        : (tensor<?xf32>, tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+    "onnx.Return"(%out) : (tensor<?xf32>) -> ()
+  }
+}
+
+// -----
+
+// Distinct symbols retain exact dynamic broadcast.
+module attributes {
+  hipdnn.onnx_dim_params_v1 = [
+    {scope = "main_graph", value_name = "a", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "b", dimensions = ["M"]},
+    {scope = "main_graph", value_name = "out", dimensions = ["K"]}
+  ]
+} {
+  // CHECK-LABEL: func.func @main_graph
+  // CHECK: arith.cmpi eq
+  // CHECK: arith.select
+  // CHECK: tensor.empty
+  func.func @main_graph(
+      %a: tensor<?xf32> {onnx.name = "a"},
+      %b: tensor<?xf32> {onnx.name = "b"}) -> tensor<?xf32> {
+    %out = "onnx.Add"(%a, %b) {node.outputs = ["out"]}
+        : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+    "onnx.Return"(%out) : (tensor<?xf32>) -> ()
+  }
+}
+
+// -----
+
+// The same symbol on two independently caller-controlled axes is conservative:
+// ORT does not enforce their runtime equality, so retain exact broadcast.
+module attributes {
+  hipdnn.onnx_dim_params_v1 = [
+    {scope = "main_graph", value_name = "a", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "b", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "out", dimensions = ["N"]}
+  ]
+} {
+  // CHECK-LABEL: func.func @main_graph
+  // CHECK: arith.cmpi eq
+  // CHECK: arith.select
+  func.func @main_graph(
+      %a: tensor<?xf32> {onnx.name = "a"},
+      %b: tensor<?xf32> {onnx.name = "b"}) -> tensor<?xf32> {
+    %out = "onnx.Add"(%a, %b) {node.outputs = ["out"]}
+        : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+    "onnx.Return"(%out) : (tensor<?xf32>) -> ()
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_dim_params_broadcast.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_dim_params_broadcast.mlir
@@ -35,6 +35,28 @@ module attributes {
 
 // -----
 
+// ORT can retain tensor shape metadata for omitted optional outputs. The
+// importer represents such result positions as none; they are not live tensor
+// identities and must not prevent conversion.
+module attributes {
+  hipdnn.onnx_dim_params_v1 = [
+    {scope = "main_graph", value_name = "val_0", dimensions = ["N"]}
+  ]
+} {
+  // CHECK-LABEL: func.func @main_graph
+  // CHECK-NOT: val_0
+  func.func @main_graph(
+      %a: tensor<?xf32> {onnx.name = "a"}) -> tensor<?xf32> {
+    %unused = "onnx.NoValue"() {
+      node.outputs = ["val_0"],
+      value
+    } : () -> none
+    "onnx.Return"(%a) : (tensor<?xf32>) -> ()
+  }
+}
+
+// -----
+
 // A successor-block argument is not a function argument. Its local argument
 // number must not inherit onnx.name from the function entry block.
 module attributes {

--- a/test/lit/Conversion/onnx-to-hip/test_dim_params_invalid.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_dim_params_invalid.mlir
@@ -1,0 +1,59 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --split-input-file --verify-diagnostics \
+// RUN:   --hip-add-context-arg --convert-onnx-to-hip %s
+
+module attributes {
+  hipdnn.onnx_dim_params_v1 = [
+    {scope = "main_graph", value_name = "a", dimensions = ["N", "M"]}
+  ]
+} {
+  // expected-error@+1 {{symbolic dimension rank mismatch for a}}
+  func.func @main_graph(
+      %a: tensor<?xf32> {onnx.name = "a"}) -> tensor<?xf32> {
+    "onnx.Return"(%a) : (tensor<?xf32>) -> ()
+  }
+}
+
+// -----
+
+// expected-error@+1 {{duplicate symbolic dimension value record: a}}
+module attributes {
+  hipdnn.onnx_dim_params_v1 = [
+    {scope = "main_graph", value_name = "a", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "a", dimensions = ["N"]}
+  ]
+} {
+  func.func @main_graph(
+      %a: tensor<?xf32> {onnx.name = "a"}) -> tensor<?xf32> {
+    "onnx.Return"(%a) : (tensor<?xf32>) -> ()
+  }
+}
+
+// -----
+
+// expected-error@+1 {{symbolic dimension record must be a dictionary}}
+module attributes {
+  hipdnn.onnx_dim_params_v1 = ["not-a-dictionary"]
+} {
+  func.func @main_graph(
+      %a: tensor<?xf32> {onnx.name = "a"}) -> tensor<?xf32> {
+    "onnx.Return"(%a) : (tensor<?xf32>) -> ()
+  }
+}
+
+// -----
+
+module {
+  func.func @main_graph(
+      %a: tensor<?xf32> {onnx.name = "a"},
+      %b: tensor<?xf32> {onnx.name = "b"}) -> tensor<?xf32> {
+    // expected-error@+1 {{pre-existing broadcast dimension-source plan is not trusted compiler metadata}}
+    %out = "onnx.Add"(%a, %b) {
+      hipdnn.broadcast_dim_sources = array<i64: 0>,
+      node.outputs = ["out"]
+    } : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+    "onnx.Return"(%out) : (tensor<?xf32>) -> ()
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_dim_params_invalid.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_dim_params_invalid.mlir
@@ -57,3 +57,21 @@ module {
     "onnx.Return"(%out) : (tensor<?xf32>) -> ()
   }
 }
+
+// -----
+
+module attributes {
+  hipdnn.onnx_dim_params_v1 = [
+    {scope = "main_graph", value_name = "a", dimensions = ["N"]}
+  ]
+} {
+  // NoneType is the only non-ranked exception. A named unranked internal
+  // tensor still fails closed because its metadata rank cannot be validated.
+  // expected-error@+1 {{symbolic dimension metadata names a non-ranked tensor value: a}}
+  func.func @main_graph(
+      %seed: tensor<?xf32> {onnx.name = "seed"}) -> tensor<?xf32> {
+    %a = "onnx.Identity"(%seed) {node.outputs = ["a"]}
+        : (tensor<?xf32>) -> tensor<*xf32>
+    "onnx.Return"(%seed) : (tensor<?xf32>) -> ()
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_dim_params_operator_matrix.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_dim_params_operator_matrix.mlir
@@ -1,0 +1,85 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s \
+// RUN:   | FileCheck --implicit-check-not=arith.select %s
+
+module attributes {
+  hipdnn.onnx_dim_params_v1 = [
+    {scope = "main_graph", value_name = "a", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "b", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "c", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "add", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "and", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "div", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "eq", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "ge", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "gt", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "le", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "lt", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "mod", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "mul", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "or", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "sub", dimensions = ["N"]},
+    {scope = "main_graph", value_name = "where", dimensions = ["N"]}
+  ]
+} {
+  // Every supported ONNX broadcast converter must consume the operation-local
+  // symbolic plan. A missed converter emits an arith.select for this dynamic
+  // equal-symbol axis.
+  // CHECK-LABEL: func.func @main_graph
+  // CHECK-DAG: hip.add
+  // CHECK-DAG: hip.sub
+  // CHECK-DAG: hip.mul
+  // CHECK-DAG: hip.div
+  // CHECK-DAG: hip.mod
+  // CHECK-DAG: hip.equal
+  // CHECK-DAG: hip.less
+  // CHECK-DAG: hip.and
+  // CHECK-DAG: hip.or
+  // CHECK-DAG: hip.where
+  func.func @main_graph(
+      %a: tensor<?xf16> {onnx.name = "a"}) -> (
+        tensor<?xf32>, tensor<?xf32>, tensor<?xf32>, tensor<?xf32>,
+        tensor<?xf32>, tensor<?xi1>, tensor<?xi1>, tensor<?xi1>,
+        tensor<?xi1>, tensor<?xi1>, tensor<?xi1>, tensor<?xi1>,
+        tensor<?xf32>) {
+    %b = "onnx.Cast"(%a) {node.outputs = ["b"], to = 1 : i64}
+        : (tensor<?xf16>) -> tensor<?xf32>
+    %c = "onnx.Cast"(%a) {node.outputs = ["c"], to = 1 : i64}
+        : (tensor<?xf16>) -> tensor<?xf32>
+    %add = "onnx.Add"(%b, %c) {node.outputs = ["add"]}
+        : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+    %sub = "onnx.Sub"(%b, %c) {node.outputs = ["sub"]}
+        : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+    %mul = "onnx.Mul"(%b, %c) {node.outputs = ["mul"]}
+        : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+    %div = "onnx.Div"(%b, %c) {node.outputs = ["div"]}
+        : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+    %mod = "onnx.Mod"(%b, %c) {
+      fmod = 1 : si64, node.outputs = ["mod"]
+    } : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+    %eq = "onnx.Equal"(%b, %c) {node.outputs = ["eq"]}
+        : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xi1>
+    %gt = "onnx.Greater"(%b, %c) {node.outputs = ["gt"]}
+        : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xi1>
+    %ge = "onnx.GreaterOrEqual"(%b, %c) {node.outputs = ["ge"]}
+        : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xi1>
+    %lt = "onnx.Less"(%b, %c) {node.outputs = ["lt"]}
+        : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xi1>
+    %le = "onnx.LessOrEqual"(%b, %c) {node.outputs = ["le"]}
+        : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xi1>
+    %and = "onnx.And"(%eq, %lt) {node.outputs = ["and"]}
+        : (tensor<?xi1>, tensor<?xi1>) -> tensor<?xi1>
+    %or = "onnx.Or"(%eq, %lt) {node.outputs = ["or"]}
+        : (tensor<?xi1>, tensor<?xi1>) -> tensor<?xi1>
+    %where = "onnx.Where"(%eq, %add, %sub) {node.outputs = ["where"]}
+        : (tensor<?xi1>, tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+    "onnx.Return"(%add, %sub, %mul, %div, %mod, %eq, %gt, %ge, %lt, %le,
+                  %and, %or, %where)
+        : (tensor<?xf32>, tensor<?xf32>, tensor<?xf32>, tensor<?xf32>,
+           tensor<?xf32>, tensor<?xi1>, tensor<?xi1>, tensor<?xi1>,
+           tensor<?xi1>, tensor<?xi1>, tensor<?xi1>, tensor<?xi1>,
+           tensor<?xf32>) -> ()
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_max.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_max.mlir
@@ -63,8 +63,13 @@ module {
   // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
   // CHECK-DAG: %[[A0:.*]] = tensor.dim %[[A]], %[[C0]] : tensor<?x?xf32>
   // CHECK-DAG: %[[A1:.*]] = tensor.dim %[[A]], %[[C1]] : tensor<?x?xf32>
-  // CHECK-NOT: arith.select
-  // CHECK: %[[INIT:.*]] = tensor.empty(%[[A0]], %[[A1]]) : tensor<?x?xf32>
+  // CHECK-DAG: %[[B0:.*]] = tensor.dim %[[B]], %[[C0]] : tensor<?x?xf32>
+  // CHECK-DAG: %[[B1:.*]] = tensor.dim %[[B]], %[[C1]] : tensor<?x?xf32>
+  // CHECK: %[[IS1_0:.*]] = arith.cmpi eq, %[[A0]], %[[C1]] : index
+  // CHECK: %[[DIM0:.*]] = arith.select %[[IS1_0]], %[[B0]], %[[A0]] : index
+  // CHECK: %[[IS1_1:.*]] = arith.cmpi eq, %[[A1]], %[[C1]] : index
+  // CHECK: %[[DIM1:.*]] = arith.select %[[IS1_1]], %[[B1]], %[[A1]] : index
+  // CHECK: %[[INIT:.*]] = tensor.empty(%[[DIM0]], %[[DIM1]]) : tensor<?x?xf32>
   // CHECK: hip.max(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x?xf32>, tensor<?x?xf32>) outs(%[[INIT]] : tensor<?x?xf32>)
 
   // --- Case 5: rank-5 against a rank-0 scalar, packed to the 4-D path ---

--- a/test/lit/Conversion/onnx-to-hip/test_min.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_min.mlir
@@ -70,8 +70,13 @@ module {
   // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
   // CHECK-DAG: %[[A0:.*]] = tensor.dim %[[A]], %[[C0]] : tensor<?x?xf32>
   // CHECK-DAG: %[[A1:.*]] = tensor.dim %[[A]], %[[C1]] : tensor<?x?xf32>
-  // CHECK-NOT: arith.select
-  // CHECK: %[[INIT:.*]] = tensor.empty(%[[A0]], %[[A1]]) : tensor<?x?xf32>
+  // CHECK-DAG: %[[B0:.*]] = tensor.dim %[[B]], %[[C0]] : tensor<?x?xf32>
+  // CHECK-DAG: %[[B1:.*]] = tensor.dim %[[B]], %[[C1]] : tensor<?x?xf32>
+  // CHECK: %[[IS1_0:.*]] = arith.cmpi eq, %[[A0]], %[[C1]] : index
+  // CHECK: %[[DIM0:.*]] = arith.select %[[IS1_0]], %[[B0]], %[[A0]] : index
+  // CHECK: %[[IS1_1:.*]] = arith.cmpi eq, %[[A1]], %[[C1]] : index
+  // CHECK: %[[DIM1:.*]] = arith.select %[[IS1_1]], %[[B1]], %[[A1]] : index
+  // CHECK: %[[INIT:.*]] = tensor.empty(%[[DIM0]], %[[DIM1]]) : tensor<?x?xf32>
   // CHECK: hip.min(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x?xf32>, tensor<?x?xf32>) outs(%[[INIT]] : tensor<?x?xf32>)
 
   // --- Case 5: rank-5 against a rank-0 scalar, packed to the 4-D path ---

--- a/test/lit/Conversion/onnx-to-hip/test_reshape_shape_provenance.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_reshape_shape_provenance.mlir
@@ -370,14 +370,13 @@ module {
     return %result : tensor<?x4xf32>
   }
 
-  // Two dynamic Add operands remain ambiguous to provenance. This stack layer
-  // still uses the foundation's deferred destination materialization policy;
-  // exact broadcast fallback is activated together with symbolic proofs later.
-  // CHECK-LABEL: func.func @ambiguous_add_defers_exact_materialization
+  // Two dynamic Add operands are ambiguous: the correct broadcast select must
+  // remain because neither dimension is proven to be the canonical source.
+  // CHECK-LABEL: func.func @ambiguous_add_keeps_select
   // CHECK-NOT: hip.readback_scalar
-  // CHECK-NOT: arith.select
+  // CHECK: arith.select
   // CHECK: tensor.reshape
-  func.func @ambiguous_add_defers_exact_materialization(
+  func.func @ambiguous_add_keeps_select(
       %lhs: tensor<?x?x4xf16>,
       %rhs: tensor<?x?x4xf16>) -> tensor<?x?x?x?xf16> {
     %sum = "onnx.Add"(%lhs, %rhs)

--- a/test/lit/Conversion/onnx-to-hip/test_where.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_where.mlir
@@ -114,16 +114,19 @@ module {
     return %output : tensor<7xf32>
   }
 
-  // Test 6: The foundation retains the established conversion-time extent
-  // source until the later activation layer can pair exact semantics with
-  // frontend symbolic identity proofs.
+  // Test 6: An earlier dynamic operand may resolve to the broadcast value 1.
+  // The destination must select X's runtime extent rather than unconditionally
+  // using condition's extent.
   func.func @test_where_dynamic_unit_broadcast(
       %cond: tensor<?xi1>, %x: tensor<?xf16>, %y: tensor<?xf16>)
       -> tensor<?xf16> {
     // CHECK-LABEL: func.func @test_where_dynamic_unit_broadcast
-    // CHECK: %[[COND_DIM:.*]] = tensor.dim %[[COND:.*]], %{{.*}} : tensor<?xi1>
-    // CHECK-NOT: arith.select
-    // CHECK: tensor.empty(%[[COND_DIM]]) : tensor<?xf16>
+    // CHECK-DAG: %[[COND_DIM:.*]] = tensor.dim %[[COND:.*]], %{{.*}} : tensor<?xi1>
+    // CHECK-DAG: %[[X_DIM:.*]] = tensor.dim %[[X:.*]], %{{.*}} : tensor<?xf16>
+    // CHECK-DAG: %[[ONE:.*]] = arith.constant 1 : index
+    // CHECK: %[[COND_IS_ONE:.*]] = arith.cmpi eq, %[[COND_DIM]], %[[ONE]] : index
+    // CHECK: %[[EXTENT:.*]] = arith.select %[[COND_IS_ONE]], %[[X_DIM]], %[[COND_DIM]] : index
+    // CHECK: tensor.empty(%{{.*}}) : tensor<?xf16>
 
     %output = "onnx.Where"(%cond, %x, %y) :
         (tensor<?xi1>, tensor<?xf16>, tensor<?xf16>) -> tensor<?xf16>


### PR DESCRIPTION
## Why

Exact NumPy broadcast sizing must choose the other operand when an earlier dynamic extent is `1`. The old first-contributor heuristic avoided shape arithmetic but was semantically wrong.

Enabling the exact runtime rule by itself created many distinct `tensor.dim`/`arith.select` values in Qwen vision graphs. Those values survived into bufferization, split dominance domains, and expanded the pool count. Gemma had a separate payload-liveness regression, addressed by the preceding reshape-provenance PR.

This PR is the activation boundary: it enables exact destination sizing only after both mitigations are present. ONNX symbolic identities fold proven-equal dynamic contributors to one canonical extent; every unproven axis retains the exact runtime fallback. If operand-value remapping cannot find a planned canonical source after a converter reorders operands, that is proof loss for that axis only—not a reason to fail conversion or discard valid proofs on other axes.

## IR example

Without an eligible symbolic proof, the exact dynamic broadcast rule remains:

```mlir
%lhs_is_one = arith.cmpi eq, %lhs_dim, %c1 : index
%extent = arith.select %lhs_is_one, %rhs_dim, %lhs_dim : index
```

The remap-miss regression covers a reversed comparison lowering with one valid leading-axis source and one missing lower-rank trailing-axis source. Conversion preserves the leading proof and falls back exactly on the missed axis:

```mlir
%c0 = arith.constant 0 : index
%c1 = arith.constant 1 : index
%leading = tensor.dim %b, %c0 : tensor<?x?xf32>
%lhs_trailing = tensor.dim %c, %c1 : tensor<?x?xf32>
%rhs_trailing = tensor.dim %b, %c1 : tensor<?x?xf32>
%lhs_is_one = arith.cmpi eq, %lhs_trailing, %c1 : index
%trailing = arith.select %lhs_is_one, %rhs_trailing, %lhs_trailing : index
%init = tensor.empty(%leading, %trailing) : tensor<?x?xi1>
```

For an eligible symbolic identity, conversion instead reuses one contributor's `tensor.dim` and emits no `arith.select`. The optimization is compile-time-only: the temporary plan and module metadata are removed before HIP IR leaves conversion.

## What changes

- Parse validated top-level symbolic dimension records into a name/rank map.
- Reject pre-existing operation-local proof attributes instead of trusting input IR.
- Require complete agreement across every dynamic non-unit broadcast contributor.
- Disable a symbolic class with more than one caller-controlled graph-input binding.
- Restrict v1 planning to direct operations in `main_graph` and entry-block function arguments.
- Remap canonical sources by operand value for reversed comparison lowerings.
- Treat a missing or stale remapped source as axis-local proof loss: preserve other proven axes and emit the exact `select(lhs == 1, rhs, lhs)` fallback only for the missed axis.
- Route Add, Sub, Mul, Div, Mod, comparisons, And, Or, and Where through the operation-local plan.
- Keep variadic Min/Max and every missing, unnamed, unequal, nested, CFG-local, malformed, or remap-missed axis on the exact fallback.
- Remove the temporary plan and module metadata before HIP IR leaves conversion.
- Add malformed-input, scope/provenance, reversed-operand, per-axis remap-miss, three-way Where, and full 13-operator matrix coverage.
- Make no runtime ABI or kernel changes.

## Stack

Merged prerequisite plus the 22 active shape PRs:

1. [#688 — refactor(hip): externalize constants after ONNX conversion](https://github.com/ROCm/hip-ep/pull/688)
2. [#724 — feat(shape): preserve symbolic compiler inputs](https://github.com/ROCm/hip-ep/pull/724)
3. [#639 — refactor(hip): establish shared shape-rule foundation](https://github.com/ROCm/hip-ep/pull/639)
4. [#681 — fix(shape): canonicalize host reshape provenance](https://github.com/ROCm/hip-ep/pull/681)
5. [#725 — fix(shape): activate exact broadcasts with symbolic proofs](https://github.com/ROCm/hip-ep/pull/725) ← this PR
6. [#734 — fix(shape): share MatMul and Gemm contracts](https://github.com/ROCm/hip-ep/pull/734)
7. [#641 — fix(shape): enforce shared broadcast contracts](https://github.com/ROCm/hip-ep/pull/641)
8. [#735 — refactor(conversion): share ONNX reduction conversion](https://github.com/ROCm/hip-ep/pull/735)
9. [#736 — fix(shape): normalize reduction contracts](https://github.com/ROCm/hip-ep/pull/736)
10. [#643 — fix(shape): share convolution contracts](https://github.com/ROCm/hip-ep/pull/643)
11. [#742 — fix(shape): share causal convolution contracts](https://github.com/ROCm/hip-ep/pull/742)
12. [#645 — fix(shape): share normalization contracts](https://github.com/ROCm/hip-ep/pull/645)
13. [#740 — fix(shape): share attention contracts](https://github.com/ROCm/hip-ep/pull/740)
14. [#741 — fix(shape): share GQA capacity contracts](https://github.com/ROCm/hip-ep/pull/741)
15. [#644 — fix(shape): share gather and tensor contracts](https://github.com/ROCm/hip-ep/pull/644)
16. [#727 — feat(shape): consume constant payload shapes directly](https://github.com/ROCm/hip-ep/pull/727)
17. [#728 — feat(shape): add exact Tile and Range destinations](https://github.com/ROCm/hip-ep/pull/728)
18. [#646 — refactor(hip): declare explicit DPS shape contracts](https://github.com/ROCm/hip-ep/pull/646)
19. [#730 — test(hip): audit explicit DPS contract inventory](https://github.com/ROCm/hip-ep/pull/730)
20. [#732 — test(hip): audit ONNX converter deduplication](https://github.com/ROCm/hip-ep/pull/732)
21. [#647 — fix(hip): harden shape refinement failure handling](https://github.com/ROCm/hip-ep/pull/647)
22. [#761 — refactor(hip): split shape utility headers by family](https://github.com/ROCm/hip-ep/pull/761)
23. [#764 — refactor(hip): clarify shape destination authority](https://github.com/ROCm/hip-ep/pull/764)

## AI assistance

AI tools assisted with the symbolic-proof design, correctness hardening, model characterization, review-feedback fixes, and regression-free stack reconstruction. The contributor reviewed and validated the resulting code.

Made-with: Cursor
