### PR TITLE
feat(slice): lower normalized exact descriptors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,9 +72,10 @@ The default layout is:
 <workspace>/install/         install prefix
 ```
 
-`build.py` runs the LIT suite plus the GPU-free plugin, output-allocator, and
-symbolic-metadata unit tests by default. To run tests manually from Linux or Git
-Bash at the repository root:
+`build.py` runs the LIT suite plus the GPU-free plugin, output-allocator,
+symbolic-metadata, MatMul/Gemm, loop-frame, Slice utility, and grouped-readback
+unit tests by default. To run tests manually from Linux or Git Bash at the
+repository root:
 
 ```bash
 BUILD_DIR=../build/$(basename "$PWD")

--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -172,8 +172,11 @@ Choose the smallest mechanism that matches the operation's semantics:
 | Permutation | `reifyTransposeByPerm` |
 | Gather/GatherND/GatherElements | Gather-specific helpers or thunks |
 | OneHot, Compress, TopK | Dedicated reification thunks |
-| Pad, Tile, Slice, Range | Fold-or-bail helpers with fallback to DPS-init shape |
+| Pad | Exact affine input-dimension arithmetic for constant/stamped pads; runtime pads use converter readback and reify from outs |
+| Slice | Shared static/SSA normalization; runtime i32/i64 controls use one grouped readback and exact extents |
 | Expand | Pure constant inference; grouped readback and checked destination construction for runtime targets |
+| Range | Constant controls fold exactly; runtime controls use one grouped readback and a checked result count |
+| Tile | Constant repeats use exact mixed shape arithmetic; runtime repeats use one bulk synchronized readback and reify from that exact init |
 | MatMul/Gemm/MatMulNBits | Dedicated shape logic based on operand dimensions and attributes |
 | Attention or normalization with multiple destinations | One shape vector per DPS init unless an op supplies a dedicated thunk |
 | Convolution, pooling, or resize with converter-computed destinations | DPS-init shape, with semantic validity handled by conversion or verification |
@@ -479,6 +482,72 @@ Static refinements propagate into bufferization sizing and downstream pool plann
 
 A data-dependent extent that reaches a graph output must additionally be a real SSA value *before* the allocation, because `hip.alloc_output` takes the extent as an operand and ORT rejects an output request whose shape differs from the one it computed for the run. The converter therefore materializes the count with a device scan plus a synchronized `hip.readback_dim` and sizes the DPS init with it; reification then reports that init extent. `onnx.Compress` follows this pattern (scanning its `condition` with `hip.nonzero`), so a padded-input encoder that drops its pad slices reports the kept-slice count rather than the padded capacity. Reporting the upper bound instead is not merely conservative — it is the wrong output shape.
 
+Pad reads compile-time pads and optional axes directly from dense
+`hip.constant` carriers during compute conversion, then attaches durable
+`static_pads` / `static_axes` metadata before standalone externalization.
+`inferPadShape` validates the parameter lengths and axes without emitting IR;
+both conversion and reification then use `reifyPadShape` for the exact affine rule
+`output[d] = input[d] + begin[d] + end[d]`. Dynamic input dimensions therefore
+produce `tensor.dim` plus a constant offset. Genuinely runtime pads retain the
+converter's synchronized payload readback, while dialect reification performs
+no payload read and lifts the already-exact destination.
+
+Slice has one semantic rule with pure static inference and standard-arithmetic
+SSA materialization. Constants are consumed directly. Every genuinely runtime
+rank-0/rank-1 i32/i64 control source participates in one
+`hip.readback_control`; the op queues all operand-major copies and performs one
+stream synchronization, sign-extends i32, preserves signed i64 without
+clamping, and returns `i1 valid` plus flattened i64 values. Its source grouping
+comes from static operand types, and its lowering respects memref descriptor
+offsets. `hip.readback_shape` remains unchanged for existing shape-only users.
+
+The Slice materializer normalizes negative or runtime axes, rejects
+duplicates/out-of-range axes and zero steps through `params_valid`, and handles
+omitted axes/steps, negative bounds/steps, zero dimensions, and `INT64_MIN`
+without signed overflow. Invalid runtime controls select zero extents/starts
+and unit steps. Positive all-constant slices may still become
+`tensor.extract_slice`; every native `hip.slice` carries exactly data,
+`params_valid`, rank normalized i64 starts/steps, rank exact extents, and the
+exact DPS destination. There are no raw parameter tensors, static-parameter
+attributes, capacity/logical-tail split, or duplicate readbacks.
+
+`wrap_slice` consumes only normalized host controls and exact shapes. It
+performs defensive count, byte, pointer, destination-shape, and first/last
+address validation; empty outputs accept null allocator storage and launch no
+kernel. Arbitrary-rank strides/starts/steps are staged into runtime-managed
+device scratch on the execution stream, so reuse is ordered after the previous
+Slice launch. The kernel loops over runtime rank and has no rank-8 metadata
+limit or capacity-tail branch.
+
+The `wrap_slice` signature and generated `hip.slice` contract replace the old
+raw-parameter ABI. Cached LLVM bitcode/native model artifacts produced against
+the prior ABI must be invalidated.
+
+Exact Slice descriptors also participate in the loop descriptor-return ABI.
+An exact `[1, 0, D]` Slice remains a zero-element borrowed `v_init` descriptor;
+it is not widened to carrier capacity. Each body iteration returns its exact
+shape-changing descriptor, and `hip-loop-body-to-out-params` redirects the
+carrier allocation to `hip.loop_alloc` in the invocation frame. Nested or
+otherwise foreign body results are copied into the parent frame's exact bank
+before publication. If the final descriptor is a graph output,
+`hip-use-output-allocator` allocates and copies the exact shape before
+`hip-finalize-loop-frames` destroys the frame. See
+[loop-carrier-descriptor-abi.md](loop-carrier-descriptor-abi.md).
+
+Tile's refinement is complete. Dense carrier repeats share
+`inferTileShape`/`reifyTileShape`, including exact multiplication of dynamic
+input dimensions. Runtime repeats are read once in bulk by the converter to
+build the exact destination; reification lifts that destination and never
+duplicates the payload readback.
+
+Slice, Pad, Tile, and Expand converters follow a pure-before-materialize
+contract. Structural validation, static inference, and imported-result
+compatibility complete before any `tensor.dim`, arithmetic, readback, or
+`tensor.empty` is emitted. An imported dynamic dimension may remain dynamic or
+be refined by a proven static extent. An imported static dimension requires an
+equal static inferred extent; unknown inference never inherits an importer
+constraint. A failed pattern therefore leaves the IR unchanged.
+
 ## Pre-conversion loop-body rank inference
 
 `--hip-infer-loop-body-shapes` is a narrow pre-conversion backstop. It runs after loop outlining and before ONNX-to-HIP conversion to establish rank for unranked loop-carried values that would otherwise block conversion; it is not the general HIP shape-inference mechanism.
@@ -524,10 +593,13 @@ Primary regression coverage:
 | `test/lit/Dialect/hip-matmul-shape-verifier.mlir` | Static MatMul shape validation |
 | `test/lit/Conversion/onnx-to-hip/test_reduce_sum.mlir` | Reduction destinations, including the non-positional `keepdims = 0` dimension mapping |
 | `test/lit/Conversion/onnx-to-hip/test_reduce_runtime_axes_invalid.mlir` | Conversion-time rejection of all runtime axes and non-contiguous constant axes |
+| `test/lit/Conversion/onnx-to-hip/test_payload_failure_atomicity.mlir` | Failed payload rewrites leave no destination/readback arithmetic |
 | `test/lit/Dialect/hip-loop-verifier.mlir` | Loop-carried type contract |
 | `test/lit/Dialect/hip-resolve-tensor-dims.mlir` | Production pre-bufferization dim folding |
 
 Complex operations may use dedicated files; common shape categories should extend the consolidated infer-shapes coverage.
+`test/runtime/test_slice_utils.cpp` covers null-storage empty outputs and
+positive/negative extreme-step extent arithmetic without a GPU.
 
 ## Current limitations
 

--- a/docs/design/pool-allocs-memory-planning.md
+++ b/docs/design/pool-allocs-memory-planning.md
@@ -70,7 +70,14 @@ caller's pool.
 
 ### Correctness and ABI preparation
 
-`hip-promote-strided-operands` materializes identity-layout temporaries for non-identity-layout DPS-input memrefs. Selecting by interface covers HIP and plugin runtime consumers without coupling the pass to a dialect or operation-name prefix. The pass must run before pooling so its temporaries become pool views.
+`hip-promote-strided-operands` materializes identity-layout temporaries for
+non-identity-layout DPS-input memrefs. Selecting by interface covers HIP and
+plugin runtime consumers without coupling the pass to a dialect or
+operation-name prefix. It also repairs post-bufferization `hip.loop` captures
+whose outlined body argument expects identity layout; repeated identical
+read-only captures share one temporary that is released after the invocation.
+Loop-carried seeds are excluded because zero-trip results may alias them. The
+pass must run before pooling so its temporaries become pool views.
 
 `hip-use-output-allocator` must run before pooling so returned buffers are rewritten to runtime-owned `hip.alloc_output` operations rather than absorbed into the transient pool. The production pipeline intentionally omits ownership-based buffer deallocation because every transient is pooled and outputs are runtime-owned. See [output-allocator-design.md](output-allocator-design.md).
 

--- a/docs/design/qwen-vision-ops.md
+++ b/docs/design/qwen-vision-ops.md
@@ -26,8 +26,8 @@ The kernels implemented in this round are:
 | Constant     | ConstantOfShape (compile-time fold; no kernel)            | —                                    |
 
 All kernels target FP16 / FP32 / INT32 / INT64 data types (a strict subset
-of ORT's CUDA EP support). Indices for GatherND, ScatterND, and Slice are
-INT64 only.
+of ORT's CUDA EP support). GatherND and ScatterND indices are INT64 only;
+Slice control tensors may be INT32 or INT64.
 
 Reference implementations were ported from
 `onnxruntime/core/providers/cuda/...` at tag **v1.22.2**. We deliberately
@@ -241,24 +241,16 @@ the existing Add/Mul/Sub family in `elementwise_kernel.hip`. If a graph
 arrives with implicit broadcasting it will fail at the lowering stage,
 not at runtime.
 
-### 3.7 Slice and ScatterND — host-side indices
+### 3.7 Slice and ScatterND — runtime controls
 
-`Slice` and `ScatterND` both move tensor data based on small INT64
-index/control tensors:
-
-| Op        | Index-shaped inputs                                | Where they live       | What we do                                |
-|-----------|----------------------------------------------------|-----------------------|-------------------------------------------|
-| Slice     | `starts`, `ends`, optional `axes`, optional `steps` | GPU tensors (graph inputs in the non-folded case) | D2H + `hipStreamSynchronize` once per call, then resolve per ONNX clamping rules host-side and pass the per-axis `(start, step)` arrays into the kernel as host int64 vectors |
-| ScatterND | `indices`                                           | GPU tensor             | **Stay on the device** — the kernel reads them inline. No D2H at all. |
-
-Slice has to D2H because per-axis (start, step) needs ONNX clamping
-(`step > 0`: `start ∈ [0, dim]`, `end ∈ [0, dim]`; `step < 0`:
-`start ∈ [0, dim-1]`, `end ∈ [-1, dim-1]`) plus the optional `axes`
-list to know which axis each entry applies to. Doing this on the GPU
-would require either a launcher prepass or an oversized device kernel
-with the same per-axis state-machine — neither is worth it for a 4×
-int64 D2H. The matching pattern in `lib/Runtime/real/pad.cpp` and
-`lib/Runtime/real/cumsum.cpp` does the same thing (one stall per call).
+`Slice` and `ScatterND` both move tensor data based on small index/control
+tensors, but their boundaries differ. Genuinely runtime Slice
+`starts`/`ends`/optional `axes`/optional `steps` may be i32 or i64 and share one
+generic `hip.readback_control`. Conversion then performs ONNX normalization in
+ordinary arith SSA, creates the exact destination, and passes only normalized
+per-rank starts/steps/extents to `wrap_slice`. The wrapper performs no D2H or
+normalization. ScatterND keeps its indices on the device and each kernel thread
+reads them inline.
 
 ScatterND keeps indices on the device because there is no clamping
 state machine to run host-side — each thread does its own
@@ -272,8 +264,8 @@ when all four index tensors are graph-constant AND every step is
 positive. It lowers to `tensor.extract_slice` (which becomes a
 `memref.subview` after bufferization and is zero-cost at runtime). Any
 graph that doesn't meet both conditions falls through to `wrap_slice`
-and the runtime path described above. Test `test_slice_negative_step`
-in `test/python/tests/test_shape_ops.py` covers both legs.
+with exact normalized controls. Tests in `test/numeric/tests/test_shape_ops.py`
+cover positive, negative, empty, runtime-control, and repeated-invocation paths.
 
 ### 3.8 ConstantOfShape and the pre-fold ordering
 
@@ -439,13 +431,12 @@ doesn't re-discover them:
   (1 = FLOAT, 10 = FLOAT16), **not** the HIPDNN_EP enum. The lowering
   passes `op.getStashType()` unchanged. Default is FLOAT.
 
-- **`Slice` non-constant indices / negative steps**: the graph-constant
-  + positive-stride case folds to `tensor.extract_slice` in
-  `lib/Conversion/OnnxToHip/SliceConversion.cpp` and never reaches the
-  runtime. The `hip_slice` kernel only services slices whose
-  `starts`/`ends`/`axes`/`steps` are graph inputs (D2H + sync once per
-  call) **or** that have at least one negative step. Indices are
-  INT64 only — INT32 indices would need a stride-aware ABI bump.
+- **`Slice` non-constant indices / negative steps**: graph-constant cases that
+  standard tensor IR can represent fold to `tensor.extract_slice`. Remaining
+  INT32/INT64 control tensors cross through one grouped
+  `hip.readback_control` synchronization, are normalized into host SSA, and
+  determine the exact output allocation. The runtime Slice kernel consumes
+  those normalized starts/steps and performs no parameter D2H readback.
 
 - **`Slice` end-sentinel for "all the way down" with `step < 0`**: per
   ONNX-13+ spec, any `end < 0` is normalised via `end += dim` **before**

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -3833,36 +3833,32 @@ def Hip_LessOp : Hip_DpsOp_Broadcast<"less", /*operandGetters=*/["Lhs", "Rhs"]> 
   }];
 }
 
