### PR TITLE
fix(shape): share GQA capacity contracts

### DIFF
--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -177,6 +177,7 @@ Choose the smallest mechanism that matches the operation's semantics:
 | LayerNormalization | Y equals input; Mean/InvStdDev use keepdims reduction shape over `[axis, rank)` |
 | LinearAttention | Shared output/state formula used by converter, reification, and verifier |
 | SkipSimplifiedLayerNormalization | Output and optional residual sum equal input; training stats rejected |
+| GroupQueryAttention | Semantic query/head mapping plus `max(past capacity, total_seq_len)` or logical length alone without past |
 | MultiHeadAttention | Default rank-3 fp16 Q/K/V result equals query; optional/cache forms route to GQA or are rejected |
 | Forward Conv (rank-3 converter/rank-4 HIP op) | Shared signed-floor spatial-window formula used by converter, reification, and verifier |
 | Rank-4 NCHW ConvTranspose | Shared ONNX formula used by converter, reification, and verifier |
@@ -362,6 +363,18 @@ LinearAttention uses one two-result rule in `HipShapeUtils`:
 call that rule. In particular, a missing `past_state` does not make key's
 positional dimensions authoritative for the state destination.
 
+GroupQueryAttention has one payload-dependent exception. With past/present
+buffer sharing, a matching past extent can be larger than the currently valid
+logical prefix; with a growing non-shared cache, the logical prefix can be
+larger than the past allocation. Conversion therefore sizes each dynamic
+present-cache sequence dimension as the nonnegative index maximum of its
+matching past dim 2 and `total_seq_len`. Without past operands, the dynamic
+present extent is `total_seq_len` directly. Conversion performs exactly one
+synchronized logical-length readback per op when any dynamic present or QK
+extent needs it, reusing that value for separate past-key/past-value maxima.
+Optional QK always uses the logical extent rather than cache capacity.
+Reification keeps the DPS-init fallback for these payload-dependent extents.
+
 The default `hip.multi_head_attention` rule matches its implemented runtime
 path, not the full Microsoft schema: Q/K/V are separate rank-3 fp16 tensors,
 Q/K/V batch and hidden extents agree, K/V sequence extents agree, hidden is
@@ -372,6 +385,7 @@ positive and divisible by `num_heads`, `unidirectional` is 0 or 1,
 masks, packed layouts, past/cache inputs, cache indirection, and present/QK
 outputs are rejected before the HIP op is created. The existing decoder
 self-attention and rank-4 cross-attention routes to `hip.gqa` run first and
+retain their separate contracts.
 
 Reductions resolve to one internal out-to-in dimension map, consumed by both
 `inferReductionShape` (static extents) and `reifyReductionResultShape` (mixed

--- a/docs/design/output-allocator-design.md
+++ b/docs/design/output-allocator-design.md
@@ -235,7 +235,7 @@ sequenceDiagram
     Note over DLL_MG: %M = memref.dim %input, 0
     DLL_MG->>RT: hipdnn_ep_alloc_output(state, out_idx, shape)
     RT->>CB: allocator->allocate(self, out_idx, shape, ...)
-    Note over CB: shape used verbatim — no present.*/share-buffer override<br/>(present dim already = past capacity via memref.dim %past_key)
+    Note over CB: shape used verbatim — no present.*/share-buffer override<br/>(present dim already = max(past capacity, logical total_seq_len))
     CB->>ORT: ctx.GetOutput(idx, shape)
     ORT-->>CB: OrtValue
     CB-->>RT: device_ptr (always GPU)
@@ -269,7 +269,7 @@ MlirCustomOp::Compute(context)
    │     │     ├─ hipdnn_ep_alloc_output(state, out_idx, shape, rank, elem)   <-- OUTPUT ALLOC
    │     │     │  └─ output_allocator.cpp: forwards to alloc.allocate(self, ...)
    │     │     │     └─ output_allocate_cb(...)   noexcept
-   │     │     │        ├─ shape used verbatim (no override; present dim already = past capacity)
+   │     │     │        ├─ shape used verbatim (no override; present dim already = max(past, logical length))
    │     │     │        ├─ ctx.GetOutput(ort_idx, shape)   ORT returns pre-bound / fresh OrtValue
    │     │     │        ├─ octx.allocated[out_idx] = true
    │     │     │        └─ GPU output  -> return ORT ptr (zero-copy)
@@ -294,7 +294,7 @@ Note the `main_graph` / `main_graph_internal` split (from `convert-hip-to-llvm`)
 | EP-local ABI mirror | `output_allocator_t` in [custom_op_mlir.hpp](../../backend-mlir-compiler/custom-op-mlir/src/custom_op_mlir.hpp) (same `static_assert`s as the runtime struct) |
 | 2-arg dispatch + setter | [InferenceState.cpp](../../backend-mlir-compiler/custom-op-mlir/src/InferenceState.cpp) (`compute`, `set_output_allocator`) |
 | Callback + per-Compute ctx + host D2H | [MlirCustomOp.cpp](../../backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp) (`output_allocate_cb`, `OutputAllocatorCtx`, `compute_with_output_allocator`) |
-| Allocator KV-cache invariant guard (present dim ← `memref.dim %past_key`) | [test/lit/e2e/test_gqa_output_allocator_present_dim.mlir](../../test/lit/e2e/test_gqa_output_allocator_present_dim.mlir) |
+| Allocator KV-cache invariant guard (present dim ← `max(memref.dim %past_key, total_seq_len)`) | [test/lit/e2e/test_gqa_output_allocator_present_dim.mlir](../../test/lit/e2e/test_gqa_output_allocator_present_dim.mlir) |
 
 **Key design points (as built):**
 
@@ -304,7 +304,7 @@ Note the `main_graph` / `main_graph_internal` split (from `convert-hip-to-llvm`)
 
 3. **Host-output D2H is EP-side and real-build-only.** The GPU scratch (one buffer per output index, grow-on-demand, reused across `Compute()`, freed in the dtor) and the `hipMemcpy` are under `#ifndef BUILD_MOCK_RUNTIME` (the EP only links `hip::host` in non-mock builds; mock writes host memory directly). The generated 2-arg `inference_compute` already ends in `hipdnn_ep_stream_sync`, so writes are complete on return and a plain **blocking** `hipMemcpy` D2H suffices — no extra stream sync.
 
-4. **KV cache share-buffer needs no special case in the callback.** `output_allocate_cb` passes the DLL's in-graph `shape` to `GetOutput` verbatim — every output is acquired the same way. The shape is already right because `hip.alloc_output`'s dynamic dims come from its producer's operands: a `present.*` output is sized from `memref.dim %past_key` (the past input buffer's actual extent), which under OGA `past_present_share_buffer` already **is** the `max_length` capacity buffer. So `GetOutput` returns the pre-bound shared `OrtValue` and the `past == present` pointer identity is preserved. Pinned by `test/lit/e2e/test_gqa_output_allocator_present_dim.mlir`. (`build_metadata_json` emits each output shape verbatim — static extent or `-1`.)
+4. **KV cache share-buffer needs no special case in the callback.** `output_allocate_cb` passes the DLL's in-graph `shape` to `GetOutput` verbatim — every output is acquired the same way. The shape is already right because `hip.alloc_output` sizes each dynamic `present.*` sequence dimension as `max(memref.dim %past_key, total_seq_len)`. Under OGA `past_present_share_buffer`, the past extent already **is** the `max_length` capacity, so `GetOutput` returns the pre-bound shared `OrtValue` and preserves `past == present`; a growing non-shared cache instead follows a larger logical `total_seq_len`. Pinned by `test/lit/e2e/test_gqa_output_allocator_present_dim.mlir`. (`build_metadata_json` emits each output shape verbatim — static extent or `-1`.)
 
 5. **Output-completeness guard.** Every declared output must be created in-graph, so each one should trigger exactly one `hip.alloc_output` → callback. Right after the inference call returns, the EP checks that every output index in the metadata was served; if one was skipped it `LOG(FATAL)`s and names it. This catches the two graph shapes we don't support yet — an output that just passes a graph input straight through, and two outputs that share (alias) one buffer — and turns them into a clear error instead of handing ORT an unfilled buffer. None of the target models have either shape.
 

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -121,6 +121,16 @@ class Hip_DpsOp_Semantic<string mnemonic,
                          string outsAccessor = "Output"> :
     Hip_DpsOp_WithInfer<mnemonic, outsAccessor, traits>;
 
+/// Multi-result semantic operation with handwritten reification.
+class Hip_DpsOp_SemanticNoInfer<string mnemonic,
+                                list<Trait> traits = []> :
+    Hip_DpsOp<mnemonic, traits>;
+
+/// Semantic operation using the default destination-based reification only.
+class Hip_DpsOp_SemanticAutoReify<string mnemonic,
+                                  list<Trait> traits = []> :
+    Hip_DpsOp_AutoReify<mnemonic, traits>;
+
 // Parameterized sub-base for ONNX-style reduction ops (reduce_sum,
 // reduce_max, reduce_prod). Auto-emits a `reifyResultShapes` body
 // that calls `mlir::hip::reifyReductionShape`. The axes operand must
@@ -3045,7 +3055,10 @@ def Hip_CausalConvWithStateOp :
 
 // ===== Group Query Attention =================================================
 
