### PR TITLE
feat(shape): add exact Tile and Range destinations

### DIFF
--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -1892,7 +1892,9 @@ def Hip_TopKOp : Hip_DpsOp<"top_k"> {
   }];
 }
 
-def Hip_RangeOp : Hip_DpsOp_WithInfer<"range"> {
+def Hip_RangeOp :
+    Hip_DpsOp_Payload<"range", /*traits=*/[],
+                      /*outsAccessor=*/"Output"> {
   let summary = "Generate 1-D range tensor";
   let description = [{
     Implements ONNX Range semantics:
@@ -3804,7 +3806,9 @@ def Hip_PadOp :
   }];
 }
 
-def Hip_TileOp : Hip_DpsOp_WithInfer<"tile"> {
+def Hip_TileOp :
+    Hip_DpsOp_Payload<"tile", /*traits=*/[],
+                      /*outsAccessor=*/"Output"> {
   let summary = "Tile a tensor by repeating along each dimension";
   let description = [{
     Constructs a new tensor by repeating `input` along each dimension by the
@@ -3826,7 +3830,8 @@ def Hip_TileOp : Hip_DpsOp_WithInfer<"tile"> {
     Hip_ContextType:$ctx,
     Hip_TensorOrMemRef:$input,
     Hip_TensorOrMemRef:$repeats,
-    Hip_TensorOrMemRef:$output
+    Hip_TensorOrMemRef:$output,
+    OptionalAttr<DenseI64ArrayAttr>:$static_repeats
   );
 
   let assemblyFormat = [{
@@ -3834,6 +3839,8 @@ def Hip_TileOp : Hip_DpsOp_WithInfer<"tile"> {
     `outs` `(` $output `:` type($output) `)`
     attr-dict (`:` type($result_tensors)^)?
   }];
+
+  let hasVerifier = 1;
 }
 
 def Hip_ExpandOp :

--- a/include/hip/Dialect/IR/HipShapeUtils.h
+++ b/include/hip/Dialect/IR/HipShapeUtils.h
@@ -494,12 +494,17 @@ LogicalResult reifyPadShape(OpBuilder &b, Location loc, Value data, Value pads,
 ///   `output[d] = input.shape[d] * repeats[d]`
 /// where `repeats` is a rank-1 i64 tensor of length `input.rank`.
 ///
-/// Same fold-or-bail strategy as `reifyPadShape`: tries to introspect
-/// `repeats` as a constant int vector, computes static output extents
-/// from `input.shape`, and returns `success()` only when EVERY dim is
-/// statically known.
+/// The pure static form validates rank/length/non-negative repeats.
+FailureOr<SmallVector<int64_t>> inferTileShape(ArrayRef<int64_t> inputShape,
+                                               ArrayRef<int64_t> repeats);
+
+/// Mixed form for constant repeats. Dynamic input dims produce exact index SSA;
+/// payload-dynamic repeats return failure so the caller can use bulk readback
+/// (converter) or outs-lift (reify).
 LogicalResult reifyTileShape(OpBuilder &b, Location loc, Value input,
-                             Value repeats, SmallVectorImpl<OpFoldResult> &out);
+                             Value repeats,
+                             std::optional<ArrayRef<int64_t>> staticRepeats,
+                             SmallVectorImpl<OpFoldResult> &out);
 
 /// Reify the result shape of an ONNX-style `expand` op:
 ///   broadcast `input.shape` against `shape`'s constant values
@@ -549,9 +554,10 @@ LogicalResult reifySliceShape(OpBuilder &b, Location loc, Value data,
 /// `IndexAttr` vector. Else `failure()` -- the dim-arith chain to
 /// compute the count at runtime is rarely useful for refinement and
 /// would persist in IR.
-LogicalResult reifyRangeShape(OpBuilder &b, Location loc, Value start,
-                              Value limit, Value delta,
-                              SmallVectorImpl<OpFoldResult> &out);
+LogicalResult
+reifyRangeShape(OpBuilder &b, Location loc, Value start, Value limit,
+                Value delta, SmallVectorImpl<OpFoldResult> &out,
+                std::optional<ArrayRef<int64_t>> staticValues = std::nullopt);
 
 } // namespace hip
 } // namespace mlir

--- a/lib/Conversion/OnnxToHip/RangeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/RangeConversion.cpp
@@ -238,34 +238,53 @@ struct RangeToHip : public RewritePattern {
     Value limitS = collapseRangeBoundToScalar(rewriter, loc, op->getOperand(1));
     Value deltaS = collapseRangeBoundToScalar(rewriter, loc, op->getOperand(2));
 
-    // Read start/limit/delta to host SSA values for the trip-count arithmetic.
-    // Constants fold; GPU-computed operands go through a synchronized
-    // hip.readback_scalar (see ReadbackScalar.h for why a plain tensor.extract
-    // is a correctness bug on true-device-memory targets).
-    Value startE = readbackScalarToHost(rewriter, loc, ctx, startS);
-    Value limitE = readbackScalarToHost(rewriter, loc, ctx, limitS);
-    Value deltaE = readbackScalarToHost(rewriter, loc, ctx, deltaS);
-
-    Value len = llvm::TypeSwitch<Type, Value>(elemTy)
-                    .Case<IntegerType>([&](IntegerType ity) {
-                      return buildIntRangeCount(rewriter, loc, startE, limitE,
-                                                deltaE, ity);
-                    })
-                    .Case<FloatType>([&](FloatType fty) {
-                      return buildFloatRangeCount(rewriter, loc, startE, limitE,
-                                                  deltaE, fty);
-                    })
-                    .Default([&](Type) { return Value(); });
-    if (!len)
-      return failure();
-
     Value init;
-    if (resultType.isDynamicDim(0)) {
-      init = tensor::EmptyOp::create(rewriter, loc, resultType.getShape(),
-                                     elemTy, ValueRange{len});
-    } else {
-      init = tensor::EmptyOp::create(rewriter, loc, resultType.getShape(),
-                                     elemTy, ValueRange{});
+    SmallVector<int64_t> startValues, limitValues, deltaValues, staticValues;
+    if (isa<IntegerType>(elemTy) &&
+        extractConstantIntTensor(op->getOperand(0), startValues) &&
+        extractConstantIntTensor(op->getOperand(1), limitValues) &&
+        extractConstantIntTensor(op->getOperand(2), deltaValues) &&
+        startValues.size() == 1 && limitValues.size() == 1 &&
+        deltaValues.size() == 1) {
+      staticValues = {startValues[0], limitValues[0], deltaValues[0]};
+      SmallVector<OpFoldResult> reifiedShape;
+      if (succeeded(mlir::hip::reifyRangeShape(
+              rewriter, loc, startS, limitS, deltaS, reifiedShape,
+              ArrayRef<int64_t>(staticValues)))) {
+        auto constantInit = createEmptyTensorFromReifiedShape(
+            rewriter, loc, resultType, reifiedShape);
+        if (failed(constantInit))
+          return rewriter.notifyMatchFailure(
+              op, "Range result type contradicts constant trip count");
+        init = *constantInit;
+      }
+    }
+
+    if (!init) {
+      // Preserve the payload-dynamic path exactly. GPU-computed bounds use
+      // synchronized scalar readback before sizing the destination.
+      Value startE = readbackScalarToHost(rewriter, loc, ctx, startS);
+      Value limitE = readbackScalarToHost(rewriter, loc, ctx, limitS);
+      Value deltaE = readbackScalarToHost(rewriter, loc, ctx, deltaS);
+      Value len = llvm::TypeSwitch<Type, Value>(elemTy)
+                      .Case<IntegerType>([&](IntegerType ity) {
+                        return buildIntRangeCount(rewriter, loc, startE, limitE,
+                                                  deltaE, ity);
+                      })
+                      .Case<FloatType>([&](FloatType fty) {
+                        return buildFloatRangeCount(rewriter, loc, startE,
+                                                    limitE, deltaE, fty);
+                      })
+                      .Default([&](Type) { return Value(); });
+      if (!len)
+        return failure();
+      init = resultType.isDynamicDim(0)
+                 ? Value(tensor::EmptyOp::create(rewriter, loc,
+                                                 resultType.getShape(), elemTy,
+                                                 ValueRange{len}))
+                 : Value(tensor::EmptyOp::create(rewriter, loc,
+                                                 resultType.getShape(), elemTy,
+                                                 ValueRange{}));
     }
 
     auto rangeOp = mlir::hip::RangeOp::create(rewriter, loc, ctx, startS,

--- a/lib/Conversion/OnnxToHip/TileConversion.cpp
+++ b/lib/Conversion/OnnxToHip/TileConversion.cpp
@@ -17,6 +17,9 @@ struct TileToHip : public mlir::RewritePattern {
   mlir::LogicalResult
   matchAndRewrite(mlir::Operation *op,
                   mlir::PatternRewriter &rewriter) const override {
+    if (op->getNumOperands() != 2 || op->getNumResults() != 1)
+      return rewriter.notifyMatchFailure(op, "expected 2 inputs, 1 output");
+
     auto ctxOrFailure = getContextArg(op, rewriter);
     if (mlir::failed(ctxOrFailure))
       return mlir::failure();
@@ -26,15 +29,87 @@ struct TileToHip : public mlir::RewritePattern {
     mlir::Value input = op->getOperand(0);
     mlir::Value repeats = op->getOperand(1);
 
+    auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(input.getType());
+    auto repeatsType =
+        mlir::dyn_cast<mlir::RankedTensorType>(repeats.getType());
     auto resultType =
-        mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    if (!inputType || !repeatsType || !resultType)
+      return rewriter.notifyMatchFailure(
+          op, "Tile requires ranked input, repeats, and result");
+    if (repeatsType.getRank() != 1 ||
+        !repeatsType.getElementType().isInteger(64) ||
+        repeatsType.isDynamicDim(0) ||
+        repeatsType.getDimSize(0) != inputType.getRank() ||
+        resultType.getRank() != inputType.getRank())
+      return rewriter.notifyMatchFailure(
+          op, "Tile repeats must be a static-length rank-1 i64 tensor whose "
+              "length equals the input/result rank");
 
-    // Trust shape inference: output rank == input rank, dims may be dynamic.
-    // Use input as the source for any dynamic dim sizes.
-    mlir::Value init = createEmptyTensor(rewriter, loc, resultType, input);
+    SmallVector<int64_t> extractedRepeats;
+    DenseI64ArrayAttr staticRepeats;
+    if (extractConstantIntVector(repeats, extractedRepeats))
+      staticRepeats = rewriter.getDenseI64ArrayAttr(extractedRepeats);
+    std::optional<ArrayRef<int64_t>> staticRepeatsValues;
+    if (staticRepeats)
+      staticRepeatsValues = staticRepeats.asArrayRef();
 
-    auto hipOp =
-        mlir::hip::TileOp::create(rewriter, loc, context, input, repeats, init);
+    SmallVector<OpFoldResult> resultShape;
+    if (staticRepeatsValues) {
+      auto inferredShape =
+          inferTileShape(inputType.getShape(), *staticRepeatsValues);
+      if (failed(inferredShape))
+        return rewriter.notifyMatchFailure(
+            op, "Tile repeats must match input rank and be non-negative");
+      if (!isResultTypeCompatibleWithPayloadShape(resultType, *inferredShape))
+        return rewriter.notifyMatchFailure(
+            op, "Tile result type contradicts constant repeats");
+      if (failed(reifyTileShape(rewriter, loc, input, repeats,
+                                staticRepeatsValues, resultShape)))
+        return failure();
+    } else {
+      // Runtime repeats are needed only for result dimensions that remain
+      // dynamic after ONNX shape inference. Imported static extents stay
+      // authoritative; this is common when a repeats tensor is assembled at
+      // runtime from one dynamic entry and one constant 1.
+      //
+      // When at least one result extent is dynamic, one bulk readback produces
+      // every repeat with a single stream synchronization. Fully static
+      // results need no host readback at all.
+      mlir::hip::ReadbackShapeOp readback;
+      SmallVector<OpFoldResult> inputSizes;
+      if (resultType.getNumDynamicDims() != 0) {
+        SmallVector<Type> dimTypes(inputType.getRank(),
+                                   rewriter.getIndexType());
+        readback = mlir::hip::ReadbackShapeOp::create(
+            rewriter, loc, dimTypes, context, repeats,
+            rewriter.getI64IntegerAttr(inputType.getRank()));
+        inputSizes = tensor::getMixedSizes(rewriter, loc, input);
+      }
+      resultShape.reserve(inputType.getRank());
+      for (int64_t dim : llvm::seq<int64_t>(inputType.getRank())) {
+        if (!resultType.isDynamicDim(dim)) {
+          resultShape.push_back(
+              rewriter.getIndexAttr(resultType.getDimSize(dim)));
+          continue;
+        }
+        OpFoldResult inputSize = inputSizes[dim];
+        Value inputExtent =
+            getValueOrCreateConstantIndexOp(rewriter, loc, inputSize);
+        resultShape.push_back(arith::MulIOp::create(rewriter, loc, inputExtent,
+                                                    readback.getDims()[dim])
+                                  .getResult());
+      }
+    }
+
+    FailureOr<Value> init = createEmptyTensorFromReifiedShape(
+        rewriter, loc, resultType, resultShape);
+    if (failed(init))
+      return rewriter.notifyMatchFailure(
+          op, "Tile result type is incompatible with inferred extents");
+
+    auto hipOp = mlir::hip::TileOp::create(rewriter, loc, context, input,
+                                           repeats, *init, staticRepeats);
     rewriter.replaceOp(op, hipOp->getResult(0));
     return mlir::success();
   }

--- a/lib/Conversion/OnnxToHip/TileConversion.cpp
+++ b/lib/Conversion/OnnxToHip/TileConversion.cpp
@@ -73,19 +73,12 @@ struct TileToHip : public mlir::RewritePattern {
       // authoritative; this is common when a repeats tensor is assembled at
       // runtime from one dynamic entry and one constant 1.
       //
-      // When at least one result extent is dynamic, one bulk readback produces
-      // every repeat with a single stream synchronization. Fully static
-      // results need no host readback at all.
-      mlir::hip::ReadbackShapeOp readback;
+      // Read only repeats that contribute to dynamic result dimensions. Each
+      // device-produced entry crosses the existing synchronized scalar
+      // boundary; fully static result dimensions need no host readback.
       SmallVector<OpFoldResult> inputSizes;
-      if (resultType.getNumDynamicDims() != 0) {
-        SmallVector<Type> dimTypes(inputType.getRank(),
-                                   rewriter.getIndexType());
-        readback = mlir::hip::ReadbackShapeOp::create(
-            rewriter, loc, dimTypes, context, repeats,
-            rewriter.getI64IntegerAttr(inputType.getRank()));
+      if (resultType.getNumDynamicDims() != 0)
         inputSizes = tensor::getMixedSizes(rewriter, loc, input);
-      }
       resultShape.reserve(inputType.getRank());
       for (int64_t dim : llvm::seq<int64_t>(inputType.getRank())) {
         if (!resultType.isDynamicDim(dim)) {
@@ -96,9 +89,13 @@ struct TileToHip : public mlir::RewritePattern {
         OpFoldResult inputSize = inputSizes[dim];
         Value inputExtent =
             getValueOrCreateConstantIndexOp(rewriter, loc, inputSize);
-        resultShape.push_back(arith::MulIOp::create(rewriter, loc, inputExtent,
-                                                    readback.getDims()[dim])
-                                  .getResult());
+        Value repeat =
+            readbackShapeEntryToHost(rewriter, loc, context, repeats, dim);
+        Value repeatIndex = arith::IndexCastOp::create(
+            rewriter, loc, rewriter.getIndexType(), repeat);
+        resultShape.push_back(
+            arith::MulIOp::create(rewriter, loc, inputExtent, repeatIndex)
+                .getResult());
       }
     }
 

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -2594,6 +2594,37 @@ void TileOp::getEffects(
   emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
 }
 
+LogicalResult TileOp::verify() {
+  if (failed(verifyDpsComputeOp(*this, {getInput(), getRepeats(), getOutput()},
+                                /*numInits=*/1)))
+    return failure();
+  auto inputType = dyn_cast<ShapedType>(getInput().getType());
+  auto repeatsType = dyn_cast<ShapedType>(getRepeats().getType());
+  auto outputType = dyn_cast<ShapedType>(getOutput().getType());
+  if (!inputType || !inputType.hasRank() || !repeatsType ||
+      !repeatsType.hasRank() || !outputType || !outputType.hasRank())
+    return emitOpError("input, repeats, and output must be ranked");
+  if (repeatsType.getRank() != 1 ||
+      !repeatsType.getElementType().isInteger(64) ||
+      repeatsType.isDynamicDim(0) ||
+      repeatsType.getDimSize(0) != inputType.getRank())
+    return emitOpError(
+        "repeats must be static-length rank-1 i64 matching input rank");
+  if (outputType.getRank() != inputType.getRank())
+    return emitOpError("output rank must match input rank");
+
+  std::optional<ArrayRef<int64_t>> staticRepeats = getStaticRepeats();
+  if (!staticRepeats)
+    return success();
+  FailureOr<SmallVector<int64_t>> expected =
+      mlir::hip::inferTileShape(inputType.getShape(), *staticRepeats);
+  if (failed(expected))
+    return emitOpError(
+        "static_repeats must match input rank and be non-negative");
+  return mlir::hip::verifyHipOpShape(
+      *this, [&]() -> FailureOr<SmallVector<int64_t>> { return *expected; });
+}
+
 //===----------------------------------------------------------------------===//
 // ExpandOp: ins(input, shape), outs(output)
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
+++ b/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
@@ -638,9 +638,10 @@ PadOp::reifyResultShapes(OpBuilder &b,
 LogicalResult
 TileOp::reifyResultShapes(OpBuilder &b,
                           ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+  std::optional<ArrayRef<int64_t>> staticRepeats = getStaticRepeats();
   SmallVector<OpFoldResult> dims;
   if (succeeded(mlir::hip::reifyTileShape(b, getLoc(), getInput(), getRepeats(),
-                                          dims))) {
+                                          staticRepeats, dims))) {
     reifiedReturnShapes.assign({std::move(dims)});
     return success();
   }

--- a/lib/Dialect/IR/HipShapeUtilsShapeOps.cpp
+++ b/lib/Dialect/IR/HipShapeUtilsShapeOps.cpp
@@ -136,45 +136,66 @@ mlir::hip::reifyPadShape(OpBuilder &b, Location loc, Value data, Value pads,
   SmallVector<OpFoldResult> inputSizes = tensor::getMixedSizes(b, loc, data);
   out.reserve(dataRank);
   for (int64_t axis : llvm::seq<int64_t>(0, dataRank)) {
-    if (!dataType.isDynamicDim(axis)) {
-      out.push_back(b.getIndexAttr(inferred->result[axis]));
-      continue;
-    }
-    Value inputExtent =
-        getValueOrCreateConstantIndexOp(b, loc, inputSizes[axis]);
-    int64_t offset = inferred->offsets[axis];
-    if (offset == 0) {
-      out.push_back(inputExtent);
-      continue;
-    }
-    Value offsetValue = arith::ConstantIndexOp::create(b, loc, offset);
-    out.push_back(
-        arith::AddIOp::create(b, loc, inputExtent, offsetValue).getResult());
+    FailureOr<OpFoldResult> extent = detail::scaleAndOffsetDim(
+        b, loc, inputSizes[axis], /*scale=*/1, inferred->offsets[axis]);
+    if (failed(extent))
+      return failure();
+    out.push_back(*extent);
   }
   return success();
 }
 
-LogicalResult mlir::hip::reifyTileShape(OpBuilder &b, Location loc, Value input,
-                                        Value repeats,
-                                        SmallVectorImpl<OpFoldResult> &out) {
+FailureOr<SmallVector<int64_t>>
+mlir::hip::inferTileShape(ArrayRef<int64_t> inputShape,
+                          ArrayRef<int64_t> repeats) {
+  if (inputShape.size() != repeats.size())
+    return failure();
+  SmallVector<int64_t> result;
+  result.reserve(inputShape.size());
+  for (auto [dim, repeat] : llvm::zip_equal(inputShape, repeats)) {
+    if (repeat < 0)
+      return failure();
+    if (ShapedType::isDynamic(dim)) {
+      result.push_back(ShapedType::kDynamic);
+      continue;
+    }
+    APInt extent = APInt(128, dim, /*isSigned=*/true) *
+                   APInt(128, repeat, /*isSigned=*/true);
+    if (!extent.isSignedIntN(64) || extent.isNegative())
+      return failure();
+    result.push_back(extent.getSExtValue());
+  }
+  return result;
+}
+
+LogicalResult
+mlir::hip::reifyTileShape(OpBuilder &b, Location loc, Value input,
+                          Value repeats,
+                          std::optional<ArrayRef<int64_t>> staticRepeats,
+                          SmallVectorImpl<OpFoldResult> &out) {
   out.clear();
   auto inputType = dyn_cast<RankedTensorType>(input.getType());
   if (!inputType)
     return failure();
-  ArrayRef<int64_t> inputShape = inputType.getShape();
-  int64_t inputRank = inputType.getRank();
 
-  SmallVector<int64_t> repeatsList;
-  if (!matchConstantIntTensor(repeats, repeatsList))
-    return failure();
-  if (static_cast<int64_t>(repeatsList.size()) != inputRank)
-    return failure();
-
-  out.reserve(inputRank);
-  for (int64_t dim : llvm::seq<int64_t>(0, inputRank)) {
-    if (ShapedType::isDynamic(inputShape[dim]) || repeatsList[dim] < 0)
+  SmallVector<int64_t> extractedRepeats;
+  if (!staticRepeats) {
+    if (!matchConstantIntTensor(repeats, extractedRepeats,
+                                /*expectedRank=*/1))
       return failure();
-    out.push_back(b.getIndexAttr(inputShape[dim] * repeatsList[dim]));
+    staticRepeats = extractedRepeats;
+  }
+  if (failed(inferTileShape(inputType.getShape(), *staticRepeats)))
+    return failure();
+
+  SmallVector<OpFoldResult> inputSizes = tensor::getMixedSizes(b, loc, input);
+  out.reserve(inputSizes.size());
+  for (auto [dim, repeat] : llvm::zip_equal(inputSizes, *staticRepeats)) {
+    FailureOr<OpFoldResult> extent =
+        detail::scaleAndOffsetDim(b, loc, dim, repeat, /*offset=*/0);
+    if (failed(extent))
+      return failure();
+    out.push_back(*extent);
   }
   return success();
 }
@@ -291,34 +312,52 @@ LogicalResult mlir::hip::reifySliceShape(OpBuilder &b, Location loc, Value data,
   return success();
 }
 
-LogicalResult mlir::hip::reifyRangeShape(OpBuilder &b, Location loc,
-                                         Value start, Value limit, Value delta,
-                                         SmallVectorImpl<OpFoldResult> &out) {
+LogicalResult
+mlir::hip::reifyRangeShape(OpBuilder &b, Location loc, Value start, Value limit,
+                           Value delta, SmallVectorImpl<OpFoldResult> &out,
+                           std::optional<ArrayRef<int64_t>> staticValues) {
   out.clear();
-  SmallVector<int64_t> starts, limits, deltas;
-  if (!matchConstantIntTensor(start, starts) ||
-      !matchConstantIntTensor(limit, limits) ||
-      !matchConstantIntTensor(delta, deltas))
+
+  // Each operand is a rank-0 (scalar) integer tensor. matchConstantIntTensor
+  // returns a 1-element vector for the rank-0 / IntegerAttr case.
+  SmallVector<int64_t> sList, lList, dList;
+  if (staticValues) {
+    if (staticValues->size() != 3)
+      return failure();
+    sList.push_back((*staticValues)[0]);
+    lList.push_back((*staticValues)[1]);
+    dList.push_back((*staticValues)[2]);
+  } else if (!matchConstantIntTensor(start, sList, /*expectedRank=*/0) ||
+             !matchConstantIntTensor(limit, lList, /*expectedRank=*/0) ||
+             !matchConstantIntTensor(delta, dList, /*expectedRank=*/0)) {
     return failure();
-  if (starts.size() != 1 || limits.size() != 1 || deltas.size() != 1)
+  }
+  if (sList.size() != 1 || lList.size() != 1 || dList.size() != 1)
+    return failure();
+  APInt s(128, sList[0], /*isSigned=*/true);
+  APInt l(128, lList[0], /*isSigned=*/true);
+  APInt d(128, dList[0], /*isSigned=*/true);
+  if (d.isZero())
     return failure();
 
-  int64_t startValue = starts[0];
-  int64_t limitValue = limits[0];
-  int64_t deltaValue = deltas[0];
-  if (deltaValue == 0)
-    return failure();
-  int64_t count = 0;
-  if ((deltaValue > 0 && limitValue > startValue) ||
-      (deltaValue < 0 && limitValue < startValue)) {
-    int64_t difference = limitValue - startValue;
-    int64_t step = deltaValue;
-    if (step < 0) {
-      difference = -difference;
+  // ONNX Range: count = max(0, ceil((limit - start) / delta)) for the
+  // direction implied by sign(delta). Negative direction (delta < 0)
+  // counts down from start to limit. Wide arithmetic is required for
+  // INT64_MIN negation and opposite-sign endpoint subtraction.
+  APInt count(128, 0, /*isSigned=*/true);
+  if ((d.isStrictlyPositive() && l.sgt(s)) || (d.isNegative() && l.slt(s))) {
+    APInt diff = l - s;
+    APInt step = d;
+    if (step.isNegative()) {
+      diff = -diff;
       step = -step;
     }
-    count = (difference + step - 1) / step;
+    APInt one(128, 1, /*isSigned=*/true);
+    count = (diff + step - one).sdiv(step);
   }
-  out.push_back(b.getIndexAttr(count));
+  if (!count.isSignedIntN(64) || count.isNegative())
+    return failure();
+
+  out.push_back(b.getIndexAttr(count.getSExtValue()));
   return success();
 }

--- a/test/lit/Conversion/onnx-to-hip/test_payload_failure_atomicity.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_payload_failure_atomicity.mlir
@@ -28,6 +28,22 @@ module {
   // CHECK-NOT: hip.pad
   // CHECK: "onnx.Pad"
 
+  func.func @tile_static_contradiction(
+      %input: tensor<2x3xf32>) -> tensor<4x8xf32> {
+    %repeats = "onnx.Constant"() {
+      value = dense<[2, 3]> : tensor<2xi64>
+    } : () -> tensor<2xi64>
+    %result = "onnx.Tile"(%input, %repeats)
+      : (tensor<2x3xf32>, tensor<2xi64>) -> tensor<4x8xf32>
+    return %result : tensor<4x8xf32>
+  }
+
+  // CHECK-LABEL: func.func @tile_static_contradiction
+  // CHECK-NOT: tensor.dim
+  // CHECK-NOT: tensor.empty
+  // CHECK-NOT: hip.tile
+  // CHECK: "onnx.Tile"
+
   func.func @expand_static_contradiction(
       %input: tensor<1x3x1xf32>) -> tensor<2x3x5xf32> {
     %shape = "onnx.Constant"() {
@@ -59,6 +75,18 @@ module {
   // CHECK: tensor.empty() : tensor<5x4xf32>
   // CHECK: hip.pad
 
+  func.func @tile_static_result_refinement(
+      %input: tensor<?x3xf32>) -> tensor<4x9xf32> {
+    %repeats = arith.constant dense<[2, 3]> : tensor<2xi64>
+    %result = "onnx.Tile"(%input, %repeats)
+      : (tensor<?x3xf32>, tensor<2xi64>) -> tensor<4x9xf32>
+    return %result : tensor<4x9xf32>
+  }
+
+  // CHECK-LABEL: func.func @tile_static_result_refinement
+  // CHECK: tensor.empty() : tensor<4x9xf32>
+  // CHECK: hip.tile
+
   func.func @expand_static_result_refinement(
       %input: tensor<?x1xf32>) -> tensor<3x4xf32> {
     %shape = arith.constant dense<[1, 4]> : tensor<2xi64>
@@ -84,6 +112,18 @@ module {
   // CHECK-LABEL: func.func @pad_dynamic_result_static_inference
   // CHECK: tensor.empty({{.*}}, {{.*}}) : tensor<?x?xf32>
   // CHECK: hip.pad
+
+  func.func @tile_dynamic_result_static_inference(
+      %input: tensor<2x3xf32>) -> tensor<?x?xf32> {
+    %repeats = arith.constant dense<[2, 3]> : tensor<2xi64>
+    %result = "onnx.Tile"(%input, %repeats)
+      : (tensor<2x3xf32>, tensor<2xi64>) -> tensor<?x?xf32>
+    return %result : tensor<?x?xf32>
+  }
+
+  // CHECK-LABEL: func.func @tile_dynamic_result_static_inference
+  // CHECK: tensor.empty({{.*}}, {{.*}}) : tensor<?x?xf32>
+  // CHECK: hip.tile
 
   func.func @expand_dynamic_result_static_inference(
       %input: tensor<1x3x1xf32>) -> tensor<?x?x?xf32> {

--- a/test/lit/Conversion/onnx-to-hip/test_range.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_range.mlir
@@ -51,6 +51,19 @@ module {
   // CHECK-LABEL: func.func @test_range_i64
   // CHECK: hip.range
 
+  func.func @test_range_i64_constant_dynamic_type() -> tensor<?xi64> {
+    %s = arith.constant dense<0> : tensor<i64>
+    %l = arith.constant dense<8> : tensor<i64>
+    %d = arith.constant dense<2> : tensor<i64>
+    %r = "onnx.Range"(%s, %l, %d) : (tensor<i64>, tensor<i64>, tensor<i64>) -> tensor<?xi64>
+    return %r : tensor<?xi64>
+  }
+  // CHECK-LABEL: func.func @test_range_i64_constant_dynamic_type
+  // CHECK: %[[COUNT:.*]] = arith.constant 4 : index
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK: tensor.empty(%[[COUNT]]) : tensor<?xi64>
+  // CHECK: hip.range
+
   func.func @test_range_f64() -> tensor<4xf64> {
     %s = arith.constant dense<0.0> : tensor<f64>
     %l = arith.constant dense<4.0> : tensor<f64>

--- a/test/lit/Conversion/onnx-to-hip/test_tile.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_tile.mlir
@@ -8,15 +8,18 @@ module {
     return %arg0 : tensor<4xf32>
   }
 
-  func.func @tile_f32(%input: tensor<2x3xf32>, %repeats: tensor<2xi64>) -> tensor<4x9xf32> {
-    %r = "onnx.Tile"(%input, %repeats) : (tensor<2x3xf32>, tensor<2xi64>) -> tensor<4x9xf32>
+  func.func @tile_f32(%input: tensor<2x3xf32>) -> tensor<4x9xf32> {
+    %repeats = arith.constant dense<[2, 3]> : tensor<2xi64>
+    %r = "onnx.Tile"(%input, %repeats)
+      : (tensor<2x3xf32>, tensor<2xi64>) -> tensor<4x9xf32>
     return %r : tensor<4x9xf32>
   }
 
   // CHECK-LABEL: func.func @tile_f32
-  // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[IN:.*]]: tensor<2x3xf32>, %[[R:.*]]: tensor<2xi64>)
+  // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[IN:.*]]: tensor<2x3xf32>)
   // CHECK: tensor.empty() : tensor<4x9xf32>
-  // CHECK: hip.tile(%[[CTX]]) ins(%[[IN]], %[[R]] : tensor<2x3xf32>, tensor<2xi64>) outs({{.*}} : tensor<4x9xf32>)
+  // CHECK: hip.tile(%[[CTX]]) ins(%[[IN]], %{{.*}} : tensor<2x3xf32>, tensor<2xi64>) outs({{.*}} : tensor<4x9xf32>)
+  // CHECK-SAME: static_repeats = array<i64: 2, 3>
 
   func.func @tile_dynamic(%input: tensor<?x?xf32>, %repeats: tensor<2xi64>) -> tensor<?x?xf32> {
     %r = "onnx.Tile"(%input, %repeats) : (tensor<?x?xf32>, tensor<2xi64>) -> tensor<?x?xf32>
@@ -24,5 +27,75 @@ module {
   }
 
   // CHECK-LABEL: func.func @tile_dynamic
-  // CHECK: hip.tile({{.*}}) ins({{.*}}, {{.*}} : tensor<?x?xf32>, tensor<2xi64>) outs({{.*}} : tensor<?x?xf32>)
+  // CHECK: %[[RB:.*]]:2 = hip.readback_shape
+  // CHECK: %[[D0:.*]] = tensor.dim %{{.*}}, %{{.*}} : tensor<?x?xf32>
+  // CHECK: %[[D1:.*]] = tensor.dim %{{.*}}, %{{.*}} : tensor<?x?xf32>
+  // CHECK: %[[O0:.*]] = arith.muli %[[D0]], %[[RB]]#0 : index
+  // CHECK: %[[O1:.*]] = arith.muli %[[D1]], %[[RB]]#1 : index
+  // CHECK: %[[INIT:.*]] = tensor.empty(%[[O0]], %[[O1]]) : tensor<?x?xf32>
+  // CHECK: hip.tile({{.*}}) ins({{.*}}, {{.*}} : tensor<?x?xf32>, tensor<2xi64>) outs(%[[INIT]] : tensor<?x?xf32>)
+
+  // Runtime repeats may coexist with imported static result extents. Only the
+  // dynamic destination dimension needs payload-derived size arithmetic.
+  func.func @tile_runtime_repeats_partial_static(
+      %input: tensor<?x1152xf32>,
+      %repeats: tensor<2xi64>) -> tensor<?x1152xf32> {
+    %r = "onnx.Tile"(%input, %repeats)
+      : (tensor<?x1152xf32>, tensor<2xi64>) -> tensor<?x1152xf32>
+    return %r : tensor<?x1152xf32>
+  }
+
+  // CHECK-LABEL: func.func @tile_runtime_repeats_partial_static
+  // CHECK: %[[PRB:.*]]:2 = hip.readback_shape
+  // CHECK: %[[PD0:.*]] = tensor.dim %{{.*}}, %{{.*}} : tensor<?x1152xf32>
+  // CHECK: %[[PO0:.*]] = arith.muli %[[PD0]], %[[PRB]]#0 : index
+  // CHECK: %[[PINIT:.*]] = tensor.empty(%[[PO0]]) : tensor<?x1152xf32>
+  // CHECK: hip.tile
+  // CHECK-SAME: outs(%[[PINIT]] : tensor<?x1152xf32>)
+
+  func.func @tile_dynamic_input_constant_repeats(
+      %input: tensor<?x?xf32>) -> tensor<?x?xf32> {
+    %repeats = arith.constant dense<[2, 3]> : tensor<2xi64>
+    %r = "onnx.Tile"(%input, %repeats)
+      : (tensor<?x?xf32>, tensor<2xi64>) -> tensor<?x?xf32>
+    return %r : tensor<?x?xf32>
+  }
+
+  // CHECK-LABEL: func.func @tile_dynamic_input_constant_repeats
+  // CHECK-NOT: hip.readback_shape
+  // CHECK: %[[CD0:.*]] = tensor.dim %{{.*}}, %{{.*}} : tensor<?x?xf32>
+  // CHECK: %[[CO0:.*]] = arith.muli %[[CD0]], %{{.*}} : index
+  // CHECK: hip.tile
+  // CHECK-SAME: static_repeats = array<i64: 2, 3>
+
+  // Imported ONNX constants are dense hip.constant carriers before compute
+  // conversion. Tile reads the carrier directly; no tile-specific stamp or
+  // prepass is required.
+  func.func @tile_carrier_repeats(
+      %input: tensor<?x?xf32>) -> tensor<?x?xf32> {
+    %repeats = "onnx.Constant"() {
+      value = dense<[4, 5]> : tensor<2xi64>
+    } : () -> tensor<2xi64>
+    %r = "onnx.Tile"(%input, %repeats)
+      : (tensor<?x?xf32>, tensor<2xi64>) -> tensor<?x?xf32>
+    return %r : tensor<?x?xf32>
+  }
+
+  // CHECK-LABEL: func.func @tile_carrier_repeats
+  // CHECK-NOT: hip.readback_shape
+  // CHECK-NOT: hipdnn.tile_repeats
+  // CHECK: hip.tile
+  // CHECK-SAME: static_repeats = array<i64: 4, 5>
+
+  func.func @tile_zero_repeat(%input: tensor<2x3xf32>) -> tensor<0x3xf32> {
+    %repeats = arith.constant dense<[0, 1]> : tensor<2xi64>
+    %r = "onnx.Tile"(%input, %repeats)
+      : (tensor<2x3xf32>, tensor<2xi64>) -> tensor<0x3xf32>
+    return %r : tensor<0x3xf32>
+  }
+
+  // CHECK-LABEL: func.func @tile_zero_repeat
+  // CHECK: tensor.empty() : tensor<0x3xf32>
+  // CHECK: hip.tile
+  // CHECK-SAME: static_repeats = array<i64: 0, 1>
 }

--- a/test/lit/Conversion/onnx-to-hip/test_tile.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_tile.mlir
@@ -27,11 +27,14 @@ module {
   }
 
   // CHECK-LABEL: func.func @tile_dynamic
-  // CHECK: %[[RB:.*]]:2 = hip.readback_shape
-  // CHECK: %[[D0:.*]] = tensor.dim %{{.*}}, %{{.*}} : tensor<?x?xf32>
-  // CHECK: %[[D1:.*]] = tensor.dim %{{.*}}, %{{.*}} : tensor<?x?xf32>
-  // CHECK: %[[O0:.*]] = arith.muli %[[D0]], %[[RB]]#0 : index
-  // CHECK: %[[O1:.*]] = arith.muli %[[D1]], %[[RB]]#1 : index
+  // CHECK-DAG: %[[D0:.*]] = tensor.dim %{{.*}}, %{{.*}} : tensor<?x?xf32>
+  // CHECK-DAG: %[[D1:.*]] = tensor.dim %{{.*}}, %{{.*}} : tensor<?x?xf32>
+  // CHECK: %[[RB0:.*]] = hip.readback_scalar
+  // CHECK: %[[R0:.*]] = arith.index_cast %[[RB0]] : i64 to index
+  // CHECK: %[[O0:.*]] = arith.muli %[[D0]], %[[R0]] : index
+  // CHECK: %[[RB1:.*]] = hip.readback_scalar
+  // CHECK: %[[R1:.*]] = arith.index_cast %[[RB1]] : i64 to index
+  // CHECK: %[[O1:.*]] = arith.muli %[[D1]], %[[R1]] : index
   // CHECK: %[[INIT:.*]] = tensor.empty(%[[O0]], %[[O1]]) : tensor<?x?xf32>
   // CHECK: hip.tile({{.*}}) ins({{.*}}, {{.*}} : tensor<?x?xf32>, tensor<2xi64>) outs(%[[INIT]] : tensor<?x?xf32>)
 
@@ -46,9 +49,10 @@ module {
   }
 
   // CHECK-LABEL: func.func @tile_runtime_repeats_partial_static
-  // CHECK: %[[PRB:.*]]:2 = hip.readback_shape
   // CHECK: %[[PD0:.*]] = tensor.dim %{{.*}}, %{{.*}} : tensor<?x1152xf32>
-  // CHECK: %[[PO0:.*]] = arith.muli %[[PD0]], %[[PRB]]#0 : index
+  // CHECK: %[[PRB:.*]] = hip.readback_scalar
+  // CHECK: %[[PRI:.*]] = arith.index_cast %[[PRB]] : i64 to index
+  // CHECK: %[[PO0:.*]] = arith.muli %[[PD0]], %[[PRI]] : index
   // CHECK: %[[PINIT:.*]] = tensor.empty(%[[PO0]]) : tensor<?x1152xf32>
   // CHECK: hip.tile
   // CHECK-SAME: outs(%[[PINIT]] : tensor<?x1152xf32>)
@@ -62,7 +66,7 @@ module {
   }
 
   // CHECK-LABEL: func.func @tile_dynamic_input_constant_repeats
-  // CHECK-NOT: hip.readback_shape
+  // CHECK-NOT: hip.readback_scalar
   // CHECK: %[[CD0:.*]] = tensor.dim %{{.*}}, %{{.*}} : tensor<?x?xf32>
   // CHECK: %[[CO0:.*]] = arith.muli %[[CD0]], %{{.*}} : index
   // CHECK: hip.tile
@@ -82,7 +86,7 @@ module {
   }
 
   // CHECK-LABEL: func.func @tile_carrier_repeats
-  // CHECK-NOT: hip.readback_shape
+  // CHECK-NOT: hip.readback_scalar
   // CHECK-NOT: hipdnn.tile_repeats
   // CHECK: hip.tile
   // CHECK-SAME: static_repeats = array<i64: 4, 5>

--- a/test/lit/Dialect/hip-range-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-range-reify-shapes.mlir
@@ -1,0 +1,63 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s
+
+// An endpoint difference larger than INT64_MAX cannot become an index
+// attribute. Reification fails cleanly and lifts the destination dimension.
+// CHECK-LABEL: func.func @count_overflow_falls_back
+// CHECK-SAME: (%{{[^:]+}}: !hip.context, %[[INIT:[^:]+]]: tensor<?xi64>)
+// CHECK: tensor.dim %[[INIT]]
+func.func @count_overflow_falls_back(
+    %ctx: !hip.context, %init: tensor<?xi64>) -> index {
+  %start = arith.constant dense<-9223372036854775808> : tensor<i64>
+  %limit = arith.constant dense<9223372036854775807> : tensor<i64>
+  %delta = arith.constant dense<1> : tensor<i64>
+  %result = hip.range(%ctx)
+    ins(%start, %limit, %delta : tensor<i64>, tensor<i64>, tensor<i64>)
+    outs(%init : tensor<?xi64>)
+    : tensor<?xi64>
+  %c0 = arith.constant 0 : index
+  %d0 = tensor.dim %result, %c0 : tensor<?xi64>
+  return %d0 : index
+}
+
+// -----
+
+// CHECK-LABEL: func.func @count_i64_boundary
+// CHECK: %[[MAX:.*]] = arith.constant 9223372036854775807 : index
+// CHECK: return %[[MAX]] : index
+func.func @count_i64_boundary(
+    %ctx: !hip.context, %init: tensor<?xi64>) -> index {
+  %start = arith.constant dense<0> : tensor<i64>
+  %limit = arith.constant dense<9223372036854775807> : tensor<i64>
+  %delta = arith.constant dense<1> : tensor<i64>
+  %result = hip.range(%ctx)
+    ins(%start, %limit, %delta : tensor<i64>, tensor<i64>, tensor<i64>)
+    outs(%init : tensor<?xi64>)
+    : tensor<?xi64>
+  %c0 = arith.constant 0 : index
+  %d0 = tensor.dim %result, %c0 : tensor<?xi64>
+  return %d0 : index
+}
+
+// -----
+
+// INT64_MIN is a valid negative delta. Its magnitude is computed in wide
+// arithmetic instead of negating the signed C++ value.
+// CHECK-LABEL: func.func @minimum_delta
+// CHECK: %[[ONE:.*]] = arith.constant 1 : index
+// CHECK: return %[[ONE]] : index
+func.func @minimum_delta(
+    %ctx: !hip.context, %init: tensor<?xi64>) -> index {
+  %start = arith.constant dense<9223372036854775807> : tensor<i64>
+  %limit = arith.constant dense<-1> : tensor<i64>
+  %delta = arith.constant dense<-9223372036854775808> : tensor<i64>
+  %result = hip.range(%ctx)
+    ins(%start, %limit, %delta : tensor<i64>, tensor<i64>, tensor<i64>)
+    outs(%init : tensor<?xi64>)
+    : tensor<?xi64>
+  %c0 = arith.constant 0 : index
+  %d0 = tensor.dim %result, %c0 : tensor<?xi64>
+  return %d0 : index
+}

--- a/test/lit/Dialect/hip-range-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-range-reify-shapes.mlir
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s
+// RUN: hip-mlir-opt --test-hip-whole-shape-dim-reify %s | FileCheck %s
 
 // An endpoint difference larger than INT64_MAX cannot become an index
 // attribute. Reification fails cleanly and lifts the destination dimension.

--- a/test/lit/Dialect/hip-tile-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-tile-reify-shapes.mlir
@@ -1,0 +1,52 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s
+
+// CHECK-LABEL: func.func @dynamic_input_constant_repeats
+// CHECK-SAME: (%{{.*}}: !hip.context, %[[INPUT:[^,]+]]: tensor<?x?xf32>,
+// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+// CHECK-DAG: %[[C2:.*]] = arith.constant 2 : index
+// CHECK-DAG: %[[C3:.*]] = arith.constant 3 : index
+// CHECK: %[[D0:.*]] = tensor.dim %[[INPUT]], %[[C0]]
+// CHECK: %[[O0:.*]] = arith.muli %[[D0]], %[[C2]]
+// CHECK: %[[D1:.*]] = tensor.dim %[[INPUT]], %[[C1]]
+// CHECK: %[[O1:.*]] = arith.muli %[[D1]], %[[C3]]
+// CHECK: return %[[O0]], %[[O1]] : index, index
+func.func @dynamic_input_constant_repeats(
+    %ctx: !hip.context,
+    %input: tensor<?x?xf32>,
+    %repeats: tensor<2xi64>,
+    %init: tensor<?x?xf32>) -> (index, index) {
+  %result = hip.tile(%ctx)
+    ins(%input, %repeats : tensor<?x?xf32>, tensor<2xi64>)
+    outs(%init : tensor<?x?xf32>)
+    {static_repeats = array<i64: 2, 3>}
+    : tensor<?x?xf32>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %d0 = tensor.dim %result, %c0 : tensor<?x?xf32>
+  %d1 = tensor.dim %result, %c1 : tensor<?x?xf32>
+  return %d0, %d1 : index, index
+}
+
+// -----
+
+// CHECK-LABEL: func.func @static_product_i64_boundary
+// CHECK: %[[MAX:.*]] = arith.constant 9223372036854775807 : index
+// CHECK: return %[[MAX]] : index
+func.func @static_product_i64_boundary(
+    %ctx: !hip.context,
+    %input: tensor<1xf32>,
+    %repeats: tensor<1xi64>,
+    %init: tensor<9223372036854775807xf32>) -> index {
+  %result = hip.tile(%ctx)
+    ins(%input, %repeats : tensor<1xf32>, tensor<1xi64>)
+    outs(%init : tensor<9223372036854775807xf32>)
+    {static_repeats = array<i64: 9223372036854775807>}
+    : tensor<9223372036854775807xf32>
+  %c0 = arith.constant 0 : index
+  %d0 = tensor.dim %result, %c0 : tensor<9223372036854775807xf32>
+  return %d0 : index
+}

--- a/test/lit/Dialect/hip-tile-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-tile-reify-shapes.mlir
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s
+// RUN: hip-mlir-opt --test-hip-whole-shape-dim-reify %s | FileCheck %s
 
 // CHECK-LABEL: func.func @dynamic_input_constant_repeats
 // CHECK-SAME: (%{{.*}}: !hip.context, %[[INPUT:[^,]+]]: tensor<?x?xf32>,

--- a/test/lit/Dialect/hip-tile-shape-verifier.mlir
+++ b/test/lit/Dialect/hip-tile-shape-verifier.mlir
@@ -1,0 +1,86 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s
+
+func.func @valid(%ctx: !hip.context,
+                 %input: memref<2x3xf32, 1>,
+                 %repeats: memref<2xi64, 1>,
+                 %output: memref<4x9xf32, 1>) {
+  hip.tile(%ctx)
+    ins(%input, %repeats : memref<2x3xf32, 1>, memref<2xi64, 1>)
+    outs(%output : memref<4x9xf32, 1>)
+    {static_repeats = array<i64: 2, 3>}
+  return
+}
+
+// -----
+
+func.func @wrong_output(%ctx: !hip.context,
+                        %input: memref<2x3xf32, 1>,
+                        %repeats: memref<2xi64, 1>,
+                        %output: memref<2x3xf32, 1>) {
+  // expected-error @+1 {{dim 0 of result mismatch: expected 4}}
+  hip.tile(%ctx)
+    ins(%input, %repeats : memref<2x3xf32, 1>, memref<2xi64, 1>)
+    outs(%output : memref<2x3xf32, 1>)
+    {static_repeats = array<i64: 2, 3>}
+  return
+}
+
+// -----
+
+func.func @negative_repeat(%ctx: !hip.context,
+                           %input: memref<2x3xf32, 1>,
+                           %repeats: memref<2xi64, 1>,
+                           %output: memref<0x3xf32, 1>) {
+  // expected-error @+1 {{static_repeats must match input rank and be non-negative}}
+  hip.tile(%ctx)
+    ins(%input, %repeats : memref<2x3xf32, 1>, memref<2xi64, 1>)
+    outs(%output : memref<0x3xf32, 1>)
+    {static_repeats = array<i64: -1, 1>}
+  return
+}
+
+// -----
+
+func.func @bad_repeats_type(%ctx: !hip.context,
+                            %input: memref<2x3xf32, 1>,
+                            %repeats: memref<2xi32, 1>,
+                            %output: memref<4x9xf32, 1>) {
+  // expected-error @+1 {{repeats must be static-length rank-1 i64 matching input rank}}
+  hip.tile(%ctx)
+    ins(%input, %repeats : memref<2x3xf32, 1>, memref<2xi32, 1>)
+    outs(%output : memref<4x9xf32, 1>)
+    {static_repeats = array<i64: 2, 3>}
+  return
+}
+
+// -----
+
+func.func @repeat_product_overflow(
+    %ctx: !hip.context,
+    %input: memref<2xf32, 1>,
+    %repeats: memref<1xi64, 1>,
+    %output: memref<?xf32, 1>) {
+  // expected-error @+1 {{static_repeats must match input rank and be non-negative}}
+  hip.tile(%ctx)
+    ins(%input, %repeats : memref<2xf32, 1>, memref<1xi64, 1>)
+    outs(%output : memref<?xf32, 1>)
+    {static_repeats = array<i64: 9223372036854775807>}
+  return
+}
+
+// -----
+
+func.func @repeat_product_i64_boundary(
+    %ctx: !hip.context,
+    %input: memref<1xf32, 1>,
+    %repeats: memref<1xi64, 1>,
+    %output: memref<9223372036854775807xf32, 1>) {
+  hip.tile(%ctx)
+    ins(%input, %repeats : memref<1xf32, 1>, memref<1xi64, 1>)
+    outs(%output : memref<9223372036854775807xf32, 1>)
+    {static_repeats = array<i64: 9223372036854775807>}
+  return
+}

--- a/test/lit/e2e/test_tile_model.mlir
+++ b/test/lit/e2e/test_tile_model.mlir
@@ -4,15 +4,16 @@
 // CHECK-SAME: hipdnn.input_count = 2
 // CHECK-SAME: hipdnn.output_count = 1
 // CHECK: llvm.func @wrap_tile
+// CHECK: llvm.func @hipdnn_ep_readback_shape_i64
 // CHECK: llvm.func @inference_init
 // CHECK: llvm.func @inference_compute
 // CHECK: llvm.func @inference_cleanup
 // CHECK: llvm.func @inference_get_metadata_json
 // CHECK-NOT: onnx.Tile
 module {
-  func.func @main_graph(%arg0: tensor<2x3xf32> {onnx.name = "input"}, %arg1: tensor<2xi64> {onnx.name = "repeats"}) -> (tensor<4x9xf32> {onnx.name = "output"}) {
-    %0 = "onnx.Tile"(%arg0, %arg1) {onnx_node_name = "tile_node"} : (tensor<2x3xf32>, tensor<2xi64>) -> tensor<4x9xf32>
-    "onnx.Return"(%0) : (tensor<4x9xf32>) -> ()
+  func.func @main_graph(%arg0: tensor<2x3xf32> {onnx.name = "input"}, %arg1: tensor<2xi64> {onnx.name = "repeats"}) -> (tensor<?x?xf32> {onnx.name = "output"}) {
+    %0 = "onnx.Tile"(%arg0, %arg1) {onnx_node_name = "tile_node"} : (tensor<2x3xf32>, tensor<2xi64>) -> tensor<?x?xf32>
+    "onnx.Return"(%0) : (tensor<?x?xf32>) -> ()
   }
   "onnx.EntryPoint"() {func = @main_graph} : () -> ()
 }

--- a/test/lit/e2e/test_tile_model.mlir
+++ b/test/lit/e2e/test_tile_model.mlir
@@ -4,7 +4,7 @@
 // CHECK-SAME: hipdnn.input_count = 2
 // CHECK-SAME: hipdnn.output_count = 1
 // CHECK: llvm.func @wrap_tile
-// CHECK: llvm.func @hipdnn_ep_readback_shape_i64
+// CHECK: llvm.func @hipdnn_ep_readback_scalar
 // CHECK: llvm.func @inference_init
 // CHECK: llvm.func @inference_compute
 // CHECK: llvm.func @inference_cleanup

--- a/test/numeric/tests/test_shape_ops.py
+++ b/test/numeric/tests/test_shape_ops.py
@@ -233,6 +233,15 @@ def _make_tile_model(dtype, input_shape: list[int], repeats: list[int]):
     return make_model_from_nodes([node], [X], [Y], initializers=[repeats_init])
 
 
+def _make_tile_runtime_repeats_model(dtype, rank: int):
+    tp = np_to_onnx_type(dtype)
+    X = helper.make_tensor_value_info("X", tp, [None] * rank)
+    repeats = helper.make_tensor_value_info("repeats", TensorProto.INT64, [rank])
+    Y = helper.make_tensor_value_info("Y", tp, [None] * rank)
+    node = helper.make_node("Tile", ["X", "repeats"], ["Y"])
+    return make_model_from_nodes([node], [X, repeats], [Y])
+
+
 class TestTile:
     @pytest.mark.parametrize(
         "dtype,shape,repeats",
@@ -251,6 +260,14 @@ class TestTile:
         else:
             x = rng.uniform(-2.0, 2.0, shape).astype(dtype)
         actual, expected = model_runner.run_sample(model, [x])
+        compare_outputs(actual, expected, atol=0)
+
+    @pytest.mark.parametrize("repeats", [[2, 3], [0, 1]])
+    def test_tile_runtime_repeats(self, model_runner, repeats):
+        model = _make_tile_runtime_repeats_model(np.float32, rank=2)
+        x = np.arange(6, dtype=np.float32).reshape(2, 3)
+        repeats_array = np.array(repeats, dtype=np.int64)
+        actual, expected = model_runner.run_sample(model, [x, repeats_array])
         compare_outputs(actual, expected, atol=0)
 
 


### PR DESCRIPTION
## Why

`Range` and `Tile` can derive allocation sizes from device payloads. Reading controls one scalar at a time, performing unchecked size arithmetic, or trusting an imported static descriptor can allocate the wrong buffer; a wrapper failure is also unsafe unless generated inference can observe it.

This PR folds visible constants directly, but routes runtime Range controls and Tile repeats through one status-bearing grouped readback per operation. Checked allocation ops validate readback status, Range count arithmetic, Tile extent and total-element overflow, and agreement with static result descriptors before allocation. Failures produce zero-safe extents and set the shared runtime error state.

## IR example

Runtime-controlled shapes use one grouped readback followed by checked sizing:

```mlir
func.func @checked_payload_sizes(
    %ctx: !hip.context, %start: tensor<i64>, %limit: tensor<i64>,
    %delta: tensor<i64>, %input0: index, %input1: index,
    %repeats: tensor<2xi64>) -> (index, index) {
  %c0 = arith.constant 0 : index
  %c1 = arith.constant 1 : index
  %range:4 = hip.readback_control(
      %ctx, %start, %limit, %delta : tensor<i64>, tensor<i64>, tensor<i64>)
      -> (i1, i64, i64, i64)
  %count = hip.checked_range_count(
      %ctx, %range#0, %range#1, %range#2, %range#3)
      data_type = 4 expected_count = -1 -> index

  %tile:3 = hip.readback_control(%ctx, %repeats : tensor<2xi64>)
      -> (i1, i64, i64)
  %v0, %extent0, %elements0 = hip.checked_tile_extent(
      %ctx, %tile#0, %input0, %tile#1, %c1)
      expected_extent = -1 -> (i1, index, index)
  %v1, %extent1, %elements1 = hip.checked_tile_extent(
      %ctx, %v0, %input1, %tile#2, %elements0)
      expected_extent = 1152 -> (i1, index, index)
  %safe0 = arith.select %v1, %extent0, %c0 : index
  return %count, %safe0 : index, index
}
```

## What changes

- Share Tile and Range infer/reify rules across conversion, reification, and verification.
- Fold constant repeats and Range controls without device readback.
- Read all runtime Range controls or Tile repeats through one status-bearing grouped boundary.
- Validate zero delta, non-finite controls, signed/count overflow, and static Range-count contradictions.
- Chain checked Tile extent and total-element products, validate static descriptor extents, and zero unsafe dimensions.
- Record readback, sizing, descriptor, and launch failures in the shared runtime error state.
- Add focused conversion, lowering, runtime, end-to-end, and numeric coverage.

## Stack

Merged prerequisite plus the 22 active shape PRs:

1. [#688 — refactor(hip): externalize constants after ONNX conversion](https://github.com/ROCm/hip-ep/pull/688)
2. [#724 — feat(shape): preserve symbolic compiler inputs](https://github.com/ROCm/hip-ep/pull/724)
3. [#639 — refactor(hip): establish shared shape-rule foundation](https://github.com/ROCm/hip-ep/pull/639)
4. [#681 — fix(shape): canonicalize host reshape provenance](https://github.com/ROCm/hip-ep/pull/681)
5. [#725 — fix(shape): activate exact broadcasts with symbolic proofs](https://github.com/ROCm/hip-ep/pull/725)
6. [#734 — fix(shape): share MatMul and Gemm contracts](https://github.com/ROCm/hip-ep/pull/734)
7. [#641 — fix(shape): enforce shared broadcast contracts](https://github.com/ROCm/hip-ep/pull/641)
8. [#735 — refactor(conversion): share ONNX reduction conversion](https://github.com/ROCm/hip-ep/pull/735)
9. [#736 — fix(shape): normalize reduction contracts](https://github.com/ROCm/hip-ep/pull/736)
10. [#643 — fix(shape): share convolution contracts](https://github.com/ROCm/hip-ep/pull/643)
11. [#742 — fix(shape): share causal convolution contracts](https://github.com/ROCm/hip-ep/pull/742)
12. [#645 — fix(shape): share normalization contracts](https://github.com/ROCm/hip-ep/pull/645)
13. [#740 — fix(shape): share attention contracts](https://github.com/ROCm/hip-ep/pull/740)
14. [#741 — fix(shape): share GQA capacity contracts](https://github.com/ROCm/hip-ep/pull/741)
15. [#644 — fix(shape): share gather and tensor contracts](https://github.com/ROCm/hip-ep/pull/644)
16. [#727 — feat(shape): consume constant payload shapes directly](https://github.com/ROCm/hip-ep/pull/727)
17. [#728 — feat(shape): add exact Tile and Range destinations](https://github.com/ROCm/hip-ep/pull/728) ← this PR
18. [#646 — refactor(hip): declare explicit DPS shape contracts](https://github.com/ROCm/hip-ep/pull/646)
19. [#730 — test(hip): audit explicit DPS contract inventory](https://github.com/ROCm/hip-ep/pull/730)
20. [#732 — test(hip): audit ONNX converter deduplication](https://github.com/ROCm/hip-ep/pull/732)
21. [#647 — fix(hip): harden shape refinement failure handling](https://github.com/ROCm/hip-ep/pull/647)
22. [#761 — refactor(hip): split shape utility headers by family](https://github.com/ROCm/hip-ep/pull/761)
23. [#764 — refactor(hip): clarify shape destination authority](https://github.com/ROCm/hip-ep/pull/764)

## AI assistance

AI tools assisted with the shared shape rules, tests, and stack preparation. The contributor reviewed the resulting code.

Made-with: Cursor