-def Hip_SliceOp : Hip_DpsOp_WithInfer<"slice", "Output", [AttrSizedOperandSegments]> {
+def Hip_SliceOp :
+    Hip_DpsOp_Payload<"slice",
+                      /*traits=*/[AttrSizedOperandSegments],
+                      /*outsAccessor=*/"Output"> {
   let summary = "Slice a tensor along multiple axes (ONNX Slice fallback)";
   let description = [{
-    Native fallback for ONNX Slice when the OnnxToHip pass cannot decompose
-    the op to `tensor.extract_slice` (e.g. non-constant slice parameters or
-    negative `steps`). Implements the standard ONNX Slice operator semantics:
+    Native fallback for ONNX Slice after conversion has resolved the complete
+    semantic contract on the host. `starts`, `steps`, and `extents` each have
+    exactly one scalar entry per data dimension. Starts and steps are normalized
+    signed i64 values; extents are exact host index values used to allocate the
+    DPS destination. `params_valid` is false for invalid runtime axes, duplicate
+    axes, or zero steps; in that case conversion supplies zero extents, zero
+    starts, and unit steps.
 
-      output[k] = data[ start[k0]:end[k0]:step[k0],
-                         start[k1]:end[k1]:step[k1], ... ]
-
-    `starts` / `ends` are 1-D integer tensors (int32 or int64), one entry per
-    axis listed in `axes`. `axes` defaults to `[0, ..., r-1]` when absent and
-    `steps` defaults to all-ones. Per-axis negative indices and negative
-    steps follow ONNX clamping rules.
-
-    The common case (compile-time constant indices, positive unit stride) is
-    handled by an upstream decompose pattern that lowers `onnx.Slice` to
-    `tensor.extract_slice` — that path produces a zero-cost view without any
-    runtime call. This op exists only to give the fallback path a stable
-    DPS-shaped representation to bufferize and lower from.
-
-    Uses destination-passing style: output buffer is provided as argument.
+    The runtime performs no parameter readback or ONNX normalization. It only
+    validates the exact shape/address contract, stages arbitrary-rank kernel
+    metadata, and launches the copy kernel. Compile-time positive-step slices
+    may still decompose to `tensor.extract_slice`.
 
     Example:
     ```mlir
-    hip.slice(%ctx) ins(%data, %starts, %ends : memref<3x4xf32, 1>,
-                                                  memref<2xi64, 1>,
-                                                  memref<2xi64, 1>)
-                    axes(%axes : memref<2xi64, 1>)
-                    steps(%steps : memref<2xi64, 1>)
+    hip.slice(%ctx) ins(%data : memref<3x4xf32, 1>)
+                    valid(%valid)
+                    starts(%s0, %s1 : i64, i64)
+                    steps(%p0, %p1 : i64, i64)
+                    extents(%e0, %e1 : index, index)
                     outs(%out : memref<3x2xf32, 1>)
     ```
   }];
@@ -3870,21 +3866,23 @@ def Hip_SliceOp : Hip_DpsOp_WithInfer<"slice", "Output", [AttrSizedOperandSegmen
   let arguments = (ins
     Hip_ContextType:$ctx,
     Hip_TensorOrMemRef:$data,
-    Hip_TensorOrMemRef:$starts,
-    Hip_TensorOrMemRef:$ends,
-    Optional<Hip_TensorOrMemRef>:$axes,
-    Optional<Hip_TensorOrMemRef>:$steps,
+    I1:$params_valid,
+    Variadic<I64>:$starts,
+    Variadic<I64>:$steps,
+    Variadic<Index>:$extents,
     Hip_TensorOrMemRef:$output
   );
 
   let assemblyFormat = [{
-    `(` $ctx `)` `ins` `(` $data `,` $starts `,` $ends `:`
-        type($data) `,` type($starts) `,` type($ends) `)`
-    (`axes` `(` $axes^ `:` type($axes) `)`)?
-    (`steps` `(` $steps^ `:` type($steps) `)`)?
+    `(` $ctx `)` `ins` `(` $data `:` type($data) `)`
+    `valid` `(` $params_valid `)`
+    `starts` `(` $starts `:` type($starts) `)`
+    `steps` `(` $steps `:` type($steps) `)`
+    `extents` `(` $extents `:` type($extents) `)`
     `outs` `(` $output `:` type($output) `)`
     attr-dict (`:` type($result_tensors)^)?
   }];
+  let hasVerifier = 1;
 }
 
 def Hip_GatherNDOp : Hip_DpsOp_WithInfer<"gather_nd"> {

--- a/lib/Conversion/HipToLLVM/SliceLowering.cpp
+++ b/lib/Conversion/HipToLLVM/SliceLowering.cpp
@@ -9,19 +9,12 @@ namespace mlir {
 namespace hip {
 namespace {
 
-// hip.slice(ctx, data, starts, ends, [axes], [steps], output)
-//   -> wrap_slice(state, data_ptr, starts_ptr, ends_ptr,
-//                 axes_ptr (or null), steps_ptr (or null), out_ptr,
-//                 data_shape_ptr, data_rank,
-//                 output_shape_ptr, output_rank,
-//                 starts_num_elements, axes_num_elements,
-//                 steps_num_elements, data_type)
+// hip.slice(ctx, data, valid, starts[R], steps[R], extents[R], output)
+//   -> wrap_slice(state, data, output, data_shape, output_shape,
+//                 starts, steps, extents, rank, dtype, valid)
 //
-// Today the runtime function is a no-op stub that only logs its parameters
-// (see lib/Runtime/real/slice.cpp). This lowering exists to keep the IR
-// pipeline (bufferize -> hip-to-llvm -> generate-interface) functional even
-// when a Slice cannot be folded to tensor.extract_slice by the OnnxToHip
-// decompose pattern.
+// Every control array is host SSA materialized by conversion. The runtime does
+// no D2H and no ONNX normalization.
 struct SliceOpLowering : public ConvertOpToLLVMPattern<SliceOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
@@ -35,92 +28,84 @@ struct SliceOpLowering : public ConvertOpToLLVMPattern<SliceOp> {
     Type i64Type = rewriter.getI64Type();
 
     auto dataType = cast<MemRefType>(op.getData().getType());
-    auto startsType = cast<MemRefType>(op.getStarts().getType());
     auto outputType = cast<MemRefType>(op.getOutput().getType());
+    int64_t rank = dataType.getRank();
+    if (outputType.getRank() != rank ||
+        static_cast<int64_t>(op.getStarts().size()) != rank ||
+        static_cast<int64_t>(op.getSteps().size()) != rank ||
+        static_cast<int64_t>(op.getExtents().size()) != rank)
+      return rewriter.notifyMatchFailure(op, "invalid exact-rank contract");
 
     int64_t hipDtype = getHipdnnDataType(dataType.getElementType());
     if (hipDtype < 0)
       return rewriter.notifyMatchFailure(op, "unsupported data element type");
 
-    Value statePtr = adaptor.getCtx();
-    Value dataPtr =
-        extractContiguousMemRefPtr(adaptor.getData(), rewriter, loc);
-    Value startsPtr =
-        extractContiguousMemRefPtr(adaptor.getStarts(), rewriter, loc);
-    Value endsPtr =
-        extractContiguousMemRefPtr(adaptor.getEnds(), rewriter, loc);
-    Value axesPtr = extractOptionalMemRefPtr(adaptor.getAxes(), rewriter, loc);
-    Value stepsPtr =
-        extractOptionalMemRefPtr(adaptor.getSteps(), rewriter, loc);
-    Value outPtr =
-        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
-
-    auto createI64Const = [&](int64_t v) {
+    auto i64Constant = [&](int64_t value) {
       return LLVM::ConstantOp::create(rewriter, loc, i64Type,
-                                      rewriter.getI64IntegerAttr(v));
+                                      rewriter.getI64IntegerAttr(value));
     };
-    Value one = createI64Const(1);
-    auto emitShapeArray = [&](MemRefType type, Value descriptor) -> Value {
-      int rank = type.getRank();
-      int arrLen = std::max(rank, 1);
-      auto arrType = LLVM::LLVMArrayType::get(i64Type, arrLen);
-      Value arr =
-          LLVM::AllocaOp::create(rewriter, loc, ptrType, arrType, one, 8);
-      for (int i = 0; i < rank; ++i) {
-        Value dim = getMemRefDimSize(type, i, descriptor, rewriter, loc);
-        Value idx = LLVM::ConstantOp::create(rewriter, loc, i32Type,
-                                             rewriter.getI32IntegerAttr(i));
-        Value elemPtr =
-            LLVM::GEPOp::create(rewriter, loc, ptrType, i64Type, arr, idx);
-        LLVM::StoreOp::create(rewriter, loc, dim, elemPtr);
+    Value one = i64Constant(1);
+    Value arrayCount = i64Constant(std::max<int64_t>(rank, 1));
+
+    auto allocateI64Array = [&]() {
+      return LLVM::AllocaOp::create(rewriter, loc, ptrType, i64Type, arrayCount,
+                                    /*alignment=*/8)
+          .getResult();
+    };
+    auto storeArrayElement = [&](Value array, int64_t index, Value value) {
+      Value indexValue = i64Constant(index);
+      Value slot = LLVM::GEPOp::create(rewriter, loc, ptrType, i64Type, array,
+                                       indexValue);
+      LLVM::StoreOp::create(rewriter, loc, value, slot);
+    };
+    auto emitShapeArray = [&](MemRefType type, Value descriptor) {
+      Value array = allocateI64Array();
+      for (int64_t dim : llvm::seq<int64_t>(rank)) {
+        storeArrayElement(
+            array, dim, getMemRefDimSize(type, dim, descriptor, rewriter, loc));
       }
-      return arr;
+      return array;
     };
 
     Value dataShape = emitShapeArray(dataType, adaptor.getData());
-    Value outShape = emitShapeArray(outputType, adaptor.getOutput());
-
-    Value startsNum =
-        computeNumElements(startsType, adaptor.getStarts(), rewriter, loc);
-    Value axesNum;
-    if (op.getAxes()) {
-      auto axesT = cast<MemRefType>(op.getAxes().getType());
-      axesNum = computeNumElements(axesT, adaptor.getAxes(), rewriter, loc);
-    } else {
-      axesNum = createI64Const(0);
-    }
-    Value stepsNum;
-    if (op.getSteps()) {
-      auto stepsT = cast<MemRefType>(op.getSteps().getType());
-      stepsNum = computeNumElements(stepsT, adaptor.getSteps(), rewriter, loc);
-    } else {
-      stepsNum = createI64Const(0);
+    Value outputShape = emitShapeArray(outputType, adaptor.getOutput());
+    Value starts = allocateI64Array();
+    Value steps = allocateI64Array();
+    Value extents = allocateI64Array();
+    for (int64_t dim : llvm::seq<int64_t>(rank)) {
+      storeArrayElement(starts, dim, adaptor.getStarts()[dim]);
+      storeArrayElement(steps, dim, adaptor.getSteps()[dim]);
+      storeArrayElement(extents, dim, adaptor.getExtents()[dim]);
     }
 
-    Value dataRank = createI64Const(dataType.getRank());
-    Value outRank = createI64Const(outputType.getRank());
-    Value dataTypeVal = createI64Const(hipDtype);
+    Value dataPtr = extractMemRefDataPtr(adaptor.getData(), dataType,
+                                         typeConverter, rewriter, loc);
+    Value outputPtr = extractMemRefDataPtr(adaptor.getOutput(), outputType,
+                                           typeConverter, rewriter, loc);
+    if (!dataPtr || !outputPtr)
+      return rewriter.notifyMatchFailure(op, "failed to compute data pointers");
 
-    SmallVector<Type, 16> paramTypes = {
-        ptrType, ptrType, ptrType, ptrType, // state, data, starts, ends
-        ptrType, ptrType, ptrType,          // axes, steps, output
-        ptrType, i64Type,                   // data_shape, data_rank
-        ptrType, i64Type,                   // out_shape,  out_rank
-        i64Type, i64Type, i64Type,          // starts_num, axes_num,
-                                            // steps_num
-        i64Type};                           // data_type
-
-    FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
-        rewriter, module, kWrapSlice, paramTypes, i32Type);
-    if (failed(funcOp))
+    SmallVector<Type> parameterTypes = {ptrType,
+                                        ptrType,
+                                        ptrType,
+                                        ptrType,
+                                        ptrType,
+                                        ptrType,
+                                        ptrType,
+                                        ptrType,
+                                        i64Type,
+                                        i64Type,
+                                        rewriter.getI1Type()};
+    FailureOr<LLVM::LLVMFuncOp> function = LLVM::lookupOrCreateFn(
+        rewriter, module, kWrapSlice, parameterTypes, i32Type);
+    if (failed(function))
       return failure();
 
-    SmallVector<Value, 16> args = {statePtr, dataPtr,  startsPtr,  endsPtr,
-                                   axesPtr,  stepsPtr, outPtr,     dataShape,
-                                   dataRank, outShape, outRank,    startsNum,
-                                   axesNum,  stepsNum, dataTypeVal};
-
-    LLVM::CallOp::create(rewriter, loc, *funcOp, args);
+    LLVM::CallOp::create(
+        rewriter, loc, *function,
+        ValueRange{adaptor.getCtx(), dataPtr, outputPtr, dataShape, outputShape,
+                   starts, steps, extents, i64Constant(rank),
+                   i64Constant(hipDtype), adaptor.getParamsValid()});
     rewriter.eraseOp(op);
     return success();
   }

--- a/lib/Conversion/OnnxToHip/SliceConversion.cpp
+++ b/lib/Conversion/OnnxToHip/SliceConversion.cpp
@@ -78,9 +78,9 @@ static SmallVector<Value> materializeValues(PatternRewriter &rewriter,
   return values;
 }
 
-struct SliceDecompose : public RewritePattern {
-  SliceDecompose(MLIRContext *context)
-      : RewritePattern("onnx.Slice", /*benefit=*/2, context) {}
+struct SliceToHip : public RewritePattern {
+  SliceToHip(MLIRContext *context)
+      : RewritePattern("onnx.Slice", /*benefit=*/1, context) {}
 
   LogicalResult matchAndRewrite(Operation *op,
                                 PatternRewriter &rewriter) const override {
@@ -200,8 +200,6 @@ struct SliceDecompose : public RewritePattern {
     bool decompose =
         allConstant && llvm::all_of(resolvedStaticSteps,
                                     [](int64_t step) { return step > 0; });
-    if (!decompose)
-      return failure();
     std::optional<hipdnn_ep::slice::NormalizedParameters> staticParameters;
     if (allConstant &&
         llvm::none_of(dataType.getShape(), ShapedType::isDynamic)) {
@@ -328,70 +326,31 @@ struct SliceDecompose : public RewritePattern {
       return success();
     }
 
-    return failure();
-  }
-};
+    SmallVector<Value> dynamicSizes;
+    for (int64_t axis : llvm::seq<int64_t>(rank))
+      if (resultType.isDynamicDim(axis))
+        dynamicSizes.push_back(extentIndices[axis]);
+    Value init =
+        tensor::EmptyOp::create(rewriter, loc, resultType.getShape(),
+                                resultType.getElementType(), dynamicSizes);
 
-struct SliceToHip : public mlir::RewritePattern {
-  SliceToHip(mlir::MLIRContext *ctx)
-      : RewritePattern("onnx.Slice", /*benefit=*/1, ctx) {}
+    SmallVector<Value> operands = {context, data, parameters.valid};
+    llvm::append_range(operands, parameters.starts);
+    llvm::append_range(operands, parameters.steps);
+    llvm::append_range(operands, extentIndices);
+    operands.push_back(init);
 
-  mlir::LogicalResult
-  matchAndRewrite(mlir::Operation *op,
-                  mlir::PatternRewriter &rewriter) const override {
-    if (op->getNumOperands() < 3 || op->getNumOperands() > 5 ||
-        op->getNumResults() != 1)
-      return rewriter.notifyMatchFailure(op, "expected 3-5 inputs, 1 output");
-
-    auto ctxOrFailure = getContextArg(op, rewriter);
-    if (mlir::failed(ctxOrFailure))
-      return mlir::failure();
-    mlir::Value context = *ctxOrFailure;
-
-    mlir::Location loc = op->getLoc();
-    mlir::Value data = op->getOperand(0);
-    mlir::Value starts = op->getOperand(1);
-    mlir::Value ends = op->getOperand(2);
-    mlir::Value axes = op->getNumOperands() >= 4
-                           ? normalizeOptional(op->getOperand(3))
-                           : mlir::Value();
-    mlir::Value steps = op->getNumOperands() == 5
-                            ? normalizeOptional(op->getOperand(4))
-                            : mlir::Value();
-
-    auto resultType =
-        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
-    if (!resultType)
-      return rewriter.notifyMatchFailure(op, "result must be ranked tensor");
-
-    auto dataType = mlir::cast<mlir::RankedTensorType>(data.getType());
-
-    // For each dynamic output dim, source an upper bound from the data
-    // dim at the same position. This is sound because ONNX Slice can
-    // never widen any axis -- output dim i is at most data dim i. The
-    // runtime stub honours `output_shape[i]` as the actual extent so the
-    // over-allocation is benign.
-    llvm::SmallVector<mlir::Value> dynSizes;
-    for (int64_t i = 0; i < resultType.getRank(); ++i) {
-      if (!resultType.isDynamicDim(i))
-        continue;
-      if (i >= dataType.getRank())
-        return rewriter.notifyMatchFailure(
-            op, "result rank exceeds data rank — invalid Slice");
-      if (dataType.isDynamicDim(i))
-        dynSizes.push_back(mlir::tensor::DimOp::create(rewriter, loc, data, i));
-      else
-        dynSizes.push_back(mlir::arith::ConstantIndexOp::create(
-            rewriter, loc, dataType.getDimSize(i)));
-    }
-    mlir::Value init =
-        mlir::tensor::EmptyOp::create(rewriter, loc, resultType.getShape(),
-                                      resultType.getElementType(), dynSizes);
-
-    auto hipOp = mlir::hip::SliceOp::create(rewriter, loc, context, data,
-                                            starts, ends, axes, steps, init);
-    rewriter.replaceOp(op, hipOp->getResult(0));
-    return mlir::success();
+    OperationState state(loc, SliceOp::getOperationName());
+    state.addOperands(operands);
+    state.addTypes(resultType);
+    state.addAttribute(
+        "operand_segment_sizes",
+        rewriter.getDenseI32ArrayAttr({1, 1, 1, static_cast<int32_t>(rank),
+                                       static_cast<int32_t>(rank),
+                                       static_cast<int32_t>(rank), 1}));
+    Operation *slice = rewriter.create(state);
+    rewriter.replaceOp(op, slice->getResult(0));
+    return success();
   }
 };
 
@@ -399,7 +358,7 @@ struct SliceToHip : public mlir::RewritePattern {
 
 void populateSliceConversionPatterns(RewritePatternSet &patterns,
                                      MLIRContext *context) {
-  patterns.add<SliceDecompose, SliceToHip>(context);
+  patterns.add<SliceToHip>(context);
 }
 
 } // namespace hip

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -10,7 +10,6 @@
 #include "llvm/Support/MathExtras.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
@@ -449,30 +448,9 @@ LogicalResult LoopOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
              << i << " type " << args[3 + i]
              << " must match loop carrier result type "
              << getResult(i).getType();
-  for (unsigned i = 0; i < numCaptures; ++i) {
-    Type bodyCapture = args[3 + numLoopCarried + i];
-    Type capture = getCaptures()[i].getType();
-    if (bodyCapture == capture)
-      continue;
-
-    // One-Shot Bufferize can turn an extract_slice capture into a strided
-    // memref while function-boundary conversion gives the outlined body an
-    // identity-layout argument. Permit only that layout-only transient; the
-    // immediately following hip-promote-strided-operands pass materializes the
-    // identity-layout copy. All semantic type mismatches remain verifier
-    // errors.
-    auto bodyMemref = dyn_cast<MemRefType>(bodyCapture);
-    auto captureMemref = dyn_cast<MemRefType>(capture);
-    bool promotableLayoutMismatch =
-        bodyDescriptorMode && bodyMemref && captureMemref &&
-        bodyMemref.getLayout().isIdentity() &&
-        !captureMemref.getLayout().isIdentity() &&
-        bodyMemref.getShape() == captureMemref.getShape() &&
-        bodyMemref.getElementType() == captureMemref.getElementType() &&
-        bodyMemref.getMemorySpace() == captureMemref.getMemorySpace();
-    if (!promotableLayoutMismatch)
+  for (unsigned i = 0; i < numCaptures; ++i)
+    if (args[3 + numLoopCarried + i] != getCaptures()[i].getType())
       return emitOpError("body_func capture #") << i << " type mismatch";
-  }
   for (unsigned i = 0; i < numCaptures; ++i) {
     Type capture = getCaptures()[i].getType();
     bool supported = bodyDescriptorMode ? isa<MemRefType>(capture)

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -10,6 +10,8 @@
 #include "llvm/Support/MathExtras.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/OpDefinition.h"
@@ -447,9 +449,30 @@ LogicalResult LoopOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
              << i << " type " << args[3 + i]
              << " must match loop carrier result type "
              << getResult(i).getType();
-  for (unsigned i = 0; i < numCaptures; ++i)
-    if (args[3 + numLoopCarried + i] != getCaptures()[i].getType())
+  for (unsigned i = 0; i < numCaptures; ++i) {
+    Type bodyCapture = args[3 + numLoopCarried + i];
+    Type capture = getCaptures()[i].getType();
+    if (bodyCapture == capture)
+      continue;
+
+    // One-Shot Bufferize can turn an extract_slice capture into a strided
+    // memref while function-boundary conversion gives the outlined body an
+    // identity-layout argument. Permit only that layout-only transient; the
+    // immediately following hip-promote-strided-operands pass materializes the
+    // identity-layout copy. All semantic type mismatches remain verifier
+    // errors.
+    auto bodyMemref = dyn_cast<MemRefType>(bodyCapture);
+    auto captureMemref = dyn_cast<MemRefType>(capture);
+    bool promotableLayoutMismatch =
+        bodyDescriptorMode && bodyMemref && captureMemref &&
+        bodyMemref.getLayout().isIdentity() &&
+        !captureMemref.getLayout().isIdentity() &&
+        bodyMemref.getShape() == captureMemref.getShape() &&
+        bodyMemref.getElementType() == captureMemref.getElementType() &&
+        bodyMemref.getMemorySpace() == captureMemref.getMemorySpace();
+    if (!promotableLayoutMismatch)
       return emitOpError("body_func capture #") << i << " type mismatch";
+  }
   for (unsigned i = 0; i < numCaptures; ++i) {
     Type capture = getCaptures()[i].getType();
     bool supported = bodyDescriptorMode ? isa<MemRefType>(capture)
@@ -2180,7 +2203,7 @@ void GatherNDOp::getEffects(
 }
 
 //===----------------------------------------------------------------------===//
-// SliceOp: ins(data, starts, ends, [axes], [steps]), outs(output)
+// SliceOp: exact normalized host controls plus DPS output
 //===----------------------------------------------------------------------===//
 
 MutableOperandRange SliceOp::getDpsInitsMutable() { return getOutputMutable(); }
@@ -2189,6 +2212,43 @@ void SliceOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
   emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
+}
+
+LogicalResult SliceOp::verify() {
+  if (failed(verifyDpsComputeOp(getOperation(), {getData(), getOutput()},
+                                /*numInits=*/1)))
+    return failure();
+
+  auto dataType = dyn_cast<ShapedType>(getData().getType());
+  auto outputType = dyn_cast<ShapedType>(getOutput().getType());
+  if (!dataType || !outputType || !dataType.hasRank() || !outputType.hasRank())
+    return emitOpError("data and output must be ranked shaped types");
+  int64_t rank = dataType.getRank();
+  if (outputType.getRank() != rank)
+    return emitOpError("output rank must equal data rank");
+  if (dataType.getElementType() != outputType.getElementType())
+    return emitOpError("output element type must equal data element type");
+  if (static_cast<int64_t>(getStarts().size()) != rank ||
+      static_cast<int64_t>(getSteps().size()) != rank ||
+      static_cast<int64_t>(getExtents().size()) != rank)
+    return emitOpError(
+        "starts, steps, and extents must each contain exactly data-rank "
+        "entries");
+
+  // In tensor mode conversion constructs the exact destination with these same
+  // extent SSA values. Static dimensions are encoded by the tensor.empty type;
+  // dynamic dimensions must be tied to the corresponding extent operand.
+  if (auto empty = getOutput().getDefiningOp<tensor::EmptyOp>()) {
+    unsigned dynamicIndex = 0;
+    for (int64_t dim : llvm::seq<int64_t>(rank)) {
+      if (!outputType.isDynamicDim(dim))
+        continue;
+      if (empty.getDynamicSizes()[dynamicIndex++] != getExtents()[dim])
+        return emitOpError("dynamic output dimension ")
+               << dim << " must be allocated from the matching exact extent";
+    }
+  }
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
+++ b/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
@@ -224,18 +224,12 @@ GemmOp::reifyResultShapes(OpBuilder &b,
 // leaf op contributes only the list of operand getter names; no
 // per-op `.cpp` thunk is needed.
 //
-// Other ops whose output dims are arithmetic functions of operand
-// values (pad, tile, expand, slice, range) have per-op Tier-1 reify
-// thunks below: each calls a dedicated `reifyPadShape` /
-// `reifyTileShape` / `reifyExpandShape` / `reifySliceShape` /
-// `reifyRangeShape` helper (`HipShapeUtils.cpp`) that computes the
-// output shape from the INPUT operands using a fold-or-bail strategy.
-// On bail (non-constant operands, dynamic input dims) the thunk falls
-// back to `cast<HipDpsOp>(getOperation()).reifyResultShapes` — i.e. the
-// shared `HipDpsOp` outs-lift default. This avoids emitting per-dim
-// `arith.addi(tensor.dim, const)` / `arith.divsi(...)` chains that
-// don't fold and would clutter the IR (particularly important for
-// slice's per-axis chain and range's count-only output).
+// Other ops whose output dims are arithmetic functions of operand values (pad,
+// tile, expand, range) have per-op Tier-1 reify thunks below that call their
+// dedicated HipShapeUtils helper. Slice is different: conversion has already
+// normalized every control and materialized exact rank extents, so its reifier
+// returns those extent operands directly and never reads payload tensors or
+// lifts destination capacity.
 //
 // Before (transpose, perm-driven mapping):
 //   %t = hip.transpose(%ctx) ins(%x : tensor<2x?x4096xf16>)
@@ -526,15 +520,16 @@ ExpandOp::reifyResultShapes(OpBuilder &b,
 LogicalResult
 SliceOp::reifyResultShapes(OpBuilder &b,
                            ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+  auto dataType = dyn_cast<RankedTensorType>(getData().getType());
+  if (!dataType ||
+      static_cast<int64_t>(getExtents().size()) != dataType.getRank())
+    return failure();
   SmallVector<OpFoldResult> dims;
-  if (succeeded(mlir::hip::reifySliceShape(b, getLoc(), getData(), getStarts(),
-                                           getEnds(), getAxes(), getSteps(),
-                                           dims))) {
-    reifiedReturnShapes.assign({std::move(dims)});
-    return success();
-  }
-  return cast<HipDpsOp>(getOperation())
-      .reifyResultShapes(b, reifiedReturnShapes);
+  dims.reserve(getExtents().size());
+  for (Value extent : getExtents())
+    dims.push_back(extent);
+  reifiedReturnShapes.assign({std::move(dims)});
+  return success();
 }
 
 LogicalResult

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -266,6 +266,7 @@ macro(compile_to_bitcode SOURCE_FILE OUTPUT_BC)
                 ${CMAKE_CURRENT_SOURCE_DIR}/op_profile.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/chrome_trace.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/debug_log.h
+                ${CMAKE_SOURCE_DIR}/include/hip/Support/SliceUtils.h
                 ${IMPL_DEPS}
                 ${CMAKE_BINARY_DIR}/schemas/model_metadata_generated.h
         COMMENT "Compiling ${SOURCE_FILE} to bitcode"

--- a/lib/Runtime/Kernels/hip/slice_kernel.hip
+++ b/lib/Runtime/Kernels/hip/slice_kernel.hip
@@ -1,191 +1,196 @@
 /*
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
- *
- * Slice (non-constant-indices / negative-step fallback).
- *
- * The compile-time-constant + positive-stride case is folded to
- * `tensor.extract_slice` upstream of the runtime (see
- * lib/Conversion/OnnxToHip/SliceConversion.cpp::SliceDecompose), so this
- * kernel only services slices whose `starts` / `ends` / `axes` / `steps`
- * are NOT graph-constant, or that have negative steps.
- *
- * The host wrapper does the heavy lifting:
- *   - D2H of the index tensors (typically tiny: a few int64s).
- *   - Per-axis resolution of `start` / `step` per ONNX spec (negative
- *     indices, clamping, axes that default to [0..r-1] when absent,
- *     steps that default to 1).
- *   - Output shape is provided by the IR (the lowering requires static
- *     output shape).
- *
- * Each kernel thread:
- *   1. Computes its output coordinate `(out_coord[0], ..., out_coord[r-1])`
- *      from its linear thread id via the output strides.
- *   2. For each dim d, computes `in_coord[d] = start[d] + out_coord[d] * step[d]`.
- *   3. Linearises `in_coord` via the input strides and copies the element.
- *
- * No bounds checks — the host wrapper is responsible for producing valid
- * (start, step, output_size) triples per axis.
- *
- * Bounded to rank <= 8 (matches kPadMaxRank / kGatherNDMaxRank).
  */
 
-#include "hip_custom_kernels.h"
 #include "debug_log.h"
+#include "hip_custom_kernels.h"
 
+#include <cstdint>
+#include <cstdlib>
+#include <cstdio>
 #include <hip/hip_fp16.h>
 #include <hip/hip_runtime.h>
-#include <cstdint>
-#include <cstdio>
+#include <limits>
 
-static constexpr int kSliceMaxRank = 8;
-
-struct SliceParams {
-  int64_t input_strides[kSliceMaxRank];
-  int64_t output_strides[kSliceMaxRank];
-  // logical_extent[d] = the actual per-axis slice output extent. For
-  // axes not touched by `axes`, equals the data dim. For touched axes,
-  // equals `(end-start) / step` (positive step) clamped to >= 0. When
-  // logical_extent[d] < the physical output dim (i.e. the IR-supplied
-  // output_shape's d-th dim), the host has OVER-ALLOCATED the output
-  // buffer because `SliceToHip` could not constant-fold the per-axis
-  // extent at compile time (typical for slices whose starts/ends are
-  // runtime Gather outputs inside an outlined loop body). The kernel
-  // iterates physical positions and fills the over-allocated tail with
-  // zeros so downstream consumers operating on the full physical extent
-  // see clean deterministic data instead of pool garbage.
-  int64_t logical_extent[kSliceMaxRank];
-  // start[d] and step[d] are signed; step may be negative when slicing
-  // with a reverse stride.
-  int64_t start_per_axis[kSliceMaxRank];
-  int64_t step_per_axis[kSliceMaxRank];
-  int rank;
-};
+namespace {
 
 template <typename T>
 __global__ void hip_slice_kernel(const T *__restrict__ input,
-                                 T *__restrict__ output, SliceParams p,
-                                 int64_t num_output_elements) {
-  int64_t out_idx =
+                                 T *__restrict__ output,
+                                 const int64_t *__restrict__ metadata, int rank,
+                                 int64_t numOutputElements) {
+  int64_t outputIndex =
       static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (out_idx >= num_output_elements)
+  if (outputIndex >= numOutputElements)
     return;
 
-  // Decode physical coord, then check whether every axis is within its
-  // logical extent. Any over-allocated tail position writes zero.
-  int64_t remaining = out_idx;
-  int64_t coord[kSliceMaxRank];
-  for (int d = 0; d < p.rank; ++d) {
-    int64_t out_stride = p.output_strides[d];
-    coord[d] = remaining / out_stride;
-    remaining -= coord[d] * out_stride;
-  }
+  const int64_t *inputStrides = metadata;
+  const int64_t *outputStrides = metadata + rank;
+  const int64_t *starts = metadata + 2 * rank;
+  const int64_t *steps = metadata + 3 * rank;
 
-  bool in_logical = true;
-  for (int d = 0; d < p.rank; ++d) {
-    if (coord[d] >= p.logical_extent[d]) {
-      in_logical = false;
-      break;
-    }
+  int64_t remaining = outputIndex;
+  int64_t inputOffset = 0;
+  for (int axis = 0; axis < rank; ++axis) {
+    int64_t coordinate = remaining / outputStrides[axis];
+    remaining -= coordinate * outputStrides[axis];
+    inputOffset += (starts[axis] + coordinate * steps[axis]) *
+                   inputStrides[axis];
   }
-  if (!in_logical) {
-    output[out_idx] = T(0);
-    return;
-  }
-
-  int64_t in_offset = 0;
-  for (int d = 0; d < p.rank; ++d) {
-    int64_t in_coord = p.start_per_axis[d] + coord[d] * p.step_per_axis[d];
-    in_offset += in_coord * p.input_strides[d];
-  }
-
-  output[out_idx] = input[in_offset];
+  output[outputIndex] = input[inputOffset];
 }
 
-static void compute_row_major_strides(const int64_t *shape, int rank,
-                                      int64_t *strides_out) {
-  int64_t suffix = 1;
-  for (int d = rank - 1; d >= 0; --d) {
-    strides_out[d] = suffix;
-    suffix *= shape[d];
+bool computeStrides(const int64_t *shape, int rank, int64_t *strides,
+                    int64_t &elements) {
+  elements = 1;
+  for (int axis = rank - 1; axis >= 0; --axis) {
+    if (shape[axis] < 0)
+      return false;
+    strides[axis] = elements;
+    if (shape[axis] != 0 &&
+        elements > std::numeric_limits<int64_t>::max() / shape[axis])
+      return false;
+    elements *= shape[axis];
   }
+  return true;
 }
+
+template <typename T>
+void launch(hipStream_t stream, const void *input, void *output,
+            const int64_t *metadata, int rank, int64_t elements,
+            uint32_t gridSize) {
+  constexpr int kBlockSize = 256;
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_slice_kernel<T>), dim3(gridSize),
+                     dim3(kBlockSize), 0, stream,
+                     static_cast<const T *>(input), static_cast<T *>(output),
+                     metadata, rank, elements);
+}
+
+void freeHostMetadata(void *metadata) { std::free(metadata); }
+
+} // namespace
 
 extern "C" int hip_slice(void *stream, const void *input, void *output,
                          const int64_t *input_shape_host,
                          const int64_t *output_shape_host,
-                         const int64_t *logical_extent_host,
                          const int64_t *starts_per_axis_host,
                          const int64_t *steps_per_axis_host, int rank,
-                         int hip_dtype) {
-  if (rank <= 0 || rank > kSliceMaxRank) {
-    fprintf(stderr,
-            "[custom_kernels] hip_slice: rank=%d out of range [1, %d]\n", rank,
-            kSliceMaxRank);
+                         int hip_dtype, void *metadata_scratch_device,
+                         size_t metadata_scratch_bytes) {
+  if (rank < 0 ||
+      (rank > 0 &&
+       (!input_shape_host || !output_shape_host || !starts_per_axis_host ||
+        !steps_per_axis_host || !metadata_scratch_device)) ||
+      !input || !output)
+    return -1;
+  if (static_cast<uint64_t>(rank) >
+      std::numeric_limits<size_t>::max() / (4 * sizeof(int64_t)))
+    return -1;
+  size_t requiredBytes =
+      static_cast<size_t>(rank) * 4 * sizeof(int64_t);
+  if (metadata_scratch_bytes < requiredBytes)
+    return -1;
+
+  int64_t *metadata = nullptr;
+  if (requiredBytes > 0) {
+    metadata = static_cast<int64_t *>(std::malloc(requiredBytes));
+    if (!metadata)
+      return -1;
+  }
+  int64_t inputElements = 0;
+  int64_t outputElements = 0;
+  int64_t *outputStrides = metadata ? metadata + rank : nullptr;
+  if (!computeStrides(input_shape_host, rank, metadata, inputElements) ||
+      !computeStrides(output_shape_host, rank, outputStrides, outputElements)) {
+    std::free(metadata);
     return -1;
   }
-
-  SliceParams p{};
-  p.rank = rank;
-  compute_row_major_strides(input_shape_host, rank, p.input_strides);
-  compute_row_major_strides(output_shape_host, rank, p.output_strides);
-  for (int d = 0; d < rank; ++d) {
-    p.start_per_axis[d] = starts_per_axis_host[d];
-    p.step_per_axis[d] = steps_per_axis_host[d];
-    p.logical_extent[d] =
-        logical_extent_host ? logical_extent_host[d] : output_shape_host[d];
+  (void)inputElements;
+  for (int axis = 0; axis < rank; ++axis) {
+    metadata[2 * rank + axis] = starts_per_axis_host[axis];
+    metadata[3 * rank + axis] = steps_per_axis_host[axis];
+  }
+  if (outputElements == 0) {
+    std::free(metadata);
+    return 0;
   }
 
-  int64_t num_output_elements = 1;
-  for (int d = 0; d < rank; ++d)
-    num_output_elements *= output_shape_host[d];
-  if (num_output_elements == 0)
-    return 0;
-
-  hipStream_t hip_stream = static_cast<hipStream_t>(stream);
-  constexpr int kBlockSize = 256;
-  int grid_size = static_cast<int>(
-      (num_output_elements + kBlockSize - 1) / kBlockSize);
-
-  CUSTOM_KERNELS_DEBUG_LOG("[custom_kernels] hip_slice: dtype=%d, rank=%d, "
-                           "num_out=%lld\n",
-                           hip_dtype, rank, (long long)num_output_elements);
-
-  switch (hip_dtype) {
-  case HIP_DTYPE_FLOAT16:
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_slice_kernel<__half>),
-                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
-                       static_cast<const __half *>(input),
-                       static_cast<__half *>(output), p, num_output_elements);
-    break;
-  case HIP_DTYPE_FLOAT32:
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_slice_kernel<float>),
-                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
-                       static_cast<const float *>(input),
-                       static_cast<float *>(output), p, num_output_elements);
-    break;
-  case HIP_DTYPE_INT32:
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_slice_kernel<int32_t>),
-                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
-                       static_cast<const int32_t *>(input),
-                       static_cast<int32_t *>(output), p, num_output_elements);
-    break;
-  case HIP_DTYPE_INT64:
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_slice_kernel<int64_t>),
-                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
-                       static_cast<const int64_t *>(input),
-                       static_cast<int64_t *>(output), p, num_output_elements);
-    break;
-  default:
+  constexpr int64_t kBlockSize = 256;
+  uint64_t gridSize =
+      (static_cast<uint64_t>(outputElements) + kBlockSize - 1) / kBlockSize;
+  if (gridSize == 0 || gridSize > std::numeric_limits<uint32_t>::max()) {
+    std::free(metadata);
+    return -1;
+  }
+  if (hip_dtype != HIP_DTYPE_FLOAT16 && hip_dtype != HIP_DTYPE_FLOAT32 &&
+      hip_dtype != HIP_DTYPE_INT32 && hip_dtype != HIP_DTYPE_INT64) {
     fprintf(stderr, "[custom_kernels] hip_slice: unsupported dtype=%d\n",
             hip_dtype);
+    std::free(metadata);
     return -1;
   }
 
-  hipError_t err = hipGetLastError();
-  if (err != hipSuccess) {
-    fprintf(stderr, "[custom_kernels] hip_slice launch failed: %s\n",
-            hipGetErrorString(err));
+  hipStream_t hipStream = static_cast<hipStream_t>(stream);
+  if (requiredBytes > 0) {
+    hipError_t copyError =
+        hipMemcpyAsync(metadata_scratch_device, metadata, requiredBytes,
+                       hipMemcpyHostToDevice, hipStream);
+    if (copyError != hipSuccess) {
+      fprintf(stderr, "[custom_kernels] hip_slice metadata H2D failed: %s\n",
+              hipGetErrorString(copyError));
+      std::free(metadata);
+      return static_cast<int>(copyError);
+    }
   }
-  return static_cast<int>(err);
+
+  (void)hipGetLastError();
+  switch (hip_dtype) {
+  case HIP_DTYPE_FLOAT16:
+    launch<__half>(hipStream, input, output,
+                   static_cast<const int64_t *>(metadata_scratch_device), rank,
+                   outputElements, static_cast<uint32_t>(gridSize));
+    break;
+  case HIP_DTYPE_FLOAT32:
+    launch<float>(hipStream, input, output,
+                  static_cast<const int64_t *>(metadata_scratch_device), rank,
+                  outputElements, static_cast<uint32_t>(gridSize));
+    break;
+  case HIP_DTYPE_INT32:
+    launch<int32_t>(hipStream, input, output,
+                    static_cast<const int64_t *>(metadata_scratch_device), rank,
+                    outputElements, static_cast<uint32_t>(gridSize));
+    break;
+  case HIP_DTYPE_INT64:
+    launch<int64_t>(hipStream, input, output,
+                    static_cast<const int64_t *>(metadata_scratch_device), rank,
+                    outputElements, static_cast<uint32_t>(gridSize));
+    break;
+  }
+
+  hipError_t launchError = hipGetLastError();
+  if (launchError != hipSuccess) {
+    fprintf(stderr, "[custom_kernels] hip_slice launch failed: %s\n",
+            hipGetErrorString(launchError));
+    (void)hipStreamSynchronize(hipStream);
+    std::free(metadata);
+    return static_cast<int>(launchError);
+  }
+  if (metadata) {
+    hipError_t cleanupError =
+        hipLaunchHostFunc(hipStream, freeHostMetadata, metadata);
+    if (cleanupError != hipSuccess) {
+      fprintf(stderr,
+              "[custom_kernels] hip_slice metadata cleanup enqueue failed: "
+              "%s\n",
+              hipGetErrorString(cleanupError));
+      (void)hipStreamSynchronize(hipStream);
+      std::free(metadata);
+      return static_cast<int>(cleanupError);
+    }
+  }
+  CUSTOM_KERNELS_DEBUG_LOG(
+      "[custom_kernels] hip_slice: dtype=%d rank=%d num_out=%lld\n", hip_dtype,
+      rank, (long long)outputElements);
+  return 0;
 }

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -1305,19 +1305,16 @@ HIP_KERNEL_API int hip_gather_nd(
  * services slices whose `starts` / `ends` / `axes` / `steps` are NOT
  * graph-constant (or have negative steps).
  *
- * The host wrapper D2Hs the (typically tiny) index tensors and resolves
- * them into per-axis `(start, step)` pairs in INPUT-space, one entry per
- * data dimension. Axes not listed default to `(0, 1)`. The kernel runs
- * one thread per output element and computes:
+ * Conversion resolves exact per-axis `(start, step, extent)` controls on the
+ * host. The launcher stages arbitrary-rank input/output strides plus starts and
+ * steps into runtime-managed device scratch on the same stream as the kernel.
+ * The kernel runs one thread per exact output element and computes:
  *
  *     in_offset = sum_d ( start[d] + out_coord[d] * step[d] ) * input_stride[d]
  *     output[out_idx] = input[in_offset]
  *
- * `step[d]` may be negative; correctness relies on the host wrapper
- * having already resolved start / end to absolute positions per ONNX's
- * negative-index and clamping rules (see lib/Runtime/real/slice.cpp).
- *
- * Bounded to rank <= 8 (matches kPadMaxRank / kGatherNDMaxRank).
+ * `step[d]` may be negative. Runtime preflight validates every first/last
+ * address before launch. There is no fixed rank cap.
  *
  * Supported dtypes: f16, f32, i32, i64.
  */
@@ -1326,23 +1323,13 @@ HIP_KERNEL_API int hip_slice(
     const void* input,
     void* output,
     const int64_t* input_shape_host,
-    const int64_t* output_shape_host,     /* physical alloc shape       */
-    const int64_t* logical_extent_host,   /* per-axis actual slice extent;
-                                             may be NULL, in which case the
-                                             kernel treats it as identical to
-                                             output_shape_host (i.e. no
-                                             over-alloc; entire physical
-                                             buffer is filled by the slice).
-                                             When set and logical[d] <
-                                             output_shape[d] for some d,
-                                             positions in the over-allocated
-                                             tail are filled with zero — the
-                                             host wrapper does not need to
-                                             pre-memset the buffer.        */
+    const int64_t* output_shape_host,
     const int64_t* starts_per_axis_host,  /* length = rank */
     const int64_t* steps_per_axis_host,   /* length = rank */
     int rank,
-    int hip_dtype);
+    int hip_dtype,
+    void *metadata_scratch_device,
+    size_t metadata_scratch_bytes);
 
 /* =========================================================================
  * ScatterND (ONNX-13+ with optional `reduction`)

--- a/lib/Runtime/Kernels/test/example/gqa/dispatch_bench/shim_back/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/test/example/gqa/dispatch_bench/shim_back/hip_custom_kernels.h
@@ -1018,27 +1018,19 @@ HIP_KERNEL_API int hip_gather_nd(
     int hip_dtype);
 
 /* =========================================================================
- * Slice (ONNX-13+ ΓÇö non-constant indices / negative-step fallback)
+ * Slice (ONNX-13+ normalized-control fallback)
  * =========================================================================
  *
- * The compile-time-constant + positive-stride case is folded to
- * `tensor.extract_slice` upstream of the runtime, so this kernel only
- * services slices whose `starts` / `ends` / `axes` / `steps` are NOT
- * graph-constant (or have negative steps).
- *
- * The host wrapper D2Hs the (typically tiny) index tensors and resolves
- * them into per-axis `(start, step)` pairs in INPUT-space, one entry per
- * data dimension. Axes not listed default to `(0, 1)`. The kernel runs
- * one thread per output element and computes:
+ * Conversion resolves exact per-axis `(start, step, extent)` controls on the
+ * host. The launcher stages arbitrary-rank input/output strides plus starts and
+ * steps into dedicated runtime-managed device scratch on the same stream. The
+ * kernel runs one thread per exact output element and computes:
  *
  *     in_offset = sum_d ( start[d] + out_coord[d] * step[d] ) * input_stride[d]
  *     output[out_idx] = input[in_offset]
  *
- * `step[d]` may be negative; correctness relies on the host wrapper
- * having already resolved start / end to absolute positions per ONNX's
- * negative-index and clamping rules (see lib/Runtime/real/slice.cpp).
- *
- * Bounded to rank <= 8 (matches kPadMaxRank / kGatherNDMaxRank).
+ * `step[d]` may be negative. Runtime preflight validates every first/last
+ * address before launch. There is no fixed rank cap.
  *
  * Supported dtypes: f16, f32, i32, i64.
  */
@@ -1047,23 +1039,13 @@ HIP_KERNEL_API int hip_slice(
     const void* input,
     void* output,
     const int64_t* input_shape_host,
-    const int64_t* output_shape_host,     /* physical alloc shape       */
-    const int64_t* logical_extent_host,   /* per-axis actual slice extent;
-                                             may be NULL, in which case the
-                                             kernel treats it as identical to
-                                             output_shape_host (i.e. no
-                                             over-alloc; entire physical
-                                             buffer is filled by the slice).
-                                             When set and logical[d] <
-                                             output_shape[d] for some d,
-                                             positions in the over-allocated
-                                             tail are filled with zero ΓÇö the
-                                             host wrapper does not need to
-                                             pre-memset the buffer.        */
+    const int64_t* output_shape_host,
     const int64_t* starts_per_axis_host,  /* length = rank */
     const int64_t* steps_per_axis_host,   /* length = rank */
     int rank,
-    int hip_dtype);
+    int hip_dtype,
+    void *metadata_scratch_device,
+    size_t metadata_scratch_bytes);
 
 /* =========================================================================
  * ScatterND (ONNX-13+ with optional `reduction`)

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -1630,23 +1630,14 @@ int wrap_sign(RuntimeState *state, void *input, void *output,
 int wrap_mod(RuntimeState *state, void *lhs, void *rhs, void *output,
              int64_t num_elements, int64_t data_type, int64_t fmod);
 
-// Slice operation wrapper (ONNX Slice native fallback).
-//
-// Today this is a stub: the OnnxToHip decompose pattern handles the common
-// case (compile-time constant starts/ends/axes/steps with positive unit
-// stride) by rewriting onnx.Slice to tensor.extract_slice, so this runtime
-// entry is only called for non-constant-indices or negative-step Slices.
-// The stub only logs its parameters and returns success — models that
-// exercise it will produce incorrect Slice output but will still link and
-// run end-to-end for IR-shape debugging.
-//
-// axes / steps may be nullptr when the corresponding optional input is absent.
-int wrap_slice(RuntimeState *state, void *data, void *starts, void *ends,
-               void *axes, void *steps, void *output, const int64_t *data_shape,
-               int64_t data_rank, const int64_t *output_shape,
-               int64_t output_rank, int64_t starts_num_elements,
-               int64_t axes_num_elements, int64_t steps_num_elements,
-               int64_t data_type);
+// Slice operation wrapper. Conversion has already normalized ONNX controls and
+// allocated the exact output. All host arrays contain exactly `rank` entries;
+// `output_shape` must equal `extents`. The runtime performs no D2H readback.
+int wrap_slice(RuntimeState *state, void *data, void *output,
+               const int64_t *data_shape, const int64_t *output_shape,
+               const int64_t *starts, const int64_t *steps,
+               const int64_t *extents, int64_t rank, int64_t data_type,
+               bool params_valid);
 
 // ScatterND: output = copy(data), then output[indices[i]] (reduction)
 // updates[i].

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -158,6 +158,9 @@ static int initialize_state_handles(RuntimeState **out_state) {
   state->num_buffers = 0;
   state->workspace = nullptr;
   state->workspace_size = 0;
+  state->slice_metadata_scratch = nullptr;
+  state->slice_metadata_scratch_size = 0;
+  state->slice_metadata_mutex = nullptr;
   state->num_host_scratch_sites = 0;
   state->host_scratch_sites = nullptr;
   // Start with no output allocator (null context + callback). The EP installs
@@ -283,6 +286,8 @@ static int initialize_state_handles(RuntimeState **out_state) {
     free(state);
     return 12;
   }
+
+  state->slice_metadata_mutex = new std::mutex();
 
   *out_state = state;
   return 0;
@@ -718,6 +723,14 @@ int hipdnn_ep_state_cleanup(RuntimeState *state) {
   if (state->workspace) {
     HIP_CLEANUP(hipFree(state->workspace));
   }
+
+  // Slice's dedicated scratch can only be in flight on state->stream, which
+  // was drained above. No host call may race state cleanup.
+  if (state->slice_metadata_scratch) {
+    HIP_CLEANUP(hipFree(state->slice_metadata_scratch));
+  }
+  delete state->slice_metadata_mutex;
+  state->slice_metadata_mutex = nullptr;
 
   // Free qmoe device scratch + pinned host mirror (if allocated)
   if (state->qmoe_scratch) {

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -2,6 +2,7 @@
  * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
  * Licensed under the MIT License.
  */
+#include "hip/Support/SliceUtils.h"
 #include "hipdnn_ep_runtime.h"
 #include "matmul_gemm_contract.h"
 #include "runtime_types.h"
@@ -9,6 +10,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <vector>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -2078,29 +2080,52 @@ int wrap_gather_nd(RuntimeState *state, void *data, void *indices, void *output,
   return 0;
 }
 
-int wrap_slice(RuntimeState *state, void *data, void *starts, void *ends,
-               void *axes, void *steps, void *output, const int64_t *data_shape,
-               int64_t data_rank, const int64_t *output_shape,
-               int64_t output_rank, int64_t starts_num_elements,
-               int64_t axes_num_elements, int64_t steps_num_elements,
-               int64_t data_type) {
-  if (!state) {
-    fprintf(stderr, "Invalid state in wrap_slice\n");
+int wrap_slice(RuntimeState *state, void *data, void *output,
+               const int64_t *data_shape, const int64_t *output_shape,
+               const int64_t *starts, const int64_t *steps,
+               const int64_t *extents, int64_t rank, int64_t data_type,
+               bool params_valid) {
+  int64_t elementBytes = hipdnn_ep_datatype_size(data_type);
+  hipdnn_ep::slice::PreflightResult checked = hipdnn_ep::slice::preflight(
+      state, data, output, data_shape, output_shape, starts, steps, extents,
+      rank, elementBytes, params_valid);
+  if (checked.status == hipdnn_ep::slice::PreflightStatus::Error) {
+    if (state)
+      (void)hipdnn_ep_state_set_error_flag(state);
     return -1;
   }
-  (void)data;
-  (void)starts;
-  (void)ends;
-  (void)output;
-  (void)data_shape;
-  (void)output_shape;
-  MOCK_PRINT("[MOCK] wrap_slice(data_rank=%lld, output_rank=%lld, "
-             "starts_n=%lld, axes_n=%lld (%s), steps_n=%lld (%s), "
-             "data_type=%s(%lld))\n",
-             (long long)data_rank, (long long)output_rank,
-             (long long)starts_num_elements, (long long)axes_num_elements,
-             axes ? "yes" : "null", (long long)steps_num_elements,
-             steps ? "yes" : "null", hipdnn_ep_datatype_name(data_type),
+  if (checked.status == hipdnn_ep::slice::PreflightStatus::EmptyOutput)
+    return 0;
+
+  std::vector<int64_t> inputStrides(static_cast<size_t>(rank));
+  std::vector<int64_t> outputStrides(static_cast<size_t>(rank));
+  int64_t inputStride = 1;
+  int64_t outputStride = 1;
+  for (int64_t axis = rank; axis-- > 0;) {
+    inputStrides[static_cast<size_t>(axis)] = inputStride;
+    outputStrides[static_cast<size_t>(axis)] = outputStride;
+    inputStride *= data_shape[axis];
+    outputStride *= output_shape[axis];
+  }
+  auto *inputBytes = static_cast<const unsigned char *>(data);
+  auto *outputBytes = static_cast<unsigned char *>(output);
+  for (uint64_t outputIndex = 0; outputIndex < checked.outputElements;
+       ++outputIndex) {
+    int64_t remaining = static_cast<int64_t>(outputIndex);
+    int64_t inputIndex = 0;
+    for (int64_t axis = 0; axis < rank; ++axis) {
+      int64_t coordinate = remaining / outputStrides[static_cast<size_t>(axis)];
+      remaining -= coordinate * outputStrides[static_cast<size_t>(axis)];
+      inputIndex += (starts[axis] + coordinate * steps[axis]) *
+                    inputStrides[static_cast<size_t>(axis)];
+    }
+    std::memcpy(outputBytes + outputIndex * static_cast<size_t>(elementBytes),
+                inputBytes + static_cast<size_t>(inputIndex) *
+                                 static_cast<size_t>(elementBytes),
+                static_cast<size_t>(elementBytes));
+  }
+  MOCK_PRINT("[MOCK] wrap_slice(rank=%lld, data_type=%s(%lld))\n",
+             (long long)rank, hipdnn_ep_datatype_name(data_type),
              (long long)data_type);
   return 0;
 }

--- a/lib/Runtime/output_allocator.cpp
+++ b/lib/Runtime/output_allocator.cpp
@@ -82,8 +82,12 @@ extern "C" void *hipdnn_ep_alloc_output(RuntimeState *state, int64_t out_idx,
                                         const int64_t *shape, int64_t rank,
                                         int64_t elem_size) {
   size_t bytes = 0;
-  if (!state || !logicalBytes(shape, rank, elem_size, bytes))
+  if (!state)
     return nullptr;
+  if (!logicalBytes(shape, rank, elem_size, bytes)) {
+    (void)recordOutputFailure(state);
+    return nullptr;
+  }
   if (!state->output_allocator.allocate) {
     fprintf(stderr,
             "hipdnn_ep_alloc_output: no output allocator installed "

--- a/lib/Runtime/real/slice.cpp
+++ b/lib/Runtime/real/slice.cpp
@@ -3,51 +3,22 @@
  * Licensed under the MIT License.
  */
 
-// Slice (ONNX-13+) -- non-constant indices / negative-step fallback.
-//
-// The compile-time-constant + positive-stride case is folded upstream to
-// `tensor.extract_slice` (see lib/Conversion/OnnxToHip/SliceConversion.cpp
-// ::SliceDecompose), so this entry point only fires for slices whose
-// `starts` / `ends` / `axes` / `steps` are not graph-constant (or that
-// use negative steps).
-//
-// Per ONNX-13+ Slice spec:
-//
-//   * `starts` and `ends` are 1-D int64 (or int32) tensors with one entry
-//     per axis listed in `axes`.
-//   * `axes` defaults to [0, ..., rank-1] when absent.
-//   * `steps` defaults to all-ones; non-zero negative steps are allowed.
-//   * Per-axis negative indices: idx<0 -> idx += dim.
-//   * Clamping:
-//       step > 0: start in [0, dim], end in [0, dim].
-//       step < 0: start in [0, dim-1], end in [-1, dim-1].
-//
-// Output shape is statically known (the SliceToHip lowering enforces
-// this), so the only work we do at runtime is:
-//
-//   1. D2H of starts / ends / (optional) axes / (optional) steps.
-//   2. Resolve to per-input-axis (start, step) per ONNX rules.
-//   3. Launch `hip_slice` -- one thread per output element.
-//
-// We assume the four index tensors are INT64 -- the standard ONNX form
-// and what every test in the LIT suite uses. If a model produces INT32
-// index tensors we will need to dispatch on stride (the ABI omits the
-// dtype for these operands today).
-
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
 #include "../op_profile.h"
+#include "../runtime_state_internal.h"
+#include "hip/Support/SliceUtils.h"
 #include "hip_custom_kernels.h"
 
-#include <algorithm>
 #include <cstdio>
-#include <hip/hip_runtime.h>
-#include <vector>
+#include <limits>
+#include <mutex>
+#include <string>
 
-static constexpr int kSliceRuntimeMaxRank = 8;
+namespace {
 
-static int slice_hipdnn_to_hip_dtype(int64_t hipdnn_type) {
-  switch (hipdnn_type) {
+int toHipDtype(int64_t dataType) {
+  switch (dataType) {
   case HIPDNN_EP_DATATYPE_HALF:
     return HIP_DTYPE_FLOAT16;
   case HIPDNN_EP_DATATYPE_FLOAT:
@@ -61,308 +32,108 @@ static int slice_hipdnn_to_hip_dtype(int64_t hipdnn_type) {
   }
 }
 
-int wrap_slice(RuntimeState *state, void *data, void *starts, void *ends,
-               void *axes, void *steps, void *output, const int64_t *data_shape,
-               int64_t data_rank, const int64_t *output_shape,
-               int64_t output_rank, int64_t starts_num_elements,
-               int64_t axes_num_elements, int64_t steps_num_elements,
-               int64_t data_type) {
-  // (Slice runtime entry trace removed; was used for the slice-empty-buffer
-  // root-cause investigation. Re-add with a HIPDNN_EP_DEBUG gate if needed.)
+} // namespace
+
+int wrap_slice(RuntimeState *state, void *data, void *output,
+               const int64_t *data_shape, const int64_t *output_shape,
+               const int64_t *starts, const int64_t *steps,
+               const int64_t *extents, int64_t rank, int64_t data_type,
+               bool params_valid) {
+  auto fail = [&]() {
+    if (state)
+      (void)hipdnn_ep_state_set_error_flag(state);
+    return -1;
+  };
+
+  int hipDtype = toHipDtype(data_type);
+  int64_t elementBytes = hipdnn_ep_datatype_size(data_type);
+  if (hipDtype < 0 || elementBytes <= 0) {
+    fprintf(stderr, "[REAL] wrap_slice: unsupported data type %s(%lld)\n",
+            hipdnn_ep_datatype_name(data_type), (long long)data_type);
+    return fail();
+  }
+  if (rank > std::numeric_limits<int>::max()) {
+    fprintf(stderr, "[REAL] wrap_slice: rank exceeds kernel ABI\n");
+    return fail();
+  }
+
+  hipdnn_ep::slice::PreflightResult checked = hipdnn_ep::slice::preflight(
+      state, data, output, data_shape, output_shape, starts, steps, extents,
+      rank, elementBytes, params_valid);
+  if (checked.status == hipdnn_ep::slice::PreflightStatus::Error) {
+    fprintf(stderr,
+            "[REAL] wrap_slice: invalid normalized shape/address contract\n");
+    return fail();
+  }
+  if (checked.status == hipdnn_ep::slice::PreflightStatus::EmptyOutput)
+    return 0;
+
+  if (!state->slice_metadata_mutex) {
+    fprintf(stderr, "[REAL] wrap_slice: metadata mutex is unavailable\n");
+    return fail();
+  }
+  std::lock_guard<std::mutex> metadataLock(*state->slice_metadata_mutex);
+
+  if (static_cast<uint64_t>(rank) >
+      std::numeric_limits<size_t>::max() / (4 * sizeof(int64_t))) {
+    fprintf(stderr, "[REAL] wrap_slice: metadata byte count overflow\n");
+    return fail();
+  }
+  size_t metadataBytes = static_cast<size_t>(rank) * 4 * sizeof(int64_t);
+  if (state->slice_metadata_scratch_size < metadataBytes) {
+    // The lock is held from scratch growth through both enqueues. If call A
+    // unlocks after enqueueing H2D(A), kernel(A), call B can only enqueue
+    // H2D(B) afterward on the same state stream. Stream order therefore makes
+    // kernel(A) consume the metadata before H2D(B) overwrites the scratch; no
+    // completion wait is needed at unlock. A grow is the exceptional case:
+    // drain the stream before freeing storage that an earlier kernel may use.
+    if (state->slice_metadata_scratch) {
+      hipError_t syncError = hipStreamSynchronize(state->stream);
+      if (syncError != hipSuccess) {
+        fprintf(stderr,
+                "[REAL] wrap_slice: metadata grow stream sync failed: %s\n",
+                hipGetErrorString(syncError));
+        return fail();
+      }
+      hipError_t freeError = hipFree(state->slice_metadata_scratch);
+      if (freeError != hipSuccess) {
+        fprintf(stderr, "[REAL] wrap_slice: metadata scratch free failed: %s\n",
+                hipGetErrorString(freeError));
+        return fail();
+      }
+      state->slice_metadata_scratch = nullptr;
+      state->slice_metadata_scratch_size = 0;
+    }
+    hipError_t allocationError =
+        hipMalloc(&state->slice_metadata_scratch, metadataBytes);
+    if (allocationError != hipSuccess) {
+      fprintf(stderr,
+              "[REAL] wrap_slice: metadata scratch allocation failed: %s\n",
+              hipGetErrorString(allocationError));
+      state->slice_metadata_scratch = nullptr;
+      return fail();
+    }
+    state->slice_metadata_scratch_size = metadataBytes;
+  }
+
   OP_PROFILE(
       "slice",
       [&] {
-        char b[64];
-        snprintf(b, sizeof(b), "r%lld:K%lld:%s", (long long)data_rank,
-                 (long long)starts_num_elements,
+        char buffer[64];
+        snprintf(buffer, sizeof(buffer), "r%lld:%s", (long long)rank,
                  hipdnn_ep_datatype_name(data_type));
-        return std::string(b);
+        return std::string(buffer);
       },
       state);
 
-  if (!state || !starts || !ends || !output || !data_shape || !output_shape) {
-    RUNTIME_DEBUG_LOG("[REAL] wrap_slice: null required argument\n");
-    return -1;
-  }
-  if (data_rank <= 0 || data_rank != output_rank) {
-    fprintf(
-        stderr,
-        "[REAL] wrap_slice: invalid ranks (data_rank=%lld, output_rank=%lld)\n",
-        (long long)data_rank, (long long)output_rank);
-    return -1;
-  }
-  // Empty input fast path: ORT passes a null `data` pointer for a tensor
-  // with zero elements (e.g. `image_features` with shape[0]==0 in the VLM
-  // embedding sub-model on a text-only call). Slicing an empty input
-  // necessarily produces an empty logical output; the physical output buffer
-  // is over-allocated by SliceToHip to the IR static dim and must be
-  // zero-filled so downstream consumers (e.g. ScatterND's updates buffer)
-  // see the zero tail the existing logical-extent==0 kernel path would have
-  // written. Returning -1 here would leave the buffer at its pool-init
-  // value and silently feed downstream ops garbage / zero, masking the
-  // missing-write as "EP produced zero output".
-  int64_t data_num_elements = 1;
-  for (int d = 0; d < data_rank; ++d)
-    data_num_elements *= data_shape[d];
-  if (!data || data_num_elements == 0) {
-    int64_t out_num_elements = 1;
-    for (int d = 0; d < output_rank; ++d)
-      out_num_elements *= output_shape[d];
-    int64_t elem_size = hipdnn_ep_datatype_size(data_type);
-    if (elem_size <= 0) {
-      fprintf(stderr,
-              "[REAL] wrap_slice: empty-input path -- unsupported "
-              "data_type=%s(%lld)\n",
-              hipdnn_ep_datatype_name(data_type), (long long)data_type);
-      return -1;
-    }
-    if (output && out_num_elements > 0) {
-      hipStream_t s =
-          static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state));
-      hipError_t err = hipMemsetAsync(output, 0,
-                                      static_cast<size_t>(out_num_elements) *
-                                          static_cast<size_t>(elem_size),
-                                      s);
-      if (err != hipSuccess) {
-        fprintf(stderr,
-                "[REAL] wrap_slice: empty-input hipMemsetAsync failed: %s\n",
-                hipGetErrorString(err));
-        return -1;
-      }
-    }
-    RUNTIME_DEBUG_LOG(
-        "[REAL] wrap_slice: empty input (data=%p data_num_elements=%lld) "
-        "-- zeroed output and returning success\n",
-        data, (long long)data_num_elements);
-    return 0;
-  }
-  if (data_rank > kSliceRuntimeMaxRank) {
-    fprintf(stderr, "[REAL] wrap_slice: data_rank=%lld exceeds max %d\n",
-            (long long)data_rank, kSliceRuntimeMaxRank);
-    return -1;
-  }
-  if (starts_num_elements <= 0) {
-    fprintf(stderr, "[REAL] wrap_slice: starts_num_elements=%lld must be > 0\n",
-            (long long)starts_num_elements);
-    return -1;
-  }
-
-  int hip_dtype = slice_hipdnn_to_hip_dtype(data_type);
-  if (hip_dtype < 0) {
-    fprintf(stderr,
-            "[REAL] wrap_slice: unsupported data_type=%s(%lld) "
-            "(supported: f16, f32, i32, i64)\n",
-            hipdnn_ep_datatype_name(data_type), (long long)data_type);
-    return -1;
-  }
-
-  hipStream_t hip_stream =
-      static_cast<hipStream_t>(hipdnn_ep_state_get_stream(state));
-
-  // D2H the (typically tiny) index tensors. Treat them as INT64 -- the
-  // standard form for ONNX Slice indices and what every model in scope
-  // emits. If a future model uses INT32 we'd need a dtype param in the
-  // ABI; for now bail explicitly rather than silently mis-read.
-  const int64_t K = starts_num_elements;
-  std::vector<int64_t> starts_host(K);
-  std::vector<int64_t> ends_host(K);
-  std::vector<int64_t> axes_host;
-  std::vector<int64_t> steps_host;
-
-  hipError_t err =
-      hipMemcpyAsync(starts_host.data(), starts, K * sizeof(int64_t),
-                     hipMemcpyDeviceToHost, hip_stream);
-  if (err != hipSuccess) {
-    fprintf(stderr, "[REAL] wrap_slice: starts D2H failed: %s\n",
-            hipGetErrorString(err));
-    return -1;
-  }
-  err = hipMemcpyAsync(ends_host.data(), ends, K * sizeof(int64_t),
-                       hipMemcpyDeviceToHost, hip_stream);
-  if (err != hipSuccess) {
-    fprintf(stderr, "[REAL] wrap_slice: ends D2H failed: %s\n",
-            hipGetErrorString(err));
-    return -1;
-  }
-
-  if (axes && axes_num_elements > 0) {
-    if (axes_num_elements != K) {
-      fprintf(stderr,
-              "[REAL] wrap_slice: axes_num_elements(%lld) != "
-              "starts_num_elements(%lld)\n",
-              (long long)axes_num_elements, (long long)K);
-      return -1;
-    }
-    axes_host.resize(K);
-    err = hipMemcpyAsync(axes_host.data(), axes, K * sizeof(int64_t),
-                         hipMemcpyDeviceToHost, hip_stream);
-    if (err != hipSuccess) {
-      fprintf(stderr, "[REAL] wrap_slice: axes D2H failed: %s\n",
-              hipGetErrorString(err));
-      return -1;
-    }
-  }
-
-  if (steps && steps_num_elements > 0) {
-    if (steps_num_elements != K) {
-      fprintf(stderr,
-              "[REAL] wrap_slice: steps_num_elements(%lld) != "
-              "starts_num_elements(%lld)\n",
-              (long long)steps_num_elements, (long long)K);
-      return -1;
-    }
-    steps_host.resize(K);
-    err = hipMemcpyAsync(steps_host.data(), steps, K * sizeof(int64_t),
-                         hipMemcpyDeviceToHost, hip_stream);
-    if (err != hipSuccess) {
-      fprintf(stderr, "[REAL] wrap_slice: steps D2H failed: %s\n",
-              hipGetErrorString(err));
-      return -1;
-    }
-  }
-
-  err = hipStreamSynchronize(hip_stream);
-  if (err != hipSuccess) {
-    fprintf(stderr, "[REAL] wrap_slice: stream sync after D2H failed: %s\n",
-            hipGetErrorString(err));
-    return -1;
-  }
-
-  // Build per-input-axis (start, step) arrays. Axes not listed in `axes`
-  // default to full-range, unit-stride: start=0, step=1.
-  int64_t start_per_axis[kSliceRuntimeMaxRank] = {};
-  int64_t step_per_axis[kSliceRuntimeMaxRank];
-  for (int d = 0; d < data_rank; ++d) {
-    step_per_axis[d] = 1;
-  }
-
-  // Validation: axes must not repeat and must be in range.
-  bool axis_set[kSliceRuntimeMaxRank] = {};
-  for (int64_t k = 0; k < K; ++k) {
-    int64_t axis = axes_host.empty() ? k : axes_host[k];
-    if (axis < 0)
-      axis += data_rank;
-    if (axis < 0 || axis >= data_rank) {
-      fprintf(stderr, "[REAL] wrap_slice: axis=%lld out of range [0, %lld)\n",
-              (long long)axis, (long long)data_rank);
-      return -1;
-    }
-    if (axis_set[axis]) {
-      fprintf(stderr, "[REAL] wrap_slice: duplicate axis %lld\n",
-              (long long)axis);
-      return -1;
-    }
-    axis_set[axis] = true;
-
-    int64_t dim = data_shape[axis];
-    int64_t start = starts_host[k];
-    int64_t end = ends_host[k];
-    int64_t step = steps_host.empty() ? 1 : steps_host[k];
-
-    if (step == 0) {
-      fprintf(stderr, "[REAL] wrap_slice: zero step on axis %lld\n",
-              (long long)axis);
-      return -1;
-    }
-
-    // Per ONNX-13+ Slice negative-index + clamping rules.
-    if (start < 0)
-      start += dim;
-    if (end < 0)
-      end += dim;
-    if (step > 0) {
-      start = std::clamp<int64_t>(start, 0, dim);
-      end = std::clamp<int64_t>(end, 0, dim);
-    } else {
-      start = std::clamp<int64_t>(start, 0, dim - 1);
-      end = std::clamp<int64_t>(end, -1, dim - 1);
-    }
-
-    start_per_axis[axis] = start;
-    step_per_axis[axis] = step;
-  }
-
-  // Per-axis logical output extent (= actual ONNX-Slice output size,
-  // possibly < the physically allocated buffer dim when SliceToHip
-  // over-allocated due to runtime-only starts/ends). Initialised to
-  // output_shape; only sliced axes are recomputed in the loop below.
-  int64_t logical_extent[kSliceRuntimeMaxRank];
-  for (int d = 0; d < data_rank; ++d)
-    logical_extent[d] = output_shape[d];
-
-  for (int d = 0; d < data_rank; ++d) {
-    if (!axis_set[d])
-      continue; // unmodified axis: output extent must == data extent.
-    int64_t dim = data_shape[d];
-    int64_t start = start_per_axis[d];
-    int64_t step = step_per_axis[d];
-    // The actual `end` was already clamp-resolved; we recompute the
-    // expected output size from start/step against ends_host[k]. Walk
-    // the K array to find the matching k for this axis.
-    int64_t end = 0;
-    for (int64_t k = 0; k < K; ++k) {
-      int64_t ax = axes_host.empty() ? k : axes_host[k];
-      if (ax < 0)
-        ax += data_rank;
-      if (ax == d) {
-        end = ends_host[k];
-        break;
-      }
-    }
-    if (end < 0)
-      end += dim;
-    if (step > 0)
-      end = std::clamp<int64_t>(end, 0, dim);
-    else
-      end = std::clamp<int64_t>(end, -1, dim - 1);
-    int64_t expected;
-    if (step > 0)
-      expected = (end - start + step - 1) / step;
-    else
-      expected = (end - start + step + 1) / step;
-    if (expected < 0)
-      expected = 0;
-    // Three cases:
-    //   (a) expected == output_shape[d]: normal, logical_extent[d] =
-    //       output_shape[d] (already initialised below).
-    //   (b) expected == 0 (empty slice). Set logical_extent[d] = 0 so the
-    //       kernel fills the entire physical extent with zeros — no
-    //       separate memset, single kernel call.
-    //   (c) expected > 0 && expected < output_shape[d]: compile-time
-    //       OVER-ALLOCATION. SliceToHip uses `tensor.dim(data, i)` as an
-    //       upper bound for dynamic output dims since the actual extent
-    //       depends on runtime starts/ends. Pass logical_extent[d] =
-    //       expected so the kernel slices the valid prefix and zeros the
-    //       over-allocated tail.
-    //   (d) expected > output_shape[d] is impossible (slice cannot widen
-    //       any axis) and remains a hard error.
-    if (expected > output_shape[d]) {
-      fprintf(stderr,
-              "[REAL] wrap_slice: derived output extent on axis %d "
-              "(%lld) > IR output_shape (%lld) -- aborting "
-              "(start=%lld end=%lld step=%lld dim=%lld data_rank=%lld "
-              "K=%lld)\n",
-              d, (long long)expected, (long long)output_shape[d],
-              (long long)start, (long long)end, (long long)step, (long long)dim,
-              (long long)data_rank, (long long)K);
-      return -1;
-    }
-    logical_extent[d] = expected;
-  }
-
-  for (int d = 0; d < data_rank; ++d) {
-    if (!axis_set[d]) {
-      start_per_axis[d] = 0;
-      step_per_axis[d] = 1;
-    }
-  }
-
-  RUNTIME_DEBUG_LOG("[REAL] wrap_slice: rank=%lld, K=%lld, data_type=%s "
-                    "-> hip_slice\n",
-                    (long long)data_rank, (long long)K,
+  void *stream = hipdnn_ep_state_get_stream(state);
+  void *scratch = state->slice_metadata_scratch;
+  int status =
+      hip_slice(stream, data, output, data_shape, output_shape, starts, steps,
+                static_cast<int>(rank), hipDtype, scratch, metadataBytes);
+  if (status != 0)
+    return fail();
+  RUNTIME_DEBUG_LOG("[REAL] wrap_slice: rank=%lld dtype=%s\n", (long long)rank,
                     hipdnn_ep_datatype_name(data_type));
-
-  return hip_slice(hipdnn_ep_state_get_stream(state), data, output, data_shape,
-                   output_shape, logical_extent, start_per_axis, step_per_axis,
-                   static_cast<int>(data_rank), hip_dtype);
+  return 0;
 }

--- a/lib/Runtime/runtime_state_internal.h
+++ b/lib/Runtime/runtime_state_internal.h
@@ -27,6 +27,8 @@
 // is acyclic.
 #include "op_state.h"
 
+#include <mutex>
+
 struct RuntimePoolSite {
   int num_domains;
   void **pool_base;
@@ -72,6 +74,15 @@ struct RuntimeState {
   // Lazily grown via hipdnn_ep_state_ensure_workspace(); never shrinks.
   void *workspace;
   size_t workspace_size;
+
+  // Dedicated device metadata scratch for Slice. It is intentionally separate
+  // from the general operator workspace so concurrent Slice host calls only
+  // serialize each other, not unrelated operators. The mutex is heap-created
+  // because RuntimeState itself is malloc-allocated and therefore does not run
+  // C++ member constructors.
+  void *slice_metadata_scratch;
+  size_t slice_metadata_scratch_size;
+  std::mutex *slice_metadata_mutex;
 
   // Per-function-site host-mapped scratch buffers for tiny host-fed scalars
   // routed away from the GPU pool by hip-materialize-host-scalars.

--- a/test/lit/Conversion/hip-to-llvm/test_slice.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_slice.mlir
@@ -3,50 +3,25 @@
 
 // RUN: hip-mlir-opt --convert-hip-to-llvm %s | FileCheck %s
 
-// Verify that hip.slice lowers to a single wrap_slice call with the full
-// (data, starts, ends, axes-or-null, steps-or-null, output, shape arrays,
-// counts, dtype) parameter pack regardless of whether the optional axes /
-// steps operands are present.
-
 module {
-  // Case 1: all five inputs present (data, starts, ends, axes, steps).
-  func.func @test_slice_full(%ctx: !hip.context,
-                              %data: memref<4x6xf32, 1>,
-                              %starts: memref<2xi64, 1>,
-                              %ends: memref<2xi64, 1>,
-                              %axes: memref<2xi64, 1>,
-                              %steps: memref<2xi64, 1>,
-                              %output: memref<2x3xf32, 1>) {
-    hip.slice(%ctx)
-        ins(%data, %starts, %ends :
-            memref<4x6xf32, 1>, memref<2xi64, 1>, memref<2xi64, 1>)
-        axes(%axes : memref<2xi64, 1>)
-        steps(%steps : memref<2xi64, 1>)
+  func.func @test_slice(%ctx: !hip.context,
+                        %data: memref<4x6xf32, 1>,
+                        %valid: i1,
+                        %s0: i64, %s1: i64,
+                        %p0: i64, %p1: i64,
+                        %e0: index, %e1: index,
+                        %output: memref<2x3xf32, 1>) {
+    hip.slice(%ctx) ins(%data : memref<4x6xf32, 1>)
+        valid(%valid)
+        starts(%s0, %s1 : i64, i64)
+        steps(%p0, %p1 : i64, i64)
+        extents(%e0, %e1 : index, index)
         outs(%output : memref<2x3xf32, 1>)
-    return
-  }
-
-  // Case 2: only the required inputs (data, starts, ends, output).
-  func.func @test_slice_minimal(%ctx: !hip.context,
-                                 %data: memref<8xf32, 1>,
-                                 %starts: memref<1xi64, 1>,
-                                 %ends: memref<1xi64, 1>,
-                                 %output: memref<4xf32, 1>) {
-    hip.slice(%ctx)
-        ins(%data, %starts, %ends :
-            memref<8xf32, 1>, memref<1xi64, 1>, memref<1xi64, 1>)
-        outs(%output : memref<4xf32, 1>)
     return
   }
 }
 
-// Each variant emits the same 15-parameter wrap_slice signature
-// (4 + 3 pointers, 2 i64 shape ranks, 4 i64 counts/dtype).
-
-// CHECK-LABEL: llvm.func @test_slice_full
-// CHECK: llvm.call @wrap_slice({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, i64, i64, i64, i64) -> i32
-
-// CHECK-LABEL: llvm.func @test_slice_minimal
-// CHECK: llvm.mlir.zero : !llvm.ptr
-// CHECK: llvm.mlir.zero : !llvm.ptr
-// CHECK: llvm.call @wrap_slice({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, i64, i64, i64, i64) -> i32
+// CHECK-LABEL: llvm.func @test_slice
+// CHECK: llvm.alloca
+// CHECK: llvm.store %{{.*}} : i64, !llvm.ptr
+// CHECK: llvm.call @wrap_slice({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i1) -> i32

--- a/test/lit/Conversion/onnx-to-hip/test_payload_failure_atomicity.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_payload_failure_atomicity.mlir
@@ -11,6 +11,47 @@ module {
     return %input : tensor<1xf32>
   }
 
+  func.func @slice_static_contradiction(
+      %input: tensor<6xf32>) -> tensor<4xf32> {
+    %starts = "onnx.Constant"() {
+      value = dense<[5]> : tensor<1xi64>
+    } : () -> tensor<1xi64>
+    %ends = "onnx.Constant"() {
+      value = dense<[0]> : tensor<1xi64>
+    } : () -> tensor<1xi64>
+    %axes = "onnx.Constant"() {
+      value = dense<[0]> : tensor<1xi64>
+    } : () -> tensor<1xi64>
+    %steps = "onnx.Constant"() {
+      value = dense<[-2]> : tensor<1xi64>
+    } : () -> tensor<1xi64>
+    %result = "onnx.Slice"(%input, %starts, %ends, %axes, %steps)
+      : (tensor<6xf32>, tensor<1xi64>, tensor<1xi64>,
+         tensor<1xi64>, tensor<1xi64>) -> tensor<4xf32>
+    return %result : tensor<4xf32>
+  }
+
+  // CHECK-LABEL: func.func @slice_static_contradiction
+  // CHECK-NOT: tensor.dim
+  // CHECK-NOT: tensor.empty
+  // CHECK-NOT: hip.slice
+  // CHECK: "onnx.Slice"
+
+  func.func @slice_dynamic_control_length(
+      %input: tensor<6xf32>, %starts: tensor<?xi32>) -> tensor<?xf32> {
+    %ends = arith.constant dense<[5]> : tensor<1xi64>
+    %result = "onnx.Slice"(%input, %starts, %ends)
+      : (tensor<6xf32>, tensor<?xi32>, tensor<1xi64>) -> tensor<?xf32>
+    return %result : tensor<?xf32>
+  }
+
+  // CHECK-LABEL: func.func @slice_dynamic_control_length
+  // CHECK-NOT: hip.readback_control
+  // CHECK-NOT: tensor.dim
+  // CHECK-NOT: tensor.empty
+  // CHECK-NOT: hip.slice
+  // CHECK: "onnx.Slice"
+
   func.func @pad_static_contradiction(
       %input: tensor<3x4xf32>) -> tensor<5x7xf32> {
     %pads = "onnx.Constant"() {
@@ -77,6 +118,22 @@ module {
   // CHECK: "onnx.Expand"
 
   // Static imported dimensions may refine dynamic payload inference.
+  func.func @slice_static_result_refinement(
+      %input: tensor<?xf32>) -> tensor<3xf32> {
+    %starts = arith.constant dense<[5]> : tensor<1xi64>
+    %ends = arith.constant dense<[0]> : tensor<1xi64>
+    %axes = arith.constant dense<[0]> : tensor<1xi64>
+    %steps = arith.constant dense<[-2]> : tensor<1xi64>
+    %result = "onnx.Slice"(%input, %starts, %ends, %axes, %steps)
+      : (tensor<?xf32>, tensor<1xi64>, tensor<1xi64>,
+         tensor<1xi64>, tensor<1xi64>) -> tensor<3xf32>
+    return %result : tensor<3xf32>
+  }
+
+  // CHECK-LABEL: func.func @slice_static_result_refinement
+  // CHECK: tensor.empty() : tensor<3xf32>
+  // CHECK: hip.slice
+
   func.func @pad_static_result_refinement(
       %input: tensor<?x4xf32>) -> tensor<5x4xf32> {
     %pads = arith.constant dense<[1, 0, 1, 0]> : tensor<4xi64>
@@ -115,6 +172,22 @@ module {
   // CHECK: hip.expand
 
   // Dynamic imported dimensions may be refined by proven static inference.
+  func.func @slice_dynamic_result_static_inference(
+      %input: tensor<6xf32>) -> tensor<?xf32> {
+    %starts = arith.constant dense<[5]> : tensor<1xi64>
+    %ends = arith.constant dense<[0]> : tensor<1xi64>
+    %axes = arith.constant dense<[0]> : tensor<1xi64>
+    %steps = arith.constant dense<[-2]> : tensor<1xi64>
+    %result = "onnx.Slice"(%input, %starts, %ends, %axes, %steps)
+      : (tensor<6xf32>, tensor<1xi64>, tensor<1xi64>,
+         tensor<1xi64>, tensor<1xi64>) -> tensor<?xf32>
+    return %result : tensor<?xf32>
+  }
+
+  // CHECK-LABEL: func.func @slice_dynamic_result_static_inference
+  // CHECK: tensor.empty({{.*}}) : tensor<?xf32>
+  // CHECK: hip.slice
+
   func.func @pad_dynamic_result_static_inference(
       %input: tensor<3x4xf32>) -> tensor<?x?xf32> {
     %pads = arith.constant dense<[1, 1, 1, 1]> : tensor<4xi64>

--- a/test/lit/Conversion/onnx-to-hip/test_slice.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_slice.mlir
@@ -1,14 +1,6 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// Verify the two ONNX Slice lowering paths:
-//
-//   1. SliceDecompose (preferred) — all slice params are compile-time
-//      constants with positive unit stride, so onnx.Slice is rewritten to
-//      a zero-cost tensor.extract_slice.
-//   2. SliceToHip (fallback) — non-constant indices or negative steps fall
-//      through to a native hip.slice op whose runtime is a stub today.
-
 // RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
 
 module {
@@ -16,131 +8,110 @@ module {
     return %arg0 : tensor<4xf32>
   }
 
-  // Test 1: classic prefix slice (axis 0, [1:3], stride 1) — decomposes to
-  // tensor.extract_slice.
-  func.func @test_slice_decompose_simple(%input: tensor<4x6xf32>) -> tensor<2x6xf32> {
-    // CHECK-LABEL: func.func @test_slice_decompose_simple
+  // CHECK-LABEL: func.func @constant_positive
+  // CHECK-NOT: hip.readback_control
+  // CHECK-NOT: hip.slice
+  // CHECK: tensor.extract_slice
+  func.func @constant_positive(%input: tensor<4x6xf32>) -> tensor<2x6xf32> {
     %starts = arith.constant dense<[1]> : tensor<1xi64>
-    %ends   = arith.constant dense<[3]> : tensor<1xi64>
-    %axes   = arith.constant dense<[0]> : tensor<1xi64>
-    %steps  = arith.constant dense<[1]> : tensor<1xi64>
+    %ends = arith.constant dense<[3]> : tensor<1xi64>
+    %axes = arith.constant dense<[0]> : tensor<1xi64>
+    %steps = arith.constant dense<[1]> : tensor<1xi64>
     %r = "onnx.Slice"(%input, %starts, %ends, %axes, %steps)
         : (tensor<4x6xf32>, tensor<1xi64>, tensor<1xi64>,
            tensor<1xi64>, tensor<1xi64>) -> tensor<2x6xf32>
-
-    // CHECK-NOT: onnx.Slice
-    // CHECK-NOT: hip.slice
-    // CHECK: tensor.extract_slice {{.*}}[1, 0] [2, 6] [1, 1]
-
     return %r : tensor<2x6xf32>
   }
 
-  // Test 2: per-axis slice with stride > 1 — still decomposes (extract_slice
-  // supports strides).
-  func.func @test_slice_decompose_stride(%input: tensor<2x4xf32>) -> tensor<1x2xf32> {
-    // CHECK-LABEL: func.func @test_slice_decompose_stride
-    %starts = arith.constant dense<[1, 0]> : tensor<2xi64>
-    %ends   = arith.constant dense<[2, 3]> : tensor<2xi64>
-    %axes   = arith.constant dense<[0, 1]> : tensor<2xi64>
-    %steps  = arith.constant dense<[1, 2]> : tensor<2xi64>
-    %r = "onnx.Slice"(%input, %starts, %ends, %axes, %steps)
-        : (tensor<2x4xf32>, tensor<2xi64>, tensor<2xi64>,
-           tensor<2xi64>, tensor<2xi64>) -> tensor<1x2xf32>
-
-    // CHECK-NOT: onnx.Slice
-    // CHECK: tensor.extract_slice {{.*}}[1, 0] [1, 2] [1, 2]
-
-    return %r : tensor<1x2xf32>
-  }
-
-  // Test 3: omitted axes / steps — default to all axes, unit stride.
-  func.func @test_slice_decompose_default_axes(%input: tensor<4x6xf32>) -> tensor<2x3xf32> {
-    // CHECK-LABEL: func.func @test_slice_decompose_default_axes
-    %starts = arith.constant dense<[0, 0]> : tensor<2xi64>
-    %ends   = arith.constant dense<[2, 3]> : tensor<2xi64>
+  // Omitted axes cover only the parameter count, not the whole data rank.
+  // CHECK-LABEL: func.func @omitted_axes_shorter_than_rank
+  // CHECK: tensor.extract_slice
+  func.func @omitted_axes_shorter_than_rank(
+      %input: tensor<4x6xf32>) -> tensor<2x6xf32> {
+    %starts = arith.constant dense<[1]> : tensor<1xi64>
+    %ends = arith.constant dense<[3]> : tensor<1xi64>
     %r = "onnx.Slice"(%input, %starts, %ends)
-        : (tensor<4x6xf32>, tensor<2xi64>, tensor<2xi64>) -> tensor<2x3xf32>
-
-    // CHECK-NOT: onnx.Slice
-    // CHECK: tensor.extract_slice {{.*}}[0, 0] [2, 3] [1, 1]
-
-    return %r : tensor<2x3xf32>
+        : (tensor<4x6xf32>, tensor<1xi64>, tensor<1xi64>)
+          -> tensor<2x6xf32>
+    return %r : tensor<2x6xf32>
   }
 
-  // Test 4: negative step forces the native fallback (hip.slice).  The
-  // runtime is a stub today, but the conversion + bufferization pipeline
-  // must still produce valid IR.
-  func.func @test_slice_native_negative_step(%input: tensor<6xf32>) -> tensor<3xf32> {
-    // CHECK-LABEL: func.func @test_slice_native_negative_step
+  // CHECK-LABEL: func.func @constant_negative
+  // CHECK-NOT: hip.readback_control
+  // CHECK: tensor.empty
+  // CHECK: hip.slice
+  // CHECK-SAME: valid(
+  // CHECK-SAME: starts(
+  // CHECK-SAME: steps(
+  // CHECK-SAME: extents(
+  func.func @constant_negative(%input: tensor<6xf32>) -> tensor<3xf32> {
     %starts = arith.constant dense<[5]> : tensor<1xi64>
-    %ends   = arith.constant dense<[-1]> : tensor<1xi64>
-    %axes   = arith.constant dense<[0]> : tensor<1xi64>
-    %steps  = arith.constant dense<[-2]> : tensor<1xi64>
+    %ends = arith.constant dense<[0]> : tensor<1xi64>
+    %axes = arith.constant dense<[0]> : tensor<1xi64>
+    %steps = arith.constant dense<[-2]> : tensor<1xi64>
     %r = "onnx.Slice"(%input, %starts, %ends, %axes, %steps)
         : (tensor<6xf32>, tensor<1xi64>, tensor<1xi64>,
            tensor<1xi64>, tensor<1xi64>) -> tensor<3xf32>
-
-    // CHECK-NOT: onnx.Slice
-    // CHECK: tensor.empty() : tensor<3xf32>
-    // CHECK: hip.slice({{.*}}) ins({{.*}}, {{.*}}, {{.*}} : tensor<6xf32>, tensor<1xi64>, tensor<1xi64>)
-
     return %r : tensor<3xf32>
   }
 
-  // Test 5: non-constant starts (block argument) also falls back to the
-  // native op — the decompose pattern needs to read the values.
-  func.func @test_slice_native_dynamic_starts(
-      %input: tensor<8xf32>, %starts: tensor<1xi64>) -> tensor<4xf32> {
-    // CHECK-LABEL: func.func @test_slice_native_dynamic_starts
-    %ends   = arith.constant dense<[7]> : tensor<1xi64>
+  // Runtime i32 is sign-extended by one generic grouped readback. Constant
+  // ends is consumed directly and is not included as a readback source.
+  // CHECK-LABEL: func.func @runtime_i32_mixed_constant
+  // CHECK-COUNT-1: hip.readback_control
+  // CHECK-SAME: tensor<1xi32>
+  // CHECK: hip.slice
+  func.func @runtime_i32_mixed_constant(
+      %input: tensor<8xf32>, %starts: tensor<1xi32>) -> tensor<?xf32> {
+    %ends = arith.constant dense<[7]> : tensor<1xi64>
     %r = "onnx.Slice"(%input, %starts, %ends)
-        : (tensor<8xf32>, tensor<1xi64>, tensor<1xi64>) -> tensor<4xf32>
-
-    // CHECK-NOT: onnx.Slice
-    // CHECK: hip.slice({{.*}}) ins(
-    return %r : tensor<4xf32>
-  }
-
-  // Test 6: SliceDecompose on a tensor with a dynamic non-sliced axis.
-  // axis 0 is sliced (input dim is static = 4), axis 1 is left alone
-  // (input dim is ? -> the corresponding extract_slice size is a
-  // tensor.dim Value, not a constant).
-  func.func @test_slice_decompose_dyn_untouched(%input: tensor<4x?xf32>) -> tensor<2x?xf32> {
-    // CHECK-LABEL: func.func @test_slice_decompose_dyn_untouched
-    %starts = arith.constant dense<[1]> : tensor<1xi64>
-    %ends   = arith.constant dense<[3]> : tensor<1xi64>
-    %axes   = arith.constant dense<[0]> : tensor<1xi64>
-    %steps  = arith.constant dense<[1]> : tensor<1xi64>
-    %r = "onnx.Slice"(%input, %starts, %ends, %axes, %steps)
-        : (tensor<4x?xf32>, tensor<1xi64>, tensor<1xi64>,
-           tensor<1xi64>, tensor<1xi64>) -> tensor<2x?xf32>
-
-    // CHECK-NOT: onnx.Slice
-    // CHECK-NOT: hip.slice
-    // CHECK-DAG: %[[A1:.*]] = arith.constant 1 : index
-    // CHECK-DAG: %[[DIM:.*]] = tensor.dim %{{.*}}, %[[A1]] : tensor<4x?xf32>
-    // Shared normalization materializes exact offsets and strides before
-    // constructing the view; the untouched dimension keeps its runtime size.
-    // CHECK: tensor.extract_slice %{{.*}}[{{.*}}] [{{.*}}] [{{.*}}] : tensor<4x?xf32> to tensor<2x?xf32>
-    return %r : tensor<2x?xf32>
-  }
-
-  // Test 7: shared normalization emits clamp SSA for a dynamic sliced axis,
-  // allowing the positive-step case to remain an exact extract_slice.
-  func.func @test_slice_native_dyn_axis(%input: tensor<?xf32>) -> tensor<?xf32> {
-    // CHECK-LABEL: func.func @test_slice_native_dyn_axis
-    %starts = arith.constant dense<[1]> : tensor<1xi64>
-    %ends   = arith.constant dense<[3]> : tensor<1xi64>
-    %axes   = arith.constant dense<[0]> : tensor<1xi64>
-    %steps  = arith.constant dense<[1]> : tensor<1xi64>
-    %r = "onnx.Slice"(%input, %starts, %ends, %axes, %steps)
-        : (tensor<?xf32>, tensor<1xi64>, tensor<1xi64>,
-           tensor<1xi64>, tensor<1xi64>) -> tensor<?xf32>
-
-    // CHECK-DAG: %[[A0:.*]] = arith.constant 0 : index
-    // CHECK-DAG: %[[DIM:.*]] = tensor.dim %{{.*}}, %[[A0]] : tensor<?xf32>
-    // CHECK-NOT: hip.slice
-    // CHECK: tensor.extract_slice %{{.*}}[{{.*}}] [{{.*}}] [{{.*}}] : tensor<?xf32> to tensor<?xf32>
+        : (tensor<8xf32>, tensor<1xi32>, tensor<1xi64>) -> tensor<?xf32>
     return %r : tensor<?xf32>
+  }
+
+  // All genuinely runtime controls share one readback, in operand-major order.
+  // CHECK-LABEL: func.func @runtime_mixed_i32_i64
+  // CHECK-COUNT-1: hip.readback_control
+  // CHECK-SAME: tensor<2xi32>, tensor<2xi64>, tensor<2xi32>, tensor<2xi64>
+  // CHECK: hip.slice
+  func.func @runtime_mixed_i32_i64(
+      %input: tensor<4x6xf32>, %starts: tensor<2xi32>,
+      %ends: tensor<2xi64>, %axes: tensor<2xi32>,
+      %steps: tensor<2xi64>) -> tensor<?x?xf32> {
+    %r = "onnx.Slice"(%input, %starts, %ends, %axes, %steps)
+        : (tensor<4x6xf32>, tensor<2xi32>, tensor<2xi64>,
+           tensor<2xi32>, tensor<2xi64>) -> tensor<?x?xf32>
+    return %r : tensor<?x?xf32>
+  }
+
+  // CHECK-LABEL: func.func @constant_empty
+  // CHECK-NOT: hip.readback_control
+  // CHECK: hip.slice
+  // CHECK: return
+  func.func @constant_empty(%input: tensor<1x8x4xf32>)
+      -> tensor<1x0x4xf32> {
+    %starts = arith.constant dense<[0]> : tensor<1xi64>
+    %ends = arith.constant dense<[0]> : tensor<1xi64>
+    %axes = arith.constant dense<[1]> : tensor<1xi64>
+    %steps = arith.constant dense<[-1]> : tensor<1xi64>
+    %r = "onnx.Slice"(%input, %starts, %ends, %axes, %steps)
+        : (tensor<1x8x4xf32>, tensor<1xi64>, tensor<1xi64>,
+           tensor<1xi64>, tensor<1xi64>) -> tensor<1x0x4xf32>
+    return %r : tensor<1x0x4xf32>
+  }
+
+  // CHECK-LABEL: func.func @negative_int64_min_step
+  // CHECK-NOT: hip.readback_control
+  // CHECK: hip.slice
+  func.func @negative_int64_min_step(%input: tensor<10xf32>)
+      -> tensor<1xf32> {
+    %starts = arith.constant dense<[9]> : tensor<1xi64>
+    %ends = arith.constant dense<[-9223372036854775808]> : tensor<1xi64>
+    %axes = arith.constant dense<[0]> : tensor<1xi64>
+    %steps = arith.constant dense<[-9223372036854775808]> : tensor<1xi64>
+    %r = "onnx.Slice"(%input, %starts, %ends, %axes, %steps)
+        : (tensor<10xf32>, tensor<1xi64>, tensor<1xi64>,
+           tensor<1xi64>, tensor<1xi64>) -> tensor<1xf32>
+    return %r : tensor<1xf32>
   }
 }

--- a/test/lit/Conversion/onnx-to-hip/test_slice_swinv2_window.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_slice_swinv2_window.mlir
@@ -5,8 +5,8 @@
 //   input  1x128x256x96
 //   axis=1, start=0, end=8  ->  1x8x256x96
 //
-// Uses onnx.Constant operands so the SliceShapeFold -> SliceDecompose path is
-// exercised before carrier conversion and externalization.
+// Uses onnx.Constant operands so SliceDecompose must consume the dense
+// hip.constant carriers directly before standalone externalization.
 
 // RUN: mkdir -p %t && hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip --hip-externalize-constants='externalize-min-num-elements=1 externalize-output-dir=%t' %s | FileCheck %s
 
@@ -30,6 +30,7 @@ module {
 
     // CHECK-NOT: onnx.Slice
     // CHECK-NOT: hip.slice
+    // CHECK-NOT: hipdnn.slice_
     // CHECK: tensor.extract_slice {{.*}}[0, 0, 0, 0] [1, 8, 256, 96] [1, 1, 1, 1]
 
     return %r : tensor<1x8x256x96xf16>

--- a/test/lit/Dialect/hip-infer-shapes.mlir
+++ b/test/lit/Dialect/hip-infer-shapes.mlir
@@ -702,11 +702,7 @@ func.func @refine_expand_tier1_constant_shape(%ctx: !hip.context,
 
 // -----
 
-// `hip.slice` Tier-1 promotion. With static `data` and constant
-// `starts` / `ends` (axes default to [0..rank), steps default to
-// all-ones), the helper computes
-// `output[axis] = ceil_div(end - start, step)`. Slicing `tensor<10x4xf32>`
-// with starts=[1, 0], ends=[6, 4] yields output [5, 4].
+// `hip.slice` uses its exact extent operands as the refinement authority.
 // CHECK-LABEL: func.func @refine_slice_tier1_constant_indices
 // CHECK:         %[[E:.*]] = tensor.empty() : tensor<5x4xf32>
 // CHECK:         %[[Y:.*]] = hip.slice
@@ -716,11 +712,19 @@ func.func @refine_slice_tier1_constant_indices(%ctx: !hip.context,
                                                  %data: tensor<10x4xf32>,
                                                  %d0: index, %d1: index)
     -> tensor<?x?xf32> {
-  %starts = arith.constant dense<[1, 0]> : tensor<2xi64>
-  %ends = arith.constant dense<[6, 4]> : tensor<2xi64>
-  %e = tensor.empty(%d0, %d1) : tensor<?x?xf32>
+  %valid = arith.constant true
+  %s0 = arith.constant 1 : i64
+  %s1 = arith.constant 0 : i64
+  %p = arith.constant 1 : i64
+  %x0 = arith.constant 5 : index
+  %x1 = arith.constant 4 : index
+  %e = tensor.empty(%x0, %x1) : tensor<?x?xf32>
   %y = hip.slice(%ctx)
-    ins(%data, %starts, %ends : tensor<10x4xf32>, tensor<2xi64>, tensor<2xi64>)
+    ins(%data : tensor<10x4xf32>)
+    valid(%valid)
+    starts(%s0, %s1 : i64, i64)
+    steps(%p, %p : i64, i64)
+    extents(%x0, %x1 : index, index)
     outs(%e : tensor<?x?xf32>)
     : tensor<?x?xf32>
   return %y : tensor<?x?xf32>
@@ -728,13 +732,7 @@ func.func @refine_slice_tier1_constant_indices(%ctx: !hip.context,
 
 // -----
 
-// `hip.slice` non-foldable case: `starts` is a function arg, not a
-// constant. The Tier-1 helper bails and the per-op thunk falls back
-// to `HipDpsOp::reifyResultShapes`'s outs-lift default. Static dims
-// of the outs (`tensor<10x?xf32>`) still tighten dim 0; the dynamic
-// dim 1 stays dynamic. This guards "no IR bloat on non-foldable slice"
-// (the dim-arith chain would have been
-// `arith.divsi(arith.subi(end, start), step)` per axis -- never emitted).
+// A mixed static/dynamic exact extent refines only the constant dimension.
 // CHECK-LABEL: func.func @refine_slice_non_foldable_falls_back_to_outs
 // CHECK-NOT:     arith.subi
 // CHECK-NOT:     arith.divsi
@@ -745,13 +743,19 @@ func.func @refine_slice_tier1_constant_indices(%ctx: !hip.context,
 func.func @refine_slice_non_foldable_falls_back_to_outs(
     %ctx: !hip.context,
     %data: tensor<10x4xf32>,
-    %starts: tensor<2xi64>,
-    %ends: tensor<2xi64>,
     %d0: index)
     -> tensor<?x?xf32> {
+  %valid = arith.constant true
+  %s = arith.constant 0 : i64
+  %p = arith.constant 1 : i64
+  %x0 = arith.constant 10 : index
   %e = tensor.empty(%d0) : tensor<10x?xf32>
   %y = hip.slice(%ctx)
-    ins(%data, %starts, %ends : tensor<10x4xf32>, tensor<2xi64>, tensor<2xi64>)
+    ins(%data : tensor<10x4xf32>)
+    valid(%valid)
+    starts(%s, %s : i64, i64)
+    steps(%p, %p : i64, i64)
+    extents(%x0, %d0 : index, index)
     outs(%e : tensor<10x?xf32>)
     : tensor<10x?xf32>
   %c = tensor.cast %y : tensor<10x?xf32> to tensor<?x?xf32>

--- a/test/lit/Dialect/hip-slice-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-slice-reify-shapes.mlir
@@ -1,0 +1,30 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s
+
+// The exact extent operands, not the destination capacity or raw parameter
+// tensors, are the sole reification authority.
+// CHECK-LABEL: func.func @exact_extents
+// CHECK-SAME: %[[E0:[^,]+]]: index
+// CHECK-SAME: %[[E1:[^)]+]]: index
+// CHECK-NOT: tensor.dim
+// CHECK: return %[[E0]], %[[E1]] : index, index
+func.func @exact_extents(
+    %ctx: !hip.context, %data: tensor<?x?xf32>, %valid: i1,
+    %s0: i64, %s1: i64, %p0: i64, %p1: i64,
+    %e0: index, %e1: index) -> (index, index) {
+  %init = tensor.empty(%e0, %e1) : tensor<?x?xf32>
+  %result = hip.slice(%ctx) ins(%data : tensor<?x?xf32>)
+      valid(%valid)
+      starts(%s0, %s1 : i64, i64)
+      steps(%p0, %p1 : i64, i64)
+      extents(%e0, %e1 : index, index)
+      outs(%init : tensor<?x?xf32>)
+      : tensor<?x?xf32>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %d0 = tensor.dim %result, %c0 : tensor<?x?xf32>
+  %d1 = tensor.dim %result, %c1 : tensor<?x?xf32>
+  return %d0, %d1 : index, index
+}

--- a/test/lit/Dialect/hip-slice-verifier.mlir
+++ b/test/lit/Dialect/hip-slice-verifier.mlir
@@ -1,0 +1,34 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s
+
+func.func @wrong_rank_controls(
+    %ctx: !hip.context, %data: tensor<2x3xf32>, %valid: i1,
+    %s: i64, %p: i64, %e: index) {
+  %init = tensor.empty() : tensor<2x3xf32>
+  // expected-error @+1 {{starts, steps, and extents must each contain exactly data-rank entries}}
+  %r = hip.slice(%ctx) ins(%data : tensor<2x3xf32>)
+      valid(%valid)
+      starts(%s : i64)
+      steps(%p : i64)
+      extents(%e : index)
+      outs(%init : tensor<2x3xf32>) : tensor<2x3xf32>
+  return
+}
+
+// -----
+
+func.func @mismatched_dynamic_destination(
+    %ctx: !hip.context, %data: tensor<?xf32>, %valid: i1,
+    %s: i64, %p: i64, %e0: index, %e1: index) {
+  %init = tensor.empty(%e0) : tensor<?xf32>
+  // expected-error @+1 {{dynamic output dimension 0 must be allocated from the matching exact extent}}
+  %r = hip.slice(%ctx) ins(%data : tensor<?xf32>)
+      valid(%valid)
+      starts(%s : i64)
+      steps(%p : i64)
+      extents(%e1 : index)
+      outs(%init : tensor<?xf32>) : tensor<?xf32>
+  return
+}

--- a/test/lit/e2e/test_slice_runtime_output_model.mlir
+++ b/test/lit/e2e/test_slice_runtime_output_model.mlir
@@ -1,0 +1,28 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s --hipdnn-pipeline | FileCheck %s
+
+// A runtime i32 Slice graph output is allocated from its exact normalized
+// extents before wrap_slice executes. One grouped readback covers starts+ends.
+// CHECK-COUNT-1: llvm.call @hipdnn_ep_readback_control
+// CHECK: llvm.call @hipdnn_ep_alloc_output
+// CHECK: llvm.call @wrap_slice
+// CHECK-NOT: llvm.call @hipdnn_ep_readback_control
+module {
+  func.func @main_graph(
+      %data: tensor<1x8x4xf32> {onnx.name = "data"},
+      %starts: tensor<1xi32> {onnx.name = "starts"},
+      %ends: tensor<1xi32> {onnx.name = "ends"})
+      -> (tensor<?x?x?xf32> {onnx.name = "output"}) {
+    %axes = "onnx.Constant"() {value = dense<[1]> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %steps = "onnx.Constant"() {value = dense<[1]> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %result = "onnx.Slice"(%data, %starts, %ends, %axes, %steps)
+        : (tensor<1x8x4xf32>, tensor<1xi32>, tensor<1xi32>,
+           tensor<1xi64>, tensor<1xi64>) -> tensor<?x?x?xf32>
+    "onnx.Return"(%result) : (tensor<?x?x?xf32>) -> ()
+  }
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}

--- a/test/numeric/framework/comparator.py
+++ b/test/numeric/framework/comparator.py
@@ -79,6 +79,11 @@ def compare_outputs(
             details.append(f"Output {i}: shape mismatch {act.shape} vs {exp.shape}")
             all_passed = False
             continue
+        if act.size == 0:
+            details.append(
+                f"Output {i}: OK (matching empty tensor, shape={list(act.shape)})"
+            )
+            continue
 
         act_f = act.flatten().astype(np.float64)
         exp_f = exp.flatten().astype(np.float64)
@@ -129,7 +134,11 @@ def print_output_summary(
     """Print a per-output summary comparing *actual* and *expected* tensors."""
     print(f"{tag} Outputs:")
     for i, (act, exp) in enumerate(zip(actual, expected)):
-        diff = float(np.abs(act.astype(np.float64) - exp.astype(np.float64)).max())
+        diff = (
+            0.0
+            if act.size == 0 and exp.size == 0
+            else float(np.abs(act.astype(np.float64) - exp.astype(np.float64)).max())
+        )
         print(
             f"{tag}   [{i}] actual  {tensor_desc(act)}"
             f"  |  expect  {tensor_desc(exp)}"

--- a/test/numeric/tests/test_shape_ops.py
+++ b/test/numeric/tests/test_shape_ops.py
@@ -9,9 +9,10 @@ GatherND, Slice, ScatterND.
 The runtime-shaped operations share a common
 property: the **shape** of an output depends on a graph-time tensor (repeats
 for Tile, shape for Expand, pads for Pad, indices for GatherND, starts/ends
-for Slice, indices for ScatterND). The runtime D2H-reads these small tensors
-once per call and dispatches a host-built launch -- so the test must pin
-both the value tensors and the data tensor in the same model.
+for Slice, indices for ScatterND). Slice groups genuinely runtime i32/i64
+controls into one readback before exact output allocation; other operations
+retain their documented payload paths. The test must pin both the value
+tensors and the data tensor in the same model.
 
 Per the runtime dtype tables in lib/Runtime/real/<op>.cpp the supported
 data dtype set is:
@@ -20,7 +21,7 @@ data dtype set is:
     Expand    : f16, f32, i32, i64
     Pad       : f16, f32, i32, i64       (modes: constant, reflect, edge, wrap)
     GatherND  : f16, f32, i32, i64       (indices: int64 only)
-    Slice     : f16, f32, i32, i64       (starts/ends/axes/steps: int64 only)
+    Slice     : f16, f32, i32, i64       (controls: int32 or int64)
     ScatterND : f16, f32, i32, i64       (indices: int64 only;
                                           reductions: none, add, mul, min, max)
 """
@@ -528,7 +529,7 @@ class TestGatherND:
 # `tensor.extract_slice` upstream; this test exercises the runtime fallback
 # kernel by:
 #   (a) feeding `starts` / `ends` as *graph inputs* (non-constant) -- forces
-#       the runtime D2H + host-side resolution path, OR
+#       one grouped readback plus compiler-materialized normalization, OR
 #   (b) using negative steps -- the fold rejects this case so it falls
 #       through to the runtime kernel as well.
 #
@@ -544,6 +545,7 @@ def _make_slice_model(
     steps: list[int] | None,
     output_shape: list[int],
     constant_indices: bool,
+    index_dtype=np.int64,
 ):
     """Build a Slice model.
 
@@ -554,6 +556,7 @@ def _make_slice_model(
     runtime kernel path.
     """
     tp = np_to_onnx_type(dtype)
+    index_tp = np_to_onnx_type(index_dtype)
     X = helper.make_tensor_value_info("X", tp, list(input_shape))
 
     input_names = ["X", "starts", "ends"]
@@ -562,42 +565,41 @@ def _make_slice_model(
 
     if constant_indices:
         initializers.append(
-            numpy_helper.from_array(np.array(starts, dtype=np.int64), name="starts")
+            numpy_helper.from_array(np.array(starts, dtype=index_dtype), name="starts")
         )
         initializers.append(
-            numpy_helper.from_array(np.array(ends, dtype=np.int64), name="ends")
+            numpy_helper.from_array(np.array(ends, dtype=index_dtype), name="ends")
         )
     else:
-        starts_vi = helper.make_tensor_value_info(
-            "starts", TensorProto.INT64, [len(starts)]
-        )
-        ends_vi = helper.make_tensor_value_info("ends", TensorProto.INT64, [len(ends)])
+        starts_vi = helper.make_tensor_value_info("starts", index_tp, [len(starts)])
+        ends_vi = helper.make_tensor_value_info("ends", index_tp, [len(ends)])
         inputs_list += [starts_vi, ends_vi]
 
     if axes is not None:
         input_names.append("axes")
         if constant_indices:
             initializers.append(
-                numpy_helper.from_array(np.array(axes, dtype=np.int64), name="axes")
+                numpy_helper.from_array(np.array(axes, dtype=index_dtype), name="axes")
             )
         else:
-            axes_vi = helper.make_tensor_value_info(
-                "axes", TensorProto.INT64, [len(axes)]
-            )
+            axes_vi = helper.make_tensor_value_info("axes", index_tp, [len(axes)])
             inputs_list.append(axes_vi)
     if steps is not None:
         input_names.append("steps")
         if constant_indices:
             initializers.append(
-                numpy_helper.from_array(np.array(steps, dtype=np.int64), name="steps")
+                numpy_helper.from_array(
+                    np.array(steps, dtype=index_dtype), name="steps"
+                )
             )
         else:
-            steps_vi = helper.make_tensor_value_info(
-                "steps", TensorProto.INT64, [len(steps)]
-            )
+            steps_vi = helper.make_tensor_value_info("steps", index_tp, [len(steps)])
             inputs_list.append(steps_vi)
 
-    Y = helper.make_tensor_value_info("Y", tp, list(output_shape))
+    declared_output_shape = (
+        list(output_shape) if constant_indices else [None] * len(output_shape)
+    )
+    Y = helper.make_tensor_value_info("Y", tp, declared_output_shape)
     node = helper.make_node("Slice", input_names, ["Y"])
     return (
         make_model_from_nodes([node], inputs_list, [Y], initializers=initializers),
@@ -672,6 +674,20 @@ class TestSlice:
             # step=-2 walking 7,5,3,1 down to 0 exclusive (so 4 elements):
             #   start=7, end=-9=-(8+1) -> end=-1, step=-2 -> 4 elements.
             (np.int32, [8], [7], [-9], [0], [-2], [4]),
+            # Exact empty native Slice: allocator may represent output [0]
+            # with a null pointer, which must remain a successful no-op.
+            (np.float32, [6], [0], [5], [0], [-1], [0]),
+            # INT64_MIN is both the negative-end sentinel and the most-negative
+            # step; magnitude/ceil division must not overflow.
+            (
+                np.float32,
+                [10],
+                [9],
+                [np.iinfo(np.int64).min],
+                [0],
+                [np.iinfo(np.int64).min],
+                [1],
+            ),
         ],
     )
     def test_slice_negative_step(
@@ -723,6 +739,61 @@ class TestSlice:
         ]
         actual, expected = model_runner.run_sample(model, feeds)
         compare_outputs(actual, expected, atol=0)
+
+    def test_slice_runtime_i32_repeated_extents(self, model_runner):
+        """One i32-control model produces different exact shapes on reuse."""
+        shape = [1, 8, 4]
+        model, _ = _make_slice_model(
+            np.float32,
+            shape,
+            [0],
+            [1],
+            [1],
+            [1],
+            [1, 1, 4],
+            constant_indices=False,
+            index_dtype=np.int32,
+        )
+        x = np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
+        for iteration, (start, end) in enumerate(((0, 3), (3, 8))):
+            feeds = [
+                x,
+                np.array([start], dtype=np.int32),
+                np.array([end], dtype=np.int32),
+                np.array([1], dtype=np.int32),
+                np.array([1], dtype=np.int32),
+            ]
+            actual, expected = model_runner.run_sample(
+                model, feeds, name=f"slice_runtime_i32_repeat_{iteration}"
+            )
+            compare_outputs(actual, expected, atol=0)
+            assert actual[0].shape == (1, end - start, 4)
+
+    def test_slice_rank_greater_than_eight(self, model_runner):
+        """Arbitrary-rank metadata uses runtime-managed scratch, not rank-8."""
+        shape = [2] * 9
+        out_shape = [2] * 8 + [1]
+        model, _ = _make_slice_model(
+            np.float32,
+            shape,
+            [1],
+            [2],
+            [8],
+            [1],
+            out_shape,
+            constant_indices=False,
+        )
+        x = np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
+        feeds = [
+            x,
+            np.array([1], dtype=np.int64),
+            np.array([2], dtype=np.int64),
+            np.array([8], dtype=np.int64),
+            np.array([1], dtype=np.int64),
+        ]
+        actual, expected = model_runner.run_sample(model, feeds)
+        compare_outputs(actual, expected, atol=0)
+        assert actual[0].shape == tuple(out_shape)
 
 
 # ---------------------------------------------------------------------------

--- a/test/runtime/test_output_allocator.cpp
+++ b/test/runtime/test_output_allocator.cpp
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <limits>
 
 int runtime_errors = 0;
 
@@ -140,10 +141,52 @@ void test_set_null_state() {
 //    `!state` half of the guard (test 2 covers the `!allocate` half).
 void test_alloc_null_state() {
   g_cap = StubCapture{};
+  runtime_errors = 0;
   const int64_t shape[1] = {1};
   void *p = hipdnn_ep_alloc_output(nullptr, 0, shape, 1, 4);
   CHECK(p == nullptr);
   CHECK(g_cap.calls == 0);
+  CHECK(runtime_errors == 0);
+}
+
+void test_invalid_logical_shapes_record_error() {
+  g_cap = StubCapture{};
+  int ctx = 0;
+  RuntimeState st = makeState();
+  hipdnn_output_allocator_t alloc{&ctx, stub_allocate};
+  hipdnn_ep_set_output_allocator(&st, &alloc);
+
+  auto expectInvalid = [&](const int64_t *shape, int64_t rank,
+                           int64_t elemSize) {
+    int previousErrors = runtime_errors;
+    int previousCalls = g_cap.calls;
+    CHECK(hipdnn_ep_alloc_output(&st, 0, shape, rank, elemSize) == nullptr);
+    CHECK(runtime_errors == previousErrors + 1);
+    CHECK(g_cap.calls == previousCalls);
+  };
+
+  runtime_errors = 0;
+  const int64_t negativeShape[1] = {-1};
+  expectInvalid(negativeShape, 1, sizeof(float));
+  expectInvalid(nullptr, 1, sizeof(float));
+  expectInvalid(negativeShape, -1, sizeof(float));
+  const int64_t overflowShape[2] = {std::numeric_limits<int64_t>::max(), 2};
+  expectInvalid(overflowShape, 2, sizeof(int64_t));
+  const int64_t validShape[1] = {1};
+  expectInvalid(validShape, 1, 0);
+}
+
+void test_zero_byte_output_remains_valid() {
+  g_cap = StubCapture{};
+  runtime_errors = 0;
+  int ctx = 0;
+  RuntimeState st = makeState();
+  hipdnn_output_allocator_t alloc{&ctx, stub_allocate};
+  hipdnn_ep_set_output_allocator(&st, &alloc);
+  const int64_t zeroShape[2] = {3, 0};
+  CHECK(hipdnn_ep_alloc_output(&st, 4, zeroShape, 2, sizeof(float)) == nullptr);
+  CHECK(g_cap.calls == 1);
+  CHECK(runtime_errors == 0);
 }
 
 void test_safe_output_copy() {
@@ -182,6 +225,8 @@ int main() {
   test_nullptr_setter_arg();
   test_set_null_state();
   test_alloc_null_state();
+  test_invalid_logical_shapes_record_error();
+  test_zero_byte_output_remains_valid();
   test_safe_output_copy();
   if (g_failures == 0) {
     std::printf("output_allocator unit test: ALL PASS\n");


### PR DESCRIPTION
## Why

The native Slice path previously passed raw starts, ends, axes, and steps to the runtime and sized outputs from imported shapes or conservative bounds. That repeated normalization after lowering, made exact dynamic allocation difficult, and left the runtime ABI responsible for reconstructing semantics that the compiler had already resolved.

This PR makes normalized descriptors the compiler/runtime boundary. Grouped control readback produces a validity flag plus exact starts, steps, and extents; those extents allocate the destination and become the sole shape-reification authority. The runtime and kernel can then dispatch from a compact, already-normalized contract while preserving valid zero-element outputs.

## Pass example

The HIP operation now carries exact normalized descriptors rather than raw ONNX parameter tensors:

```mlir
func.func @test_slice(
    %ctx: !hip.context, %data: memref<4x6xf32, 1>,
    %valid: i1, %s0: i64, %s1: i64,
    %p0: i64, %p1: i64, %e0: index, %e1: index,
    %output: memref<2x3xf32, 1>) {
  hip.slice(%ctx) ins(%data : memref<4x6xf32, 1>)
      valid(%valid)
      starts(%s0, %s1 : i64, i64)
      steps(%p0, %p1 : i64, i64)
      extents(%e0, %e1 : index, index)
      outs(%output : memref<2x3xf32, 1>)
  return
}
```

Lowering packs those descriptors for the revised runtime ABI:

```mlir
%status = llvm.call @wrap_slice(
    %ctx, %data, %output, %inputShape, %starts,
    %steps, %extents, %rank, %elementBytes, %valid)
    : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
       !llvm.ptr, !llvm.ptr, i64, i64, i1) -> i32
```

## What changes

- Redefine `hip.slice` around normalized validity, starts, steps, and exact extents.
- Group genuinely runtime Slice controls into one synchronized readback while consuming constant controls directly.
- Allocate dynamic outputs from exact normalized extents and reify shapes solely from those operands.
- Replace the raw-parameter runtime ABI with the normalized descriptor ABI.
- Update real and mock runtimes, custom kernels, runtime state, and exported declarations together.
- Preserve empty-output behavior without requiring non-null storage.
- Keep strided loop-capture compatibility isolated for the immediate integration PR.
- Add lowering, dialect, conversion, end-to-end, numeric, and allocator coverage.

## Stack

1. [#688 — constant externalization](https://github.com/ROCm/hip-ep/pull/688)
2. [#754 — i1 pool sizing](https://github.com/ROCm/hip-ep/pull/754)
3. [#756 — ORT error propagation](https://github.com/ROCm/hip-ep/pull/756)
4. [#758 — exact output views](https://github.com/ROCm/hip-ep/pull/758)
5. [#755 — pool namespaces](https://github.com/ROCm/hip-ep/pull/755)
6. [#757 — host-scratch namespaces](https://github.com/ROCm/hip-ep/pull/757)
7. [#724 — symbolic transport](https://github.com/ROCm/hip-ep/pull/724)
8. [#759 — artifact ABI guard](https://github.com/ROCm/hip-ep/pull/759)
9. [#639 — shape-rule foundation](https://github.com/ROCm/hip-ep/pull/639)
10. [#681 — reshape provenance](https://github.com/ROCm/hip-ep/pull/681)
11. [#725 — broadcast activation](https://github.com/ROCm/hip-ep/pull/725)
12. [#763 — Softmax buffer reuse](https://github.com/ROCm/hip-ep/pull/763)
13. [#640 — MatMul/Gemm runtime](https://github.com/ROCm/hip-ep/pull/640)
14. [#734 — MatMul/Gemm shapes](https://github.com/ROCm/hip-ep/pull/734)
15. [#641 — broadcast contracts](https://github.com/ROCm/hip-ep/pull/641)
16. [#735 — reduction conversion](https://github.com/ROCm/hip-ep/pull/735)
17. [#736 — reduction contracts](https://github.com/ROCm/hip-ep/pull/736)
18. [#689 — loop frame ABI](https://github.com/ROCm/hip-ep/pull/689)
19. [#737 — shape-changing loops](https://github.com/ROCm/hip-ep/pull/737)
20. [#762 — loop bank recycling](https://github.com/ROCm/hip-ep/pull/762)
21. [#642 — grouped readback](https://github.com/ROCm/hip-ep/pull/642)
22. [#727 — payload shapes](https://github.com/ROCm/hip-ep/pull/727)
23. [#728 — Tile/Range destinations](https://github.com/ROCm/hip-ep/pull/728)
24. [#729 — Slice normalization](https://github.com/ROCm/hip-ep/pull/729)
25. [#731 — exact Slice ABI](https://github.com/ROCm/hip-ep/pull/731) ← this PR
26. [#733 — loop payload integration](https://github.com/ROCm/hip-ep/pull/733)
27. [#643 — convolution contracts](https://github.com/ROCm/hip-ep/pull/643)
28. [#738 — pooling contracts](https://github.com/ROCm/hip-ep/pull/738)
29. [#742 — causal convolution contracts](https://github.com/ROCm/hip-ep/pull/742)
30. [#644 — gather/tensor contracts](https://github.com/ROCm/hip-ep/pull/644)
31. [#739 — block-quantized Gather](https://github.com/ROCm/hip-ep/pull/739)
32. [#645 — normalization contracts](https://github.com/ROCm/hip-ep/pull/645)
33. [#740 — attention contracts](https://github.com/ROCm/hip-ep/pull/740)
34. [#741 — GQA capacity](https://github.com/ROCm/hip-ep/pull/741)
35. [#743 — GQA feature rejection](https://github.com/ROCm/hip-ep/pull/743)
36. [#646 — explicit DPS contracts](https://github.com/ROCm/hip-ep/pull/646)
37. [#730 — contract inventory audit](https://github.com/ROCm/hip-ep/pull/730)
38. [#732 — converter dedup audit](https://github.com/ROCm/hip-ep/pull/732)
39. [#647 — refinement hardening](https://github.com/ROCm/hip-ep/pull/647)
40. [#761 — split shape utilities](https://github.com/ROCm/hip-ep/pull/761)
41. [#764 — destination authority](https://github.com/ROCm/hip-ep/pull/764)

## AI assistance

AI tools assisted with the ABI refactoring, compiler/runtime updates, tests, and stack preparation. The contributor reviewed the resulting code.

Made-with: Cursor

Made with [Cursor](https://cursor.com)