### PR TITLE
fix(shape): share attention contracts

### DIFF
--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -175,7 +175,9 @@ Choose the smallest mechanism that matches the operation's semantics:
 | Pad, Tile, Expand, Slice, Range | Fold-or-bail helpers with fallback to DPS-init shape |
 | MatMul/Gemm/MatMulNBits | Dedicated shape logic based on operand dimensions and attributes |
 | LayerNormalization | Y equals input; Mean/InvStdDev use keepdims reduction shape over `[axis, rank)` |
+| LinearAttention | Shared output/state formula used by converter, reification, and verifier |
 | SkipSimplifiedLayerNormalization | Output and optional residual sum equal input; training stats rejected |
+| MultiHeadAttention | Default rank-3 fp16 Q/K/V result equals query; optional/cache forms route to GQA or are rejected |
 | Forward Conv (rank-3 converter/rank-4 HIP op) | Shared signed-floor spatial-window formula used by converter, reification, and verifier |
 | Rank-4 NCHW ConvTranspose | Shared ONNX formula used by converter, reification, and verifier |
 | CausalConvWithState | Runtime-supported 1D output/state formulas from input and depthwise kernel |
@@ -352,6 +354,24 @@ training outputs and are not implemented by `hip.skip_rms_norm`. Conversion
 accepts every inference output arity (one to four schema slots with omitted
 stats) but rejects a real stats tensor rather than treating the last present
 tensor as the residual output.