-def Hip_GqaOp : Hip_DpsOp_AutoReify<"gqa", [AttrSizedOperandSegments, OpStateOpInterface]> {
+def Hip_GqaOp :
+    Hip_DpsOp_SemanticAutoReify<"gqa",
+                                [AttrSizedOperandSegments,
+                                 OpStateOpInterface]> {
   let summary = "Group Query Attention - Full MS spec implementation";
   let description = [{
     Complete implementation of com.microsoft.GroupQueryAttention (v1) specification.

--- a/lib/Conversion/OnnxToHip/GqaConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GqaConversion.cpp
@@ -197,16 +197,34 @@ mlir::LogicalResult GroupQueryAttentionToHip::matchAndRewrite(
 
   // === Create DPS init tensors ===
 
+  mlir::FailureOr<GqaSequenceExtents> sequenceExtents =
+      resolveGqaSequenceExtents(rewriter, loc, op, totalSeqLen, pastKey,
+                                pastValue, presentKeyType, presentValueType,
+                                outputQkType);
+  if (mlir::failed(sequenceExtents))
+    return rewriter.notifyMatchFailure(
+        op, "cannot derive the GQA sequence extents");
+
   mlir::Value outputInit = createEmptyTensor(rewriter, loc, outputType, query);
-  mlir::Value presentKeyInit = createEmptyTensor(
-      rewriter, loc, presentKeyType, pastKey ? pastKey : (key ? key : query));
-  mlir::Value presentValueInit =
-      createEmptyTensor(rewriter, loc, presentValueType,
-                        pastValue ? pastValue : (value ? value : query));
+  mlir::FailureOr<mlir::Value> presentKeyInit =
+      createGqaPresentEmpty(rewriter, loc, presentKeyType, query, key,
+                            sequenceExtents->presentKey, numHeads, kvNumHeads);
+  mlir::FailureOr<mlir::Value> presentValueInit = createGqaPresentEmpty(
+      rewriter, loc, presentValueType, query, value,
+      sequenceExtents->presentValue, numHeads, kvNumHeads);
+  if (mlir::failed(presentKeyInit) || mlir::failed(presentValueInit))
+    return rewriter.notifyMatchFailure(
+        op, "cannot derive the GQA present-cache destination shape");
 
   mlir::Value outputQkInit = nullptr;
-  if (outputQkType)
-    outputQkInit = createEmptyTensor(rewriter, loc, outputQkType, query);
+  if (outputQkType) {
+    mlir::FailureOr<mlir::Value> init = createGqaQkEmpty(
+        rewriter, loc, outputQkType, query, sequenceExtents->logical, numHeads);
+    if (mlir::failed(init))
+      return rewriter.notifyMatchFailure(
+          op, "cannot derive the GQA QK destination shape");
+    outputQkInit = *init;
+  }
 
   // === Create hip.gqa operation ===
 
@@ -247,8 +265,8 @@ mlir::LogicalResult GroupQueryAttentionToHip::matchAndRewrite(
   if (vScale)
     operands.push_back(vScale);
   operands.push_back(outputInit);
-  operands.push_back(presentKeyInit);
-  operands.push_back(presentValueInit);
+  operands.push_back(*presentKeyInit);
+  operands.push_back(*presentValueInit);
   if (outputQkInit)
     operands.push_back(outputQkInit);
 

--- a/lib/Conversion/OnnxToHip/HipGqaBuilder.cpp
+++ b/lib/Conversion/OnnxToHip/HipGqaBuilder.cpp
@@ -35,14 +35,23 @@ buildHipGqaCall(mlir::Operation *op, mlir::PatternRewriter &rewriter,
                 mlir::RankedTensorType presentValueType) {
   mlir::Location loc = op->getLoc();
 
-  // DPS init buffers.  Derive dynamic dims of present_* from past_* when
-  // available (same buffer shape after concat), otherwise from query (size
-  // unused at compile time for the static-shape Whisper case).
+  mlir::FailureOr<GqaSequenceExtents> sequenceExtents =
+      resolveGqaSequenceExtents(rewriter, loc, op, totalSeqLen, pastKey,
+                                pastValue, presentKeyType, presentValueType);
+  if (mlir::failed(sequenceExtents))
+    return rewriter.notifyMatchFailure(
+        op, "cannot derive the hip.gqa sequence extents");
+
   mlir::Value outputInit = createEmptyTensor(rewriter, loc, outputType, query);
-  mlir::Value presentKeyInit = createEmptyTensor(rewriter, loc, presentKeyType,
-                                                 pastKey ? pastKey : query);
-  mlir::Value presentValueInit = createEmptyTensor(
-      rewriter, loc, presentValueType, pastValue ? pastValue : query);
+  mlir::FailureOr<mlir::Value> presentKeyInit =
+      createGqaPresentEmpty(rewriter, loc, presentKeyType, query, key,
+                            sequenceExtents->presentKey, numHeads, numHeads);
+  mlir::FailureOr<mlir::Value> presentValueInit =
+      createGqaPresentEmpty(rewriter, loc, presentValueType, query, value,
+                            sequenceExtents->presentValue, numHeads, numHeads);
+  if (mlir::failed(presentKeyInit) || mlir::failed(presentValueInit))
+    return rewriter.notifyMatchFailure(
+        op, "cannot derive the hip.gqa present-cache destination shape");
 
   llvm::SmallVector<mlir::Type> resultTypes = {outputType, presentKeyType,
                                                presentValueType};
@@ -60,8 +69,8 @@ buildHipGqaCall(mlir::Operation *op, mlir::PatternRewriter &rewriter,
   operands.push_back(seqlensK);
   operands.push_back(totalSeqLen);
   operands.push_back(outputInit);
-  operands.push_back(presentKeyInit);
-  operands.push_back(presentValueInit);
+  operands.push_back(*presentKeyInit);
+  operands.push_back(*presentValueInit);
 
   // segmentSizes order MUST match HipOps.td Hip_GqaOp argument order.
   llvm::SmallVector<int32_t> segmentSizes;

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.cpp
@@ -7,6 +7,22 @@
 #include "OnnxToHipUtils.h"
 
 namespace mlir::hip {
+namespace {
+
+bool areCompatibleStaticExtents(int64_t lhs, int64_t rhs) {
+  return mlir::ShapedType::isDynamic(lhs) || mlir::ShapedType::isDynamic(rhs) ||
+         lhs == rhs;
+}
+
+mlir::Value indexDivByConstant(mlir::PatternRewriter &rewriter,
+                               mlir::Location loc, mlir::Value extent,
+                               int64_t divisor) {
+  mlir::Value divisorValue =
+      mlir::arith::ConstantIndexOp::create(rewriter, loc, divisor);
+  return mlir::arith::DivUIOp::create(rewriter, loc, extent, divisorValue);
+}
+
+} // namespace
 
 DenseElementsAttr getCompileTimeConstantTensor(Value value) {
   if (DenseElementsAttr dense = matchHipCompileTimeConstantTensor(value))
@@ -61,8 +77,194 @@ resolveReductionAxes(Operation *op, Value data, int64_t noopWithEmptyAxes,
   return llvm::ArrayRef<int64_t>(storage);
 }
 
-FailureOr<RankedTensorType>
-inferReduceResultType(Operation *op, Value data,
+mlir::FailureOr<GqaSequenceExtents>
+resolveGqaSequenceExtents(mlir::PatternRewriter &rewriter, mlir::Location loc,
+                          mlir::Operation *op, mlir::Value totalSeqLen,
+                          mlir::Value pastKey, mlir::Value pastValue,
+                          mlir::RankedTensorType presentKeyType,
+                          mlir::RankedTensorType presentValueType,
+                          mlir::RankedTensorType outputQkType) {
+  if (static_cast<bool>(pastKey) != static_cast<bool>(pastValue)) {
+    rewriter.notifyMatchFailure(
+        op, "past_key and past_value must both be present or both be absent");
+    return mlir::failure();
+  }
+  if (!presentKeyType || !presentValueType || presentKeyType.getRank() != 4 ||
+      presentValueType.getRank() != 4) {
+    rewriter.notifyMatchFailure(
+        op, "present_key and present_value must be rank-4 BNSH tensors");
+    return mlir::failure();
+  }
+  if (outputQkType && outputQkType.getRank() != 4) {
+    rewriter.notifyMatchFailure(op, "output_qk must be a rank-4 tensor");
+    return mlir::failure();
+  }
+
+  if (pastKey) {
+    auto pastKeyType =
+        mlir::dyn_cast<mlir::RankedTensorType>(pastKey.getType());
+    auto pastValueType =
+        mlir::dyn_cast<mlir::RankedTensorType>(pastValue.getType());
+    if (!pastKeyType || !pastValueType || pastKeyType.getRank() != 4 ||
+        pastValueType.getRank() != 4) {
+      rewriter.notifyMatchFailure(
+          op, "past_key and past_value must be rank-4 BNSH tensors");
+      return mlir::failure();
+    }
+  }
+
+  GqaSequenceExtents extents;
+  bool needsLogical = presentKeyType.isDynamicDim(2) ||
+                      presentValueType.isDynamicDim(2) ||
+                      (outputQkType && outputQkType.isDynamicDim(3));
+  if (!needsLogical)
+    return extents;
+
+  auto totalSeqLenType =
+      totalSeqLen
+          ? mlir::dyn_cast<mlir::RankedTensorType>(totalSeqLen.getType())
+          : mlir::RankedTensorType();
+  if (!totalSeqLenType || totalSeqLenType.getRank() != 0 ||
+      !mlir::isa<mlir::IntegerType, mlir::IndexType>(
+          totalSeqLenType.getElementType())) {
+    rewriter.notifyMatchFailure(
+        op, "total_sequence_length must be a scalar integer tensor");
+    return mlir::failure();
+  }
+
+  extents.logical =
+      readbackScalarToIndexOrExtract(rewriter, loc, op, totalSeqLen);
+  auto resolvePresent = [&](mlir::RankedTensorType resultType,
+                            mlir::Value past) -> mlir::Value {
+    if (!resultType.isDynamicDim(2))
+      return {};
+    if (!past)
+      return extents.logical;
+    mlir::Value pastExtent =
+        mlir::tensor::DimOp::create(rewriter, loc, past, 2);
+    return mlir::arith::MaxUIOp::create(rewriter, loc, pastExtent,
+                                        extents.logical);
+  };
+  extents.presentKey = resolvePresent(presentKeyType, pastKey);
+  extents.presentValue = resolvePresent(presentValueType, pastValue);
+  return extents;
+}
+
+mlir::FailureOr<mlir::Value>
+createGqaPresentEmpty(mlir::PatternRewriter &rewriter, mlir::Location loc,
+                      mlir::RankedTensorType resultType, mlir::Value query,
+                      mlir::Value key, mlir::Value totalSeqExtent,
+                      int64_t numHeads, int64_t kvNumHeads) {
+  auto queryType = mlir::dyn_cast<mlir::RankedTensorType>(query.getType());
+  auto keyType = key ? mlir::dyn_cast<mlir::RankedTensorType>(key.getType())
+                     : mlir::RankedTensorType();
+  if (!queryType || queryType.getRank() != 3 || resultType.getRank() != 4 ||
+      (totalSeqExtent && !totalSeqExtent.getType().isIndex()) ||
+      (resultType.isDynamicDim(2) && !totalSeqExtent) || numHeads <= 0 ||
+      kvNumHeads <= 0 || (key && !keyType) ||
+      (keyType && keyType.getRank() != 3 && keyType.getRank() != 4))
+    return mlir::failure();
+
+  if (!areCompatibleStaticExtents(resultType.getDimSize(0),
+                                  queryType.getDimSize(0)) ||
+      (resultType.getDimSize(1) != mlir::ShapedType::kDynamic &&
+       resultType.getDimSize(1) != kvNumHeads) ||
+      (!keyType && resultType.isDynamicDim(3)))
+    return mlir::failure();
+  if (resultType.isDynamicDim(3) && keyType.getRank() == 3) {
+    int64_t hidden = keyType.getDimSize(2);
+    if (!mlir::ShapedType::isDynamic(hidden) && hidden % kvNumHeads != 0)
+      return mlir::failure();
+  }
+
+  llvm::SmallVector<mlir::Value> dynamicSizes;
+  dynamicSizes.reserve(resultType.getNumDynamicDims());
+  for (int64_t dim : llvm::seq<int64_t>(0, resultType.getRank())) {
+    if (!resultType.isDynamicDim(dim))
+      continue;
+    switch (dim) {
+    case 0:
+      dynamicSizes.push_back(
+          mlir::tensor::DimOp::create(rewriter, loc, query, 0));
+      break;
+    case 1:
+      dynamicSizes.push_back(
+          mlir::arith::ConstantIndexOp::create(rewriter, loc, kvNumHeads));
+      break;
+    case 2:
+      dynamicSizes.push_back(totalSeqExtent);
+      break;
+    case 3:
+      if (keyType && keyType.getRank() == 4) {
+        dynamicSizes.push_back(
+            mlir::tensor::DimOp::create(rewriter, loc, key, 3));
+      } else {
+        mlir::Value source = key;
+        mlir::Value hidden =
+            mlir::tensor::DimOp::create(rewriter, loc, source, 2);
+        dynamicSizes.push_back(
+            indexDivByConstant(rewriter, loc, hidden, kvNumHeads));
+      }
+      break;
+    default:
+      llvm_unreachable("rank-4 GQA present shape has an invalid dimension");
+    }
+  }
+
+  return mlir::Value(
+      mlir::tensor::EmptyOp::create(rewriter, loc, resultType.getShape(),
+                                    resultType.getElementType(), dynamicSizes));
+}
+
+mlir::FailureOr<mlir::Value>
+createGqaQkEmpty(mlir::PatternRewriter &rewriter, mlir::Location loc,
+                 mlir::RankedTensorType resultType, mlir::Value query,
+                 mlir::Value totalSeqExtent, int64_t numHeads) {
+  auto queryType = mlir::dyn_cast<mlir::RankedTensorType>(query.getType());
+  if (!queryType || queryType.getRank() != 3 || resultType.getRank() != 4 ||
+      (totalSeqExtent && !totalSeqExtent.getType().isIndex()) ||
+      (resultType.isDynamicDim(3) && !totalSeqExtent) || numHeads <= 0 ||
+      !areCompatibleStaticExtents(resultType.getDimSize(0),
+                                  queryType.getDimSize(0)) ||
+      (resultType.getDimSize(1) != mlir::ShapedType::kDynamic &&
+       resultType.getDimSize(1) != numHeads) ||
+      !areCompatibleStaticExtents(resultType.getDimSize(2),
+                                  queryType.getDimSize(1)))
+    return mlir::failure();
+
+  llvm::SmallVector<mlir::Value> dynamicSizes;
+  dynamicSizes.reserve(resultType.getNumDynamicDims());
+  for (int64_t dim : llvm::seq<int64_t>(0, resultType.getRank())) {
+    if (!resultType.isDynamicDim(dim))
+      continue;
+    switch (dim) {
+    case 0:
+      dynamicSizes.push_back(
+          mlir::tensor::DimOp::create(rewriter, loc, query, 0));
+      break;
+    case 1:
+      dynamicSizes.push_back(
+          mlir::arith::ConstantIndexOp::create(rewriter, loc, numHeads));
+      break;
+    case 2:
+      dynamicSizes.push_back(
+          mlir::tensor::DimOp::create(rewriter, loc, query, 1));
+      break;
+    case 3:
+      dynamicSizes.push_back(totalSeqExtent);
+      break;
+    default:
+      llvm_unreachable("rank-4 GQA QK shape has an invalid dimension");
+    }
+  }
+
+  return mlir::Value(
+      mlir::tensor::EmptyOp::create(rewriter, loc, resultType.getShape(),
+                                    resultType.getElementType(), dynamicSizes));
+}
+
+mlir::FailureOr<mlir::RankedTensorType>
+inferReduceResultType(mlir::Operation *op, mlir::Value data,
                       llvm::ArrayRef<int64_t> reducedAxes, int64_t keepdims) {
   auto ranked = dyn_cast<RankedTensorType>(op->getResult(0).getType());
   auto inputType = dyn_cast<RankedTensorType>(data.getType());

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.cpp
@@ -85,18 +85,18 @@ resolveGqaSequenceExtents(mlir::PatternRewriter &rewriter, mlir::Location loc,
                           mlir::RankedTensorType presentValueType,
                           mlir::RankedTensorType outputQkType) {
   if (static_cast<bool>(pastKey) != static_cast<bool>(pastValue)) {
-    rewriter.notifyMatchFailure(
+    (void)rewriter.notifyMatchFailure(
         op, "past_key and past_value must both be present or both be absent");
     return mlir::failure();
   }
   if (!presentKeyType || !presentValueType || presentKeyType.getRank() != 4 ||
       presentValueType.getRank() != 4) {
-    rewriter.notifyMatchFailure(
+    (void)rewriter.notifyMatchFailure(
         op, "present_key and present_value must be rank-4 BNSH tensors");
     return mlir::failure();
   }
   if (outputQkType && outputQkType.getRank() != 4) {
-    rewriter.notifyMatchFailure(op, "output_qk must be a rank-4 tensor");
+    (void)rewriter.notifyMatchFailure(op, "output_qk must be a rank-4 tensor");
     return mlir::failure();
   }
 
@@ -107,7 +107,7 @@ resolveGqaSequenceExtents(mlir::PatternRewriter &rewriter, mlir::Location loc,
         mlir::dyn_cast<mlir::RankedTensorType>(pastValue.getType());
     if (!pastKeyType || !pastValueType || pastKeyType.getRank() != 4 ||
         pastValueType.getRank() != 4) {
-      rewriter.notifyMatchFailure(
+      (void)rewriter.notifyMatchFailure(
           op, "past_key and past_value must be rank-4 BNSH tensors");
       return mlir::failure();
     }
@@ -127,7 +127,7 @@ resolveGqaSequenceExtents(mlir::PatternRewriter &rewriter, mlir::Location loc,
   if (!totalSeqLenType || totalSeqLenType.getRank() != 0 ||
       !mlir::isa<mlir::IntegerType, mlir::IndexType>(
           totalSeqLenType.getElementType())) {
-    rewriter.notifyMatchFailure(
+    (void)rewriter.notifyMatchFailure(
         op, "total_sequence_length must be a scalar integer tensor");
     return mlir::failure();
   }

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -422,6 +422,18 @@ readbackScalarToHostOrExtract(mlir::PatternRewriter &rewriter,
   return readbackScalarToHost(rewriter, loc, *ctx, rank0Tensor);
 }
 
+inline mlir::Value
+readbackScalarToIndexOrExtract(mlir::PatternRewriter &rewriter,
+                               mlir::Location loc, mlir::Operation *op,
+                               mlir::Value rank0Tensor) {
+  mlir::Value scalar =
+      readbackScalarToHostOrExtract(rewriter, loc, op, rank0Tensor);
+  if (scalar.getType().isIndex())
+    return scalar;
+  return mlir::arith::IndexCastOp::create(rewriter, loc,
+                                          rewriter.getIndexType(), scalar);
+}
+
 /// `readbackShapeEntryToHost` recovering !hip.context from `op`. Falls back to
 /// a bare `tensor.extract %shape[idx]` when there is no context arg.
 inline mlir::Value
@@ -437,6 +449,51 @@ readbackShapeEntryToHostOrExtract(mlir::PatternRewriter &rewriter,
   }
   return readbackShapeEntryToHost(rewriter, loc, *ctx, shape, idx);
 }
+
+/// Dynamic sequence extents used by GQA destination construction.
+///
+/// A null field means the corresponding result dimension is static.
+struct GqaSequenceExtents {
+  mlir::Value logical;
+  mlir::Value presentKey;
+  mlir::Value presentValue;
+};
+
+/// Validate and materialize the payload-dependent GQA sequence extents.
+///
+/// When any dynamic present-cache or QK extent needs `total_seq_len`, this
+/// helper performs one synchronized readback and reuses the resulting
+/// nonnegative index. A dynamic present-cache extent is the unsigned maximum
+/// of that logical extent and its matching past-cache dim 2 when past exists;
+/// without past it is the logical extent directly. Optional QK always uses the
+/// logical extent, never cache capacity.
+///
+/// Pair/rank validation happens before any IR is emitted.
+mlir::FailureOr<GqaSequenceExtents>
+resolveGqaSequenceExtents(mlir::PatternRewriter &rewriter, mlir::Location loc,
+                          mlir::Operation *op, mlir::Value totalSeqLen,
+                          mlir::Value pastKey, mlir::Value pastValue,
+                          mlir::RankedTensorType presentKeyType,
+                          mlir::RankedTensorType presentValueType,
+                          mlir::RankedTensorType outputQkType = nullptr);
+
+/// Build an exact GQA present-cache destination in BNSH layout.
+///
+/// The caller supplies the sequence capacity resolved by
+/// `resolveGqaSequenceExtents`.
+/// Dynamic batch and head-size extents are derived from the query/KV operands;
+/// all static extents remain authoritative in `resultType`.
+mlir::FailureOr<mlir::Value>
+createGqaPresentEmpty(mlir::PatternRewriter &rewriter, mlir::Location loc,
+                      mlir::RankedTensorType resultType, mlir::Value query,
+                      mlir::Value key, mlir::Value totalSeqExtent,
+                      int64_t numHeads, int64_t kvNumHeads);
+
+/// Build an exact optional GQA QK destination `[B, H, S_q, S_kv]`.
+mlir::FailureOr<mlir::Value>
+createGqaQkEmpty(mlir::PatternRewriter &rewriter, mlir::Location loc,
+                 mlir::RankedTensorType resultType, mlir::Value query,
+                 mlir::Value totalSeqExtent, int64_t numHeads);
 
 // Pattern population functions (one per operator file)
 void populateMatMulConversionPatterns(RewritePatternSet &patterns,

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -2030,6 +2030,42 @@ LogicalResult LinearAttentionOp::verify() {
 }
 
 LogicalResult GqaOp::verify() {
+  SmallVector<Value> operands = {getQuery()};
+  auto appendIfPresent = [&](Value value) {
+    if (value)
+      operands.push_back(value);
+  };
+  appendIfPresent(getKey());
+  appendIfPresent(getValue());
+  appendIfPresent(getPastKey());
+  appendIfPresent(getPastValue());
+  operands.push_back(getSeqlensK());
+  operands.push_back(getTotalSeqLen());
+  appendIfPresent(getCosCache());
+  appendIfPresent(getSinCache());
+  appendIfPresent(getPositionIds());
+  appendIfPresent(getAttentionBias());
+  appendIfPresent(getHeadSink());
+  appendIfPresent(getKScale());
+  appendIfPresent(getVScale());
+  operands.push_back(getOutput());
+  operands.push_back(getPresentKey());
+  operands.push_back(getPresentValue());
+  appendIfPresent(getOutputQk());
+  unsigned numInits = getOutputQk() ? 4 : 3;
+  if (failed(verifyDpsComputeOp(*this, operands, numInits)))
+    return failure();
+
+  bool hasPastKey = getPastKey() != nullptr;
+  bool hasPastValue = getPastValue() != nullptr;
+  if (hasPastKey != hasPastValue)
+    return emitOpError(
+        "past_key and past_value must both be provided or both be omitted");
+  if (getNumHeads() <= 0 || getKvNumHeads() <= 0)
+    return emitOpError("num_heads and kv_num_heads must be positive");
+  if (getNumHeads() % getKvNumHeads() != 0)
+    return emitOpError("num_heads must be divisible by kv_num_heads");
+
   // Verify quantization parameter consistency
   auto kQuantType = getKQuantType().str();
   auto vQuantType = getVQuantType().str();
@@ -2073,11 +2109,9 @@ LogicalResult GqaOp::verify() {
     return emitOpError("qk_output must be 0, 1, or 2, got ") << qkOutput;
   }
 
-  // If qk_output != 0, output_qk must be provided
-  if (qkOutput != 0 && !getOutputQk()) {
-    return emitOpError("qk_output is ")
-           << qkOutput << " but output_qk buffer is not provided";
-  }
+  if ((qkOutput != 0) != static_cast<bool>(getOutputQk()))
+    return emitOpError(
+        "output_qk must be present exactly when qk_output is nonzero");
 
   // Verify paired optional inputs: cos_cache/sin_cache must both be present or
   // both absent
@@ -2099,6 +2133,173 @@ LogicalResult GqaOp::verify() {
                        "(found key=")
            << (hasKey ? "present" : "absent")
            << ", value=" << (hasValue ? "present" : "absent") << ")";
+  }
+
+  auto queryType = cast<ShapedType>(getQuery().getType());
+  auto outputType = cast<ShapedType>(getOutput().getType());
+  auto presentKeyType = cast<ShapedType>(getPresentKey().getType());
+  auto presentValueType = cast<ShapedType>(getPresentValue().getType());
+  if (queryType.getRank() != 3 || outputType.getRank() != 3)
+    return emitOpError("query and output must be rank-3");
+  if (presentKeyType.getRank() != 4 || presentValueType.getRank() != 4)
+    return emitOpError("present_key and present_value must be rank-4 BNSH");
+
+  auto checkCompatible = [&](int64_t lhs, int64_t rhs,
+                             const Twine &what) -> LogicalResult {
+    if (!ShapedType::isDynamic(lhs) && !ShapedType::isDynamic(rhs) &&
+        lhs != rhs)
+      return emitOpError() << what << " (" << lhs << " vs " << rhs << ")";
+    return success();
+  };
+  auto checkDim = [&](ShapedType lhsType, int64_t lhsDim, ShapedType rhsType,
+                      int64_t rhsDim, const Twine &what) -> LogicalResult {
+    return checkCompatible(lhsType.getDimSize(lhsDim),
+                           rhsType.getDimSize(rhsDim), what);
+  };
+  auto checkStaticValue = [&](ShapedType type, int64_t dim, int64_t expected,
+                              const Twine &what) -> LogicalResult {
+    int64_t actual = type.getDimSize(dim);
+    if (!ShapedType::isDynamic(actual) && actual != expected)
+      return emitOpError() << what << " (expected " << expected << ", got "
+                           << actual << ")";
+    return success();
+  };
+
+  if (failed(checkDim(outputType, 0, queryType, 0,
+                      "output batch must match query batch")) ||
+      failed(checkDim(outputType, 1, queryType, 1,
+                      "output sequence must match query sequence")) ||
+      failed(checkDim(presentKeyType, 0, queryType, 0,
+                      "present_key batch must match query batch")) ||
+      failed(checkDim(presentValueType, 0, queryType, 0,
+                      "present_value batch must match query batch")) ||
+      failed(
+          checkStaticValue(presentKeyType, 1, getKvNumHeads(),
+                           "present_key head count must equal kv_num_heads")) ||
+      failed(
+          checkStaticValue(presentValueType, 1, getKvNumHeads(),
+                           "present_value head count must equal kv_num_heads")))
+    return failure();
+  for (int64_t dim : llvm::seq<int64_t>(0, 4))
+    if (failed(checkDim(presentKeyType, dim, presentValueType, dim,
+                        "present_key and present_value shapes must match")))
+      return failure();
+
+  int64_t headDivisor =
+      hasKey ? getNumHeads() : getNumHeads() + 2 * getKvNumHeads();
+  int64_t queryHidden = queryType.getDimSize(2);
+  std::optional<int64_t> knownHeadSize;
+  if (!ShapedType::isDynamic(queryHidden)) {
+    if (queryHidden % headDivisor != 0)
+      return emitOpError("query hidden extent must be divisible by ")
+             << (hasKey ? "num_heads" : "num_heads + 2 * kv_num_heads");
+    knownHeadSize = queryHidden / headDivisor;
+  }
+
+  auto mergeKnownHeadSize = [&](int64_t candidate,
+                                const Twine &name) -> LogicalResult {
+    if (ShapedType::isDynamic(candidate))
+      return success();
+    if (knownHeadSize && *knownHeadSize != candidate)
+      return emitOpError() << name
+                           << " head size must match the query head size";
+    knownHeadSize = candidate;
+    return success();
+  };
+  auto mergeHeadSize = [&](int64_t hidden, int64_t heads,
+                           const Twine &name) -> LogicalResult {
+    if (ShapedType::isDynamic(hidden))
+      return success();
+    if (hidden % heads != 0)
+      return emitOpError() << name << " hidden extent must be divisible by "
+                           << heads;
+    return mergeKnownHeadSize(hidden / heads, name);
+  };
+
+  if (hasKey) {
+    auto keyType = cast<ShapedType>(getKey().getType());
+    auto valueType = cast<ShapedType>(getValue().getType());
+    if ((keyType.getRank() != 3 && keyType.getRank() != 4) ||
+        valueType.getRank() != keyType.getRank())
+      return emitOpError(
+          "key and value must have the same rank, either rank-3 or rank-4");
+    if (failed(checkDim(keyType, 0, queryType, 0,
+                        "key batch must match query batch")) ||
+        failed(checkDim(valueType, 0, queryType, 0,
+                        "value batch must match query batch")))
+      return failure();
+    if (keyType.getRank() == 3) {
+      if (failed(checkDim(keyType, 1, valueType, 1,
+                          "key and value sequence extents must match")) ||
+          failed(
+              mergeHeadSize(keyType.getDimSize(2), getKvNumHeads(), "key")) ||
+          failed(
+              mergeHeadSize(valueType.getDimSize(2), getKvNumHeads(), "value")))
+        return failure();
+    } else {
+      for (int64_t dim : llvm::seq<int64_t>(0, 4))
+        if (failed(checkDim(keyType, dim, valueType, dim,
+                            "key and value shapes must match")))
+          return failure();
+      if (failed(checkStaticValue(keyType, 1, getKvNumHeads(),
+                                  "key head count must equal kv_num_heads")) ||
+          failed(mergeKnownHeadSize(keyType.getDimSize(3), "key")))
+        return failure();
+    }
+  }
+
+  if (knownHeadSize) {
+    if (failed(checkStaticValue(outputType, 2, getNumHeads() * *knownHeadSize,
+                                "output hidden extent is incompatible with "
+                                "num_heads")) ||
+        failed(checkStaticValue(presentKeyType, 3, *knownHeadSize,
+                                "present_key head size is incompatible")) ||
+        failed(checkStaticValue(presentValueType, 3, *knownHeadSize,
+                                "present_value head size is incompatible")))
+      return failure();
+  }
+
+  if (hasPastKey) {
+    auto pastKeyType = cast<ShapedType>(getPastKey().getType());
+    auto pastValueType = cast<ShapedType>(getPastValue().getType());
+    if (pastKeyType.getRank() != 4 || pastValueType.getRank() != 4)
+      return emitOpError("past_key and past_value must be rank-4 BNSH");
+    for (int64_t dim : llvm::seq<int64_t>(0, 4))
+      if (failed(checkDim(pastKeyType, dim, pastValueType, dim,
+                          "past_key and past_value shapes must match")))
+        return failure();
+    if (failed(checkDim(pastKeyType, 0, queryType, 0,
+                        "past cache batch must match query batch")) ||
+        failed(checkStaticValue(pastKeyType, 1, getKvNumHeads(),
+                                "past cache head count must equal "
+                                "kv_num_heads")) ||
+        failed(checkDim(pastKeyType, 0, presentKeyType, 0,
+                        "past and present cache batches must match")) ||
+        failed(checkDim(pastKeyType, 1, presentKeyType, 1,
+                        "past and present cache head counts must match")) ||
+        failed(checkDim(pastKeyType, 3, presentKeyType, 3,
+                        "past and present cache head sizes must match")))
+      return failure();
+    int64_t pastCapacity = pastKeyType.getDimSize(2);
+    int64_t presentCapacity = presentKeyType.getDimSize(2);
+    if (!ShapedType::isDynamic(pastCapacity) &&
+        !ShapedType::isDynamic(presentCapacity) &&
+        presentCapacity < pastCapacity)
+      return emitOpError(
+          "present cache capacity cannot be smaller than past capacity");
+  }
+
+  if (Value outputQk = getOutputQk()) {
+    auto outputQkType = cast<ShapedType>(outputQk.getType());
+    if (outputQkType.getRank() != 4)
+      return emitOpError("output_qk must be rank-4");
+    if (failed(checkDim(outputQkType, 0, queryType, 0,
+                        "output_qk batch must match query batch")) ||
+        failed(checkStaticValue(outputQkType, 1, getNumHeads(),
+                                "output_qk head count must equal num_heads")) ||
+        failed(checkDim(outputQkType, 2, queryType, 1,
+                        "output_qk query sequence must match query")))
+      return failure();
   }
 
   return success();

--- a/test/lit/Conversion/onnx-to-hip/test_gqa.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_gqa.mlir
@@ -74,7 +74,7 @@ module {
   // Test 2: Packed QKV - Key and Value are optional (QKV fused in query)
   // ===========================================================================
   func.func @test_packed_qkv(
-      %query: tensor<1x128x12288xf16>,
+      %query: tensor<1x128x6144xf16>,
       %past_key: tensor<1x8x0x128xf16>,
       %past_value: tensor<1x8x0x128xf16>,
       %seqlens_k: tensor<1xi32>,
@@ -100,7 +100,7 @@ module {
          softcap = 0.000000e+00 : f32,
          do_rotary = 0 : si64,
          rotary_interleaved = 0 : si64}
-        : (tensor<1x128x12288xf16>, none, none,
+        : (tensor<1x128x6144xf16>, none, none,
            tensor<1x8x0x128xf16>, tensor<1x8x0x128xf16>,
            tensor<1xi32>, tensor<i32>, none, none)
         -> (tensor<1x128x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>)
@@ -162,8 +162,8 @@ module {
   // ===========================================================================
   func.func @test_full_spec(
       %query: tensor<1x128x4096xf16>,
-      %key: tensor<1x128x4096xf16>,
-      %value: tensor<1x128x4096xf16>,
+      %key: tensor<1x128x1024xf16>,
+      %value: tensor<1x128x1024xf16>,
       %past_key: tensor<1x8x0x128xf16>,
       %past_value: tensor<1x8x0x128xf16>,
       %seqlens_k: tensor<1xi32>,
@@ -199,7 +199,7 @@ module {
          k_quant_type = "PER_CHANNEL",
          v_quant_type = "PER_CHANNEL",
          kv_cache_bit_width = 8 : si64}
-        : (tensor<1x128x4096xf16>, tensor<1x128x4096xf16>, tensor<1x128x4096xf16>,
+        : (tensor<1x128x4096xf16>, tensor<1x128x1024xf16>, tensor<1x128x1024xf16>,
            tensor<1x8x0x128xf16>, tensor<1x8x0x128xf16>,
            tensor<1xi32>, tensor<i32>,
            tensor<2048x64xf16>, tensor<2048x64xf16>, tensor<1x128xi64>,
@@ -222,5 +222,52 @@ module {
     // CHECK-SAME: v_quant_type = "PER_CHANNEL"
 
     return %out#0, %out#1, %out#2, %out#3 : tensor<1x128x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>, tensor<1x32x128x128xf16>
+  }
+
+  // Dynamic present-cache sequence capacity is the maximum of the matching
+  // past buffer and the total_seq_len logical prefix.
+  func.func @test_dynamic_cache_capacity(
+      %query: tensor<?x?x4096xf16>,
+      %key: tensor<?x?x1024xf16>,
+      %value: tensor<?x?x1024xf16>,
+      %past_key: tensor<?x8x?x128xf16>,
+      %past_value: tensor<?x8x?x128xf16>,
+      %seqlens_k: tensor<?xi32>,
+      %total_seq_len: tensor<i32>)
+      -> (tensor<?x?x4096xf16>, tensor<?x8x?x128xf16>, tensor<?x8x?x128xf16>) {
+    %none1 = "onnx.NoValue"() {value} : () -> none
+    %none2 = "onnx.NoValue"() {value} : () -> none
+
+    %out:3 = "onnx.Custom"(%query, %key, %value, %past_key, %past_value,
+                            %seqlens_k, %total_seq_len, %none1, %none2)
+        <{function_name = "GroupQueryAttention"}>
+        {domain_name = "com.microsoft",
+         num_heads = 32 : si64,
+         kv_num_heads = 8 : si64}
+        : (tensor<?x?x4096xf16>, tensor<?x?x1024xf16>,
+           tensor<?x?x1024xf16>, tensor<?x8x?x128xf16>,
+           tensor<?x8x?x128xf16>, tensor<?xi32>, tensor<i32>, none, none)
+        -> (tensor<?x?x4096xf16>, tensor<?x8x?x128xf16>,
+            tensor<?x8x?x128xf16>)
+
+    // CHECK-LABEL: func.func @test_dynamic_cache_capacity
+    // CHECK-SAME: %[[CTX:.*]]: !hip.context
+    // CHECK-SAME: %[[PK:[^,]+]]: tensor<?x8x?x128xf16>
+    // CHECK-SAME: %[[PV:[^,]+]]: tensor<?x8x?x128xf16>
+    // CHECK-SAME: %[[TOTAL:[^,)]+]]: tensor<i32>
+    // CHECK: %[[TOTAL_I32:.*]] = hip.readback_scalar(%[[CTX]], %[[TOTAL]] : tensor<i32>) -> i32
+    // CHECK: %[[TOTAL_IDX:.*]] = arith.index_cast %[[TOTAL_I32]] : i32 to index
+    // CHECK: %[[PKS:.*]] = tensor.dim %[[PK]]
+    // CHECK: %[[PK_CAP:.*]] = arith.maxui %[[PKS]], %[[TOTAL_IDX]] : index
+    // CHECK: %[[PVS:.*]] = tensor.dim %[[PV]]
+    // CHECK: %[[PV_CAP:.*]] = arith.maxui %[[PVS]], %[[TOTAL_IDX]] : index
+    // CHECK-NOT: hip.readback_scalar
+    // CHECK: tensor.empty(%{{.*}}, %[[PK_CAP]]) : tensor<?x8x?x128xf16>
+    // CHECK: tensor.empty(%{{.*}}, %[[PV_CAP]]) : tensor<?x8x?x128xf16>
+    // CHECK: hip.gqa
+
+    return %out#0, %out#1, %out#2
+        : tensor<?x?x4096xf16>, tensor<?x8x?x128xf16>,
+          tensor<?x8x?x128xf16>
   }
 }

--- a/test/lit/Conversion/onnx-to-hip/test_gqa_capacity.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_gqa_capacity.mlir
@@ -1,0 +1,195 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+
+module {
+  // A shared cache can be larger than the logical prefix. Pin the capacity
+  // rule with past dim 16 and total_seq_len 8.
+  // CHECK-LABEL: func.func @main_graph
+  // CHECK-SAME: %[[PK:[^,]+]]: tensor<1x2x16x4xf16>
+  // CHECK-SAME: %[[PV:[^,]+]]: tensor<1x2x16x4xf16>
+  // CHECK: %[[TOTAL_I32:.*]] = arith.constant 8 : i32
+  // CHECK: %[[TOTAL:.*]] = arith.index_cast %[[TOTAL_I32]] : i32 to index
+  // CHECK: %[[PK_DIM:.*]] = tensor.dim %[[PK]]
+  // CHECK: %[[PK_CAP:.*]] = arith.maxui %[[PK_DIM]], %[[TOTAL]] : index
+  // CHECK: %[[PV_DIM:.*]] = tensor.dim %[[PV]]
+  // CHECK: %[[PV_CAP:.*]] = arith.maxui %[[PV_DIM]], %[[TOTAL]] : index
+  // CHECK: tensor.empty(%[[PK_CAP]]) : tensor<1x2x?x4xf16>
+  // CHECK: tensor.empty(%[[PV_CAP]]) : tensor<1x2x?x4xf16>
+  func.func @main_graph(
+      %query: tensor<1x1x16xf16>,
+      %key: tensor<1x1x8xf16>,
+      %value: tensor<1x1x8xf16>,
+      %past_key: tensor<1x2x16x4xf16>,
+      %past_value: tensor<1x2x16x4xf16>,
+      %seqlens_k: tensor<1xi32>)
+      -> (tensor<1x1x16xf16>, tensor<1x2x?x4xf16>,
+          tensor<1x2x?x4xf16>) {
+    %total = arith.constant dense<8> : tensor<i32>
+    %out:3 = "onnx.Custom"(%query, %key, %value, %past_key, %past_value,
+                           %seqlens_k, %total)
+        {domain_name = "com.microsoft", function_name = "GroupQueryAttention",
+         kv_num_heads = 2 : si64, num_heads = 4 : si64}
+        : (tensor<1x1x16xf16>, tensor<1x1x8xf16>, tensor<1x1x8xf16>,
+           tensor<1x2x16x4xf16>, tensor<1x2x16x4xf16>, tensor<1xi32>,
+           tensor<i32>)
+        -> (tensor<1x1x16xf16>, tensor<1x2x?x4xf16>,
+            tensor<1x2x?x4xf16>)
+    return %out#0, %out#1, %out#2
+        : tensor<1x1x16xf16>, tensor<1x2x?x4xf16>,
+          tensor<1x2x?x4xf16>
+  }
+
+  // A non-shared growing cache can have a smaller past buffer. Pin the same
+  // max rule with past dim 4 and total_seq_len 8.
+  // CHECK-LABEL: func.func @growing_non_shared_total_exceeds_past
+  // CHECK-SAME: %[[GROW_PK:[^,]+]]: tensor<1x2x4x4xf16>
+  // CHECK-SAME: %[[GROW_PV:[^,]+]]: tensor<1x2x4x4xf16>
+  // CHECK: %[[GROW_TOTAL_I32:.*]] = arith.constant 8 : i32
+  // CHECK: %[[GROW_TOTAL:.*]] = arith.index_cast %[[GROW_TOTAL_I32]] : i32 to index
+  // CHECK: %[[GROW_PK_DIM:.*]] = tensor.dim %[[GROW_PK]]
+  // CHECK: %[[GROW_PK_CAP:.*]] = arith.maxui %[[GROW_PK_DIM]], %[[GROW_TOTAL]] : index
+  // CHECK: %[[GROW_PV_DIM:.*]] = tensor.dim %[[GROW_PV]]
+  // CHECK: %[[GROW_PV_CAP:.*]] = arith.maxui %[[GROW_PV_DIM]], %[[GROW_TOTAL]] : index
+  // CHECK: tensor.empty(%[[GROW_PK_CAP]]) : tensor<1x2x?x4xf16>
+  // CHECK: tensor.empty(%[[GROW_PV_CAP]]) : tensor<1x2x?x4xf16>
+  func.func @growing_non_shared_total_exceeds_past(
+      %query: tensor<1x1x16xf16>,
+      %key: tensor<1x1x8xf16>,
+      %value: tensor<1x1x8xf16>,
+      %past_key: tensor<1x2x4x4xf16>,
+      %past_value: tensor<1x2x4x4xf16>,
+      %seqlens_k: tensor<1xi32>)
+      -> (tensor<1x1x16xf16>, tensor<1x2x?x4xf16>,
+          tensor<1x2x?x4xf16>) {
+    %total = arith.constant dense<8> : tensor<i32>
+    %out:3 = "onnx.Custom"(%query, %key, %value, %past_key, %past_value,
+                           %seqlens_k, %total)
+        {domain_name = "com.microsoft", function_name = "GroupQueryAttention",
+         kv_num_heads = 2 : si64, num_heads = 4 : si64}
+        : (tensor<1x1x16xf16>, tensor<1x1x8xf16>, tensor<1x1x8xf16>,
+           tensor<1x2x4x4xf16>, tensor<1x2x4x4xf16>, tensor<1xi32>,
+           tensor<i32>)
+        -> (tensor<1x1x16xf16>, tensor<1x2x?x4xf16>,
+            tensor<1x2x?x4xf16>)
+    return %out#0, %out#1, %out#2
+        : tensor<1x1x16xf16>, tensor<1x2x?x4xf16>,
+          tensor<1x2x?x4xf16>
+  }
+
+  // Without past, both dynamic present outputs use logical total_seq_len
+  // directly and share its one synchronized readback.
+  // CHECK-LABEL: func.func @no_past_uses_logical_total
+  // CHECK-SAME: %[[NOPAST_CTX:.*]]: !hip.context
+  // CHECK-SAME: %[[NOPAST_TOTAL:[^,)]+]]: tensor<i32>
+  // CHECK: %[[NOPAST_I32:.*]] = hip.readback_scalar(%[[NOPAST_CTX]], %[[NOPAST_TOTAL]] : tensor<i32>) -> i32
+  // CHECK: %[[NOPAST_IDX:.*]] = arith.index_cast %[[NOPAST_I32]] : i32 to index
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK-NOT: arith.maxui
+  // CHECK: tensor.empty(%[[NOPAST_IDX]]) : tensor<1x2x?x4xf16>
+  // CHECK: tensor.empty(%[[NOPAST_IDX]]) : tensor<1x2x?x4xf16>
+  // CHECK: hip.gqa
+  func.func @no_past_uses_logical_total(
+      %query: tensor<1x1x16xf16>,
+      %key: tensor<1x1x8xf16>,
+      %value: tensor<1x1x8xf16>,
+      %seqlens_k: tensor<1xi32>,
+      %total: tensor<i32>)
+      -> (tensor<1x1x16xf16>, tensor<1x2x?x4xf16>,
+          tensor<1x2x?x4xf16>) {
+    %none_key = "onnx.NoValue"() {value} : () -> none
+    %none_value = "onnx.NoValue"() {value} : () -> none
+    %out:3 = "onnx.Custom"(%query, %key, %value, %none_key, %none_value,
+                           %seqlens_k, %total)
+        {domain_name = "com.microsoft", function_name = "GroupQueryAttention",
+         kv_num_heads = 2 : si64, num_heads = 4 : si64}
+        : (tensor<1x1x16xf16>, tensor<1x1x8xf16>, tensor<1x1x8xf16>,
+           none, none, tensor<1xi32>, tensor<i32>)
+        -> (tensor<1x1x16xf16>, tensor<1x2x?x4xf16>,
+            tensor<1x2x?x4xf16>)
+    return %out#0, %out#1, %out#2
+        : tensor<1x1x16xf16>, tensor<1x2x?x4xf16>,
+          tensor<1x2x?x4xf16>
+  }
+
+  // Matching key/value capacities remain independent while both max
+  // operations reuse exactly one logical total_seq_len readback.
+  // CHECK-LABEL: func.func @two_present_outputs_reuse_logical_readback
+  // CHECK-SAME: %[[REUSE_CTX:.*]]: !hip.context
+  // CHECK-SAME: %[[REUSE_PK:[^,]+]]: tensor<1x2x?x4xf16>
+  // CHECK-SAME: %[[REUSE_PV:[^,]+]]: tensor<1x2x?x4xf16>
+  // CHECK-SAME: %[[REUSE_TOTAL:[^,)]+]]: tensor<i32>
+  // CHECK: %[[REUSE_I32:.*]] = hip.readback_scalar(%[[REUSE_CTX]], %[[REUSE_TOTAL]] : tensor<i32>) -> i32
+  // CHECK: %[[REUSE_IDX:.*]] = arith.index_cast %[[REUSE_I32]] : i32 to index
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK: %[[REUSE_PK_DIM:.*]] = tensor.dim %[[REUSE_PK]]
+  // CHECK: %[[REUSE_PK_CAP:.*]] = arith.maxui %[[REUSE_PK_DIM]], %[[REUSE_IDX]] : index
+  // CHECK: %[[REUSE_PV_DIM:.*]] = tensor.dim %[[REUSE_PV]]
+  // CHECK: %[[REUSE_PV_CAP:.*]] = arith.maxui %[[REUSE_PV_DIM]], %[[REUSE_IDX]] : index
+  // CHECK: tensor.empty(%[[REUSE_PK_CAP]]) : tensor<1x2x?x4xf16>
+  // CHECK: tensor.empty(%[[REUSE_PV_CAP]]) : tensor<1x2x?x4xf16>
+  func.func @two_present_outputs_reuse_logical_readback(
+      %query: tensor<1x1x16xf16>,
+      %key: tensor<1x1x8xf16>,
+      %value: tensor<1x1x8xf16>,
+      %past_key: tensor<1x2x?x4xf16>,
+      %past_value: tensor<1x2x?x4xf16>,
+      %seqlens_k: tensor<1xi32>,
+      %total: tensor<i32>)
+      -> (tensor<1x1x16xf16>, tensor<1x2x?x4xf16>,
+          tensor<1x2x?x4xf16>) {
+    %out:3 = "onnx.Custom"(%query, %key, %value, %past_key, %past_value,
+                           %seqlens_k, %total)
+        {domain_name = "com.microsoft", function_name = "GroupQueryAttention",
+         kv_num_heads = 2 : si64, num_heads = 4 : si64}
+        : (tensor<1x1x16xf16>, tensor<1x1x8xf16>, tensor<1x1x8xf16>,
+           tensor<1x2x?x4xf16>, tensor<1x2x?x4xf16>, tensor<1xi32>,
+           tensor<i32>)
+        -> (tensor<1x1x16xf16>, tensor<1x2x?x4xf16>,
+            tensor<1x2x?x4xf16>)
+    return %out#0, %out#1, %out#2
+        : tensor<1x1x16xf16>, tensor<1x2x?x4xf16>,
+          tensor<1x2x?x4xf16>
+  }
+
+  // Optional QK is sized by the logical extent, not either present capacity.
+  // CHECK-LABEL: func.func @qk_uses_logical_extent
+  // CHECK-SAME: %[[QK_CTX:.*]]: !hip.context
+  // CHECK-SAME: %[[QK_PK:[^,]+]]: tensor<1x2x?x4xf16>
+  // CHECK-SAME: %[[QK_PV:[^,]+]]: tensor<1x2x?x4xf16>
+  // CHECK-SAME: %[[QK_TOTAL:[^,)]+]]: tensor<i32>
+  // CHECK: %[[QK_I32:.*]] = hip.readback_scalar(%[[QK_CTX]], %[[QK_TOTAL]] : tensor<i32>) -> i32
+  // CHECK: %[[QK_LOGICAL:.*]] = arith.index_cast %[[QK_I32]] : i32 to index
+  // CHECK-NOT: hip.readback_scalar
+  // CHECK: %[[QK_PK_DIM:.*]] = tensor.dim %[[QK_PK]]
+  // CHECK: %[[QK_PK_CAP:.*]] = arith.maxui %[[QK_PK_DIM]], %[[QK_LOGICAL]] : index
+  // CHECK: %[[QK_PV_DIM:.*]] = tensor.dim %[[QK_PV]]
+  // CHECK: %[[QK_PV_CAP:.*]] = arith.maxui %[[QK_PV_DIM]], %[[QK_LOGICAL]] : index
+  // CHECK: tensor.empty(%[[QK_PK_CAP]]) : tensor<1x2x?x4xf16>
+  // CHECK: tensor.empty(%[[QK_PV_CAP]]) : tensor<1x2x?x4xf16>
+  // CHECK: tensor.empty(%[[QK_LOGICAL]]) : tensor<1x4x1x?xf16>
+  func.func @qk_uses_logical_extent(
+      %query: tensor<1x1x16xf16>,
+      %key: tensor<1x1x8xf16>,
+      %value: tensor<1x1x8xf16>,
+      %past_key: tensor<1x2x?x4xf16>,
+      %past_value: tensor<1x2x?x4xf16>,
+      %seqlens_k: tensor<1xi32>,
+      %total: tensor<i32>)
+      -> (tensor<1x1x16xf16>, tensor<1x2x?x4xf16>,
+          tensor<1x2x?x4xf16>, tensor<1x4x1x?xf16>) {
+    %out:4 = "onnx.Custom"(%query, %key, %value, %past_key, %past_value,
+                           %seqlens_k, %total)
+        {domain_name = "com.microsoft", function_name = "GroupQueryAttention",
+         kv_num_heads = 2 : si64, num_heads = 4 : si64, qk_output = 1 : si64}
+        : (tensor<1x1x16xf16>, tensor<1x1x8xf16>, tensor<1x1x8xf16>,
+           tensor<1x2x?x4xf16>, tensor<1x2x?x4xf16>, tensor<1xi32>,
+           tensor<i32>)
+        -> (tensor<1x1x16xf16>, tensor<1x2x?x4xf16>,
+            tensor<1x2x?x4xf16>, tensor<1x4x1x?xf16>)
+    return %out#0, %out#1, %out#2, %out#3
+        : tensor<1x1x16xf16>, tensor<1x2x?x4xf16>,
+          tensor<1x2x?x4xf16>, tensor<1x4x1x?xf16>
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_gqa_prefill_sentinel.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_gqa_prefill_sentinel.mlir
@@ -34,7 +34,7 @@ module {
   // the value.
   // Function must be named @main_graph for --hip-add-context-arg to fire.
   func.func @main_graph(
-      %query: tensor<1x128x12288xf16>,
+      %query: tensor<1x128x6144xf16>,
       %past_key: tensor<1x8x0x128xf16>,
       %past_value: tensor<1x8x0x128xf16>,
       %total_seq_len: tensor<i32>)
@@ -62,7 +62,7 @@ module {
          softcap = 0.000000e+00 : f32,
          do_rotary = 0 : si64,
          rotary_interleaved = 0 : si64}
-        : (tensor<1x128x12288xf16>, none, none,
+        : (tensor<1x128x6144xf16>, none, none,
            tensor<1x8x0x128xf16>, tensor<1x8x0x128xf16>,
            tensor<1xi32>, tensor<i32>, none, none)
         -> (tensor<1x128x4096xf16>, tensor<1x8x128x128xf16>, tensor<1x8x128x128xf16>)

--- a/test/lit/Dialect/hip-gqa-shape-verifier.mlir
+++ b/test/lit/Dialect/hip-gqa-shape-verifier.mlir
@@ -1,0 +1,201 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s
+
+func.func @valid_separate(
+    %ctx: !hip.context,
+    %query: tensor<1x2x32xf16>,
+    %key: tensor<1x3x16xf16>,
+    %value: tensor<1x3x16xf16>,
+    %past_key: tensor<1x2x4x8xf16>,
+    %past_value: tensor<1x2x4x8xf16>,
+    %seqlens: tensor<1xi32>,
+    %total: tensor<i32>,
+    %out: tensor<1x2x32xf16>,
+    %present_key: tensor<1x2x5x8xf16>,
+    %present_value: tensor<1x2x5x8xf16>)
+    -> (tensor<1x2x32xf16>, tensor<1x2x5x8xf16>,
+        tensor<1x2x5x8xf16>) {
+  %result:3 = hip.gqa(%ctx)
+    ins(%query, %key, %value, %past_key, %past_value, %seqlens, %total :
+        tensor<1x2x32xf16>, tensor<1x3x16xf16>, tensor<1x3x16xf16>,
+        tensor<1x2x4x8xf16>, tensor<1x2x4x8xf16>, tensor<1xi32>,
+        tensor<i32>)
+    outs(%out, %present_key, %present_value :
+        tensor<1x2x32xf16>, tensor<1x2x5x8xf16>, tensor<1x2x5x8xf16>)
+    {num_heads = 4 : i64, kv_num_heads = 2 : i64}
+    : tensor<1x2x32xf16>, tensor<1x2x5x8xf16>,
+      tensor<1x2x5x8xf16>
+  return %result#0, %result#1, %result#2 :
+      tensor<1x2x32xf16>, tensor<1x2x5x8xf16>, tensor<1x2x5x8xf16>
+}
+
+// -----
+
+func.func @valid_memref(
+    %ctx: !hip.context,
+    %query: memref<1x2x32xf16, 1>,
+    %key: memref<1x3x16xf16, 1>,
+    %value: memref<1x3x16xf16, 1>,
+    %past_key: memref<1x2x4x8xf16, 1>,
+    %past_value: memref<1x2x4x8xf16, 1>,
+    %seqlens: memref<1xi32, 1>,
+    %total: memref<i32, 1>,
+    %out: memref<1x2x32xf16, 1>,
+    %present_key: memref<1x2x5x8xf16, 1>,
+    %present_value: memref<1x2x5x8xf16, 1>) {
+  hip.gqa(%ctx)
+    ins(%query, %key, %value, %past_key, %past_value, %seqlens, %total :
+        memref<1x2x32xf16, 1>, memref<1x3x16xf16, 1>,
+        memref<1x3x16xf16, 1>, memref<1x2x4x8xf16, 1>,
+        memref<1x2x4x8xf16, 1>, memref<1xi32, 1>, memref<i32, 1>)
+    outs(%out, %present_key, %present_value :
+        memref<1x2x32xf16, 1>, memref<1x2x5x8xf16, 1>,
+        memref<1x2x5x8xf16, 1>)
+    {num_heads = 4 : i64, kv_num_heads = 2 : i64}
+  return
+}
+
+// -----
+
+func.func @invalid_head_divisibility(
+    %ctx: !hip.context,
+    %query: memref<1x2x30xf16, 1>,
+    %key: memref<1x3x16xf16, 1>,
+    %value: memref<1x3x16xf16, 1>,
+    %past_key: memref<1x2x4x8xf16, 1>,
+    %past_value: memref<1x2x4x8xf16, 1>,
+    %seqlens: memref<1xi32, 1>,
+    %total: memref<i32, 1>,
+    %out: memref<1x2x30xf16, 1>,
+    %present_key: memref<1x2x5x8xf16, 1>,
+    %present_value: memref<1x2x5x8xf16, 1>) {
+  // expected-error @+1 {{query hidden extent must be divisible by num_heads}}
+  hip.gqa(%ctx)
+    ins(%query, %key, %value, %past_key, %past_value, %seqlens, %total :
+        memref<1x2x30xf16, 1>, memref<1x3x16xf16, 1>,
+        memref<1x3x16xf16, 1>, memref<1x2x4x8xf16, 1>,
+        memref<1x2x4x8xf16, 1>, memref<1xi32, 1>, memref<i32, 1>)
+    outs(%out, %present_key, %present_value :
+        memref<1x2x30xf16, 1>, memref<1x2x5x8xf16, 1>,
+        memref<1x2x5x8xf16, 1>)
+    {num_heads = 4 : i64, kv_num_heads = 2 : i64}
+  return
+}
+
+// -----
+
+func.func @invalid_present_heads(
+    %ctx: !hip.context,
+    %query: memref<1x2x32xf16, 1>,
+    %key: memref<1x3x16xf16, 1>,
+    %value: memref<1x3x16xf16, 1>,
+    %past_key: memref<1x3x4x8xf16, 1>,
+    %past_value: memref<1x3x4x8xf16, 1>,
+    %seqlens: memref<1xi32, 1>,
+    %total: memref<i32, 1>,
+    %out: memref<1x2x32xf16, 1>,
+    %present_key: memref<1x3x5x8xf16, 1>,
+    %present_value: memref<1x3x5x8xf16, 1>) {
+  // expected-error @+1 {{present_key head count must equal kv_num_heads}}
+  hip.gqa(%ctx)
+    ins(%query, %key, %value, %past_key, %past_value, %seqlens, %total :
+        memref<1x2x32xf16, 1>, memref<1x3x16xf16, 1>,
+        memref<1x3x16xf16, 1>, memref<1x3x4x8xf16, 1>,
+        memref<1x3x4x8xf16, 1>, memref<1xi32, 1>, memref<i32, 1>)
+    outs(%out, %present_key, %present_value :
+        memref<1x2x32xf16, 1>, memref<1x3x5x8xf16, 1>,
+        memref<1x3x5x8xf16, 1>)
+    {num_heads = 4 : i64, kv_num_heads = 2 : i64}
+  return
+}
+
+// -----
+
+func.func @invalid_result_cardinality(
+    %ctx: !hip.context,
+    %query: tensor<1x2x32xf16>,
+    %key: tensor<1x3x16xf16>,
+    %value: tensor<1x3x16xf16>,
+    %past_key: tensor<1x2x4x8xf16>,
+    %past_value: tensor<1x2x4x8xf16>,
+    %seqlens: tensor<1xi32>,
+    %total: tensor<i32>,
+    %out: tensor<1x2x32xf16>,
+    %present_key: tensor<1x2x5x8xf16>,
+    %present_value: tensor<1x2x5x8xf16>)
+    -> (tensor<1x2x32xf16>, tensor<1x2x5x8xf16>) {
+  // expected-error @+1 {{tensor mode requires 3 result(s), got 2}}
+  %result:2 = hip.gqa(%ctx)
+    ins(%query, %key, %value, %past_key, %past_value, %seqlens, %total :
+        tensor<1x2x32xf16>, tensor<1x3x16xf16>, tensor<1x3x16xf16>,
+        tensor<1x2x4x8xf16>, tensor<1x2x4x8xf16>, tensor<1xi32>,
+        tensor<i32>)
+    outs(%out, %present_key, %present_value :
+        tensor<1x2x32xf16>, tensor<1x2x5x8xf16>, tensor<1x2x5x8xf16>)
+    {num_heads = 4 : i64, kv_num_heads = 2 : i64}
+    : tensor<1x2x32xf16>, tensor<1x2x5x8xf16>
+  return %result#0, %result#1 :
+      tensor<1x2x32xf16>, tensor<1x2x5x8xf16>
+}
+
+// -----
+
+func.func @unpaired_key_value(
+    %ctx: !hip.context,
+    %query: tensor<1x2x32xf16>,
+    %key: tensor<1x3x16xf16>,
+    %seqlens: tensor<1xi32>,
+    %total: tensor<i32>,
+    %out: tensor<1x2x32xf16>,
+    %present_key: tensor<1x2x5x8xf16>,
+    %present_value: tensor<1x2x5x8xf16>)
+    -> (tensor<1x2x32xf16>, tensor<1x2x5x8xf16>,
+        tensor<1x2x5x8xf16>) {
+  // expected-error @+1 {{key and value must both be provided or both be omitted}}
+  %result:3 = "hip.gqa"(
+      %ctx, %query, %key, %seqlens, %total, %out, %present_key, %present_value)
+      <{num_heads = 4 : i64, kv_num_heads = 2 : i64,
+        operandSegmentSizes =
+          array<i32: 1, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0>}>
+      : (!hip.context, tensor<1x2x32xf16>, tensor<1x3x16xf16>,
+         tensor<1xi32>, tensor<i32>, tensor<1x2x32xf16>,
+         tensor<1x2x5x8xf16>, tensor<1x2x5x8xf16>)
+      -> (tensor<1x2x32xf16>, tensor<1x2x5x8xf16>,
+          tensor<1x2x5x8xf16>)
+  return %result#0, %result#1, %result#2 :
+      tensor<1x2x32xf16>, tensor<1x2x5x8xf16>, tensor<1x2x5x8xf16>
+}
+
+// -----
+
+func.func @unpaired_past_key_value(
+    %ctx: !hip.context,
+    %query: tensor<1x2x32xf16>,
+    %key: tensor<1x3x16xf16>,
+    %value: tensor<1x3x16xf16>,
+    %past_key: tensor<1x2x4x8xf16>,
+    %seqlens: tensor<1xi32>,
+    %total: tensor<i32>,
+    %out: tensor<1x2x32xf16>,
+    %present_key: tensor<1x2x5x8xf16>,
+    %present_value: tensor<1x2x5x8xf16>)
+    -> (tensor<1x2x32xf16>, tensor<1x2x5x8xf16>,
+        tensor<1x2x5x8xf16>) {
+  // expected-error @+1 {{past_key and past_value must both be provided or both be omitted}}
+  %result:3 = "hip.gqa"(
+      %ctx, %query, %key, %value, %past_key, %seqlens, %total, %out,
+      %present_key, %present_value)
+      <{num_heads = 4 : i64, kv_num_heads = 2 : i64,
+        operandSegmentSizes =
+          array<i32: 1, 1, 1, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0>}>
+      : (!hip.context, tensor<1x2x32xf16>, tensor<1x3x16xf16>,
+         tensor<1x3x16xf16>, tensor<1x2x4x8xf16>, tensor<1xi32>,
+         tensor<i32>, tensor<1x2x32xf16>, tensor<1x2x5x8xf16>,
+         tensor<1x2x5x8xf16>)
+      -> (tensor<1x2x32xf16>, tensor<1x2x5x8xf16>,
+          tensor<1x2x5x8xf16>)
+  return %result#0, %result#1, %result#2 :
+      tensor<1x2x32xf16>, tensor<1x2x5x8xf16>, tensor<1x2x5x8xf16>
+}

--- a/test/lit/e2e/test_gqa_output_allocator_present_dim.mlir
+++ b/test/lit/e2e/test_gqa_output_allocator_present_dim.mlir
@@ -6,14 +6,14 @@
 //
 // In allocator mode the EP callback hands the DLL's in-graph output shape to
 // GetOutput verbatim (no override). That is sound only because each dynamic-seq
-// present.* output is sized in-graph from its matching past input buffer's
-// actual extent -- under OGA past_present_share_buffer that is the max_length
-// capacity buffer, so GetOutput returns the pre-bound shared OrtValue and the
-// past==present pointer identity is preserved.
+// present.* output is sized in-graph to max(matching past extent,
+// total_seq_len). Under OGA past_present_share_buffer the past extent is the
+// max_length capacity, so GetOutput returns the pre-bound shared OrtValue and
+// the past==present pointer identity is preserved. For a growing non-shared
+// cache, total_seq_len can instead exceed the past extent.
 //
-// This test pins that invariant: each dynamic present.* output must lower to a
-// hip.alloc_output whose dynamic operand is a memref.dim of the matching
-// past_key_values input.
+// This test pins that each matching past extent is maxed with one shared,
+// synchronized total_seq_len readback.
 //===----------------------------------------------------------------------===//
 
 // RUN: hip-mlir-opt %s --onnx-to-hip-pipeline 2>&1 | FileCheck %s
@@ -21,12 +21,16 @@
 // CHECK-LABEL: func.func @main_graph
 // CHECK-SAME:    %[[PK:[a-zA-Z0-9_]+]]: memref<1x8x?x128xf16> {onnx.name = "past_key_values.0.key"}
 // CHECK-SAME:    %[[PV:[a-zA-Z0-9_]+]]: memref<1x8x?x128xf16> {onnx.name = "past_key_values.0.value"}
-// present.0.key: dynamic dim comes from memref.dim of past_key (NOT attention_mask).
+// CHECK-SAME:    %[[TOTAL:[a-zA-Z0-9_]+]]: memref<i32> {onnx.name = "total_seq"}
+// CHECK:         %[[TOTAL_I32:.*]] = hip.readback_scalar(%{{.*}}, %[[TOTAL]] : memref<i32>) -> i32
+// CHECK:         %[[LOGICAL:.*]] = arith.index_cast %[[TOTAL_I32]] : i32 to index
 // CHECK:         %[[DK:.*]] = memref.dim %[[PK]], %{{.*}} : memref<1x8x?x128xf16>
-// CHECK:         hip.alloc_output(%{{.*}}, %[[DK]]) {out_idx = 0 : i64} : memref<1x8x?x128xf16>
-// present.0.value: dynamic dim comes from memref.dim of past_value.
+// CHECK:         %[[CK:.*]] = arith.maxui %[[DK]], %[[LOGICAL]] : index
 // CHECK:         %[[DV:.*]] = memref.dim %[[PV]], %{{.*}} : memref<1x8x?x128xf16>
-// CHECK:         hip.alloc_output(%{{.*}}, %[[DV]]) {out_idx = 1 : i64} : memref<1x8x?x128xf16>
+// CHECK:         %[[CV:.*]] = arith.maxui %[[DV]], %[[LOGICAL]] : index
+// CHECK-NOT:     hip.readback_scalar
+// CHECK:         hip.alloc_output(%{{.*}}, %[[CK]]) {out_idx = 0 : i64} : memref<1x8x?x128xf16>
+// CHECK:         hip.alloc_output(%{{.*}}, %[[CV]]) {out_idx = 1 : i64} : memref<1x8x?x128xf16>
 
 module {
   func.func @main_graph(


### PR DESCRIPTION
## Why

GQA present-cache buffers carry physical capacity, while `total_seq_len` carries the logical sequence extent. A shared cache may already be larger than the logical prefix, and a growing non-shared cache may be smaller. Using either value unconditionally can shrink reusable storage or under-allocate the next result.

Conversion, reification, verification, and output allocation need one rule: present capacity is the maximum of past capacity and logical sequence length, while logical-only outputs remain sized by `total_seq_len`.

## IR example

The capacity test pins the generated maximum for a past cache of 16 and logical sequence length of 8:

```mlir
%total = arith.index_cast %total_i32 : i32 to index
%past_capacity = tensor.dim %past_key, %c2 : tensor<1x2x16x4xf16>
%present_capacity = arith.maxui %past_capacity, %total : index
%present_key = tensor.empty(%present_capacity) : tensor<1x2x?x4xf16>
```

## What changes

- Separate GQA logical sequence extent from present-key and present-value storage capacity.
- Size each present cache as `max(past capacity, total_seq_len)` and use logical length directly when no past cache exists.
- Reuse one synchronized logical-length readback across dynamic key/value destinations.
- Share converter, reification, verifier, and output-allocator constraints, with focused capacity and prefill-sentinel coverage.

## Stack

Merged prerequisite plus the 22 active shape PRs:

1. [#688 — refactor(hip): externalize constants after ONNX conversion](https://github.com/ROCm/hip-ep/pull/688)
2. [#724 — feat(shape): preserve symbolic compiler inputs](https://github.com/ROCm/hip-ep/pull/724)
3. [#639 — refactor(hip): establish shared shape-rule foundation](https://github.com/ROCm/hip-ep/pull/639)
4. [#681 — fix(shape): canonicalize host reshape provenance](https://github.com/ROCm/hip-ep/pull/681)
5. [#725 — fix(shape): activate exact broadcasts with symbolic proofs](https://github.com/ROCm/hip-ep/pull/725)
6. [#734 — fix(shape): share MatMul and Gemm contracts](https://github.com/ROCm/hip-ep/pull/734)
7. [#641 — fix(shape): enforce shared broadcast contracts](https://github.com/ROCm/hip-ep/pull/641)
8. [#735 — refactor(conversion): share ONNX reduction conversion](https://github.com/ROCm/hip-ep/pull/735)
9. [#736 — fix(shape): normalize reduction contracts](https://github.com/ROCm/hip-ep/pull/736)
10. [#643 — fix(shape): share convolution contracts](https://github.com/ROCm/hip-ep/pull/643)
11. [#742 — fix(shape): share causal convolution contracts](https://github.com/ROCm/hip-ep/pull/742)
12. [#645 — fix(shape): share normalization contracts](https://github.com/ROCm/hip-ep/pull/645)
13. [#740 — fix(shape): share attention contracts](https://github.com/ROCm/hip-ep/pull/740)
14. [#741 — fix(shape): share GQA capacity contracts](https://github.com/ROCm/hip-ep/pull/741) ← this PR
15. [#644 — fix(shape): share gather and tensor contracts](https://github.com/ROCm/hip-ep/pull/644)
16. [#727 — feat(shape): consume constant payload shapes directly](https://github.com/ROCm/hip-ep/pull/727)
17. [#728 — feat(shape): add exact Tile and Range destinations](https://github.com/ROCm/hip-ep/pull/728)
18. [#646 — refactor(hip): declare explicit DPS shape contracts](https://github.com/ROCm/hip-ep/pull/646)
19. [#730 — test(hip): audit explicit DPS contract inventory](https://github.com/ROCm/hip-ep/pull/730)
20. [#732 — test(hip): audit ONNX converter deduplication](https://github.com/ROCm/hip-ep/pull/732)
21. [#647 — fix(hip): harden shape refinement failure handling](https://github.com/ROCm/hip-ep/pull/647)
22. [#761 — refactor(hip): split shape utility headers by family](https://github.com/ROCm/hip-ep/pull/761)
23. [#764 — refactor(hip): clarify shape destination authority](https://github.com/ROCm/hip-ep/pull/764)

## AI assistance

AI tools assisted with the refactoring and stack reconstruction. The contributor reviewed and validated the resulting code.

Made-with: Cursor

