### PR TITLE
fix(loop): support shape-changing loop carriers

### DIFF
--- a/docs/design/loop-carrier-descriptor-abi.md
+++ b/docs/design/loop-carrier-descriptor-abi.md
@@ -6,11 +6,12 @@ Licensed under the MIT License.
 
 ## Contract
 
-This ABI layer requires `v_init`, the source Loop result, the body current
-argument, and the body yield to have exactly equal ranked tensor types.
-Shape-changing and nested carriers are rejected before outlining; a following
-shape-contract layer adds conservative joins and parent-frame threading without
-changing the descriptor-return runtime ABI.
+Each carrier contract is the compatible join of `v_init`, the source Loop
+result, the body current argument, and the body yield. Rank and element type
+must agree. Conflicting static extents are rejected; a dimension remains static
+only when every participant is ranked and agrees on the same static value.
+Otherwise it is dynamic. The seed is cast to this joined type and later shape
+inference never narrows the contract from the seed.
 
 Bufferization preserves one ranked memref result per carrier and appends a
 compiler-visible `!hip.loop_frame` ownership token. A zero-trip loop returns
@@ -39,8 +40,9 @@ from swapping the next descriptor set.
 
 Before a body return, any carrier descriptor not equal to the current borrowed
 descriptor and not rooted in that body's own carrier bank is materialized into
-an exact `hip.loop_alloc` plus checked copy. A trampoline therefore observes
-only pass-through or its own bank.
+an exact `hip.loop_alloc` plus checked copy. This includes nested-loop results
+owned by child frames and arbitrary captured/body-produced descriptors, so a
+parent trampoline only ever observes pass-through or its own bank.
 
 `!hip.loop_frame` is an opaque per-invocation handle. `hip.loop_alloc` uses it
 to obtain a carrier's writable next bank from
@@ -63,14 +65,15 @@ therefore excluded from PoolAllocs and ownership-based deallocation. Ordinary
 body `memref.alloc` operations remain poolable.
 
 `hip-finalize-loop-frames` inserts `hip.loop_frame_destroy` after the last
-carrier descriptor use and after any graph-output copy. Normal invocations
-therefore retain no per-run frame. If synchronization fails during destruction,
-only that frame is quarantined for a later successful synchronization or state
-cleanup.
+carrier descriptor use and after any graph-output copy. An escaping nested
+carrier transfers its child frame to the enclosing parent frame; explicit child
+destruction unlinks it. Normal invocations therefore retain no per-run frame.
+If synchronization fails during destruction, only that frame is quarantined
+for a later successful synchronization or state cleanup.
 
-Lifetime analysis follows conditional zero-trip/pass-through aliases through
-later loop `v_init` edges and view chains. Therefore `b = loop(a)` keeps `a`'s
-frame alive through every possible consumer of `b`.
+Lifetime analysis follows conditional zero-trip/pass-through aliases
+transitively through later loop `v_init` edges and view chains. Therefore
+`b = loop(a)` keeps `a`'s frame alive through every possible consumer of `b`.
 
 ## Graph outputs and errors
 
@@ -86,10 +89,9 @@ status plus safe current descriptors before any later body kernel or copy.
 Driver failure exposes only borrowed initial descriptors and a null frame
 token. Every failure sets the existing generated-graph runtime error flag.
 
-## Concurrency
+## Concurrency and nesting
 
 Iteration storage, condition storage, events, descriptor sets, and carrier
-banks are frame-local. Simultaneous driver invocations on one runtime state
-therefore do not share loop slots. Only the failed-destruction quarantine list
-is shared and mutex-protected. Nested loops are rejected until parent-frame
-threading lands in the shape-carrier layer.
+banks are frame-local. Nested loops and simultaneous driver invocations on one
+runtime state therefore do not share loop slots. Only the failed-destruction
+quarantine list is shared and mutex-protected.

--- a/lib/Conversion/OnnxToHip/LoopOutline.cpp
+++ b/lib/Conversion/OnnxToHip/LoopOutline.cpp
@@ -164,18 +164,52 @@ static FailureOr<Value> unboxCondInit(OpBuilder &builder, Location loc,
 }
 
 static FailureOr<RankedTensorType>
