### PR TITLE
fix(loop): integrate exact payload Slice carriers

### DIFF
--- a/docs/design/loop-carrier-descriptor-abi.md
+++ b/docs/design/loop-carrier-descriptor-abi.md
@@ -19,6 +19,11 @@ the borrowed `v_init` descriptor unchanged and a null frame token. A loop that
 executes its body returns the final successfully published descriptor and its
 owning frame; `v_init` is never mutated, freed, or adopted.
 
+This includes exact zero-element Slice seeds. A `[1, 0, D]` seed stays exact
+and may carry null storage; it is never replaced by an input-shaped capacity.
+When the body grows that carrier, its result allocation is redirected to
+`hip.loop_alloc`, and the returned descriptor carries the new exact extent.
+
 ## Outlined body ABI
 
 An outlined body has the source-level signature:

--- a/include/hip/Dialect/Transforms/Passes.td
+++ b/include/hip/Dialect/Transforms/Passes.td
@@ -177,8 +177,8 @@ def OptimizeMemRefsPass : Pass<"hip-optimize-memrefs", "mlir::func::FuncOp"> {
 
 def PromoteStridedHipOperandsPass
     : Pass<"hip-promote-strided-operands", "mlir::func::FuncOp"> {
-  let summary = "Materialize identity-layout temporaries for DPS-input memrefs "
-                "with non-identity layouts";
+  let summary = "Materialize identity-layout temporaries for bare-pointer "
+                "consumer memrefs with non-identity layouts";
   let description = [{
     Walks every DestinationStyleOpInterface op. For each DPS-input memref with
     a non-identity layout (a non-zero offset or non-contiguous strides), inserts:
@@ -195,6 +195,13 @@ def PromoteStridedHipOperandsPass
     semantics. The production pipeline normally supplies identity-layout inits
     through fresh allocations, `hip.alloc_output`, or `IdentityLayoutMap` at
     function boundaries.
+
+    Post-bufferization `hip.loop` captures are also promoted when the outlined
+    body argument expects identity layout. The pass validates the body symbol
+    and capture ABI before mutation, shares a copy across repeated identical
+    read-only captures, and deallocates it immediately after the invocation.
+    Loop-carried `v_init` operands are never promoted here because zero-trip
+    results may alias their borrowed seed descriptors.
 
     The pass exists to bridge the contract gap between the IR (which can
     represent non-identity layouts faithfully) and runtime ABIs that receive a

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -10,6 +10,7 @@
 #include "llvm/Support/MathExtras.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h"
@@ -448,9 +449,30 @@ LogicalResult LoopOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
              << i << " type " << args[3 + i]
              << " must match loop carrier result type "
              << getResult(i).getType();
-  for (unsigned i = 0; i < numCaptures; ++i)
-    if (args[3 + numLoopCarried + i] != getCaptures()[i].getType())
+  for (unsigned i = 0; i < numCaptures; ++i) {
+    Type bodyCapture = args[3 + numLoopCarried + i];
+    Type capture = getCaptures()[i].getType();
+    if (bodyCapture == capture)
+      continue;
+
+    // One-Shot Bufferize can turn an extract_slice capture into a strided
+    // memref while function-boundary conversion gives the outlined body an
+    // identity-layout argument. Permit only that layout-only transient; the
+    // immediately following hip-promote-strided-operands pass materializes the
+    // identity-layout copy. All semantic type mismatches remain verifier
+    // errors.
+    auto bodyMemref = dyn_cast<MemRefType>(bodyCapture);
+    auto captureMemref = dyn_cast<MemRefType>(capture);
+    bool promotableLayoutMismatch =
+        bodyDescriptorMode && bodyMemref && captureMemref &&
+        bodyMemref.getLayout().isIdentity() &&
+        !captureMemref.getLayout().isIdentity() &&
+        bodyMemref.getShape() == captureMemref.getShape() &&
+        bodyMemref.getElementType() == captureMemref.getElementType() &&
+        bodyMemref.getMemorySpace() == captureMemref.getMemorySpace();
+    if (!promotableLayoutMismatch)
       return emitOpError("body_func capture #") << i << " type mismatch";
+  }
   for (unsigned i = 0; i < numCaptures; ++i) {
     Type capture = getCaptures()[i].getType();
     bool supported = bodyDescriptorMode ? isa<MemRefType>(capture)

--- a/lib/Dialect/Transforms/PromoteStridedHipOperands.cpp
+++ b/lib/Dialect/Transforms/PromoteStridedHipOperands.cpp
@@ -4,8 +4,9 @@
  */
 //===- PromoteStridedHipOperands.cpp - Normalize DPS input layouts --------===//
 //
-// Materializes an identity-layout temporary for each DPS-input memref operand
-// with a non-identity layout (a non-zero offset or non-contiguous strides).
+// Materializes an identity-layout temporary for each bare-pointer consumer
+// memref operand with a non-identity layout (a non-zero offset or
+// non-contiguous strides).
 //
 // Why this pass exists
 // --------------------
@@ -29,6 +30,15 @@
 // hip.alloc_output, or IdentityLayoutMap at function boundaries. Lowerings
 // that extract a bare pointer rely on that independent output-side invariant.
 //
+// Loop captures
+// -------------
+// After bufferization, a hip.loop capture may be a strided view while its
+// outlined body argument has the identity layout selected for function
+// boundaries. Captures are read-only and cannot alias loop results, so one
+// identity-layout copy per distinct capture is live only across the loop
+// invocation. Loop-carried v_init operands are deliberately excluded: a
+// zero-trip loop may return the borrowed seed descriptor.
+//
 // Pipeline placement
 // ------------------
 // Run between hip-optimize-memrefs and hip-pool-allocs (see Pipelines.cpp).
@@ -38,20 +48,23 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hip/Dialect/IR/HipDialect.h"
 #include "hip/Dialect/Transforms/Passes.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/Debug.h"
 
 #define DEBUG_TYPE "hip-promote-strided-operands"
 
 STATISTIC(NumOperandsPromoted,
-          "Number of non-identity-layout DPS inputs promoted");
+          "Number of non-identity-layout operands promoted");
 
 namespace mlir {
 namespace hip {
@@ -89,17 +102,15 @@ static SmallVector<Value> collectDynamicSizes(OpBuilder &builder, Location loc,
   return sizes;
 }
 
-/// Materializes an identity-layout copy of \p input immediately before
-/// \p consumer and rewrites the operand to use it. Returns the temporary so the
-/// caller can place a paired deallocation.
+/// Materializes an identity-layout copy of \p source immediately before
+/// \p consumer. Returns the temporary so the caller can rewrite the operand and
+/// place a paired deallocation.
 ///
 /// Resulting IR (alloc + copy only):
 ///   %tmp = memref.alloc(%dyn0, %dyn1, ...) : memref<...identity...>
 ///   memref.copy %source, %tmp
 ///   <consumer rewritten to read %tmp>
-static Value materializeIdentityLayoutCopy(OpOperand &input,
-                                           Operation *consumer) {
-  Value source = input.get();
+static Value materializeIdentityLayoutCopy(Value source, Operation *consumer) {
   auto sourceType = cast<MemRefType>(source.getType());
   MemRefType identityType = makeIdentityLayoutType(sourceType);
 
@@ -112,8 +123,6 @@ static Value materializeIdentityLayoutCopy(OpOperand &input,
   auto allocOp = memref::AllocOp::create(builder, loc, identityType, dynSizes);
   memref::CopyOp::create(builder, loc, source, allocOp.getResult());
 
-  input.set(allocOp.getResult());
-
   ++NumOperandsPromoted;
   LLVM_DEBUG(llvm::dbgs() << "  promoted " << sourceType << " -> "
                           << identityType << " before " << consumer->getName()
@@ -121,6 +130,22 @@ static Value materializeIdentityLayoutCopy(OpOperand &input,
 
   return allocOp.getResult();
 }
+
+/// Places paired deallocations immediately after \p consumer in allocation
+/// order.
+static void deallocateAfter(Operation *consumer, ValueRange temporaries) {
+  Operation *anchor = consumer;
+  OpBuilder builder(consumer);
+  for (Value temporary : temporaries) {
+    builder.setInsertionPointAfter(anchor);
+    anchor = memref::DeallocOp::create(builder, consumer->getLoc(), temporary);
+  }
+}
+
+struct LoopPromotionPlan {
+  LoopOp loop;
+  SmallVector<unsigned> captureIndices;
+};
 
 struct PromoteStridedHipOperandsPass
     : public impl::PromoteStridedHipOperandsPassBase<
@@ -138,6 +163,115 @@ void PromoteStridedHipOperandsPass::runOnOperation() {
   if (funcOp.empty())
     return;
 
+  // Validate every loop plan before changing any IR. A malformed body ABI must
+  // not leave earlier loops partially promoted.
+  SymbolTableCollection symbolTable;
+  SmallVector<LoopPromotionPlan> loopPlans;
+  WalkResult loopValidation = funcOp.walk([&](LoopOp loop) {
+    SmallVector<unsigned> candidates;
+    for (auto [index, capture] : llvm::enumerate(loop.getCaptures())) {
+      auto captureType = dyn_cast<MemRefType>(capture.getType());
+      if (captureType && isNonIdentityMemRef(captureType))
+        candidates.push_back(index);
+    }
+    if (candidates.empty())
+      return WalkResult::advance();
+
+    auto body = symbolTable.lookupNearestSymbolFrom<func::FuncOp>(
+        loop, loop.getBodyFuncAttr());
+    if (!body) {
+      loop.emitOpError("cannot promote strided captures: body_func '")
+          << loop.getBodyFunc() << "' does not reference a func.func";
+      return WalkResult::interrupt();
+    }
+
+    unsigned numCarriers = loop.getNumLoopCarried();
+    unsigned expectedArgs = 4 + numCarriers + loop.getCaptures().size();
+    if (body.getNumArguments() != expectedArgs) {
+      loop.emitOpError("cannot promote strided captures: body_func argument "
+                       "count mismatch; expected ")
+          << expectedArgs
+          << " (context, iter, cond, carriers, captures, frame), "
+          << "got " << body.getNumArguments();
+      return WalkResult::interrupt();
+    }
+
+    LoopPromotionPlan plan{loop, {}};
+    for (unsigned index : candidates) {
+      auto sourceType = cast<MemRefType>(loop.getCaptures()[index].getType());
+      unsigned bodyArgIndex = 3 + numCarriers + index;
+      auto bodyType =
+          dyn_cast<MemRefType>(body.getArgumentTypes()[bodyArgIndex]);
+      if (!bodyType) {
+        loop.emitOpError("cannot promote strided capture #")
+            << index << ": body argument #" << bodyArgIndex
+            << " must be a ranked memref";
+        return WalkResult::interrupt();
+      }
+      if (!bodyType.getLayout().isIdentity()) {
+        if (bodyType == sourceType)
+          continue;
+        loop.emitOpError("cannot promote strided capture #")
+            << index << ": body argument #" << bodyArgIndex
+            << " has an unsupported non-identity layout mismatch";
+        return WalkResult::interrupt();
+      }
+      if (bodyType.getRank() != sourceType.getRank()) {
+        loop.emitOpError("cannot promote strided capture #")
+            << index << ": body argument rank " << bodyType.getRank()
+            << " does not match capture rank " << sourceType.getRank();
+        return WalkResult::interrupt();
+      }
+      if (bodyType.getElementType() != sourceType.getElementType()) {
+        loop.emitOpError("cannot promote strided capture #")
+            << index << ": body argument element type "
+            << bodyType.getElementType()
+            << " does not match capture element type "
+            << sourceType.getElementType();
+        return WalkResult::interrupt();
+      }
+      MemRefType promotedType = makeIdentityLayoutType(sourceType);
+      if (bodyType.getShape() != promotedType.getShape()) {
+        loop.emitOpError("cannot promote strided capture #")
+            << index << ": body argument shape " << bodyType.getShape()
+            << " does not match capture shape " << promotedType.getShape();
+        return WalkResult::interrupt();
+      }
+      if (bodyType.getMemorySpace() != promotedType.getMemorySpace()) {
+        loop.emitOpError("cannot promote strided capture #")
+            << index << ": body argument memory space "
+            << bodyType.getMemorySpace()
+            << " does not match capture memory space "
+            << promotedType.getMemorySpace();
+        return WalkResult::interrupt();
+      }
+      plan.captureIndices.push_back(index);
+    }
+    if (!plan.captureIndices.empty())
+      loopPlans.push_back(std::move(plan));
+    return WalkResult::advance();
+  });
+  if (loopValidation.wasInterrupted())
+    return signalPassFailure();
+
+  for (LoopPromotionPlan &plan : loopPlans) {
+    DenseMap<Value, Value> promoted;
+    SmallVector<Value> temporaries;
+    MutableOperandRange captures = plan.loop.getCapturesMutable();
+    for (unsigned index : plan.captureIndices) {
+      OpOperand &capture = captures[index];
+      Value source = capture.get();
+      auto [it, inserted] = promoted.try_emplace(source);
+      if (inserted) {
+        it->second =
+            materializeIdentityLayoutCopy(source, plan.loop.getOperation());
+        temporaries.push_back(it->second);
+      }
+      capture.set(it->second);
+    }
+    deallocateAfter(plan.loop.getOperation(), temporaries);
+  }
+
   // Collect candidate consumers first so that rewriting (which inserts new
   // ops) does not invalidate the walk.
   SmallVector<DestinationStyleOpInterface> consumers;
@@ -151,21 +285,12 @@ void PromoteStridedHipOperandsPass::runOnOperation() {
       auto type = dyn_cast<MemRefType>(input->get().getType());
       if (!type || !isNonIdentityMemRef(type))
         continue;
-      temporaries.push_back(materializeIdentityLayoutCopy(*input, consumer));
+      Value temporary = materializeIdentityLayoutCopy(input->get(), consumer);
+      input->set(temporary);
+      temporaries.push_back(temporary);
     }
 
-    // Emit deallocs in the same order as the allocations (TA, TB, ...).
-    // Without anchoring, repeated `setInsertionPointAfter(consumer)` would
-    // push each new dealloc directly after the consumer, reversing the
-    // sequence.  Advancing the anchor preserves source order and makes the
-    // IR easier to read in tests / dumps.
-    Operation *anchor = consumer;
-    OpBuilder builder(consumer);
-    for (Value temporary : temporaries) {
-      builder.setInsertionPointAfter(anchor);
-      anchor =
-          memref::DeallocOp::create(builder, consumer->getLoc(), temporary);
-    }
+    deallocateAfter(consumer, temporaries);
   }
 }
 

--- a/test/lit/Dialect/hip-promote-strided-loop-captures-invalid.mlir
+++ b/test/lit/Dialect/hip-promote-strided-loop-captures-invalid.mlir
@@ -1,0 +1,146 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --split-input-file --verify-diagnostics \
+// RUN:   --hip-promote-strided-operands %s
+
+func.func @missing_body(
+    %ctx: !hip.context, %parent: memref<4x8xf32>,
+    %seed: memref<4x4xf32>) {
+  %zero = arith.constant 0 : index
+  %true = arith.constant true
+  %capture = memref.subview %parent[0, 2][4, 4][1, 1]
+      : memref<4x8xf32>
+        to memref<4x4xf32, strided<[8, 1], offset: 2>>
+  // expected-error @below {{body_func 'missing_body_func' does not reference a func.func}}
+  %result, %frame = hip.loop(%ctx, %zero, %true)
+      iter_args(%seed : memref<4x4xf32>)
+      captures(%capture
+        : memref<4x4xf32, strided<[8, 1], offset: 2>>)
+      -> (memref<4x4xf32>, !hip.loop_frame)
+      body @missing_body_func
+      {cond_is_passthrough, descriptor_return,
+       num_loop_carried = 1 : i32}
+  return
+}
+
+// -----
+
+func.func private @bad_count_body(
+    %ctx: !hip.context, %iter: memref<i64>, %cond: memref<i1>,
+    %current: memref<4x4xf32>, %frame: !hip.loop_frame)
+    -> (i32, memref<4x4xf32>) {
+  %status = arith.constant 0 : i32
+  return %status, %current : i32, memref<4x4xf32>
+}
+
+func.func @bad_count(
+    %ctx: !hip.context, %parent: memref<4x8xf32>,
+    %seed: memref<4x4xf32>) {
+  %zero = arith.constant 0 : index
+  %true = arith.constant true
+  %capture = memref.subview %parent[0, 2][4, 4][1, 1]
+      : memref<4x8xf32>
+        to memref<4x4xf32, strided<[8, 1], offset: 2>>
+  // expected-error @below {{body_func argument count mismatch: expected 6 (context, iter, cond, carriers, captures, frame), got 5}}
+  %result, %frame = hip.loop(%ctx, %zero, %true)
+      iter_args(%seed : memref<4x4xf32>)
+      captures(%capture
+        : memref<4x4xf32, strided<[8, 1], offset: 2>>)
+      -> (memref<4x4xf32>, !hip.loop_frame)
+      body @bad_count_body
+      {cond_is_passthrough, descriptor_return,
+       num_loop_carried = 1 : i32}
+  return
+}
+
+// -----
+
+func.func private @bad_rank_body(
+    %ctx: !hip.context, %iter: memref<i64>, %cond: memref<i1>,
+    %current: memref<4x4xf32>, %capture: memref<16xf32>,
+    %frame: !hip.loop_frame) -> (i32, memref<4x4xf32>) {
+  %status = arith.constant 0 : i32
+  return %status, %current : i32, memref<4x4xf32>
+}
+
+func.func @bad_rank(
+    %ctx: !hip.context, %parent: memref<4x8xf32>,
+    %seed: memref<4x4xf32>) {
+  %zero = arith.constant 0 : index
+  %true = arith.constant true
+  %capture = memref.subview %parent[0, 2][4, 4][1, 1]
+      : memref<4x8xf32>
+        to memref<4x4xf32, strided<[8, 1], offset: 2>>
+  // expected-error @below {{body_func capture #0 type mismatch}}
+  %result, %frame = hip.loop(%ctx, %zero, %true)
+      iter_args(%seed : memref<4x4xf32>)
+      captures(%capture
+        : memref<4x4xf32, strided<[8, 1], offset: 2>>)
+      -> (memref<4x4xf32>, !hip.loop_frame)
+      body @bad_rank_body
+      {cond_is_passthrough, descriptor_return,
+       num_loop_carried = 1 : i32}
+  return
+}
+
+// -----
+
+func.func private @bad_element_body(
+    %ctx: !hip.context, %iter: memref<i64>, %cond: memref<i1>,
+    %current: memref<4x4xf32>, %capture: memref<4x4xf16>,
+    %frame: !hip.loop_frame) -> (i32, memref<4x4xf32>) {
+  %status = arith.constant 0 : i32
+  return %status, %current : i32, memref<4x4xf32>
+}
+
+func.func @bad_element(
+    %ctx: !hip.context, %parent: memref<4x8xf32>,
+    %seed: memref<4x4xf32>) {
+  %zero = arith.constant 0 : index
+  %true = arith.constant true
+  %capture = memref.subview %parent[0, 2][4, 4][1, 1]
+      : memref<4x8xf32>
+        to memref<4x4xf32, strided<[8, 1], offset: 2>>
+  // expected-error @below {{body_func capture #0 type mismatch}}
+  %result, %frame = hip.loop(%ctx, %zero, %true)
+      iter_args(%seed : memref<4x4xf32>)
+      captures(%capture
+        : memref<4x4xf32, strided<[8, 1], offset: 2>>)
+      -> (memref<4x4xf32>, !hip.loop_frame)
+      body @bad_element_body
+      {cond_is_passthrough, descriptor_return,
+       num_loop_carried = 1 : i32}
+  return
+}
+
+// -----
+
+func.func private @bad_layout_body(
+    %ctx: !hip.context, %iter: memref<i64>, %cond: memref<i1>,
+    %current: memref<4x4xf32>,
+    %capture: memref<4x4xf32, strided<[4, 1], offset: 1>>,
+    %frame: !hip.loop_frame) -> (i32, memref<4x4xf32>) {
+  %status = arith.constant 0 : i32
+  return %status, %current : i32, memref<4x4xf32>
+}
+
+func.func @bad_layout(
+    %ctx: !hip.context, %parent: memref<4x8xf32>,
+    %seed: memref<4x4xf32>) {
+  %zero = arith.constant 0 : index
+  %true = arith.constant true
+  %capture = memref.subview %parent[0, 2][4, 4][1, 1]
+      : memref<4x8xf32>
+        to memref<4x4xf32, strided<[8, 1], offset: 2>>
+  // expected-error @below {{body_func capture #0 type mismatch}}
+  %result, %frame = hip.loop(%ctx, %zero, %true)
+      iter_args(%seed : memref<4x4xf32>)
+      captures(%capture
+        : memref<4x4xf32, strided<[8, 1], offset: 2>>)
+      -> (memref<4x4xf32>, !hip.loop_frame)
+      body @bad_layout_body
+      {cond_is_passthrough, descriptor_return,
+       num_loop_carried = 1 : i32}
+  return
+}

--- a/test/lit/Dialect/hip-promote-strided-operands.mlir
+++ b/test/lit/Dialect/hip-promote-strided-operands.mlir
@@ -338,3 +338,55 @@ func.func @non_hip_dps_input_promoted(
   }
   return
 }
+
+// ----------------------------------------------------------------------------
+// Loop captures use the outlined body signature as their ABI contract. Repeated
+// read-only captures of the same strided value share one identity-layout copy,
+// which remains live through the invocation and is deallocated immediately
+// afterward. The carrier seed is not promoted or deallocated: a zero-trip loop
+// may return that borrowed descriptor.
+//
+// The input intentionally models the verifier-supported transient
+// post-bufferization layout mismatch repaired by this pass.
+// ----------------------------------------------------------------------------
+// CHECK-LABEL: func.func @loop_capture_promoted_once
+// CHECK-SAME:    %[[SEED:[^ ,]+]]: memref<4x4xf32>
+// CHECK:         %[[CAPTURE:.*]] = memref.subview
+// CHECK:         %[[TMP:.*]] = memref.alloc() : memref<4x4xf32>
+// CHECK-NEXT:    memref.copy %[[CAPTURE]], %[[TMP]]
+// CHECK-NEXT:    %[[LOOP:.*]]:2 = hip.loop
+// CHECK-SAME:      iter_args(%[[SEED]] : memref<4x4xf32>)
+// CHECK-SAME:      captures(%[[TMP]], %[[TMP]] : memref<4x4xf32>, memref<4x4xf32>)
+// CHECK-NEXT:    memref.dealloc %[[TMP]]
+// CHECK-NEXT:    memref.copy %[[LOOP]]#0
+// CHECK-NOT:     memref.dealloc %[[SEED]]
+func.func private @loop_capture_promoted_once_body(
+    %ctx: !hip.context, %iter: memref<i64>, %cond: memref<i1>,
+    %current: memref<4x4xf32>, %capture0: memref<4x4xf32>,
+    %capture1: memref<4x4xf32>, %frame: !hip.loop_frame)
+    -> (i32, memref<4x4xf32>) {
+  %status = arith.constant 0 : i32
+  return %status, %current : i32, memref<4x4xf32>
+}
+
+func.func @loop_capture_promoted_once(
+    %ctx: !hip.context, %parent: memref<4x8xf32>,
+    %seed: memref<4x4xf32>, %after: memref<4x4xf32>) {
+  %zero = arith.constant 0 : index
+  %true = arith.constant true
+  %capture = memref.subview %parent[0, 2][4, 4][1, 1]
+      : memref<4x8xf32>
+        to memref<4x4xf32, strided<[8, 1], offset: 2>>
+  %result, %loop_frame = hip.loop(%ctx, %zero, %true)
+      iter_args(%seed : memref<4x4xf32>)
+      captures(%capture, %capture
+        : memref<4x4xf32, strided<[8, 1], offset: 2>>,
+          memref<4x4xf32, strided<[8, 1], offset: 2>>)
+      -> (memref<4x4xf32>, !hip.loop_frame)
+      body @loop_capture_promoted_once_body
+      {cond_is_passthrough, descriptor_return,
+       num_loop_carried = 1 : i32}
+  memref.copy %result, %after : memref<4x4xf32> to memref<4x4xf32>
+  hip.loop_frame_destroy(%ctx, %loop_frame)
+  return
+}

--- a/test/lit/Pipeline/loop-exact-slice-seed.mlir
+++ b/test/lit/Pipeline/loop-exact-slice-seed.mlir
@@ -1,0 +1,59 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --onnx-to-hip-pipeline %s | FileCheck %s
+// RUN: hip-mlir-opt --hipdnn-pipeline %s | FileCheck %s --check-prefix=LLVM
+
+// An exact [1,0,D] Slice is a valid borrowed loop seed. Body allocations use
+// the parent invocation's carrier bank with the exact growing descriptor, and
+// the graph output is copied from the final descriptor before frame destroy.
+// CHECK-LABEL: func.func @main_graph
+// CHECK: memref.view
+// CHECK-SAME: memref<1x0x3xf32>
+// CHECK: memref.cast
+// CHECK-SAME: memref<1x0x3xf32> to memref<1x?x3xf32>
+// CHECK: %[[LOOP:.*]]:2 = hip.loop
+// CHECK-SAME: -> (memref<1x?x3xf32>, !hip.loop_frame)
+// CHECK: hip.alloc_output
+// CHECK: hip.copy_output
+// CHECK: hip.loop_frame_destroy
+// CHECK-LABEL: func.func private @main_graph_loop_body_n0
+// CHECK-SAME: %[[FRAME:[^ ,]+]]: !hip.loop_frame
+// CHECK: hip.loop_alloc(%[[FRAME]],
+// CHECK-SAME: memref<1x?x3xf32>
+// LLVM-LABEL: llvm.func private @main_graph(
+// LLVM: llvm.call @hipdnn_ep_run_counted_loop
+// LLVM: llvm.call @hipdnn_ep_alloc_output
+// LLVM: llvm.call @hipdnn_ep_loop_frame_destroy
+module {
+  func.func @main_graph(%row: tensor<1x1x3xf32> {onnx.name = "row"})
+      -> (tensor<1x?x3xf32> {onnx.name = "output"}) {
+    %starts = "onnx.Constant"() {value = dense<[0]> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %ends = "onnx.Constant"() {value = dense<[0]> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %axes = "onnx.Constant"() {value = dense<[1]> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %steps = "onnx.Constant"() {value = dense<[1]> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %seed = "onnx.Slice"(%row, %starts, %ends, %axes, %steps)
+        : (tensor<1x1x3xf32>, tensor<1xi64>, tensor<1xi64>,
+           tensor<1xi64>, tensor<1xi64>) -> tensor<1x0x3xf32>
+    %m = "onnx.Constant"() {value = dense<2> : tensor<i64>}
+        : () -> tensor<i64>
+    %cond = "onnx.Constant"() {value = dense<true> : tensor<i1>}
+        : () -> tensor<i1>
+    %result = "onnx.Loop"(%m, %cond, %seed) ({
+    ^bb0(%iter: tensor<i64>, %cond_in: tensor<i1>,
+         %acc: tensor<1x?x3xf32>):
+      %next = "onnx.Concat"(%acc, %row) {axis = 1 : si64}
+          : (tensor<1x?x3xf32>, tensor<1x1x3xf32>)
+            -> tensor<1x?x3xf32>
+      "onnx.Yield"(%cond_in, %next)
+          : (tensor<i1>, tensor<1x?x3xf32>) -> ()
+    }) : (tensor<i64>, tensor<i1>, tensor<1x0x3xf32>)
+         -> tensor<1x?x3xf32>
+    "onnx.Return"(%result) : (tensor<1x?x3xf32>) -> ()
+  }
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}

--- a/test/lit/Pipeline/loop-strided-capture.mlir
+++ b/test/lit/Pipeline/loop-strided-capture.mlir
@@ -1,0 +1,53 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --onnx-to-hip-pipeline \
+// RUN:   --mlir-print-ir-after=hip-promote-strided-operands %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=PROMOTE
+// RUN: hip-mlir-opt --hipdnn-pipeline %s \
+// RUN:   | FileCheck %s --check-prefix=LLVM
+
+// Bufferization turns the outer tensor.extract_slice capture into a strided
+// memref.subview while selecting an identity-layout function-boundary type for
+// the outlined body argument. The promotion pass repairs that transient ABI
+// mismatch with one copy live exactly across hip.loop. The identity-layout
+// carrier seed remains the loop operand, preserving its zero-trip may-alias
+// lifetime.
+//
+// PROMOTE-LABEL: func.func @main_graph
+// PROMOTE-SAME:    %[[PARENT:[^ ,]+]]: memref<4x8xf32>
+// PROMOTE-SAME:    %[[SEED:[^ ,]+]]: memref<4x4xf32>
+// PROMOTE:         %[[CAPTURE:.*]] = memref.subview %[[PARENT]]
+// PROMOTE:         %[[TMP:.*]] = memref.alloc() : memref<4x4xf32>
+// PROMOTE-NEXT:    memref.copy %[[CAPTURE]], %[[TMP]]
+// PROMOTE-NEXT:    %[[LOOP:.*]]:2 = hip.loop
+// PROMOTE-SAME:      iter_args(%[[SEED]] : memref<4x4xf32>)
+// PROMOTE-SAME:      captures(%[[TMP]] : memref<4x4xf32>)
+// PROMOTE-NEXT:    memref.dealloc %[[TMP]]
+// PROMOTE-NOT:     memref.dealloc %[[SEED]]
+// PROMOTE-LABEL: func.func private @main_graph_loop_body_n0
+// PROMOTE-SAME:    , %{{[^,]+}}: memref<4x4xf32>,
+// PROMOTE-SAME:    %{{[^,]+}}: !hip.loop_frame)
+// LLVM-LABEL: llvm.func private @main_graph
+// LLVM: llvm.call @hipdnn_ep_run_counted_loop
+module {
+  func.func @main_graph(%parent: tensor<4x8xf32>, %seed: tensor<4x4xf32>)
+      -> tensor<4x4xf32> {
+    %capture = tensor.extract_slice %parent[0, 2] [4, 4] [1, 1]
+        : tensor<4x8xf32> to tensor<4x4xf32>
+    %m = "onnx.Constant"() {value = dense<0> : tensor<i64>}
+        : () -> tensor<i64>
+    %cond = "onnx.Constant"() {value = dense<true> : tensor<i1>}
+        : () -> tensor<i1>
+    %result = "onnx.Loop"(%m, %cond, %seed) ({
+    ^bb0(%iter: tensor<i64>, %cond_in: tensor<i1>,
+         %current: tensor<4x4xf32>):
+      %next = "onnx.Add"(%current, %capture)
+          : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+      "onnx.Yield"(%cond_in, %next)
+          : (tensor<i1>, tensor<4x4xf32>) -> ()
+    }) : (tensor<i64>, tensor<i1>, tensor<4x4xf32>)
+         -> tensor<4x4xf32>
+    return %result : tensor<4x4xf32>
+  }
+}

--- a/test/numeric/tests/test_loop.py
+++ b/test/numeric/tests/test_loop.py
@@ -46,6 +46,51 @@ def _append_from_empty_model(trip_count: int, width: int):
     )
 
 
+def _append_from_exact_slice_seed_model(trip_count: int, width: int):
+    body_iter = helper.make_tensor_value_info("iter", TensorProto.INT64, [])
+    body_cond = helper.make_tensor_value_info("cond_in", TensorProto.BOOL, [])
+    body_acc = helper.make_tensor_value_info(
+        "acc_in", TensorProto.FLOAT, [1, None, width]
+    )
+    body_cond_out = helper.make_tensor_value_info("cond_out", TensorProto.BOOL, [])
+    body_acc_out = helper.make_tensor_value_info(
+        "acc_out", TensorProto.FLOAT, [1, None, width]
+    )
+    body = helper.make_graph(
+        [
+            helper.make_node("Concat", ["acc_in", "row"], ["acc_out"], axis=1),
+            helper.make_node("Identity", ["cond_in"], ["cond_out"]),
+        ],
+        "slice_seed_append_body",
+        [body_iter, body_cond, body_acc],
+        [body_cond_out, body_acc_out],
+    )
+
+    row_info = helper.make_tensor_value_info("row", TensorProto.FLOAT, [1, 1, width])
+    output_info = helper.make_tensor_value_info(
+        "Y", TensorProto.FLOAT, [1, None, width]
+    )
+    initializers = [
+        helper.make_tensor("starts", TensorProto.INT64, [1], [0]),
+        helper.make_tensor("ends", TensorProto.INT64, [1], [0]),
+        helper.make_tensor("axes", TensorProto.INT64, [1], [1]),
+        helper.make_tensor("steps", TensorProto.INT64, [1], [1]),
+        helper.make_tensor("M", TensorProto.INT64, [], [trip_count]),
+        helper.make_tensor("cond", TensorProto.BOOL, [], [True]),
+    ]
+    slice_node = helper.make_node(
+        "Slice", ["row", "starts", "ends", "axes", "steps"], ["seed"]
+    )
+    loop = helper.make_node("Loop", ["M", "cond", "seed"], ["Y"], body=body)
+    return make_model_from_nodes(
+        [slice_node, loop],
+        [row_info],
+        [output_info],
+        initializers=initializers,
+        opset=17,
+    )
+
+
 @pytest.mark.parametrize("trip_count", [0, 1, 4])
 def test_loop_append_from_exact_empty_seed(model_runner, trip_count):
     model = _append_from_empty_model(trip_count=trip_count, width=3)
@@ -57,3 +102,17 @@ def test_loop_append_from_exact_empty_seed(model_runner, trip_count):
         name=f"loop_append_from_empty_seed_{trip_count}",
     )
     compare_outputs(actual, expected, atol=0.0, rtol=0.0)
+
+
+@pytest.mark.parametrize("trip_count", [0, 1, 4])
+def test_loop_append_from_exact_slice_seed(model_runner, trip_count):
+    model = _append_from_exact_slice_seed_model(trip_count=trip_count, width=3)
+    row = np.arange(3, dtype=np.float32).reshape(1, 1, 3)
+    actual, expected = model_runner.run_sample(
+        model,
+        [row],
+        reference="cpu",
+        name=f"loop_append_from_exact_slice_seed_{trip_count}",
+    )
+    compare_outputs(actual, expected, atol=0.0, rtol=0.0)
+    assert actual[0].shape == (1, trip_count, 3)


### PR DESCRIPTION
## Why

Exact Slice lowering can produce zero-length seeds and strided views that cross outlined loop boundaries. Bufferization represents captured views with strided layouts, while outlined loop body arguments and carrier banks require stable identity-layout descriptors. Without an explicit integration step, those layout mismatches can invalidate loop captures or lose the exact growing descriptor carried across iterations.

This PR promotes only the affected captures to identity-layout temporaries around `hip.loop` and preserves exact Slice seed/output descriptors through the loop frame. Zero-trip aliasing remains valid, growing carriers retain their exact runtime shapes, and graph outputs are copied before the frame is destroyed.

## Pass example

An exact empty Slice can seed a shape-growing loop:

```mlir
%seed = "onnx.Slice"(%row, %starts, %ends, %axes, %steps)
    : (tensor<1x1x3xf32>, tensor<1xi64>, tensor<1xi64>,
       tensor<1xi64>, tensor<1xi64>) -> tensor<1x0x3xf32>
%result = "onnx.Loop"(%tripCount, %condition, %seed) ({
^bb0(%iter: tensor<i64>, %condIn: tensor<i1>,
     %acc: tensor<1x?x3xf32>):
  %next = "onnx.Concat"(%acc, %row) {axis = 1 : si64}
      : (tensor<1x?x3xf32>, tensor<1x1x3xf32>) -> tensor<1x?x3xf32>
  "onnx.Yield"(%condIn, %next)
      : (tensor<i1>, tensor<1x?x3xf32>) -> ()
}) : (tensor<i64>, tensor<i1>, tensor<1x0x3xf32>)
     -> tensor<1x?x3xf32>
```

After conversion, the exact seed descriptor remains the loop carrier and the final descriptor is copied before frame destruction:

```mlir
%seedView = memref.view %seedBuffer[] [] : memref<1x0x3xf32>
%seedCarrier = memref.cast %seedView
    : memref<1x0x3xf32> to memref<1x?x3xf32>
%result, %frame = hip.loop iter_args(%seedCarrier : memref<1x?x3xf32>)
    -> (memref<1x?x3xf32>, !hip.loop_frame)
hip.copy_output %result, %output
hip.loop_frame_destroy %frame
```

## What changes

- Promote strided loop captures to identity-layout temporaries when outlined body signatures require them.
- Keep promotion copies live exactly across `hip.loop` and deallocate them afterward.
- Preserve identity-layout carrier seeds so zero-trip loops retain may-alias semantics.
- Carry exact zero-length Slice seeds and shape-growing result descriptors through loop frames.
- Copy final graph outputs before destroying descriptor-return frames.
- Diagnose unsupported strided capture and carrier combinations explicitly.
- Add pipeline, dialect, invalid-case, and numeric loop coverage.

## Stack

Full 41-PR order:

1. [#688 — refactor(hip): externalize constants after ONNX conversion](https://github.com/ROCm/hip-ep/pull/688)
2. [#754 — fix(pool-alloc): size i1 buffers by physical bytes](https://github.com/ROCm/hip-ep/pull/754)
3. [#756 — fix(runtime): propagate generated failures to ORT](https://github.com/ROCm/hip-ep/pull/756)
4. [#758 — fix(output): materialize exact supported output views](https://github.com/ROCm/hip-ep/pull/758)
5. [#755 — fix(pool-alloc): namespace pools by function site](https://github.com/ROCm/hip-ep/pull/755)
6. [#757 — fix(host-scratch): namespace storage by function site](https://github.com/ROCm/hip-ep/pull/757)
7. [#724 — feat(shape): preserve symbolic compiler inputs](https://github.com/ROCm/hip-ep/pull/724)
8. [#759 — fix(runtime): reject stale artifact ABI before dispatch](https://github.com/ROCm/hip-ep/pull/759)
9. [#639 — refactor(hip): establish shared shape-rule foundation](https://github.com/ROCm/hip-ep/pull/639)
10. [#681 — fix(shape): canonicalize host reshape provenance](https://github.com/ROCm/hip-ep/pull/681)
11. [#725 — fix(shape): activate exact broadcasts with symbolic proofs](https://github.com/ROCm/hip-ep/pull/725)
12. [#763 — perf(softmax): reuse transient attention score buffers](https://github.com/ROCm/hip-ep/pull/763)
13. [#640 — fix(runtime): harden MatMul and Gemm contracts](https://github.com/ROCm/hip-ep/pull/640)
14. [#734 — fix(shape): share MatMul and Gemm contracts](https://github.com/ROCm/hip-ep/pull/734)
15. [#641 — fix(shape): enforce shared broadcast contracts](https://github.com/ROCm/hip-ep/pull/641)
16. [#735 — refactor(conversion): share ONNX reduction conversion](https://github.com/ROCm/hip-ep/pull/735)
17. [#736 — fix(shape): normalize reduction contracts](https://github.com/ROCm/hip-ep/pull/736)
18. [#689 — refactor(loop): return carriers through owned descriptor frames](https://github.com/ROCm/hip-ep/pull/689)
19. [#737 — fix(loop): support shape-changing loop carriers](https://github.com/ROCm/hip-ep/pull/737)
20. [#762 — perf(loop): recycle carrier banks across frames](https://github.com/ROCm/hip-ep/pull/762)
21. [#642 — feat(hip): add grouped shape readback](https://github.com/ROCm/hip-ep/pull/642)
22. [#727 — feat(shape): consume constant payload shapes directly](https://github.com/ROCm/hip-ep/pull/727)
23. [#728 — feat(shape): add exact Tile and Range destinations](https://github.com/ROCm/hip-ep/pull/728)
24. [#729 — refactor(slice): share overflow-safe normalization](https://github.com/ROCm/hip-ep/pull/729)
25. [#731 — feat(slice): lower normalized exact descriptors](https://github.com/ROCm/hip-ep/pull/731)
26. [#733 — fix(loop): integrate exact payload Slice carriers](https://github.com/ROCm/hip-ep/pull/733) ← this PR
27. [#643 — fix(shape): share convolution contracts](https://github.com/ROCm/hip-ep/pull/643)
28. [#738 — fix(shape): share pooling contracts](https://github.com/ROCm/hip-ep/pull/738)
29. [#742 — fix(shape): share causal convolution contracts](https://github.com/ROCm/hip-ep/pull/742)
30. [#644 — fix(shape): share gather and tensor contracts](https://github.com/ROCm/hip-ep/pull/644)
31. [#739 — fix(shape): share block-quantized Gather contracts](https://github.com/ROCm/hip-ep/pull/739)
32. [#645 — fix(shape): share normalization contracts](https://github.com/ROCm/hip-ep/pull/645)
33. [#740 — fix(shape): share attention contracts](https://github.com/ROCm/hip-ep/pull/740)
34. [#741 — fix(shape): share GQA capacity contracts](https://github.com/ROCm/hip-ep/pull/741)
35. [#743 — fix(gqa): reject unsupported optional features](https://github.com/ROCm/hip-ep/pull/743)
36. [#646 — refactor(hip): declare explicit DPS shape contracts](https://github.com/ROCm/hip-ep/pull/646)
37. [#730 — test(hip): audit explicit DPS contract inventory](https://github.com/ROCm/hip-ep/pull/730)
38. [#732 — test(hip): audit ONNX converter deduplication](https://github.com/ROCm/hip-ep/pull/732)
39. [#647 — fix(hip): harden shape refinement failure handling](https://github.com/ROCm/hip-ep/pull/647)
40. [#761 — refactor(hip): split shape utility headers by family](https://github.com/ROCm/hip-ep/pull/761)
41. [#764 — refactor(hip): clarify shape destination authority](https://github.com/ROCm/hip-ep/pull/764)

## AI assistance

AI tools assisted with the loop-carrier integration, tests, and stack preparation. The contributor reviewed the resulting code.

Made-with: Cursor

Made with [Cursor](https://cursor.com)
