### PR TITLE
test(hip): audit explicit DPS contract inventory

### DIFF
--- a/docs/design/hip-shape-contract-inventory.md
+++ b/docs/design/hip-shape-contract-inventory.md
@@ -4,7 +4,14 @@ Licensed under the MIT License.
 -->
 # HIP shape contract inventory
 
-This ledger is the reviewed classification for every HIP DPS op. `test/lit/Dialect/hip-shape-contract-inventory.mlir` cross-checks the op and contract columns against TableGen. Status entries are migration work, not separate contract categories. Every leaf must inherit exactly one explicit contract base: `Hip_DpsOp_SameShape`, `Hip_DpsOp_Broadcast`, `Hip_DpsOp_Reduction`, `Hip_DpsOp_Semantic`, `Hip_DpsOp_Payload`, or `Hip_DpsOp_OutsAuthoritative`. The default local build runs the audit and fails when a DPS leaf uses `Hip_DpsOp` directly, mismatches the inventory, or bypasses the required verifier/reify policy.
+This ledger is the reviewed classification for every HIP DPS op.
+`test/lit/Dialect/hip-shape-contract-inventory.mlir` cross-checks the op and
+contract columns against TableGen. Status entries are migration work, not
+separate contract categories. Every leaf must inherit exactly one explicit
+same-shape, broadcast, reduction, semantic, payload, or outs-authoritative
+behavior family. The default local build runs the audit and fails when a DPS
+leaf uses `Hip_DpsOp` directly, selects multiple families, mismatches the
+inventory, or omits verifier wiring required by its family.
 
 The audit resolves the actual TableGen interface traits rather than inferring
 DPS status from `Hip_DpsOp` inheritance. Constant carriers, synchronized
@@ -17,15 +24,14 @@ implement the compute-only `HipDpsOpInterface` reifier contract. Adding a
 compute DPS contract without both interfaces, or leaving any direct
 destination-style HIP op unclassified, fails the audit.
 
-The Python checkers are repository-convention guards, not C++ semantic
-analyzers. They resolve TableGen records exactly, then tokenize the limited C++
-forms used in this tree: direct/static and `OpBuilder::create` empty builders,
-simple `using`/`typedef` aliases, straightforward assignment aliases, and
-destination-rooted mixed-size call chains. Supported forms are fail-closed:
-every occurrence must match its reviewed count, and an unreviewed occurrence
-fails. Arbitrary templates, macros, overload resolution, and general C++ data
-flow remain compiler/code-review responsibilities; the tests must not describe
-the token checkers as proof for those cases.
+The audit consumes `llvm-tblgen --dump-json`: superclass identity, generated
+interface traits, contract metadata, named same-shape sources, and
+`hasVerifier` are checked as structured records. Verifier-bearing families set
+`hasVerifier` in their TableGen base, so ODS emits the verifier declaration and
+dispatch; C++ compilation/linking rejects a missing implementation. Focused
+`--verify-diagnostics` and reification LIT fixtures test semantic behavior.
+The inventory audit deliberately does not infer C++ control or data flow and
+does not claim that every handwritten reifier is free of destination fallback.
 
 | HIP control op | Classification | Destination/result policy |
 |---|---|---|
@@ -51,12 +57,12 @@ the token checkers as proof for those cases.
 | `expand` | `payload` | Target shape tensor; constant fold or synchronized readback | audited payload policy |
 | `fast_gelu` | `same_shape` | Result shape equals `input` | shared named-source base |
 | `gather` | `semantic` | data prefix + indices shape + data suffix | shared infer/reify/verifier |
-| `gather_block_quantized` | `semantic` | Gather over logical data; byte-packed int4 doubles the surviving quantize-axis extent | shared infer/reify/verifier |
+| `gather_block_quantized` | `outs_authoritative` | Existing converter destination remains authoritative until the runtime-tail semantic/signedness layer | audited outs-authoritative |
 | `gather_elements` | `same_shape` | Result shape equals `indices` | shared named-source base |
 | `gather_nd` | `semantic` | data batch prefix + indices outer dims + data tail | shared infer/reify/verifier; dynamic tuple width uses outs fallback |
 | `gelu` | `same_shape` | Result shape equals `input` | shared named-source base |
 | `gemm` | `semantic` | Transpose-aware M/N from A/B; C validates only | shared |
-| `global_pool` | `semantic` | N/C from input; every spatial result extent is 1 | shared infer/reify/verifier |
+| `global_pool` | `outs_authoritative` | Existing converter destination remains authoritative until the pooling semantic layer | audited outs-authoritative |
 | `gqa` | `semantic` | Output follows query; present BNSH capacity is `max(matching past dim 2, total_seq_len)` (or logical length alone without past); optional QK stays `[B,H,Sq,logical Skv]` | shared converter extent utility + payload fallback + partial static verifier |
 | `hipdnn_graph` | `outs_authoritative` | Outlined hipDNN graph owns output metadata | audited outs-authoritative |
 | `layer_norm` | `semantic` | Y=input shape; Mean/InvStdDev=keepdims reduction at axis | shared |
@@ -79,7 +85,7 @@ the token checkers as proof for those cases.
 | `one_hot` | `payload` | Inserted axis extent comes from depth payload readback | audited payload policy |
 | `or` | `broadcast` | NumPy right-aligned broadcast over declared inputs | shared |
 | `pad` | `payload` | Dense carrier pads use exact affine input extents; runtime pads use synchronized converter readback and outs reify | affine refinement complete |
-| `pool` | `semantic` | N/C from input plus ONNX pooling spatial formula; optional indices match values | shared infer/reify/verifier |
+| `pool` | `outs_authoritative` | Existing converter destination remains authoritative until the pooling semantic/runtime split | audited outs-authoritative |
 | `qmoe` | `same_shape` | Result shape equals `input` | shared named-source base |
 | `range` | `payload` | Length depends on start/limit/delta payload values | audited payload policy |
 | `reciprocal` | `same_shape` | Result shape equals `input` | shared named-source base |
@@ -100,12 +106,12 @@ the token checkers as proof for those cases.
 | `sin` | `same_shape` | Result shape equals `input` | shared named-source base |
 | `size` | `semantic` | Rank-zero scalar result | shared infer/converter/verifier |
 | `skip_rms_norm` | `semantic` | Output and optional residual equal input; training stats unsupported | shared infer/reify/verifier |
-| `slice` | `payload` | Constant controls use exact static/SSA normalization; runtime i32/i64 controls use one grouped readback and exact extents | complete; exact grouped control readback |
+| `slice` | `payload` | Existing constant-fold-or-destination fallback remains authoritative until the exact-Slice runtime tail | audited payload policy |
 | `softplus` | `same_shape` | Result shape equals `input` | shared named-source base |
 | `sqrt` | `same_shape` | Result shape equals `input` | shared named-source base |
 | `sub` | `broadcast` | NumPy right-aligned broadcast over declared inputs | shared |
 | `tanh` | `same_shape` | Result shape equals `input` | shared named-source base |
-| `tile` | `payload` | Each extent=inputDim*repeats payload | refinement complete; shared constant rule + one bulk runtime readback |
+| `tile` | `payload` | Each extent is inputDim multiplied by a constant or synchronized runtime repeat | audited payload policy |
 | `top_k` | `payload` | Selected axis extent comes from K payload | audited payload policy |
 | `transpose` | `semantic` | output[i] = input[perm[i]] | shared infer/reify/verifier |
 | `where` | `broadcast` | NumPy right-aligned broadcast over declared inputs | shared |
@@ -126,6 +132,11 @@ making its reviewed policy explicit. `Hip_DpsOp_SameShape` additionally records
 the named source accessor and generates reification plus structural DPS and
 static output verification. No DPS leaf may inherit `Hip_DpsOp` directly or
 retain `unclassified` in TableGen.
+
+Semantic families and the `SameShapeManualVerify` and
+`PayloadManualVerify` variants request verifier generation structurally.
+Their handwritten verifier definitions remain ordinary C++ checked by the
+compiler and by operation-specific negative LIT fixtures.
 
 Every `broadcast` and `reduction` row inherits a generated verifier from its
 parameterized TableGen base. Those verifiers compose the full structural DPS

--- a/docs/design/hip-shape-contract-inventory.md
+++ b/docs/design/hip-shape-contract-inventory.md
@@ -43,6 +43,7 @@ does not claim that every handwritten reifier is free of destination fallback.
 | `abs` | `same_shape` | Result shape equals `input` | shared named-source base |
 | `add` | `broadcast` | NumPy right-aligned broadcast over declared inputs | shared |
 | `and` | `broadcast` | NumPy right-aligned broadcast over declared inputs | shared |
+| `atan` | `same_shape` | Result shape equals `x` | shared named-source base |
 | `bias_gelu` | `same_shape` | Result shape equals `data` | shared named-source base |
 | `cast` | `same_shape` | Result shape equals `input` | shared named-source base |
 | `causal_conv_with_state` | `semantic` | Runtime-supported 1D: output=input; state `[B,C,weight.K-1]` | shared infer/reify/verifier |
@@ -54,9 +55,11 @@ does not claim that every handwritten reifier is free of destination fallback.
 | `cumsum` | `same_shape` | Result shape equals `x` | shared named-source base |
 | `div` | `broadcast` | NumPy right-aligned broadcast over declared inputs | shared |
 | `equal` | `broadcast` | NumPy right-aligned broadcast over declared inputs | shared |
+| `erf` | `same_shape` | Result shape equals `x` | shared named-source base |
 | `exp` | `same_shape` | Result shape equals `input` | shared named-source base |
 | `expand` | `payload` | Target shape tensor; constant fold or synchronized readback | audited payload policy |
 | `fast_gelu` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `floor` | `same_shape` | Result shape equals `x` | shared named-source base |
 | `gather` | `semantic` | data prefix + indices shape + data suffix | shared infer/reify/verifier |
 | `gather_block_quantized` | `outs_authoritative` | Existing converter destination remains authoritative until the runtime-tail semantic/signedness layer | audited outs-authoritative |
 | `gather_elements` | `same_shape` | Result shape equals `indices` | shared named-source base |
@@ -65,7 +68,9 @@ does not claim that every handwritten reifier is free of destination fallback.
 | `gemm` | `semantic` | Transpose-aware M/N from A/B; C validates only | shared |
 | `global_pool` | `outs_authoritative` | Existing converter destination remains authoritative until the pooling semantic layer | audited outs-authoritative |
 | `gqa` | `semantic` | Output follows query; present BNSH capacity is `max(matching past dim 2, total_seq_len)` (or logical length alone without past); optional QK stays `[B,H,Sq,logical Skv]` | shared converter extent utility + payload fallback + partial static verifier |
+| `grid_sample` | `semantic` | Output `[input.N, input.C, grid.H_out, grid.W_out]` | destination-based reify + manual verifier |
 | `hipdnn_graph` | `outs_authoritative` | Outlined hipDNN graph owns output metadata | audited outs-authoritative |
+| `instance_norm` | `same_shape` | Result shape equals `input` | shared named-source base |
 | `layer_norm` | `semantic` | Y=input shape; Mean/InvStdDev=keepdims reduction at axis | shared |
 | `leaky_relu` | `same_shape` | Result shape equals `x` | shared named-source base |
 | `less` | `broadcast` | NumPy right-aligned broadcast over declared inputs | shared |
@@ -99,6 +104,7 @@ does not claim that every handwritten reifier is free of destination fallback.
 | `resize` | `semantic` | N/C from input; static spatial extents from imported output template because sizes/scales are not carried | shared infer/reify/verifier |
 | `rms_norm` | `same_shape` | Result shape equals `input` | shared named-source base |
 | `rope` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `round` | `same_shape` | Result shape equals `x` | shared named-source base |
 | `scatter_elements` | `same_shape` | Result shape equals `data` | shared named-source base |
 | `scatter_nd` | `same_shape` | Result shape equals `data` | shared named-source base |
 | `sigmoid` | `same_shape` | Result shape equals `input` | shared named-source base |

--- a/docs/design/hip-shape-contract-inventory.md
+++ b/docs/design/hip-shape-contract-inventory.md
@@ -36,6 +36,7 @@ does not claim that every handwritten reifier is free of destination fallback.
 | HIP control op | Classification | Destination/result policy |
 |---|---|---|
 | `if` | `control_flow_dps` | Each tensor result is tied to the matching `o_init`; memref mode writes branch results through those destinations |
+| `loop` | `control_flow_dps` | Tensor loop-carried results are tied positionally to `v_init`; outlined-body signatures preserve those carrier slots |
 
 | HIP op | Contract | Shape rule / payload policy | Status |
 |---|---|---|---|
