### PR TITLE
fix(shape): share causal convolution contracts

### DIFF
--- a/docs/design/hip-shape-inference.md
+++ b/docs/design/hip-shape-inference.md
@@ -177,6 +177,7 @@ Choose the smallest mechanism that matches the operation's semantics:
 | Attention or normalization with multiple destinations | One shape vector per DPS init unless an op supplies a dedicated thunk |
 | Forward Conv (rank-3 converter/rank-4 HIP op) | Shared signed-floor spatial-window formula used by converter, reification, and verifier |
 | Rank-4 NCHW ConvTranspose | Shared ONNX formula used by converter, reification, and verifier |
+| CausalConvWithState | Runtime-supported 1D output/state formulas from input and depthwise kernel |
 | Resize | DPS-init shape, with semantic validity handled by conversion |
 | Runtime-dependent count, such as NonZero or Compress | DPS-init shape; unresolved dimensions remain dynamic |
 
@@ -327,6 +328,15 @@ wraparound and stays equivalent to the static APInt rule. Before narrowing,
 each final extent must be in `[0, INT64_MAX]`; invalid extents select zero so
 destination allocation remains bounded. Runtime rejection of those invalid
 dynamic combinations belongs to the later runtime-hardening layer.
+
+CausalConvWithState uses the backend's implemented 1D contract. For input
+`[B,C,L]` and depthwise weight `[C,1,K]`, output is `[B,C,L]` and
+`present_state` is `[B,C,K-1]`. Optional `past_state` must have that same state
+shape, but it is a validator rather than an extent source: when it is absent or
+more dynamic than the weight, the state length still comes from `weight.K-1`.
+The mixed helper emits subtraction only after its pure helper has validated
+rank, depthwise layout, channel agreement, optional bias/state, and the current
+runtime restriction `ndim=1`.
 
 Reductions resolve to one internal out-to-in dimension map, consumed by both
 `inferReductionShape` (static extents) and `reifyReductionResultShape` (mixed

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -2931,7 +2931,10 @@ def Hip_ReduceMinOp : Hip_DpsOp_Reduction<"reduce_min"> {
 
 // ===== Causal Conv with State ================================================
 
-def Hip_CausalConvWithStateOp : Hip_DpsOp_AutoReify<"causal_conv_with_state", [AttrSizedOperandSegments, OpStateOpInterface]> {
+def Hip_CausalConvWithStateOp :
+    Hip_DpsOp_SemanticNoInfer<"causal_conv_with_state",
+                              [AttrSizedOperandSegments,
+                               OpStateOpInterface]> {
   let summary = "Stateful causal depthwise convolution";
   let description = [{
     Causal depthwise convolution with carry state for incremental decoding.
@@ -3026,6 +3029,7 @@ def Hip_CausalConvWithStateOp : Hip_DpsOp_AutoReify<"causal_conv_with_state", [A
           "hipdnn_ep_op_state_construct_causal_conv_with_state", {});
     }
   }];
+  let hasVerifier = 1;
 }
 
 // ===== Group Query Attention =================================================

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -2932,9 +2932,8 @@ def Hip_ReduceMinOp : Hip_DpsOp_Reduction<"reduce_min"> {
 // ===== Causal Conv with State ================================================
 
 def Hip_CausalConvWithStateOp :
-    Hip_DpsOp_SemanticNoInfer<"causal_conv_with_state",
-                              [AttrSizedOperandSegments,
-                               OpStateOpInterface]> {
+    Hip_DpsOp<"causal_conv_with_state",
+              [AttrSizedOperandSegments, OpStateOpInterface]> {
   let summary = "Stateful causal depthwise convolution";
   let description = [{
     Causal depthwise convolution with carry state for incremental decoding.

--- a/include/hip/Dialect/IR/HipShapeUtils.h
+++ b/include/hip/Dialect/IR/HipShapeUtils.h
@@ -301,22 +301,23 @@ reifyReductionResultShape(OpBuilder &b, Location loc, Value data,
                           ArrayRef<int64_t> axes, int64_t keepdims);
 
 /// CausalConvWithState output shapes for the runtime-supported 1D layout:
-///   output        = input = [B, C, L]
+///   output        = input = [B, C, L] or [B, L, C] when channels-last
 ///   present_state = [B, C, weight[2] - 1]
 ///
 /// Also validates the depthwise weight layout `[C, 1, K]`, optional bias
-/// `[C]`, and optional past state `[B, C, K - 1]`.
+/// `[C]`, and optional past state `[B, C, K - 1]`. The state layout remains
+/// channels-first regardless of the input/output layout.
 FailureOr<SmallVector<SmallVector<int64_t>>>
 inferCausalConvWithStateOutputShapes(
     ArrayRef<int64_t> inputShape, ArrayRef<int64_t> weightShape,
     std::optional<ArrayRef<int64_t>> biasShape,
     std::optional<ArrayRef<int64_t>> pastStateShape, int64_t ndim,
-    function_ref<InFlightDiagnostic()> emitError);
+    bool channelsLast, function_ref<InFlightDiagnostic()> emitError);
 
 /// Mixed-shape form of `inferCausalConvWithStateOutputShapes`.
 FailureOr<ReifiedRankedShapedTypeDims> reifyCausalConvWithStateOutputShapes(
     OpBuilder &b, Location loc, Value input, Value weight, Value bias,
-    Value pastState, int64_t ndim,
+    Value pastState, int64_t ndim, bool channelsLast,
     function_ref<InFlightDiagnostic()> emitError);
 
 /// One-shot reify body for ONNX-style reduction ops. Structurally-proven

--- a/include/hip/Dialect/IR/HipShapeUtils.h
+++ b/include/hip/Dialect/IR/HipShapeUtils.h
@@ -300,6 +300,25 @@ FailureOr<SmallVector<OpFoldResult>>
 reifyReductionResultShape(OpBuilder &b, Location loc, Value data,
                           ArrayRef<int64_t> axes, int64_t keepdims);
 
+/// CausalConvWithState output shapes for the runtime-supported 1D layout:
+///   output        = input = [B, C, L]
+///   present_state = [B, C, weight[2] - 1]
+///
+/// Also validates the depthwise weight layout `[C, 1, K]`, optional bias
+/// `[C]`, and optional past state `[B, C, K - 1]`.
+FailureOr<SmallVector<SmallVector<int64_t>>>
+inferCausalConvWithStateOutputShapes(
+    ArrayRef<int64_t> inputShape, ArrayRef<int64_t> weightShape,
+    std::optional<ArrayRef<int64_t>> biasShape,
+    std::optional<ArrayRef<int64_t>> pastStateShape, int64_t ndim,
+    function_ref<InFlightDiagnostic()> emitError);
+
+/// Mixed-shape form of `inferCausalConvWithStateOutputShapes`.
+FailureOr<ReifiedRankedShapedTypeDims> reifyCausalConvWithStateOutputShapes(
+    OpBuilder &b, Location loc, Value input, Value weight, Value bias,
+    Value pastState, int64_t ndim,
+    function_ref<InFlightDiagnostic()> emitError);
+
 /// One-shot reify body for ONNX-style reduction ops. Structurally-proven
 /// constant `axes` use the shared semantic dimension map. Runtime,
 /// malformed, and non-contiguous axes fail without emitting IR.

--- a/lib/Conversion/OnnxToHip/CausalConvWithStateConversion.cpp
+++ b/lib/Conversion/OnnxToHip/CausalConvWithStateConversion.cpp
@@ -101,7 +101,8 @@ mlir::LogicalResult CausalConvWithStateToHip::matchAndRewrite(
     pastStateShape = pastStateType.getShape();
   auto staticShapes = mlir::hip::inferCausalConvWithStateOutputShapes(
       inputType.getShape(), weightType.getShape(), biasShape, pastStateShape,
-      ndimAttr.getInt(), [&]() { return op->emitError(); });
+      ndimAttr.getInt(), /*channelsLast=*/false,
+      [&]() { return op->emitError(); });
   if (mlir::failed(staticShapes))
     return mlir::failure();
 
@@ -126,7 +127,7 @@ mlir::LogicalResult CausalConvWithStateToHip::matchAndRewrite(
   // precondition before emitting dynamic dimension arithmetic.
   auto resultShapes = mlir::hip::reifyCausalConvWithStateOutputShapes(
       rewriter, loc, input, weight, bias, pastState, ndimAttr.getInt(),
-      [&]() { return op->emitError(); });
+      /*channelsLast=*/false, [&]() { return op->emitError(); });
   if (mlir::failed(resultShapes))
     return mlir::failure();
   auto outputInit = createEmptyTensorFromReifiedShape(rewriter, loc, outputType,

--- a/lib/Conversion/OnnxToHip/CausalConvWithStateConversion.cpp
+++ b/lib/Conversion/OnnxToHip/CausalConvWithStateConversion.cpp
@@ -71,21 +71,71 @@ mlir::LogicalResult CausalConvWithStateToHip::matchAndRewrite(
           ? rewriter.getI64IntegerAttr(ndimAttrOnnx.getValue().getSExtValue())
           : rewriter.getI64IntegerAttr(1);
 
-  // Outputs: output (same shape as input), present_state
+  // Outputs: output (same shape as input), present_state [B,C,K-1].
   size_t numResults = op->getNumResults();
   if (numResults != 2)
     return rewriter.notifyMatchFailure(
         op, "CausalConvWithState expects exactly 2 results");
 
   auto outputType =
-      mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
+      mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
   auto presentStateType =
-      mlir::cast<mlir::RankedTensorType>(op->getResult(1).getType());
+      mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(1).getType());
+  auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(input.getType());
+  auto weightType = mlir::dyn_cast<mlir::RankedTensorType>(weight.getType());
+  auto biasType = bias ? mlir::dyn_cast<mlir::RankedTensorType>(bias.getType())
+                       : mlir::RankedTensorType{};
+  auto pastStateType =
+      pastState ? mlir::dyn_cast<mlir::RankedTensorType>(pastState.getType())
+                : mlir::RankedTensorType{};
+  if (!outputType || !presentStateType || !inputType || !weightType ||
+      (bias && !biasType) || (pastState && !pastStateType))
+    return rewriter.notifyMatchFailure(
+        op, "CausalConvWithState requires ranked tensor operands and results");
 
-  // Create DPS init tensors
-  mlir::Value outputInit = createEmptyTensor(rewriter, loc, outputType, input);
-  mlir::Value presentStateInit = createEmptyTensor(
-      rewriter, loc, presentStateType, pastState ? pastState : input);
+  std::optional<llvm::ArrayRef<int64_t>> biasShape;
+  if (biasType)
+    biasShape = biasType.getShape();
+  std::optional<llvm::ArrayRef<int64_t>> pastStateShape;
+  if (pastStateType)
+    pastStateShape = pastStateType.getShape();
+  auto staticShapes = mlir::hip::inferCausalConvWithStateOutputShapes(
+      inputType.getShape(), weightType.getShape(), biasShape, pastStateShape,
+      ndimAttr.getInt(), [&]() { return op->emitError(); });
+  if (mlir::failed(staticShapes))
+    return mlir::failure();
+
+  auto importedTypeAgrees = [](mlir::RankedTensorType imported,
+                               llvm::ArrayRef<int64_t> expected) {
+    if (imported.getRank() != static_cast<int64_t>(expected.size()))
+      return false;
+    for (int64_t dim : llvm::seq<int64_t>(0, imported.getRank()))
+      if (!imported.isDynamicDim(dim) &&
+          !mlir::ShapedType::isDynamic(expected[dim]) &&
+          imported.getDimSize(dim) != expected[dim])
+        return false;
+    return true;
+  };
+  if (!importedTypeAgrees(outputType, (*staticShapes)[0]) ||
+      !importedTypeAgrees(presentStateType, (*staticShapes)[1]))
+    return rewriter.notifyMatchFailure(
+        op, "CausalConvWithState imported result types disagree with "
+            "[input, (B,C,K-1)]");
+
+  // The same mixed helper backs op reification. It validates every shape
+  // precondition before emitting dynamic dimension arithmetic.
+  auto resultShapes = mlir::hip::reifyCausalConvWithStateOutputShapes(
+      rewriter, loc, input, weight, bias, pastState, ndimAttr.getInt(),
+      [&]() { return op->emitError(); });
+  if (mlir::failed(resultShapes))
+    return mlir::failure();
+  auto outputInit = createEmptyTensorFromReifiedShape(rewriter, loc, outputType,
+                                                      (*resultShapes)[0]);
+  auto presentStateInit = createEmptyTensorFromReifiedShape(
+      rewriter, loc, presentStateType, (*resultShapes)[1]);
+  if (mlir::failed(outputInit) || mlir::failed(presentStateInit))
+    return rewriter.notifyMatchFailure(
+        op, "CausalConvWithState result types are not reifiable");
 
   // Build operands
   mlir::SmallVector<mlir::Value> operands;
@@ -96,8 +146,8 @@ mlir::LogicalResult CausalConvWithStateToHip::matchAndRewrite(
     operands.push_back(bias);
   if (pastState)
     operands.push_back(pastState);
-  operands.push_back(outputInit);
-  operands.push_back(presentStateInit);
+  operands.push_back(*outputInit);
+  operands.push_back(*presentStateInit);
 
   // Build attributes
   mlir::SmallVector<mlir::NamedAttribute> attrs;

--- a/lib/Dialect/IR/CMakeLists.txt
+++ b/lib/Dialect/IR/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(HipDialectIR STATIC
   HipOpStateInterface.cpp
   HipReifyResultShapesImpl.cpp
   HipShapeUtils.cpp
+  HipShapeUtilsAttention.cpp
   HipShapeUtilsConvPool.cpp
   HipShapeUtilsGather.cpp
   HipShapeUtilsMatmulGemm.cpp

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -1585,7 +1585,8 @@ LogicalResult CausalConvWithStateOp::verify() {
   FailureOr<SmallVector<SmallVector<int64_t>>> expected =
       inferCausalConvWithStateOutputShapes(
           inputType.getShape(), weightType.getShape(), biasShape,
-          pastStateShape, getNdim(), [&]() { return this->emitOpError(); });
+          pastStateShape, getNdim(), getChannelsLast(),
+          [&]() { return this->emitOpError(); });
   if (failed(expected))
     return failure();
   if (getActivation() != "none" && getActivation() != "silu" &&

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -1551,6 +1551,70 @@ void CausalConvWithStateOp::getEffects(
   emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
 }
 
+LogicalResult CausalConvWithStateOp::verify() {
+  SmallVector<Value> operands = {getInput(), getWeight()};
+  if (Value bias = getBias())
+    operands.push_back(bias);
+  if (Value pastState = getPastState())
+    operands.push_back(pastState);
+  operands.push_back(getOutput());
+  operands.push_back(getPresentState());
+  if (failed(verifyDpsComputeOp(*this, operands, /*numInits=*/2)))
+    return failure();
+
+  auto inputType = dyn_cast<ShapedType>(getInput().getType());
+  auto weightType = dyn_cast<ShapedType>(getWeight().getType());
+  if (!inputType || !inputType.hasRank() || !weightType ||
+      !weightType.hasRank())
+    return emitOpError("input and weight must be ranked");
+  std::optional<ArrayRef<int64_t>> biasShape;
+  if (Value bias = getBias()) {
+    auto biasType = dyn_cast<ShapedType>(bias.getType());
+    if (!biasType || !biasType.hasRank())
+      return emitOpError("bias must be ranked");
+    biasShape = biasType.getShape();
+  }
+  std::optional<ArrayRef<int64_t>> pastStateShape;
+  if (Value pastState = getPastState()) {
+    auto pastStateType = dyn_cast<ShapedType>(pastState.getType());
+    if (!pastStateType || !pastStateType.hasRank())
+      return emitOpError("past_state must be ranked");
+    pastStateShape = pastStateType.getShape();
+  }
+
+  FailureOr<SmallVector<SmallVector<int64_t>>> expected =
+      inferCausalConvWithStateOutputShapes(
+          inputType.getShape(), weightType.getShape(), biasShape,
+          pastStateShape, getNdim(), [&]() { return this->emitOpError(); });
+  if (failed(expected))
+    return failure();
+  if (getActivation() != "none" && getActivation() != "silu" &&
+      getActivation() != "swish")
+    return emitOpError("activation must be one of: none, silu, swish");
+
+  Type elementType = inputType.getElementType();
+  if (!elementType.isF16() && !elementType.isF32())
+    return emitOpError("runtime supports only f16/f32 input");
+  for (Value value : operands)
+    if (cast<ShapedType>(value.getType()).getElementType() != elementType)
+      return emitOpError("all input and output element types must match");
+
+  for (unsigned index = 0; index < 2; ++index) {
+    if (failed(verifyHipOpShape(
+            *this,
+            [&]() -> FailureOr<SmallVector<int64_t>> {
+              return (*expected)[index];
+            },
+            index)))
+      return failure();
+    Value init = index == 0 ? getOutput() : getPresentState();
+    if (getNumResults() && getResult(index).getType() != init.getType())
+      return emitOpError("tensor result #")
+             << index << " type must match its output buffer type";
+  }
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // GemmOp
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
+++ b/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
@@ -67,6 +67,24 @@ LogicalResult ConvTransposeOp::reifyResultShapes(
 }
 
 //===----------------------------------------------------------------------===//
+// CausalConvWithStateOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult CausalConvWithStateOp::reifyResultShapes(
+    OpBuilder &b, ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+  if (getNumResults() != 2)
+    return failure();
+  FailureOr<ReifiedRankedShapedTypeDims> shapes =
+      mlir::hip::reifyCausalConvWithStateOutputShapes(
+          b, getLoc(), getInput(), getWeight(), getBias(), getPastState(),
+          getNdim(), [&]() { return this->emitOpError(); });
+  if (failed(shapes))
+    return failure();
+  reifiedReturnShapes = std::move(*shapes);
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // MatmulOp
 //
 // Reify delegates to the shared MatMul helper used by converter destination

--- a/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
+++ b/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
@@ -77,7 +77,7 @@ LogicalResult CausalConvWithStateOp::reifyResultShapes(
   FailureOr<ReifiedRankedShapedTypeDims> shapes =
       mlir::hip::reifyCausalConvWithStateOutputShapes(
           b, getLoc(), getInput(), getWeight(), getBias(), getPastState(),
-          getNdim(), [&]() { return this->emitOpError(); });
+          getNdim(), getChannelsLast(), [&]() { return this->emitOpError(); });
   if (failed(shapes))
     return failure();
   reifiedReturnShapes = std::move(*shapes);

--- a/lib/Dialect/IR/HipShapeUtilsAttention.cpp
+++ b/lib/Dialect/IR/HipShapeUtilsAttention.cpp
@@ -29,7 +29,7 @@ mlir::hip::inferCausalConvWithStateOutputShapes(
     ArrayRef<int64_t> inputShape, ArrayRef<int64_t> weightShape,
     std::optional<ArrayRef<int64_t>> biasShape,
     std::optional<ArrayRef<int64_t>> pastStateShape, int64_t ndim,
-    function_ref<InFlightDiagnostic()> emitError) {
+    bool channelsLast, function_ref<InFlightDiagnostic()> emitError) {
   if (ndim != 1) {
     emitError() << "causal_conv_with_state runtime supports only ndim=1";
     return failure();
@@ -40,7 +40,8 @@ mlir::hip::inferCausalConvWithStateOutputShapes(
     return failure();
   }
 
-  if (!areCompatibleStaticExtents(inputShape[1], weightShape[0])) {
+  const size_t channelDim = channelsLast ? 2 : 1;
+  if (!areCompatibleStaticExtents(inputShape[channelDim], weightShape[0])) {
     emitError() << "causal_conv_with_state weight channels must match input "
                    "channels";
     return failure();
@@ -60,7 +61,7 @@ mlir::hip::inferCausalConvWithStateOutputShapes(
       emitError() << "causal_conv_with_state bias must have rank 1";
       return failure();
     }
-    if (!areCompatibleStaticExtents((*biasShape)[0], inputShape[1])) {
+    if (!areCompatibleStaticExtents((*biasShape)[0], inputShape[channelDim])) {
       emitError() << "causal_conv_with_state bias length must match input "
                      "channels";
       return failure();
@@ -70,7 +71,8 @@ mlir::hip::inferCausalConvWithStateOutputShapes(
   int64_t stateLength = ShapedType::isDynamic(weightShape[2])
                             ? ShapedType::kDynamic
                             : weightShape[2] - 1;
-  SmallVector<int64_t> stateShape = {inputShape[0], inputShape[1], stateLength};
+  SmallVector<int64_t> stateShape = {inputShape[0], inputShape[channelDim],
+                                     stateLength};
   if (pastStateShape) {
     if (pastStateShape->size() != stateShape.size()) {
       emitError() << "causal_conv_with_state past_state must have rank 3";
@@ -93,7 +95,7 @@ mlir::hip::inferCausalConvWithStateOutputShapes(
 FailureOr<ReifiedRankedShapedTypeDims>
 mlir::hip::reifyCausalConvWithStateOutputShapes(
     OpBuilder &b, Location loc, Value input, Value weight, Value bias,
-    Value pastState, int64_t ndim,
+    Value pastState, int64_t ndim, bool channelsLast,
     function_ref<InFlightDiagnostic()> emitError) {
   auto inputType = dyn_cast<RankedTensorType>(input.getType());
   auto weightType = dyn_cast<RankedTensorType>(weight.getType());
@@ -116,7 +118,7 @@ mlir::hip::reifyCausalConvWithStateOutputShapes(
     pastStateShape = pastStateType.getShape();
   if (failed(inferCausalConvWithStateOutputShapes(
           inputType.getShape(), weightType.getShape(), biasShape,
-          pastStateShape, ndim, emitError)))
+          pastStateShape, ndim, channelsLast, emitError)))
     return failure();
 
   SmallVector<OpFoldResult> outputShape = tensor::getMixedSizes(b, loc, input);
@@ -125,9 +127,10 @@ mlir::hip::reifyCausalConvWithStateOutputShapes(
                                 /*scale=*/1, /*offset=*/-1);
   if (failed(stateLength))
     return failure();
+  const int64_t channelDim = channelsLast ? 2 : 1;
   SmallVector<OpFoldResult> presentStateShape = {
       tensor::getMixedSize(b, loc, input, 0),
-      tensor::getMixedSize(b, loc, input, 1), *stateLength};
+      tensor::getMixedSize(b, loc, input, channelDim), *stateLength};
   return ReifiedRankedShapedTypeDims{std::move(outputShape),
                                      std::move(presentStateShape)};
 }

--- a/lib/Dialect/IR/HipShapeUtilsAttention.cpp
+++ b/lib/Dialect/IR/HipShapeUtilsAttention.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- HipShapeUtilsAttention.cpp - Attention shape helpers --------------===//
+
+#include "HipShapeUtilsInternal.h"
+#include "hip/Dialect/IR/HipShapeUtils.h"
+
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "llvm/ADT/Sequence.h"
+
+#include <optional>
+
+using namespace mlir;
+using namespace mlir::hip;
+
+namespace {
+
+bool areCompatibleStaticExtents(int64_t lhs, int64_t rhs) {
+  return ShapedType::isDynamic(lhs) || ShapedType::isDynamic(rhs) || lhs == rhs;
+}
+
+} // namespace
+
+FailureOr<SmallVector<SmallVector<int64_t>>>
+mlir::hip::inferCausalConvWithStateOutputShapes(
+    ArrayRef<int64_t> inputShape, ArrayRef<int64_t> weightShape,
+    std::optional<ArrayRef<int64_t>> biasShape,
+    std::optional<ArrayRef<int64_t>> pastStateShape, int64_t ndim,
+    function_ref<InFlightDiagnostic()> emitError) {
+  if (ndim != 1) {
+    emitError() << "causal_conv_with_state runtime supports only ndim=1";
+    return failure();
+  }
+  if (inputShape.size() != 3 || weightShape.size() != 3) {
+    emitError() << "causal_conv_with_state input and weight must have rank 3 "
+                   "for ndim=1";
+    return failure();
+  }
+
+  if (!areCompatibleStaticExtents(inputShape[1], weightShape[0])) {
+    emitError() << "causal_conv_with_state weight channels must match input "
+                   "channels";
+    return failure();
+  }
+  if (!ShapedType::isDynamic(weightShape[1]) && weightShape[1] != 1) {
+    emitError() << "causal_conv_with_state weight dimension 1 must be 1 for "
+                   "depthwise convolution";
+    return failure();
+  }
+  if (!ShapedType::isDynamic(weightShape[2]) && weightShape[2] <= 0) {
+    emitError() << "causal_conv_with_state kernel extent must be positive";
+    return failure();
+  }
+
+  if (biasShape) {
+    if (biasShape->size() != 1) {
+      emitError() << "causal_conv_with_state bias must have rank 1";
+      return failure();
+    }
+    if (!areCompatibleStaticExtents((*biasShape)[0], inputShape[1])) {
+      emitError() << "causal_conv_with_state bias length must match input "
+                     "channels";
+      return failure();
+    }
+  }
+
+  int64_t stateLength = ShapedType::isDynamic(weightShape[2])
+                            ? ShapedType::kDynamic
+                            : weightShape[2] - 1;
+  SmallVector<int64_t> stateShape = {inputShape[0], inputShape[1], stateLength};
+  if (pastStateShape) {
+    if (pastStateShape->size() != stateShape.size()) {
+      emitError() << "causal_conv_with_state past_state must have rank 3";
+      return failure();
+    }
+    for (size_t dim : llvm::seq<size_t>(0, stateShape.size())) {
+      if (!areCompatibleStaticExtents((*pastStateShape)[dim],
+                                      stateShape[dim])) {
+        emitError() << "causal_conv_with_state past_state dimension " << dim
+                    << " must match [B, C, K-1]";
+        return failure();
+      }
+    }
+  }
+
+  return SmallVector<SmallVector<int64_t>>{SmallVector<int64_t>(inputShape),
+                                           std::move(stateShape)};
+}
+
+FailureOr<ReifiedRankedShapedTypeDims>
+mlir::hip::reifyCausalConvWithStateOutputShapes(
+    OpBuilder &b, Location loc, Value input, Value weight, Value bias,
+    Value pastState, int64_t ndim,
+    function_ref<InFlightDiagnostic()> emitError) {
+  auto inputType = dyn_cast<RankedTensorType>(input.getType());
+  auto weightType = dyn_cast<RankedTensorType>(weight.getType());
+  auto biasType =
+      bias ? dyn_cast<RankedTensorType>(bias.getType()) : RankedTensorType{};
+  auto pastStateType = pastState
+                           ? dyn_cast<RankedTensorType>(pastState.getType())
+                           : RankedTensorType{};
+  if (!inputType || !weightType || (bias && !biasType) ||
+      (pastState && !pastStateType)) {
+    emitError() << "causal_conv_with_state operands must be ranked tensors";
+    return failure();
+  }
+
+  std::optional<ArrayRef<int64_t>> biasShape;
+  if (biasType)
+    biasShape = biasType.getShape();
+  std::optional<ArrayRef<int64_t>> pastStateShape;
+  if (pastStateType)
+    pastStateShape = pastStateType.getShape();
+  if (failed(inferCausalConvWithStateOutputShapes(
+          inputType.getShape(), weightType.getShape(), biasShape,
+          pastStateShape, ndim, emitError)))
+    return failure();
+
+  SmallVector<OpFoldResult> outputShape = tensor::getMixedSizes(b, loc, input);
+  FailureOr<OpFoldResult> stateLength =
+      detail::scaleAndOffsetDim(b, loc, tensor::getMixedSize(b, loc, weight, 2),
+                                /*scale=*/1, /*offset=*/-1);
+  if (failed(stateLength))
+    return failure();
+  SmallVector<OpFoldResult> presentStateShape = {
+      tensor::getMixedSize(b, loc, input, 0),
+      tensor::getMixedSize(b, loc, input, 1), *stateLength};
+  return ReifiedRankedShapedTypeDims{std::move(outputShape),
+                                     std::move(presentStateShape)};
+}

--- a/test/lit/Conversion/onnx-to-hip/test_causal_conv_with_state.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_causal_conv_with_state.mlir
@@ -13,6 +13,7 @@
 // 4. causal_conv_no_activation           — different shape, activation=none
 // 5. causal_conv_dynamic                 — dynamic batch + seq_len (LLM decode)
 // 6. causal_conv_dynamic_no_past_state   — dynamic input with no past_state
+// 7. causal_conv_fully_dynamic_weight     — present K-1 comes from weight
 //
 // All static cases assert:
 // - context argument prepended
@@ -134,8 +135,8 @@ module {
   //    Expectations:
   //    - output init: tensor.dim for dims 0 and 2 of input + tensor.empty with
   //      two dynamic sizes.
-  //    - present_state init: tensor.dim for dim 0 of past_state + tensor.empty
-  //      with one dynamic size.
+  //    - present_state init: batch comes from input (past_state validates but
+  //      does not own the state shape).
   // --------------------------------------------------------------------------
   func.func @causal_conv_dynamic(
       %input: tensor<?x64x?xf16>,
@@ -155,12 +156,9 @@ module {
 
   // CHECK-LABEL: func.func @causal_conv_dynamic
   // CHECK-SAME: (%[[CTX5:.*]]: !hip.context, %[[IN5:.*]]: tensor<?x64x?xf16>, %[[W5:.*]]: tensor<64x1x4xf16>, %[[B5:.*]]: tensor<64xf16>, %[[PS5:.*]]: tensor<?x64x3xf16>)
-  // output init: dims 0 and 2 of input extracted at runtime, fed into empty.
-  // CHECK: tensor.dim %[[IN5]]
-  // CHECK: tensor.dim %[[IN5]]
+  // output + present init: input supplies B twice and output L once.
+  // CHECK-COUNT-3: tensor.dim %[[IN5]]
   // CHECK: tensor.empty({{.*}}) : tensor<?x64x?xf16>
-  // present_state init: dim 0 of past_state extracted at runtime.
-  // CHECK: tensor.dim %[[PS5]]
   // CHECK: tensor.empty({{.*}}) : tensor<?x64x3xf16>
   // CHECK: hip.causal_conv_with_state(%[[CTX5]]) ins(%[[IN5]], %[[W5]], %[[B5]], %[[PS5]] : tensor<?x64x?xf16>, tensor<64x1x4xf16>, tensor<64xf16>, tensor<?x64x3xf16>) outs({{.*}}, {{.*}} : tensor<?x64x?xf16>, tensor<?x64x3xf16>) {activation = "silu"
   // CHECK-NOT: hip.alloc
@@ -186,11 +184,36 @@ module {
 
   // CHECK-LABEL: func.func @causal_conv_dynamic_no_past_state
   // CHECK-SAME: (%[[CTX6:.*]]: !hip.context, %[[IN6:.*]]: tensor<?x64x?xf16>, %[[W6:.*]]: tensor<64x1x4xf16>)
-  // CHECK: tensor.dim %[[IN6]]
+  // CHECK-COUNT-3: tensor.dim %[[IN6]]
   // CHECK: tensor.empty({{.*}}) : tensor<?x64x?xf16>
-  // present_state falls back to input for dim extraction (batch only).
-  // CHECK: tensor.dim %[[IN6]]
   // CHECK: tensor.empty({{.*}}) : tensor<?x64x3xf16>
   // CHECK: hip.causal_conv_with_state(%[[CTX6]]) ins(%[[IN6]], %[[W6]] : tensor<?x64x?xf16>, tensor<64x1x4xf16>) outs({{.*}}, {{.*}} : tensor<?x64x?xf16>, tensor<?x64x3xf16>)
+  // CHECK-NOT: hip.alloc
+
+  // --------------------------------------------------------------------------
+  // 7. Dynamic kernel: present_state's final extent is weight.K - 1, not an
+  //    input or absent-past-state dimension.
+  // --------------------------------------------------------------------------
+  func.func @causal_conv_fully_dynamic_weight(
+      %input: tensor<?x?x?xf16>,
+      %weight: tensor<?x?x?xf16>
+  ) -> (tensor<?x?x?xf16>, tensor<?x?x?xf16>) {
+    %none = "onnx.NoValue"() {value} : () -> none
+    %output, %present_state = "onnx.Custom"(%input, %weight, %none, %none) {
+      function_name = "CausalConvWithState",
+      domain_name = "com.microsoft",
+      ndim = 1 : si64
+    } : (tensor<?x?x?xf16>, tensor<?x?x?xf16>, none, none)
+      -> (tensor<?x?x?xf16>, tensor<?x?x?xf16>)
+    return %output, %present_state : tensor<?x?x?xf16>, tensor<?x?x?xf16>
+  }
+
+  // CHECK-LABEL: func.func @causal_conv_fully_dynamic_weight
+  // CHECK-SAME: %[[IN7:[^,]+]]: tensor<?x?x?xf16>
+  // CHECK-SAME: %[[W7:[^)]+]]: tensor<?x?x?xf16>
+  // CHECK: %[[K:.*]] = tensor.dim %[[W7]], %{{.*}} : tensor<?x?x?xf16>
+  // CHECK: %[[STATE_LEN:.*]] = arith.addi %[[K]], %{{.*}} : index
+  // CHECK: tensor.empty({{.*}}, {{.*}}, %[[STATE_LEN]]) : tensor<?x?x?xf16>
+  // CHECK: hip.causal_conv_with_state({{.*}})
   // CHECK-NOT: hip.alloc
 }

--- a/test/lit/Dialect/hip-causal-conv-channels-last.mlir
+++ b/test/lit/Dialect/hip-causal-conv-channels-last.mlir
@@ -135,7 +135,7 @@ module {
   func.func @no_fold_wrong_permutation(
       %ctx: !hip.context,
       %x: tensor<128x1x64xf16>,
-      %w: tensor<1x1x4xf16>)
+      %w: tensor<128x1x4xf16>)
       -> (tensor<128x1x64xf16>, tensor<1x128x3xf16>) {
     // CHECK-LABEL: func.func @no_fold_wrong_permutation
     // CHECK: hip.transpose
@@ -149,7 +149,7 @@ module {
     %e1 = tensor.empty() : tensor<1x128x64xf16>
     %e2 = tensor.empty() : tensor<1x128x3xf16>
     %y, %s = hip.causal_conv_with_state(%ctx)
-        ins(%t0, %w : tensor<1x128x64xf16>, tensor<1x1x4xf16>)
+        ins(%t0, %w : tensor<1x128x64xf16>, tensor<128x1x4xf16>)
         outs(%e1, %e2 : tensor<1x128x64xf16>, tensor<1x128x3xf16>)
         {ndim = 1 : i64}
         : tensor<1x128x64xf16>, tensor<1x128x3xf16>

--- a/test/lit/Dialect/hip-causal-conv-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-causal-conv-reify-shapes.mlir
@@ -34,3 +34,25 @@ func.func @dynamic_kernel(
   return %out_b, %out_l, %state_b, %state_c, %state_len
       : index, index, index, index, index
 }
+
+// The carry state remains [B, C, K-1] for channels-last input [B, L, C].
+// CHECK-LABEL: func.func @dynamic_channels_last
+// CHECK-SAME: %[[INPUT:[^,]+]]: tensor<?x?x?xf16>
+// CHECK: %[[C2:.*]] = arith.constant 2 : index
+// CHECK: %[[STATE_C:.*]] = tensor.dim %[[INPUT]], %[[C2]]
+// CHECK: return %[[STATE_C]]
+func.func @dynamic_channels_last(
+    %ctx: !hip.context,
+    %input: tensor<?x?x?xf16>,
+    %weight: tensor<?x1x?xf16>,
+    %output: tensor<?x?x?xf16>,
+    %present: tensor<?x?x?xf16>) -> index {
+  %result:2 = hip.causal_conv_with_state(%ctx)
+      ins(%input, %weight : tensor<?x?x?xf16>, tensor<?x1x?xf16>)
+      outs(%output, %present : tensor<?x?x?xf16>, tensor<?x?x?xf16>)
+      {ndim = 1 : i64, channels_last = true}
+      : tensor<?x?x?xf16>, tensor<?x?x?xf16>
+  %c1 = arith.constant 1 : index
+  %state_c = tensor.dim %result#1, %c1 : tensor<?x?x?xf16>
+  return %state_c : index
+}

--- a/test/lit/Dialect/hip-causal-conv-reify-shapes.mlir
+++ b/test/lit/Dialect/hip-causal-conv-reify-shapes.mlir
@@ -1,0 +1,36 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --resolve-shaped-type-result-dims %s | FileCheck %s
+
+// CHECK-LABEL: func.func @dynamic_kernel
+// CHECK-SAME: %[[INPUT:[^,]+]]: tensor<?x32x?xf16>
+// CHECK-SAME: %[[WEIGHT:[^,]+]]: tensor<32x1x?xf16>
+// CHECK: %[[OUT_B:.*]] = tensor.dim %[[INPUT]], %{{.*}}
+// CHECK: %[[OUT_L:.*]] = tensor.dim %[[INPUT]], %{{.*}}
+// CHECK: %[[STATE_B:.*]] = tensor.dim %[[INPUT]], %{{.*}}
+// CHECK: %[[K:.*]] = tensor.dim %[[WEIGHT]], %{{.*}}
+// CHECK: %[[STATE_LEN:.*]] = arith.addi %[[K]], %{{.*}} : index
+// CHECK: return %[[OUT_B]], %[[OUT_L]], %[[STATE_B]], %{{.*}}, %[[STATE_LEN]]
+func.func @dynamic_kernel(
+    %ctx: !hip.context,
+    %input: tensor<?x32x?xf16>,
+    %weight: tensor<32x1x?xf16>,
+    %output: tensor<?x32x?xf16>,
+    %present: tensor<?x32x?xf16>) -> (index, index, index, index, index) {
+  %result:2 = hip.causal_conv_with_state(%ctx)
+      ins(%input, %weight : tensor<?x32x?xf16>, tensor<32x1x?xf16>)
+      outs(%output, %present : tensor<?x32x?xf16>, tensor<?x32x?xf16>)
+      {ndim = 1 : i64}
+      : tensor<?x32x?xf16>, tensor<?x32x?xf16>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %out_b = tensor.dim %result#0, %c0 : tensor<?x32x?xf16>
+  %out_l = tensor.dim %result#0, %c2 : tensor<?x32x?xf16>
+  %state_b = tensor.dim %result#1, %c0 : tensor<?x32x?xf16>
+  %state_c = tensor.dim %result#1, %c1 : tensor<?x32x?xf16>
+  %state_len = tensor.dim %result#1, %c2 : tensor<?x32x?xf16>
+  return %out_b, %out_l, %state_b, %state_c, %state_len
+      : index, index, index, index, index
+}

--- a/test/lit/Dialect/hip-causal-conv-shape-verifier.mlir
+++ b/test/lit/Dialect/hip-causal-conv-shape-verifier.mlir
@@ -1,0 +1,86 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --verify-diagnostics %s
+
+func.func @wrong_output(
+    %ctx: !hip.context, %input: memref<2x8x16xf16>,
+    %weight: memref<8x1x4xf16>, %output: memref<2x8x15xf16>,
+    %present: memref<2x8x3xf16>) {
+  // expected-error @+1 {{'hip.causal_conv_with_state' op dim 2 of result mismatch: expected 16}}
+  hip.causal_conv_with_state(%ctx)
+      ins(%input, %weight : memref<2x8x16xf16>, memref<8x1x4xf16>)
+      outs(%output, %present : memref<2x8x15xf16>, memref<2x8x3xf16>)
+  return
+}
+
+func.func @wrong_present(
+    %ctx: !hip.context, %input: memref<2x8x16xf16>,
+    %weight: memref<8x1x4xf16>, %output: memref<2x8x16xf16>,
+    %present: memref<2x8x4xf16>) {
+  // expected-error @+1 {{'hip.causal_conv_with_state' op dim 2 of result mismatch: expected 3}}
+  hip.causal_conv_with_state(%ctx)
+      ins(%input, %weight : memref<2x8x16xf16>, memref<8x1x4xf16>)
+      outs(%output, %present : memref<2x8x16xf16>, memref<2x8x4xf16>)
+  return
+}
+
+func.func @bad_weight_layout(
+    %ctx: !hip.context, %input: memref<2x8x16xf16>,
+    %weight: memref<7x2x4xf16>, %output: memref<2x8x16xf16>,
+    %present: memref<2x8x3xf16>) {
+  // expected-error @+1 {{'hip.causal_conv_with_state' op causal_conv_with_state weight channels must match input channels}}
+  hip.causal_conv_with_state(%ctx)
+      ins(%input, %weight : memref<2x8x16xf16>, memref<7x2x4xf16>)
+      outs(%output, %present : memref<2x8x16xf16>, memref<2x8x3xf16>)
+  return
+}
+
+func.func @bad_past_state(
+    %ctx: !hip.context, %input: memref<2x8x16xf16>,
+    %weight: memref<8x1x4xf16>, %bias: memref<8xf16>,
+    %past: memref<1x8x3xf16>,
+    %output: memref<2x8x16xf16>, %present: memref<2x8x3xf16>) {
+  // expected-error @+1 {{'hip.causal_conv_with_state' op causal_conv_with_state past_state dimension 0 must match [B, C, K-1]}}
+  hip.causal_conv_with_state(%ctx)
+      ins(%input, %weight, %bias, %past :
+          memref<2x8x16xf16>, memref<8x1x4xf16>, memref<8xf16>,
+          memref<1x8x3xf16>)
+      outs(%output, %present : memref<2x8x16xf16>, memref<2x8x3xf16>)
+  return
+}
+
+func.func @unsupported_ndim(
+    %ctx: !hip.context, %input: memref<2x8x16xf16>,
+    %weight: memref<8x1x4xf16>, %output: memref<2x8x16xf16>,
+    %present: memref<2x8x3xf16>) {
+  // expected-error @+1 {{'hip.causal_conv_with_state' op causal_conv_with_state runtime supports only ndim=1}}
+  hip.causal_conv_with_state(%ctx)
+      ins(%input, %weight : memref<2x8x16xf16>, memref<8x1x4xf16>)
+      outs(%output, %present : memref<2x8x16xf16>, memref<2x8x3xf16>)
+      {ndim = 2 : i64}
+  return
+}
+
+func.func @bad_activation(
+    %ctx: !hip.context, %input: memref<2x8x16xf16>,
+    %weight: memref<8x1x4xf16>, %output: memref<2x8x16xf16>,
+    %present: memref<2x8x3xf16>) {
+  // expected-error @+1 {{'hip.causal_conv_with_state' op activation must be one of: none, silu, swish}}
+  hip.causal_conv_with_state(%ctx)
+      ins(%input, %weight : memref<2x8x16xf16>, memref<8x1x4xf16>)
+      outs(%output, %present : memref<2x8x16xf16>, memref<2x8x3xf16>)
+      {activation = "relu"}
+  return
+}
+
+func.func @mismatched_dtype(
+    %ctx: !hip.context, %input: memref<2x8x16xf16>,
+    %weight: memref<8x1x4xf32>, %output: memref<2x8x16xf16>,
+    %present: memref<2x8x3xf16>) {
+  // expected-error @+1 {{'hip.causal_conv_with_state' op all input and output element types must match}}
+  hip.causal_conv_with_state(%ctx)
+      ins(%input, %weight : memref<2x8x16xf16>, memref<8x1x4xf32>)
+      outs(%output, %present : memref<2x8x16xf16>, memref<2x8x3xf16>)
+  return
+}


### PR DESCRIPTION
## Why

CausalConvWithState has two coupled results: the convolution output preserves the input sequence length, while the present state uses the depthwise kernel history length. Computing those destinations separately from reification and verification allowed rank, channel, and kernel assumptions to diverge.

One validated 1D depthwise rule should define both results and reject incompatible inputs before conversion emits destination IR.

## IR example

The dynamic-kernel reification test derives output batch and length from the input and present-state length from `kernel - 1`:

```mlir
%result:2 = hip.causal_conv_with_state(%ctx)
  ins(%input, %weight : tensor<?x32x?xf16>, tensor<32x1x?xf16>)
  outs(%output, %present : tensor<?x32x?xf16>, tensor<?x32x?xf16>)
  {ndim = 1 : i64}
  : tensor<?x32x?xf16>, tensor<?x32x?xf16>
```

## What changes

- Add one pure CausalConvWithState shape rule for output and present-state extents.
- Share that rule across converter destinations, result reification, and dialect verification.
- Validate the supported 1D depthwise layout, channel agreement, and kernel-derived state length before emitting IR.
- Add focused conversion, dynamic reification, verifier, and shape-contract documentation coverage.

## Stack

Merged prerequisite plus the 22 active shape PRs:

1. [#688 — refactor(hip): externalize constants after ONNX conversion](https://github.com/ROCm/hip-ep/pull/688)
2. [#724 — feat(shape): preserve symbolic compiler inputs](https://github.com/ROCm/hip-ep/pull/724)
3. [#639 — refactor(hip): establish shared shape-rule foundation](https://github.com/ROCm/hip-ep/pull/639)
4. [#681 — fix(shape): canonicalize host reshape provenance](https://github.com/ROCm/hip-ep/pull/681)
5. [#725 — fix(shape): activate exact broadcasts with symbolic proofs](https://github.com/ROCm/hip-ep/pull/725)
6. [#734 — fix(shape): share MatMul and Gemm contracts](https://github.com/ROCm/hip-ep/pull/734)
7. [#641 — fix(shape): enforce shared broadcast contracts](https://github.com/ROCm/hip-ep/pull/641)
8. [#735 — refactor(conversion): share ONNX reduction conversion](https://github.com/ROCm/hip-ep/pull/735)
9. [#736 — fix(shape): normalize reduction contracts](https://github.com/ROCm/hip-ep/pull/736)
10. [#643 — fix(shape): share convolution contracts](https://github.com/ROCm/hip-ep/pull/643)
11. [#742 — fix(shape): share causal convolution contracts](https://github.com/ROCm/hip-ep/pull/742) ← this PR
12. [#645 — fix(shape): share normalization contracts](https://github.com/ROCm/hip-ep/pull/645)
13. [#740 — fix(shape): share attention contracts](https://github.com/ROCm/hip-ep/pull/740)
14. [#741 — fix(shape): share GQA capacity contracts](https://github.com/ROCm/hip-ep/pull/741)
15. [#644 — fix(shape): share gather and tensor contracts](https://github.com/ROCm/hip-ep/pull/644)
16. [#727 — feat(shape): consume constant payload shapes directly](https://github.com/ROCm/hip-ep/pull/727)
17. [#728 — feat(shape): add exact Tile and Range destinations](https://github.com/ROCm/hip-ep/pull/728)
18. [#646 — refactor(hip): declare explicit DPS shape contracts](https://github.com/ROCm/hip-ep/pull/646)
19. [#730 — test(hip): audit explicit DPS contract inventory](https://github.com/ROCm/hip-ep/pull/730)
20. [#732 — test(hip): audit ONNX converter deduplication](https://github.com/ROCm/hip-ep/pull/732)
21. [#647 — fix(hip): harden shape refinement failure handling](https://github.com/ROCm/hip-ep/pull/647)
22. [#761 — refactor(hip): split shape utility headers by family](https://github.com/ROCm/hip-ep/pull/761)
23. [#764 — refactor(hip): clarify shape destination authority](https://github.com/ROCm/hip-ep/pull/764)

## AI assistance

AI tools assisted with the refactoring and stack reconstruction. The contributor reviewed and validated the resulting code.

Made-with: Cursor

