### PR TITLE
fix(perf-harness): make the 16K measurement trustworthy, and write up the Qwen3.6 prefill

### DIFF
--- a/docs/perf/qwen36-16k-bottleneck.md
+++ b/docs/perf/qwen36-16k-bottleneck.md
@@ -620,3 +620,47 @@ Worth noting for the record: the branch itself predicted this would *not* be
 resolvable end-to-end, having been measured at 4K where the effect is ~71 ms
 against a ±200 ms noise floor. At 16K the same defect costs 5x more while the
 noise floor is unchanged, which is what makes it measurable.
+
+## Step 3: halve the linear-attention launch window
+
+Landed as [#726](https://github.com/ROCm/hip-ep/pull/726). One constant,
+`LA_WINDOW_CHUNKS` 32 -> 16. Measured on top of steps 1 and 2, so the baseline
+arm is the chunked-bucketing build:
+
+| round | order | bucket | la | delta |
+|---|---|---:|---:|---:|
+| 1 | bucket first | 15,080 | 14,312 | -768 |
+| 2 | bucket first | 14,886 | 14,291 | -595 |
+| 3 | la first | 15,108 | 14,319 | -789 |
+| 4 | la first | 14,869 | 14,326 | -543 |
+
+**-674 ms (-4.49%), 95% CI [-870, -477]**, sd of paired differences 123 ms,
+better in all four rounds and in both orderings.
+
+This is the one step that beat its prediction, and by more than a factor of two:
+the same constant was worth -294 ms when measured before any of this round's
+work landed. The mechanism explains the growth. The window governs how much
+scratch the pass1 -> scan -> pass3 chain streams through between writing a
+Uloc/W tile and reading it back, so its value depends on what else is competing
+for cache in that interval. Step 1 deleted 60 Transpose dispatches, each of
+which had been streaming a full 18,646-token activation through the same cache,
+so the 25 MiB this change keeps resident now survives where it previously did
+not. Stacked wins are usually sub-additive; this pair is the opposite, and only
+because the first change removed the thing that was evicting the second.
+
+## Where the three land
+
+| stage | TTFT | vs previous | cumulative |
+|---|---:|---:|---:|
+| baseline | 17,129 | -- | -- |
+| + channels-last conv | 15,334 | -1,772 | -10.4% |
+| + chunked bucketing | 14,986 | -348 | -12.5% |
+| + LA window 16 | 14,312 | -674 | -16.4% |
+
+**-2,817 ms, -16.4%**, all four arms measured in one interleaved series so the
+box's drift cancels across the whole table.
+
+The plan expected roughly 3.0 s and 21%. The 2.8 s is within reach of that; the
+percentage falls short only because the denominator moved, since today's box
+runs 17.1 s where the plan was written against 14.5 s. Against that original
+baseline the same relative reduction would read 12.1 s.

--- a/docs/perf/qwen36-16k-bottleneck.md
+++ b/docs/perf/qwen36-16k-bottleneck.md
@@ -642,11 +642,12 @@ the same constant was worth -294 ms when measured before any of this round's
 work landed. The mechanism explains the growth. The window governs how much
 scratch the pass1 -> scan -> pass3 chain streams through between writing a
 Uloc/W tile and reading it back, so its value depends on what else is competing
-for cache in that interval. Step 1 deleted 60 Transpose dispatches, each of
-which had been streaming a full 18,646-token activation through the same cache,
-so the 25 MiB this change keeps resident now survives where it previously did
-not. Stacked wins are usually sub-additive; this pair is the opposite, and only
-because the first change removed the thing that was evicting the second.
+for cache in that interval. Step 1 deleted 60 Transpose dispatches, and the
+capture confirms that at least one per linear-attention block was streaming a
+full 18,646x8192 activation through the same cache, so the 25 MiB this change
+keeps resident now survives where it previously did not. Stacked wins are
+usually sub-additive; this pair is the opposite, and only because the first
+change removed the thing that was evicting the second.
 
 ## Where the three land
 
@@ -664,3 +665,201 @@ The plan expected roughly 3.0 s and 21%. The 2.8 s is within reach of that; the
 percentage falls short only because the denominator moved, since today's box
 runs 17.1 s where the plan was written against 14.5 s. Against that original
 baseline the same relative reduction would read 12.1 s.
+
+# Fourth round: re-profile after the three landings
+
+Clean baseline on the stacked build: **14,537 ms**, sd 1 ms over four reps. Three
+fresh fence windows, `-Buf default`, no SPM, no EP instrumentation, all three
+gated through `inspect_capture.py` as steady state with zero artifact dispatches
+and no tuner sweep:
+
+| window | fence | dispatches | span | round 2 |
+|---|---|---:|---:|---:|
+| one linear-attention block | `causal_conv` skip 40 | 240 | 76.91 ms | 148.40 ms |
+| one MoE block | `qmoe` skip 45 | 1,250 | 48.50 ms | 58.49 ms |
+| vision encoder | `multi_head_attention` skip 40 | 119 | 47.80 ms/layer | 47.80 ms/layer |
+
+Each decoder window is exactly one period: 73 `la_pf_scan` launches and one
+`causal_conv` in the first, one `topk_routing` in the second. Vision is a
+control -- nothing this round touched it, and it reproduced to within 1% on every
+row (`mha_flash_prefill` 20,369 us against 20,344), which is also what
+establishes that the box was in a comparable state for the two decoder windows.
+
+The vision capture had to be retried without `-Counters`. SPM worked for this
+window in round 2 and this time produced no `.rgp` at all, so SPM at 16K is
+unreliable rather than simply unavailable.
+
+## The block model now closes to 2%
+
+| block | count | round 2 | round 3 | delta |
+|---|---:|---:|---:|---:|
+| linear-attention | 30 | 4,452 | 2,307 | -2,145 |
+| MoE | 40 | 2,340 | 1,940 | -400 |
+| full-attention, `gqa` only | 10 | 2,240 | 2,240 | 0 |
+| vision layers | 27 | 1,291 | 1,291 | 0 |
+| **sum** | | **10,322** | **7,778** | **-2,545** |
+
+Against the interleaved A/B series, which moved TTFT 17,129 -> 14,312 for
+**-2,592 ms**, the captures predict -2,545 ms. That is 2% agreement between
+per-kernel GPU time and end-to-end wall time, across three independent changes,
+and it is the strongest validation the harness has produced. It also means the
+uncaptured remainder did not move, which is the assumption the block model needs.
+
+Per change, capture-predicted against realised:
+
+| change | capture predicts | realised | ratio |
+|---|---:|---:|---:|
+| channels-last conv + Transpose fold | -1,635 | -1,772 | 1.08 |
+| chunked bucketing | -348 | -348 | 1.00 |
+| LA window 16 | -551 | -674 | 1.22 |
+
+Realised meets or beats the capture in all three, which is the expected
+direction: RGP pegs clocks, so a saving measured under SQTT understates what the
+same saving is worth on a box running at production clocks.
+
+Note that the conv prediction here is -1,635 ms where the plan's was -2,334 ms
+and only 76% of it was realised. The plan's figure came from `[PERF]` call counts
+(60 Transpose dispatches at 26.7 ms), while the capture sees one such dispatch
+per linear-attention block, i.e. 30. Taking the capture instead, the prediction
+is -1,635 ms and the realised -1,772 ms *exceeds* it. So the "shortfall" recorded
+under step 1 was an artifact of counting, not a real underperformance.
+
+## Per-kernel deltas in one linear-attention block
+
+| kernel | round 2 | round 3 | delta |
+|---|---:|---:|---:|
+| `causal_conv_prefill` -> `_nlc` | 31.54 | 3.75 | -27.79 |
+| `transpose_tiled` (38.2M threads) | 26.70 | absent | -26.70 |
+| `la_pf_pass3_wmma` | 30.66 | 14.36 | -16.30 |
+| `la_pf_pass1_local` | 10.12 | 8.64 | -1.48 |
+| `la_pf_scan` | 15.89 | 15.31 | -0.58 |
+| `T5LayernormFwdContiguous` | 16.34 | 16.30 | -0.04 |
+| `cast_f32_to_f16` | 0.76 | 2.20 | **+1.44** |
+| everything else | 16.49 | 16.35 | -0.14 |
+| **total** | **148.40** | **76.91** | **-71.49** |
+
+The `cast_f32_to_f16` row is the one apparent regression and it is not one. At
+76,374,016 elements the kernel moves 458 MB, so 748 us implies 613 GB/s on a part
+whose roofline is 256 GB/s: round 2's number was **239% of achievable bandwidth**
+and therefore never real. Round 3's 2,180 us is 82% of roofline, which is a
+healthy figure for a streaming cast. The cause of the round-2 reading was not
+identified; it is 43 ms across the model either way, and the end-to-end A/B was
+strongly negative regardless.
+
+`bucket_tokens_kernel` is confirmed gone from the MoE window. Its replacement is
+three kernels totalling 138 us against 8,829 us, and the original's 256-thread
+launch geometry is visible directly in the dispatch record, which is what made
+that row the round-2 table's most clear-cut defect.
+
+## Grouping by family was hiding shapes
+
+The round-2 table ranked by kernel family, which averaged dispatches whose sizes
+differ by 100x. One linear-attention block runs `ew_bcast4d` at both 596,736 and
+76,374,016 threads, and `T5Layernorm` at both 76,374,016 and 152,748,032. A mean
+over those is not a shape, so a floor computed from it is not a floor.
+
+This matters most for the row the plan named as the next target. Round 2 gave
+`T5LayernormFwdContiguous` a floor from an assumed 298,336x128 = 38.2M elements,
+producing 16% utilisation and 505 ms recoverable. The dispatches are actually 2x
+and 4x that size, so the floor is 1.79 and 3.58 ms against measured 4.07 and
+8.15, i.e. **44% of roofline and 274 ms recoverable**, not 16% and 505 ms.
+
+The plan's *mechanism* for it survives: at 256 threads per workgroup the 76.4M
+shape is 298,336 workgroups in 4.07 ms, or 73 M/s, against the 167 M/s that
+reaching 256 GB/s would need. It is dispatch-rate bound as described, by 2.3x
+rather than 6x.
+
+The same correction shrinks `gather_tokens` + `scatter_add`: 55% and 83% of
+roofline for 124 ms recoverable, against the 201 ms round 2 claimed from a
+guessed shape.
+
+## Refreshed ranking
+
+Floors are `max(bytes/BW, FLOP/peak)` at 256 GB/s and 59.4 TFLOP/s, computed per
+*dispatch shape* from the capture's own thread counts.
+
+| kernel | calls | ms/call | total | floor | util | recoverable | confidence |
+|---|---:|---:|---:|---:|---:|---:|---|
+| `gqa_flash_prefill_v8` | 10 | 224.00 | 2,240 | 47.95 | 21% | 1,761 | upper bound |
+| `MatMulNBits` (MoE, all variants) | 40 blk | 32.63 | 1,305 | 15.80 | 48% | 673 | medium |
+| vision `mha_flash_prefill` | 27 | 20.37 | 550 | 4.13 | 20% | 438 | upper bound |
+| vision `gemm` (Tensile) | 27 lyr | 14.81 | 400 | 3.74 | 25% | 299 | high |
+| `T5LayernormFwdContiguous` | 90 | 5.43 | 489 | 2.39 | **44%** | **274** | high |
+| `strided_copy` (16.8M) | 90 | 1.58 | 143 | 0.26 | **17%** | **119** | high |
+| `gather_tokens` | 40 blk | 5.09 | 204 | 2.81 | 55% | 91 | high |
+| `ew_bcast4d` f32 (76.4M) | 30 | 5.18 | 156 | 2.39 | 46% | 84 | high |
+| `causal_conv_prefill_nlc` | 30 | 3.75 | 113 | 2.39 | 64% | 41 | high |
+| `scatter_add` | 40 blk | 5.02 | 201 | 4.19 | 83% | 33 | high |
+| `cast_f16_to_f32` (76.4M) | 30 | 2.47 | 74 | 1.79 | 72% | 20 | high |
+| `ew_bcast4d` f16 (38.2M) | 30 | 1.05 | 31 | 0.60 | 57% | 14 | high |
+| `cast_f32_to_f16` (76.4M) | 30 | 2.18 | 65 | 1.79 | 82% | 12 | high |
+| `swiglu` | 40 blk | 1.10 | 44 | 1.05 | 95% | 2 | high |
+
+Recoverable: **994 ms high confidence**, 673 ms medium, 2,199 ms
+upper-bound-only.
+
+The three linear-attention passes stay measured-only, because a defensible FLOP
+count for the chunked scan still could not be derived:
+
+| kernel | calls | ms/call | total | round 2 |
+|---|---:|---:|---:|---:|
+| `la_pf_scan` | 2,190 | 0.2097 | 459 | 477 |
+| `la_pf_pass3_wmma` | 2,190 | 0.1967 | 431 | 920 |
+| `la_pf_pass1_local` | 2,190 | 0.1184 | 259 | 304 |
+| **total** | | | **1,149** | **1,700** |
+
+`matmul_nbits_add_bias_rowmajor` is listed without a floor: at any traffic model
+consistent with its arguments its measured 2.93 ms/block is faster than the
+implied floor, so `threads` is not its element count and the floor cannot be
+derived from the capture alone.
+
+## What changed about the ranking
+
+The second round's headline was that data movement had overtaken GQA. That has
+reversed. High-confidence recoverable data movement fell from 3,563 ms to 994 ms,
+and `gqa_flash_prefill_v8` is once again the largest single line by a factor of
+1.8 over everything else combined.
+
+Both of the round-2 table's top data-movement rows are gone: `transpose_tiled`
+was 1,602 ms at 2% of roofline and no longer runs at that shape, and
+`causal_conv_prefill` was 946 ms at 8% and is now 113 ms at 64%.
+
+Three observations for whoever picks the next target:
+
+- **`gqa_flash_prefill_v8` is 2,240 ms and its floor is not known.** Its 1,761 ms
+  is an upper bound that omits softmax, and ablation already showed softmax is
+  41.1 ms of the kernel's 203 ms, so the true floor is far above 47.95 ms. Sizing
+  this honestly needs a softmax-inclusive model, not another roofline.
+- **`strided_copy` is the worst-utilised kernel left at 17%**, but it is only
+  119 ms. It is the best ratio of confidence to effort on the board.
+- **The MoE `MatMulNBits` row is now second largest and it is a real GEMM.** 48%
+  of roofline on int4 weights is not obviously improvable, and the round-3 window
+  shows the autotuner picked `WMMA_NoZP` where round 2 picked `Fp16GEMM` for many
+  shapes, so about 1.3 ms/block of the MoE delta is autotune reshuffling rather
+  than the bucketing change.
+
+Stopping here for target selection rather than assuming this ranking implies the
+next move.
+
+## Reproducing round 4
+
+```powershell
+. C:\Users\zyq\hipep-env.ps1
+Remove-Item Env:HIPDNN_EP_TRACE_FILE,Env:HIPDNN_EP_PERF,Env:HIPDNN_EP_DEBUG -EA SilentlyContinue
+
+.\bench\bench_ttft.ps1 -Tag p3-stack-clean -Driver vlm -SeqLen 18646 `
+  -MaxLength 18900 -Reps 4 -Warmup 1 -ExecutionProvider AMDGPU
+
+# one window per fence; drop -Counters, SPM produced no .rgp for vision this time
+foreach ($f in 'causal_conv','qmoe','multi_head_attention') {
+  .\capture\rgp_capture.ps1 -Op $f -Skip 40 -Driver vlm -Reps 3 `
+    -PromptFile C:\Users\zyq\prompt_16k.txt -SeqLen 16384 -MaxLength 18900 `
+    -ExecutionProvider AMDGPU -MaxTokens 1 -Buf default `
+    -ArmTimeoutSec 900 -Dwell 40 -Tag "p3_$f"
+}
+```
+
+`qmoe` needs `-Skip 45`, not 40. The per-shape tables come from `shape_table.py`
+and `moe_plumbing.py`, which sit beside `qwen_floors.py` in the captures
+directory; they group by `(kernel, threads)` from `*_dispatches.csv` rather than
+by family, which is the distinction that produced the corrected floors above.

--- a/docs/perf/qwen36-16k-bottleneck.md
+++ b/docs/perf/qwen36-16k-bottleneck.md
@@ -306,20 +306,24 @@ The likely cause is that the first-round run was instrumented. Enabling
 `HIPDNN_EP_TRACE_FILE` on the current build measures **17,545 ms**, which matches
 the unexplained 17,587 ms to 0.24%.
 
-**`Clear-HarnessProfilingEnv` cannot prevent this.** It removes `HIPDNN_EP_PERF`
-and `HIPDNN_EP_DEBUG` only:
+**`Clear-HarnessProfilingEnv` could not prevent this.** It removed
+`HIPDNN_EP_PERF` and `HIPDNN_EP_DEBUG` only:
 
 ```powershell
-# tools/perf-harness/common.ps1
+# tools/perf-harness/common.ps1, before the fix
 Remove-Item Env:HIPDNN_EP_PERF, Env:HIPDNN_EP_DEBUG -EA SilentlyContinue
 ```
 
 But `hipdnn_ep_perf_enabled()` is true if **either** `HIPDNN_EP_PERF` is set *or*
 `HIPDNN_EP_TRACE_FILE` is non-empty (`lib/Runtime/debug_log.h:41-44`). A leaked
-`HIPDNN_EP_TRACE_FILE` therefore turns on full instrumentation, costs ~21% of
-TTFT, and no harness script clears it. It should be added to that list. Nothing
-is set at User or Machine scope on this box, so the leak would have been
-per-shell.
+`HIPDNN_EP_TRACE_FILE` therefore turned on full instrumentation, cost ~21% of
+TTFT, and no harness script cleared it. Nothing is set at User or Machine scope
+on this box, so the leak was per-shell.
+
+`HIPDNN_EP_TRACE_FILE` is now in that list, and the variable is worth treating
+as the dangerous one of the three: unlike `HIPDNN_EP_PERF` it prints nothing to
+the console, so an instrumented run is indistinguishable from a clean one except
+by its number.
 
 ## KV-cache oversizing is real but small
 
@@ -498,3 +502,121 @@ $env:HIPDNN_EP_TRACE_FILE = 'C:\Users\zyq\logs\eptrace\qwen16k.json'
 being the obvious guess), on `causal_conv` or `qmoe` for the decoder, and note
 that fencing on `gqa` wastes the window because that one kernel fills the buffer
 by itself.
+
+The numeric suite needs `profile=hip`, which is easy to miss because leaving it
+out fails with `Conflicting session configuration: explicitly added the CPU EP`
+rather than with anything about profiles. The real error is one frame further in:
+`amdgpu EP: no backend available for the requested profile`. The EP defaults to
+`Profile::Auto`, which resolves a backend only in a build carrying `USE_DML` or
+`USE_MIGRAPHX`; provider creation fails without one, and ORT then falls back to
+CPU, which is what actually trips `disable_cpu_ep_fallback`.
+
+```powershell
+cd test\numeric
+& $env:HIPEP_PY -m pytest -c pytest.ini --rootdir . tests\test_causal_conv_with_state.py `
+  --backend ort_ep --ep-name AMDGPUExecutionProvider `
+  --ep-dll "$env:HIPEP_BIN\amdgpu-ep.dll" --ep-option profile=hip -q
+```
+
+# Third round: landing the prepared work
+
+The second round's top targets already had implementations on unlanded branches.
+This round integrates them one at a time and measures each at 16K, which none of
+them had been.
+
+## Absolute TTFT moved, and it was the box
+
+Today's clean baseline is **17,129-17,481 ms**, about 19% above the
+14,455-14,610 ms recorded a few hours earlier from the same source. The gap is
+machine state, not a regression, and three things establish that:
+
+- It appeared across an unrelated reboot (02:37) that separates the two sets of
+  runs. Nothing in `lib/` differs.
+- It is not confined to prefill. Decode moved 19.70 -> 23.27 ms/token and
+  CPU-side image preprocessing moved 154 -> 191 ms, so the whole SoC is slower,
+  not one kernel.
+- It scales with sequence length: 4K is +8.9% where 16K is +20.1%, which is the
+  signature of reduced memory bandwidth rather than a flat clock drop.
+
+Instrumentation was ruled out directly: zero `[PERF]` lines in the run logs and
+no trace file written. The `Ultimate Performance` power plan was tried and made
+things *worse* (4K: 4,398 ms against 4,186 ms on `Balanced`), which is consistent
+with a shared-TDP APU where keeping cores unparked steals budget from the iGPU.
+The cause was not identified further.
+
+**None of this affects the deltas below**, because every one is a paired
+interleaved A/B where both arms run in the same window. It does mean the absolute
+figures here cannot be compared against the second round's.
+
+Run-to-run spread today is tight: 17,360 and 17,481 ms on repeat baseline runs
+(121 ms, 0.7%), and 145 ms as the sd of paired differences across four rounds.
+
+## Two harness defects that would have hidden the result
+
+**`build_deploy.ps1` did not deploy `hip-compiler.dll`.** Every MLIR pass, fold
+and canonicalization lives there, not in `hipgpu.dll`. The causal-conv Transpose
+fold is entirely a canonicalization, so deploying the old pair would have shipped
+the new conv *kernel* while silently discarding the fold, and reported the
+Transpose elimination as worthless. Confirmed by symbol lookup:
+`FoldTransposePairIntoChannelsLast` resolves in `hip-compiler.dll` and is absent
+from `hipgpu.dll`.
+
+This is worse than a stale kernel because it is invisible. A graph-level change
+lowers to the same runtime entry points, so the run is correct and merely misses
+the rewrite.
+
+**`ab_interleaved.ps1` swapped one DLL per arm**, which cannot express a change
+spanning the kernel and the compiler. Arms now take a `dlls` list, and the script
+refuses arms that do not list the same file names -- a file swapped by one arm
+but not another persists into the next run and reads as a real effect.
+
+## Step 1: channels-last causal convolution
+
+Landed as [#722](https://github.com/ROCm/hip-ep/pull/722). Interleaved
+order-reversed A/B, 3 reps per run:
+
+| round | order | base | conv | delta |
+|---|---|---:|---:|---:|
+| 1 | base first | 17,217 | 15,253 | -1,964 |
+| 2 | base first | 17,221 | 15,495 | -1,726 |
+| 4 | conv first | 16,959 | 15,341 | -1,618 |
+| 5 | conv first | 17,118 | 15,337 | -1,781 |
+
+**-1,772 ms (-10.35%), 95% CI [-2,002, -1,542]**, better in all four rounds and
+in both orderings. The op profile confirms the mechanism independently: 100
+`transpose` calls become 40, with `causal_conv` unchanged at 30.
+
+Against the round-2 prediction of 2,334 ms (1,459 recoverable on transpose plus
+875 on the conv), the realised 1,772 ms is 76%. The roofline floor assumes a
+pegged clock, and today's box is not that, so the shortfall is expected rather
+than surprising.
+
+The fold needed one fix before landing. It set `channels_last` without checking
+the kernel width, and only the custom prefill kernel can read `[B, L, C]` -- the
+MIOpen path behind it refuses the attribute rather than misreading the buffer. On
+a k > 8 convolution the fold therefore turned a working graph into a hard runtime
+failure. It now guards on the same envelope the runtime enforces.
+
+## Step 2: chunked MoE token bucketing
+
+Measured on top of step 1, so the baseline arm here is the channels-last build:
+
+| round | order | conv | bucket | delta |
+|---|---|---:|---:|---:|
+| 1 | conv first | 15,197 | 14,880 | -317 |
+| 2 | conv first | 15,266 | 14,874 | -392 |
+| 3 | bucket first | 15,451 | 15,097 | -354 |
+| 4 | bucket first | 15,417 | 15,087 | -330 |
+
+**-348 ms (-2.27%), 95% CI [-401, -296]**, sd of paired differences 33 ms.
+
+This is the round-2 table's cleanest prediction and it landed almost exactly:
+353 ms predicted, 348 ms realised. That is the expected outcome for this row and
+not luck -- `bucket_tokens_kernel` was not bandwidth-limited but
+dispatch-limited, running in a single 256-thread workgroup on 1 of 40 CUs, so
+there was no clock-dependent floor to fall short of.
+
+Worth noting for the record: the branch itself predicted this would *not* be
+resolvable end-to-end, having been measured at 4K where the effect is ~71 ms
+against a ±200 ms noise floor. At 16K the same defect costs 5x more while the
+noise floor is unchanged, which is what makes it measurable.

--- a/docs/perf/qwen36-16k-bottleneck.md
+++ b/docs/perf/qwen36-16k-bottleneck.md
@@ -1,0 +1,500 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+# Qwen3.6-35B-A3B 16K prefill: where the time actually goes
+
+SQTT (RGP) profile of a 16K VLM prefill, taken on repaired model weights. This
+supersedes the withdrawn attribution in `qwen36-ttft-attribution.md`, which was
+measured against a half-zeroed `text.onnx.data`.
+
+## Operating point and build
+
+`vlm_benchmark.py` with `dog.jpg` and `prompt_16k.txt`: **18,646 prompt tokens**
+(16,823 text, 1,823 image), `max_length 33024`, `-e AMDGPU`. Build is
+`feat/rgp-capture-fence-v2` with all three binaries redeployed together
+(`hipgpu.dll`, `custom_kernels_gfx1151.dll`, `hip-compiler.dll`).
+
+Uninstrumented TTFT at this point is **19,526 ms** (3 reps, stddev 293 ms)
+against CI's 16,702 ms at 18,755 tokens. The attribution below is all measured at
+that baseline; the v8 prefill kernel has since been optimised.
+
+> **The 17,587 ms post-optimisation figure quoted below is not reproducible and
+> should not be used.** The same binaries and the same `max_length 33024` now
+> measure **14,734 ms**, and 14,455-14,610 ms with a right-sized KV cache. See
+> "Second profiling round" for the current baseline and for why that number was
+> probably instrumented.
+
+Fitting the 4K and 16K points for each environment separates startup from
+throughput:
+
+| | fixed | per token |
+|---|---:|---:|
+| local, as first measured | 634 ms | 1.013 ms |
+| local, warm and verified clean | 940 ms | **0.729 ms** |
+| CI | 1,016 ms | 0.836 ms |
+
+The first local row was fitted on runs that are now believed to be instrumented.
+On the clean re-measurement local starts up slower than CI but is 13% *faster*
+per token, so on these figures the per-token gap to CI has closed and reversed.
+
+## The layer stack
+
+Op call counts per prefill: `qmoe` 40, `matmul_nbits` 391, `causal_conv` 30,
+`linear_attention` 30, `gqa` 10. That is a 40-layer hybrid stack: 30
+linear-attention layers and 10 full-attention layers, every layer with its own
+MoE block.
+
+Each capture window contains exactly one `topk_routing` and one
+`bucket_tokens`, i.e. exactly one MoE block, which confirms one window equals
+one layer and lets per-layer cost be scaled by layer count.
+
+## Per-layer cost
+
+**Full-attention layer — 463.8 ms GPU busy, 943 dispatches, 0.5% idle**
+
+| kernel | count | total ms | % layer | occ | limiter | bound |
+|---|---:|---:|---:|---:|---|---|
+| `gqa_flash_prefill_v8_kernel` | 1 | 386.6 | 83.3 | 25% | LDS | latency/low-occupancy |
+<!-- The v8 row is the pre-optimisation measurement. It has since been cut to
+     203.9 ms/call uninstrumented; see "Optimising the v8 prefill kernel" below,
+     which also explains why its *instrumented* cost barely moved. -->
+
+| `MatMulNBitsFp16GEMM` | 61 | 29.1 | 6.3 | 55% | VGPR | undetermined |
+| `MatMulNBitsWMMA_NoZP` | 189 | 15.1 | 3.3 | 69% | VGPR | undetermined |
+| `bucket_tokens_kernel` | 1 | 8.9 | 1.9 | 100% | - | undetermined |
+
+**Linear-attention layer — 122.2 ms GPU busy, 490 dispatches, 1.4% idle**
+
+| kernel | count | total ms | % layer |
+|---|---:|---:|---:|
+| `la_pf_pass3_wmma` | 37 | 30.8 | 25.2 |
+| `MatMulNBitsFp16GEMM` | 24 | 20.4 | 16.7 |
+| `la_pf_scan` | 37 | 16.0 | 13.1 |
+| `la_pf_pass1_local` | 37 | 10.4 | 8.5 |
+| `T5LayernormFwdContiguous` | 2 | 9.4 | 7.7 |
+| `bucket_tokens_kernel` | 1 | 8.8 | 7.2 |
+| `ew_bcast4d_kernel` | 1 | 5.2 | 4.3 |
+| `cast_f16_to_f32` + `cast_f32_to_f16` | 2 | 5.0 | 4.1 |
+
+The 37 repeats of each `la_pf_*` pass are the chunked scan over 18,646 tokens,
+so all 37 belong to a single `linear_attention` op.
+
+## Whole-prefill budget
+
+Scaling measured per-call cost by call count:
+
+| item | per call | calls | total ms |
+|---|---:|---:|---:|
+| `gqa_flash_prefill_v8` | 386.6 ms | 10 | 3,866 |
+| `gqa_flash_prefill_v8`, after optimisation | 203.9 ms | 10 | 2,039 |
+| linear attention (3 passes) | 57.2 ms | 30 | 1,716 |
+| dense `MatMulNBits` (all variants) | - | - | ~1,050 |
+| `bucket_tokens` | 8.8 ms | 40 | 352 |
+| `topk_routing` | 1.2 ms | 40 | 48 |
+| **10 full-attention layers, whole layer** | 463.8 ms | 10 | **4,638** |
+| **30 linear-attention layers, whole layer** | 122.2 ms | 30 | **3,666** |
+
+Modelled decoder GPU busy is therefore about **8,304 ms**, against a 19,526 ms
+TTFT. The captures cover the decoder only; the remainder is the vision encoder,
+the embedding model, `lm_head` and host time, none of which were captured. Do
+not read the 8,304 ms as a complete TTFT decomposition.
+
+> Superseded by "Second profiling round", which measures all three sessions. The
+> vision encoder is 1.2 s, the embedding model 78 ms, and `lm_head` is not a cost
+> at all: `text.onnx` already emits `logits` as `[batch, 1, 248320]`, so it is
+> last-row-only. Host time and idle gaps together are under 20 ms.
+
+## Conclusions
+
+**The prefill is GPU-bound, not launch-bound.** Idle is 0.5% over 943
+dispatches in the full-attention window and 1.4% over 490 in the
+linear-attention window, with total launch overhead of 33.5 us and 9.9 us
+respectively. The earlier claim that ~85% of TTFT was host-side kernel-launch
+overhead does not survive contact with SQTT on a correct model.
+
+**The single largest kernel is `gqa_flash_prefill_v8_kernel`** at 386.6 ms per
+call and 3.9 s across the ten full-attention layers. It is the only kernel the
+parser classes as `latency/low-occupancy`: 25% occupancy with **LDS as the
+binding resource**. Its cost is cleanly quadratic in sequence length (17.0
+ms/call at 3,985 tokens against 361 ms/call at 18,646, a 21.2x rise for a 21.9x
+rise in n^2), and the runtime's own uninstrumented autotune independently
+measures 361.4 ms/call for the winning config, so the SQTT figure is not an
+instrumentation artifact.
+
+This kernel has since been cut to 203.9 ms/call, taking TTFT to 17,587 ms. The
+`latency/low-occupancy` classification turned out to be a red herring: raising
+occupancy makes it slower, and the win came from removing redundant per-wave work.
+Note also that once `BKV=16` won, the SQTT per-call figure *did* become an
+instrumentation artifact, for the reason given in that section.
+
+**The most egregious inefficiency is `bucket_tokens_kernel`.** It launches a
+*single* 256-thread workgroup, 8 wavefronts, and holds the GPU for 8.8 ms:
+
+```
+bucket_tokens_kernel   threads: 256   workgroup: 256   wavefronts: 8      dur: 8,822.7 us
+topk_routing_kernel    threads: 4,773,376        wavefronts: 149,168      dur: 1,227.7 us
+```
+
+Every other kernel in the MoE block is massively parallel; this one serialises
+the whole device. At 40 layers it is ~350 ms, and it is followed by the largest
+idle gap in either capture (1.0 ms, and 4.0 ms in the full-attention window).
+`origin/perf/qwen-bucket-tokens` already carries a chunked rewrite of exactly
+this kernel and is the obvious thing to re-measure first.
+
+**Ten full-attention layers cost more than thirty linear-attention layers**
+(4,638 ms against 3,666 ms), so attention-shape work, not layer count, sets the
+scaling.
+
+## Optimising the v8 prefill kernel
+
+The kernel above was then optimised directly. Result at the same operating point:
+
+| | before | after |
+|---|---:|---:|
+| per call, uninstrumented (runtime autotune, sq=18646) | 361.4 ms | **203.9 ms** |
+| per call, standalone microbenchmark | 348.1 ms | **203.4 ms** |
+| per call, SQTT-instrumented | 386.6 ms | 380.8 ms |
+| config (ND, MT, BKV) | 4, 1, 32 | 2, 1, 16 |
+| VGPRs / LDS bytes | 192 / 26112 | 240 / 11264 |
+| occupancy / limiter | 25.0% / LDS | 31.2% / LDS |
+| workgroup / wavefronts | 128 / 74,624 | 64 / 37,312 |
+| **16K TTFT** (3 reps) | **19,526 ms** (sd 293) | **17,587 ms** (sd 286) |
+
+**43% off the kernel and 1,939 ms (9.9%) off TTFT.** Accuracy improved at the same
+time: `relL2` against the CPU reference went from 5.7e-04 to 3.3e-04 at sq=2048.
+
+### Do not use the SQTT per-call time to A/B this kernel
+
+The instrumented cost moved 1.5% while the uninstrumented cost fell 43%. The
+instrumented figure is the artifact: SQTT overhead scales with instruction issue,
+and the winning config uses `BKV=16`, which doubles the KV-tile trip count (583
+tiles per block instead of 292) for half the work per tile. Three independent
+uninstrumented measurements agree with each other and not with SQTT — the
+standalone microbenchmark, the runtime's own autotune inside the real process, and
+end-to-end TTFT. A 5.8 ms/call improvement over 10 calls cannot produce a 1,939 ms
+TTFT drop, so SQTT is what is wrong here, not the other three.
+
+### Occupancy was the wrong target
+
+The premise going in was that 25% occupancy with LDS as the binding resource was
+the problem. It was not. Measured at sq=18646, with compiler register/LDS figures
+from `-Rpass-analysis=kernel-resource-usage`:
+
+| cfg | vgpr | spill | occupancy | ms/call |
+|---|---:|---:|---:|---:|
+| 2,1,16 | 239 | 0 | 37.5% | **204** |
+| 4,1,16 | 135 | 0 | 62.5% | 219 |
+| 4,1,32 | 175 | 0 | 50.0% | 249 |
+| 8,1,16 | 82 | 0 | 100.0% | 276 |
+
+Occupancy is inversely correlated with speed across this whole sweep. The fully
+occupant config is 35% slower than the winner, because occupancy here is a
+function of `ND`, and raising `ND` adds cross-wave score-reduction traffic and
+per-wave softmax cost that outweigh the extra residency. The final kernel is still
+LDS-limited at 31.2% and that is fine. Six of the eleven instantiated configs also
+spill (up to 768 registers), which no occupancy figure reveals — spilling
+configurations had been sitting in the autotune candidate list.
+
+### What actually paid, in order
+
+1. **`BKV=16`** (absent from the candidate table). 348 -> 248 ms. Halves `V_lds`.
+2. **Stop repeating the softmax in every wave.** The ablation mask showed softmax
+   was 136 ms of 348 ms, and all `ND` waves computed it identically. Splitting its
+   rows `ND` ways: 248 -> 215 ms. Handing it to one wave instead was tried first
+   and is worse — the other waves then idle at the barrier while that copy sits on
+   the critical path.
+3. **fp32 accumulator.** The WMMA accumulator is already fp32, so keeping `O` in
+   fp16 meant unpacking and repacking every tile. 215 -> 204 ms, and it is the
+   accuracy improvement above.
+4. **Pruning the candidate list** to non-spilling configs, which also cut the
+   first-call autotune sweep from 11 candidates to 4 (~40 s each at this shape).
+
+### What was measured and rejected
+
+- **Reducing the 3 barriers per KV tile.** Ablating all three (mask bit 32) saves
+  5.5 ms of 203 ms, so the restructuring the barriers would need cannot pay.
+- **Skipping the `O` rescale when `corr == 1.0`**, which is most tiles once the
+  running max settles: 0.3%, inside run-to-run noise. Those fp32 multiplies hide
+  behind the tile's memory traffic.
+- **Compacting `Sp_lds`.** Aimed at buying occupancy headroom, which the table
+  above shows is not worth buying. It is also only ~10% of the kernel's LDS
+  traffic, against `V_lds`'s 16 KB per tile.
+- **`ND=8` with `__launch_bounds__`** to force `vgpr <= 128`: reaches 100%
+  occupancy and is the slowest config measured.
+
+### Where the remaining 203 ms sits
+
+By ablation at the shipped config (`HIPDNN_PREFILL_V8_ABLATE`, bit per phase):
+
+| phase | cost | share |
+|---|---:|---:|
+| value GEMM | 45.8 ms | 23% |
+| softmax | 41.1 ms | 20% |
+| V staging | 37.2 ms | 18% |
+| score GEMM | 19.9 ms | 10% |
+| K loads | 13.2 ms | 7% |
+| barriers | 5.5 ms | 3% |
+
+No single phase dominates any more, which is why this stopped here. The largest
+remaining structural cost is that the value GEMM's `V` fragment needs 16
+consecutive `kv` values at a fixed `d`, while the KV cache is `[B,G,seq,d]` — so
+each fragment is a 16-instruction strided LDS gather. Storing `V` d-major would
+make it two contiguous loads, but that is a KV-cache layout change spanning the
+append/concat/decode kernels, not a change to this kernel.
+
+### Reproducing
+
+`test_gqa_prefill.cpp` gained the Qwen d=256 shapes (nothing covered the v8 kernel
+before, so it had no correctness test at all) plus `--sq`, `--only`, and
+`--dump`/`--ref` for checking a kernel change against a previous build's output at
+sq=18646, where a CPU reference is infeasible. Two env knobs were added:
+`HIPDNN_PREFILL_V8_CFG="ND,MT,BKV"` pins a config, and
+`HIPDNN_PREFILL_V8_ABLATE` drives the in-kernel ablation mask, which previously
+had no reachable caller.
+
+## What could not be measured, and why
+
+No bound class is better than `compute-or-memory (undetermined)` for anything
+except the GQA kernel, because SPM counters had to be dropped. Per
+`tools/rgp_parser/README.md` the SQTT buffer, the SPM counter buffers and the
+model's activations all compete for the same physical memory on a shared-memory
+APU. With `--rgp-counter-collection` on at 16K the workload slowed so far that
+the fence could not arm inside a 10-minute window; without SPM it armed
+normally. Separating memory-bound from compute-bound at 16K would need a bigger
+memory budget than this box has.
+
+Two further limits found the hard way:
+
+- `--rgp-sqtt-buffer-size minimum` is enough for an MoE block (56 MB, 179
+  dispatches) but **not** for a full-attention layer: the 386 ms attention
+  kernel's token stream produced `TraceError` chunks and `sqtt=0`, an unusable
+  capture. `default` works and yields 180 MB and 943 dispatches. `maximum`
+  remains untested here and is documented as wedging the workload.
+- The harness's fence-arm deadline was hardcoded to 600 s, which a 16K VLM
+  cannot meet: model load, the per-process prefill autotune sweep and a cold
+  first rep all precede the fence. It is now the `-ArmTimeoutSec` parameter.
+
+The box hard-faulted once during this work (bugcheck `0x7F`, double fault); an
+identical bugcheck is in the event log from earlier the same day, so it is a
+recurring failure mode at this operating point rather than something a single
+capture caused. Model weights were re-verified against the CI share afterwards
+and are intact.
+
+# Second profiling round: the whole TTFT
+
+The first round fenced on one decoder op and modelled the decoder from two
+single-layer windows, covering 8,304 ms of a 19,526 ms TTFT. This round measures
+all three ONNX sessions and re-establishes the baseline. It changes the answer.
+
+## The baseline was wrong, and the harness cannot prevent that
+
+| tag | max_length | TTFT | within-run sd |
+|---|---:|---:|---:|
+| `gqa_v8_opt_16k` (first round) | 33,024 | 17,587 ms | 286 ms |
+| `p0-16k-33k` (same binaries, same config) | 33,024 | **14,734 ms** | 77 ms |
+| `p0-16k-tight` | 18,900 | **14,610 ms** | 15 ms |
+| `p0-16k-tight-r2` | 18,900 | **14,455 ms** | 14 ms |
+
+Warm between-run spread is 155 ms (1.1%) and within-run 14 ms, so the 2,853 ms
+gap to the first-round number is not noise. Neither is it the kernel: the GQA
+autotune measured 223.5, 224.1 and 233.3 ms/call across these runs, and decode
+was *faster* in the slow run (19.93 against 20.09 ms/token), which rules out
+thermal throttling.
+
+The likely cause is that the first-round run was instrumented. Enabling
+`HIPDNN_EP_TRACE_FILE` on the current build measures **17,545 ms**, which matches
+the unexplained 17,587 ms to 0.24%.
+
+**`Clear-HarnessProfilingEnv` cannot prevent this.** It removes `HIPDNN_EP_PERF`
+and `HIPDNN_EP_DEBUG` only:
+
+```powershell
+# tools/perf-harness/common.ps1
+Remove-Item Env:HIPDNN_EP_PERF, Env:HIPDNN_EP_DEBUG -EA SilentlyContinue
+```
+
+But `hipdnn_ep_perf_enabled()` is true if **either** `HIPDNN_EP_PERF` is set *or*
+`HIPDNN_EP_TRACE_FILE` is non-empty (`lib/Runtime/debug_log.h:41-44`). A leaked
+`HIPDNN_EP_TRACE_FILE` therefore turns on full instrumentation, costs ~21% of
+TTFT, and no harness script clears it. It should be added to that list. Nothing
+is set at User or Machine scope on this box, so the leak would have been
+per-shell.
+
+## KV-cache oversizing is real but small
+
+`max_length 33024` for an 18,646-token prompt allocates 77% more KV cache than
+the prompt needs, and it does show up: peak RSS 1,365 MB against 1,103 MB, a
+262 MB difference that matches the KV geometry. But the TTFT cost is only
+**124-280 ms** (14,734 against 14,455-14,610), about 1-2%. The hypothesis that
+this explained seconds of TTFT is falsified.
+
+## Whole-TTFT session decomposition
+
+`HIPDNN_EP_TRACE_FILE` writes one Chrome trace per session on a shared absolute
+`steady_clock`, so all three sessions lie on one timeline. Merged with
+`tools/perf-report/merge_chrome_traces.py` (no `--zero`), the warm iteration is:
+
+| bucket | ms | share |
+|---|---:|---:|
+| decoder session | 16,209.5 | 92.4% |
+| vision session | 1,229.9 | 7.0% |
+| embedding session | 77.9 | 0.4% |
+| inter-session gaps | 15.9 | 0.1% |
+| host inside session windows | 3.6 | 0.02% |
+| **wall, first start to last end** | **17,533.2** | |
+
+Against a 17,544.7 ms instrumented TTFT, that accounts for all but 11.5 ms
+(0.07%). **The prefill is essentially 100% GPU kernel time**: there is no host
+bottleneck, no launch-bound region and no idle to recover. This is the same
+conclusion the first round reached from idle percentages, now established for the
+whole TTFT rather than two windows.
+
+The vision encoder is measured here for the first time. At 1.2 s it is 7% of
+TTFT, not the multi-second unknown it was assumed to be. Its cost is dominated by
+`mha_flash_prefill` and Tensile GEMMs, and it is still worth noting that the
+config fix keeping it on the GPU is load-bearing: with `session_options` present
+on the `vision` entry, ORT silently runs all 4,154 of its nodes on
+`CPUExecutionProvider` for 29.2 s of node time.
+
+## The EP's own per-op timings are not usable for attribution
+
+The `[PERF]` table is not merely inflated, its **per-op attribution is wrong**.
+Checked against RGP windows taken with no EP instrumentation:
+
+| op | `[PERF]` ms/call | RGP ms/call | error |
+|---|---:|---:|---|
+| vision `gemm` (7296x1152x4304) | 4.43 | 4.61 | agrees |
+| vision `gemm` (7296x4304x1152) | 4.23 | 4.23 | agrees |
+| `causal_conv` | 30.6 | 31.5 | agrees |
+| `gqa` | 27.2 | 380.0 | **14x low** |
+| vision `multi_head_attention` | 0.56 | 20.34 | **36x low** |
+| `linear_attention` | 8.6 | 56.7 | 6.6x low |
+| vision `slice` | 5.68 | 0.34 | **17x high** |
+| `cast` (596672) | 46.4 | 1.23 | **38x high** |
+
+`[PERF]` puts vision MHA at 0.56 ms/call when that call is 245 GFLOP, whose floor
+at 59.4 TFLOP/s is 4.13 ms — below the hardware limit, so it is provably wrong
+rather than merely noisy.
+
+The mechanism is the timing model. GPU time is the gap between consecutive
+fenceless event markers on the in-order stream, so an op that blocks the host and
+drains the queue is charged for work that was already outstanding. `slice` and
+`cast` are exactly that: `slice`'s CPU time equals its GPU time (594 against
+614 ms) and the vision session issues 199 `readback_scalar` calls, so those ops
+absorb the attention and GEMM work queued ahead of them.
+
+The practical rule: take **call counts and shapes** from `[PERF]`, since those are
+plain counters, and take **all timing** from RGP. The "`transpose` is 25.7% and
+`cast` is 21.4% of the decoder" reading that this table first produced does not
+survive; `cast` is ~74 ms over the whole prefill, not 3,473 ms.
+
+## Ranked by recoverable time
+
+Per-call times from three RGP windows fenced on `multi_head_attention` (vision),
+`gqa`, `causal_conv` and `qmoe`, all with `-Buf default`, no SPM and no EP
+instrumentation; all four gated through `inspect_capture.py` as steady state.
+Floors are `max(bytes/BW, FLOP/peak)` at 256 GB/s and 59.4 TFLOP/s, computed per
+shape by `qwen_floors.py` alongside the captures.
+
+| kernel | calls | ms/call | total ms | floor | util | recoverable | confidence |
+|---|---:|---:|---:|---:|---:|---:|---|
+| `gqa_flash_prefill_v8` | 10 | 224.00 | 2,240 | 47.95 | 21% | 1,761 | upper bound |
+| `transpose_tiled` (18646x8192) | 60 | 26.70 | 1,602 | 2.39 | **9%** | **1,459** | high |
+| `causal_conv_prefill` | 30 | 31.54 | 946 | 2.39 | **8%** | **875** | high |
+| `MatMulNBits` (MoE, all variants) | 40 blk | 32.77 | 1,311 | 15.80 | 48% | 679 | medium |
+| `T5LayernormFwdContiguous` | 111 | 5.45 | 605 | 0.90 | 16% | 505 | high |
+| vision `mha_flash_prefill` | 27 | 20.34 | 549 | 4.13 | 20% | 438 | upper bound |
+| `bucket_tokens_kernel` | 40 | 8.83 | 353 | ~0 | **0%** | **353** | high |
+| vision `gemm` (Tensile) | 27 lyr | 14.81 | 400 | 3.74 | 25% | 299 | high |
+| `gather_tokens` + `scatter_add` | 40 blk | 9.80 | 392 | 4.77 | 49% | 201 | medium |
+| `cast_f16_to_f32` (596672) | 60 | 1.23 | 74 | 0.01 | 1% | 73 | high |
+
+Rows marked `blk` are per MoE block and `lyr` per vision layer, aggregating the
+several kernel launches of that kind inside one block or layer; every other row is
+per individual dispatch.
+
+Recoverable totals: **3,563 ms high confidence** (all pure data movement),
+880 ms medium, 2,198 ms upper-bound-only.
+
+Two rows carry a floor that omits real work and so must not be ranked against the
+rest. Both attention kernels do softmax, whose transcendentals and reductions are
+absent from `max(bytes/BW, FLOP/peak)`; for the v8 kernel, ablation already showed
+softmax is 41.1 ms of its 203 ms, so its true floor is far above 47.95 ms.
+
+The three linear-attention passes are reported measured-only, because a defensible
+FLOP count for the chunked scan could not be derived:
+
+| kernel | calls | ms/call | total ms |
+|---|---:|---:|---:|
+| `la_pf_pass3_wmma` | 1,110 | 0.829 | 920 |
+| `la_pf_scan` | 1,110 | 0.430 | 477 |
+| `la_pf_pass1_local` | 1,110 | 0.274 | 304 |
+| **total** | | | **1,700** |
+
+## Block model against measured TTFT
+
+| block | count | ms each | total |
+|---|---:|---:|---:|
+| MoE blocks | 40 | 58.49 | 2,340 |
+| linear-attention blocks | 30 | 148.40 | 4,452 |
+| full-attention, `gqa` kernel only | 10 | 224.00 | 2,240 |
+| vision encoder layers | 27 | 47.80 | 1,291 |
+| **sum of captured blocks** | | | **10,322** |
+| clean uninstrumented TTFT | | | 14,455 |
+| not covered by a capture window | | | 4,133 |
+
+The 4,133 ms residual is honest, not hidden time. The full-attention window
+filled the SQTT buffer after 12 dispatches, so everything in those ten layers
+except the GQA kernel itself — the QKV and o_proj matmuls, two large transposes
+per layer, rotary, KV append — is uncaptured. RGP also pegs clocks, so per-kernel
+times are systematically optimistic against production.
+
+## Conclusions
+
+**GQA is no longer the top target, and data movement is.** `transpose_tiled`,
+`causal_conv_prefill` and `T5LayernormFwdContiguous` are pure data movement
+running at 8-16% of achievable bandwidth, and together they are 3,153 ms of
+measured time with 2,839 ms recoverable against a floor that genuinely applies to
+them. That is more recoverable time than the entire GQA kernel now costs, and
+unlike GQA it needs no algorithmic insight: `causal_conv_prefill` moves 611 MB in
+31.5 ms, which is 19 GB/s out of 256.
+
+**`bucket_tokens_kernel` remains the most clear-cut defect** and is now confirmed
+at 8.83 ms per MoE block in a single 256-thread workgroup, using 1 of 40 CUs, for
+353 ms of the prefill that is almost entirely recoverable.
+`origin/perf/qwen-bucket-tokens` already carries a chunked rewrite.
+
+**The MoE block is 41% plumbing.** Of 58.49 ms, real GEMM work is 32.8 ms; the
+other 24 ms is `bucket_tokens` 8.8, `scatter_add` 4.9, `gather_tokens` 4.9,
+`add_bias` 2.9, `swiglu` 1.3 and `topk_routing` 1.2.
+
+**Sequence-dependent work is 94% of TTFT** (940 ms fixed, 0.729 ms/token), so
+there is no startup cost worth attacking.
+
+## Reproducing
+
+```powershell
+. C:\Users\zyq\hipep-env.ps1
+$env:HIPEP_PROMPT_FILE = 'C:\Users\zyq\prompt_16k.txt'
+
+# clean baseline -- verify no HIPDNN_EP_PERF/DEBUG/TRACE_FILE is set first
+.\bench\bench_ttft.ps1 -Tag p0-16k-tight -Driver vlm -SeqLen 16384 `
+  -MaxLength 18900 -Reps 3 -Warmup 1 -ExecutionProvider AMDGPU
+
+# per-session decomposition (instrumented: proportions only, never a TTFT)
+$env:HIPDNN_EP_TRACE_FILE = 'C:\Users\zyq\logs\eptrace\qwen16k.json'
+
+# per-kernel timing (clean). SPM must be off: with -Counters the 16K decoder
+# dies in the allocator ("memrefCopy failed") and no .rgp is written.
+.\capture\rgp_capture.ps1 -Op qmoe -Skip 45 -Driver vlm -Reps 3 `
+  -PromptFile C:\Users\zyq\prompt_16k.txt -MaxLength 18900 `
+  -ExecutionProvider AMDGPU -MaxTokens 1 -Buf default -ArmTimeoutSec 900
+```
+
+`-Skip` must land in the second iteration: the first decoder inference takes
+~236 s because of the autotune sweeps, and is not steady state. Fence on
+`multi_head_attention` for vision (`conv` does not exist in this export, despite
+being the obvious guess), on `causal_conv` or `qmoe` for the decoder, and note
+that fencing on `gqa` wastes the window because that one kernel fills the buffer
+by itself.

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -77,6 +77,11 @@ extern "C" hipError_t hipStreamSynchronize(hipStream_t stream) {
   return hipSuccess;
 }
 
+extern "C" hipError_t hipDeviceSynchronize(void) {
+  MOCK_PRINT("[MOCK] hipDeviceSynchronize()\n");
+  return hipSuccess;
+}
+
 extern "C" hipError_t hipEventCreate(hipEvent_t *event) {
   *event = malloc(sizeof(void *));
   return hipSuccess;

--- a/lib/Runtime/mock/mock_types.h
+++ b/lib/Runtime/mock/mock_types.h
@@ -51,6 +51,7 @@ extern "C" hipError_t hipGetDeviceProperties(hipDeviceProp_t *prop, int device);
 extern "C" hipError_t hipStreamCreate(hipStream_t *stream);
 extern "C" hipError_t hipStreamDestroy(hipStream_t stream);
 extern "C" hipError_t hipStreamSynchronize(hipStream_t stream);
+extern "C" hipError_t hipDeviceSynchronize(void);
 extern "C" hipError_t hipMalloc(void **ptr, size_t size);
 extern "C" hipError_t hipFree(void *ptr);
 extern "C" hipError_t hipHostMalloc(void **ptr, size_t size,

--- a/lib/Runtime/op_profile.cpp
+++ b/lib/Runtime/op_profile.cpp
@@ -3,6 +3,11 @@
  * Licensed under the MIT License.
  */
 
+// The HIP types and entry points below arrive through op_profile.h ->
+// runtime_types.h, which resolves to real/ or mock/ depending on the build.
+// Including <hip/hip_runtime.h> directly here would be redundant for the real
+// runtime and fatal for the mock one, which has no ROCm headers on its include
+// path.
 #include "op_profile.h"
 #include "chrome_trace.h"
 #include <algorithm>
@@ -11,7 +16,6 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-#include <hip/hip_runtime.h>
 #include <map>
 #include <string>
 #include <vector>

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -740,17 +740,17 @@ static bool gqa_no_expand_prefill_enabled() {
 // are quadratic in sequence length, so at long prompts the ungrouped size stops
 // being allocatable: H=16 at a 16K prompt wants 24.5 GiB in one block. The
 // default keeps every head resident for short sequences -- where the whole
-// buffer is a few hundred MB and grouping would only cost launches -- and starts
-// splitting once the buffer would exceed the budget.
+// buffer is a few hundred MB and grouping would only cost launches -- and
+// starts splitting once the buffer would exceed the budget.
 //
-// The budget is deliberately generous, because splitting is not free: each group
-// is a separate pair of strided-batched GEMMs over a smaller batch, so more
-// groups means more launches with less work each. Measured on gfx1151 with a
-// Gemma-4 16K prompt, 8 groups of 2 heads cost 39.8 s of TTFT against 38.1 s for
-// 2 groups of 8, and forcing groups at 12K -- where the ungrouped buffer still
-// fits -- cost 0.5%. So the default is set just above what a 12K prompt needs
-// ungrouped (14.1 GiB), which leaves everything that already worked ungrouped
-// and splits only where the alternative is not running at all.
+// The budget is deliberately generous, because splitting is not free: each
+// group is a separate pair of strided-batched GEMMs over a smaller batch, so
+// more groups means more launches with less work each. Measured on gfx1151 with
+// a Gemma-4 16K prompt, 8 groups of 2 heads cost 39.8 s of TTFT against 38.1 s
+// for 2 groups of 8, and forcing groups at 12K -- where the ungrouped buffer
+// still fits -- cost 0.5%. So the default is set just above what a 12K prompt
+// needs ungrouped (14.1 GiB), which leaves everything that already worked
+// ungrouped and splits only where the alternative is not running at all.
 static size_t gqa_score_budget_bytes() {
   static const size_t budget = [] {
     constexpr size_t kDefaultMiB = 16384;
@@ -1568,8 +1568,8 @@ static int gqa_forward_hipblaslt(
   //
   // Grouping renumbers the head index that kernels see, so it is restricted to
   // cases where no consumer depends on the absolute head: a per-head additive
-  // bias or a per-head softmax sink both would. no-expand is excluded too, since
-  // its K/V operands are addressed per KV head rather than per Q head.
+  // bias or a per-head softmax sink both would. no-expand is excluded too,
+  // since its K/V operands are addressed per KV head rather than per Q head.
   const bool bias_head_broadcast =
       attention_bias == nullptr ||
       (attn_bias_batch <= 1 && attn_bias_num_heads <= 1);
@@ -1835,106 +1835,105 @@ static int gqa_forward_hipblaslt(
     // heads_per_group == B*H this loop runs once and every pointer below is the
     // buffer base, identical to the ungrouped pipeline.
     for (int64_t head0 = 0; head0 < B * H; head0 += heads_per_group) {
-    // Byte offsets of this group inside the whole-head Q/K/V/O buffers. Q and O
-    // are BNSD [B,H,sq,d]; the expanded K/V are [B*H,total_seq,d].
-    const size_t group_q_off =
-        static_cast<size_t>(head0) * sq * d * elem_sz;
-    const size_t group_kv_off =
-        static_cast<size_t>(head0) * total_seq * d * elem_sz;
+      // Byte offsets of this group inside the whole-head Q/K/V/O buffers. Q and
+      // O are BNSD [B,H,sq,d]; the expanded K/V are [B*H,total_seq,d].
+      const size_t group_q_off = static_cast<size_t>(head0) * sq * d * elem_sz;
+      const size_t group_kv_off =
+          static_cast<size_t>(head0) * total_seq * d * elem_sz;
 
-    // ---- Step 8: Score GEMM (fp16/fp32 in, fp32 out) ----
-    // A = K: no-expand reads present_key directly, expand reads d_Kexp.
-    // B = Q: need_transpose reads d_Qtrans (BNSD), else qSrc (BSHD==BNSD@sq=1).
-    const void *scoreA =
-        use_no_expand ? present_key
-                      : static_cast<const char *>(d_Kexp) + group_kv_off;
-    const void *scoreB =
-        need_transpose ? static_cast<const char *>(d_Qtrans) + group_q_off
-                       : qSrc;
-    float scoreAlpha = scale;
-    float beta = 0.0f;
-    hipblasLtMatmulAlgo_t sAlgo = scoreState->algo;
+      // ---- Step 8: Score GEMM (fp16/fp32 in, fp32 out) ----
+      // A = K: no-expand reads present_key directly, expand reads d_Kexp.
+      // B = Q: need_transpose reads d_Qtrans (BNSD), else qSrc
+      // (BSHD==BNSD@sq=1).
+      const void *scoreA =
+          use_no_expand ? present_key
+                        : static_cast<const char *>(d_Kexp) + group_kv_off;
+      const void *scoreB =
+          need_transpose ? static_cast<const char *>(d_Qtrans) + group_q_off
+                         : qSrc;
+      float scoreAlpha = scale;
+      float beta = 0.0f;
+      hipblasLtMatmulAlgo_t sAlgo = scoreState->algo;
 
-    HIPBLAS_CHECK(hipblasLtMatmul(
-        ltHandle, scoreState->desc, &scoreAlpha, scoreA, scoreState->layA,
-        scoreB, scoreState->layB, &beta, d_S_f32, scoreState->layC, d_S_f32,
-        scoreState->layD, &sAlgo, gemm_ws_ptr, gemm_ws_bytes, stream));
+      HIPBLAS_CHECK(hipblasLtMatmul(
+          ltHandle, scoreState->desc, &scoreAlpha, scoreA, scoreState->layA,
+          scoreB, scoreState->layB, &beta, d_S_f32, scoreState->layC, d_S_f32,
+          scoreState->layD, &sAlgo, gemm_ws_ptr, gemm_ws_bytes, stream));
 
-    // ---- Step 8b: Add external attention bias (onnx.Attention attn_mask) ----
-    int scoreF32BatchStride = static_cast<int>(sq * total_seq);
-    if (attention_bias) {
-      HIP_CHECK(hip_gqa_add_attention_bias_f32(
-          stream, d_S_f32, const_cast<void *>(attention_bias),
-          static_cast<int>(heads_per_group), static_cast<int>(H),
-          static_cast<int>(attn_bias_batch),
-          static_cast<int>(attn_bias_num_heads), static_cast<int>(sq),
-          static_cast<int>(total_seq), scoreF32BatchStride,
-          static_cast<int>(elem_sz)));
-    }
+      // ---- Step 8b: Add external attention bias (onnx.Attention attn_mask)
+      // ----
+      int scoreF32BatchStride = static_cast<int>(sq * total_seq);
+      if (attention_bias) {
+        HIP_CHECK(hip_gqa_add_attention_bias_f32(
+            stream, d_S_f32, const_cast<void *>(attention_bias),
+            static_cast<int>(heads_per_group), static_cast<int>(H),
+            static_cast<int>(attn_bias_batch),
+            static_cast<int>(attn_bias_num_heads), static_cast<int>(sq),
+            static_cast<int>(total_seq), scoreF32BatchStride,
+            static_cast<int>(elem_sz)));
+      }
 
-    // ---- Step 9: Causal Mask (fp32) + Softmax (fp32 -> fp16/fp32) ----
-    // S is treated as [B*H, sq, total_seq] (head stride sq*total_seq) by both
-    // GEMM flavours. softmax dtype follows gemm_fp32.
-    //
-    // The built-in causal triangle is applied whenever !no_causal,
-    // INDEPENDENTLY of attention_bias. This mirrors the ONNX Attention
-    // reference and the ORT GQA op: the additive mask (Step 8b, e.g.
-    // onnx.Attention attn_mask or a GQA/ALiBi bias) is ADDED first, then, if
-    // the op is causal, the upper triangle is masked out. For a mask that
-    // already encodes causal (the common HF export) this is idempotent (-inf
-    // stays -inf); for a padding-only mask + is_causal it supplies the missing
-    // triangle. The bidirectional paths (no_causal, e.g. Whisper
-    // encoder/cross-attn or onnx.Attention is_causal=0) set no_causal=true and
-    // thus skip this, letting the mask carry all masking. Note this Step is a
-    // no-op at sq==1 (single-query decode has no future tokens), gated by (sq >
-    // 1 || local_window_size > 0).
-    int scoreFp16BatchStride = static_cast<int>(sq * total_seq);
-    if ((sq > 1 || local_window_size > 0) && !no_causal) {
-      // The causal / window mask is the same for every head, so a group needs no
-      // head offset -- only the group's head count.
-      HIP_CHECK(hip_gqa_causal_mask_f32(
-          stream, d_S_f32, static_cast<int>(heads_per_group),
-          static_cast<int>(total_seq), static_cast<int>(sq),
-          scoreF32BatchStride, static_cast<int>(past_len),
-          static_cast<int>(local_window_size)));
-    }
-    // fp16 GQA: softmax writes fp16 probabilities for the fp16 Value GEMM.
-    // fp32 GQA (Whisper no_causal): softmax writes fp32 probabilities for the
-    // fp32 Value GEMM. d_S_fp16 is the probabilities buffer either way (sized
-    // by elem_sz above), so the name is fp16-specific but holds fp32 when
-    // gemm_fp32.
-    if (gemm_fp32) {
-      HIP_CHECK(hip_gqa_softmax_f32_to_f32(
-          stream, d_S_f32, d_S_fp16,
-          static_cast<int>(heads_per_group * sq), static_cast<int>(total_seq),
-          static_cast<int>(sq), scoreF32BatchStride, scoreFp16BatchStride,
-          head_sink, static_cast<int>(H),
-          static_cast<int>(use_smooth_softmax)));
-    } else {
-      HIP_CHECK(hip_gqa_softmax_f32_to_f16(
-          stream, d_S_f32, d_S_fp16,
-          static_cast<int>(heads_per_group * sq), static_cast<int>(total_seq),
-          static_cast<int>(sq), scoreF32BatchStride, scoreFp16BatchStride,
-          head_sink, static_cast<int>(H),
-          static_cast<int>(use_smooth_softmax)));
-    }
+      // ---- Step 9: Causal Mask (fp32) + Softmax (fp32 -> fp16/fp32) ----
+      // S is treated as [B*H, sq, total_seq] (head stride sq*total_seq) by both
+      // GEMM flavours. softmax dtype follows gemm_fp32.
+      //
+      // The built-in causal triangle is applied whenever !no_causal,
+      // INDEPENDENTLY of attention_bias. This mirrors the ONNX Attention
+      // reference and the ORT GQA op: the additive mask (Step 8b, e.g.
+      // onnx.Attention attn_mask or a GQA/ALiBi bias) is ADDED first, then, if
+      // the op is causal, the upper triangle is masked out. For a mask that
+      // already encodes causal (the common HF export) this is idempotent (-inf
+      // stays -inf); for a padding-only mask + is_causal it supplies the
+      // missing triangle. The bidirectional paths (no_causal, e.g. Whisper
+      // encoder/cross-attn or onnx.Attention is_causal=0) set no_causal=true
+      // and thus skip this, letting the mask carry all masking. Note this Step
+      // is a no-op at sq==1 (single-query decode has no future tokens), gated
+      // by (sq > 1 || local_window_size > 0).
+      int scoreFp16BatchStride = static_cast<int>(sq * total_seq);
+      if ((sq > 1 || local_window_size > 0) && !no_causal) {
+        // The causal / window mask is the same for every head, so a group needs
+        // no head offset -- only the group's head count.
+        HIP_CHECK(hip_gqa_causal_mask_f32(
+            stream, d_S_f32, static_cast<int>(heads_per_group),
+            static_cast<int>(total_seq), static_cast<int>(sq),
+            scoreF32BatchStride, static_cast<int>(past_len),
+            static_cast<int>(local_window_size)));
+      }
+      // fp16 GQA: softmax writes fp16 probabilities for the fp16 Value GEMM.
+      // fp32 GQA (Whisper no_causal): softmax writes fp32 probabilities for the
+      // fp32 Value GEMM. d_S_fp16 is the probabilities buffer either way (sized
+      // by elem_sz above), so the name is fp16-specific but holds fp32 when
+      // gemm_fp32.
+      if (gemm_fp32) {
+        HIP_CHECK(hip_gqa_softmax_f32_to_f32(
+            stream, d_S_f32, d_S_fp16, static_cast<int>(heads_per_group * sq),
+            static_cast<int>(total_seq), static_cast<int>(sq),
+            scoreF32BatchStride, scoreFp16BatchStride, head_sink,
+            static_cast<int>(H), static_cast<int>(use_smooth_softmax)));
+      } else {
+        HIP_CHECK(hip_gqa_softmax_f32_to_f16(
+            stream, d_S_f32, d_S_fp16, static_cast<int>(heads_per_group * sq),
+            static_cast<int>(total_seq), static_cast<int>(sq),
+            scoreF32BatchStride, scoreFp16BatchStride, head_sink,
+            static_cast<int>(H), static_cast<int>(use_smooth_softmax)));
+      }
 
-    // ---- Step 10: Value GEMM (fp16/fp32 in, fp16/fp32 out) ----
-    // A = V: no-expand reads present_value directly, expand reads d_Vexp.
-    // C = O: need_transpose writes d_O (BNSD, transposed below); at sq==1 the
-    //        GEMM writes straight to output (BSHD==BNSD).
-    const void *valueA =
-        use_no_expand ? present_value
-                      : static_cast<const char *>(d_Vexp) + group_kv_off;
-    void *valueC = need_transpose ? static_cast<char *>(d_O) + group_q_off
-                                  : output;
-    float valAlpha = 1.0f;
-    hipblasLtMatmulAlgo_t vAlgo = valueState->algo;
+      // ---- Step 10: Value GEMM (fp16/fp32 in, fp16/fp32 out) ----
+      // A = V: no-expand reads present_value directly, expand reads d_Vexp.
+      // C = O: need_transpose writes d_O (BNSD, transposed below); at sq==1 the
+      //        GEMM writes straight to output (BSHD==BNSD).
+      const void *valueA =
+          use_no_expand ? present_value
+                        : static_cast<const char *>(d_Vexp) + group_kv_off;
+      void *valueC =
+          need_transpose ? static_cast<char *>(d_O) + group_q_off : output;
+      float valAlpha = 1.0f;
+      hipblasLtMatmulAlgo_t vAlgo = valueState->algo;
 
-    HIPBLAS_CHECK(hipblasLtMatmul(
-        ltHandle, valueState->desc, &valAlpha, valueA, valueState->layA,
-        d_S_fp16, valueState->layB, &beta, valueC, valueState->layC, valueC,
-        valueState->layD, &vAlgo, gemm_ws_ptr, gemm_ws_bytes, stream));
+      HIPBLAS_CHECK(hipblasLtMatmul(
+          ltHandle, valueState->desc, &valAlpha, valueA, valueState->layA,
+          d_S_fp16, valueState->layB, &beta, valueC, valueState->layC, valueC,
+          valueState->layD, &vAlgo, gemm_ws_ptr, gemm_ws_bytes, stream));
     } // head group
 
     // ---- Step 11: O Transpose BNSD [B,H,sq,d] -> BSHD [B,sq,H,d] ----

--- a/tools/perf-harness/README.md
+++ b/tools/perf-harness/README.md
@@ -110,8 +110,17 @@ Each of these is here because ignoring it produced a confident wrong answer.
 
 `HIPDNN_EP_PERF=1` costs about 4% on its own, which is larger than most changes
 worth shipping. SQTT is hardware thread tracing and perturbs far less, so it
-carries the timing. The harness clears `HIPDNN_EP_PERF` and `HIPDNN_EP_DEBUG`
-before every run rather than trusting the shell to be clean.
+carries the timing. The harness clears `HIPDNN_EP_PERF`, `HIPDNN_EP_DEBUG` and
+`HIPDNN_EP_TRACE_FILE` before every run rather than trusting the shell to be
+clean.
+
+`HIPDNN_EP_TRACE_FILE` is the dangerous one. `hipdnn_ep_perf_enabled()` is true
+for it as well as for `HIPDNN_EP_PERF`, so it enables the profiler while
+printing none of PERF's console output, and it survives in the shell after the
+capture that wanted it. A 16K VLM baseline was reported as 17,587 ms for a
+whole round of analysis on that basis; the same binaries measure 14,455-14,610
+ms once the variable is gone, and re-setting it reproduces 17,545 ms on demand.
+Cross-check any suspicious baseline by re-running it in a fresh shell.
 
 ### Rank by utilisation, not by share of runtime
 

--- a/tools/perf-harness/analysis/attrib_regions.py
+++ b/tools/perf-harness/analysis/attrib_regions.py
@@ -24,8 +24,9 @@ from perfcommon import INT4_FAMILIES, Capture, add_common_args, specs_from_args
 
 
 def main() -> None:
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     add_common_args(ap, many=True)
     args = ap.parse_args()
     spec, _ = specs_from_args(args)
@@ -50,37 +51,49 @@ def main() -> None:
         chunk_us = (total - cap.lm_head_us) * k + cap.lm_head_us
 
         print(f"\n######## {path}")
-        print(f"window {total/1000:.1f} ms over {len(cap.rows)} dispatches, "
-              f"{cap.layers_in_window} layer-groups -> x{k:.2f}")
+        print(
+            f"window {total / 1000:.1f} ms over {len(cap.rows)} dispatches, "
+            f"{cap.layers_in_window} layer-groups -> x{k:.2f}"
+        )
         print(f"{'region':10} {'window ms':>10} {'%window':>8} {'ms/chunk':>10}")
         for reg in ("qmoe", "dense", "lm_head"):
             us = by_region.get(reg, 0.0)
             if not us:
                 continue
             per_chunk = us if reg == "lm_head" else us * k
-            print(f"{reg:10} {us/1000:10.1f} {100*us/total:8.1f} {per_chunk/1000:10.1f}")
-        print(f"{'chunk':10} {'':>10} {'':>8} {chunk_us/1000:10.1f}")
+            print(
+                f"{reg:10} {us / 1000:10.1f} {100 * us / total:8.1f} {per_chunk / 1000:10.1f}"
+            )
+        print(f"{'chunk':10} {'':>10} {'':>8} {chunk_us / 1000:10.1f}")
 
-        print(f"\n--- int4 stack by region ---")
+        print("\n--- int4 stack by region ---")
         print(f"{'region':8} {'kernel':32} {'count':>6} {'ms':>9} {'%window':>8}")
         for (reg, fam), us in sorted(int4_us.items(), key=lambda kv: -kv[1]):
-            print(f"{reg:8} {fam:32} {int4_n[(reg, fam)]:6d} {us/1000:9.2f} {100*us/total:8.2f}")
+            print(
+                f"{reg:8} {fam:32} {int4_n[(reg, fam)]:6d} {us / 1000:9.2f} {100 * us / total:8.2f}"
+            )
 
         q = sum(v for (reg, _), v in int4_us.items() if reg == "qmoe")
         d = sum(v for (reg, _), v in int4_us.items() if reg == "dense")
         lm = sum(v for (reg, _), v in int4_us.items() if reg == "lm_head")
         tot4 = q + d + lm
         if tot4:
-            print(f"\nint4 stack = {100*tot4/total:.1f}% of the window "
-                  f"(qmoe {100*q/tot4:.1f}%, dense {100*d/tot4:.1f}%, lm_head {100*lm/tot4:.1f}% "
-                  f"of the stack)")
+            print(
+                f"\nint4 stack = {100 * tot4 / total:.1f}% of the window "
+                f"(qmoe {100 * q / tot4:.1f}%, dense {100 * d / tot4:.1f}%, lm_head {100 * lm / tot4:.1f}% "
+                f"of the stack)"
+            )
         # headroom.py's dense floor is built from the QKV/o_proj/router weights,
         # so it must be fed the int4 projection time -- not the whole dense
         # region, which also carries attention, layernorm and rope.
-        print(f"\nfeed headroom.py:  --dense-ms {d*k/1000:.1f} "
-              f"--lm-head-ms {cap.lm_head_us/1000:.1f}")
-        print(f"  (dense int4 projections only; the full dense region incl. attention "
-              f"is {by_region.get('dense', 0)*k/1000:.1f} ms/chunk)")
+        print(
+            f"\nfeed headroom.py:  --dense-ms {d * k / 1000:.1f} "
+            f"--lm-head-ms {cap.lm_head_us / 1000:.1f}"
+        )
+        print(
+            f"  (dense int4 projections only; the full dense region incl. attention "
+            f"is {by_region.get('dense', 0) * k / 1000:.1f} ms/chunk)"
+        )
 
         print(f"\n--- expert blocks: {len(cap.blocks)} ---")
         paths: dict[str, list] = defaultdict(lambda: [0, 0.0, 0])
@@ -90,8 +103,10 @@ def main() -> None:
             paths[key][1] += b.dur_us
             paths[key][2] += b.m
         for key, (n, us, toks) in sorted(paths.items(), key=lambda kv: -kv[1][1]):
-            print(f"  {key:45} n={n:4d}  {us/1000:8.2f} ms  mean {us/n:7.1f} us  "
-                  f"mean M {toks/n:7.1f}")
+            print(
+                f"  {key:45} n={n:4d}  {us / 1000:8.2f} ms  mean {us / n:7.1f} us  "
+                f"mean M {toks / n:7.1f}"
+            )
 
 
 if __name__ == "__main__":

--- a/tools/perf-harness/analysis/expert_blocks.py
+++ b/tools/perf-harness/analysis/expert_blocks.py
@@ -22,16 +22,25 @@ Read it with two cautions:
 import argparse
 from collections import defaultdict
 
-from perfcommon import (M_BUCKETS, Capture, add_common_args, bucket_label,
-                        specs_from_args)
+from perfcommon import (
+    M_BUCKETS,
+    Capture,
+    add_common_args,
+    bucket_label,
+    specs_from_args,
+)
 
 
 def main() -> None:
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     add_common_args(ap, many=True)
-    ap.add_argument("--shapes", action="store_true",
-                    help="also list the routing distribution block by block")
+    ap.add_argument(
+        "--shapes",
+        action="store_true",
+        help="also list the routing distribution block by block",
+    )
     args = ap.parse_args()
     spec, dev = specs_from_args(args)
 
@@ -42,15 +51,27 @@ def main() -> None:
         floor_us = spec.expert_weight_bytes / dev.bw_bytes_s * 1e6
 
         print(f"\n######## {path}")
-        print(f"window {cap.total_us/1000:.1f} ms, {len(cap.rows)} dispatches, "
-              f"{cap.layers_in_window} layer-groups -> x{k:.2f} for {spec.layers} layers")
-        print(f"reconstructed chunk ({spec.chunk_tokens} tok): {chunk_us/1000:.1f} ms"
-              + (f"  (incl. lm_head {cap.lm_head_us/1000:.1f} ms)" if cap.lm_head_us else ""))
-        print(f"one expert = {spec.expert_weight_bytes/1e6:.1f} MB of weights+scales "
-              f"-> {floor_us:.1f} us at {dev.bw_bytes_s/1e9:.0f} GB/s\n")
+        print(
+            f"window {cap.total_us / 1000:.1f} ms, {len(cap.rows)} dispatches, "
+            f"{cap.layers_in_window} layer-groups -> x{k:.2f} for {spec.layers} layers"
+        )
+        print(
+            f"reconstructed chunk ({spec.chunk_tokens} tok): {chunk_us / 1000:.1f} ms"
+            + (
+                f"  (incl. lm_head {cap.lm_head_us / 1000:.1f} ms)"
+                if cap.lm_head_us
+                else ""
+            )
+        )
+        print(
+            f"one expert = {spec.expert_weight_bytes / 1e6:.1f} MB of weights+scales "
+            f"-> {floor_us:.1f} us at {dev.bw_bytes_s / 1e9:.0f} GB/s\n"
+        )
 
-        print(f"{'M range':>10} {'blocks':>7} {'tokens':>7} {'ms/chunk':>9} {'%chunk':>7} "
-              f"{'us/blk':>8} {'mean M':>7} {'x floor':>8} {'eff GB/s':>9}  path")
+        print(
+            f"{'M range':>10} {'blocks':>7} {'tokens':>7} {'ms/chunk':>9} {'%chunk':>7} "
+            f"{'us/blk':>8} {'mean M':>7} {'x floor':>8} {'eff GB/s':>9}  path"
+        )
         for lo, hi in M_BUCKETS:
             sel = [b for b in cap.blocks if lo <= b.m <= hi]
             if not sel:
@@ -60,18 +81,26 @@ def main() -> None:
             toks = sum(b.m for b in sel)
             paths = defaultdict(int)
             for b in sel:
-                paths["+".join(sorted(x.replace("MatMulNBits", "") for x in b.kernels))] += 1
-            pretty = " ".join(f"{n}x{c}" for n, c in sorted(paths.items(), key=lambda kv: -kv[1]))
-            print(f"{bucket_label(lo, hi):>10} {len(sel):7d} {toks:7d} {us*k/1000:9.2f} "
-                  f"{100*us*k/chunk_us:7.2f} {mean:8.1f} {toks/len(sel):7.1f} "
-                  f"{mean/floor_us:8.2f} {spec.expert_weight_bytes/mean/1e3:9.0f}  {pretty}")
+                paths[
+                    "+".join(sorted(x.replace("MatMulNBits", "") for x in b.kernels))
+                ] += 1
+            pretty = " ".join(
+                f"{n}x{c}" for n, c in sorted(paths.items(), key=lambda kv: -kv[1])
+            )
+            print(
+                f"{bucket_label(lo, hi):>10} {len(sel):7d} {toks:7d} {us * k / 1000:9.2f} "
+                f"{100 * us * k / chunk_us:7.2f} {mean:8.1f} {toks / len(sel):7.1f} "
+                f"{mean / floor_us:8.2f} {spec.expert_weight_bytes / mean / 1e3:9.0f}  {pretty}"
+            )
 
         small = [b for b in cap.blocks if b.m <= 63]
         if small and cap.blocks:
             tok_all = sum(b.m for b in cap.blocks)
-            print(f"\nM<=63: {len(small)}/{len(cap.blocks)} blocks, "
-                  f"{100*sum(b.m for b in small)/tok_all:.1f}% of routed tokens, "
-                  f"{100*sum(b.dur_us for b in small)*k/chunk_us:.1f}% of a chunk")
+            print(
+                f"\nM<=63: {len(small)}/{len(cap.blocks)} blocks, "
+                f"{100 * sum(b.m for b in small) / tok_all:.1f}% of routed tokens, "
+                f"{100 * sum(b.dur_us for b in small) * k / chunk_us:.1f}% of a chunk"
+            )
 
         # Same expert size, two different paths: does skipping the fused dequant
         # actually pay? Only comparable within one bucket.
@@ -79,13 +108,20 @@ def main() -> None:
         fused = [b for b in big if b.dequant_us == 0]
         split = [b for b in big if b.dequant_us > 0]
         if fused and split:
-            print("\n=== fused WMMA vs dequant+Fp16GEMM at the same expert size (M>=256) ===")
-            for label, sel in (("fused WMMA only", fused), ("dequant + Fp16GEMM", split)):
+            print(
+                "\n=== fused WMMA vs dequant+Fp16GEMM at the same expert size (M>=256) ==="
+            )
+            for label, sel in (
+                ("fused WMMA only", fused),
+                ("dequant + Fp16GEMM", split),
+            ):
                 us = sum(b.dur_us for b in sel)
                 tok = sum(b.m for b in sel)
-                print(f"  {label:22} n={len(sel):3d}  meanM={tok/len(sel):6.1f}  "
-                      f"{us/len(sel):8.1f} us/block  {us/tok:6.2f} us/token  "
-                      f"dequant {sum(b.dequant_us for b in sel)/len(sel):6.1f} us/block")
+                print(
+                    f"  {label:22} n={len(sel):3d}  meanM={tok / len(sel):6.1f}  "
+                    f"{us / len(sel):8.1f} us/block  {us / tok:6.2f} us/token  "
+                    f"dequant {sum(b.dequant_us for b in sel) / len(sel):6.1f} us/block"
+                )
 
         if args.shapes:
             print("\n=== routing distribution ===")

--- a/tools/perf-harness/analysis/inspect_capture.py
+++ b/tools/perf-harness/analysis/inspect_capture.py
@@ -33,26 +33,37 @@ from perfcommon import Capture, add_common_args, specs_from_args
 
 
 def main() -> None:
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     add_common_args(ap, many=True)
-    ap.add_argument("--genai-config", help="genai_config.json to cross-check shapes against")
-    ap.add_argument("--sweep-threshold", type=int, default=40,
-                    help="consecutive same-kernel dispatches that look like a tuner sweep")
+    ap.add_argument(
+        "--genai-config", help="genai_config.json to cross-check shapes against"
+    )
+    ap.add_argument(
+        "--sweep-threshold",
+        type=int,
+        default=40,
+        help="consecutive same-kernel dispatches that look like a tuner sweep",
+    )
     args = ap.parse_args()
     spec, _ = specs_from_args(args)
 
     for path in args.captures:
         cap = Capture(path, spec)
         print(f"\n######## {path}")
-        print(f"{len(cap.rows)} dispatches, {cap.total_us/1000:.1f} ms, "
-              f"{cap.layers_in_window} topk_routing (layer groups)")
+        print(
+            f"{len(cap.rows)} dispatches, {cap.total_us / 1000:.1f} ms, "
+            f"{cap.layers_in_window} topk_routing (layer groups)"
+        )
 
         tk = [i for i, r in enumerate(cap.rows) if r["family"] == "topk_routing"]
         if len(tk) > 1:
             strides = [b - a for a, b in zip(tk, tk[1:])]
-            print(f"layer starts at {tk[:8]}{' ...' if len(tk) > 8 else ''}  "
-                  f"stride {min(strides)}..{max(strides)}")
+            print(
+                f"layer starts at {tk[:8]}{' ...' if len(tk) > 8 else ''}  "
+                f"stride {min(strides)}..{max(strides)}"
+            )
 
         # --- runaway repetition: the tuner-sweep signature --------------------
         runs, cur, n = [], None, 0
@@ -66,51 +77,74 @@ def main() -> None:
         if cur is not None and n >= args.sweep_threshold:
             runs.append((cur, n))
         if runs:
-            print("\n!! long consecutive runs of one kernel -- check for a tuner sweep:")
+            print(
+                "\n!! long consecutive runs of one kernel -- check for a tuner sweep:"
+            )
             for fam, count in runs:
                 durs = [float(r["dur_us"]) for r in cap.rows if r["family"] == fam]
                 distinct = len({round(d, 1) for d in durs})
                 share = 100 * sum(durs) / cap.total_us
-                print(f"   {fam:34} {count:5d} in a row, {share:5.1f}% of the window, "
-                      f"{distinct} distinct durations")
+                print(
+                    f"   {fam:34} {count:5d} in a row, {share:5.1f}% of the window, "
+                    f"{distinct} distinct durations"
+                )
             print("   One kernel running back to back and dominating the window is the")
-            print("   autotuner working through configurations, not steady state -- the")
+            print(
+                "   autotuner working through configurations, not steady state -- the"
+            )
             print("   durations are trials. Re-capture with a larger --skip.")
         else:
             print("no runaway kernel repetition (no obvious tuner sweep)")
 
         # --- the big dispatches ----------------------------------------------
-        big = sorted(((float(r["dur_us"]), r["family"], int(r["threads"]))
-                      for r in cap.rows), reverse=True)[:8]
+        big = sorted(
+            ((float(r["dur_us"]), r["family"], int(r["threads"])) for r in cap.rows),
+            reverse=True,
+        )[:8]
         print(f"\n{'longest dispatches':34} {'us':>9} {'threads':>12}")
         for dur, fam, threads in big:
             print(f"  {fam:32} {dur:9.1f} {threads:12d}")
         if cap.lm_head_idx:
-            print(f"lm_head: {len(cap.lm_head_idx)} dispatch(es), {cap.lm_head_us/1000:.1f} ms, "
-                  f"threads={int(cap.rows[cap.lm_head_idx[0]]['threads']):,}")
+            print(
+                f"lm_head: {len(cap.lm_head_idx)} dispatch(es), {cap.lm_head_us / 1000:.1f} ms, "
+                f"threads={int(cap.rows[cap.lm_head_idx[0]]['threads']):,}"
+            )
 
         # --- expert routing spread -------------------------------------------
         if cap.blocks:
             ms = sorted(b.m for b in cap.blocks)
-            print(f"\nexpert blocks {len(cap.blocks)}: M from {ms[0]} to {ms[-1]}, "
-                  f"median {ms[len(ms)//2]}, {sum(ms)} routed tokens")
+            print(
+                f"\nexpert blocks {len(cap.blocks)}: M from {ms[0]} to {ms[-1]}, "
+                f"median {ms[len(ms) // 2]}, {sum(ms)} routed tokens"
+            )
 
         # --- parser-flagged artifacts ----------------------------------------
         if cap.rows and "is_artifact" in cap.rows[0]:
             flags = Counter(r["is_artifact"] for r in cap.rows)
-            art = [r for r in cap.rows if r["is_artifact"] not in ("0", "False", "false", "")]
-            print(f"\nis_artifact {dict(flags)}"
-                  + (f" -- {len(art)} flagged, "
-                     f"{100*sum(float(r['dur_us']) for r in art)/cap.total_us:.1f}% of the window"
-                     if art else ""))
+            art = [
+                r
+                for r in cap.rows
+                if r["is_artifact"] not in ("0", "False", "false", "")
+            ]
+            print(
+                f"\nis_artifact {dict(flags)}"
+                + (
+                    f" -- {len(art)} flagged, "
+                    f"{100 * sum(float(r['dur_us']) for r in art) / cap.total_us:.1f}% of the window"
+                    if art
+                    else ""
+                )
+            )
 
         # --- config cross-check -----------------------------------------------
         if args.genai_config:
             cfg = json.load(open(args.genai_config))
             model = cfg.get("model", {})
             dec = model.get("decoder", {})
-            print(f"\nconfig: vocab={model.get('vocab_size')} "
-                  f"hidden={dec.get('hidden_size')} layers={dec.get('num_hidden_layers')}")
+            print(
+                f"\nconfig: vocab={model.get('vocab_size')} "
+                f"hidden={dec.get('hidden_size')} layers={dec.get('num_hidden_layers')}"
+            )
             for out in dec.get("outputs", {}).items():
                 print(f"  output {out[0]}: {out[1]}")
 
@@ -120,7 +154,7 @@ def main() -> None:
             fams[r["family"]][1] += float(r["dur_us"])
         print(f"\n{'family':36} {'n':>6} {'ms':>9} {'%':>7}")
         for fam, (n, us) in sorted(fams.items(), key=lambda kv: -kv[1][1])[:14]:
-            print(f"{fam:36} {n:6d} {us/1000:9.2f} {100*us/cap.total_us:7.2f}")
+            print(f"{fam:36} {n:6d} {us / 1000:9.2f} {100 * us / cap.total_us:7.2f}")
 
 
 if __name__ == "__main__":

--- a/tools/perf-harness/analysis/prefill_model.py
+++ b/tools/perf-harness/analysis/prefill_model.py
@@ -29,20 +29,29 @@ ATTN_FAMILY = "gqa_flash_prefill_v5"
 
 
 def main() -> None:
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     add_common_args(ap, many=True)
-    ap.add_argument("--at-chunk", type=float, nargs="+", required=True,
-                    help="chunk index each capture sits at, same order as the captures "
-                         "(e.g. --at-chunk 2.5 31.5)")
-    ap.add_argument("--measured-ttft-s", type=float,
-                    help="clean TTFT to compare the model against")
+    ap.add_argument(
+        "--at-chunk",
+        type=float,
+        nargs="+",
+        required=True,
+        help="chunk index each capture sits at, same order as the captures "
+        "(e.g. --at-chunk 2.5 31.5)",
+    )
+    ap.add_argument(
+        "--measured-ttft-s", type=float, help="clean TTFT to compare the model against"
+    )
     ap.add_argument("--attn-family", default=ATTN_FAMILY)
     args = ap.parse_args()
     spec, _ = specs_from_args(args)
     if len(args.captures) != 2 or len(args.at_chunk) != 2:
-        raise SystemExit("need exactly two captures and two --at-chunk positions "
-                         "(one shallow, one deep)")
+        raise SystemExit(
+            "need exactly two captures and two --at-chunk positions "
+            "(one shallow, one deep)"
+        )
 
     order = sorted(range(2), key=lambda i: args.at_chunk[i])
     names = ("shallow", "deep")
@@ -57,63 +66,87 @@ def main() -> None:
         for j, r in enumerate(cap.rows):
             fam, dur = r["family"], float(r["dur_us"])
             if j in cap.lm_head_idx:
-                agg["lm_head"] += dur          # once per chunk, never scaled
+                agg["lm_head"] += dur  # once per chunk, never scaled
             else:
                 agg[f"{cap.regions[j]}:{fam}"] += dur * k
         per_chunk[name] = agg
         # The full-attention and sliding-window layers interleave; splitting the
         # per-layer durations at the median separates them without needing to
         # know the pattern.
-        g = sorted((float(r["dur_us"]) for r in cap.rows
-                    if r["family"] == args.attn_family), reverse=True)
+        g = sorted(
+            (float(r["dur_us"]) for r in cap.rows if r["family"] == args.attn_family),
+            reverse=True,
+        )
         if len(g) < 2:
-            raise SystemExit(f"{args.captures[i]}: too few '{args.attn_family}' dispatches")
+            raise SystemExit(
+                f"{args.captures[i]}: too few '{args.attn_family}' dispatches"
+            )
         half = len(g) // 2
-        attn[name] = (sum(g[:half]) / half, sum(g[half:]) / (len(g) - half),
-                      k * len(g) / 2)
+        attn[name] = (
+            sum(g[:half]) / half,
+            sum(g[half:]) / (len(g) - half),
+            k * len(g) / 2,
+        )
 
     print("=== attention: measured at two depths ===")
     for n in names:
         f, s, npl = attn[n]
-        print(f"  {n:8} chunk~{depth[n]:4.1f}  full {f:9.1f} us/layer   "
-              f"sliding {s:7.1f} us/layer   {npl:.1f} layers of each per chunk")
+        print(
+            f"  {n:8} chunk~{depth[n]:4.1f}  full {f:9.1f} us/layer   "
+            f"sliding {s:7.1f} us/layer   {npl:.1f} layers of each per chunk"
+        )
     f0, s0, npl = attn["shallow"]
     f1, s1, _ = attn["deep"]
     p = math.log(f1 / f0) / math.log(depth["deep"] / depth["shallow"])
-    print(f"  full attention scales as KV^{p:.2f} "
-          f"({f1/f0:.1f}x over {depth['deep']/depth['shallow']:.1f}x KV)")
-    print(f"  sliding window is depth-independent: {s0:.1f} -> {s1:.1f} us "
-          f"({100*(s1-s0)/s0:+.1f}%)  <- if this is large the segmentation is wrong")
+    print(
+        f"  full attention scales as KV^{p:.2f} "
+        f"({f1 / f0:.1f}x over {depth['deep'] / depth['shallow']:.1f}x KV)"
+    )
+    print(
+        f"  sliding window is depth-independent: {s0:.1f} -> {s1:.1f} us "
+        f"({100 * (s1 - s0) / s0:+.1f}%)  <- if this is large the segmentation is wrong"
+    )
 
     sl_ms = s0 * npl / 1000
-    full_ms = [f0 * (c / depth["shallow"]) ** p * npl / 1000 for c in range(1, spec.chunks + 1)]
+    full_ms = [
+        f0 * (c / depth["shallow"]) ** p * npl / 1000 for c in range(1, spec.chunks + 1)
+    ]
     attn_total = sum(full_ms) + sl_ms * spec.chunks
 
     base: dict[str, float] = defaultdict(float)
     for key in set(per_chunk["shallow"]) | set(per_chunk["deep"]):
         if args.attn_family in key:
             continue
-        base[key] = (per_chunk["shallow"].get(key, 0.0)
-                     + per_chunk["deep"].get(key, 0.0)) / 2 / 1000
+        base[key] = (
+            (per_chunk["shallow"].get(key, 0.0) + per_chunk["deep"].get(key, 0.0))
+            / 2
+            / 1000
+        )
     base_chunk = sum(base.values())
     total = base_chunk * spec.chunks + attn_total
 
     print(f"\n=== modelled prefill ({spec.chunks} chunks of {spec.chunk_tokens}) ===")
-    print(f"  depth-independent  {base_chunk:7.1f} ms/chunk x {spec.chunks} = "
-          f"{base_chunk*spec.chunks/1000:5.2f} s")
-    print(f"  attention                                  = {attn_total/1000:5.2f} s")
-    print(f"  modelled total                             = {total/1000:5.2f} s")
+    print(
+        f"  depth-independent  {base_chunk:7.1f} ms/chunk x {spec.chunks} = "
+        f"{base_chunk * spec.chunks / 1000:5.2f} s"
+    )
+    print(f"  attention                                  = {attn_total / 1000:5.2f} s")
+    print(f"  modelled total                             = {total / 1000:5.2f} s")
     if args.measured_ttft_s:
         d = 100 * (total / 1000 - args.measured_ttft_s) / args.measured_ttft_s
-        print(f"  vs measured TTFT {args.measured_ttft_s:.2f} s -> {d:+.0f}% "
-              f"(a few % under is expected: RGP pegs clocks)")
+        print(
+            f"  vs measured TTFT {args.measured_ttft_s:.2f} s -> {d:+.0f}% "
+            f"(a few % under is expected: RGP pegs clocks)"
+        )
 
     share = dict(base)
     share[f"attention ({args.attn_family})"] = attn_total / spec.chunks
-    print(f"\n=== whole-prefill ranking ===")
+    print("\n=== whole-prefill ranking ===")
     print(f"{'component':46} {'s over prefill':>15} {'%':>7}")
     for key, v in sorted(share.items(), key=lambda kv: -kv[1])[:16]:
-        print(f"{key:46} {v*spec.chunks/1000:15.2f} {100*v*spec.chunks/total:7.2f}")
+        print(
+            f"{key:46} {v * spec.chunks / 1000:15.2f} {100 * v * spec.chunks / total:7.2f}"
+        )
 
     fam: dict[str, float] = defaultdict(float)
     for key, v in share.items():
@@ -130,9 +163,13 @@ def main() -> None:
             fam["everything else"] += v
     print(f"\n{'family':46} {'s over prefill':>15} {'%':>7}")
     for key, v in sorted(fam.items(), key=lambda kv: -kv[1]):
-        print(f"{key:46} {v*spec.chunks/1000:15.2f} {100*v*spec.chunks/total:7.2f}")
-    print("\nfeed headroom.py:  "
-          f"--attention-s {attn_total/1000:.2f} --prefill-s {total/1000:.2f}")
+        print(
+            f"{key:46} {v * spec.chunks / 1000:15.2f} {100 * v * spec.chunks / total:7.2f}"
+        )
+    print(
+        "\nfeed headroom.py:  "
+        f"--attention-s {attn_total / 1000:.2f} --prefill-s {total / 1000:.2f}"
+    )
 
 
 if __name__ == "__main__":

--- a/tools/perf-harness/bench/ab_interleaved.ps1
+++ b/tools/perf-harness/bench/ab_interleaved.ps1
@@ -27,6 +27,16 @@
 ##
 ## The named DLL is copied over the same filename in $env:HIPEP_BIN before each
 ## run, so every arm is measured through one identical harness.
+##
+## Use "dlls" instead when an arm spans more than one artifact:
+##
+##   { "base": { "dlls": ["D:\\b\\base\\hipgpu.dll",
+##                        "D:\\b\\base\\custom_kernels_gfx1151.dll"] }, ... }
+##
+## Anything touching lib/Conversion or lib/Runtime/real lands in hipgpu.dll, and
+## the two share the extern "C" kernel ABI, so swapping only one of the pair
+## measures a mix of both arms. Every arm must list the same file names, or the
+## unlisted one silently persists from whichever arm ran last.
 
 param(
   [Parameter(Mandatory = $true)][string]$Manifest,
@@ -57,9 +67,35 @@ $ErrorActionPreference = 'Stop'
 $armDefs = Get-Content $Manifest -Raw | ConvertFrom-Json
 $allArms = $armDefs.PSObject.Properties.Name
 if (-not $Arms) { $Arms = $allArms }
+
+function Get-ArmDlls {
+  param([string]$Name)
+  $def = $armDefs.$Name
+  $has = $def.PSObject.Properties.Name
+  if ($has -contains 'dlls') { return @($def.dlls) }
+  if ($has -contains 'dll')  { return @($def.dll) }
+  throw "Arm '$Name' declares neither 'dll' nor 'dlls'."
+}
+
 foreach ($a in $Arms) {
   if ($a -notin $allArms) { throw "Arm '$a' is not in $Manifest (have: $($allArms -join ', '))" }
-  if (-not (Test-Path $armDefs.$a.dll)) { throw "Arm '$a': DLL not found: $($armDefs.$a.dll)" }
+  foreach ($d in (Get-ArmDlls $a)) {
+    if (-not (Test-Path $d)) { throw "Arm '$a': DLL not found: $d" }
+  }
+}
+
+# A file swapped by one arm but not another keeps that arm's build for every
+# later run, which reads as a real effect and is invisible in the output.
+$armFileSets = @{}
+foreach ($a in $Arms) {
+  $armFileSets[$a] = @(Get-ArmDlls $a | ForEach-Object { Split-Path -Leaf $_ } | Sort-Object)
+}
+$reference = $armFileSets[$Arms[0]]
+foreach ($a in $Arms) {
+  if (Compare-Object $reference $armFileSets[$a]) {
+    throw ("Arms swap different files, so one arm's build would leak into the other. " +
+           "'$($Arms[0])' has [$($reference -join ', ')], '$a' has [$($armFileSets[$a] -join ', ')].")
+  }
 }
 
 if (-not $OutDir) { $OutDir = Join-Path $HarnessEnv.OutRoot 'ttft' }
@@ -68,9 +104,9 @@ $benchTtft = Join-Path $PSScriptRoot 'bench_ttft.ps1'
 
 function Invoke-Arm {
   param([string]$Name, [string]$Tag, [int]$RunReps)
-  $dll  = $armDefs.$Name.dll
-  $dest = Join-Path $HarnessEnv.Bin (Split-Path -Leaf $dll)
-  Copy-Item $dll $dest -Force
+  foreach ($dll in (Get-ArmDlls $Name)) {
+    Copy-Item $dll (Join-Path $HarnessEnv.Bin (Split-Path -Leaf $dll)) -Force
+  }
   $temp = Join-Path $cacheRoot $Name
   New-Item -ItemType Directory -Force -Path $temp | Out-Null
   $env:TEMP = $temp; $env:TMP = $temp

--- a/tools/perf-harness/bench/ab_interleaved.ps1
+++ b/tools/perf-harness/bench/ab_interleaved.ps1
@@ -36,7 +36,19 @@ param(
   [int]$StartRound = 1,
   [switch]$Reverse,
   [switch]$SkipPrime,                 # caches survive while the DLLs are unchanged
-  [string]$OutDir
+  [string]$OutDir,
+  # Everything below only shapes the workload and is forwarded verbatim to
+  # bench_ttft.ps1, whose defaults these mirror. Without them an A/B silently
+  # measures bench_ttft's defaults rather than the operating point the arms were
+  # built for -- on a VLM that means the text-only driver, a 16k sequence, and
+  # whatever provider the model's genai_config happens to name.
+  [ValidateSet('model_benchmark', 'vlm')]
+  [string]$Driver = 'model_benchmark',
+  [int]$SeqLen = 16384,
+  [int]$MaxTokens = 4,
+  [int]$MaxLength,
+  [string]$ExecutionProvider = 'follow_config',
+  [string[]]$SetEnv = @()
 )
 
 $ErrorActionPreference = 'Stop'
@@ -62,7 +74,15 @@ function Invoke-Arm {
   $temp = Join-Path $cacheRoot $Name
   New-Item -ItemType Directory -Force -Path $temp | Out-Null
   $env:TEMP = $temp; $env:TMP = $temp
-  & $benchTtft -Tag $Tag -Reps $RunReps -Warmup 1 -OutDir $OutDir 2>&1 |
+  $fwd = @{
+    Driver           = $Driver
+    SeqLen           = $SeqLen
+    MaxTokens        = $MaxTokens
+    ExecutionProvider = $ExecutionProvider
+    SetEnv           = $SetEnv
+  }
+  if ($PSBoundParameters.ContainsKey('MaxLength')) { $fwd.MaxLength = $MaxLength }
+  & $benchTtft -Tag $Tag -Reps $RunReps -Warmup 1 -OutDir $OutDir @fwd 2>&1 |
     Where-Object { $_ -match 'TTFT \[' }
 }
 

--- a/tools/perf-harness/bench/ab_interleaved.ps1
+++ b/tools/perf-harness/bench/ab_interleaved.ps1
@@ -2,41 +2,42 @@
 ## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 ## Licensed under the MIT License.
 ##
-## Interleaved, order-reversed A/B (or A/B/C/...) of DLL variants by TTFT.
-##
-## Why not just run arm A a few times, then arm B a few times:
-##
-##  - Run-to-run spread on a thermally managed APU is comparable to the effects
-##    worth shipping (~0.8% vs ~1-2%), so block-sequential runs let slow drift
-##    land entirely on one arm. Interleaving and pairing by round cancels it.
-##  - Position within a round is itself a bias. Always run at least one block
-##    with -Reverse and check the delta survives; if it flips, you measured the
-##    order, not the change.
-##  - Discard rounds taken while the box is shedding heat from a build or a test
-##    suite. They report a different answer -- in one measured case the opposite
-##    sign -- and they are recognisable by sitting well above the known baseline.
-##
-## Each arm gets its OWN TEMP, and therefore its own autotune cache file: the
-## on-disk WMMA cache holds a single build timestamp and is discarded when it
-## does not match, so a shared TEMP would make every DLL swap a cold-tune run.
-##
-## Arms are defined in a JSON manifest:
-##
-##   { "base":  { "dll": "D:\\builds\\base\\custom_kernels_gfx1151.dll" },
-##     "cand":  { "dll": "D:\\builds\\cand\\custom_kernels_gfx1151.dll" } }
-##
-## The named DLL is copied over the same filename in $env:HIPEP_BIN before each
-## run, so every arm is measured through one identical harness.
-##
-## Use "dlls" instead when an arm spans more than one artifact:
-##
-##   { "base": { "dlls": ["D:\\b\\base\\hipgpu.dll",
-##                        "D:\\b\\base\\custom_kernels_gfx1151.dll"] }, ... }
-##
-## Anything touching lib/Conversion or lib/Runtime/real lands in hipgpu.dll, and
-## the two share the extern "C" kernel ABI, so swapping only one of the pair
-## measures a mix of both arms. Every arm must list the same file names, or the
-## unlisted one silently persists from whichever arm ran last.
+
+# Interleaved, order-reversed A/B (or A/B/C/...) of DLL variants by TTFT.
+#
+# Why not just run arm A a few times, then arm B a few times:
+#
+#  - Run-to-run spread on a thermally managed APU is comparable to the effects
+#    worth shipping (~0.8% vs ~1-2%), so block-sequential runs let slow drift
+#    land entirely on one arm. Interleaving and pairing by round cancels it.
+#  - Position within a round is itself a bias. Always run at least one block
+#    with -Reverse and check the delta survives; if it flips, you measured the
+#    order, not the change.
+#  - Discard rounds taken while the box is shedding heat from a build or a test
+#    suite. They report a different answer -- in one measured case the opposite
+#    sign -- and they are recognisable by sitting well above the known baseline.
+#
+# Each arm gets its OWN TEMP, and therefore its own autotune cache file: the
+# on-disk WMMA cache holds a single build timestamp and is discarded when it
+# does not match, so a shared TEMP would make every DLL swap a cold-tune run.
+#
+# Arms are defined in a JSON manifest:
+#
+#   { "base":  { "dll": "D:\\builds\\base\\custom_kernels_gfx1151.dll" },
+#     "cand":  { "dll": "D:\\builds\\cand\\custom_kernels_gfx1151.dll" } }
+#
+# The named DLL is copied over the same filename in $env:HIPEP_BIN before each
+# run, so every arm is measured through one identical harness.
+#
+# Use "dlls" instead when an arm spans more than one artifact:
+#
+#   { "base": { "dlls": ["D:\\b\\base\\hipgpu.dll",
+#                        "D:\\b\\base\\custom_kernels_gfx1151.dll"] }, ... }
+#
+# Anything touching lib/Conversion or lib/Runtime/real lands in hipgpu.dll, and
+# the two share the extern "C" kernel ABI, so swapping only one of the pair
+# measures a mix of both arms. Every arm must list the same file names, or the
+# unlisted one silently persists from whichever arm ran last.
 
 param(
   [Parameter(Mandatory = $true)][string]$Manifest,

--- a/tools/perf-harness/bench/ab_summary.py
+++ b/tools/perf-harness/bench/ab_summary.py
@@ -19,10 +19,28 @@ import statistics as st
 from collections import defaultdict
 
 # two-sided t critical values at 95% by degrees of freedom
-_TCRIT = {1: 12.706, 2: 4.303, 3: 3.182, 4: 2.776, 5: 2.571, 6: 2.447, 7: 2.365,
-          8: 2.306, 9: 2.262, 10: 2.228, 11: 2.201, 12: 2.179, 13: 2.160,
-          14: 2.145, 15: 2.131, 16: 2.120, 17: 2.110, 18: 2.101, 19: 2.093,
-          20: 2.086}
+_TCRIT = {
+    1: 12.706,
+    2: 4.303,
+    3: 3.182,
+    4: 2.776,
+    5: 2.571,
+    6: 2.447,
+    7: 2.365,
+    8: 2.306,
+    9: 2.262,
+    10: 2.228,
+    11: 2.201,
+    12: 2.179,
+    13: 2.160,
+    14: 2.145,
+    15: 2.131,
+    16: 2.120,
+    17: 2.110,
+    18: 2.101,
+    19: 2.093,
+    20: 2.086,
+}
 DEFAULT_TAG = r"^ab\d*_(?P<arm>.+)_r(?P<round>\d+)$"
 
 
@@ -33,10 +51,17 @@ def tcrit(df: int) -> float:
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("csv", help="ttft_summary.csv written by bench_ttft.ps1")
-    ap.add_argument("--baseline", required=True, help="arm every other arm is compared against")
-    ap.add_argument("--drop", type=int, nargs="*", default=[], help="round numbers to exclude")
-    ap.add_argument("--tag-re", default=DEFAULT_TAG,
-                    help="regex with 'arm' and 'round' groups, matched against the tag column")
+    ap.add_argument(
+        "--baseline", required=True, help="arm every other arm is compared against"
+    )
+    ap.add_argument(
+        "--drop", type=int, nargs="*", default=[], help="round numbers to exclude"
+    )
+    ap.add_argument(
+        "--tag-re",
+        default=DEFAULT_TAG,
+        help="regex with 'arm' and 'round' groups, matched against the tag column",
+    )
     args = ap.parse_args()
     tag_re = re.compile(args.tag_re)
 
@@ -49,19 +74,26 @@ def main() -> None:
     kept = sorted(r for r in runs if r not in args.drop)
     if not kept:
         raise SystemExit("no rounds left after --drop")
-    arms = [args.baseline] + sorted({a for r in kept for a in runs[r]} - {args.baseline})
+    arms = [args.baseline] + sorted(
+        {a for r in kept for a in runs[r]} - {args.baseline}
+    )
 
     print("round  " + "".join(f"{a:>10}" for a in arms))
     for r in sorted(runs):
         cells = "".join(f"{runs[r].get(a, float('nan')):10.0f}" for a in arms)
         print(f"{r:5d}  {cells}" + ("   <- dropped" if r in args.drop else ""))
 
-    print(f"\n{'arm':>10} {'n':>3} {'mean':>8} {'vs base':>9} {'sd of diff':>11} {'95% CI':>18} {'%':>8}")
+    print(
+        f"\n{'arm':>10} {'n':>3} {'mean':>8} {'vs base':>9} {'sd of diff':>11} {'95% CI':>18} {'%':>8}"
+    )
     base = [runs[r][args.baseline] for r in kept if args.baseline in runs[r]]
     print(f"{args.baseline:>10} {len(base):3d} {st.mean(base):8.0f} {'--':>9}")
     for arm in arms[1:]:
-        pairs = [(runs[r][arm] - runs[r][args.baseline]) for r in kept
-                 if arm in runs[r] and args.baseline in runs[r]]
+        pairs = [
+            (runs[r][arm] - runs[r][args.baseline])
+            for r in kept
+            if arm in runs[r] and args.baseline in runs[r]
+        ]
         if len(pairs) < 2:
             print(f"{arm:>10} {len(pairs):3d}  (need >=2 paired rounds)")
             continue
@@ -69,8 +101,10 @@ def main() -> None:
         m, sd = st.mean(pairs), st.stdev(pairs)
         half = tcrit(len(pairs) - 1) * sd / len(pairs) ** 0.5
         verdict = "" if (m - half) * (m + half) > 0 else "   (spans zero)"
-        print(f"{arm:>10} {len(pairs):3d} {st.mean(vals):8.0f} {m:+9.0f} {sd:11.0f} "
-              f"{f'[{m-half:+.0f}, {m+half:+.0f}]':>18} {100*m/st.mean(base):+8.2f}{verdict}")
+        print(
+            f"{arm:>10} {len(pairs):3d} {st.mean(vals):8.0f} {m:+9.0f} {sd:11.0f} "
+            f"{f'[{m - half:+.0f}, {m + half:+.0f}]':>18} {100 * m / st.mean(base):+8.2f}{verdict}"
+        )
 
 
 if __name__ == "__main__":

--- a/tools/perf-harness/bench/bench_ttft.ps1
+++ b/tools/perf-harness/bench/bench_ttft.ps1
@@ -24,7 +24,11 @@ param(
   [ValidateSet('model_benchmark', 'vlm')]
   [string]$Driver = 'model_benchmark',
   [int]$MaxTokens = 4,              # vlm only: keep decode short, TTFT is the target
-  [int]$MaxLength                   # vlm only: KV cache size; defaults to prompt + headroom
+  [int]$MaxLength,                  # vlm only: KV cache size; defaults to prompt + headroom
+  # vlm only. 'follow_config' leaves the model's own genai_config provider list
+  # alone; naming a provider overrides it, which is what an export pinned to
+  # another EP (a -dml directory, say) needs to run here.
+  [string]$ExecutionProvider = 'follow_config'
 )
 
 $ErrorActionPreference = 'Continue'
@@ -70,6 +74,7 @@ if ($Driver -eq 'vlm') {
   & $HarnessEnv.Python '-u' $HarnessEnv.VlmBench `
     '-m' $HarnessEnv.Model '-i' $HarnessEnv.Image '--prompt_file' $HarnessEnv.PromptFile `
     '--max_tokens' "$MaxTokens" '--max_length' "$MaxLength" `
+    '-e' $ExecutionProvider `
     '-n' "$Reps" '-w' "$Warmup" '-o' $json *>&1 |
     Tee-Object -FilePath $log | Out-Null
   $rc = $LASTEXITCODE

--- a/tools/perf-harness/bench/bench_ttft.ps1
+++ b/tools/perf-harness/bench/bench_ttft.ps1
@@ -2,14 +2,15 @@
 ## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 ## Licensed under the MIT License.
 ##
-## One clean TTFT measurement, appended to a CSV.
-##
-## Deliberately no HIPDNN_EP_PERF / HIPDNN_EP_DEBUG: CLAUDE.md forbids measuring
-## throughput with either (PERF alone costs ~4%).
-##
-## Warmup reps are not optional. Autotune caches are per-process and partly
-## on-disk keyed by build timestamp, so iteration 1 of a fresh build always pays
-## tuning cost and is not a measurement of the kernel.
+
+# One clean TTFT measurement, appended to a CSV.
+#
+# Deliberately no HIPDNN_EP_PERF / HIPDNN_EP_DEBUG: CLAUDE.md forbids measuring
+# throughput with either (PERF alone costs ~4%).
+#
+# Warmup reps are not optional. Autotune caches are per-process and partly
+# on-disk keyed by build timestamp, so iteration 1 of a fresh build always pays
+# tuning cost and is not a measurement of the kernel.
 
 param(
   [Parameter(Mandatory = $true)][string]$Tag,

--- a/tools/perf-harness/bench/build_deploy.ps1
+++ b/tools/perf-harness/bench/build_deploy.ps1
@@ -2,36 +2,37 @@
 ## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 ## Licensed under the MIT License.
 ##
-## Build the runtime artifacts and deploy them where the benchmark drivers load
-## them from, so an A/B is one command and cannot silently measure a stale DLL.
-##
-## Why this exists as a script rather than a documented copy step. The perf
-## harness measures whatever is in $HIPEP_BIN, which for the vlm driver is a
-## venv's onnxruntime\capi -- not the cmake install prefix. Nothing connects the
-## two, so a hand-run build followed by a forgotten copy reports the previous
-## DLL's number as the new one. That failure is silent and produces a plausible
-## result, which is the worst kind. Deploying prints each file's hash so a
-## comparison against the previous run's hash proves the binary actually moved.
-##
-## Three artifacts carry the operators the harness profiles:
-##   hipgpu.dll                  lib/Runtime (gqa.cpp, matmul_nbits.cpp)
-##   custom_kernels_<arch>.dll   lib/Runtime/Kernels/hip (gqa_kernel.hip,
-##                               matmul_nbits_kernel.hip)
-##   hip-compiler.dll            lib/Dialect and lib/Conversion -- every MLIR
-##                               pass, fold and canonicalization
-## They are deployed as a set on purpose. hipgpu and custom_kernels share the
-## extern "C" kernel ABI, so a mixed pair is only accidentally correct -- and a
-## mixed pair was in fact deployed on this machine (hipgpu from one build,
-## custom_kernels from an eight-hour-older one), which is unattributable as a
-## baseline.
-##
-## hip-compiler.dll is here because leaving it out is silent in a way the other
-## two are not. A graph-level change lowers to the same runtime entry points, so
-## a stale compiler produces a correct, fast-looking run that simply never
-## applies the rewrite. The causal-conv Transpose fold lives entirely in
-## hip-compiler.dll (lib/Dialect/IR/HipCausalConvCanonicalize.cpp); deploying
-## without it measures the conv kernel change alone and reports the fold as
-## worthless.
+
+# Build the runtime artifacts and deploy them where the benchmark drivers load
+# them from, so an A/B is one command and cannot silently measure a stale DLL.
+#
+# Why this exists as a script rather than a documented copy step. The perf
+# harness measures whatever is in $HIPEP_BIN, which for the vlm driver is a
+# venv's onnxruntime\capi -- not the cmake install prefix. Nothing connects the
+# two, so a hand-run build followed by a forgotten copy reports the previous
+# DLL's number as the new one. That failure is silent and produces a plausible
+# result, which is the worst kind. Deploying prints each file's hash so a
+# comparison against the previous run's hash proves the binary actually moved.
+#
+# Three artifacts carry the operators the harness profiles:
+#   hipgpu.dll                  lib/Runtime (gqa.cpp, matmul_nbits.cpp)
+#   custom_kernels_<arch>.dll   lib/Runtime/Kernels/hip (gqa_kernel.hip,
+#                               matmul_nbits_kernel.hip)
+#   hip-compiler.dll            lib/Dialect and lib/Conversion -- every MLIR
+#                               pass, fold and canonicalization
+# They are deployed as a set on purpose. hipgpu and custom_kernels share the
+# extern "C" kernel ABI, so a mixed pair is only accidentally correct -- and a
+# mixed pair was in fact deployed on this machine (hipgpu from one build,
+# custom_kernels from an eight-hour-older one), which is unattributable as a
+# baseline.
+#
+# hip-compiler.dll is here because leaving it out is silent in a way the other
+# two are not. A graph-level change lowers to the same runtime entry points, so
+# a stale compiler produces a correct, fast-looking run that simply never
+# applies the rewrite. The causal-conv Transpose fold lives entirely in
+# hip-compiler.dll (lib/Dialect/IR/HipCausalConvCanonicalize.cpp); deploying
+# without it measures the conv kernel change alone and reports the fold as
+# worthless.
 
 [CmdletBinding()]
 param(

--- a/tools/perf-harness/bench/build_deploy.ps1
+++ b/tools/perf-harness/bench/build_deploy.ps1
@@ -13,15 +13,25 @@
 ## result, which is the worst kind. Deploying prints each file's hash so a
 ## comparison against the previous run's hash proves the binary actually moved.
 ##
-## Only two artifacts matter for the operators the harness profiles:
-##   hipgpu.dll                  lib/Runtime (gqa.cpp, matmul_nbits.cpp) and
-##                               lib/Conversion
+## Three artifacts carry the operators the harness profiles:
+##   hipgpu.dll                  lib/Runtime (gqa.cpp, matmul_nbits.cpp)
 ##   custom_kernels_<arch>.dll   lib/Runtime/Kernels/hip (gqa_kernel.hip,
 ##                               matmul_nbits_kernel.hip)
-## They are deployed as a pair on purpose. They share the extern "C" kernel ABI,
-## so a mixed pair is only accidentally correct -- and a mixed pair was in fact
-## deployed on this machine (hipgpu from one build, custom_kernels from an
-## eight-hour-older one), which is unattributable as a baseline.
+##   hip-compiler.dll            lib/Dialect and lib/Conversion -- every MLIR
+##                               pass, fold and canonicalization
+## They are deployed as a set on purpose. hipgpu and custom_kernels share the
+## extern "C" kernel ABI, so a mixed pair is only accidentally correct -- and a
+## mixed pair was in fact deployed on this machine (hipgpu from one build,
+## custom_kernels from an eight-hour-older one), which is unattributable as a
+## baseline.
+##
+## hip-compiler.dll is here because leaving it out is silent in a way the other
+## two are not. A graph-level change lowers to the same runtime entry points, so
+## a stale compiler produces a correct, fast-looking run that simply never
+## applies the rewrite. The causal-conv Transpose fold lives entirely in
+## hip-compiler.dll (lib/Dialect/IR/HipCausalConvCanonicalize.cpp); deploying
+## without it measures the conv kernel change alone and reports the fold as
+## worthless.
 
 [CmdletBinding()]
 param(
@@ -112,7 +122,7 @@ $arch = (Select-String -Path (Join-Path $BuildDir 'CMakeCache.txt') `
 $arch = ($arch -split ';')[0].Trim()
 if (-not $arch) { throw "Could not read HIP_ARCHITECTURES from the cmake cache." }
 
-$artifacts = @('hipgpu.dll', "custom_kernels_$arch.dll")
+$artifacts = @('hipgpu.dll', "custom_kernels_$arch.dll", 'hip-compiler.dll')
 
 if (-not $SkipBuild) {
   Write-Host ">>> build [$Config] $BuildDir"
@@ -124,7 +134,7 @@ if (-not $SkipBuild) {
     # versioned unique id and only its OUTPUT_NAME is hipgpu, so ask cmake for
     # the file and let ninja resolve the producing target.
     $cmd += @('--target')
-    $cmd += @("bin/hipgpu.dll", "bin/custom_kernels_$arch.dll")
+    $cmd += @($artifacts | ForEach-Object { "bin/$_" })
   }
   $sw = [Diagnostics.Stopwatch]::StartNew()
   & cmake @cmd

--- a/tools/perf-harness/capture/rgp_capture.ps1
+++ b/tools/perf-harness/capture/rgp_capture.ps1
@@ -43,6 +43,10 @@ param(
   [string]$Driver = 'model_benchmark',
   [int]$MaxTokens = 2,                           # vlm only
   [int]$MaxLength,                               # vlm only
+  # vlm only. 'follow_config' leaves the model's own genai_config provider list
+  # alone; naming a provider overrides it, which is what an export pinned to
+  # another EP (a -dml directory, say) needs to run here.
+  [string]$ExecutionProvider = 'follow_config',
   [int]$Gen = 1,
   [int]$Reps = 2,                                # RGP streams the dump from the LIVE process; see note below
   [int]$OpCount = 4000,                          # --rgp-render-op-count: window size, not usability
@@ -124,7 +128,8 @@ if ($isVlm) {
   $exe   = $HarnessEnv.Python
   $margs = @('-u', $HarnessEnv.VlmBench, '-m', $HarnessEnv.Model, '-i', $HarnessEnv.Image,
              '--prompt_file', $PromptFile, '--max_tokens', "$MaxTokens",
-             '--max_length', "$MaxLength", '-n', "$Reps", '-w', '0')
+             '--max_length', "$MaxLength", '-e', $ExecutionProvider,
+             '-n', "$Reps", '-w', '0')
   $wd    = Split-Path -Parent $HarnessEnv.VlmBench
 } else {
   $exe   = Join-Path $HarnessEnv.Bin 'model_benchmark.exe'

--- a/tools/perf-harness/capture/rgp_capture.ps1
+++ b/tools/perf-harness/capture/rgp_capture.ps1
@@ -54,6 +54,11 @@ param(
   [string]$Buf = 'default',
   [switch]$Counters,                             # SPM: required for memory/compute bound classification
   [int]$Dwell = 30,                              # seconds to let the .rgp finish dumping
+  # How long to wait for the fence to arm. A 16K VLM prefill under the panel
+  # needs far more than the 10 minutes that suffices for a 2K one: model load,
+  # the per-process prefill autotune sweep and a cold first rep all land before
+  # the fence can fire.
+  [int]$ArmTimeoutSec = 600,
   [string]$OutDir
 )
 
@@ -148,7 +153,7 @@ Write-Host "model PID=$($bench.Id) launched"
 # In fence mode, watch stderr for the armed marker and trigger inside the idle
 # window. In trigger mode there is nothing to wait for; the panel fires itself.
 $triggered = ($PSCmdlet.ParameterSetName -ne 'Fence')
-$deadline = (Get-Date).AddSeconds(600)
+$deadline = (Get-Date).AddSeconds($ArmTimeoutSec)
 while (-not $bench.HasExited -and (Get-Date) -lt $deadline) {
   if ($pOutTask.IsCompleted) { if ($pOutTask.Result) { Add-Content $panelLog $pOutTask.Result }; $pOutTask = $pOut.ReadLineAsync() }
   if ($pErrTask.IsCompleted) { if ($pErrTask.Result) { Add-Content $panelLog $pErrTask.Result }; $pErrTask = $pErr.ReadLineAsync() }

--- a/tools/perf-harness/capture/rgp_capture.ps1
+++ b/tools/perf-harness/capture/rgp_capture.ps1
@@ -169,8 +169,21 @@ while (-not $bench.HasExited -and (Get-Date) -lt $deadline) {
 # nothing -- that is what -Reps buys, not extra measurement.
 Write-Host "model exited=$($bench.HasExited) triggered=$triggered ; dwell ${Dwell}s for the dump"
 Start-Sleep $Dwell
+# The panel writes the .rgp as it shuts down, not when the transfer finishes, so
+# it has to be allowed to exit on its own. Killing it a few seconds after 'quit'
+# loses the whole capture: the trace transfers to 100%, the panel dies
+# mid-write, and no file is ever created.
 try { $panel.StandardInput.WriteLine('quit'); $panel.StandardInput.Flush() } catch {}
-Start-Sleep 4
+$sz = -1
+for ($i = 0; $i -lt 100; $i++) {
+  if ($panel.HasExited) { break }
+  Start-Sleep 3
+  if (Test-Path $OutRgp) {
+    $now = (Get-Item $OutRgp).Length
+    if ($now -gt 0 -and $now -eq $sz) { break }   # written and no longer growing
+    $sz = $now
+  }
+}
 Stop-HarnessProcesses -IncludePython:$isVlm
 Remove-Item Env:RGP_FENCE, Env:RGP_FENCE_SKIP, Env:RGP_FENCE_MS -EA SilentlyContinue
 

--- a/tools/perf-harness/capture/rgp_capture.ps1
+++ b/tools/perf-harness/capture/rgp_capture.ps1
@@ -2,24 +2,25 @@
 ## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 ## Licensed under the MIT License.
 ##
-## Drive one RGP dispatch-mode capture of a model_benchmark run, then decode it
-## with tools/rgp_parser.
-##
-## Positioning a capture on a specific op is the hard part. Two modes:
-##
-##   -Op <name>   Fence mode. The runtime's rgp_capture_fence (op_profile.cpp)
-##                drains the GPU and idles right before that op's Nth instance,
-##                printing [RGP_FENCE_ARMED]. This script watches for the marker
-##                and triggers RGP inside the idle window, so the very next
-##                dispatches are the op you asked for. Deterministic.
-##
-##   -Trigger     Auto-capture mode: RGP's own dispatch:<delay>:<count> trigger.
-##                No runtime support needed, but it positions blind by dispatch
-##                index, which drifts run to run. Use when the build under test
-##                has no fence.
-##
-## Deliberately no HIPDNN_EP_PERF / HIPDNN_EP_DEBUG: CLAUDE.md forbids measuring
-## throughput with either. SQTT already carries the timing.
+
+# Drive one RGP dispatch-mode capture of a model_benchmark run, then decode it
+# with tools/rgp_parser.
+#
+# Positioning a capture on a specific op is the hard part. Two modes:
+#
+#   -Op <name>   Fence mode. The runtime's rgp_capture_fence (op_profile.cpp)
+#                drains the GPU and idles right before that op's Nth instance,
+#                printing [RGP_FENCE_ARMED]. This script watches for the marker
+#                and triggers RGP inside the idle window, so the very next
+#                dispatches are the op you asked for. Deterministic.
+#
+#   -Trigger     Auto-capture mode: RGP's own dispatch:<delay>:<count> trigger.
+#                No runtime support needed, but it positions blind by dispatch
+#                index, which drifts run to run. Use when the build under test
+#                has no fence.
+#
+# Deliberately no HIPDNN_EP_PERF / HIPDNN_EP_DEBUG: CLAUDE.md forbids measuring
+# throughput with either. SQTT already carries the timing.
 
 [CmdletBinding(DefaultParameterSetName = 'Fence')]
 param(

--- a/tools/perf-harness/capture/verify_rgp.py
+++ b/tools/perf-harness/capture/verify_rgp.py
@@ -25,8 +25,11 @@ from rgp_parser.struct.rdf import RdfFile  # noqa: E402
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("capture", help="path to the .rgp file")
-    ap.add_argument("--require-spm", action="store_true",
-                    help="also fail when the capture carries no SPM counters")
+    ap.add_argument(
+        "--require-spm",
+        action="store_true",
+        help="also fail when the capture carries no SPM counters",
+    )
     args = ap.parse_args()
 
     counts = RdfFile.from_path(args.capture).counts()

--- a/tools/perf-harness/common.ps1
+++ b/tools/perf-harness/common.ps1
@@ -87,8 +87,14 @@ function Set-HarnessPath {
 
 # Throughput must never be measured with the EP's own instrumentation: PERF
 # alone costs ~4%. SQTT carries the timing instead.
+#
+# HIPDNN_EP_TRACE_FILE has to go too: hipdnn_ep_perf_enabled() is true for
+# either variable, so a trace path left over from an earlier shell turns the
+# profiler on with none of PERF's console output to give it away. That leak
+# inflated a 16K VLM baseline from 14,610 ms to 17,545 ms before it was found.
 function Clear-HarnessProfilingEnv {
-  Remove-Item Env:HIPDNN_EP_PERF, Env:HIPDNN_EP_DEBUG -EA SilentlyContinue
+  Remove-Item Env:HIPDNN_EP_PERF, Env:HIPDNN_EP_DEBUG, Env:HIPDNN_EP_TRACE_FILE `
+    -EA SilentlyContinue
 }
 
 function Stop-HarnessProcesses {

--- a/tools/perf-harness/common.ps1
+++ b/tools/perf-harness/common.ps1
@@ -2,10 +2,11 @@
 ## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 ## Licensed under the MIT License.
 ##
-## Shared environment resolution for the perf-harness scripts.
-##
-## Everything is an environment variable with a discovery fallback, so the same
-## scripts run on any machine. Dot-source this, then use the $HarnessEnv fields.
+
+# Shared environment resolution for the perf-harness scripts.
+#
+# Everything is an environment variable with a discovery fallback, so the same
+# scripts run on any machine. Dot-source this, then use the $HarnessEnv fields.
 
 Set-StrictMode -Version Latest
 


### PR DESCRIPTION
Six harness fixes and the Qwen3.6-35B-A3B 16K profiling writeup. Two of the fixes
are the reason the rest of this workstream's numbers can be trusted at all; the
other four are what the 16K VLM workload needed that the harness did not do.

Based on `feat/rgp-capture-fence`, which is not yet merged.

## The measurement was wrong by 21%

`hipdnn_ep_perf_enabled()` returns true for *either* `HIPDNN_EP_PERF` or
`HIPDNN_EP_TRACE_FILE`, but `Clear-HarnessProfilingEnv` only removed the former:

```powershell
Remove-Item Env:HIPDNN_EP_PERF, Env:HIPDNN_EP_DEBUG -EA SilentlyContinue
```

A `HIPDNN_EP_TRACE_FILE` left over from an earlier shell therefore enabled full EP
instrumentation, including a per-inference `hipStreamSynchronize`, on runs the
harness reported as clean. That inflated the Qwen3.6 16K baseline from 14,455 ms
to 17,545 ms and stood as the published baseline for a while.

Confirmed rather than assumed: re-setting `HIPDNN_EP_TRACE_FILE` on the current
build reproduces 17,545 ms against the earlier 17,587 ms, a 0.24% match.

## `build_deploy.ps1` did not deploy `hip-compiler.dll`

It deployed `hipgpu.dll` and `custom_kernels_gfx1151.dll` only. Every MLIR pass,
fold and canonicalization lives in `hip-compiler.dll`, so any graph-level change
was silently discarded at runtime while the kernel-level part of the same commit
shipped.

This is worse than a stale kernel because it is invisible: the graph lowers to the
same runtime entry points, so the run is correct and merely misses the rewrite. It
would have reported #722's Transpose fold -- the largest win of the round -- as
worthless. Confirmed by symbol lookup: `FoldTransposePairIntoChannelsLast`
resolves in `hip-compiler.dll` and is absent from `hipgpu.dll`.

`ab_interleaved.ps1` had the matching gap: one DLL per arm cannot express a change
spanning the kernel and the compiler. Arms now take a `dlls` list, and the script
refuses arms that do not list the same file names, because a file swapped by one
arm but not another persists into the next run and reads as a real effect.

## The rest

- **`-ExecutionProvider`**: the VLM driver followed the model's genai config, so
  measuring the AMDGPU EP on a model configured for another one was not expressible.
- **RGP panel race**: the harness killed the panel before it finished writing, so
  captures were intermittently truncated. It now waits for the file.
- **Fence arm deadline**: hardcoded at 600 s, which a 16K VLM prefill exceeds --
  the first decoder inference alone takes ~236 s for autotune sweeps, and warmup
  plus the first rep all precede the fence. Now `-ArmTimeoutSec`.
- **`ab_interleaved.ps1` dropped workload knobs**: `-SeqLen`, `-MaxLength` and
  friends were not forwarded to `bench_ttft.ps1`, so both arms silently ran the
  default workload instead of the one asked for.

## The fence did not build against the mock runtime

`op_profile.cpp`, which carries the capture fence, is compiled for both runtimes
but included `<hip/hip_runtime.h>` directly, and the mock build has no ROCm
headers on its include path -- so `build-windows-mock` failed on it. The include
was redundant either way, since the HIP types arrive through
`op_profile.h` -> `runtime_types.h`, which resolves per build; `mock_types.h` was
already carrying `hipEventDisableSystemFence` with a comment pointing at this
file, so only the direct include stood in the way. `hipDeviceSynchronize` needed
a mock declaration, the fence being its only caller.

This is a defect in the base branch that had never run through CI, because
`feat/rgp-capture-fence` has no PR of its own.

## One thing worth knowing about `licenseheaders`

The last two commits are formatting, and one of them is a hazard rather than
housekeeping. For `.ps1` and `.py`, `LICENSES/settings.json` sets
`lineCommentStartPattern` to `^\s*#`, so the hook claims the *entire* leading
run of `#` lines and replaces it with the canonical two-line header. A
file-purpose comment written directly under the header is therefore deleted, not
reformatted: on these five scripts it was 95 lines, all deletions and no
insertions.

A blank line ends the run, so the prose survives below one. Anyone adding a
documented script under `tools/` should leave that blank line in place.

`lintrunner` also reformats `lib/Runtime/real/gqa.cpp`, which this branch does
not touch. The head-group loop added by `fix(gemma4)` on the base branch left its
body at the old indentation, and since CI runs `pre-commit --all-files` the debt
fails any PR stacked on it. Fixed here in its own commit.

## The writeup

`docs/perf/qwen36-16k-bottleneck.md` covers four rounds on Qwen3.6-35B-A3B at
18,646 prompt tokens: session decomposition, per-kernel RGP timing with no EP
instrumentation, a roofline ranking by recoverable time, the three landings from
this round (#722, #723, #726) and a re-profile afterwards.

Two findings in it are about method rather than about this model:

- **`[PERF]` per-op timing is not just inflated, its attribution is wrong.**
  It put vision MHA at 0.56 ms/call against RGP's 20.34, and GQA at 27 ms/call
  against 380. The MHA figure is below the kernel's own arithmetic floor of
  4.13 ms, so it is impossible, not merely optimistic. Call counts and shapes from
  `[PERF]` are plain counters and stay usable; the timings are not.
- **Ranking by kernel family averages shapes that differ by 100x.** One
  linear-attention block runs `ew_bcast4d` at both 596,736 and 76,374,016 threads.
  Grouping per `(kernel, threads)` instead corrected `T5Layernorm` from 16% of
  roofline and 505 ms recoverable to 44% and 274 ms, and caught a round-2 dispatch
  timing that implied 239% of achievable bandwidth and so was never real.

## Test plan

- [x] `HIPDNN_EP_TRACE_FILE` inflation reproduced and then eliminated: 17,545 ->
      14,537 ms on the same binaries
- [x] `hip-compiler.dll` omission confirmed by symbol lookup, and #722's fold
      measured only after the fix (-1,772 ms; it reads as ~0 without it)
- [x] Multi-DLL arms used for all three A/B series in this round, 4 paired rounds
      each, both orderings
- [x] Three RGP fence windows captured at 16K and gated through
      `inspect_capture.py`; the block model agrees with end-to-end TTFT to 2%