@@ -111,7 +112,7 @@ does not claim that every handwritten reifier is free of destination fallback.
 | `sqrt` | `same_shape` | Result shape equals `input` | shared named-source base |
 | `sub` | `broadcast` | NumPy right-aligned broadcast over declared inputs | shared |
 | `tanh` | `same_shape` | Result shape equals `input` | shared named-source base |
-| `tile` | `payload` | Each extent is inputDim multiplied by a constant or synchronized runtime repeat | audited payload policy |
+| `tile` | `payload` | Each extent is inputDim multiplied by a constant or synchronized per-entry runtime repeat | audited payload policy |
 | `top_k` | `payload` | Selected axis extent comes from K payload | audited payload policy |
 | `transpose` | `semantic` | output[i] = input[perm[i]] | shared infer/reify/verifier |
 | `where` | `broadcast` | NumPy right-aligned broadcast over declared inputs | shared |

--- a/docs/design/hip-shape-contract-inventory.md
+++ b/docs/design/hip-shape-contract-inventory.md
@@ -1,0 +1,136 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+# HIP shape contract inventory
+
+This ledger is the reviewed classification for every HIP DPS op. `test/lit/Dialect/hip-shape-contract-inventory.mlir` cross-checks the op and contract columns against TableGen. Status entries are migration work, not separate contract categories. Every leaf must inherit exactly one explicit contract base: `Hip_DpsOp_SameShape`, `Hip_DpsOp_Broadcast`, `Hip_DpsOp_Reduction`, `Hip_DpsOp_Semantic`, `Hip_DpsOp_Payload`, or `Hip_DpsOp_OutsAuthoritative`. The default local build runs the audit and fails when a DPS leaf uses `Hip_DpsOp` directly, mismatches the inventory, or bypasses the required verifier/reify policy.
+
+The audit resolves the actual TableGen interface traits rather than inferring
+DPS status from `Hip_DpsOp` inheritance. Constant carriers, synchronized
+readbacks, allocation/frame ownership operations, and `hip.loop` do not
+implement `DestinationStyleOpInterface`; they have no DPS init and no
+result-shape contract to inventory. `hip.if` is different: it directly
+implements `DestinationStyleOpInterface`, ties each tensor result to an
+`o_init`, and is inventoried separately as control-flow DPS because it does not
+implement the compute-only `HipDpsOpInterface` reifier contract. Adding a
+compute DPS contract without both interfaces, or leaving any direct
+destination-style HIP op unclassified, fails the audit.
+
+The Python checkers are repository-convention guards, not C++ semantic
+analyzers. They resolve TableGen records exactly, then tokenize the limited C++
+forms used in this tree: direct/static and `OpBuilder::create` empty builders,
+simple `using`/`typedef` aliases, straightforward assignment aliases, and
+destination-rooted mixed-size call chains. Supported forms are fail-closed:
+every occurrence must match its reviewed count, and an unreviewed occurrence
+fails. Arbitrary templates, macros, overload resolution, and general C++ data
+flow remain compiler/code-review responsibilities; the tests must not describe
+the token checkers as proof for those cases.
+
+| HIP control op | Classification | Destination/result policy |
+|---|---|---|
+| `if` | `control_flow_dps` | Each tensor result is tied to the matching `o_init`; memref mode writes branch results through those destinations |
+
+| HIP op | Contract | Shape rule / payload policy | Status |
+|---|---|---|---|
+| `abs` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `add` | `broadcast` | NumPy right-aligned broadcast over declared inputs | shared |
+| `and` | `broadcast` | NumPy right-aligned broadcast over declared inputs | shared |
+| `bias_gelu` | `same_shape` | Result shape equals `data` | shared named-source base |
+| `cast` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `causal_conv_with_state` | `semantic` | Runtime-supported 1D: output=input; state `[B,C,weight.K-1]` | shared infer/reify/verifier |
+| `ceil` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `compress` | `payload` | Selected count comes from condition payload; outs/reify policy | audited payload policy |
+| `conv` | `semantic` | N from input, C from weights, ONNX spatial convolution formula | shared infer/reify/verifier |
+| `conv_transpose` | `semantic` | N from input, C=weights[1]*group, ONNX transpose formula | shared |
+| `cos` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `cumsum` | `same_shape` | Result shape equals `x` | shared named-source base |
+| `div` | `broadcast` | NumPy right-aligned broadcast over declared inputs | shared |
+| `equal` | `broadcast` | NumPy right-aligned broadcast over declared inputs | shared |
+| `exp` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `expand` | `payload` | Target shape tensor; constant fold or synchronized readback | audited payload policy |
+| `fast_gelu` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `gather` | `semantic` | data prefix + indices shape + data suffix | shared infer/reify/verifier |
+| `gather_block_quantized` | `semantic` | Gather over logical data; byte-packed int4 doubles the surviving quantize-axis extent | shared infer/reify/verifier |
+| `gather_elements` | `same_shape` | Result shape equals `indices` | shared named-source base |
+| `gather_nd` | `semantic` | data batch prefix + indices outer dims + data tail | shared infer/reify/verifier; dynamic tuple width uses outs fallback |
+| `gelu` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `gemm` | `semantic` | Transpose-aware M/N from A/B; C validates only | shared |
+| `global_pool` | `semantic` | N/C from input; every spatial result extent is 1 | shared infer/reify/verifier |
+| `gqa` | `semantic` | Output follows query; present BNSH capacity is `max(matching past dim 2, total_seq_len)` (or logical length alone without past); optional QK stays `[B,H,Sq,logical Skv]` | shared converter extent utility + payload fallback + partial static verifier |
+| `hipdnn_graph` | `outs_authoritative` | Outlined hipDNN graph owns output metadata | audited outs-authoritative |
+| `layer_norm` | `semantic` | Y=input shape; Mean/InvStdDev=keepdims reduction at axis | shared |
+| `leaky_relu` | `same_shape` | Result shape equals `x` | shared named-source base |
+| `less` | `broadcast` | NumPy right-aligned broadcast over declared inputs | shared |
+| `linear_attention` | `semantic` | Output `[B,T,max(Hq,Hkv)*Dv]`; state `[B,Hkv,Dk,Dv]` | shared infer/reify/verifier |
+| `log` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `matmul` | `semantic` | Broadcasted batch + M from A + N from B | shared |
+| `matmul_nbits` | `semantic` | A leading dims plus static N attribute | shared infer/reify/verifier |
+| `max` | `broadcast` | NumPy right-aligned broadcast over declared inputs | shared |
+| `min` | `broadcast` | NumPy right-aligned broadcast over declared inputs | shared |
+| `miopen.add` | `broadcast` | NumPy right-aligned broadcast over declared inputs | shared |
+| `miopen.softmax` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `mod` | `broadcast` | NumPy right-aligned broadcast over declared inputs | shared |
+| `mul` | `broadcast` | NumPy right-aligned broadcast over declared inputs | shared |
+| `multi_head_attention` | `semantic` | Default runtime: separate rank-3 fp16 Q/K/V; output exactly query shape; no optional inputs/outputs | shared infer/reify/verifier; GQA forms routed before default |
+| `neg` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `nonzero` | `payload` | Capacity from input numel; true count produced at runtime | audited payload policy |
+| `not` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `one_hot` | `payload` | Inserted axis extent comes from depth payload readback | audited payload policy |
+| `or` | `broadcast` | NumPy right-aligned broadcast over declared inputs | shared |
+| `pad` | `payload` | Dense carrier pads use exact affine input extents; runtime pads use synchronized converter readback and outs reify | affine refinement complete |
+| `pool` | `semantic` | N/C from input plus ONNX pooling spatial formula; optional indices match values | shared infer/reify/verifier |
+| `qmoe` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `range` | `payload` | Length depends on start/limit/delta payload values | audited payload policy |
+| `reciprocal` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `reduce_l2` | `reduction` | ONNX axes/keepdims/noop reduction shape | shared |
+| `reduce_max` | `reduction` | ONNX axes/keepdims/noop reduction shape | shared |
+| `reduce_mean` | `reduction` | ONNX axes/keepdims/noop reduction shape | shared |
+| `reduce_min` | `reduction` | ONNX axes/keepdims/noop reduction shape | shared |
+| `reduce_prod` | `reduction` | ONNX axes/keepdims/noop reduction shape | shared |
+| `reduce_sum` | `reduction` | ONNX axes/keepdims/noop reduction shape | shared |
+| `resize` | `semantic` | N/C from input; static spatial extents from imported output template because sizes/scales are not carried | shared infer/reify/verifier |
+| `rms_norm` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `rope` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `scatter_elements` | `same_shape` | Result shape equals `data` | shared named-source base |
+| `scatter_nd` | `same_shape` | Result shape equals `data` | shared named-source base |
+| `sigmoid` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `sign` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `silu` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `sin` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `size` | `semantic` | Rank-zero scalar result | shared infer/converter/verifier |
+| `skip_rms_norm` | `semantic` | Output and optional residual equal input; training stats unsupported | shared infer/reify/verifier |
+| `slice` | `payload` | Constant controls use exact static/SSA normalization; runtime i32/i64 controls use one grouped readback and exact extents | complete; exact grouped control readback |
+| `softplus` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `sqrt` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `sub` | `broadcast` | NumPy right-aligned broadcast over declared inputs | shared |
+| `tanh` | `same_shape` | Result shape equals `input` | shared named-source base |
+| `tile` | `payload` | Each extent=inputDim*repeats payload | refinement complete; shared constant rule + one bulk runtime readback |
+| `top_k` | `payload` | Selected axis extent comes from K payload | audited payload policy |
+| `transpose` | `semantic` | output[i] = input[perm[i]] | shared infer/reify/verifier |
+| `where` | `broadcast` | NumPy right-aligned broadcast over declared inputs | shared |
+
+## Contract meanings
+
+- `same_shape`: result shape equals one named input; converter/reify/verifier use that source.
+- `broadcast`: shared NumPy broadcast rule.
+- `reduction`: shared ONNX axes/keepdims rule.
+- `semantic`: dedicated operand/attribute formula.
+- `payload`: output shape depends on tensor payload values and uses an explicit constant-fold/readback/runtime policy.
+- `outs_authoritative`: the converter/runtime graph owns correct output metadata and reify intentionally lifts outs.
+
+Every row must inherit the exact explicit base for its contract. The three
+mechanical bases generate their shared shape behavior; the semantic, payload,
+and outs-authoritative wrappers only preserve the leaf's existing options while
+making its reviewed policy explicit. `Hip_DpsOp_SameShape` additionally records
+the named source accessor and generates reification plus structural DPS and
+static output verification. No DPS leaf may inherit `Hip_DpsOp` directly or
+retain `unclassified` in TableGen.
+
+Every `broadcast` and `reduction` row inherits a generated verifier from its
+parameterized TableGen base. Those verifiers compose the full structural DPS
+contract (uniform tensor/memref mode and tensor result/init parity) before
+checking shape semantics. Broadcast verifies all statically decidable extents.
+Reduction verifies exact output shape only for compile-time axes; payload-
+dynamic axes retain the converter-selected outs shape after rank, dtype, and
+attribute validation.

--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -200,6 +200,21 @@ Frontend-neutral destination construction lives in
 lookup. `OnnxToHipUtils` retains only ONNX import semantics and wrappers, so a
 future frontend can target HIP without depending on the ONNX conversion layer.
 
+
+The same-shape inventory guard requires every `same_shape` op to use a
+generated named-source family. Converter destinations materialize this contract
+with `createSameShapeEmptyTensor`, so dynamic extents and static compatibility
+come from the same source as reification and verification.
+
+Every HIP compute DPS op has one reviewed category in
+[hip-shape-contract-inventory.md](hip-shape-contract-inventory.md). TableGen's
+`hipShapeContract` field is source-level inventory metadata, not emitted IR.
+The audit resolves `DestinationStyleOpInterface` and the exact behavior-family
+superclass from `llvm-tblgen --dump-json`; it rejects unclassified compute DPS,
+incorrectly labeled non-DPS infrastructure, and missing family-required
+verifier wiring. Focused negative LIT fixtures validate handwritten verifier
+and reifier behavior.
+
 Pure descriptor transformations such as Reshape, Squeeze, and Unsqueeze
 generally lower to standard tensor operations rather than HIP DPS compute
 operations. Their result-extent inference and dim folding use MLIR's standard

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -128,6 +128,7 @@ class Hip_DpsOp_Semantic<string mnemonic,
     Hip_DpsOp_WithInfer<mnemonic, outsAccessor, traits> {
   let hipShapeContract = "semantic";
   let hipHasExplicitShapeContract = 1;
+  let hasVerifier = 1;
 }
 
 /// Multi-result semantic operation with handwritten reification.
@@ -136,14 +137,17 @@ class Hip_DpsOp_SemanticNoInfer<string mnemonic,
     Hip_DpsOp<mnemonic, traits> {
   let hipShapeContract = "semantic";
   let hipHasExplicitShapeContract = 1;
+  let hasVerifier = 1;
 }
 
 /// Semantic operation using the default destination-based reification only.
