### PR TITLE
perf(linear_attention): halve the launch window to 16 chunks, -674 ms TTFT at 16K

### DIFF
--- a/lib/Runtime/Kernels/hip/linear_attention_kernel.hip
+++ b/lib/Runtime/Kernels/hip/linear_attention_kernel.hip
@@ -1332,6 +1332,16 @@ static int la_launch_parallel(
                                     ? LA_CHUNK * dk : dk * (LA_CHUNK + LA_KT_PAD)) +
                                dvs * LA_CHUNK) * sizeof(__half);
     // Pass 3 (WMMA) LDS: QWS(M*dv) + Pm + (Asm,clog) floats, QW(M*dk) + K(C*dk) half.
+    //
+    // 29,824 B at dk=dv=128, which is over 65536/3 = 21845 and so caps pass 3 at
+    // two workgroups per CU. Tried and rejected: QWS in half puts it at 21,632 B
+    // and does land the third workgroup, but it is worth 2.4% (7.43 -> 7.25 ms
+    // per layer at 3985 tokens) and costs output accuracy (relL2 3.5e-4 against
+    // the fp32-QWS result; the state is unaffected, pass 3 does not feed the
+    // recurrence). Occupancy is not what binds this kernel -- it reads a 32 KB
+    // S0 tile per (head,chunk) block, ~256 MB per layer, so it is bound by that
+    // stream and a third resident workgroup has nothing to hide. Shrink the S0
+    // traffic before spending accuracy on occupancy here.
     const size_t s3 = (size_t)(2 * LA_CHUNK * dv + LA_CHUNK * LA_CHUNK +
                                2 * LA_CHUNK) * sizeof(float) +
                       (size_t)(2 * LA_CHUNK * dk + LA_CHUNK * dk) * sizeof(__half);

