### PR TITLE
feat(hipsr): add hipsr-add-context-arg pass

### DIFF
--- a/include/hip/Dialect/Hipsr/Transforms/Passes.td
+++ b/include/hip/Dialect/Hipsr/Transforms/Passes.td
@@ -13,6 +13,21 @@
 
 include "mlir/Pass/PassBase.td"
 
+def AddContextArgPass : Pass<"hipsr-add-context-arg", "mlir::ModuleOp"> {
+  let summary = "Insert !hipsr.context as arg 0 into every func.func";
+  let description = [{
+    Inserts a !hipsr.context argument at position 0 into every func.func in
+    the module. The OnnxToHipsr conversion patterns assume that the context
+    value is always available as the first function argument.
+
+    Skips functions that already have a !hipsr.context as argument 0.
+  }];
+  let dependentDialects = [
+    "::mlir::hipsr::HipsrDialect",
+    "::mlir::func::FuncDialect"
+  ];
+}
+
 def PopulateShapeRegionPass
     : Pass<"hipsr-populate-shape-region", "mlir::func::FuncOp"> {
   let summary = "Fill empty hipsr shape regions";

--- a/lib/Dialect/Hipsr/Pipelines/Pipelines.cpp
+++ b/lib/Dialect/Hipsr/Pipelines/Pipelines.cpp
@@ -5,10 +5,13 @@
 
 #include "hip/Dialect/Hipsr/Pipelines/Pipelines.h"
 
+#include "hip/Dialect/Hipsr/Transforms/Passes.h"
+
 #include "mlir/Pass/PassRegistry.h"
 
-void mlir::hipsr::buildHipsrPipeline(OpPassManager & /*pm*/,
+void mlir::hipsr::buildHipsrPipeline(OpPassManager &pm,
                                      const HipsrPipelineOptions & /*options*/) {
+  pm.addPass(createAddContextArgPass());
 }
 
 void mlir::hipsr::registerHipsrPipelines() {

--- a/lib/Dialect/Hipsr/Transforms/AddContextArgPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/AddContextArgPass.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- AddContextArgPass.cpp - Insert !hipsr.context as function arg 0 ----===//
+//
+// Inserts !hipsr.context as the first argument of every func.func in the
+// module and updates all func.call sites to forward the context.
+//
+// Two-phase approach:
+//   Phase 1: Walk all func.func ops, insert !hipsr.context as arg 0.
+//   Phase 2: Collect all func.call ops targeting updated functions,
+//            then prepend the caller's !hipsr.context argument.
+//
+//===----------------------------------------------------------------------===//
+
+#include "hip/Dialect/Hipsr/Transforms/Passes.h"
+
+#include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+
+namespace mlir {
+namespace hipsr {
+
+#define GEN_PASS_DEF_ADDCONTEXTARGPASS
+#include "hip/Dialect/Hipsr/Transforms/Passes.h.inc"
+
+namespace {
+
+struct AddContextArgPass : impl::AddContextArgPassBase<AddContextArgPass> {
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    Type ctxType = ContextType::get(&getContext());
+
+    DenseSet<StringRef> updatedNames;
+    module.walk([&](func::FuncOp funcOp) {
+      if (!funcOp.getArguments().empty() &&
+          funcOp.getArgument(0).getType() == ctxType) {
+        return;
+      }
+
+      (void)funcOp.insertArgument(0, ctxType, {}, funcOp.getLoc());
+      updatedNames.insert(funcOp.getName());
+    });
+
+    if (updatedNames.empty()) {
+      return;
+    }
+
+    SmallVector<func::CallOp> callsToUpdate;
+    module.walk([&](func::CallOp callOp) {
+      if (updatedNames.contains(callOp.getCallee())) {
+        callsToUpdate.push_back(callOp);
+      }
+    });
+
+    for (func::CallOp callOp : callsToUpdate) {
+      auto callerFunc = callOp->getParentOfType<func::FuncOp>();
+      if (!callerFunc) {
+        callOp.emitError("call op is not inside a func.func");
+        return signalPassFailure();
+      }
+      if (callerFunc.getArguments().empty() ||
+          !isa<ContextType>(callerFunc.getArgument(0).getType())) {
+        callOp.emitError("caller @")
+            << callerFunc.getName() << " does not have !hipsr.context as arg 0";
+        return signalPassFailure();
+      }
+
+      Value callerCtx = callerFunc.getArgument(0);
+      SmallVector<Value> newOperands = {callerCtx};
+      newOperands.append(callOp.getOperands().begin(),
+                         callOp.getOperands().end());
+      OpBuilder builder(callOp);
+      auto newCall =
+          func::CallOp::create(builder, callOp.getLoc(), callOp.getCallee(),
+                               callOp.getResultTypes(), newOperands);
+      callOp.replaceAllUsesWith(newCall.getResults());
+      callOp.erase();
+    }
+  }
+};
+
+} // namespace
+
+} // namespace hipsr
+} // namespace mlir

--- a/lib/Dialect/Hipsr/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/Transforms/CMakeLists.txt
@@ -4,6 +4,7 @@
 ##
 
 add_library(HipsrDialectTransforms STATIC
+  AddContextArgPass.cpp
   BufferizableOpInterfaceImpl.cpp
   ExternalizeConstants.cpp
   HipsrPoolAllocPass.cpp

--- a/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
@@ -15,6 +15,7 @@
 // RUN: hip-mlir-opt --hipsr-pipeline %s | FileCheck %s
 
 // CHECK-LABEL: func.func @main_graph(
+// CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:      %[[IDS:.*]]: tensor<?x?xi64> {onnx.name = "input_ids"},
 // CHECK-SAME:      %[[FEATURES:.*]]: tensor<?x4096xf16> {onnx.name = "image_features"})
 // CHECK-SAME:      -> (tensor<?x?x4096xf16> {onnx.name = "inputs_embeds"})

--- a/test/lit/Dialect/Hipsr/Transforms/AddContextArg/add-context-arg.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/AddContextArg/add-context-arg.mlir
@@ -1,0 +1,50 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// FileCheck tests for --hipsr-add-context-arg (insert !hipsr.context as arg 0).
+//
+// Two-phase behavior verified by these tests:
+//   Phase 1: Every func.func gains !hipsr.context as its first argument.
+//   Phase 2: Every func.call targeting an updated function is rewritten to
+//            forward the caller's !hipsr.context.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --hipsr-add-context-arg %s | FileCheck %s
+
+// ===== Basic: single function gains !hipsr.context =====
+//
+// CHECK-LABEL: func.func @single_func
+// CHECK-SAME:    (%arg0: !hipsr.context, %arg1: tensor<8x8xf32>)
+// CHECK:         return
+func.func @single_func(%a: tensor<8x8xf32>) -> tensor<8x8xf32> {
+  return %a : tensor<8x8xf32>
+}
+
+// ===== Skip: function already has !hipsr.context =====
+//
+// CHECK-LABEL: func.func @already_has_context
+// CHECK-SAME:    (%arg0: !hipsr.context, %arg1: tensor<8x8xf32>)
+// CHECK-NOT:     !hipsr.context, !hipsr.context
+// CHECK:         return
+func.func @already_has_context(%ctx: !hipsr.context, %a: tensor<8x8xf32>) -> tensor<8x8xf32> {
+  return %a : tensor<8x8xf32>
+}
+
+// ===== Call site update: caller passes context to callee =====
+//
+// CHECK-LABEL: func.func @callee_for_call_test
+// CHECK-SAME:    (%arg0: !hipsr.context, %arg1: tensor<8x8xf32>)
+
+// CHECK-LABEL: func.func @caller_updates_call
+// CHECK-SAME:    (%[[CTX:.*]]: !hipsr.context, %[[A:.*]]: tensor<8x8xf32>)
+// CHECK:         call @callee_for_call_test(%[[CTX]], %[[A]])
+// CHECK:         return
+func.func @callee_for_call_test(%a: tensor<8x8xf32>) -> tensor<8x8xf32> {
+  return %a : tensor<8x8xf32>
+}
+
+func.func @caller_updates_call(%a: tensor<8x8xf32>) -> tensor<8x8xf32> {
+  %res = func.call @callee_for_call_test(%a) : (tensor<8x8xf32>) -> tensor<8x8xf32>
+  return %res : tensor<8x8xf32>
+}


### PR DESCRIPTION
## Summary

Add `hipsr-add-context-arg`, which inserts a `!hipsr.context` argument at position 0 into every `func.func`, and make it the first pass of `buildHipsrPipeline`.

## What

- Functions that already have `!hipsr.context` as argument 0 are skipped.
- Inserting the argument changes the function type, so every `func.call` to an updated function is rewritten to forward the caller's own context. 
- `buildHipsrPipeline` was an empty stub. The new pass has to run before any conversion, since the conversion patterns depend on argument 0 already being the context.

## Test plan

- [x] New `test/lit/Dialect/Hipsr/Transforms/AddContextArg/add-context-arg.mlir`: argument insertion, skipping a function that already has the context, and call-site forwarding.
- [x] `test/lit/Dialect/Hipsr/Pipelines/embedding.mlir` updated because `--hipsr-pipeline` is no longer a no-op.