-class Hip_DpsOp_SemanticAutoReify<string mnemonic,
-                                  list<Trait> traits = []> :
+/// Semantic operation with destination reification and handwritten verifier.
+class Hip_DpsOp_SemanticAutoReifyManualVerify<
+    string mnemonic, list<Trait> traits = []> :
     Hip_DpsOp_AutoReify<mnemonic, traits> {
   let hipShapeContract = "semantic";
   let hipHasExplicitShapeContract = 1;
+  let hasVerifier = 1;
 }
 
 /// Semantic operation whose destination remains authoritative for reification.
@@ -153,6 +157,7 @@ class Hip_DpsOp_SemanticAutoReifyInfer<
     Hip_DpsOp_AutoReifyInfer<mnemonic, outsAccessor, traits> {
   let hipShapeContract = "semantic";
   let hipHasExplicitShapeContract = 1;
+  let hasVerifier = 1;
 }
 
 /// Single-result operations whose output shape equals one named input.
@@ -208,6 +213,16 @@ class Hip_DpsOp_Payload<string mnemonic,
     Hip_DpsOp_WithInfer<mnemonic, outsAccessor, traits> {
   let hipShapeContract = "payload";
   let hipHasExplicitShapeContract = 1;
+}
+
+/// Payload-shaped operation with an op-specific handwritten verifier.
+class Hip_DpsOp_PayloadManualVerify<string mnemonic,
+                                    list<Trait> traits = [],
+                                    string outsAccessor = "Output"> :
+    Hip_DpsOp_WithInfer<mnemonic, outsAccessor, traits> {
+  let hipShapeContract = "payload";
+  let hipHasExplicitShapeContract = 1;
+  let hasVerifier = 1;
 }
 
 class Hip_DpsOp_PayloadNoInfer<string mnemonic,
@@ -1122,7 +1137,7 @@ def Hip_QMoEOp :
 }
 
 def Hip_GatherBlockQuantizedOp :