--- a/lib/Runtime/Kernels/hip/linear_attention_kernel.hip
+++ b/lib/Runtime/Kernels/hip/linear_attention_kernel.hip
@@ -1221,13 +1221,38 @@ __global__ void __launch_bounds__(256) la_pf_pass3_wmma(
 
 // Chunks processed per launch window. The passes run one window at a time, so
 // the per-(head,chunk) scratch is sized for a window instead of the whole
-// sequence and stops growing with seq_len. 32 chunks = 512 tokens still gives
-// B*Hkv*32 = 1024 blocks per launch at Hkv=32, far more than the 40 CUs need to
-// stay saturated, so the chunk-parallel speedup is unaffected. The extra
-// launches this costs are not a real cost: holding LA_CHUNK at 16 and varying
-// only this constant, 32 (37 windows for an 18.8k prompt, 49.1 MiB of scratch)
-// beats 128 (10 windows, 193.3 MiB) by 9.6%.
-static constexpr int LA_WINDOW_CHUNKS = 32;
+// sequence and stops growing with seq_len. 16 chunks = 256 tokens still gives
+// B*Hkv*16 = 512 blocks per launch at Hkv=32, far more than the 40 CUs need to
+// stay saturated, so the chunk-parallel speedup is unaffected.
+//
+// This constant is a cache-residency knob, not just a memory-footprint one, and
+// that is what picks 16. The window sets how much scratch the pass1 -> scan ->
+// pass3 chain streams through between the write and the read of the same Uloc/W
+// tile, so shrinking it keeps that tile resident instead of going to DRAM.
+// Swept at 3985 tokens (Hkv=32, dk=dv=128), GPU time for one layer's three
+// passes, alongside the wall time for the same work:
+//
+//   win  scratch    gpu ms   wall ms   launches
+//     1    2.5 MiB    1.27     14.71        750
+//     2    4.0         1.68      9.79        375
+//     4    7.0         2.76      7.91        189
+//     8   13.0         5.58      7.66         96
+//    16   25.0         7.46      7.56         48
+//    32   49.1        12.87     12.91         24   (was here)
+//
+// Below 16 the GPU number keeps falling and the wall number does not: the host
+// cannot issue 3 launches per window fast enough to keep the queue fed, and
+// TTFT pays the wall column. 16 is where the two meet. End-to-end on
+// Qwen3.6-35B-A3B at 3985 tokens, 6 interleaved order-reversed rounds, 16 beat
+// 32 in every round: -294 ms TTFT, 95% CI [-495, -94]. 8 was measured too and
+// is within noise of 16 (-241 ms, n=4) while doubling the launches again, so
+// there is nothing to buy below 16.
+//
+// The window is numerically inert -- the passes recompute the same per-chunk
+// quantities and the scan carries the recurrent state across windows -- and
+// that was checked, not assumed: output and final state are bit-identical to
+// the 32-chunk window at 3985 tokens for every window from 1 to 32.
+static constexpr int LA_WINDOW_CHUNKS = 16;
 
 // Scratch layout for the chunk-parallel path. The buffer itself is owned by
 // the runtime (RuntimeState::la_scratch, grown on demand, freed on session


### PR DESCRIPTION
`LA_WINDOW_CHUNKS` bounds the per-(head,chunk) scratch that the pass1 -> scan -> pass3
chain streams through between writing a Uloc/W tile and reading it back. It was picked
as a footprint knob and set to 32, which is 49.1 MiB per layer, so every tile makes a
DRAM round trip. It is also a cache-residency knob, and on that axis 32 is the wrong
end of the curve. This sets it to 16.

One constant. The window is numerically inert -- the passes recompute the same
per-chunk quantities and the scan carries the recurrent state across windows -- and
that was checked rather than assumed: output and final state are bit-identical to the
32-chunk window for every window from 1 to 32.

## Why 16 and not lower

Swept at 3985 tokens (Hkv=32, dk=dv=128), GPU time for one layer's three passes
alongside the wall time for the same work:

| win | scratch | gpu ms | wall ms | launches |
| --- | --- | --- | --- | --- |
| 1 | 2.5 MiB | 1.27 | 14.71 | 750 |
| 2 | 4.0 | 1.68 | 9.79 | 375 |
| 4 | 7.0 | 2.76 | 7.91 | 189 |
| 8 | 13.0 | 5.58 | 7.66 | 96 |
| 16 | 25.0 | 7.46 | 7.56 | 48 |
| 32 | 49.1 | 12.87 | 12.91 | 24 |

The GPU column keeps falling below 16 and the wall column does not: the host cannot
issue three launches per window fast enough to keep the queue fed, and TTFT pays wall,
not GPU. 16 is where the two meet. Taking the GPU column alone would have argued for a
window of 1, which is 2x worse end-to-end.

## Measurement at 16K

Interleaved order-reversed A/B on Qwen3.6-35B-A3B, 18,646 prompt tokens, four paired
rounds of four reps, no EP instrumentation. The baseline arm is this branch's parent
state with PR #722 and PR #723 already applied, since the surrounding layout changed
under it.

| round | window 32 | window 16 | delta |
| --- | --- | --- | --- |
| 1 (fwd) | 15,080 | 14,312 | -768 |
| 2 (fwd) | 14,886 | 14,291 | -595 |
| 3 (rev) | 15,108 | 14,319 | -789 |
| 4 (rev) | 14,869 | 14,326 | -543 |

**-674 ms (-4.49%)**, 95% CI [-870, -477], sd of the paired difference 123 ms. Better
in all four rounds and in both orderings.

This is more than the -294 ms measured for the same constant before PR #722 landed,
which is consistent with the mechanism: absorbing the Transpose pair into the
convolution removed a large streaming resident set from between the linear-attention
passes, so the scratch this change keeps in cache now has a better chance of staying
there.

Halving the scratch to 25.0 MiB is a secondary win on a shared-memory part where the
SQTT buffer, the model's activations and this arena compete.

`LA_SCAN_NSPLIT` stays at 4: re-swept at the new window, 4 still wins (7.43 ms vs
7.92 / 7.58 / 8.47 for 1 / 2 / 8).

The second commit is comment-only. It records that pass 3's 29,824 B LDS block is not
worth cutting: halving QWS reaches 21,632 B and a third resident workgroup for 2.4%,
but the pass is bound by the 32 KB S0 tile each block streams, not by occupancy, and
the change costs accuracy (relL2 3.5e-4).

## Test plan

- [x] `test/numeric/tests/test_linear_attention.py` -- 4 passed
- [x] Bit-identical output and final state against the 32-chunk window, every window 1..32, every `LA_SCAN_NSPLIT` in 1/2/4/8
- [x] 16K TTFT A/B above, four paired rounds, both orderings