+
+LinearAttention uses one two-result rule in `HipShapeUtils`:
+`Dk = query[-1] / Hq`, `Dv = value[-1] / Hkv`, output shape
+`[B, T, max(Hq, Hkv) * Dv]`, and recurrent-state shape
+`[B, Hkv, Dk, Dv]`. Conversion, `reifyResultShapes`, and the op verifier all
+call that rule. In particular, a missing `past_state` does not make key's
+positional dimensions authoritative for the state destination.
+
+The default `hip.multi_head_attention` rule matches its implemented runtime
+path, not the full Microsoft schema: Q/K/V are separate rank-3 fp16 tensors,
+Q/K/V batch and hidden extents agree, K/V sequence extents agree, hidden is
+positive and divisible by `num_heads`, `unidirectional` is 0 or 1,
+`mask_filter_value` remains its -10000 default, and the sole output is exactly
+`[query.B, query.S, query.hidden]`. The runtime honors an explicit `scale`
+(with zero retaining the automatic `1/sqrt(head_size)` sentinel). Biases,
+masks, packed layouts, past/cache inputs, cache indirection, and present/QK
+outputs are rejected before the HIP op is created. The existing decoder
+self-attention and rank-4 cross-attention routes to `hip.gqa` run first and
 
 Reductions resolve to one internal out-to-in dimension map, consumed by both
 `inferReductionShape` (static extents) and `reifyReductionResultShape` (mixed

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -3312,9 +3312,8 @@ def Hip_HipDNNGraphOp : Hip_DpsOp_AutoReify<"hipdnn_graph", [
 // ===== Multi-Head Attention =================================================
 
 def Hip_MultiHeadAttentionOp :
-    Hip_DpsOp_SemanticNoInfer<"multi_head_attention",
-                              [AttrSizedOperandSegments,
-                               OpStateOpInterface]> {
+    Hip_DpsOp<"multi_head_attention",
+              [AttrSizedOperandSegments, OpStateOpInterface]> {
   let summary = "Multi-Head Attention (com.microsoft.MultiHeadAttention v1)";
   let description = [{
     Implements the com.microsoft.MultiHeadAttention operator (opset v1).
@@ -3482,8 +3481,7 @@ def Hip_MultiHeadAttentionOp :
 }
 
 def Hip_LinearAttentionOp :
-    Hip_DpsOp_SemanticNoInfer<"linear_attention",
-                              [AttrSizedOperandSegments]> {
+    Hip_DpsOp<"linear_attention", [AttrSizedOperandSegments]> {
   let summary = "Linear attention with recurrent state (com.microsoft.LinearAttention)";
   let description = [{
     Unified linear attention operator for autoregressive decoding (T=1) and

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -3311,17 +3311,28 @@ def Hip_HipDNNGraphOp : Hip_DpsOp_AutoReify<"hipdnn_graph", [
 
 // ===== Multi-Head Attention =================================================
 
-def Hip_MultiHeadAttentionOp : Hip_DpsOp_AutoReify<"multi_head_attention", [AttrSizedOperandSegments, OpStateOpInterface]> {
+def Hip_MultiHeadAttentionOp :
+    Hip_DpsOp_SemanticNoInfer<"multi_head_attention",
+                              [AttrSizedOperandSegments,
+                               OpStateOpInterface]> {
   let summary = "Multi-Head Attention (com.microsoft.MultiHeadAttention v1)";
   let description = [{
     Implements the com.microsoft.MultiHeadAttention operator (opset v1).
 
-    Multi-Head Self/Cross Attention with optional bias from input projection.
-    Supports packed QKV in `query`, packed KV in `key`, separate Q/K/V,
-    optional key padding mask, optional additive attention bias, KV cache
-    (past_key/past_value) with optional buffer-sharing
-    (past_sequence_length), unidirectional (causal) masking, and an optional
-    cache_indirection buffer for beam-search decoding.
+    The default runtime implements self/cross attention for separate rank-3
+    fp16 Q/K/V only:
+      * query: `(batch, query_sequence, hidden)`
+      * key/value: `(batch, kv_sequence, hidden)`
+      * output: `(batch, query_sequence, hidden)`
+      * `hidden` is positive and divisible by `num_heads`
+      * `unidirectional` is 0 or 1
+      * `mask_filter_value` remains its schema default, -10000
+
+    Biases, masks, packed layouts, KV cache inputs, cache indirection, and the
+    optional present/QK outputs are not implemented by this HIP op and are
+    rejected by its verifier. The ONNX converter routes separately supported
+    decoder/cache and rank-4 cross-attention forms to `hip.gqa` before applying
+    this default-path contract.
 
     Inputs (1-10, MS spec order):
       1. query                 (required, T) - either:
@@ -3466,9 +3477,13 @@ def Hip_MultiHeadAttentionOp : Hip_DpsOp_AutoReify<"multi_head_attention", [Attr
           "hipdnn_ep_op_state_construct_multi_head_attention", {});
     }
   }];
+
+  let hasVerifier = 1;
 }
 
-def Hip_LinearAttentionOp : Hip_DpsOp_AutoReify<"linear_attention", [AttrSizedOperandSegments]> {
+def Hip_LinearAttentionOp :
+    Hip_DpsOp_SemanticNoInfer<"linear_attention",
+                              [AttrSizedOperandSegments]> {
   let summary = "Linear attention with recurrent state (com.microsoft.LinearAttention)";
   let description = [{
     Unified linear attention operator for autoregressive decoding (T=1) and
@@ -3564,6 +3579,8 @@ def Hip_LinearAttentionOp : Hip_DpsOp_AutoReify<"linear_attention", [AttrSizedOp
               type($output) `,` type($present_state) `)`
     attr-dict (`:` type($result_tensors)^)?
   }];
+
+  let hasVerifier = 1;
 }
 
 def Hip_GemmOp :

--- a/include/hip/Dialect/IR/HipShapeUtils.h
+++ b/include/hip/Dialect/IR/HipShapeUtils.h
@@ -220,6 +220,22 @@ reifyConvTransposeResultShape(OpBuilder &b, Location loc, Value input,
                               ArrayRef<int64_t> outputPadding, int64_t group,
                               function_ref<InFlightDiagnostic()> emitError);
 
+/// Compute the only output shape implemented by the default
+/// `hip.multi_head_attention` runtime: separate rank-3 fp16 Q/K/V with equal
+/// batch and hidden extents, and equal K/V sequence extents. The result is
+/// exactly `[query.B, query.S, query.hidden]`.
+FailureOr<SmallVector<int64_t>> inferMultiHeadAttentionOutputShape(
+    ArrayRef<int64_t> queryShape, ArrayRef<int64_t> keyShape,
+    ArrayRef<int64_t> valueShape, int64_t numHeads,
+    function_ref<InFlightDiagnostic()> emitError);
+
+/// Mixed-shape form of `inferMultiHeadAttentionOutputShape`. Validation
+/// completes before dimensions are materialized; all result extents come from
+/// `query`.
+FailureOr<SmallVector<OpFoldResult>> reifyMultiHeadAttentionOutputShape(
+    OpBuilder &b, Location loc, Value query, Value key, Value value,
+    int64_t numHeads, function_ref<InFlightDiagnostic()> emitError);
+
 /// Reify the result shape of a transpose op as `output[i] = input[perm[i]]`.
 /// `perm` must be a permutation of `[0, rank-1)` and have the same length
 /// as `input`'s rank.
@@ -315,6 +331,25 @@ reifyLayerNormOutputShapes(OpBuilder &b, Location loc, Value input,
 /// Runtime-supported LayerNormalization stats element type for ONNX
 /// `stash_type` (TensorProto enum): 0/1 -> f32, 10 -> f16.
 FailureOr<Type> inferLayerNormStatsType(MLIRContext *ctx, int64_t stashType);
+
+/// LinearAttention result shapes:
+///   output        = [B, T, max(Hq, Hkv) * Dv]
+///   present_state = [B, Hkv, Dk, Dv]
+/// where Dk = query[-1] / Hq and Dv = value[-1] / Hkv.
+///
+/// Also validates the statically knowable head-count and key-sharing
+/// constraints from the op contract.
+FailureOr<SmallVector<SmallVector<int64_t>>> inferLinearAttentionOutputShapes(
+    ArrayRef<int64_t> queryShape, ArrayRef<int64_t> keyShape,
+    ArrayRef<int64_t> valueShape, int64_t qNumHeads, int64_t kvNumHeads,
+    function_ref<InFlightDiagnostic()> emitError);
+
+/// Mixed-shape form of `inferLinearAttentionOutputShapes`.
+FailureOr<ReifiedRankedShapedTypeDims>
+reifyLinearAttentionOutputShapes(OpBuilder &b, Location loc, Value query,
+                                 Value key, Value value, int64_t qNumHeads,
+                                 int64_t kvNumHeads,
+                                 function_ref<InFlightDiagnostic()> emitError);
 
 /// CausalConvWithState output shapes for the runtime-supported 1D layout:
 ///   output        = input = [B, C, L] or [B, L, C] when channels-last

--- a/lib/Conversion/OnnxToHip/LinearAttentionConversion.cpp
+++ b/lib/Conversion/OnnxToHip/LinearAttentionConversion.cpp
@@ -122,9 +122,23 @@ LinearAttentionToHip::matchAndRewrite(mlir::Operation *op,
       mlir::cast<mlir::RankedTensorType>(op->getResult(1).getType());
 
   // === Create DPS init tensors ===
-  mlir::Value outputInit = createEmptyTensor(rewriter, loc, outputType, query);
-  mlir::Value presentStateInit = createEmptyTensor(
-      rewriter, loc, presentStateType, pastState ? pastState : key);
+  int64_t kvNumHeads = kvNumHeadsAttr.getValue().getSExtValue();
+  mlir::FailureOr<mlir::ReifiedRankedShapedTypeDims> outputShapes =
+      reifyLinearAttentionOutputShapes(rewriter, loc, query, key, value,
+                                       qNumHeads, kvNumHeads,
+                                       [&]() { return op->emitError(); });
+  if (mlir::failed(outputShapes))
+    return rewriter.notifyMatchFailure(
+        op, "cannot derive LinearAttention output shapes");
+
+  mlir::FailureOr<mlir::Value> outputInit = createEmptyTensorFromReifiedShape(
+      rewriter, loc, outputType, (*outputShapes)[0]);
+  mlir::FailureOr<mlir::Value> presentStateInit =
+      createEmptyTensorFromReifiedShape(rewriter, loc, presentStateType,
+                                        (*outputShapes)[1]);
+  if (mlir::failed(outputInit) || mlir::failed(presentStateInit))
+    return rewriter.notifyMatchFailure(
+        op, "LinearAttention result types disagree with inferred shapes");
 
   // === Create hip.linear_attention operation ===
   mlir::SmallVector<mlir::Type> resultTypes;
@@ -142,8 +156,8 @@ LinearAttentionToHip::matchAndRewrite(mlir::Operation *op,
     operands.push_back(decay);
   if (beta)
     operands.push_back(beta);
-  operands.push_back(outputInit);
-  operands.push_back(presentStateInit);
+  operands.push_back(*outputInit);
+  operands.push_back(*presentStateInit);
 
   mlir::SmallVector<mlir::NamedAttribute> attrs;
   attrs.push_back(rewriter.getNamedAttr("q_num_heads", qNumHeadsAttr));

--- a/lib/Conversion/OnnxToHip/MultiHeadAttentionConversion.cpp
+++ b/lib/Conversion/OnnxToHip/MultiHeadAttentionConversion.cpp
@@ -30,11 +30,9 @@ namespace {
 ///      tensor [Skv,…,Skv] equal to the K's static sequence length.  Cross-
 ///      attention is bidirectional (Q can see all of K).
 ///
-///   3. Everything else (8-input pre-surgery decoder self-attn, plain 3-input
-///      MHA, models with bias / mask / attention_bias, etc.) — keep the
-///      existing `hip.multi_head_attention` lowering.  This preserves Llama
-///      and gpt-oss behaviour and gives the unmodified Whisper self-attn form
-///      a working (if slower) CPU-fallback path.
+///   3. Plain separate-Q/K/V rank-3 fp16 MHA with one output lowers to
+///      `hip.multi_head_attention`. Other forms are rejected before HIP IR is
+///      emitted because the default runtime returns an error for them.
 ///
 /// The constant `seqlens_k` / `total_sequence_length` for the cross-attn case
 /// are emitted as `arith.constant` (not `onnx.Constant`): the greedy rewrite
@@ -74,6 +72,10 @@ mlir::LogicalResult MultiHeadAttentionToHip::matchAndRewrite(
   if (numOps < 1 || numOps > 10)
     return rewriter.notifyMatchFailure(
         op, "MultiHeadAttention expects 1-10 operands");
+  size_t numResults = op->getNumResults();
+  if (numResults < 1 || numResults > 4)
+    return rewriter.notifyMatchFailure(
+        op, "MultiHeadAttention expects 1-4 results");
 
   // Helper: get optional operand (check for NoneType / out-of-range).
   auto getOptionalOperand = [&](size_t idx) -> mlir::Value {
@@ -178,8 +180,19 @@ mlir::LogicalResult MultiHeadAttentionToHip::matchAndRewrite(
     // emit a constant tensor of `present_key.shape[2]` — the static buffer
     // size from the IR (== `past_sequence_length_max + S`, baked in at compile
     // time).
+    if (numResults != 3)
+      return rewriter.notifyMatchFailure(
+          op, "post-surgery self-attn GQA route requires output, present_key, "
+              "and present_value");
+    auto outputType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
     auto presentKType =
         mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(1).getType());
+    auto presentValueType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(2).getType());
+    if (!outputType || !presentValueType)
+      return rewriter.notifyMatchFailure(
+          op, "post-surgery self-attn requires ranked output types");
     if (!presentKType || presentKType.getRank() != 4 ||
         presentKType.isDynamicDim(2))
       return rewriter.notifyMatchFailure(
@@ -192,11 +205,6 @@ mlir::LogicalResult MultiHeadAttentionToHip::matchAndRewrite(
         totalSeqLenType, llvm::APInt(32, totalLen, /*isSigned=*/true));
     mlir::Value totalSeqLen =
         mlir::arith::ConstantOp::create(rewriter, loc, totalSeqLenAttr);
-
-    auto outputType =
-        mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
-    auto presentValueType =
-        mlir::cast<mlir::RankedTensorType>(op->getResult(2).getType());
 
     return buildHipGqaCall(
         op, rewriter, context, query, key, value, pastKey, pastValue,
@@ -219,6 +227,9 @@ mlir::LogicalResult MultiHeadAttentionToHip::matchAndRewrite(
   // intend cross-attn semantics.
   if (numOps >= 8 && noExtraInputs && key && value && !pastKey && !pastValue &&
       !pastSequenceLength && !cacheIndirection) {
+    if (numResults != 1)
+      return rewriter.notifyMatchFailure(
+          op, "cross-attn GQA route supports only the primary output");
     // Cross-attn: no_causal=true, seqlens_k = constant [Skv,…,Skv].
     //
     // Skv is K's sequence-length dim.  ONNX MHA's K can come in two layouts:
@@ -241,6 +252,13 @@ mlir::LogicalResult MultiHeadAttentionToHip::matchAndRewrite(
       return rewriter.notifyMatchFailure(
           op, "cross-attn rank-3 key not yet supported; expected rank-4 BNSH");
 
+    auto outputType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    auto valueType = mlir::dyn_cast<mlir::RankedTensorType>(value.getType());
+    if (!outputType || !valueType)
+      return rewriter.notifyMatchFailure(
+          op, "cross-attn dispatch requires ranked output and value");
+
     auto i32Ty = rewriter.getIntegerType(32);
     auto seqlensKType = mlir::RankedTensorType::get({batch}, i32Ty);
     llvm::SmallVector<llvm::APInt, 1> seqlensVals(
@@ -256,14 +274,10 @@ mlir::LogicalResult MultiHeadAttentionToHip::matchAndRewrite(
     mlir::Value totalSeqLen =
         mlir::arith::ConstantOp::create(rewriter, loc, totalSeqLenAttr);
 
-    auto outputType =
-        mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
-
     // hip.gqa always emits present_key / present_value buffers.  Cross-attn
     // has no KV cache exposed at the ONNX boundary, so the present_* types
     // just mirror K/V (they're discarded after the call).  K is guaranteed to
     // be rank-4 BNSH here — the rank-3 case was rejected above.
-    auto valueType = mlir::cast<mlir::RankedTensorType>(value.getType());
     mlir::RankedTensorType presentKType = keyType;
     mlir::RankedTensorType presentVType = valueType;
     const int64_t numHeads = numHeadsAttr.getValue().getSExtValue();
@@ -275,90 +289,85 @@ mlir::LogicalResult MultiHeadAttentionToHip::matchAndRewrite(
         /*noCausal=*/true, outputType, presentKType, presentVType);
   }
 
-  // === Default: existing hip.multi_head_attention lowering (unchanged) =====
+  // === Default: runtime-supported hip.multi_head_attention subset ==========
 
-  // === Check Outputs (1-4: output, [present_key, present_value, qk]) ===
+  if (!key || !value)
+    return op->emitError(
+        "default MultiHeadAttention runtime requires separate key and value");
+  if (bias || keyPaddingMask || attentionBias || pastKey || pastValue ||
+      pastSequenceLength || cacheIndirection)
+    return op->emitError(
+        "default MultiHeadAttention runtime does not support bias, masks, "
+        "past/cache inputs, or cache indirection");
+  if (numResults != 1)
+    return op->emitError(
+        "default MultiHeadAttention runtime supports only the primary output; "
+        "present_key, present_value, and qk are unsupported");
 
-  size_t numResults = op->getNumResults();
-  if (numResults < 1 || numResults > 4)
-    return rewriter.notifyMatchFailure(
-        op, "MultiHeadAttention expects 1-4 results");
-
+  auto queryType = mlir::dyn_cast<mlir::RankedTensorType>(query.getType());
+  auto keyType = mlir::dyn_cast<mlir::RankedTensorType>(key.getType());
+  auto valueType = mlir::dyn_cast<mlir::RankedTensorType>(value.getType());
   auto outputType =
-      mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
+      mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+  if (!queryType || !keyType || !valueType || !outputType)
+    return op->emitError(
+        "default MultiHeadAttention runtime requires ranked Q/K/V and output");
+  if (!queryType.getElementType().isF16() ||
+      keyType.getElementType() != queryType.getElementType() ||
+      valueType.getElementType() != queryType.getElementType() ||
+      outputType.getElementType() != queryType.getElementType())
+    return op->emitError(
+        "default MultiHeadAttention runtime requires fp16 Q/K/V and output");
+  if (unidirectionalAttr.getValue().getSExtValue() != 0 &&
+      unidirectionalAttr.getValue().getSExtValue() != 1)
+    return op->emitError("MultiHeadAttention unidirectional must be 0 or 1");
+  if (maskFilterValueAttr.getValue().convertToFloat() != -10000.0f)
+    return op->emitError(
+        "default MultiHeadAttention runtime supports only the default "
+        "mask_filter_value -10000");
 
-  mlir::RankedTensorType presentKeyType = nullptr;
-  mlir::RankedTensorType presentValueType = nullptr;
-  mlir::RankedTensorType qkType = nullptr;
-  if (numResults >= 2)
-    presentKeyType =
-        mlir::cast<mlir::RankedTensorType>(op->getResult(1).getType());
-  if (numResults >= 3)
-    presentValueType =
-        mlir::cast<mlir::RankedTensorType>(op->getResult(2).getType());
-  if (numResults >= 4)
-    qkType = mlir::cast<mlir::RankedTensorType>(op->getResult(3).getType());
+  const int64_t numHeads = numHeadsAttr.getValue().getSExtValue();
+  mlir::FailureOr<llvm::SmallVector<int64_t>> expectedShape =
+      mlir::hip::inferMultiHeadAttentionOutputShape(
+          queryType.getShape(), keyType.getShape(), valueType.getShape(),
+          numHeads, [&]() { return op->emitError(); });
+  if (mlir::failed(expectedShape))
+    return mlir::failure();
 
-  // === Create DPS init tensors ===
+  if (outputType.getRank() != static_cast<int64_t>(expectedShape->size()))
+    return op->emitError(
+        "MultiHeadAttention output rank contradicts Q/K/V shape contract");
+  for (int64_t dim : llvm::seq<int64_t>(outputType.getRank())) {
+    int64_t expected = (*expectedShape)[dim];
+    int64_t actual = outputType.getDimSize(dim);
+    if (mlir::ShapedType::isDynamic(expected)) {
+      if (!mlir::ShapedType::isDynamic(actual))
+        return op->emitError("MultiHeadAttention output dimension ")
+               << dim << " must remain dynamic because query is dynamic";
+    } else if (!mlir::ShapedType::isDynamic(actual) && actual != expected) {
+      return op->emitError("MultiHeadAttention output dimension ")
+             << dim << " must equal query extent " << expected;
+    }
+  }
 
-  mlir::Value outputInit = createEmptyTensor(rewriter, loc, outputType, query);
-
-  // For present_key/present_value, derive dynamic dims from the most
-  // appropriate source: past_key/past_value when present (same buffer
-  // shape), otherwise key/value, otherwise query (packed QKV).
-  mlir::Value presentKeyInit = nullptr;
-  mlir::Value presentValueInit = nullptr;
-  mlir::Value qkInit = nullptr;
-  if (presentKeyType)
-    presentKeyInit = createEmptyTensor(rewriter, loc, presentKeyType,
-                                       pastKey ? pastKey : (key ? key : query));
-  if (presentValueType)
-    presentValueInit =
-        createEmptyTensor(rewriter, loc, presentValueType,
-                          pastValue ? pastValue : (value ? value : query));
-  if (qkType)
-    qkInit = createEmptyTensor(rewriter, loc, qkType, query);
+  mlir::FailureOr<llvm::SmallVector<mlir::OpFoldResult>> reifiedShape =
+      mlir::hip::reifyMultiHeadAttentionOutputShape(
+          rewriter, loc, query, key, value, numHeads,
+          [&]() { return op->emitError(); });
+  if (mlir::failed(reifiedShape))
+    return mlir::failure();
+  mlir::FailureOr<mlir::Value> outputInit = createEmptyTensorFromReifiedShape(
+      rewriter, loc, outputType, *reifiedShape);
+  if (mlir::failed(outputInit))
+    return op->emitError(
+        "MultiHeadAttention output type contradicts Q/K/V shape contract");
 
   // === Build the new hip.multi_head_attention op ===
 
-  mlir::SmallVector<mlir::Type> resultTypes;
-  resultTypes.push_back(outputType);
-  if (presentKeyType)
-    resultTypes.push_back(presentKeyType);
-  if (presentValueType)
-    resultTypes.push_back(presentValueType);
-  if (qkType)
-    resultTypes.push_back(qkType);
+  mlir::SmallVector<mlir::Type> resultTypes = {outputType};
 
-  // Build operands: ctx + inputs (only non-null) + outputs (only non-null).
-  mlir::SmallVector<mlir::Value> operands;
-  operands.push_back(context);
-  operands.push_back(query);
-  if (key)
-    operands.push_back(key);
-  if (value)
-    operands.push_back(value);
-  if (bias)
-    operands.push_back(bias);
-  if (keyPaddingMask)
-    operands.push_back(keyPaddingMask);
-  if (attentionBias)
-    operands.push_back(attentionBias);
-  if (pastKey)
-    operands.push_back(pastKey);
-  if (pastValue)
-    operands.push_back(pastValue);
-  if (pastSequenceLength)
-    operands.push_back(pastSequenceLength);
-  if (cacheIndirection)
-    operands.push_back(cacheIndirection);
-  operands.push_back(outputInit);
-  if (presentKeyInit)
-    operands.push_back(presentKeyInit);
-  if (presentValueInit)
-    operands.push_back(presentValueInit);
-  if (qkInit)
-    operands.push_back(qkInit);
+  mlir::SmallVector<mlir::Value> operands = {context, query, key, value,
+                                             *outputInit};
 
   // Build named attributes.
   mlir::SmallVector<mlir::NamedAttribute> attrs;
@@ -383,19 +392,19 @@ mlir::LogicalResult MultiHeadAttentionToHip::matchAndRewrite(
   llvm::SmallVector<int32_t> segmentSizes;
   segmentSizes.push_back(1); // ctx
   segmentSizes.push_back(1); // query
-  segmentSizes.push_back(key ? 1 : 0);
-  segmentSizes.push_back(value ? 1 : 0);
-  segmentSizes.push_back(bias ? 1 : 0);
-  segmentSizes.push_back(keyPaddingMask ? 1 : 0);
-  segmentSizes.push_back(attentionBias ? 1 : 0);
-  segmentSizes.push_back(pastKey ? 1 : 0);
-  segmentSizes.push_back(pastValue ? 1 : 0);
-  segmentSizes.push_back(pastSequenceLength ? 1 : 0);
-  segmentSizes.push_back(cacheIndirection ? 1 : 0);
+  segmentSizes.push_back(1); // key
+  segmentSizes.push_back(1); // value
+  segmentSizes.push_back(0); // bias
+  segmentSizes.push_back(0); // key_padding_mask
+  segmentSizes.push_back(0); // attention_bias
+  segmentSizes.push_back(0); // past_key
+  segmentSizes.push_back(0); // past_value
+  segmentSizes.push_back(0); // past_sequence_length
+  segmentSizes.push_back(0); // cache_indirection
   segmentSizes.push_back(1); // output
-  segmentSizes.push_back(presentKeyInit ? 1 : 0);
-  segmentSizes.push_back(presentValueInit ? 1 : 0);
-  segmentSizes.push_back(qkInit ? 1 : 0);
+  segmentSizes.push_back(0); // present_key
+  segmentSizes.push_back(0); // present_value
+  segmentSizes.push_back(0); // qk
 
   state.addAttribute("operand_segment_sizes",
                      rewriter.getDenseI32ArrayAttr(segmentSizes));

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -1856,6 +1856,63 @@ void MultiHeadAttentionOp::getEffects(
   emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
 }
 
+LogicalResult MultiHeadAttentionOp::verify() {
+  if (!getKey() || !getValue())
+    return emitOpError(
+        "default runtime requires separate query, key, and value inputs");
+  if (getBias() || getKeyPaddingMask() || getAttentionBias() || getPastKey() ||
+      getPastValue() || getPastSequenceLength() || getCacheIndirection())
+    return emitOpError(
+        "default runtime does not support bias, masks, past/cache inputs, or "
+        "cache indirection");
+  if (getPresentKey() || getPresentValue() || getQk())
+    return emitOpError(
+        "default runtime does not support present_key, present_value, or qk "
+        "outputs");
+
+  SmallVector<Value> operands = {getQuery(), getKey(), getValue(), getOutput()};
+  if (failed(verifyDpsComputeOp(*this, operands, /*numInits=*/1)))
+    return failure();
+
+  auto queryType = cast<ShapedType>(getQuery().getType());
+  auto keyType = cast<ShapedType>(getKey().getType());
+  auto valueType = cast<ShapedType>(getValue().getType());
+  auto outputType = cast<ShapedType>(getOutput().getType());
+  if (!queryType.getElementType().isF16() ||
+      keyType.getElementType() != queryType.getElementType() ||
+      valueType.getElementType() != queryType.getElementType() ||
+      outputType.getElementType() != queryType.getElementType())
+    return emitOpError(
+        "default runtime requires fp16 query, key, value, and output");
+  if (getUnidirectional() != 0 && getUnidirectional() != 1)
+    return emitOpError("unidirectional must be 0 or 1");
+  if (getMaskFilterValue().convertToFloat() != -10000.0f)
+    return emitOpError(
+        "default runtime supports only mask_filter_value = -10000");
+
+  FailureOr<SmallVector<int64_t>> expected = inferMultiHeadAttentionOutputShape(
+      queryType.getShape(), keyType.getShape(), valueType.getShape(),
+      getNumHeads(), [&]() { return this->emitOpError(); });
+  if (failed(expected))
+    return failure();
+
+  // An output template may keep a known query extent dynamic, but it cannot
+  // make an unknown runtime query extent static.
+  ArrayRef<int64_t> outputShape = outputType.getShape();
+  if (outputShape.size() == expected->size()) {
+    for (size_t dim : llvm::seq<size_t>(0, outputShape.size())) {
+      if (ShapedType::isDynamic((*expected)[dim]) &&
+          !ShapedType::isDynamic(outputShape[dim]))
+        return emitOpError("output dimension ")
+               << dim
+               << " must remain dynamic because the corresponding "
+                  "query extent is dynamic";
+    }
+  }
+  return verifyHipOpShape(
+      *this, [&]() -> FailureOr<SmallVector<int64_t>> { return *expected; });
+}
+
 //===----------------------------------------------------------------------===//
 // GqaOp: ins(query, [key, value, past_key, past_value,]
 //             seqlens_k, total_seq_len, [cos_cache, ...])
@@ -1912,6 +1969,64 @@ void GqaOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
   emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
+}
+
+LogicalResult LinearAttentionOp::verify() {
+  SmallVector<Value> operands = {getQuery(), getKey(), getValue()};
+  if (Value past = getPastState())
+    operands.push_back(past);
+  if (Value decay = getDecay())
+    operands.push_back(decay);
+  if (Value beta = getBeta())
+    operands.push_back(beta);
+  operands.push_back(getOutput());
+  operands.push_back(getPresentState());
+  if (failed(verifyDpsComputeOp(*this, operands, /*numInits=*/2)))
+    return failure();
+
+  auto queryType = dyn_cast<ShapedType>(getQuery().getType());
+  auto keyType = dyn_cast<ShapedType>(getKey().getType());
+  auto valueType = dyn_cast<ShapedType>(getValue().getType());
+  if (!queryType || !queryType.hasRank() || !keyType || !keyType.hasRank() ||
+      !valueType || !valueType.hasRank())
+    return emitOpError("query, key, and value must be ranked");
+  if (queryType.getElementType() != keyType.getElementType() ||
+      queryType.getElementType() != valueType.getElementType())
+    return emitOpError("query, key, and value element types must match");
+
+  FailureOr<SmallVector<SmallVector<int64_t>>> expected =
+      inferLinearAttentionOutputShapes(queryType.getShape(), keyType.getShape(),
+                                       valueType.getShape(), getQNumHeads(),
+                                       getKvNumHeads(),
+                                       [&]() { return this->emitOpError(); });
+  if (failed(expected))
+    return failure();
+
+  auto verifyShape = [&](Value value, ArrayRef<int64_t> wanted,
+                         StringRef name) -> LogicalResult {
+    auto type = dyn_cast<ShapedType>(value.getType());
+    if (!type || !type.hasRank() ||
+        type.getRank() != static_cast<int64_t>(wanted.size()))
+      return emitOpError() << name << " has the wrong rank";
+    for (int64_t dim : llvm::seq<int64_t>(0, type.getRank())) {
+      int64_t actual = type.getDimSize(dim);
+      if (!ShapedType::isDynamic(actual) &&
+          !ShapedType::isDynamic(wanted[dim]) && actual != wanted[dim])
+        return emitOpError()
+               << name << " dimension " << dim << " must be " << wanted[dim];
+    }
+    if (type.getElementType() != queryType.getElementType())
+      return emitOpError() << name << " element type must match query";
+    return success();
+  };
+
+  if (failed(verifyShape(getOutput(), (*expected)[0], "output")) ||
+      failed(verifyShape(getPresentState(), (*expected)[1], "present_state")))
+    return failure();
+  if (Value past = getPastState())
+    if (failed(verifyShape(past, (*expected)[1], "past_state")))
+      return failure();
+  return success();
 }
 
 LogicalResult GqaOp::verify() {

--- a/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
+++ b/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
@@ -67,6 +67,24 @@ LogicalResult ConvTransposeOp::reifyResultShapes(
 }
 
 //===----------------------------------------------------------------------===//
+// MultiHeadAttentionOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult MultiHeadAttentionOp::reifyResultShapes(
+    OpBuilder &b, ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+  if (getNumResults() != 1 || !getKey() || !getValue())
+    return failure();
+  FailureOr<SmallVector<OpFoldResult>> shape =
+      mlir::hip::reifyMultiHeadAttentionOutputShape(
+          b, getLoc(), getQuery(), getKey(), getValue(), getNumHeads(),
+          [&]() { return this->emitOpError(); });
+  if (failed(shape))
+    return failure();
+  reifiedReturnShapes.assign({std::move(*shape)});
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // CausalConvWithStateOp
 //===----------------------------------------------------------------------===//
 
@@ -147,6 +165,24 @@ LogicalResult LayerNormOp::reifyResultShapes(
   FailureOr<ReifiedRankedShapedTypeDims> shapes =
       mlir::hip::reifyLayerNormOutputShapes(b, getLoc(), getInput(), getAxis(),
                                             getNumResults());
+  if (failed(shapes))
+    return failure();
+  reifiedReturnShapes = std::move(*shapes);
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// LinearAttentionOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult LinearAttentionOp::reifyResultShapes(
+    OpBuilder &b, ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+  if (getNumResults() != 2)
+    return failure();
+  FailureOr<ReifiedRankedShapedTypeDims> shapes =
+      mlir::hip::reifyLinearAttentionOutputShapes(
+          b, getLoc(), getQuery(), getKey(), getValue(), getQNumHeads(),
+          getKvNumHeads(), [&]() { return this->emitOpError(); });
   if (failed(shapes))
     return failure();
   reifiedReturnShapes = std::move(*shapes);

--- a/lib/Dialect/IR/HipShapeUtils.cpp
+++ b/lib/Dialect/IR/HipShapeUtils.cpp
@@ -221,6 +221,32 @@ FailureOr<OpFoldResult> scaleAndOffsetDim(OpBuilder &b, Location loc,
 
 } // namespace mlir::hip::detail
 
+namespace mlir::hip::detail {
+
+FailureOr<OpFoldResult> scaleAndOffsetDim(OpBuilder &b, Location loc,
+                                          OpFoldResult dim, int64_t scale,
+                                          int64_t offset) {
+  if (std::optional<int64_t> constant = getConstantIntValue(dim)) {
+    APInt value = APInt(128, *constant, /*isSigned=*/true) *
+                      APInt(128, scale, /*isSigned=*/true) +
+                  APInt(128, offset, /*isSigned=*/true);
+    if (!value.isSignedIntN(64))
+      return failure();
+    return OpFoldResult(b.getIndexAttr(value.getSExtValue()));
+  }
+
+  Value value = getValueOrCreateConstantIndexOp(b, loc, dim);
+  if (scale != 1)
+    value = arith::MulIOp::create(
+        b, loc, value, arith::ConstantIndexOp::create(b, loc, scale));
+  if (offset != 0)
+    value = arith::AddIOp::create(
+        b, loc, value, arith::ConstantIndexOp::create(b, loc, offset));
+  return OpFoldResult(value);
+}
+
+} // namespace mlir::hip::detail
+
 LogicalResult mlir::hip::verifyDpsComputeOp(Operation *op,
                                             ArrayRef<Value> dataOperands,
                                             unsigned numInits) {

--- a/lib/Dialect/IR/HipShapeUtils.cpp
+++ b/lib/Dialect/IR/HipShapeUtils.cpp
@@ -221,32 +221,6 @@ FailureOr<OpFoldResult> scaleAndOffsetDim(OpBuilder &b, Location loc,
 
 } // namespace mlir::hip::detail
 
-namespace mlir::hip::detail {
-
-FailureOr<OpFoldResult> scaleAndOffsetDim(OpBuilder &b, Location loc,
-                                          OpFoldResult dim, int64_t scale,
-                                          int64_t offset) {
-  if (std::optional<int64_t> constant = getConstantIntValue(dim)) {
-    APInt value = APInt(128, *constant, /*isSigned=*/true) *
-                      APInt(128, scale, /*isSigned=*/true) +
-                  APInt(128, offset, /*isSigned=*/true);
-    if (!value.isSignedIntN(64))
-      return failure();
-    return OpFoldResult(b.getIndexAttr(value.getSExtValue()));
-  }
-
-  Value value = getValueOrCreateConstantIndexOp(b, loc, dim);
-  if (scale != 1)
-    value = arith::MulIOp::create(
-        b, loc, value, arith::ConstantIndexOp::create(b, loc, scale));
-  if (offset != 0)
-    value = arith::AddIOp::create(
-        b, loc, value, arith::ConstantIndexOp::create(b, loc, offset));
-  return OpFoldResult(value);
-}
-
-} // namespace mlir::hip::detail
-
 LogicalResult mlir::hip::verifyDpsComputeOp(Operation *op,
                                             ArrayRef<Value> dataOperands,
                                             unsigned numInits) {

--- a/lib/Dialect/IR/HipShapeUtilsAttention.cpp
+++ b/lib/Dialect/IR/HipShapeUtilsAttention.cpp
@@ -12,11 +12,23 @@
 #include "HipShapeUtilsInternal.h"
 #include "hip/Dialect/IR/HipShapeUtils.h"
 
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Traits.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
+#include "llvm/ADT/APInt.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Sequence.h"
+#include "llvm/ADT/SmallBitVector.h"
+#include "llvm/Support/raw_ostream.h"
 
+#include <algorithm>
+#include <limits>
 #include <optional>
 
 using namespace mlir;
@@ -28,7 +40,84 @@ bool areCompatibleStaticExtents(int64_t lhs, int64_t rhs) {
   return ShapedType::isDynamic(lhs) || ShapedType::isDynamic(rhs) || lhs == rhs;
 }
 
+LogicalResult validateRank3Qkv(StringRef opName, ArrayRef<int64_t> queryShape,
+                               ArrayRef<int64_t> keyShape,
+                               ArrayRef<int64_t> valueShape,
+                               function_ref<InFlightDiagnostic()> emitError) {
+  if (queryShape.size() == 3 && keyShape.size() == 3 && valueShape.size() == 3)
+    return success();
+  emitError() << opName << " query, key, and value must have rank 3";
+  return failure();
+}
+
 } // namespace
+
+FailureOr<SmallVector<int64_t>> mlir::hip::inferMultiHeadAttentionOutputShape(
+    ArrayRef<int64_t> queryShape, ArrayRef<int64_t> keyShape,
+    ArrayRef<int64_t> valueShape, int64_t numHeads,
+    function_ref<InFlightDiagnostic()> emitError) {
+  if (failed(validateRank3Qkv("multi_head_attention", queryShape, keyShape,
+                              valueShape, emitError)))
+    return failure();
+  if (numHeads <= 0) {
+    emitError() << "multi_head_attention num_heads must be positive";
+    return failure();
+  }
+
+  if (!areCompatibleStaticExtents(queryShape[0], keyShape[0]) ||
+      !areCompatibleStaticExtents(queryShape[0], valueShape[0])) {
+    emitError() << "multi_head_attention Q/K/V batch extents must agree";
+    return failure();
+  }
+  if (!areCompatibleStaticExtents(keyShape[1], valueShape[1])) {
+    emitError() << "multi_head_attention K/V sequence extents must agree";
+    return failure();
+  }
+  if (!areCompatibleStaticExtents(queryShape[2], keyShape[2]) ||
+      !areCompatibleStaticExtents(queryShape[2], valueShape[2])) {
+    emitError() << "multi_head_attention Q/K/V hidden extents must agree";
+    return failure();
+  }
+
+  auto verifyPositive = [&](StringRef name,
+                            ArrayRef<int64_t> shape) -> LogicalResult {
+    for (auto [dim, extent] : llvm::enumerate(shape)) {
+      if (!ShapedType::isDynamic(extent) && extent <= 0) {
+        emitError() << "multi_head_attention " << name << " dimension " << dim
+                    << " must be positive";
+        return failure();
+      }
+    }
+    return success();
+  };
+  if (failed(verifyPositive("query", queryShape)) ||
+      failed(verifyPositive("key", keyShape)) ||
+      failed(verifyPositive("value", valueShape)))
+    return failure();
+  if (!ShapedType::isDynamic(queryShape[2]) && queryShape[2] % numHeads != 0) {
+    emitError() << "multi_head_attention query hidden extent " << queryShape[2]
+                << " must be divisible by num_heads " << numHeads;
+    return failure();
+  }
+  return SmallVector<int64_t>(queryShape);
+}
+
+FailureOr<SmallVector<OpFoldResult>>
+mlir::hip::reifyMultiHeadAttentionOutputShape(
+    OpBuilder &b, Location loc, Value query, Value key, Value value,
+    int64_t numHeads, function_ref<InFlightDiagnostic()> emitError) {
+  auto queryType = dyn_cast<RankedTensorType>(query.getType());
+  auto keyType = dyn_cast<RankedTensorType>(key.getType());
+  auto valueType = dyn_cast<RankedTensorType>(value.getType());
+  if (!queryType || !keyType || !valueType ||
+      failed(inferMultiHeadAttentionOutputShape(
+          queryType.getShape(), keyType.getShape(), valueType.getShape(),
+          numHeads, emitError)))
+    return failure();
+
+  // Validation above is complete before mixed sizes materialize tensor.dim.
+  return tensor::getMixedSizes(b, loc, query);
+}
 
 FailureOr<SmallVector<SmallVector<int64_t>>>
 mlir::hip::inferLayerNormOutputShapes(ArrayRef<int64_t> inputShape,
@@ -89,6 +178,124 @@ FailureOr<Type> mlir::hip::inferLayerNormStatsType(MLIRContext *ctx,
   if (stashType == 10)
     return Float16Type::get(ctx);
   return failure();
+}
+
+FailureOr<SmallVector<SmallVector<int64_t>>>
+mlir::hip::inferLinearAttentionOutputShapes(
+    ArrayRef<int64_t> queryShape, ArrayRef<int64_t> keyShape,
+    ArrayRef<int64_t> valueShape, int64_t qNumHeads, int64_t kvNumHeads,
+    function_ref<InFlightDiagnostic()> emitError) {
+  if (failed(validateRank3Qkv("linear_attention", queryShape, keyShape,
+                              valueShape, emitError)))
+    return failure();
+  if (qNumHeads <= 0 || kvNumHeads <= 0) {
+    emitError() << "linear_attention head counts must be positive";
+    return failure();
+  }
+  if (qNumHeads % kvNumHeads != 0 && kvNumHeads % qNumHeads != 0) {
+    emitError() << "linear_attention q_num_heads and kv_num_heads must divide "
+                   "one another, got "
+                << qNumHeads << " and " << kvNumHeads;
+    return failure();
+  }
+
+  for (int64_t dim : {0, 1}) {
+    if (!areCompatibleStaticExtents(queryShape[dim], keyShape[dim]) ||
+        !areCompatibleStaticExtents(queryShape[dim], valueShape[dim])) {
+      emitError() << "linear_attention batch/sequence extent mismatch at "
+                     "dimension "
+                  << dim;
+      return failure();
+    }
+  }
+
+  auto divideStatic = [&](int64_t extent, int64_t divisor,
+                          StringRef name) -> FailureOr<int64_t> {
+    if (ShapedType::isDynamic(extent))
+      return ShapedType::kDynamic;
+    if (extent <= 0 || extent % divisor != 0) {
+      emitError() << "linear_attention " << name << " extent " << extent
+                  << " must be positive and divisible by " << divisor;
+      return failure();
+    }
+    return extent / divisor;
+  };
+
+  FailureOr<int64_t> dk =
+      divideStatic(queryShape[2], qNumHeads, "query hidden");
+  FailureOr<int64_t> dv =
+      divideStatic(valueShape[2], kvNumHeads, "value hidden");
+  if (failed(dk) || failed(dv))
+    return failure();
+
+  if (!ShapedType::isDynamic(keyShape[2]) && !ShapedType::isDynamic(*dk)) {
+    if (keyShape[2] <= 0 || keyShape[2] % *dk != 0) {
+      emitError() << "linear_attention key hidden extent " << keyShape[2]
+                  << " must be positive and divisible by Dk " << *dk;
+      return failure();
+    }
+    int64_t keyHeads = keyShape[2] / *dk;
+    if (keyHeads <= 0 || kvNumHeads % keyHeads != 0) {
+      emitError() << "linear_attention derived key head count " << keyHeads
+                  << " must divide kv_num_heads " << kvNumHeads;
+      return failure();
+    }
+  }
+
+  int64_t outputHidden = ShapedType::kDynamic;
+  if (!ShapedType::isDynamic(*dv)) {
+    APInt hidden =
+        APInt(128, std::max(qNumHeads, kvNumHeads), /*isSigned=*/true) *
+        APInt(128, *dv, /*isSigned=*/true);
+    if (!hidden.isSignedIntN(64) || hidden.isNegative()) {
+      emitError()
+          << "linear_attention inferred output hidden extent is out of range";
+      return failure();
+    }
+    outputHidden = hidden.getSExtValue();
+  }
+  return SmallVector<SmallVector<int64_t>>{
+      {queryShape[0], queryShape[1], outputHidden},
+      {queryShape[0], kvNumHeads, *dk, *dv}};
+}
+
+FailureOr<ReifiedRankedShapedTypeDims>
+mlir::hip::reifyLinearAttentionOutputShapes(
+    OpBuilder &b, Location loc, Value query, Value key, Value value,
+    int64_t qNumHeads, int64_t kvNumHeads,
+    function_ref<InFlightDiagnostic()> emitError) {
+  auto queryType = dyn_cast<RankedTensorType>(query.getType());
+  auto keyType = dyn_cast<RankedTensorType>(key.getType());
+  auto valueType = dyn_cast<RankedTensorType>(value.getType());
+  if (!queryType || !keyType || !valueType ||
+      failed(inferLinearAttentionOutputShapes(
+          queryType.getShape(), keyType.getShape(), valueType.getShape(),
+          qNumHeads, kvNumHeads, emitError)))
+    return failure();
+
+  OpFoldResult batch = tensor::getMixedSize(b, loc, query, 0);
+  OpFoldResult sequence = tensor::getMixedSize(b, loc, query, 1);
+  OpFoldResult queryHidden = tensor::getMixedSize(b, loc, query, 2);
+  OpFoldResult valueHidden = tensor::getMixedSize(b, loc, value, 2);
+
+  auto divideExtent = [&](OpFoldResult extent,
+                          int64_t divisor) -> OpFoldResult {
+    if (std::optional<int64_t> constant = getConstantIntValue(extent))
+      return b.getIndexAttr(*constant / divisor);
+    Value extentValue = getValueOrCreateConstantIndexOp(b, loc, extent);
+    Value divisorValue = arith::ConstantIndexOp::create(b, loc, divisor);
+    return arith::DivUIOp::create(b, loc, extentValue, divisorValue)
+        .getResult();
+  };
+  OpFoldResult dk = divideExtent(queryHidden, qNumHeads);
+  OpFoldResult dv = divideExtent(valueHidden, kvNumHeads);
+  FailureOr<OpFoldResult> outputHidden = detail::scaleAndOffsetDim(
+      b, loc, dv, std::max(qNumHeads, kvNumHeads), /*offset=*/0);
+  if (failed(outputHidden))
+    return failure();
+  return ReifiedRankedShapedTypeDims{
+      {batch, sequence, *outputHidden},
+      {batch, b.getIndexAttr(kvNumHeads), dk, dv}};
 }
 
 FailureOr<SmallVector<SmallVector<int64_t>>>

--- a/test/lit/Conversion/onnx-to-hip/test_linear_attention.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_linear_attention.mlir
@@ -183,8 +183,8 @@ module {
   // Expectations:
   // - output init: tensor.dim for dims 0 and 1 of query + tensor.empty with
   //   two dynamic sizes (output's last dim H_q*d_v stays static).
-  // - present_state init: no past_state, so source is key -- tensor.dim for
-  //   dim 0 of key + tensor.empty with one dynamic size (B). Remaining dims
+  // - present_state init: batch is semantically query dim 0 -- the same SSA
+  //   extent is reused by both destinations. Remaining dims
   //   (H_kv=8, d_k=128, d_v=128) are static per spec.
   // ===========================================================================
   func.func @test_linear_dynamic_prefill(
@@ -206,13 +206,11 @@ module {
            tensor<?x?x1024xf16>)
         -> (tensor<?x?x4096xf16>, tensor<?x8x128x128xf16>)
 
-    // output init: dims 0 and 1 of query extracted at runtime.
-    // CHECK: tensor.dim %[[Q5]]
-    // CHECK: tensor.dim %[[Q5]]
-    // CHECK: tensor.empty({{.*}}) : tensor<?x?x4096xf16>
-    // present_state init: no past_state -> source is key, only dim 0 dynamic.
-    // CHECK: tensor.dim %[[K5]]
-    // CHECK: tensor.empty({{.*}}) : tensor<?x8x128x128xf16>
+    // output and state share query's batch extent.
+    // CHECK: %[[B5:.*]] = tensor.dim %[[Q5]]
+    // CHECK: %[[S5:.*]] = tensor.dim %[[Q5]]
+    // CHECK: tensor.empty(%[[B5]], %[[S5]]) : tensor<?x?x4096xf16>
+    // CHECK: tensor.empty(%[[B5]]) : tensor<?x8x128x128xf16>
     // CHECK: hip.linear_attention(%[[CTX5]])
     // CHECK-SAME: ins(%[[Q5]], %[[K5]], %[[V5]]
     // CHECK-SAME: kv_num_heads = 8
@@ -225,13 +223,12 @@ module {
   // ===========================================================================
   // Test 6: Dynamic batch + seq_len with past_state (gated_delta decode).
   //
-  // When past_state is provided it becomes the preferred source for the
-  // present_state init, which means every present_state dim can be sourced
-  // from the matching past_state dim (shapes are identical per spec).
+  // past_state must agree with the semantic state shape, but the destination
+  // is still built from query/value plus the head-count attributes.
   //
   // Expectations:
   // - output init: tensor.dim for dims 0 and 1 of query + tensor.empty(...).
-  // - present_state init: tensor.dim for dim 0 of past_state + tensor.empty.
+  // - present_state init reuses query dim 0 + tensor.empty.
   // ===========================================================================
   func.func @test_linear_dynamic_decode_with_state(
       %query: tensor<?x?x4096xf16>,
@@ -256,19 +253,51 @@ module {
            tensor<?x?x1024xf16>, tensor<?x?x8xf16>)
         -> (tensor<?x?x4096xf16>, tensor<?x8x128x128xf16>)
 
-    // output init: dims 0 and 1 of query extracted at runtime.
-    // CHECK: tensor.dim %[[Q6]]
-    // CHECK: tensor.dim %[[Q6]]
-    // CHECK: tensor.empty({{.*}}) : tensor<?x?x4096xf16>
-    // present_state init: past_state provided -> source is past_state for
-    // the dynamic batch dim.
-    // CHECK: tensor.dim %[[PS6]]
-    // CHECK: tensor.empty({{.*}}) : tensor<?x8x128x128xf16>
+    // output and state share query's batch extent.
+    // CHECK: %[[B6:.*]] = tensor.dim %[[Q6]]
+    // CHECK: %[[S6:.*]] = tensor.dim %[[Q6]]
+    // CHECK: tensor.empty(%[[B6]], %[[S6]]) : tensor<?x?x4096xf16>
+    // CHECK: tensor.empty(%[[B6]]) : tensor<?x8x128x128xf16>
     // CHECK: hip.linear_attention(%[[CTX6]])
     // CHECK-SAME: ins(%[[Q6]], %[[K6]], %[[V6]]
     // CHECK-SAME: kv_num_heads = 8
     // CHECK-SAME: q_num_heads = 32
 
     return %out#0, %out#1 : tensor<?x?x4096xf16>, tensor<?x8x128x128xf16>
+  }
+
+  // Fully dynamic hidden extents must be mapped semantically rather than
+  // copied positionally from query/key:
+  //   Dk = query_hidden / Hq, Dv = value_hidden / Hkv.
+  func.func @test_linear_dynamic_hidden(
+      %query: tensor<?x?x?xf16>,
+      %key: tensor<?x?x?xf16>,
+      %value: tensor<?x?x?xf16>)
+      -> (tensor<?x?x?xf16>, tensor<?x8x?x?xf16>) {
+    %out:2 = "onnx.Custom"(%query, %key, %value)
+        <{function_name = "LinearAttention"}>
+        {domain_name = "com.microsoft",
+         q_num_heads = 32 : si64,
+         kv_num_heads = 8 : si64}
+        : (tensor<?x?x?xf16>, tensor<?x?x?xf16>, tensor<?x?x?xf16>)
+        -> (tensor<?x?x?xf16>, tensor<?x8x?x?xf16>)
+
+    // CHECK-LABEL: func.func @test_linear_dynamic_hidden
+    // CHECK-SAME: %[[Q7:[^,]+]]: tensor<?x?x?xf16>
+    // CHECK-SAME: %[[K7:[^,]+]]: tensor<?x?x?xf16>
+    // CHECK-SAME: %[[V7:[^)]+]]: tensor<?x?x?xf16>
+    // CHECK: %[[B7:.*]] = tensor.dim %[[Q7]]
+    // CHECK: %[[S7:.*]] = tensor.dim %[[Q7]]
+    // CHECK: %[[QH7:.*]] = tensor.dim %[[Q7]]
+    // CHECK: %[[VH7:.*]] = tensor.dim %[[V7]]
+    // CHECK: %[[DK7:.*]] = arith.divui %[[QH7]]
+    // CHECK: %[[DV7:.*]] = arith.divui %[[VH7]]
+    // CHECK: %[[OH7:.*]] = arith.muli %[[DV7]]
+    // CHECK: tensor.empty(%[[B7]], %[[S7]], %[[OH7]]) : tensor<?x?x?xf16>
+    // CHECK: tensor.empty(%[[B7]], %[[DK7]], %[[DV7]]) : tensor<?x8x?x?xf16>
+    // CHECK: hip.linear_attention
+
+    return %out#0, %out#1
+        : tensor<?x?x?xf16>, tensor<?x8x?x?xf16>
   }
 }

--- a/test/lit/Conversion/onnx-to-hip/test_multi_head_attention.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_multi_head_attention.mlir
@@ -8,17 +8,15 @@
 //
 // This test suite validates:
 // - Custom ONNX op matching by function_name and domain_name
-// - Optional inputs handling (key, value, bias, mask, past KV, etc.)
-// - Optional outputs handling (present_key, present_value, qk)
+// - Runtime-supported separate rank-3 fp16 Q/K/V subset
 // - Attribute preservation (num_heads, scale, mask_filter_value,
 //   unidirectional)
-// - Tensor-first DPS: tensor.empty() for each output
+// - Tensor-first DPS: output shape comes from query
 //
 // Test cases:
 // 1. Basic self-attention with separate Q/K/V (single output)
 // 2. Cross-attention with explicit K/V from encoder (single output)
-// 3. With KV cache (past_key/past_value -> present_key/present_value)
-// 4. Causal masking (unidirectional = 1)
+// 3. Causal masking (unidirectional = 1)
 // ============================================================================
 
 // RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
@@ -87,46 +85,7 @@ module {
   }
 
   // ===========================================================================
-  // Test 3: KV cache (past_key/past_value -> present_key/present_value)
-  // ===========================================================================
-  func.func @test_kv_cache(
-      %query: tensor<1x1x4096xf16>,
-      %key: tensor<1x1x4096xf16>,
-      %value: tensor<1x1x4096xf16>,
-      %bias: tensor<12288xf16>,
-      %key_padding_mask: tensor<1x128xi32>,
-      %attention_bias: tensor<1x32x1x128xf16>,
-      %past_key: tensor<1x32x127x128xf16>,
-      %past_value: tensor<1x32x127x128xf16>)
-      -> (tensor<1x1x4096xf16>, tensor<1x32x128x128xf16>, tensor<1x32x128x128xf16>) {
-
-    // CHECK-LABEL: func.func @test_kv_cache
-    // CHECK-SAME: (%[[CTX:.*]]: !hip.context,
-
-    %out:3 = "onnx.Custom"(%query, %key, %value, %bias, %key_padding_mask,
-                           %attention_bias, %past_key, %past_value)
-        <{function_name = "MultiHeadAttention"}>
-        {domain_name = "com.microsoft",
-         num_heads = 32 : si64,
-         scale = 0.0883883461 : f32}
-        : (tensor<1x1x4096xf16>, tensor<1x1x4096xf16>, tensor<1x1x4096xf16>,
-           tensor<12288xf16>, tensor<1x128xi32>, tensor<1x32x1x128xf16>,
-           tensor<1x32x127x128xf16>, tensor<1x32x127x128xf16>)
-        -> (tensor<1x1x4096xf16>, tensor<1x32x128x128xf16>, tensor<1x32x128x128xf16>)
-
-    // Three tensor.empty() inits (output + present_key + present_value)
-    // CHECK: tensor.empty() : tensor<1x1x4096xf16>
-    // CHECK: tensor.empty() : tensor<1x32x128x128xf16>
-    // CHECK: tensor.empty() : tensor<1x32x128x128xf16>
-    // CHECK: hip.multi_head_attention(%[[CTX]])
-    // CHECK-SAME: ins(
-    // CHECK-SAME: num_heads = 32
-
-    return %out#0, %out#1, %out#2 : tensor<1x1x4096xf16>, tensor<1x32x128x128xf16>, tensor<1x32x128x128xf16>
-  }
-
-  // ===========================================================================
-  // Test 4: Causal self-attention (unidirectional = 1)
+  // Test 3: Causal self-attention (unidirectional = 1)
   // ===========================================================================
   func.func @test_causal(
       %query: tensor<1x128x4096xf16>,

--- a/test/lit/Conversion/onnx-to-hip/test_multi_head_attention_invalid.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_multi_head_attention_invalid.mlir
@@ -1,0 +1,89 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip --split-input-file %s 2>&1 | FileCheck %s
+
+module {
+  func.func @main_graph(
+      %q: tensor<1x1x1280xf16>,
+      %k: tensor<1x1x1280xf16>,
+      %v: tensor<1x1x1280xf16>,
+      %pastK: tensor<1x20x447x64xf16>,
+      %pastV: tensor<1x20x447x64xf16>)
+      -> (tensor<1x1x1280xf16>, tensor<1x20x448x64xf16>,
+          tensor<1x20x448x64xf16>) {
+    %none0 = "onnx.NoValue"() {value} : () -> none
+    %none1 = "onnx.NoValue"() {value} : () -> none
+    %none2 = "onnx.NoValue"() {value} : () -> none
+    // CHECK: error: default MultiHeadAttention runtime does not support bias, masks, past/cache inputs, or cache indirection
+    %out:3 = "onnx.Custom"(%q, %k, %v, %none0, %none1, %none2,
+                           %pastK, %pastV)
+        <{function_name = "MultiHeadAttention"}>
+        {domain_name = "com.microsoft", num_heads = 20 : si64}
+        : (tensor<1x1x1280xf16>, tensor<1x1x1280xf16>,
+           tensor<1x1x1280xf16>, none, none, none,
+           tensor<1x20x447x64xf16>, tensor<1x20x447x64xf16>)
+        -> (tensor<1x1x1280xf16>, tensor<1x20x448x64xf16>,
+            tensor<1x20x448x64xf16>)
+    return %out#0, %out#1, %out#2
+        : tensor<1x1x1280xf16>, tensor<1x20x448x64xf16>,
+          tensor<1x20x448x64xf16>
+  }
+}
+
+// -----
+
+module {
+  func.func @main_graph(
+      %q: tensor<1x8x130xf16>,
+      %k: tensor<1x16x130xf16>,
+      %v: tensor<1x16x130xf16>) -> tensor<1x8x130xf16> {
+    // CHECK: error: multi_head_attention query hidden extent 130 must be divisible by num_heads 8
+    %out = "onnx.Custom"(%q, %k, %v)
+        <{function_name = "MultiHeadAttention"}>
+        {domain_name = "com.microsoft", num_heads = 8 : si64}
+        : (tensor<1x8x130xf16>, tensor<1x16x130xf16>,
+           tensor<1x16x130xf16>) -> tensor<1x8x130xf16>
+    return %out : tensor<1x8x130xf16>
+  }
+}
+
+// -----
+
+module {
+  func.func @main_graph(
+      %q: tensor<1x8x128xf32>,
+      %k: tensor<1x16x128xf32>,
+      %v: tensor<1x16x128xf32>) -> tensor<1x8x128xf32> {
+    // CHECK: error: default MultiHeadAttention runtime requires fp16 Q/K/V and output
+    %out = "onnx.Custom"(%q, %k, %v)
+        <{function_name = "MultiHeadAttention"}>
+        {domain_name = "com.microsoft", num_heads = 8 : si64}
+        : (tensor<1x8x128xf32>, tensor<1x16x128xf32>,
+           tensor<1x16x128xf32>) -> tensor<1x8x128xf32>
+    return %out : tensor<1x8x128xf32>
+  }
+}
+
+// -----
+
+module {
+  func.func @main_graph(
+      %q: tensor<1x8x128xf16>,
+      %k: tensor<1x16x128xf16>,
+      %v: tensor<1x16x128xf16>)
+      -> (tensor<1x8x128xf16>, tensor<1x8x16x16xf16>) {
+    // CHECK: error: default MultiHeadAttention runtime supports only the primary output; present_key, present_value, and qk are unsupported
+    %out:2 = "onnx.Custom"(%q, %k, %v)
+        <{function_name = "MultiHeadAttention"}>
+        {domain_name = "com.microsoft", num_heads = 8 : si64}
+        : (tensor<1x8x128xf16>, tensor<1x16x128xf16>,
+           tensor<1x16x128xf16>)
+        -> (tensor<1x8x128xf16>, tensor<1x8x16x16xf16>)
+    return %out#0, %out#1
+        : tensor<1x8x128xf16>, tensor<1x8x16x16xf16>
+  }
+}
+
+// CHECK-NOT: tensor.empty
+// CHECK-NOT: hip.multi_head_attention

--- a/test/lit/Conversion/onnx-to-hip/test_whisper_cross_mha.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_whisper_cross_mha.mlir
@@ -61,42 +61,4 @@ module {
     return %0 : tensor<1x1x1280xf16>
   }
 
-  // ===========================================================================
-  // Regression: pre-surgery decoder self-attn (8-input WITH past_key/past_value
-  // non-empty) MUST keep lowering to hip.multi_head_attention — Task 8 only
-  // changes the empty-past 8-input case.  The post-surgery 9-input form is
-  // covered by test_whisper_self_mha_with_past.mlir.
-  // ===========================================================================
-  func.func @decoder_self_pre_surgery(
-      %q:        tensor<1x1x1280xf16>,
-      %k:        tensor<1x1x1280xf16>,
-      %v:        tensor<1x1x1280xf16>,
-      %past_k:   tensor<1x20x447x64xf16>,
-      %past_v:   tensor<1x20x447x64xf16>)
-      -> (tensor<1x1x1280xf16>, tensor<1x20x448x64xf16>, tensor<1x20x448x64xf16>) {
-    // CHECK-LABEL: func.func @decoder_self_pre_surgery
-
-    %none1 = "onnx.NoValue"() {value} : () -> none
-    %none2 = "onnx.NoValue"() {value} : () -> none
-    %none3 = "onnx.NoValue"() {value} : () -> none
-
-    %out:3 = "onnx.Custom"(%q, %k, %v, %none1, %none2, %none3, %past_k, %past_v)
-        <{function_name = "MultiHeadAttention"}>
-        {domain_name = "com.microsoft",
-         num_heads = 20 : si64,
-         scale = 1.250000e-01 : f32,
-         unidirectional = 1 : si64,
-         mask_filter_value = -1.000000e+04 : f32}
-        : (tensor<1x1x1280xf16>, tensor<1x1x1280xf16>, tensor<1x1x1280xf16>,
-           none, none, none, tensor<1x20x447x64xf16>, tensor<1x20x447x64xf16>)
-        -> (tensor<1x1x1280xf16>, tensor<1x20x448x64xf16>, tensor<1x20x448x64xf16>)
-
-    // 8-input WITH past_key/past_value present and no past_sequence_length
-    // → existing hip.multi_head_attention lowering (NOT hip.gqa).
-    // CHECK: hip.multi_head_attention
-    // CHECK-NOT: hip.gqa
-
-    return %out#0, %out#1, %out#2
-      : tensor<1x1x1280xf16>, tensor<1x20x448x64xf16>, tensor<1x20x448x64xf16>
-  }
 }

--- a/test/lit/Conversion/onnx-to-hip/test_whisper_self_mha_with_past.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_whisper_self_mha_with_past.mlir
@@ -74,47 +74,4 @@ module {
       : tensor<1x1x1280xf16>, tensor<1x20x448x64xf16>, tensor<1x20x448x64xf16>
   }
 
-  // ===========================================================================
-  // Regression: 9-input MHA with an EMPTY past_sequence_length slot (slot 8 is
-  // none) MUST keep falling through to hip.multi_head_attention.  The branch-2
-  // hip.gqa dispatch is gated on the PRESENCE of the past_sequence_length
-  // operand (Task-9 surgery wires a real [1]-i32 tensor there); a graph that
-  // declares the slot but leaves it empty is not the post-surgery shared-buffer
-  // form and must take the legacy path.
-  // ===========================================================================
-  func.func @main_graph_no_past_seqlen(
-      %q:        tensor<1x1x1280xf16>,
-      %k:        tensor<1x1x1280xf16>,
-      %v:        tensor<1x1x1280xf16>,
-      %past_k:   tensor<1x20x448x64xf16>,
-      %past_v:   tensor<1x20x448x64xf16>)
-      -> (tensor<1x1x1280xf16>, tensor<1x20x448x64xf16>, tensor<1x20x448x64xf16>) {
-
-    // CHECK-LABEL: func.func @main_graph_no_past_seqlen
-
-    %none1 = "onnx.NoValue"() {value} : () -> none
-    %none2 = "onnx.NoValue"() {value} : () -> none
-    %none3 = "onnx.NoValue"() {value} : () -> none
-    %none4 = "onnx.NoValue"() {value} : () -> none
-
-    // 9-input shape but slot 8 (past_sequence_length) is none.  Must NOT
-    // dispatch to branch-2 hip.gqa self-attn.
-    %out:3 = "onnx.Custom"(%q, %k, %v, %none1, %none2, %none3, %past_k, %past_v, %none4)
-        <{function_name = "MultiHeadAttention"}>
-        {domain_name = "com.microsoft",
-         num_heads = 20 : si64,
-         scale = 1.250000e-01 : f32,
-         unidirectional = 1 : si64,
-         mask_filter_value = -1.000000e+04 : f32}
-        : (tensor<1x1x1280xf16>, tensor<1x1x1280xf16>, tensor<1x1x1280xf16>,
-           none, none, none, tensor<1x20x448x64xf16>, tensor<1x20x448x64xf16>,
-           none)
-        -> (tensor<1x1x1280xf16>, tensor<1x20x448x64xf16>, tensor<1x20x448x64xf16>)
-
-    // CHECK: hip.multi_head_attention
-    // CHECK-NOT: hip.gqa
-
-    return %out#0, %out#1, %out#2
-      : tensor<1x1x1280xf16>, tensor<1x20x448x64xf16>, tensor<1x20x448x64xf16>
-  }
 }

--- a/test/lit/Dialect/hip-linear-attention-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-linear-attention-reify-shapes.mlir
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s
+// RUN: hip-mlir-opt --test-hip-whole-shape-dim-reify %s | FileCheck %s
 
 // CHECK-LABEL: func.func @dynamic_hidden
 // CHECK-SAME: %[[Q:[^,]+]]: tensor<?x?x?xf16>

--- a/test/lit/Dialect/hip-linear-attention-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-linear-attention-reify-shapes.mlir
@@ -1,0 +1,71 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s
+
+// CHECK-LABEL: func.func @dynamic_hidden
+// CHECK-SAME: %[[Q:[^,]+]]: tensor<?x?x?xf16>
+// CHECK-SAME: %[[K:[^,]+]]: tensor<?x?x?xf16>
+// CHECK-SAME: %[[V:[^,]+]]: tensor<?x?x?xf16>
+// CHECK: %[[VH0:.*]] = tensor.dim %[[V]], %{{.*}}
+// CHECK: %[[DV0:.*]] = arith.divui %[[VH0]], %{{.*}} : index
+// CHECK: %[[OH:.*]] = arith.muli %[[DV0]], %{{.*}} : index
+// CHECK: %[[B:.*]] = tensor.dim %[[Q]], %{{.*}}
+// CHECK: %[[QH:.*]] = tensor.dim %[[Q]], %{{.*}}
+// CHECK: %[[DK:.*]] = arith.divui %[[QH]], %{{.*}} : index
+// CHECK: %[[VH1:.*]] = tensor.dim %[[V]], %{{.*}}
+// CHECK: %[[DV1:.*]] = arith.divui %[[VH1]], %{{.*}} : index
+// CHECK: return %[[OH]], %[[B]], %{{.*}}, %[[DK]], %[[DV1]]
+func.func @dynamic_hidden(
+    %ctx: !hip.context,
+    %query: tensor<?x?x?xf16>,
+    %key: tensor<?x?x?xf16>,
+    %value: tensor<?x?x?xf16>,
+    %output: tensor<?x?x?xf16>,
+    %state: tensor<?x8x?x?xf16>) -> (index, index, index, index, index) {
+  %result:2 = hip.linear_attention(%ctx)
+      ins(%query, %key, %value :
+          tensor<?x?x?xf16>, tensor<?x?x?xf16>, tensor<?x?x?xf16>)
+      outs(%output, %state : tensor<?x?x?xf16>, tensor<?x8x?x?xf16>)
+      {q_num_heads = 32 : i64, kv_num_heads = 8 : i64}
+      : tensor<?x?x?xf16>, tensor<?x8x?x?xf16>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %out_hidden = tensor.dim %result#0, %c2 : tensor<?x?x?xf16>
+  %state_batch = tensor.dim %result#1, %c0 : tensor<?x8x?x?xf16>
+  %state_heads = tensor.dim %result#1, %c1 : tensor<?x8x?x?xf16>
+  %state_dk = tensor.dim %result#1, %c2 : tensor<?x8x?x?xf16>
+  %state_dv = tensor.dim %result#1, %c3 : tensor<?x8x?x?xf16>
+  return %out_hidden, %state_batch, %state_heads, %state_dk, %state_dv
+      : index, index, index, index, index
+}
+
+// -----
+
+// CHECK-LABEL: func.func @static_hidden_i64_boundary
+// CHECK: %[[BOUNDARY:.*]] = arith.constant 9223372036854775806 : index
+// CHECK: return %[[BOUNDARY]] : index
+func.func @static_hidden_i64_boundary(
+    %ctx: !hip.context,
+    %query: tensor<1x1x2xf16>,
+    %key: tensor<1x1x1xf16>,
+    %value: tensor<1x1x4611686018427387903xf16>,
+    %output: tensor<1x1x9223372036854775806xf16>,
+    %state: tensor<1x1x1x4611686018427387903xf16>) -> index {
+  %result:2 = hip.linear_attention(%ctx)
+      ins(%query, %key, %value :
+          tensor<1x1x2xf16>, tensor<1x1x1xf16>,
+          tensor<1x1x4611686018427387903xf16>)
+      outs(%output, %state :
+           tensor<1x1x9223372036854775806xf16>,
+           tensor<1x1x1x4611686018427387903xf16>)
+      {q_num_heads = 2 : i64, kv_num_heads = 1 : i64}
+      : tensor<1x1x9223372036854775806xf16>,
+        tensor<1x1x1x4611686018427387903xf16>
+  %c2 = arith.constant 2 : index
+  %hidden = tensor.dim %result#0, %c2
+      : tensor<1x1x9223372036854775806xf16>
+  return %hidden : index
+}

--- a/test/lit/Dialect/hip-linear-attention-shape-verifier.mlir
+++ b/test/lit/Dialect/hip-linear-attention-shape-verifier.mlir
@@ -1,0 +1,85 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --verify-diagnostics %s
+
+func.func @wrong_state_shape(
+    %ctx: !hip.context,
+    %query: tensor<1x4x4096xf16>,
+    %key: tensor<1x4x1024xf16>,
+    %value: tensor<1x4x1024xf16>,
+    %output: tensor<1x4x4096xf16>,
+    %state: tensor<1x8x64x128xf16>) {
+  // expected-error @+1 {{'hip.linear_attention' op present_state dimension 2 must be 128}}
+  %result:2 = hip.linear_attention(%ctx)
+      ins(%query, %key, %value :
+          tensor<1x4x4096xf16>, tensor<1x4x1024xf16>,
+          tensor<1x4x1024xf16>)
+      outs(%output, %state :
+           tensor<1x4x4096xf16>, tensor<1x8x64x128xf16>)
+      {q_num_heads = 32 : i64, kv_num_heads = 8 : i64}
+      : tensor<1x4x4096xf16>, tensor<1x8x64x128xf16>
+  return
+}
+
+func.func @incompatible_head_counts(
+    %ctx: !hip.context,
+    %query: tensor<1x4x3840xf16>,
+    %key: tensor<1x4x1024xf16>,
+    %value: tensor<1x4x1024xf16>,
+    %output: tensor<1x4x3840xf16>,
+    %state: tensor<1x8x128x128xf16>) {
+  // expected-error @+1 {{'hip.linear_attention' op linear_attention q_num_heads and kv_num_heads must divide one another, got 30 and 8}}
+  %result:2 = hip.linear_attention(%ctx)
+      ins(%query, %key, %value :
+          tensor<1x4x3840xf16>, tensor<1x4x1024xf16>,
+          tensor<1x4x1024xf16>)
+      outs(%output, %state :
+           tensor<1x4x3840xf16>, tensor<1x8x128x128xf16>)
+      {q_num_heads = 30 : i64, kv_num_heads = 8 : i64}
+      : tensor<1x4x3840xf16>, tensor<1x8x128x128xf16>
+  return
+}
+
+// -----
+
+func.func @output_hidden_product_overflow(
+    %ctx: !hip.context,
+    %query: tensor<1x1x2xf16>,
+    %key: tensor<1x1x1xf16>,
+    %value: tensor<1x1x9223372036854775807xf16>,
+    %output: tensor<1x1x?xf16>,
+    %state: tensor<1x1x1x?xf16>) {
+  // expected-error @+1 {{'hip.linear_attention' op linear_attention inferred output hidden extent is out of range}}
+  %result:2 = hip.linear_attention(%ctx)
+      ins(%query, %key, %value :
+          tensor<1x1x2xf16>, tensor<1x1x1xf16>,
+          tensor<1x1x9223372036854775807xf16>)
+      outs(%output, %state :
+           tensor<1x1x?xf16>, tensor<1x1x1x?xf16>)
+      {q_num_heads = 2 : i64, kv_num_heads = 1 : i64}
+      : tensor<1x1x?xf16>, tensor<1x1x1x?xf16>
+  return
+}
+
+// -----
+
+func.func @output_hidden_product_i64_boundary(
+    %ctx: !hip.context,
+    %query: tensor<1x1x2xf16>,
+    %key: tensor<1x1x1xf16>,
+    %value: tensor<1x1x4611686018427387903xf16>,
+    %output: tensor<1x1x9223372036854775806xf16>,
+    %state: tensor<1x1x1x4611686018427387903xf16>) {
+  %result:2 = hip.linear_attention(%ctx)
+      ins(%query, %key, %value :
+          tensor<1x1x2xf16>, tensor<1x1x1xf16>,
+          tensor<1x1x4611686018427387903xf16>)
+      outs(%output, %state :
+           tensor<1x1x9223372036854775806xf16>,
+           tensor<1x1x1x4611686018427387903xf16>)
+      {q_num_heads = 2 : i64, kv_num_heads = 1 : i64}
+      : tensor<1x1x9223372036854775806xf16>,
+        tensor<1x1x1x4611686018427387903xf16>
+  return
+}

--- a/test/lit/Dialect/hip-multi-head-attention-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-multi-head-attention-reify-shapes.mlir
@@ -1,7 +1,7 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s
+// RUN: hip-mlir-opt --test-hip-whole-shape-dim-reify %s | FileCheck %s
 
 // CHECK-LABEL: func.func @dynamic_batch_and_sequences
 // CHECK-SAME: %[[QUERY:[^,]+]]: tensor<?x?x128xf16>

--- a/test/lit/Dialect/hip-multi-head-attention-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-multi-head-attention-reify-shapes.mlir
@@ -1,0 +1,31 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s
+
+// CHECK-LABEL: func.func @dynamic_batch_and_sequences
+// CHECK-SAME: %[[QUERY:[^,]+]]: tensor<?x?x128xf16>
+// CHECK-DAG: %[[B:.*]] = tensor.dim %[[QUERY]], %{{.*}}
+// CHECK-DAG: %[[SQ:.*]] = tensor.dim %[[QUERY]], %{{.*}}
+// CHECK: return %[[B]], %[[SQ]], %{{.*}} : index, index, index
+func.func @dynamic_batch_and_sequences(
+    %ctx: !hip.context,
+    %query: tensor<?x?x128xf16>,
+    %key: tensor<?x?x128xf16>,
+    %value: tensor<?x?x128xf16>,
+    %output: tensor<?x?x128xf16>) -> (index, index, index) {
+  %result = hip.multi_head_attention(%ctx)
+      ins(%query, %key, %value :
+          tensor<?x?x128xf16>, tensor<?x?x128xf16>,
+          tensor<?x?x128xf16>)
+      outs(%output : tensor<?x?x128xf16>)
+      {num_heads = 8 : i64}
+      : tensor<?x?x128xf16>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %b = tensor.dim %result, %c0 : tensor<?x?x128xf16>
+  %sq = tensor.dim %result, %c1 : tensor<?x?x128xf16>
+  %hidden = tensor.dim %result, %c2 : tensor<?x?x128xf16>
+  return %b, %sq, %hidden : index, index, index
+}

--- a/test/lit/Dialect/hip-multi-head-attention-shape-verifier.mlir
+++ b/test/lit/Dialect/hip-multi-head-attention-shape-verifier.mlir
@@ -1,0 +1,91 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --verify-diagnostics %s
+
+func.func @hidden_mismatch(
+    %ctx: !hip.context,
+    %query: tensor<1x8x128xf16>,
+    %key: tensor<1x16x128xf16>,
+    %value: tensor<1x16x64xf16>,
+    %output: tensor<1x8x128xf16>) {
+  // expected-error @+1 {{'hip.multi_head_attention' op multi_head_attention Q/K/V hidden extents must agree}}
+  %result = hip.multi_head_attention(%ctx)
+      ins(%query, %key, %value :
+          tensor<1x8x128xf16>, tensor<1x16x128xf16>,
+          tensor<1x16x64xf16>)
+      outs(%output : tensor<1x8x128xf16>)
+      {num_heads = 8 : i64}
+      : tensor<1x8x128xf16>
+  return
+}
+
+func.func @kv_sequence_mismatch(
+    %ctx: !hip.context,
+    %query: tensor<1x8x128xf16>,
+    %key: tensor<1x16x128xf16>,
+    %value: tensor<1x15x128xf16>,
+    %output: tensor<1x8x128xf16>) {
+  // expected-error @+1 {{'hip.multi_head_attention' op multi_head_attention K/V sequence extents must agree}}
+  %result = hip.multi_head_attention(%ctx)
+      ins(%query, %key, %value :
+          tensor<1x8x128xf16>, tensor<1x16x128xf16>,
+          tensor<1x15x128xf16>)
+      outs(%output : tensor<1x8x128xf16>)
+      {num_heads = 8 : i64}
+      : tensor<1x8x128xf16>
+  return
+}
+
+func.func @unsupported_present_output(
+    %ctx: !hip.context,
+    %query: tensor<1x8x128xf16>,
+    %key: tensor<1x16x128xf16>,
+    %value: tensor<1x16x128xf16>,
+    %output: tensor<1x8x128xf16>,
+    %presentKey: tensor<1x8x16x16xf16>) {
+  // expected-error @+1 {{'hip.multi_head_attention' op default runtime does not support present_key, present_value, or qk outputs}}
+  %result:2 = hip.multi_head_attention(%ctx)
+      ins(%query, %key, %value :
+          tensor<1x8x128xf16>, tensor<1x16x128xf16>,
+          tensor<1x16x128xf16>)
+      outs(%output, %presentKey :
+          tensor<1x8x128xf16>, tensor<1x8x16x16xf16>)
+      {num_heads = 8 : i64}
+      : tensor<1x8x128xf16>, tensor<1x8x16x16xf16>
+  return
+}
+
+func.func @output_mismatch(
+    %ctx: !hip.context,
+    %query: tensor<1x8x128xf16>,
+    %key: tensor<1x16x128xf16>,
+    %value: tensor<1x16x128xf16>,
+    %output: tensor<1x7x128xf16>) {
+  // expected-error @+1 {{'hip.multi_head_attention' op dim 1 of result mismatch: expected 8 [1, 8, 128] but outs has 7 [1, 7, 128]}}
+  %result = hip.multi_head_attention(%ctx)
+      ins(%query, %key, %value :
+          tensor<1x8x128xf16>, tensor<1x16x128xf16>,
+          tensor<1x16x128xf16>)
+      outs(%output : tensor<1x7x128xf16>)
+      {num_heads = 8 : i64}
+      : tensor<1x7x128xf16>
+  return
+}
+
+func.func @unsupported_mask_filter_value(
+    %ctx: !hip.context,
+    %query: tensor<1x8x128xf16>,
+    %key: tensor<1x16x128xf16>,
+    %value: tensor<1x16x128xf16>,
+    %output: tensor<1x8x128xf16>) {
+  // expected-error @+1 {{'hip.multi_head_attention' op default runtime supports only mask_filter_value = -10000}}
+  %result = hip.multi_head_attention(%ctx)
+      ins(%query, %key, %value :
+          tensor<1x8x128xf16>, tensor<1x16x128xf16>,
+          tensor<1x16x128xf16>)
+      outs(%output : tensor<1x8x128xf16>)
+      {num_heads = 8 : i64, mask_filter_value = -5.0 : f32}
+      : tensor<1x8x128xf16>
+  return
+}


### PR DESCRIPTION
## Why

MultiHeadAttention, LinearAttention, and RotaryEmbedding each had shape and configuration decisions spread across converter destination construction and later dialect handling. That made dynamic sequence dimensions and unsupported schema forms susceptible to inconsistent acceptance or output shapes.

Each attention family should validate once and share the same result contract through conversion, reification, and verification.

## IR example

The MultiHeadAttention reification test derives dynamic batch and query-sequence dimensions from the query tensor:

```mlir
%result = hip.multi_head_attention(%ctx)
  ins(%query, %key, %value :
      tensor<?x?x128xf16>, tensor<?x?x128xf16>, tensor<?x?x128xf16>)
  outs(%output : tensor<?x?x128xf16>)
  {num_heads = 8 : i64}
  : tensor<?x?x128xf16>
```

## What changes

- Share MultiHeadAttention and LinearAttention output-shape rules across destination construction, reification, and verification.
- Centralize RotaryEmbedding configuration resolution for both supported converter paths.
- Validate ranks, head configuration, and supported schema forms before materializing destination IR.
- Add focused conversion, reification, verifier, and invalid-form tests plus shape-contract documentation.

## Stack

Merged prerequisite plus the 22 active shape PRs:

1. [#688 — refactor(hip): externalize constants after ONNX conversion](https://github.com/ROCm/hip-ep/pull/688)
2. [#724 — feat(shape): preserve symbolic compiler inputs](https://github.com/ROCm/hip-ep/pull/724)
3. [#639 — refactor(hip): establish shared shape-rule foundation](https://github.com/ROCm/hip-ep/pull/639)
4. [#681 — fix(shape): canonicalize host reshape provenance](https://github.com/ROCm/hip-ep/pull/681)
5. [#725 — fix(shape): activate exact broadcasts with symbolic proofs](https://github.com/ROCm/hip-ep/pull/725)
6. [#734 — fix(shape): share MatMul and Gemm contracts](https://github.com/ROCm/hip-ep/pull/734)
7. [#641 — fix(shape): enforce shared broadcast contracts](https://github.com/ROCm/hip-ep/pull/641)
8. [#735 — refactor(conversion): share ONNX reduction conversion](https://github.com/ROCm/hip-ep/pull/735)
9. [#736 — fix(shape): normalize reduction contracts](https://github.com/ROCm/hip-ep/pull/736)
10. [#643 — fix(shape): share convolution contracts](https://github.com/ROCm/hip-ep/pull/643)
11. [#742 — fix(shape): share causal convolution contracts](https://github.com/ROCm/hip-ep/pull/742)
12. [#645 — fix(shape): share normalization contracts](https://github.com/ROCm/hip-ep/pull/645)
13. [#740 — fix(shape): share attention contracts](https://github.com/ROCm/hip-ep/pull/740) ← this PR
14. [#741 — fix(shape): share GQA capacity contracts](https://github.com/ROCm/hip-ep/pull/741)
15. [#644 — fix(shape): share gather and tensor contracts](https://github.com/ROCm/hip-ep/pull/644)
16. [#727 — feat(shape): consume constant payload shapes directly](https://github.com/ROCm/hip-ep/pull/727)
17. [#728 — feat(shape): add exact Tile and Range destinations](https://github.com/ROCm/hip-ep/pull/728)
18. [#646 — refactor(hip): declare explicit DPS shape contracts](https://github.com/ROCm/hip-ep/pull/646)
19. [#730 — test(hip): audit explicit DPS contract inventory](https://github.com/ROCm/hip-ep/pull/730)
20. [#732 — test(hip): audit ONNX converter deduplication](https://github.com/ROCm/hip-ep/pull/732)
21. [#647 — fix(hip): harden shape refinement failure handling](https://github.com/ROCm/hip-ep/pull/647)
22. [#761 — refactor(hip): split shape utility headers by family](https://github.com/ROCm/hip-ep/pull/761)
23. [#764 — refactor(hip): clarify shape destination authority](https://github.com/ROCm/hip-ep/pull/764)

## AI assistance

AI tools assisted with the refactoring and stack reconstruction. The contributor reviewed and validated the resulting code.

Made-with: Cursor