-    Hip_DpsOp_SemanticAutoReify<"gather_block_quantized"> {
+    Hip_DpsOp_OutsAuthoritative<"gather_block_quantized"> {
   let summary = "Gather + block-wise dequantize "
                 "(com.microsoft GatherBlockQuantized)";
   let description = [{
@@ -3221,7 +3236,7 @@ def Hip_CausalConvWithStateOp :
 // ===== Group Query Attention =================================================
 
 def Hip_GqaOp :
-    Hip_DpsOp_SemanticAutoReify<"gqa",
+    Hip_DpsOp_SemanticAutoReifyManualVerify<"gqa",
                                 [AttrSizedOperandSegments,
                                  OpStateOpInterface]> {
   let summary = "Group Query Attention - Full MS spec implementation";
@@ -3922,8 +3937,8 @@ def Hip_PadOp :
 }
 
 def Hip_TileOp :
-    Hip_DpsOp_Payload<"tile", /*traits=*/[],
-                      /*outsAccessor=*/"Output"> {
+    Hip_DpsOp_PayloadManualVerify<"tile", /*traits=*/[],
+                                  /*outsAccessor=*/"Output"> {
   let summary = "Tile a tensor by repeating along each dimension";
   let description = [{
     Constructs a new tensor by repeating `input` along each dimension by the
@@ -3955,7 +3970,6 @@ def Hip_TileOp :
     attr-dict (`:` type($result_tensors)^)?
   }];
 
-  let hasVerifier = 1;
 }
 
 def Hip_ExpandOp :
@@ -3993,7 +4007,8 @@ def Hip_ExpandOp :
   }];
 }
 
-def Hip_GlobalPoolOp : Hip_DpsOp_AutoReify<"global_pool"> {
+def Hip_GlobalPoolOp :
+    Hip_DpsOp_OutsAuthoritative<"global_pool"> {
   let summary = "Global pooling over spatial dimensions (average / max / lp)";
   let description = [{
     Unified lowering for ONNX GlobalAveragePool / GlobalMaxPool / GlobalLpPool.
@@ -4420,7 +4435,7 @@ def Hip_NonZeroOp :
 }
 
 def Hip_PoolOp :
-    Hip_DpsOp_SemanticAutoReify<"pool"> {
+    Hip_DpsOp_OutsAuthoritative<"pool"> {
   let summary = "Spatial pooling (ONNX MaxPool / AveragePool / LpPool)";
   let description = [{
     Unified window pooling for ONNX MaxPool / AveragePool / LpPool. For an

--- a/test/lit/Dialect/hip-shape-contract-inventory.mlir
+++ b/test/lit/Dialect/hip-shape-contract-inventory.mlir
@@ -5,12 +5,10 @@
 // RUN:   --tblgen llvm-tblgen \
 // RUN:   --project-include %S/../../../include \
 // RUN:   --ops %S/../../../include/hip/Dialect/IR/HipOps.td \
-// RUN:   --inventory %S/../../../docs/design/hip-shape-contract-inventory.md \
-// RUN:   --reifiers %S/../../../lib/Dialect/IR/HipReifyResultShapesImpl.cpp \
-// RUN:   --verifiers %S/../../../lib/Dialect/IR/HipDialect.cpp
+// RUN:   --inventory %S/../../../docs/design/hip-shape-contract-inventory.md
 // RUN: %python %S/../Inputs/check_hip_shape_contracts.py --self-test
 
 // This file intentionally contains no IR. The RUN line verifies that every
 // HIP destination-style op is classified as compute or control-flow DPS, every
-// compute leaf inherits its exact reviewed shape-contract base, handwritten
-// outs-lift fallback is guarded by its verifier, and malformed fixtures fail.
+// compute leaf inherits its exact reviewed behavior family, verifier-bearing
+// families request generated verifier wiring, and malformed fixtures fail.

--- a/test/lit/Dialect/hip-shape-contract-inventory.mlir
+++ b/test/lit/Dialect/hip-shape-contract-inventory.mlir
@@ -1,0 +1,16 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: %python %S/../Inputs/check_hip_shape_contracts.py \
+// RUN:   --tblgen llvm-tblgen \
+// RUN:   --project-include %S/../../../include \
+// RUN:   --ops %S/../../../include/hip/Dialect/IR/HipOps.td \
+// RUN:   --inventory %S/../../../docs/design/hip-shape-contract-inventory.md \
+// RUN:   --reifiers %S/../../../lib/Dialect/IR/HipReifyResultShapesImpl.cpp \
+// RUN:   --verifiers %S/../../../lib/Dialect/IR/HipDialect.cpp
+// RUN: %python %S/../Inputs/check_hip_shape_contracts.py --self-test
+
+// This file intentionally contains no IR. The RUN line verifies that every
+// HIP destination-style op is classified as compute or control-flow DPS, every
+// compute leaf inherits its exact reviewed shape-contract base, handwritten
+// outs-lift fallback is guarded by its verifier, and malformed fixtures fail.

--- a/test/lit/Inputs/check_hip_shape_contracts.py
+++ b/test/lit/Inputs/check_hip_shape_contracts.py
@@ -3,13 +3,11 @@
 # Licensed under the MIT License.
 #
 
-"""Cross-check HIP op roles and repository-convention DPS contract patterns.
+"""Cross-check structural HIP DPS contracts against the reviewed inventory.
 
-The primary policy checks require exactly one explicit behavior family, reject
-bare DPS leaves, and audit semantic destination-shape fallbacks. Family-owned
-metadata consistency is intentionally secondary. Handwritten C++ checks
-tokenize supported in-tree forms and fail closed on count drift; they are not a
-general C++ parser.
+The checker consumes llvm-tblgen's JSON record graph. It does not parse C++:
+generated verifier declarations, C++ compilation/linking, and focused MLIR
+negative tests enforce method-level behavior.
 """
 
 from __future__ import annotations
@@ -22,74 +20,37 @@ import sys
 from pathlib import Path
 
 
-ALLOWED_CONTRACTS = {
-    "same_shape",
-    "broadcast",
-    "reduction",
-    "semantic",
-    "payload",
-    "outs_authoritative",
-}
-CONTRACT_BASES = {
-    "same_shape": (
+CONTRACT_FAMILIES = {
+    "same_shape": {
         "Hip_DpsOp_SameShape",
         "Hip_DpsOp_SameShapeManualVerify",
-    ),
-    "broadcast": ("Hip_DpsOp_Broadcast",),
-    "reduction": ("Hip_DpsOp_Reduction",),
-    "semantic": (
+    },
+    "broadcast": {"Hip_DpsOp_Broadcast"},
+    "reduction": {"Hip_DpsOp_Reduction"},
+    "semantic": {
         "Hip_DpsOp_Semantic",
         "Hip_DpsOp_SemanticNoInfer",
         "Hip_DpsOp_SemanticAutoReifyInfer",
-    ),
-    "payload": (
+        "Hip_DpsOp_SemanticAutoReifyManualVerify",
+    },
+    "payload": {
         "Hip_DpsOp_Payload",
+        "Hip_DpsOp_PayloadManualVerify",
         "Hip_DpsOp_PayloadNoInfer",
         "Hip_DpsOp_PayloadAutoReify",
-    ),
-    "outs_authoritative": ("Hip_DpsOp_OutsAuthoritative",),
+    },
+    "outs_authoritative": {"Hip_DpsOp_OutsAuthoritative"},
 }
-SEMANTIC_OUTS_REIFY_ALLOWLIST = {
-    "gather_nd": {
-        "status": "shared infer/reify/verifier; dynamic tuple width uses outs fallback",
-        "generated": 0,
-        "handwritten": 1,
-        "mixed_size": 0,
-        "cpp_class": "GatherNDOp",
-        "reifier_markers": ("if (failed(dims))",),
-        "verifier_markers": ("indicesType.isDynamicDim(indicesType.getRank() - 1)",),
-    },
-    "gqa": {
-        "status": (
-            "shared converter extent utility + payload fallback + partial "
-            "static verifier"
-        ),
-        "generated": 0,
-        "handwritten": 1,
-        "mixed_size": 0,
-        "cpp_class": "GqaOp",
-        "reifier_markers": (
-            "getPositionIds()",
-            "getOutputQk()",
-            "getQkOutput()",
-            "getSoftcap()",
-        ),
-        "verifier_markers": (
-            "getPositionIds()",
-            "getOutputQk()",
-            "getQkOutput()",
-            "getSoftcap()",
-        ),
-    },
-    "size": {
-        "status": "shared infer/converter/verifier",
-        "generated": 1,
-        "handwritten": 0,
-        "mixed_size": 0,
-        "cpp_class": "SizeOp",
-        "reifier_markers": (),
-        "verifier_markers": (),
-    },
+VERIFIER_FAMILIES = {
+    "Hip_DpsOp_SameShape",
+    "Hip_DpsOp_SameShapeManualVerify",
+    "Hip_DpsOp_Broadcast",
+    "Hip_DpsOp_Reduction",
+    "Hip_DpsOp_Semantic",
+    "Hip_DpsOp_SemanticNoInfer",
+    "Hip_DpsOp_SemanticAutoReifyInfer",
+    "Hip_DpsOp_SemanticAutoReifyManualVerify",
+    "Hip_DpsOp_PayloadManualVerify",
 }
 REVIEWED_POLICY_STATUSES = {
     "payload": {
@@ -100,121 +61,11 @@ REVIEWED_POLICY_STATUSES = {
     },
     "outs_authoritative": {"audited outs-authoritative"},
 }
-DEFAULT_OUTS_REIFY_MARKER = "::mlir::hip::HipDpsOp"
-HANDWRITTEN_OUTS_REIFY_MARKER = re.compile(r"\bcast<(?:::mlir::hip::)?HipDpsOp>")
 DPS_BASE = "Hip_DpsOp"
 HIP_OP_BASE = "Hip_Op"
 DESTINATION_STYLE_INTERFACE = "DestinationStyleOpInterface"
 INVENTORY_ROW = re.compile(r"^\| `([^`]+)` \| `([^`]+)` \|[^|]*\| ([^|]+) \|$")
 CONTROL_DPS_ROW = re.compile(r"^\| `([^`]+)` \| `control_flow_dps` \| ([^|]+) \|$")
-CPP_TOKEN = re.compile(
-    r"""
-    //[^\n]* | /\*.*?\*/ |
-    "(?:\\.|[^"\\])*" | '(?:\\.|[^'\\])*' |
-    :: | -> | == | != | <= | >= | && | \|\| |
-    [A-Za-z_]\w* | \d+ | \S
-    """,
-    re.DOTALL | re.VERBOSE,
-)
-DESTINATION_GETTERS = {
-    "getC",
-    "getDpsInit",
-    "getDpsInits",
-    "getOInit",
-    "getOutput",
-    "getOutputs",
-    "getResult",
-    "getResultTensors",
-    "getY",
-}
-MIXED_SIZE_CALLS = {"getMixedSize", "getMixedSizes"}
-
-
-def _cpp_tokens(text: str) -> list[str]:
-    return [
-        token
-        for token in CPP_TOKEN.findall(text)
-        if not token.startswith(("//", "/*", '"', "'"))
-    ]
-
-
-def _contains_destination_source(tokens: list[str], aliases: set[str]) -> bool:
-    for index, token in enumerate(tokens):
-        if token in aliases:
-            return True
-        if token in DESTINATION_GETTERS and tokens[index + 1 : index + 2] == ["("]:
-            return True
-    return False
-
-
-def _call_arguments(tokens: list[str], open_paren: int) -> list[str]:
-    depth = 0
-    for index in range(open_paren, len(tokens)):
-        if tokens[index] == "(":
-            depth += 1
-        elif tokens[index] == ")":
-            depth -= 1
-            if depth == 0:
-                return tokens[open_paren + 1 : index]
-    raise ValueError("unterminated C++ call expression in handwritten reifier")
-
-
-def _count_destination_mixed_size_lifts(text: str) -> int:
-    tokens = _cpp_tokens(text)
-    aliases: set[str] = set()
-    statements: list[list[str]] = []
-    start = 0
-    for index, token in enumerate(tokens):
-        if token == ";":
-            statements.append(tokens[start:index])
-            start = index + 1
-    if start < len(tokens):
-        statements.append(tokens[start:])
-
-    changed = True
-    while changed:
-        changed = False
-        for statement in statements:
-            if "=" not in statement:
-                continue
-            equals = statement.index("=")
-            lhs_identifiers = [
-                token
-                for token in statement[:equals]
-                if re.fullmatch(r"[A-Za-z_]\w*", token)
-            ]
-            if not lhs_identifiers:
-                continue
-            alias = lhs_identifiers[-1]
-            if alias not in aliases and _contains_destination_source(
-                statement[equals + 1 :], aliases
-            ):
-                aliases.add(alias)
-                changed = True
-
-    count = 0
-    for statement in statements:
-        expression_is_destination_rooted = _contains_destination_source(
-            statement, aliases
-        )
-        for index, token in enumerate(statement):
-            if token not in MIXED_SIZE_CALLS or statement[index + 1 : index + 2] != [
-                "("
-            ]:
-                continue
-            arguments = _call_arguments(statement, index + 1)
-            receiver_is_destination = (
-                index >= 2
-                and statement[index - 1] in {".", "->"}
-                and statement[index - 2] in aliases
-            )
-            if (
-                expression_is_destination_rooted
-                or receiver_is_destination
-                or _contains_destination_source(arguments, aliases)
-            ):
-                count += 1
-    return count
 
 
 def _implements_interface(
@@ -235,26 +86,6 @@ def _implements_interface(
     return False
 
 
-def _method_body(text: str, cpp_class: str, method: str) -> str | None:
-    matches = list(re.finditer(rf"\b{re.escape(cpp_class)}::{method}\s*\(", text))
-    if not matches:
-        return None
-    if len(matches) != 1:
-        raise ValueError(f"expected one {cpp_class}::{method} definition")
-    open_brace = text.find("{", matches[0].end())
-    if open_brace < 0:
-        raise ValueError(f"{cpp_class}::{method} has no function body")
-    depth = 0
-    for index in range(open_brace, len(text)):
-        if text[index] == "{":
-            depth += 1
-        elif text[index] == "}":
-            depth -= 1
-            if depth == 0:
-                return text[open_brace + 1 : index]
-    raise ValueError(f"{cpp_class}::{method} has an unterminated function body")
-
-
 def _llvm_include_dir(tblgen: Path) -> Path:
     suffix = ".exe" if tblgen.suffix.lower() == ".exe" else ""
     llvm_config = tblgen.with_name(f"llvm-config{suffix}")
@@ -271,28 +102,26 @@ def _llvm_include_dir(tblgen: Path) -> Path:
 
 def _audit_tablegen(
     records: dict[str, object],
-    *,
-    reifiers_text: str = "",
-    verifiers_text: str = "",
-    require_complete_allowlist: bool = False,
-) -> tuple[dict[str, str], dict[str, str], set[str], set[str], set[str]]:
+) -> tuple[dict[str, str], dict[str, str], set[str], set[str]]:
     contracts: dict[str, str] = {}
     same_shape_mechanisms: dict[str, str] = {}
-    outs_reify_exceptions: set[str] = set()
     control_dps_ops: set[str] = set()
     non_dps_ops: set[str] = set()
+    all_families = set().union(*CONTRACT_FAMILIES.values())
+
     for name, untyped_record in records.items():
         if not (name.startswith("Hip_") and name.endswith("Op")):
             continue
         if not isinstance(untyped_record, dict):
             continue
         record = untyped_record
-        superclasses = record.get("!superclasses", [])
+        superclasses = set(record.get("!superclasses", []))
         inherits_compute_dps = DPS_BASE in superclasses
         implements_dps = _implements_interface(
             record, records, DESTINATION_STYLE_INTERFACE
         )
         contract = record.get("hipShapeContract")
+
         if contract is None:
             if inherits_compute_dps:
                 raise ValueError(
@@ -306,6 +135,7 @@ def _audit_tablegen(
             else:
                 non_dps_ops.add(record["opName"])
             continue
+
         op_name = record["opName"]
         if not inherits_compute_dps or not implements_dps:
             raise ValueError(
@@ -315,38 +145,38 @@ def _audit_tablegen(
         if not record.get("hipHasExplicitShapeContract", 0):
             raise ValueError(
                 f"{name} ({op_name}) must inherit an explicit HIP DPS "
-                "shape-contract base"
+                "shape-contract family"
             )
         if contract == "unclassified":
             raise ValueError(f"{name} ({op_name}) has no reviewed shape contract")
-        if contract not in ALLOWED_CONTRACTS:
+        if contract not in CONTRACT_FAMILIES:
             raise ValueError(
                 f"{name} ({op_name}) has unknown shape contract {contract!r}"
             )
 
-        all_contract_bases = {
-            base
-            for contract_bases in CONTRACT_BASES.values()
-            for base in contract_bases
-        }
-        inherited_category_bases = sorted(set(superclasses) & all_contract_bases)
-        if len(inherited_category_bases) != 1:
+        inherited_families = sorted(superclasses & all_families)
+        if len(inherited_families) != 1:
             raise ValueError(
                 f"{name} ({op_name}) must inherit exactly one DPS shape "
-                f"category base, found {inherited_category_bases}"
+                f"behavior family, found {inherited_families}"
             )
-        expected_bases = CONTRACT_BASES[contract]
-        if inherited_category_bases[0] not in expected_bases:
+        family = inherited_families[0]
+        if family not in CONTRACT_FAMILIES[contract]:
             raise ValueError(
                 f"{name} ({op_name}) contract metadata {contract!r} conflicts "
-                f"with inherited base {inherited_category_bases[0]}"
+                f"with inherited behavior family {family}"
+            )
+        if family in VERIFIER_FAMILIES and not record.get("hasVerifier", 0):
+            raise ValueError(
+                f"{name} ({op_name}) behavior family {family} requires "
+                "generated verifier wiring"
             )
 
         same_shape_source = record.get("hipSameShapeSource", "")
         if contract == "same_shape":
             if not same_shape_source:
                 raise ValueError(
-                    f"{name} ({op_name}) uses Hip_DpsOp_SameShape without a "
+                    f"{name} ({op_name}) uses a same-shape family without a "
                     "named source accessor"
                 )
             same_shape_mechanisms[op_name] = "shared named-source base"
@@ -356,95 +186,16 @@ def _audit_tablegen(
                 f"contract {contract!r}"
             )
 
-        if contract == "semantic":
-            if not record.get("hasVerifier", 0):
-                raise ValueError(
-                    f"{name} ({op_name}) semantic contract requires verifier wiring"
-                )
-            generated_count = (record.get("extraClassDefinition") or "").count(
-                DEFAULT_OUTS_REIFY_MARKER
-            )
-            fallback = SEMANTIC_OUTS_REIFY_ALLOWLIST.get(op_name)
-            cpp_class = (
-                fallback["cpp_class"]
-                if fallback
-                else record.get("cppClassName", name.removeprefix("Hip_"))
-            )
-            reifier_body = _method_body(
-                reifiers_text, str(cpp_class), "reifyResultShapes"
-            )
-            handwritten_count = (
-                len(HANDWRITTEN_OUTS_REIFY_MARKER.findall(reifier_body))
-                if reifier_body
-                else 0
-            )
-            mixed_size_count = (
-                _count_destination_mixed_size_lifts(reifier_body) if reifier_body else 0
-            )
-            if generated_count or handwritten_count or mixed_size_count:
-                if fallback is None:
-                    raise ValueError(
-                        f"{name} ({op_name}) semantic contract uses outs-lift "
-                        "reification without a reviewed exception"
-                    )
-                if (
-                    generated_count != fallback["generated"]
-                    or (handwritten_count != fallback["handwritten"])
-                    or mixed_size_count != fallback["mixed_size"]
-                ):
-                    raise ValueError(
-                        f"{name} ({op_name}) outs-lift count mismatch: "
-                        f"generated={generated_count}, "
-                        f"handwritten={handwritten_count}, "
-                        f"mixed_size={mixed_size_count}"
-                    )
-                for marker in fallback["reifier_markers"]:
-                    if not reifier_body or marker not in reifier_body:
-                        raise ValueError(
-                            f"{name} ({op_name}) handwritten fallback is "
-                            f"missing reifier guard {marker!r}"
-                        )
-                if handwritten_count:
-                    verifier_body = _method_body(
-                        verifiers_text, str(cpp_class), "verify"
-                    )
-                    if verifier_body is None:
-                        raise ValueError(
-                            f"{name} ({op_name}) handwritten fallback requires "
-                            "a handwritten verifier"
-                        )
-                    for marker in fallback["verifier_markers"]:
-                        if marker not in verifier_body:
-                            raise ValueError(
-                                f"{name} ({op_name}) handwritten fallback is "
-                                f"missing verifier guard {marker!r}"
-                            )
-                outs_reify_exceptions.add(op_name)
-
         if op_name in contracts:
             raise ValueError(f"duplicate HIP op name in TableGen: {op_name}")
         contracts[op_name] = contract
-    if require_complete_allowlist:
-        stale_exceptions = sorted(
-            set(SEMANTIC_OUTS_REIFY_ALLOWLIST) - outs_reify_exceptions
-        )
-        if stale_exceptions:
-            raise ValueError(
-                "stale semantic outs-lift allowlist entries: "
-                f"{', '.join(stale_exceptions)}"
-            )
-    return (
-        contracts,
-        same_shape_mechanisms,
-        outs_reify_exceptions,
-        control_dps_ops,
-        non_dps_ops,
-    )
+
+    return contracts, same_shape_mechanisms, control_dps_ops, non_dps_ops
 
 
 def _load_tablegen(
     args: argparse.Namespace,
-) -> tuple[dict[str, str], dict[str, str], set[str], set[str], set[str]]:
+) -> tuple[dict[str, str], dict[str, str], set[str], set[str]]:
     command = [
         str(args.tblgen),
         "--dump-json",
@@ -455,13 +206,7 @@ def _load_tablegen(
         str(args.ops),
     ]
     result = subprocess.run(command, check=True, capture_output=True, text=True)
-    records = json.loads(result.stdout)
-    return _audit_tablegen(
-        records,
-        reifiers_text=args.reifiers.read_text(),
-        verifiers_text=args.verifiers.read_text(),
-        require_complete_allowlist=True,
-    )
+    return _audit_tablegen(json.loads(result.stdout))
 
 
 def _load_inventory(
@@ -495,20 +240,12 @@ def _validate_inventory_statuses(
     contracts: dict[str, str],
     statuses: dict[str, str],
     same_shape_mechanisms: dict[str, str],
-    outs_reify_exceptions: set[str],
 ) -> None:
     for op_name, expected_status in same_shape_mechanisms.items():
         if statuses[op_name] != expected_status:
             raise ValueError(
                 f"{op_name}: same-shape mechanism requires inventory status "
                 f"{expected_status!r}, found {statuses[op_name]!r}"
-            )
-    for op_name in outs_reify_exceptions:
-        expected_status = SEMANTIC_OUTS_REIFY_ALLOWLIST[op_name]["status"]
-        if statuses[op_name] != expected_status:
-            raise ValueError(
-                f"{op_name}: semantic outs-lift exception requires inventory "
-                f"status {expected_status!r}, found {statuses[op_name]!r}"
             )
     for op_name, contract in contracts.items():
         allowed_statuses = REVIEWED_POLICY_STATUSES.get(contract)
@@ -522,269 +259,120 @@ def _validate_inventory_statuses(
             )
 
 
+def _inventory_differences(
+    tablegen: dict[str, str],
+    inventory: dict[str, str],
+) -> tuple[list[str], list[str], list[str]]:
+    return (
+        sorted(set(tablegen) - set(inventory)),
+        sorted(set(inventory) - set(tablegen)),
+        sorted(
+            op for op in set(tablegen) & set(inventory) if tablegen[op] != inventory[op]
+        ),
+    )
+
+
 def _fixture_record(
     contract: str,
     *,
     op_name: str = "fixture",
     explicit: bool = True,
-    base: str | None = None,
+    family: str | None = None,
     verifier: bool = True,
-    outs_reify: bool = False,
 ) -> dict[str, object]:
+    family = family or sorted(CONTRACT_FAMILIES[contract])[0]
     return {
         "opName": op_name,
         "hipShapeContract": contract,
         "hipHasExplicitShapeContract": int(explicit),
         "hipSameShapeSource": "Input" if contract == "same_shape" else "",
-        "!superclasses": [
-            HIP_OP_BASE,
-            DPS_BASE,
-            base or CONTRACT_BASES[contract][0],
-        ],
+        "!superclasses": [HIP_OP_BASE, DPS_BASE, family],
         "_testInterfaces": [DESTINATION_STYLE_INTERFACE],
         "hasVerifier": int(verifier),
-        "extraClassDefinition": DEFAULT_OUTS_REIFY_MARKER if outs_reify else "",
     }
 
 
 def _run_self_test() -> int:
-    def expect_failure(
-        record: dict[str, object],
-        message: str,
-        *,
-        reifiers_text: str = "",
-        verifiers_text: str = "",
-    ) -> None:
+    def expect_failure(record: dict[str, object], message: str) -> None:
         try:
-            _audit_tablegen(
-                {"Hip_FixtureOp": record},
-                reifiers_text=reifiers_text,
-                verifiers_text=verifiers_text,
-            )
+            _audit_tablegen({"Hip_FixtureOp": record})
         except ValueError as exc:
             if message not in str(exc):
                 raise AssertionError(f"expected {message!r}, got {exc!r}") from exc
         else:
             raise AssertionError(f"expected failure containing {message!r}")
 
-    expect_failure(_fixture_record("semantic", explicit=False), "explicit HIP DPS")
+    bare_dps = {
+        "opName": "fixture",
+        "hipShapeContract": "unclassified",
+        "hipHasExplicitShapeContract": 0,
+        "hipSameShapeSource": "",
+        "!superclasses": [HIP_OP_BASE, DPS_BASE],
+        "_testInterfaces": [DESTINATION_STYLE_INTERFACE],
+    }
+    expect_failure(bare_dps, "explicit HIP DPS shape-contract family")
 
-    missing_category = _fixture_record("semantic", base=DPS_BASE)
-    expect_failure(missing_category, "exactly one DPS shape category base")
+    missing_family = _fixture_record("semantic")
+    missing_family["!superclasses"] = [HIP_OP_BASE, DPS_BASE]
+    expect_failure(missing_family, "exactly one DPS shape behavior family")
 
-    multiple_categories = _fixture_record("semantic")
-    multiple_categories["!superclasses"].append(CONTRACT_BASES["broadcast"][0])
-    expect_failure(multiple_categories, "exactly one DPS shape category base")
+    multiple_families = _fixture_record("semantic")
+    multiple_families["!superclasses"].append("Hip_DpsOp_Broadcast")
+    expect_failure(multiple_families, "exactly one DPS shape behavior family")
 
     expect_failure(
-        _fixture_record("broadcast", base="Hip_DpsOp_Semantic"),
-        "contract metadata 'broadcast' conflicts with inherited base",
+        _fixture_record("broadcast", family="Hip_DpsOp_Semantic"),
+        "conflicts with inherited behavior family",
     )
     expect_failure(
-        _fixture_record("semantic", verifier=False), "requires verifier wiring"
+        _fixture_record("semantic", verifier=False),
+        "requires generated verifier wiring",
     )
     expect_failure(
-        _fixture_record("semantic", outs_reify=True),
-        "without a reviewed exception",
+        _fixture_record(
+            "same_shape",
+            family="Hip_DpsOp_SameShapeManualVerify",
+            verifier=False,
+        ),
+        "requires generated verifier wiring",
     )
 
-    payload = _fixture_record("payload")
-    contracts, same_shape, exceptions, control_dps, non_dps = _audit_tablegen(
+    payload = _fixture_record("payload", verifier=False)
+    contracts, same_shape, control_dps, non_dps = _audit_tablegen(
         {"Hip_FixtureOp": payload}
     )
-    assert not control_dps and not non_dps
+    assert not same_shape and not control_dps and not non_dps
     try:
-        _validate_inventory_statuses(
-            contracts, {"fixture": "no-op stub"}, same_shape, exceptions
-        )
+        _validate_inventory_statuses(contracts, {"fixture": "no-op stub"}, same_shape)
     except ValueError as exc:
         if "reviewed inventory status" not in str(exc):
             raise
     else:
         raise AssertionError("payload no-op status unexpectedly passed")
 
-    size = _fixture_record("semantic", op_name="size", outs_reify=True)
-    contracts, same_shape, exceptions, control_dps, non_dps = _audit_tablegen(
-        {"Hip_SizeOp": size}
-    )
-    assert not control_dps and not non_dps
-    _validate_inventory_statuses(
-        contracts,
-        {"size": SEMANTIC_OUTS_REIFY_ALLOWLIST["size"]["status"]},
-        same_shape,
-        exceptions,
-    )
-
-    missing_contract = _fixture_record("semantic")
-    del missing_contract["hipShapeContract"]
-    expect_failure(missing_contract, "without shape-contract metadata")
-
-    non_dps_with_fake_contract = _fixture_record("payload")
-    non_dps_with_fake_contract["!superclasses"] = [HIP_OP_BASE]
-    expect_failure(
-        non_dps_with_fake_contract,
-        "without both Hip_DpsOp and DestinationStyleOpInterface",
-    )
-
-    missing_interface = _fixture_record("semantic")
-    missing_interface["_testInterfaces"] = []
-    expect_failure(missing_interface, "without both Hip_DpsOp")
-
-    contracts, same_shape, exceptions, control_dps, non_dps = _audit_tablegen(
-        {
-            "Hip_ConstantOp": {
-                "opName": "constant",
-                "!superclasses": [HIP_OP_BASE],
-            },
-            "Hip_ReadbackControlOp": {
-                "opName": "readback_control",
-                "!superclasses": [HIP_OP_BASE],
-            },
-            "Hip_LoopOp": {
-                "opName": "loop",
-                "!superclasses": [HIP_OP_BASE],
-            },
-            "Hip_IfOp": {
-                "opName": "if",
-                "!superclasses": [HIP_OP_BASE],
-                "_testInterfaces": [DESTINATION_STYLE_INTERFACE],
-            },
-        }
-    )
-    assert not contracts and not same_shape and not exceptions
+    control_and_non_dps = {
+        "Hip_ConstantOp": {
+            "opName": "constant",
+            "!superclasses": [HIP_OP_BASE],
+        },
+        "Hip_IfOp": {
+            "opName": "if",
+            "!superclasses": [HIP_OP_BASE],
+            "_testInterfaces": [DESTINATION_STYLE_INTERFACE],
+        },
+    }
+    contracts, _, control_dps, non_dps = _audit_tablegen(control_and_non_dps)
+    assert not contracts
     assert control_dps == {"if"}
-    assert non_dps == {"constant", "readback_control", "loop"}
+    assert non_dps == {"constant"}
 
-    gqa = _fixture_record("semantic", op_name="gqa")
-    gqa_reifier = """
-LogicalResult GqaOp::reifyResultShapes() {
-  getPositionIds();
-  getOutputQk();
-  getQkOutput();
-  getSoftcap();
-  return cast<::mlir::hip::HipDpsOp>(getOperation()).reifyResultShapes();
-}
-"""
-    gqa_verifier = """
-LogicalResult GqaOp::verify() {
-  getPositionIds();
-  getOutputQk();
-  getQkOutput();
-  getSoftcap();
-  return success();
-}
-"""
-    _, _, exceptions, _, _ = _audit_tablegen(
-        {"Hip_GqaOp": gqa},
-        reifiers_text=gqa_reifier,
-        verifiers_text=gqa_verifier,
+    missing, stale, mismatched = _inventory_differences(
+        {"a": "semantic", "b": "payload"},
+        {"b": "semantic", "c": "payload"},
     )
-    assert exceptions == {"gqa"}
-    expect_failure(
-        gqa,
-        "missing verifier guard 'getSoftcap()'",
-        reifiers_text=gqa_reifier,
-        verifiers_text=gqa_verifier.replace("getSoftcap();", ""),
-    )
-    expect_failure(
-        gqa,
-        "outs-lift count mismatch",
-        reifiers_text=gqa_reifier.replace(
-            "return cast<::mlir::hip::HipDpsOp>",
-            "cast<::mlir::hip::HipDpsOp>(getOperation()).reifyResultShapes();\n"
-            "  return cast<::mlir::hip::HipDpsOp>",
-        ),
-        verifiers_text=gqa_verifier,
-    )
-    expect_failure(
-        gqa,
-        "mixed_size=1",
-        reifiers_text=gqa_reifier.replace(
-            "getSoftcap();",
-            "getSoftcap();\n"
-            "  auto dims = tensor::getMixedSizes(b, getLoc(), getOutput());",
-        ),
-        verifiers_text=gqa_verifier,
-    )
+    assert missing == ["a"] and stale == ["c"] and mismatched == ["b"]
 
-    gather_nd = _fixture_record("semantic", op_name="gather_nd")
-    gather_reifier = """
-LogicalResult GatherNDOp::reifyResultShapes() {
-  if (failed(dims))
-    return cast<HipDpsOp>(getOperation()).reifyResultShapes();
-  return success();
-}
-"""
-    gather_verifier = """
-LogicalResult GatherNDOp::verify() {
-  if (indicesType.isDynamicDim(indicesType.getRank() - 1))
-    return success();
-  return verifyShape();
-}
-"""
-    _, _, exceptions, _, _ = _audit_tablegen(
-        {"Hip_GatherNDOp": gather_nd},
-        reifiers_text=gather_reifier,
-        verifiers_text=gather_verifier,
-    )
-    assert exceptions == {"gather_nd"}
-    expect_failure(
-        gather_nd,
-        "missing verifier guard",
-        reifiers_text=gather_reifier,
-        verifiers_text=gather_verifier.replace(
-            "indicesType.isDynamicDim(indicesType.getRank() - 1)", "dynamic"
-        ),
-    )
-
-    unreviewed = _fixture_record("semantic")
-    expect_failure(
-        unreviewed,
-        "without a reviewed exception",
-        reifiers_text="""
-LogicalResult FixtureOp::reifyResultShapes() {
-  return cast<::mlir::hip::HipDpsOp>(getOperation()).reifyResultShapes();
-}
-""",
-    )
-    mixed_size_bypasses = (
-        """
-LogicalResult FixtureOp::reifyResultShapes() {
-  auto dims = tensor::getMixedSizes(b, getLoc(), getOutput());
-  return success();
-}
-""",
-        """
-LogicalResult FixtureOp::reifyResultShapes() {
-  auto init = getDpsInits()[0];
-  auto alias = init;
-  auto dims = mlir :: memref :: getMixedSizes (b, getLoc(), alias);
-  return success();
-}
-""",
-        """
-LogicalResult FixtureOp::reifyResultShapes() {
-  auto init = getOutput();
-  auto empty = init.getDefiningOp<tensor::EmptyOp>();
-  auto dims = empty.getMixedSizes();
-  return success();
-}
-""",
-        """
-LogicalResult FixtureOp::reifyResultShapes() {
-  auto dims = cast<tensor::EmptyOp>(
-      getDpsInit().getDefiningOp()).getMixedSizes();
-  return success();
-}
-""",
-    )
-    for reifier in mixed_size_bypasses:
-        expect_failure(
-            unreviewed,
-            "without a reviewed exception",
-            reifiers_text=reifier,
-        )
-    print("verified shape-contract guard fixtures")
+    print("verified structural shape-contract guard fixtures")
     return 0
 
 
@@ -794,22 +382,13 @@ def main() -> int:
     parser.add_argument("--project-include", type=Path)
     parser.add_argument("--ops", type=Path)
     parser.add_argument("--inventory", type=Path)
-    parser.add_argument("--reifiers", type=Path)
-    parser.add_argument("--verifiers", type=Path)
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
 
     try:
         if args.self_test:
             return _run_self_test()
-        required = (
-            "tblgen",
-            "project_include",
-            "ops",
-            "inventory",
-            "reifiers",
-            "verifiers",
-        )
+        required = ("tblgen", "project_include", "ops", "inventory")
         if missing := [
             f"--{name.replace('_', '-')}"
             for name in required
@@ -817,24 +396,14 @@ def main() -> int:
         ]:
             parser.error(f"the following arguments are required: {', '.join(missing)}")
 
-        (
-            tablegen,
-            same_shape_mechanisms,
-            outs_reify_exceptions,
-            control_dps_ops,
-            non_dps_ops,
-        ) = _load_tablegen(args)
+        tablegen, same_shape_mechanisms, control_dps_ops, non_dps_ops = _load_tablegen(
+            args
+        )
         inventory, inventory_statuses, inventory_control_dps = _load_inventory(
             args.inventory
         )
-        if tablegen != inventory:
-            missing = sorted(set(tablegen) - set(inventory))
-            stale = sorted(set(inventory) - set(tablegen))
-            mismatched = sorted(
-                op
-                for op in set(tablegen) & set(inventory)
-                if tablegen[op] != inventory[op]
-            )
+        missing, stale, mismatched = _inventory_differences(tablegen, inventory)
+        if missing or stale or mismatched:
             if missing:
                 print(f"missing inventory ops: {', '.join(missing)}", file=sys.stderr)
             if stale:
@@ -859,11 +428,9 @@ def main() -> int:
                     file=sys.stderr,
                 )
             return 1
+
         _validate_inventory_statuses(
-            tablegen,
-            inventory_statuses,
-            same_shape_mechanisms,
-            outs_reify_exceptions,
+            tablegen, inventory_statuses, same_shape_mechanisms
         )
         print(
             f"verified {len(tablegen)} HIP DPS shape contracts and "

--- a/test/lit/Inputs/check_hip_shape_contracts.py
+++ b/test/lit/Inputs/check_hip_shape_contracts.py
@@ -1,0 +1,885 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+"""Cross-check HIP op roles and repository-convention DPS contract patterns.
+
+The primary policy checks require exactly one explicit behavior family, reject
+bare DPS leaves, and audit semantic destination-shape fallbacks. Family-owned
+metadata consistency is intentionally secondary. Handwritten C++ checks
+tokenize supported in-tree forms and fail closed on count drift; they are not a
+general C++ parser.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+ALLOWED_CONTRACTS = {
+    "same_shape",
+    "broadcast",
+    "reduction",
+    "semantic",
+    "payload",
+    "outs_authoritative",
+}
+CONTRACT_BASES = {
+    "same_shape": (
+        "Hip_DpsOp_SameShape",
+        "Hip_DpsOp_SameShapeManualVerify",
+    ),
+    "broadcast": ("Hip_DpsOp_Broadcast",),
+    "reduction": ("Hip_DpsOp_Reduction",),
+    "semantic": (
+        "Hip_DpsOp_Semantic",
+        "Hip_DpsOp_SemanticNoInfer",
+        "Hip_DpsOp_SemanticAutoReifyInfer",
+    ),
+    "payload": (
+        "Hip_DpsOp_Payload",
+        "Hip_DpsOp_PayloadNoInfer",
+        "Hip_DpsOp_PayloadAutoReify",
+    ),
+    "outs_authoritative": ("Hip_DpsOp_OutsAuthoritative",),
+}
+SEMANTIC_OUTS_REIFY_ALLOWLIST = {
+    "gather_nd": {
+        "status": "shared infer/reify/verifier; dynamic tuple width uses outs fallback",
+        "generated": 0,
+        "handwritten": 1,
+        "mixed_size": 0,
+        "cpp_class": "GatherNDOp",
+        "reifier_markers": ("if (failed(dims))",),
+        "verifier_markers": ("indicesType.isDynamicDim(indicesType.getRank() - 1)",),
+    },
+    "gqa": {
+        "status": (
+            "shared converter extent utility + payload fallback + partial "
+            "static verifier"
+        ),
+        "generated": 0,
+        "handwritten": 1,
+        "mixed_size": 0,
+        "cpp_class": "GqaOp",
+        "reifier_markers": (
+            "getPositionIds()",
+            "getOutputQk()",
+            "getQkOutput()",
+            "getSoftcap()",
+        ),
+        "verifier_markers": (
+            "getPositionIds()",
+            "getOutputQk()",
+            "getQkOutput()",
+            "getSoftcap()",
+        ),
+    },
+    "size": {
+        "status": "shared infer/converter/verifier",
+        "generated": 1,
+        "handwritten": 0,
+        "mixed_size": 0,
+        "cpp_class": "SizeOp",
+        "reifier_markers": (),
+        "verifier_markers": (),
+    },
+}
+REVIEWED_POLICY_STATUSES = {
+    "payload": {
+        "audited payload policy",
+        "affine refinement complete",
+        "complete; exact grouped control readback",
+        "refinement complete; shared constant rule + one bulk runtime readback",
+    },
+    "outs_authoritative": {"audited outs-authoritative"},
+}
+DEFAULT_OUTS_REIFY_MARKER = "::mlir::hip::HipDpsOp"
+HANDWRITTEN_OUTS_REIFY_MARKER = re.compile(r"\bcast<(?:::mlir::hip::)?HipDpsOp>")
+DPS_BASE = "Hip_DpsOp"
+HIP_OP_BASE = "Hip_Op"
+DESTINATION_STYLE_INTERFACE = "DestinationStyleOpInterface"
+INVENTORY_ROW = re.compile(r"^\| `([^`]+)` \| `([^`]+)` \|[^|]*\| ([^|]+) \|$")
+CONTROL_DPS_ROW = re.compile(r"^\| `([^`]+)` \| `control_flow_dps` \| ([^|]+) \|$")
+CPP_TOKEN = re.compile(
+    r"""
+    //[^\n]* | /\*.*?\*/ |
+    "(?:\\.|[^"\\])*" | '(?:\\.|[^'\\])*' |
+    :: | -> | == | != | <= | >= | && | \|\| |
+    [A-Za-z_]\w* | \d+ | \S
+    """,
+    re.DOTALL | re.VERBOSE,
+)
+DESTINATION_GETTERS = {
+    "getC",
+    "getDpsInit",
+    "getDpsInits",
+    "getOInit",
+    "getOutput",
+    "getOutputs",
+    "getResult",
+    "getResultTensors",
+    "getY",
+}
+MIXED_SIZE_CALLS = {"getMixedSize", "getMixedSizes"}
+
+
+def _cpp_tokens(text: str) -> list[str]:
+    return [
+        token
+        for token in CPP_TOKEN.findall(text)
+        if not token.startswith(("//", "/*", '"', "'"))
+    ]
+
+
+def _contains_destination_source(tokens: list[str], aliases: set[str]) -> bool:
+    for index, token in enumerate(tokens):
+        if token in aliases:
+            return True
+        if token in DESTINATION_GETTERS and tokens[index + 1 : index + 2] == ["("]:
+            return True
+    return False
+
+
+def _call_arguments(tokens: list[str], open_paren: int) -> list[str]:
+    depth = 0
+    for index in range(open_paren, len(tokens)):
+        if tokens[index] == "(":
+            depth += 1
+        elif tokens[index] == ")":
+            depth -= 1
+            if depth == 0:
+                return tokens[open_paren + 1 : index]
+    raise ValueError("unterminated C++ call expression in handwritten reifier")
+
+
+def _count_destination_mixed_size_lifts(text: str) -> int:
+    tokens = _cpp_tokens(text)
+    aliases: set[str] = set()
+    statements: list[list[str]] = []
+    start = 0
+    for index, token in enumerate(tokens):
+        if token == ";":
+            statements.append(tokens[start:index])
+            start = index + 1
+    if start < len(tokens):
+        statements.append(tokens[start:])
+
+    changed = True
+    while changed:
+        changed = False
+        for statement in statements:
+            if "=" not in statement:
+                continue
+            equals = statement.index("=")
+            lhs_identifiers = [
+                token
+                for token in statement[:equals]
+                if re.fullmatch(r"[A-Za-z_]\w*", token)
+            ]
+            if not lhs_identifiers:
+                continue
+            alias = lhs_identifiers[-1]
+            if alias not in aliases and _contains_destination_source(
+                statement[equals + 1 :], aliases
+            ):
+                aliases.add(alias)
+                changed = True
+
+    count = 0
+    for statement in statements:
+        expression_is_destination_rooted = _contains_destination_source(
+            statement, aliases
+        )
+        for index, token in enumerate(statement):
+            if token not in MIXED_SIZE_CALLS or statement[index + 1 : index + 2] != [
+                "("
+            ]:
+                continue
+            arguments = _call_arguments(statement, index + 1)
+            receiver_is_destination = (
+                index >= 2
+                and statement[index - 1] in {".", "->"}
+                and statement[index - 2] in aliases
+            )
+            if (
+                expression_is_destination_rooted
+                or receiver_is_destination
+                or _contains_destination_source(arguments, aliases)
+            ):
+                count += 1
+    return count
+
+
+def _implements_interface(
+    record: dict[str, object],
+    records: dict[str, object],
+    interface_name: str,
+) -> bool:
+    if interface_name in record.get("_testInterfaces", []):
+        return True
+    for trait in record.get("traits", []):
+        if not isinstance(trait, dict):
+            continue
+        trait_record = records.get(trait.get("def"))
+        if isinstance(trait_record, dict) and (
+            trait_record.get("cppInterfaceName") == interface_name
+        ):
+            return True
+    return False
+
+
+def _method_body(text: str, cpp_class: str, method: str) -> str | None:
+    matches = list(re.finditer(rf"\b{re.escape(cpp_class)}::{method}\s*\(", text))
+    if not matches:
+        return None
+    if len(matches) != 1:
+        raise ValueError(f"expected one {cpp_class}::{method} definition")
+    open_brace = text.find("{", matches[0].end())
+    if open_brace < 0:
+        raise ValueError(f"{cpp_class}::{method} has no function body")
+    depth = 0
+    for index in range(open_brace, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[open_brace + 1 : index]
+    raise ValueError(f"{cpp_class}::{method} has an unterminated function body")
+
+
+def _llvm_include_dir(tblgen: Path) -> Path:
+    suffix = ".exe" if tblgen.suffix.lower() == ".exe" else ""
+    llvm_config = tblgen.with_name(f"llvm-config{suffix}")
+    if llvm_config.exists():
+        result = subprocess.run(
+            [str(llvm_config), "--includedir"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return Path(result.stdout.strip())
+    return tblgen.parent.parent / "include"
+
+
+def _audit_tablegen(
+    records: dict[str, object],
+    *,
+    reifiers_text: str = "",
+    verifiers_text: str = "",
+    require_complete_allowlist: bool = False,
+) -> tuple[dict[str, str], dict[str, str], set[str], set[str], set[str]]:
+    contracts: dict[str, str] = {}
+    same_shape_mechanisms: dict[str, str] = {}
+    outs_reify_exceptions: set[str] = set()
+    control_dps_ops: set[str] = set()
+    non_dps_ops: set[str] = set()
+    for name, untyped_record in records.items():
+        if not (name.startswith("Hip_") and name.endswith("Op")):
+            continue
+        if not isinstance(untyped_record, dict):
+            continue
+        record = untyped_record
+        superclasses = record.get("!superclasses", [])
+        inherits_compute_dps = DPS_BASE in superclasses
+        implements_dps = _implements_interface(
+            record, records, DESTINATION_STYLE_INTERFACE
+        )
+        contract = record.get("hipShapeContract")
+        if contract is None:
+            if inherits_compute_dps:
+                raise ValueError(
+                    f"{name} ({record['opName']}) is a HIP DPS op without "
+                    "shape-contract metadata"
+                )
+            if HIP_OP_BASE not in superclasses:
+                raise ValueError(f"{name} is not derived from the HIP op base")
+            if implements_dps:
+                control_dps_ops.add(record["opName"])
+            else:
+                non_dps_ops.add(record["opName"])
+            continue
+        op_name = record["opName"]
+        if not inherits_compute_dps or not implements_dps:
+            raise ValueError(
+                f"{name} ({op_name}) carries a DPS shape contract without "
+                "both Hip_DpsOp and DestinationStyleOpInterface"
+            )
+        if not record.get("hipHasExplicitShapeContract", 0):
+            raise ValueError(
+                f"{name} ({op_name}) must inherit an explicit HIP DPS "
+                "shape-contract base"
+            )
+        if contract == "unclassified":
+            raise ValueError(f"{name} ({op_name}) has no reviewed shape contract")
+        if contract not in ALLOWED_CONTRACTS:
+            raise ValueError(
+                f"{name} ({op_name}) has unknown shape contract {contract!r}"
+            )
+
+        all_contract_bases = {
+            base
+            for contract_bases in CONTRACT_BASES.values()
+            for base in contract_bases
+        }
+        inherited_category_bases = sorted(set(superclasses) & all_contract_bases)
+        if len(inherited_category_bases) != 1:
+            raise ValueError(
+                f"{name} ({op_name}) must inherit exactly one DPS shape "
+                f"category base, found {inherited_category_bases}"
+            )
+        expected_bases = CONTRACT_BASES[contract]
+        if inherited_category_bases[0] not in expected_bases:
+            raise ValueError(
+                f"{name} ({op_name}) contract metadata {contract!r} conflicts "
+                f"with inherited base {inherited_category_bases[0]}"
+            )
+
+        same_shape_source = record.get("hipSameShapeSource", "")
+        if contract == "same_shape":
+            if not same_shape_source:
+                raise ValueError(
+                    f"{name} ({op_name}) uses Hip_DpsOp_SameShape without a "
+                    "named source accessor"
+                )
+            same_shape_mechanisms[op_name] = "shared named-source base"
+        elif same_shape_source:
+            raise ValueError(
+                f"{name} ({op_name}) has same-shape source metadata but "
+                f"contract {contract!r}"
+            )
+
+        if contract == "semantic":
+            if not record.get("hasVerifier", 0):
+                raise ValueError(
+                    f"{name} ({op_name}) semantic contract requires verifier wiring"
+                )
+            generated_count = (record.get("extraClassDefinition") or "").count(
+                DEFAULT_OUTS_REIFY_MARKER
+            )
+            fallback = SEMANTIC_OUTS_REIFY_ALLOWLIST.get(op_name)
+            cpp_class = (
+                fallback["cpp_class"]
+                if fallback
+                else record.get("cppClassName", name.removeprefix("Hip_"))
+            )
+            reifier_body = _method_body(
+                reifiers_text, str(cpp_class), "reifyResultShapes"
+            )
+            handwritten_count = (
+                len(HANDWRITTEN_OUTS_REIFY_MARKER.findall(reifier_body))
+                if reifier_body
+                else 0
+            )
+            mixed_size_count = (
+                _count_destination_mixed_size_lifts(reifier_body) if reifier_body else 0
+            )
+            if generated_count or handwritten_count or mixed_size_count:
+                if fallback is None:
+                    raise ValueError(
+                        f"{name} ({op_name}) semantic contract uses outs-lift "
+                        "reification without a reviewed exception"
+                    )
+                if (
+                    generated_count != fallback["generated"]
+                    or (handwritten_count != fallback["handwritten"])
+                    or mixed_size_count != fallback["mixed_size"]
+                ):
+                    raise ValueError(
+                        f"{name} ({op_name}) outs-lift count mismatch: "
+                        f"generated={generated_count}, "
+                        f"handwritten={handwritten_count}, "
+                        f"mixed_size={mixed_size_count}"
+                    )
+                for marker in fallback["reifier_markers"]:
+                    if not reifier_body or marker not in reifier_body:
+                        raise ValueError(
+                            f"{name} ({op_name}) handwritten fallback is "
+                            f"missing reifier guard {marker!r}"
+                        )
+                if handwritten_count:
+                    verifier_body = _method_body(
+                        verifiers_text, str(cpp_class), "verify"
+                    )
+                    if verifier_body is None:
+                        raise ValueError(
+                            f"{name} ({op_name}) handwritten fallback requires "
+                            "a handwritten verifier"
+                        )
+                    for marker in fallback["verifier_markers"]:
+                        if marker not in verifier_body:
+                            raise ValueError(
+                                f"{name} ({op_name}) handwritten fallback is "
+                                f"missing verifier guard {marker!r}"
+                            )
+                outs_reify_exceptions.add(op_name)
+
+        if op_name in contracts:
+            raise ValueError(f"duplicate HIP op name in TableGen: {op_name}")
+        contracts[op_name] = contract
+    if require_complete_allowlist:
+        stale_exceptions = sorted(
+            set(SEMANTIC_OUTS_REIFY_ALLOWLIST) - outs_reify_exceptions
+        )
+        if stale_exceptions:
+            raise ValueError(
+                "stale semantic outs-lift allowlist entries: "
+                f"{', '.join(stale_exceptions)}"
+            )
+    return (
+        contracts,
+        same_shape_mechanisms,
+        outs_reify_exceptions,
+        control_dps_ops,
+        non_dps_ops,
+    )
+
+
+def _load_tablegen(
+    args: argparse.Namespace,
+) -> tuple[dict[str, str], dict[str, str], set[str], set[str], set[str]]:
+    command = [
+        str(args.tblgen),
+        "--dump-json",
+        "-I",
+        str(args.project_include),
+        "-I",
+        str(_llvm_include_dir(args.tblgen)),
+        str(args.ops),
+    ]
+    result = subprocess.run(command, check=True, capture_output=True, text=True)
+    records = json.loads(result.stdout)
+    return _audit_tablegen(
+        records,
+        reifiers_text=args.reifiers.read_text(),
+        verifiers_text=args.verifiers.read_text(),
+        require_complete_allowlist=True,
+    )
+
+
+def _load_inventory(
+    path: Path,
+) -> tuple[dict[str, str], dict[str, str], set[str]]:
+    contracts: dict[str, str] = {}
+    statuses: dict[str, str] = {}
+    control_dps_ops: set[str] = set()
+    for line in path.read_text().splitlines():
+        control_match = CONTROL_DPS_ROW.match(line)
+        if control_match:
+            op_name, _ = control_match.groups()
+            if op_name in control_dps_ops:
+                raise ValueError(
+                    f"duplicate control-flow DPS op in inventory: {op_name}"
+                )
+            control_dps_ops.add(op_name)
+            continue
+        match = INVENTORY_ROW.match(line)
+        if not match:
+            continue
+        op_name, contract, status = match.groups()
+        if op_name in contracts:
+            raise ValueError(f"duplicate HIP op in inventory: {op_name}")
+        contracts[op_name] = contract
+        statuses[op_name] = status.strip()
+    return contracts, statuses, control_dps_ops
+
+
+def _validate_inventory_statuses(
+    contracts: dict[str, str],
+    statuses: dict[str, str],
+    same_shape_mechanisms: dict[str, str],
+    outs_reify_exceptions: set[str],
+) -> None:
+    for op_name, expected_status in same_shape_mechanisms.items():
+        if statuses[op_name] != expected_status:
+            raise ValueError(
+                f"{op_name}: same-shape mechanism requires inventory status "
+                f"{expected_status!r}, found {statuses[op_name]!r}"
+            )
+    for op_name in outs_reify_exceptions:
+        expected_status = SEMANTIC_OUTS_REIFY_ALLOWLIST[op_name]["status"]
+        if statuses[op_name] != expected_status:
+            raise ValueError(
+                f"{op_name}: semantic outs-lift exception requires inventory "
+                f"status {expected_status!r}, found {statuses[op_name]!r}"
+            )
+    for op_name, contract in contracts.items():
+        allowed_statuses = REVIEWED_POLICY_STATUSES.get(contract)
+        if allowed_statuses is None:
+            continue
+        status = statuses[op_name]
+        if status not in allowed_statuses:
+            raise ValueError(
+                f"{op_name}: {contract} contract requires a reviewed inventory "
+                f"status, found {status!r}"
+            )
+
+
+def _fixture_record(
+    contract: str,
+    *,
+    op_name: str = "fixture",
+    explicit: bool = True,
+    base: str | None = None,
+    verifier: bool = True,
+    outs_reify: bool = False,
+) -> dict[str, object]:
+    return {
+        "opName": op_name,
+        "hipShapeContract": contract,
+        "hipHasExplicitShapeContract": int(explicit),
+        "hipSameShapeSource": "Input" if contract == "same_shape" else "",
+        "!superclasses": [
+            HIP_OP_BASE,
+            DPS_BASE,
+            base or CONTRACT_BASES[contract][0],
+        ],
+        "_testInterfaces": [DESTINATION_STYLE_INTERFACE],
+        "hasVerifier": int(verifier),
+        "extraClassDefinition": DEFAULT_OUTS_REIFY_MARKER if outs_reify else "",
+    }
+
+
+def _run_self_test() -> int:
+    def expect_failure(
+        record: dict[str, object],
+        message: str,
+        *,
+        reifiers_text: str = "",
+        verifiers_text: str = "",
+    ) -> None:
+        try:
+            _audit_tablegen(
+                {"Hip_FixtureOp": record},
+                reifiers_text=reifiers_text,
+                verifiers_text=verifiers_text,
+            )
+        except ValueError as exc:
+            if message not in str(exc):
+                raise AssertionError(f"expected {message!r}, got {exc!r}") from exc
+        else:
+            raise AssertionError(f"expected failure containing {message!r}")
+
+    expect_failure(_fixture_record("semantic", explicit=False), "explicit HIP DPS")
+
+    missing_category = _fixture_record("semantic", base=DPS_BASE)
+    expect_failure(missing_category, "exactly one DPS shape category base")
+
+    multiple_categories = _fixture_record("semantic")
+    multiple_categories["!superclasses"].append(CONTRACT_BASES["broadcast"][0])
+    expect_failure(multiple_categories, "exactly one DPS shape category base")
+
+    expect_failure(
+        _fixture_record("broadcast", base="Hip_DpsOp_Semantic"),
+        "contract metadata 'broadcast' conflicts with inherited base",
+    )
+    expect_failure(
+        _fixture_record("semantic", verifier=False), "requires verifier wiring"
+    )
+    expect_failure(
+        _fixture_record("semantic", outs_reify=True),
+        "without a reviewed exception",
+    )
+
+    payload = _fixture_record("payload")
+    contracts, same_shape, exceptions, control_dps, non_dps = _audit_tablegen(
+        {"Hip_FixtureOp": payload}
+    )
+    assert not control_dps and not non_dps
+    try:
+        _validate_inventory_statuses(
+            contracts, {"fixture": "no-op stub"}, same_shape, exceptions
+        )
+    except ValueError as exc:
+        if "reviewed inventory status" not in str(exc):
+            raise
+    else:
+        raise AssertionError("payload no-op status unexpectedly passed")
+
+    size = _fixture_record("semantic", op_name="size", outs_reify=True)
+    contracts, same_shape, exceptions, control_dps, non_dps = _audit_tablegen(
+        {"Hip_SizeOp": size}
+    )
+    assert not control_dps and not non_dps
+    _validate_inventory_statuses(
+        contracts,
+        {"size": SEMANTIC_OUTS_REIFY_ALLOWLIST["size"]["status"]},
+        same_shape,
+        exceptions,
+    )
+
+    missing_contract = _fixture_record("semantic")
+    del missing_contract["hipShapeContract"]
+    expect_failure(missing_contract, "without shape-contract metadata")
+
+    non_dps_with_fake_contract = _fixture_record("payload")
+    non_dps_with_fake_contract["!superclasses"] = [HIP_OP_BASE]
+    expect_failure(
+        non_dps_with_fake_contract,
+        "without both Hip_DpsOp and DestinationStyleOpInterface",
+    )
+
+    missing_interface = _fixture_record("semantic")
+    missing_interface["_testInterfaces"] = []
+    expect_failure(missing_interface, "without both Hip_DpsOp")
+
+    contracts, same_shape, exceptions, control_dps, non_dps = _audit_tablegen(
+        {
+            "Hip_ConstantOp": {
+                "opName": "constant",
+                "!superclasses": [HIP_OP_BASE],
+            },
+            "Hip_ReadbackControlOp": {
+                "opName": "readback_control",
+                "!superclasses": [HIP_OP_BASE],
+            },
+            "Hip_LoopOp": {
+                "opName": "loop",
+                "!superclasses": [HIP_OP_BASE],
+            },
+            "Hip_IfOp": {
+                "opName": "if",
+                "!superclasses": [HIP_OP_BASE],
+                "_testInterfaces": [DESTINATION_STYLE_INTERFACE],
+            },
+        }
+    )
+    assert not contracts and not same_shape and not exceptions
+    assert control_dps == {"if"}
+    assert non_dps == {"constant", "readback_control", "loop"}
+
+    gqa = _fixture_record("semantic", op_name="gqa")
+    gqa_reifier = """
+LogicalResult GqaOp::reifyResultShapes() {
+  getPositionIds();
+  getOutputQk();
+  getQkOutput();
+  getSoftcap();
+  return cast<::mlir::hip::HipDpsOp>(getOperation()).reifyResultShapes();
+}
+"""
+    gqa_verifier = """
+LogicalResult GqaOp::verify() {
+  getPositionIds();
+  getOutputQk();
+  getQkOutput();
+  getSoftcap();
+  return success();
+}
+"""
+    _, _, exceptions, _, _ = _audit_tablegen(
+        {"Hip_GqaOp": gqa},
+        reifiers_text=gqa_reifier,
+        verifiers_text=gqa_verifier,
+    )
+    assert exceptions == {"gqa"}
+    expect_failure(
+        gqa,
+        "missing verifier guard 'getSoftcap()'",
+        reifiers_text=gqa_reifier,
+        verifiers_text=gqa_verifier.replace("getSoftcap();", ""),
+    )
+    expect_failure(
+        gqa,
+        "outs-lift count mismatch",
+        reifiers_text=gqa_reifier.replace(
+            "return cast<::mlir::hip::HipDpsOp>",
+            "cast<::mlir::hip::HipDpsOp>(getOperation()).reifyResultShapes();\n"
+            "  return cast<::mlir::hip::HipDpsOp>",
+        ),
+        verifiers_text=gqa_verifier,
+    )
+    expect_failure(
+        gqa,
+        "mixed_size=1",
+        reifiers_text=gqa_reifier.replace(
+            "getSoftcap();",
+            "getSoftcap();\n"
+            "  auto dims = tensor::getMixedSizes(b, getLoc(), getOutput());",
+        ),
+        verifiers_text=gqa_verifier,
+    )
+
+    gather_nd = _fixture_record("semantic", op_name="gather_nd")
+    gather_reifier = """
+LogicalResult GatherNDOp::reifyResultShapes() {
+  if (failed(dims))
+    return cast<HipDpsOp>(getOperation()).reifyResultShapes();
+  return success();
+}
+"""
+    gather_verifier = """
+LogicalResult GatherNDOp::verify() {
+  if (indicesType.isDynamicDim(indicesType.getRank() - 1))
+    return success();
+  return verifyShape();
+}
+"""
+    _, _, exceptions, _, _ = _audit_tablegen(
+        {"Hip_GatherNDOp": gather_nd},
+        reifiers_text=gather_reifier,
+        verifiers_text=gather_verifier,
+    )
+    assert exceptions == {"gather_nd"}
+    expect_failure(
+        gather_nd,
+        "missing verifier guard",
+        reifiers_text=gather_reifier,
+        verifiers_text=gather_verifier.replace(
+            "indicesType.isDynamicDim(indicesType.getRank() - 1)", "dynamic"
+        ),
+    )
+
+    unreviewed = _fixture_record("semantic")
+    expect_failure(
+        unreviewed,
+        "without a reviewed exception",
+        reifiers_text="""
+LogicalResult FixtureOp::reifyResultShapes() {
+  return cast<::mlir::hip::HipDpsOp>(getOperation()).reifyResultShapes();
+}
+""",
+    )
+    mixed_size_bypasses = (
+        """
+LogicalResult FixtureOp::reifyResultShapes() {
+  auto dims = tensor::getMixedSizes(b, getLoc(), getOutput());
+  return success();
+}
+""",
+        """
+LogicalResult FixtureOp::reifyResultShapes() {
+  auto init = getDpsInits()[0];
+  auto alias = init;
+  auto dims = mlir :: memref :: getMixedSizes (b, getLoc(), alias);
+  return success();
+}
+""",
+        """
+LogicalResult FixtureOp::reifyResultShapes() {
+  auto init = getOutput();
+  auto empty = init.getDefiningOp<tensor::EmptyOp>();
+  auto dims = empty.getMixedSizes();
+  return success();
+}
+""",
+        """
+LogicalResult FixtureOp::reifyResultShapes() {
+  auto dims = cast<tensor::EmptyOp>(
+      getDpsInit().getDefiningOp()).getMixedSizes();
+  return success();
+}
+""",
+    )
+    for reifier in mixed_size_bypasses:
+        expect_failure(
+            unreviewed,
+            "without a reviewed exception",
+            reifiers_text=reifier,
+        )
+    print("verified shape-contract guard fixtures")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tblgen", type=Path)
+    parser.add_argument("--project-include", type=Path)
+    parser.add_argument("--ops", type=Path)
+    parser.add_argument("--inventory", type=Path)
+    parser.add_argument("--reifiers", type=Path)
+    parser.add_argument("--verifiers", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        if args.self_test:
+            return _run_self_test()
+        required = (
+            "tblgen",
+            "project_include",
+            "ops",
+            "inventory",
+            "reifiers",
+            "verifiers",
+        )
+        if missing := [
+            f"--{name.replace('_', '-')}"
+            for name in required
+            if not getattr(args, name)
+        ]:
+            parser.error(f"the following arguments are required: {', '.join(missing)}")
+
+        (
+            tablegen,
+            same_shape_mechanisms,
+            outs_reify_exceptions,
+            control_dps_ops,
+            non_dps_ops,
+        ) = _load_tablegen(args)
+        inventory, inventory_statuses, inventory_control_dps = _load_inventory(
+            args.inventory
+        )
+        if tablegen != inventory:
+            missing = sorted(set(tablegen) - set(inventory))
+            stale = sorted(set(inventory) - set(tablegen))
+            mismatched = sorted(
+                op
+                for op in set(tablegen) & set(inventory)
+                if tablegen[op] != inventory[op]
+            )
+            if missing:
+                print(f"missing inventory ops: {', '.join(missing)}", file=sys.stderr)
+            if stale:
+                print(f"stale inventory ops: {', '.join(stale)}", file=sys.stderr)
+            for op in mismatched:
+                print(
+                    f"{op}: TableGen={tablegen[op]}, inventory={inventory[op]}",
+                    file=sys.stderr,
+                )
+            return 1
+        if control_dps_ops != inventory_control_dps:
+            missing = sorted(control_dps_ops - inventory_control_dps)
+            stale = sorted(inventory_control_dps - control_dps_ops)
+            if missing:
+                print(
+                    f"missing control-flow DPS inventory ops: {', '.join(missing)}",
+                    file=sys.stderr,
+                )
+            if stale:
+                print(
+                    f"stale control-flow DPS inventory ops: {', '.join(stale)}",
+                    file=sys.stderr,
+                )
+            return 1
+        _validate_inventory_statuses(
+            tablegen,
+            inventory_statuses,
+            same_shape_mechanisms,
+            outs_reify_exceptions,
+        )
+        print(
+            f"verified {len(tablegen)} HIP DPS shape contracts and "
+            f"{len(control_dps_ops)} control-flow DPS op and "
+            f"{len(non_dps_ops)} structurally non-DPS HIP ops"
+        )
+        return 0
+    except (
+        OSError,
+        subprocess.CalledProcessError,
+        ValueError,
+        json.JSONDecodeError,
+    ) as exc:
+        print(f"shape-contract audit failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/lit/lit.cfg.py
+++ b/test/lit/lit.cfg.py
@@ -84,6 +84,7 @@ llvm_config.with_environment("PATH", hip_tools_dirs, append_path=True)
 tools = [
     "hip-mlir-opt",
     "hip-compiler",
+    "llvm-tblgen",
     "FileCheck",
     "not",
     "split-file",

--- a/test/lit/lit.site.cfg.py.in
+++ b/test/lit/lit.site.cfg.py.in
@@ -17,6 +17,7 @@ import lit.llvm
 # llvm_tools_dir must be set before lit.llvm.initialize() because LLVMConfig()
 # reads it immediately when constructed in lit.cfg.py.
 config.llvm_tools_dir = r"@LLVM_TOOLS_BINARY_DIR@"
+config.python_executable = r"@Python3_EXECUTABLE@"
 
 # hip_build_dir: base build directory; lit.cfg.py appends per-tool subdirs.
 config.hip_build_dir = r"@CMAKE_BINARY_DIR@"


### PR DESCRIPTION
## Why

The HIP dialect assigns every destination-style compute operation to an explicit shape-contract family, but that policy is durable only when the reviewed inventory and the ODS records remain structurally identical.

This PR audits the contract graph emitted by `llvm-tblgen --dump-json`: destination-style interface membership, exact behavior-family inheritance, contract metadata, named same-shape sources, and `hasVerifier` wiring. The checked Markdown ledger remains the human-reviewed statement of each compute DPS, control-flow DPS, and structurally non-DPS operation.

The current revision no longer tokenizes or counts handwritten C++. ODS-generated declarations plus compilation/linking enforce manual verifier presence, while focused semantic LIT tests enforce behavior. Compared with the superseded branch-local scanner, the structural redesign adds 171 lines and deletes 584 (net -413), and deliberately makes no claim about arbitrary C++ control or data flow.

## IR example

A normal destination-style operation remains ordinary MLIR; the audit classifies `hip.add` structurally as a broadcast-family compute DPS op and requires the inventory to agree:

```mlir
%result = hip.add(%ctx)
    ins(%lhs, %rhs : tensor<?x4xf32>, tensor<1x4xf32>)
    outs(%output : tensor<?x4xf32>)
    : tensor<?x4xf32>
```

Adding a new HIP DPS leaf without exactly one reviewed family, or labeling a non-DPS op as compute DPS, fails the default LIT audit before semantic tests run.

## What changes

- Add the reviewed shape-contract inventory for every compute DPS op, `hip.if` as control-flow DPS, and all structurally non-DPS HIP operations.
- Consume TableGen JSON to resolve generated interface traits, exact family superclasses, contract metadata, same-shape source accessors, and verifier declarations.
- Require each compute DPS leaf to inherit exactly one same-shape, broadcast, reduction, semantic, payload, or outs-authoritative family and match its inventory row.
- Reject bare DPS leaves, unknown or conflicting contracts, missing family-required verifier wiring, stale inventory rows, and unreviewed payload/outs-authoritative statuses.
- Encode verifier requirements in the ODS family bases, including explicit manual-verifier payload bases used by Slice and Tile.
- Add structural negative self-tests and run the inventory checker in the default LIT suite with configured Python and `llvm-tblgen` paths.
- Delete the former handwritten C++ token/occurrence scanner and fallback-count policy rather than maintaining a parallel source audit.
- Document the boundary between structural TableGen/ODS guarantees and operation-specific semantic IR coverage.

## Stack

Merged prerequisite plus the 22 active shape PRs:

1. [#688 — refactor(hip): externalize constants after ONNX conversion](https://github.com/ROCm/hip-ep/pull/688)
2. [#724 — feat(shape): preserve symbolic compiler inputs](https://github.com/ROCm/hip-ep/pull/724)
3. [#639 — refactor(hip): establish shared shape-rule foundation](https://github.com/ROCm/hip-ep/pull/639)
4. [#681 — fix(shape): canonicalize host reshape provenance](https://github.com/ROCm/hip-ep/pull/681)
5. [#725 — fix(shape): activate exact broadcasts with symbolic proofs](https://github.com/ROCm/hip-ep/pull/725)
6. [#734 — fix(shape): share MatMul and Gemm contracts](https://github.com/ROCm/hip-ep/pull/734)
7. [#641 — fix(shape): enforce shared broadcast contracts](https://github.com/ROCm/hip-ep/pull/641)
8. [#735 — refactor(conversion): share ONNX reduction conversion](https://github.com/ROCm/hip-ep/pull/735)
9. [#736 — fix(shape): normalize reduction contracts](https://github.com/ROCm/hip-ep/pull/736)
10. [#643 — fix(shape): share convolution contracts](https://github.com/ROCm/hip-ep/pull/643)
11. [#742 — fix(shape): share causal convolution contracts](https://github.com/ROCm/hip-ep/pull/742)
12. [#645 — fix(shape): share normalization contracts](https://github.com/ROCm/hip-ep/pull/645)
13. [#740 — fix(shape): share attention contracts](https://github.com/ROCm/hip-ep/pull/740)
14. [#741 — fix(shape): share GQA capacity contracts](https://github.com/ROCm/hip-ep/pull/741)
15. [#644 — fix(shape): share gather and tensor contracts](https://github.com/ROCm/hip-ep/pull/644)
16. [#727 — feat(shape): consume constant payload shapes directly](https://github.com/ROCm/hip-ep/pull/727)
17. [#728 — feat(shape): add exact Tile and Range destinations](https://github.com/ROCm/hip-ep/pull/728)
18. [#646 — refactor(hip): declare explicit DPS shape contracts](https://github.com/ROCm/hip-ep/pull/646)
19. [#730 — test(hip): audit explicit DPS contract inventory](https://github.com/ROCm/hip-ep/pull/730) ← this PR
20. [#732 — test(hip): audit ONNX converter deduplication](https://github.com/ROCm/hip-ep/pull/732)
21. [#647 — fix(hip): harden shape refinement failure handling](https://github.com/ROCm/hip-ep/pull/647)
22. [#761 — refactor(hip): split shape utility headers by family](https://github.com/ROCm/hip-ep/pull/761)
23. [#764 — refactor(hip): clarify shape destination authority](https://github.com/ROCm/hip-ep/pull/764)

## AI assistance

AI tools assisted with the structural audit design, documentation, and stack reconstruction. The contributor reviewed and validated the resulting code.

Made-with: Cursor