-validateCarrierEquality(Operation *loopOp, unsigned carrierIndex,
-                        ArrayRef<Type> participantTypes) {
+computeCarrierJoin(Operation *loopOp, unsigned carrierIndex,
+                   ArrayRef<Type> participantTypes) {
   auto initType = dyn_cast<RankedTensorType>(participantTypes.front());
   if (!initType)
     return loopOp->emitOpError("loop carrier #")
            << carrierIndex << " requires a ranked v_init type";
 
-  // Normalize under-refined source boundaries to v_init. The outlined function
-  // and hip.loop verifier then enforce exact current/result equality; actual
-  // shape evolution is deferred to the conservative-join layer.
-  (void)participantTypes;
-  return initType;
+  int64_t rank = initType.getRank();
+  Type elementType = initType.getElementType();
+  SmallVector<int64_t> shape(rank, ShapedType::kDynamic);
+  for (int64_t dim = 0; dim < rank; ++dim) {
+    std::optional<int64_t> agreedStatic;
+    bool allStatic = true;
+    for (Type type : participantTypes) {
+      auto tensor = dyn_cast<TensorType>(type);
+      if (!tensor)
+        return loopOp->emitOpError("loop carrier #")
+               << carrierIndex << " participant is not a tensor: " << type;
+      if (tensor.getElementType() != elementType)
+        return loopOp->emitOpError("loop carrier #")
+               << carrierIndex << " has contradictory element types "
+               << elementType << " and " << tensor.getElementType();
+      auto ranked = dyn_cast<RankedTensorType>(tensor);
+      if (!ranked) {
+        allStatic = false;
+        continue;
+      }
+      if (ranked.getRank() != rank)
+        return loopOp->emitOpError("loop carrier #")
+               << carrierIndex << " has contradictory ranks " << rank << " and "
+               << ranked.getRank();
+      int64_t extent = ranked.getDimSize(dim);
+      if (ShapedType::isDynamic(extent)) {
+        allStatic = false;
+        continue;
+      }
+      if (agreedStatic && *agreedStatic != extent)
+        return loopOp->emitOpError("loop carrier #")
+               << carrierIndex << " has contradictory static extents "
+               << *agreedStatic << " and " << extent << " at dimension " << dim;
+      agreedStatic = extent;
+    }
+    if (allStatic && agreedStatic)
+      shape[dim] = *agreedStatic;
+  }
+  return RankedTensorType::get(shape, elementType, initType.getEncoding());
 }
 
 //===----------------------------------------------------------------------===//
@@ -261,9 +295,9 @@ LogicalResult OnnxLoopOutlinePass::outlineLoop(Operation *loopOp,
     return loopOp->emitOpError("onnx.Loop body arg count mismatch: expected ")
            << (2 + numLoopCarried) << ", got " << bodyBlock.getNumArguments();
 
-  // The descriptor-frame ABI lands before shape-changing carrier joins. Keep
-  // this layer independently safe by requiring one exact carrier type at every
-  // source boundary.
+  // Compute the conservative carrier contract before mutating any IR. Static
+  // extents survive only when v_init, the source Loop result, the body current
+  // argument, and the body yield all agree on the same static value.
   SmallVector<RankedTensorType> carrierTypes;
   carrierTypes.reserve(numLoopCarried);
   for (unsigned i = 0; i < numLoopCarried; ++i) {
@@ -272,7 +306,7 @@ LogicalResult OnnxLoopOutlinePass::outlineLoop(Operation *loopOp,
                            bodyBlock.getArgument(2 + i).getType(),
                            yieldOp->getOperand(1 + i).getType()};
     FailureOr<RankedTensorType> joined =
-        validateCarrierEquality(loopOp, i, participants);
+        computeCarrierJoin(loopOp, i, participants);
     if (failed(joined))
       return failure();
     carrierTypes.push_back(*joined);
@@ -448,7 +482,13 @@ LogicalResult OnnxLoopOutlinePass::outlineLoop(Operation *loopOp,
   for (Operation &op : bodyBlock) {
     if (&op == yieldOp)
       continue;
-    bodyBuilder.clone(op, mapping);
+    Operation *cloned = bodyBuilder.clone(op, mapping);
+    if (auto nested = dyn_cast<LoopOp>(cloned)) {
+      if (nested.getParentFrame())
+        return loopOp->emitOpError(
+            "nested hip.loop already carries a parent frame before outlining");
+      nested.getParentFrameMutable().assign(entry->getArguments().back());
+    }
   }
 
   // In passthrough mode the yield's cond_out came from a chain of
@@ -572,25 +612,26 @@ LogicalResult OnnxLoopOutlinePass::outlineLoop(Operation *loopOp,
 }
 
 LogicalResult OnnxLoopOutlinePass::outlineAll(ModuleOp module) {
-  // Nested frame threading lands with shape-changing carriers. Reject nesting
-  // transactionally in this ABI-only layer so a child can never escape without
-  // an explicit parent lifetime.
+  // Collect in post-order so nested loops are outlined before their parents.
+  // Each runtime invocation now owns a distinct frame, iter slot, condition
+  // slot, event, and carrier banks, so nesting no longer aliases per-state
+  // scratch.
   unsigned counter = 0;
-  SmallVector<Operation *> loops;
-  module.walk([&](Operation *op) {
-    if (op->getName().getStringRef() == "onnx.Loop")
-      loops.push_back(op);
-  });
-  for (Operation *loopOp : loops) {
-    for (Operation *parent = loopOp->getParentOp(); parent;
-         parent = parent->getParentOp()) {
-      if (parent->getName().getStringRef() != "onnx.Loop")
-        continue;
-      return loopOp->emitOpError(
-          "nested onnx.Loop requires shape-carrier frame threading");
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    SmallVector<Operation *> loops;
+    module.walk<WalkOrder::PostOrder>([&](Operation *op) {
+      if (op->getName().getStringRef() == "onnx.Loop")
+        loops.push_back(op);
+    });
+    if (loops.empty())
+      break;
+    for (Operation *loopOp : loops) {
+      if (failed(outlineLoop(loopOp, counter)))
+        return failure();
+      changed = true;
     }
-    if (failed(outlineLoop(loopOp, counter)))
-      return failure();
   }
   return success();
 }

--- a/lib/Dialect/Transforms/InferLoopBodyShapesPass.cpp
+++ b/lib/Dialect/Transforms/InferLoopBodyShapesPass.cpp
@@ -243,12 +243,13 @@ static void inferLoopBodyShapes(func::FuncOp body, hip::LoopOp loopOp) {
   Operation::operand_range vInit = loopOp.getVInit();
   static constexpr unsigned kArgVCarryStart = 3;
 
-  // 1. Seed loop-carried block args from the exact v_init types. This ABI-only
-  //    layer rejects shape-changing carriers before outlining.
+  // 1. Seed loop-carried block args from the conservative joined loop result
+  //    types. Never re-narrow from a more-static zero/one-trip seed.
   for (auto [i, v] : llvm::enumerate(vInit)) {
+    (void)v;
     unsigned argSlot = kArgVCarryStart + i;
     if (argSlot < entry.getNumArguments())
-      entry.getArgument(argSlot).setType(v.getType());
+      entry.getArgument(argSlot).setType(loopOp.getResult(i).getType());
   }
 
   // 2. Forward-infer unranked onnx.* results from their (seeded) operands.
@@ -267,13 +268,13 @@ static void inferLoopBodyShapes(func::FuncOp body, hip::LoopOp loopOp) {
     if (auto cast = carried.getDefiningOp<tensor::CastOp>()) {
       Value source = cast.getSource();
       if (isa<UnrankedTensorType>(source.getType())) {
-        Type contract = v.getType();
+        Type contract = loopOp.getResult(i).getType();
         source.setType(contract);
         ++NumLoopContractRanked;
       }
     }
     if (isa<UnrankedTensorType>(carried.getType())) {
-      Type contract = v.getType();
+      Type contract = loopOp.getResult(i).getType();
       LLVM_DEBUG(DBGS() << "backstop return slot " << slot << ": "
                         << carried.getType() << " -> " << contract << "\n");
       carried.setType(contract);

--- a/lib/Dialect/Transforms/InferShapesPass.cpp
+++ b/lib/Dialect/Transforms/InferShapesPass.cpp
@@ -17,9 +17,10 @@
 //   Phase 1: per-func reify walk. Each `func.func` (main_graph + every
 //            outlined `hip.loop` body func) has its reify-impl ops
 //            collected in post-order and refined via `refineFuncBody`.
-//   Phase 2: hip.loop signature catch-up. This ABI-only layer requires exact
-//            carrier equality, so the v_init operand types synchronize the loop
-//            results and body current/result slots.
+//   Phase 2: hip.loop body signature catch-up. The loop's joined carrier
+//            result types are authoritative and never re-narrow from v_init.
+//            `refineLoopSignatures` synchronizes body current/result slots from
+//            that joined contract and re-walks changed bodies.
 //
 // See `docs/design/hip-shape-inference.md` for rationale, layout, and the
 // recipe for wiring a new op.
@@ -57,8 +58,7 @@ STATISTIC(NumResultsRefined,
 STATISTIC(NumProducersRefined,
           "Number of tensor.empty producers rebuilt with a more-static shape");
 STATISTIC(NumLoopSignaturesRefined,
-          "Number of hip.loop op + body func signatures synced from refined "
-          "v_init operand types");
+          "Number of hip.loop body signatures synced from joined results");
 
 namespace mlir {
 namespace hip {
@@ -338,21 +338,22 @@ static LogicalResult refineFuncBody(func::FuncOp funcOp, IRRewriter &rewriter) {
 }
 
 /// Sync `bodyFunc`'s `FunctionType` + entry-block-arg types at the
-/// v_carry slots from `loopOp`'s `$v_init` operand types. The outlined
+/// v_carry slots from `loopOp`'s joined result types. The outlined
 /// body func's argument layout is fixed by `OnnxLoopOutlinePass`:
 ///
 ///   [0]      ctx        (!hip.context)
 ///   [1]      iter       (rank-0 i64 tensor)
 ///   [2]      cond_in    (rank-0 i1 tensor)
-///   [3..3+N) v_carry    (loop-carried values; types must match v_init)
+///   [3..3+N) v_carry    (types match the joined loop result contract)
 ///   [3+N..]  captures   (outer-graph values referenced inside the body)
 ///
 /// Body result #0 is i32 status. Carrier results occupy [1..1+N) for
 /// passthrough condition and [2..2+N) otherwise, after cond_out.
 ///
 /// Both arg slots and the corresponding return slots are kept in sync
-/// with v_init types — keeping just one side would leave `func.return`
-/// type-incompatible with the FunctionType result list and fail verification.
+/// with joined loop result types — keeping just one side would leave
+/// `func.return` type-incompatible with the FunctionType result list and fail
+/// verification.
 ///
 /// Returns true iff any signature type was rewritten (arg or result).
 static bool syncBodyFuncSignatureFromVInit(func::FuncOp bodyFunc,
@@ -371,7 +372,8 @@ static bool syncBodyFuncSignatureFromVInit(func::FuncOp bodyFunc,
 
   bool changed = false;
   for (auto [i, v] : llvm::enumerate(vInit)) {
-    Type vt = v.getType();
+    (void)v;
+    Type vt = loopOp.getResult(i).getType();
 
     unsigned argSlot = kArgVCarryStart + i;
     if (argSlot < newInputs.size() && newInputs[argSlot] != vt) {
@@ -392,37 +394,13 @@ static bool syncBodyFuncSignatureFromVInit(func::FuncOp bodyFunc,
   return changed;
 }
 
-/// Sync `loopOp`'s result types from its `$v_init` operand types and emit a
-/// `tensor.cast` on every non-DPS-init use of any result whose type changed.
-static bool syncLoopResultsAndInsertCasts(IRRewriter &rewriter,
-                                          hip::LoopOp loopOp) {
-  Operation::operand_range vInit = loopOp.getVInit();
-  bool changed = false;
-  for (auto [i, v] : llvm::enumerate(vInit)) {
-    if (i >= loopOp.getNumLoopCarried())
-      break;
-    Value result = loopOp.getResult(i);
-    Type newType = v.getType();
-    if (result.getType() == newType)
-      continue;
-    Type oldType = result.getType();
-    SmallVector<OpOperand *> usesToCast =
-        snapshotNonDpsInitUses(result, newType);
-    result.setType(newType);
-    rewireUsesThroughCast(rewriter, loopOp.getOperation(), result, oldType,
-                          usesToCast);
-    changed = true;
-  }
-  return changed;
-}
-
 /// Phase 2 worker: walk every `hip.loop` in `module` until fixed point,
-/// syncing its result types and outlined body func signature from `$v_init`,
-/// then re-walking the body func once per change.
+/// syncing its outlined body func signature from joined loop result types and
+/// re-walking the body func once per change so
+/// body op result types catch up with the now-tighter entry block args.
 ///
 /// `module.walk` is depth-agnostic, so the helper is safe on hand-written
-/// test cases nesting one `hip.loop` inside another. Production outlining
-/// rejects nesting in this layer.
+/// test cases and production graphs nesting one `hip.loop` inside another.
 ///
 /// Why iterate. Body op refinement is monotone (`?` dims only narrow),
 /// but the order in which sibling `hip.loop` ops show up in
@@ -465,8 +443,7 @@ static LogicalResult refineLoopSignatures(ModuleOp module,
         return WalkResult::advance();
 
       bool bodyChanged = syncBodyFuncSignatureFromVInit(bodyFunc, loopOp);
-      bool resultsChanged = syncLoopResultsAndInsertCasts(rewriter, loopOp);
-      if (bodyChanged || resultsChanged) {
+      if (bodyChanged) {
         ++NumLoopSignaturesRefined;
         changed = true;
       }
@@ -504,7 +481,8 @@ void InferShapesPass::runOnOperation() {
   IRRewriter rewriter(&getContext());
 
   // Phase 1: per-func reify walk. Refines all hip-dialect Hip_DpsOp
-  // result types in-place; cast insertion preserves consumer signatures.
+  // result types in-place; cast insertion preserves consumer signatures except
+  // on ordinary DPS-init uses. Loop seed casts are propagation barriers.
   WalkResult walkResult = module.walk([&](func::FuncOp funcOp) -> WalkResult {
     return succeeded(refineFuncBody(funcOp, rewriter))
                ? WalkResult::advance()
@@ -513,8 +491,8 @@ void InferShapesPass::runOnOperation() {
   if (walkResult.wasInterrupted())
     return signalPassFailure();
 
-  // Phase 2: synchronize each loop and body from the v_init carrier contract,
-  // then re-walk changed bodies.
+  // Phase 2: synchronize each loop body from the loop's joined carrier result
+  // contract, then re-walk changed bodies.
   if (failed(refineLoopSignatures(module, rewriter)))
     signalPassFailure();
 }

--- a/test/lit/Conversion/onnx-to-hip/test_loop_outline.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_loop_outline.mlir
@@ -255,20 +255,23 @@ module {
   }
 
   // CHECK-LABEL: func.func @main_graph_v_init_refined
-  // The ABI-only layer normalizes under-refined body boundaries to v_init.
+  // The joined carrier contract widens because the body current/yield are
+  // dynamic even though v_init and the source Loop result are static.
+  // CHECK: %[[SEED_CAST:.*]] = tensor.cast %{{.*}} : tensor<16xf32> to tensor<?xf32>
   // CHECK: %[[R:.*]] = hip.loop
-  // CHECK-SAME: iter_args(%{{.*}} : tensor<16xf32>)
-  // CHECK-SAME: -> (tensor<16xf32>)
+  // CHECK-SAME: iter_args(%[[SEED_CAST]] : tensor<?xf32>)
+  // CHECK-SAME: -> (tensor<?xf32>)
   // CHECK-SAME: body @main_graph_v_init_refined_loop_body_n0
-  // CHECK: return %[[R]] : tensor<16xf32>
+  // CHECK: %[[RESULT_CAST:.*]] = tensor.cast %[[R]] : tensor<?xf32> to tensor<16xf32>
+  // CHECK: return %[[RESULT_CAST]] : tensor<16xf32>
   //
-  // Body current/result slots use the same exact descriptor contract.
+  // Body current/result slots use the same joined dynamic contract.
   // CHECK-LABEL: func.func private @main_graph_v_init_refined_loop_body_n0
   // CHECK-SAME: (%{{.*}}: !hip.context,
   // CHECK-SAME:  %{{.*}}: tensor<i64>,
   // CHECK-SAME:  %{{.*}}: tensor<i1>,
-  // CHECK-SAME:  %[[V_IN:.*]]: tensor<16xf32>,
-  // CHECK-SAME:  %{{.*}}: !hip.loop_frame) -> (i32, tensor<16xf32>)
+  // CHECK-SAME:  %[[V_IN:.*]]: tensor<?xf32>,
+  // CHECK-SAME:  %{{.*}}: !hip.loop_frame) -> (i32, tensor<?xf32>)
 }
 
 // -----

--- a/test/lit/Conversion/onnx-to-hip/test_loop_outline_invalid.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_loop_outline_invalid.mlir
@@ -3,26 +3,23 @@
 
 // ============================================================================
 // TEST PURPOSE:
-// Verify the `--onnx-loop-outline` pass rejects unsupported onnx.Loop
-// constructs at compile time with clean, actionable diagnostics instead of
-// producing IR that would later fail at codegen / runtime.
+// Verify nested onnx.Loop constructs are outlined in post-order now that every
+// invocation owns independent iter/condition storage and carrier banks.
 //
-// This file uses `--verify-diagnostics` (not FileCheck) -- the pass is
-// expected to fail and emit specific diagnostics.  Sister file
-// `test_loop_outline.mlir` covers the happy paths via FileCheck.
-//
-// This test validates:
-// - Nested onnx.Loop is rejected until the shape-carrier layer threads the
-//   child frame through its outlined parent body.
 // ============================================================================
 
-// RUN: hip-mlir-opt --hip-add-context-arg --onnx-loop-outline --split-input-file --verify-diagnostics %s
+// RUN: hip-mlir-opt --hip-add-context-arg --onnx-loop-outline --split-input-file %s | FileCheck %s
 
 // -----
 
-// Nested onnx.Loop: outer body contains an inner onnx.Loop.
-
 module {
+  // CHECK-LABEL: func.func @nested_loop
+  // CHECK: hip.loop{{.*}}body @nested_loop_loop_body_n1
+  // CHECK-LABEL: func.func private @nested_loop_loop_body_n0
+  // CHECK-SAME: !hip.loop_frame
+  // CHECK-LABEL: func.func private @nested_loop_loop_body_n1
+  // CHECK-SAME: !hip.loop_frame
+  // CHECK: hip.loop{{.*}}body @nested_loop_loop_body_n0
   func.func @nested_loop(%arg0: tensor<16xf32>) -> tensor<16xf32> {
     %M_outer = "onnx.Constant"() {value = dense<4> : tensor<i64>} : () -> tensor<i64>
     %c_outer = "onnx.Constant"() {value = dense<1> : tensor<i1>} : () -> tensor<i1>
@@ -30,7 +27,6 @@ module {
     ^bb0(%iter_o: tensor<i64>, %cond_in_o: tensor<i1>, %v_in_o: tensor<16xf32>):
       %M_inner = "onnx.Constant"() {value = dense<2> : tensor<i64>} : () -> tensor<i64>
       %c_inner = "onnx.Constant"() {value = dense<1> : tensor<i1>} : () -> tensor<i1>
-      // expected-error @+1 {{'onnx.Loop' op nested onnx.Loop requires shape-carrier frame threading}}
       %v_inner = "onnx.Loop"(%M_inner, %c_inner, %v_in_o) ({
       ^bb1(%iter_i: tensor<i64>, %cond_in_i: tensor<i1>, %v_in_i: tensor<16xf32>):
         %v_out_i = "onnx.Add"(%v_in_i, %v_in_i) : (tensor<16xf32>, tensor<16xf32>) -> tensor<16xf32>

--- a/test/lit/Conversion/onnx-to-hip/test_loop_outline_join_invalid.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_loop_outline_join_invalid.mlir
@@ -1,0 +1,47 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --hip-add-context-arg --onnx-loop-outline --split-input-file --verify-diagnostics %s
+
+module {
+  func.func @rank_conflict(%seed: tensor<4xf32>) -> tensor<2x2xf32> {
+    %m = "onnx.Constant"() {value = dense<1> : tensor<i64>} : () -> tensor<i64>
+    %c = "onnx.Constant"() {value = dense<true> : tensor<i1>} : () -> tensor<i1>
+    // expected-error @below {{'onnx.Loop' op loop carrier #0 has contradictory ranks 1 and 2}}
+    %r = "onnx.Loop"(%m, %c, %seed) ({
+    ^bb0(%i: tensor<i64>, %cond: tensor<i1>, %current: tensor<4xf32>):
+      "onnx.Yield"(%cond, %current) : (tensor<i1>, tensor<4xf32>) -> ()
+    }) : (tensor<i64>, tensor<i1>, tensor<4xf32>) -> tensor<2x2xf32>
+    return %r : tensor<2x2xf32>
+  }
+}
+
+// -----
+
+module {
+  func.func @element_conflict(%seed: tensor<4xf32>) -> tensor<4xf16> {
+    %m = "onnx.Constant"() {value = dense<1> : tensor<i64>} : () -> tensor<i64>
+    %c = "onnx.Constant"() {value = dense<true> : tensor<i1>} : () -> tensor<i1>
+    // expected-error @below {{'onnx.Loop' op loop carrier #0 has contradictory element types 'f32' and 'f16'}}
+    %r = "onnx.Loop"(%m, %c, %seed) ({
+    ^bb0(%i: tensor<i64>, %cond: tensor<i1>, %current: tensor<4xf32>):
+      "onnx.Yield"(%cond, %current) : (tensor<i1>, tensor<4xf32>) -> ()
+    }) : (tensor<i64>, tensor<i1>, tensor<4xf32>) -> tensor<4xf16>
+    return %r : tensor<4xf16>
+  }
+}
+
+// -----
+
+module {
+  func.func @static_conflict(%seed: tensor<4xf32>) -> tensor<8xf32> {
+    %m = "onnx.Constant"() {value = dense<1> : tensor<i64>} : () -> tensor<i64>
+    %c = "onnx.Constant"() {value = dense<true> : tensor<i1>} : () -> tensor<i1>
+    // expected-error @below {{'onnx.Loop' op loop carrier #0 has contradictory static extents 4 and 8 at dimension 0}}
+    %r = "onnx.Loop"(%m, %c, %seed) ({
+    ^bb0(%i: tensor<i64>, %cond: tensor<i1>, %current: tensor<4xf32>):
+      "onnx.Yield"(%cond, %current) : (tensor<i1>, tensor<4xf32>) -> ()
+    }) : (tensor<i64>, tensor<i1>, tensor<4xf32>) -> tensor<8xf32>
+    return %r : tensor<8xf32>
+  }
+}

--- a/test/lit/Pipeline/loop-descriptor-lifetime.mlir
+++ b/test/lit/Pipeline/loop-descriptor-lifetime.mlir
@@ -4,8 +4,46 @@
 // RUN: hip-mlir-opt --onnx-to-hip-pipeline --split-input-file %s | FileCheck %s
 // RUN: hip-mlir-opt --hipdnn-pipeline --split-input-file %s | FileCheck %s --check-prefix=LLVM
 
+// Full-pipeline nested loop: the inner loop must use the outer body's frame as
+// parent ownership, and only the top-level frame is explicitly destroyed.
+module {
+  // CHECK-LABEL: func.func @main_graph
+  // CHECK: %[[OUTER:.*]]:2 = hip.loop
+  // CHECK: hip.alloc_output
+  // CHECK: hip.copy_output
+  // CHECK: hip.loop_frame_destroy
+  // CHECK-LABEL: func.func private @main_graph_loop_body_n1
+  // CHECK-SAME: %[[PARENT:[^ ,]+]]: !hip.loop_frame
+  // CHECK: hip.loop
+  // CHECK-SAME: parent(%[[PARENT]])
+  // CHECK-SAME: -> (memref<16xf32>, !hip.loop_frame)
+  // CHECK: hip.loop_alloc(%[[PARENT]])
+  // CHECK: hip.copy_output
+  // LLVM-LABEL: llvm.func private @main_graph(
+  // LLVM: llvm.call @hipdnn_ep_run_counted_loop
+  // LLVM: llvm.call @hipdnn_ep_loop_frame_destroy
+  func.func @main_graph(%seed: tensor<16xf32>) -> tensor<16xf32> {
+    %outer_m = "onnx.Constant"() {value = dense<2> : tensor<i64>} : () -> tensor<i64>
+    %outer_c = "onnx.Constant"() {value = dense<true> : tensor<i1>} : () -> tensor<i1>
+    %result = "onnx.Loop"(%outer_m, %outer_c, %seed) ({
+    ^bb0(%oi: tensor<i64>, %oc: tensor<i1>, %outer: tensor<16xf32>):
+      %inner_m = "onnx.Constant"() {value = dense<1> : tensor<i64>} : () -> tensor<i64>
+      %inner_c = "onnx.Constant"() {value = dense<true> : tensor<i1>} : () -> tensor<i1>
+      %inner = "onnx.Loop"(%inner_m, %inner_c, %outer) ({
+      ^bb1(%ii: tensor<i64>, %ic: tensor<i1>, %current: tensor<16xf32>):
+        %next = "onnx.Add"(%current, %current) :
+            (tensor<16xf32>, tensor<16xf32>) -> tensor<16xf32>
+        "onnx.Yield"(%ic, %next) : (tensor<i1>, tensor<16xf32>) -> ()
+      }) : (tensor<i64>, tensor<i1>, tensor<16xf32>) -> tensor<16xf32>
+      "onnx.Yield"(%oc, %inner) : (tensor<i1>, tensor<16xf32>) -> ()
+    }) : (tensor<i64>, tensor<i1>, tensor<16xf32>) -> tensor<16xf32>
+    return %result : tensor<16xf32>
+  }
+}
+
 // Dynamic condition takes the slow runtime path and exits after the body's
 // first false condition publication.
+// -----
 module {
   // CHECK-LABEL: func.func @main_graph
   // CHECK: hip.loop

--- a/test/numeric/tests/test_loop.py
+++ b/test/numeric/tests/test_loop.py
@@ -1,0 +1,59 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+import numpy as np
+import pytest
+from onnx import TensorProto, helper
+
+from framework.comparator import compare_outputs
+from framework.onnx_utils import make_model_from_nodes
+
+
+def _append_from_empty_model(trip_count: int, width: int):
+    body_iter = helper.make_tensor_value_info("iter", TensorProto.INT64, [])
+    body_cond = helper.make_tensor_value_info("cond_in", TensorProto.BOOL, [])
+    body_acc = helper.make_tensor_value_info("acc_in", TensorProto.FLOAT, [None, width])
+    body_cond_out = helper.make_tensor_value_info("cond_out", TensorProto.BOOL, [])
+    body_acc_out = helper.make_tensor_value_info(
+        "acc_out", TensorProto.FLOAT, [None, width]
+    )
+    axes = helper.make_tensor("axes_value", TensorProto.INT64, [1], [0])
+    body = helper.make_graph(
+        [
+            helper.make_node("Constant", [], ["axes"], value=axes),
+            helper.make_node("Gather", ["X", "iter"], ["row"], axis=0),
+            helper.make_node("Unsqueeze", ["row", "axes"], ["row_2d"]),
+            helper.make_node("Concat", ["acc_in", "row_2d"], ["acc_out"], axis=0),
+            helper.make_node("Identity", ["cond_in"], ["cond_out"]),
+        ],
+        "append_body",
+        [body_iter, body_cond, body_acc],
+        [body_cond_out, body_acc_out],
+    )
+
+    x_info = helper.make_tensor_value_info("X", TensorProto.FLOAT, [trip_count, width])
+    y_info = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [None, width])
+    initializers = [
+        helper.make_tensor("M", TensorProto.INT64, [], [trip_count]),
+        helper.make_tensor("cond", TensorProto.BOOL, [], [True]),
+        helper.make_tensor("seed", TensorProto.FLOAT, [0, width], []),
+    ]
+    loop = helper.make_node("Loop", ["M", "cond", "seed"], ["Y"], body=body)
+    return make_model_from_nodes(
+        [loop], [x_info], [y_info], initializers=initializers, opset=17
+    )
+
+
+@pytest.mark.parametrize("trip_count", [0, 1, 4])
+def test_loop_append_from_exact_empty_seed(model_runner, trip_count):
+    model = _append_from_empty_model(trip_count=trip_count, width=3)
+    x = np.arange(trip_count * 3, dtype=np.float32).reshape(trip_count, 3)
+    actual, expected = model_runner.run_sample(
+        model,
+        [x],
+        reference="cpu",
+        name=f"loop_append_from_empty_seed_{trip_count}",
+    )
+    compare_outputs(actual, expected, atol=0.0, rtol=0.0)


### PR DESCRIPTION
## Why

Loop-carried tensors can have a refined seed type while the body current value or yield is dynamic. Requiring all three spellings to match exactly either rejected valid ONNX loops or propagated an under-refined body type across the loop boundary.

Descriptor-return lifetimes also need to follow those changing carrier shapes safely, including nested and zero-trip loops. This PR joins carrier types conservatively and gives each invocation a frame that owns descriptors until publication and teardown complete.

## IR example

The updated outlining fixture covers a static seed with a dynamic body carrier and result:

```mlir
func.func @main_graph_v_init_refined(
    %A: tensor<16xf32>) -> tensor<16xf32> {
  %M = "onnx.Constant"() {value = dense<4> : tensor<i64>}
      : () -> tensor<i64>
  %cond = "onnx.Constant"() {value = dense<1> : tensor<i1>}
      : () -> tensor<i1>
  %result = "onnx.Loop"(%M, %cond, %A) ({
  ^bb0(%iter: tensor<i64>, %c: tensor<i1>, %current: tensor<?xf32>):
    %next = "onnx.Identity"(%current) : (tensor<?xf32>) -> tensor<?xf32>
    "onnx.Yield"(%c, %next) : (tensor<i1>, tensor<?xf32>) -> ()
  }) : (tensor<i64>, tensor<i1>, tensor<16xf32>) -> tensor<16xf32>
  return %result : tensor<16xf32>
}
```

The outlined `hip.loop` uses the joined `tensor<?xf32>` carrier contract, with boundary casts preserving the original static function result.

## What changes

- Join seed, body-current, body-yield, and declared-result carrier types conservatively.
- Insert boundary casts while keeping body and loop carrier slots on one contract.
- Thread parent frame ownership through nested loops and preserve exact zero-trip seed descriptors.
- Return loop-carried descriptors through per-invocation frames without mutating borrowed seeds.
- Make frame publication, output copying, failure cleanup, and teardown transactional.
- Add outlining, pipeline, runtime, and numeric coverage for dynamic, nested, multi-carrier, and zero-trip loops.

## Stack

1. [#688 — constant externalization](https://github.com/ROCm/hip-ep/pull/688)
2. [#754 — i1 pool sizing](https://github.com/ROCm/hip-ep/pull/754)
3. [#756 — ORT error propagation](https://github.com/ROCm/hip-ep/pull/756)
4. [#758 — exact output views](https://github.com/ROCm/hip-ep/pull/758)
5. [#755 — pool namespaces](https://github.com/ROCm/hip-ep/pull/755)
6. [#757 — host-scratch namespaces](https://github.com/ROCm/hip-ep/pull/757)
7. [#724 — symbolic transport](https://github.com/ROCm/hip-ep/pull/724)
8. [#759 — artifact ABI guard](https://github.com/ROCm/hip-ep/pull/759)
9. [#639 — shape-rule foundation](https://github.com/ROCm/hip-ep/pull/639)
10. [#681 — reshape provenance](https://github.com/ROCm/hip-ep/pull/681)
11. [#725 — broadcast activation](https://github.com/ROCm/hip-ep/pull/725)
12. [#763 — Softmax buffer reuse](https://github.com/ROCm/hip-ep/pull/763)
13. [#640 — MatMul/Gemm runtime](https://github.com/ROCm/hip-ep/pull/640)
14. [#734 — MatMul/Gemm shapes](https://github.com/ROCm/hip-ep/pull/734)
15. [#641 — broadcast contracts](https://github.com/ROCm/hip-ep/pull/641)
16. [#735 — reduction conversion](https://github.com/ROCm/hip-ep/pull/735)
17. [#736 — reduction contracts](https://github.com/ROCm/hip-ep/pull/736)
18. [#689 — loop frame ABI](https://github.com/ROCm/hip-ep/pull/689)
19. [#737 — shape-changing loops](https://github.com/ROCm/hip-ep/pull/737) ← this PR
20. [#762 — loop bank recycling](https://github.com/ROCm/hip-ep/pull/762)
21. [#642 — grouped readback](https://github.com/ROCm/hip-ep/pull/642)
22. [#727 — payload shapes](https://github.com/ROCm/hip-ep/pull/727)
23. [#728 — Tile/Range destinations](https://github.com/ROCm/hip-ep/pull/728)
24. [#729 — Slice normalization](https://github.com/ROCm/hip-ep/pull/729)
25. [#731 — exact Slice ABI](https://github.com/ROCm/hip-ep/pull/731)
26. [#733 — loop payload integration](https://github.com/ROCm/hip-ep/pull/733)
27. [#643 — convolution contracts](https://github.com/ROCm/hip-ep/pull/643)
28. [#738 — pooling contracts](https://github.com/ROCm/hip-ep/pull/738)
29. [#742 — causal convolution contracts](https://github.com/ROCm/hip-ep/pull/742)
30. [#644 — gather/tensor contracts](https://github.com/ROCm/hip-ep/pull/644)
31. [#739 — block-quantized Gather](https://github.com/ROCm/hip-ep/pull/739)
32. [#645 — normalization contracts](https://github.com/ROCm/hip-ep/pull/645)
33. [#740 — attention contracts](https://github.com/ROCm/hip-ep/pull/740)
34. [#741 — GQA capacity](https://github.com/ROCm/hip-ep/pull/741)
35. [#743 — GQA feature rejection](https://github.com/ROCm/hip-ep/pull/743)
36. [#646 — explicit DPS contracts](https://github.com/ROCm/hip-ep/pull/646)
37. [#730 — contract inventory audit](https://github.com/ROCm/hip-ep/pull/730)
38. [#732 — converter dedup audit](https://github.com/ROCm/hip-ep/pull/732)
39. [#647 — refinement hardening](https://github.com/ROCm/hip-ep/pull/647)
40. [#761 — split shape utilities](https://github.com/ROCm/hip-ep/pull/761)
41. [#764 — destination authority](https://github.com/ROCm/hip-ep/pull/764)

## AI assistance

AI tools assisted with the loop carrier contracts, descriptor-frame lifetime work, tests, and stack reconstruction. The contributor reviewed the resulting code.

Made-with: Cursor