### PR TITLE
feat(hipsr): convert onnx.Shape to a hipsr.compute

### DIFF
--- a/include/hip/Conversion/OnnxToHipsr/OnnxToHipsr.h
+++ b/include/hip/Conversion/OnnxToHipsr/OnnxToHipsr.h
@@ -39,6 +39,10 @@ void populateExpandConversionPatterns(
     const ::mlir::TypeConverter &typeConverter,
     ::mlir::RewritePatternSet &patterns, ::mlir::MLIRContext *ctx);
 
+void populateShapeConversionPatterns(const ::mlir::TypeConverter &typeConverter,
+                                     ::mlir::RewritePatternSet &patterns,
+                                     ::mlir::MLIRContext *ctx);
+
 void populateReturnConversionPatterns(::mlir::RewritePatternSet &patterns,
                                       ::mlir::MLIRContext *ctx);
 

--- a/include/hip/Dialect/Hipsr/IR/HipsrShapeRegionPopulationUtils.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrShapeRegionPopulationUtils.h
@@ -9,6 +9,7 @@
 #include "hip/Dialect/Hipsr/IR/HipsrOps.h"
 
 #include "mlir/IR/Block.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/Value.h"
 
 #include "llvm/ADT/StringRef.h"
@@ -20,8 +21,23 @@
 namespace mlir {
 namespace hipsr {
 
+/// Creates the entry block of a placeholder's shape region, one argument per
+/// entry in `getShapeRegionArgumentTypes`. Shared by
+/// hipsr-populate-shape-region and the conversions that fill a region
+/// themselves.
+inline Block &createPlaceholderShapeBlock(OpBuilder &builder,
+                                          PlaceholderOp placeholder) {
+  Region &shapeRegion = placeholder.getShapeRegion();
+  Block &block = *builder.createBlock(&shapeRegion);
+  for (Type type : placeholder.getShapeRegionArgumentTypes()) {
+    block.addArgument(type, placeholder.getLoc());
+  }
+  return block;
+}
+
 /// Accesses block arguments of a placeholder-owned shape region.
-/// Missing arguments are fatal because the population pass creates this block.
+/// Missing arguments are fatal because createPlaceholderShapeBlock adds one per
+/// entry in `getShapeRegionArgumentTypes`.
 struct PlaceholderShapeRegionArgs {
   PlaceholderShapeRegionArgs(Block &block) : block(block) {}
 

--- a/lib/Conversion/OnnxToHipsr/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHipsr/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(OnnxToHipsr STATIC
   CastConversion.cpp
   MatMulConversion.cpp
   ExpandConversion.cpp
+  ShapeConversion.cpp
   ReturnConversion.cpp
 )
 

--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
@@ -90,7 +90,7 @@ struct ConvertOnnxToHipsrPass
       if (type.getRank() == 0 || type.getEncoding()) {
         return type;
       }
-      return deviceTensorType(type);
+      return tensorTypeInSpace(type, MemorySpace::Device);
     });
 
     ConversionTarget target(getContext());
@@ -106,8 +106,11 @@ struct ConvertOnnxToHipsrPass
     });
     target.addDynamicallyLegalOp<func::ReturnOp>(
         [&](func::ReturnOp op) { return converter.isLegal(op); });
+    // Helper operations are legal in the hipsr region that owns them: a compute
+    // body or a placeholder's shape region.
     target.markUnknownOpDynamicallyLegal([](Operation *op) {
-      return op->getParentOfType<ComputeOp>() != nullptr;
+      return op->getParentOfType<ComputeOp>() != nullptr ||
+             op->getParentOfType<PlaceholderOp>() != nullptr;
     });
 
     RewritePatternSet patterns(&getContext());
@@ -115,6 +118,7 @@ struct ConvertOnnxToHipsrPass
     populateCastConversionPatterns(converter, patterns, &getContext());
     populateMatMulConversionPatterns(converter, patterns, &getContext());
     populateExpandConversionPatterns(converter, patterns, &getContext());
+    populateShapeConversionPatterns(converter, patterns, &getContext());
     populateReturnConversionPatterns(patterns, &getContext());
     populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(patterns,
                                                                    converter);

--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsrUtils.h
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsrUtils.h
@@ -22,13 +22,11 @@
 namespace mlir {
 namespace hipsr {
 
-// Force change memoryspace to device
-inline ::mlir::RankedTensorType
-deviceTensorType(::mlir::RankedTensorType type) {
-  auto space = ::mlir::hipsr::MemorySpaceAttr::get(type.getContext(),
-                                                   MemorySpace::Device);
-  return ::mlir::RankedTensorType::get(type.getShape(), type.getElementType(),
-                                       space);
+// Force change memoryspace to space
+inline ::mlir::RankedTensorType tensorTypeInSpace(::mlir::RankedTensorType type,
+                                                  MemorySpace space) {
+  return type.cloneWithEncoding(
+      ::mlir::hipsr::MemorySpaceAttr::get(type.getContext(), space));
 }
 
 /// Gets the `!hipsr.context` from function argument 0. The ONNX phase adds it

--- a/lib/Conversion/OnnxToHipsr/ShapeConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/ShapeConversion.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- ShapeConversion.cpp - Convert onnx.Shape to hipsr.compute ---------===//
+//
+// onnx.Shape returns its input's extents as a 1-D i64 tensor. That is a few
+// tensor and arith ops rather than a library call, so no hipsr op matches it
+// and the conversion groups them in a hipsr.compute.
+//
+// It also fills the placeholder's shape region, which
+// hipsr-populate-shape-region cannot: a compute's result shape follows its
+// body, so that pass has nothing to dispatch on. It leaves a filled region
+// alone.
+//
+// Extents are read on the host, so the chain is built in #hipsr.mem<host>, the
+// space hipsr.expand takes its shape operand from, whatever the ONNX result
+// names. Data keeps the #hipsr.mem<device> the pass gives a tensor naming no
+// space.
+//
+// A graph that reads these extents has to name host on the ONNX result as well,
+// because the consumer's pattern maps that type through the pass converter.
+//
+// Before:
+//   %s = "onnx.Shape"(%x) : (tensor<?x128xf16, #hipsr.mem<device>>)
+//       -> tensor<2xi64>
+//
+// After:
+//   %init = hipsr.placeholder(%ctx)
+//       {placeholder_type = #hipsr.placeholder_type<normal>}
+//       : tensor<2xi64, #hipsr.mem<host>> shape_region {
+//     %c2 = arith.constant 2 : index
+//     %shape = shape.from_extents %c2 : index
+//     hipsr.shape_yield %shape : !shape.shape
+//   }
+//   %s = hipsr.compute(%ctx) ins(%x : tensor<?x128xf16, #hipsr.mem<device>>)
+//                            outs(%init : tensor<2xi64, #hipsr.mem<host>>) {
+//   ^bb0(%body_ctx: !hipsr.context, %in: tensor<?x128xf16, #hipsr.mem<device>>,
+//        %dest: tensor<2xi64, #hipsr.mem<host>>):
+//     %c0 = arith.constant 0 : index
+//     %d0 = tensor.dim %in, %c0 : tensor<?x128xf16, #hipsr.mem<device>>
+//     %e0 = arith.index_cast %d0 : index to i64
+//     %e1 = arith.constant 128 : i64
+//     %shape = tensor.from_elements %e0, %e1 : tensor<2xi64, #hipsr.mem<host>>
+//     hipsr.compute_yield %shape : tensor<2xi64, #hipsr.mem<host>>
+//   } : tensor<2xi64, #hipsr.mem<host>>
+//
+//===----------------------------------------------------------------------===//
+
+#include "OnnxToHipsrUtils.h"
+
+#include "hip/Conversion/OnnxToHipsr/OnnxToHipsr.h"
+#include "hip/Dialect/Hipsr/IR/HipsrOps.h"
+#include "hip/Dialect/Hipsr/IR/HipsrShapeRegionPopulationUtils.h"
+#include "hip/Dialect/Hipsr/IR/HipsrTypes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Shape/IR/Shape.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include "llvm/ADT/Sequence.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/SmallVectorExtras.h"
+
+#include <algorithm>
+#include <utility>
+
+namespace mlir {
+namespace hipsr {
+namespace {
+
+// Resolves the optional start/end attributes against the input rank. ONNX adds
+// the rank to a negative bound and clamps the result into [0, rank], so a bound
+// past either end is legal and names that end rather than being an error.
+std::pair<int64_t, int64_t> resolveAxisRange(Operation *op, int64_t rank) {
+  int64_t start = 0;
+  int64_t end = rank;
+  // getSInt/getInt assert on a signedness this attribute may not carry.
+  if (auto startAttr = op->getAttrOfType<IntegerAttr>("start")) {
+    start = startAttr.getValue().getSExtValue();
+  }
+  if (auto endAttr = op->getAttrOfType<IntegerAttr>("end")) {
+    end = endAttr.getValue().getSExtValue();
+  }
+  if (start < 0) {
+    start += rank;
+  }
+  if (end < 0) {
+    end += rank;
+  }
+  return {std::clamp<int64_t>(start, 0, rank),
+          std::clamp<int64_t>(end, 0, rank)};
+}
+
+// The input's rank fixes the result length, so the region is constant and needs
+// no shape-graph inputs.
+void populateShapeRegion(OpBuilder &builder, PlaceholderOp placeholder,
+                         int64_t numExtents) {
+  OpBuilder::InsertionGuard guard(builder);
+  Block &block = createPlaceholderShapeBlock(builder, placeholder);
+  builder.setInsertionPointToStart(&block);
+
+  Location loc = placeholder.getLoc();
+  Value extent = arith::ConstantIndexOp::create(builder, loc, numExtents);
+  Value shape = shape::FromExtentsOp::create(
+      builder, loc, shape::ShapeType::get(builder.getContext()),
+      ValueRange{extent});
+  ShapeYieldOp::create(builder, loc, ValueRange{shape});
+}
+
+// A static axis becomes a constant, so only a dynamic one needs a tensor.dim.
+void populateComputeBody(OpBuilder &builder, ComputeOp computeOp,
+                         RankedTensorType inputType,
+                         RankedTensorType extentsType, int64_t start,
+                         int64_t end) {
+  OpBuilder::InsertionGuard guard(builder);
+  Location loc = computeOp.getLoc();
+
+  // The body's arguments are the operands: ctx, then the inputs, then the
+  // outputs.
+  TypeRange argTypes = computeOp->getOperandTypes();
+  SmallVector<Location> argLocs(argTypes.size(), loc);
+  Block *body =
+      builder.createBlock(&computeOp.getBody(), {}, argTypes, argLocs);
+  builder.setInsertionPointToStart(body);
+
+  Value input = body->getArgument(1);
+  auto extentOf = [&](int64_t axis) -> Value {
+    if (!inputType.isDynamicDim(axis)) {
+      return arith::ConstantOp::create(
+          builder, loc, builder.getI64IntegerAttr(inputType.getDimSize(axis)));
+    }
+    Value dim = tensor::DimOp::create(builder, loc, input, axis);
+    return arith::IndexCastOp::create(builder, loc, builder.getI64Type(), dim);
+  };
+  SmallVector<Value> extents =
+      llvm::map_to_vector(llvm::seq(start, end), extentOf);
+
+  Value shape =
+      tensor::FromElementsOp::create(builder, loc, extentsType, extents);
+  ComputeYieldOp::create(builder, loc, ValueRange{shape});
+}
+
+struct ShapeToHipsr : public ConversionPattern {
+  // Takes the pass converter to match the other patterns; converts no type
+  // itself.
+  ShapeToHipsr(const TypeConverter &typeConverter, MLIRContext *ctx)
+      : ConversionPattern(typeConverter, "onnx.Shape", /*benefit=*/1, ctx) {}
+
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (operands.size() != 1 || op->getNumResults() != 1) {
+      return rewriter.notifyMatchFailure(
+          op, "expected one operand and a single result");
+    }
+
+    Value input = operands[0];
+    auto inputType = dyn_cast<RankedTensorType>(input.getType());
+    if (!inputType) {
+      return rewriter.notifyMatchFailure(op, "expected ranked tensor input");
+    }
+
+    auto resultType = dyn_cast<RankedTensorType>(op->getResult(0).getType());
+    if (!resultType || resultType.getRank() != 1 ||
+        !resultType.getElementType().isInteger(64)) {
+      return rewriter.notifyMatchFailure(op, "expected a rank-1 i64 result");
+    }
+
+    // An ONNX result names no space, so this names host. Another space would
+    // need a copy this does not emit.
+    if (resultType.getEncoding() && !isHostRankedTensor(resultType)) {
+      return rewriter.notifyMatchFailure(
+          op, "expected a result in the host memory space");
+    }
+    RankedTensorType extentsType =
+        tensorTypeInSpace(resultType, MemorySpace::Host);
+
+    auto [start, end] = resolveAxisRange(op, inputType.getRank());
+    // ONNX returns a zero-element tensor here, and a zero-extent destination
+    // has nothing to allocate.
+    if (start >= end) {
+      return rewriter.notifyMatchFailure(op, "expected a non-empty axis range");
+    }
+    if (extentsType.getDimSize(0) != end - start) {
+      return rewriter.notifyMatchFailure(
+          op, "result length must equal the number of selected axes");
+    }
+
+    FailureOr<Value> ctx = getHipsrContextArg(op, rewriter);
+    if (failed(ctx)) {
+      return failure();
+    }
+
+    Location loc = op->getLoc();
+    auto init =
+        PlaceholderOp::create(rewriter, loc, TypeRange{extentsType}, *ctx,
+                              ValueRange{}, PlaceholderType::Normal);
+    populateShapeRegion(rewriter, init, extentsType.getDimSize(0));
+
+    auto computeOp =
+        ComputeOp::create(rewriter, loc, TypeRange{extentsType}, *ctx,
+                          ValueRange{input}, ValueRange{init.getResult(0)});
+    populateComputeBody(rewriter, computeOp, inputType, extentsType, start,
+                        end);
+
+    rewriter.replaceOp(op, computeOp.getResult(0));
+    return success();
+  }
+};
+
+} // namespace
+
+void populateShapeConversionPatterns(const TypeConverter &typeConverter,
+                                     RewritePatternSet &patterns,
+                                     MLIRContext *ctx) {
+  patterns.add<ShapeToHipsr>(typeConverter, ctx);
+}
+
+} // namespace hipsr
+} // namespace mlir

--- a/lib/Dialect/Hipsr/Transforms/PopulateShapeRegionPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/PopulateShapeRegionPass.cpp
@@ -21,6 +21,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "hip/Dialect/Hipsr/IR/HipsrOps.h"
+#include "hip/Dialect/Hipsr/IR/HipsrShapeRegionPopulationUtils.h"
 #include "hip/Dialect/Hipsr/Transforms/Passes.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -49,16 +50,6 @@ LogicalResult populateMatMulShapeRegion(OpBuilder &builder, Block &block,
 #include "hip/Dialect/Hipsr/Transforms/Passes.h.inc"
 
 namespace {
-
-Block &createPlaceholderShapeBlock(OpBuilder &builder,
-                                   PlaceholderOp placeholder) {
-  Region &shapeRegion = placeholder.getShapeRegion();
-  Block &block = *builder.createBlock(&shapeRegion);
-  for (Type type : placeholder.getShapeRegionArgumentTypes()) {
-    block.addArgument(type, placeholder.getLoc());
-  }
-  return block;
-}
 
 LogicalResult populatePlaceholderShapeRegion(OpBuilder &builder,
                                              PlaceholderOp placeholder) {

--- a/test/lit/Conversion/onnx-to-hipsr/shape-invalid.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/shape-invalid.mlir
@@ -1,0 +1,86 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+//===----------------------------------------------------------------------===//
+// onnx.Shape forms the conversion rejects.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --convert-onnx-to-hipsr --split-input-file --verify-diagnostics %s
+
+// The number of extents to read comes from the input's rank.
+func.func @unranked_input(%ctx: !hipsr.context, %input: tensor<*xf16>)
+    -> tensor<3xi64, #hipsr.mem<host>> {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Shape'}}
+  %0 = "onnx.Shape"(%input) : (tensor<*xf16>) -> tensor<3xi64, #hipsr.mem<host>>
+  return %0 : tensor<3xi64, #hipsr.mem<host>>
+}
+
+// -----
+
+// ONNX Shape returns extents as i64.
+func.func @result_element_type(%ctx: !hipsr.context,
+                               %input: tensor<2x3xf16>)
+    -> tensor<2xi32, #hipsr.mem<host>> {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Shape'}}
+  %0 = "onnx.Shape"(%input)
+      : (tensor<2x3xf16>) -> tensor<2xi32, #hipsr.mem<host>>
+  return %0 : tensor<2xi32, #hipsr.mem<host>>
+}
+
+// -----
+
+// The result is an extent vector, so it must be rank 1.
+func.func @result_rank(%ctx: !hipsr.context, %input: tensor<2x3xf16>)
+    -> tensor<1x2xi64, #hipsr.mem<host>> {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Shape'}}
+  %0 = "onnx.Shape"(%input)
+      : (tensor<2x3xf16>) -> tensor<1x2xi64, #hipsr.mem<host>>
+  return %0 : tensor<1x2xi64, #hipsr.mem<host>>
+}
+
+// -----
+
+// The body fills a host buffer, so a result naming another space is rejected
+// rather than copied. A result naming no space is fine; the conversion names
+// host for it.
+func.func @result_names_device(%ctx: !hipsr.context, %input: tensor<2x3xf16>)
+    -> tensor<2xi64, #hipsr.mem<device>> {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Shape'}}
+  %0 = "onnx.Shape"(%input)
+      : (tensor<2x3xf16>) -> tensor<2xi64, #hipsr.mem<device>>
+  return %0 : tensor<2xi64, #hipsr.mem<device>>
+}
+
+// -----
+
+// ONNX allows an empty axis range, but a zero-extent destination has nothing to
+// allocate.
+func.func @empty_axis_range(%ctx: !hipsr.context, %input: tensor<2x3x4xf16>)
+    -> tensor<0xi64, #hipsr.mem<host>> {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Shape'}}
+  %0 = "onnx.Shape"(%input) {start = 2 : si64, end = 1 : si64}
+      : (tensor<2x3x4xf16>) -> tensor<0xi64, #hipsr.mem<host>>
+  return %0 : tensor<0xi64, #hipsr.mem<host>>
+}
+
+// -----
+
+// The result length must equal the number of selected axes.
+func.func @result_length(%ctx: !hipsr.context, %input: tensor<2x3x4xf16>)
+    -> tensor<2xi64, #hipsr.mem<host>> {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Shape'}}
+  %0 = "onnx.Shape"(%input)
+      : (tensor<2x3x4xf16>) -> tensor<2xi64, #hipsr.mem<host>>
+  return %0 : tensor<2xi64, #hipsr.mem<host>>
+}
+
+// -----
+
+// Every hipsr op threads the context from function argument 0.
+func.func @missing_context(%input: tensor<2x3xf16>)
+    -> tensor<2xi64, #hipsr.mem<host>> {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Shape'}}
+  %0 = "onnx.Shape"(%input)
+      : (tensor<2x3xf16>) -> tensor<2xi64, #hipsr.mem<host>>
+  return %0 : tensor<2xi64, #hipsr.mem<host>>
+}

--- a/test/lit/Conversion/onnx-to-hipsr/shape.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/shape.mlir
@@ -1,0 +1,227 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+//===----------------------------------------------------------------------===//
+// Converts onnx.Shape to a hipsr.compute that reads the input extents, and fills
+// the placeholder's shape region while it builds the body. Rejected forms live
+// in shape-invalid.mlir.
+//
+// Extents are read on the host, so the chain holding them names
+// #hipsr.mem<host>: the placeholder, the destination, the yielded value and the
+// result. Data keeps the #hipsr.mem<device> the pass gives a tensor that names
+// no space.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt %s --split-input-file -allow-unregistered-dialect -convert-onnx-to-hipsr | FileCheck %s
+
+// Only a dynamic axis needs a query; a static one is a constant. The shape
+// region is constant too, since the input's rank fixes the result length.
+// CHECK-LABEL:   func.func @shape_full(
+// CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[INPUT:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>) -> tensor<3xi64, #hipsr.mem<host>> {
+// CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<3xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:        %[[LEN:.*]] = arith.constant 3 : index
+// CHECK-NEXT:        %[[SHAPE:.*]] = shape.from_extents %[[LEN]] : index
+// CHECK-NEXT:        hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:      }
+// CHECK-NEXT:      %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<3xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:      ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %{{.*}}: tensor<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:        %[[C0:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[DIM0:.*]] = tensor.dim %[[IN]], %[[C0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[EXT0:.*]] = arith.index_cast %[[DIM0]] : index to i64
+// CHECK-NEXT:        %[[C1:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[DIM1:.*]] = tensor.dim %[[IN]], %[[C1]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[EXT1:.*]] = arith.index_cast %[[DIM1]] : index to i64
+// CHECK-NEXT:        %[[EXT2:.*]] = arith.constant 4096 : i64
+// CHECK-NEXT:        %[[EXTENTS:.*]] = tensor.from_elements %[[EXT0]], %[[EXT1]], %[[EXT2]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.compute_yield %[[EXTENTS]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      } : tensor<3xi64, #hipsr.mem<host>>{{$}}
+// CHECK-NEXT:      return %[[RESULT]] : tensor<3xi64, #hipsr.mem<host>>
+func.func @shape_full(%ctx: !hipsr.context, %input: tensor<?x?x4096xf16>)
+    -> tensor<3xi64, #hipsr.mem<host>> {
+  %0 = "onnx.Shape"(%input)
+      : (tensor<?x?x4096xf16>) -> tensor<3xi64, #hipsr.mem<host>>
+  return %0 : tensor<3xi64, #hipsr.mem<host>>
+}
+
+// -----
+
+// start drops the leading axes, so axis 0 is never queried.
+// CHECK-LABEL:   func.func @shape_start(
+// CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[INPUT:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>) -> tensor<2xi64, #hipsr.mem<host>> {
+// CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:        %[[LEN:.*]] = arith.constant 2 : index
+// CHECK-NEXT:        %[[SHAPE:.*]] = shape.from_extents %[[LEN]] : index
+// CHECK-NEXT:        hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:      }
+// CHECK-NEXT:      %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:      ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %{{.*}}: tensor<2xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:        %[[C1:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[DIM1:.*]] = tensor.dim %[[IN]], %[[C1]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[EXT0:.*]] = arith.index_cast %[[DIM1]] : index to i64
+// CHECK-NEXT:        %[[EXT1:.*]] = arith.constant 4096 : i64
+// CHECK-NEXT:        %[[EXTENTS:.*]] = tensor.from_elements %[[EXT0]], %[[EXT1]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.compute_yield %[[EXTENTS]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      } : tensor<2xi64, #hipsr.mem<host>>{{$}}
+// CHECK-NEXT:      return %[[RESULT]] : tensor<2xi64, #hipsr.mem<host>>
+func.func @shape_start(%ctx: !hipsr.context, %input: tensor<?x?x4096xf16>)
+    -> tensor<2xi64, #hipsr.mem<host>> {
+  %0 = "onnx.Shape"(%input) {start = 1 : si64}
+      : (tensor<?x?x4096xf16>) -> tensor<2xi64, #hipsr.mem<host>>
+  return %0 : tensor<2xi64, #hipsr.mem<host>>
+}
+
+// -----
+
+// A negative start counts back from the end, selecting the last axis alone. That
+// axis is static, so the body queries nothing.
+// CHECK-LABEL:   func.func @shape_negative_start(
+// CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[INPUT:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>) -> tensor<1xi64, #hipsr.mem<host>> {
+// CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<1xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:        %[[LEN:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[SHAPE:.*]] = shape.from_extents %[[LEN]] : index
+// CHECK-NEXT:        hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:      }
+// CHECK-NEXT:      %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<1xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:      ^bb0(%{{.*}}: !hipsr.context, %{{.*}}: tensor<?x?x4096xf16, #hipsr.mem<device>>, %{{.*}}: tensor<1xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:        %[[EXT0:.*]] = arith.constant 4096 : i64
+// CHECK-NEXT:        %[[EXTENTS:.*]] = tensor.from_elements %[[EXT0]] : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.compute_yield %[[EXTENTS]] : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      } : tensor<1xi64, #hipsr.mem<host>>{{$}}
+// CHECK-NEXT:      return %[[RESULT]] : tensor<1xi64, #hipsr.mem<host>>
+func.func @shape_negative_start(%ctx: !hipsr.context,
+                                %input: tensor<?x?x4096xf16>)
+    -> tensor<1xi64, #hipsr.mem<host>> {
+  %0 = "onnx.Shape"(%input) {start = -1 : si64}
+      : (tensor<?x?x4096xf16>) -> tensor<1xi64, #hipsr.mem<host>>
+  return %0 : tensor<1xi64, #hipsr.mem<host>>
+}
+
+// -----
+
+// end truncates the window, leaving out the trailing static axis.
+// CHECK-LABEL:   func.func @shape_end(
+// CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[INPUT:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>) -> tensor<2xi64, #hipsr.mem<host>> {
+// CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:        %[[LEN:.*]] = arith.constant 2 : index
+// CHECK-NEXT:        %[[SHAPE:.*]] = shape.from_extents %[[LEN]] : index
+// CHECK-NEXT:        hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:      }
+// CHECK-NEXT:      %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:      ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %{{.*}}: tensor<2xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:        %[[C0:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[DIM0:.*]] = tensor.dim %[[IN]], %[[C0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[EXT0:.*]] = arith.index_cast %[[DIM0]] : index to i64
+// CHECK-NEXT:        %[[C1:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[DIM1:.*]] = tensor.dim %[[IN]], %[[C1]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[EXT1:.*]] = arith.index_cast %[[DIM1]] : index to i64
+// CHECK-NEXT:        %[[EXTENTS:.*]] = tensor.from_elements %[[EXT0]], %[[EXT1]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.compute_yield %[[EXTENTS]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      } : tensor<2xi64, #hipsr.mem<host>>{{$}}
+// CHECK-NEXT:      return %[[RESULT]] : tensor<2xi64, #hipsr.mem<host>>
+func.func @shape_end(%ctx: !hipsr.context, %input: tensor<?x?x4096xf16>)
+    -> tensor<2xi64, #hipsr.mem<host>> {
+  %0 = "onnx.Shape"(%input) {end = 2 : si64}
+      : (tensor<?x?x4096xf16>) -> tensor<2xi64, #hipsr.mem<host>>
+  return %0 : tensor<2xi64, #hipsr.mem<host>>
+}
+
+// -----
+
+// ONNX clamps a bound that runs past either end, so this selects every axis
+// instead of being rejected.
+// CHECK-LABEL:   func.func @shape_bounds_past_the_ends(
+// CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[INPUT:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>) -> tensor<3xi64, #hipsr.mem<host>> {
+// CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<3xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:        %[[LEN:.*]] = arith.constant 3 : index
+// CHECK-NEXT:        %[[SHAPE:.*]] = shape.from_extents %[[LEN]] : index
+// CHECK-NEXT:        hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:      }
+// CHECK-NEXT:      %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<3xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:      ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %{{.*}}: tensor<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:        %[[C0:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[DIM0:.*]] = tensor.dim %[[IN]], %[[C0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[EXT0:.*]] = arith.index_cast %[[DIM0]] : index to i64
+// CHECK-NEXT:        %[[C1:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[DIM1:.*]] = tensor.dim %[[IN]], %[[C1]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[EXT1:.*]] = arith.index_cast %[[DIM1]] : index to i64
+// CHECK-NEXT:        %[[EXT2:.*]] = arith.constant 4096 : i64
+// CHECK-NEXT:        %[[EXTENTS:.*]] = tensor.from_elements %[[EXT0]], %[[EXT1]], %[[EXT2]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.compute_yield %[[EXTENTS]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      } : tensor<3xi64, #hipsr.mem<host>>{{$}}
+// CHECK-NEXT:      return %[[RESULT]] : tensor<3xi64, #hipsr.mem<host>>
+func.func @shape_bounds_past_the_ends(%ctx: !hipsr.context,
+                                      %input: tensor<?x?x4096xf16>)
+    -> tensor<3xi64, #hipsr.mem<host>> {
+  %0 = "onnx.Shape"(%input) {start = -8 : si64, end = 8 : si64}
+      : (tensor<?x?x4096xf16>) -> tensor<3xi64, #hipsr.mem<host>>
+  return %0 : tensor<3xi64, #hipsr.mem<host>>
+}
+
+// -----
+
+// A result naming no space, as an ONNX graph writes it, still puts the extents
+// in host memory. Nothing reads them here, since a consumer carrying the type
+// converter would ask for this result in the space that converter picks.
+// CHECK-LABEL:   func.func @result_names_no_space(
+// CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[INPUT:.*]]: tensor<2x3xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:        %[[LEN:.*]] = arith.constant 2 : index
+// CHECK-NEXT:        %[[SHAPE:.*]] = shape.from_extents %[[LEN]] : index
+// CHECK-NEXT:        hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:      }
+// CHECK-NEXT:      hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<2x3xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:      ^bb0(%{{.*}}: !hipsr.context, %{{.*}}: tensor<2x3xf16, #hipsr.mem<device>>, %{{.*}}: tensor<2xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:        %[[EXT0:.*]] = arith.constant 2 : i64
+// CHECK-NEXT:        %[[EXT1:.*]] = arith.constant 3 : i64
+// CHECK-NEXT:        %[[EXTENTS:.*]] = tensor.from_elements %[[EXT0]], %[[EXT1]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.compute_yield %[[EXTENTS]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      } : tensor<2xi64, #hipsr.mem<host>>{{$}}
+// CHECK-NEXT:      return{{$}}
+func.func @result_names_no_space(%ctx: !hipsr.context,
+                                 %input: tensor<2x3xf16>) {
+  %0 = "onnx.Shape"(%input) : (tensor<2x3xf16>) -> tensor<2xi64>
+  return
+}
+
+// -----
+
+// The extents feed the shape graph as well as the data graph, and each takes a
+// different value: the barrier placeholder's input names the buffer holding
+// them, which is the compute's destination, while the expand reads what the
+// compute wrote. Reading host extents says nothing about where the expand keeps
+// its own data, which stays in the #hipsr.mem<device> its input and init
+// require.
+// CHECK-LABEL:   func.func @extents_feed_an_expand(
+// CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[INPUT:.*]]: tensor<?x3xf16, #hipsr.mem<device>>) -> tensor<?x?xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:      %[[EXTENTS_INIT:.*]] = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:        %[[LEN:.*]] = arith.constant 2 : index
+// CHECK-NEXT:        %[[SHAPE:.*]] = shape.from_extents %[[LEN]] : index
+// CHECK-NEXT:        hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:      }
+// CHECK-NEXT:      %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x3xf16, #hipsr.mem<device>>) outs(%[[EXTENTS_INIT]] : tensor<2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:      ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x3xf16, #hipsr.mem<device>>, %{{.*}}: tensor<2xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:        %[[C0:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[DIM0:.*]] = tensor.dim %[[IN]], %[[C0]] : tensor<?x3xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[EXT0:.*]] = arith.index_cast %[[DIM0]] : index to i64
+// CHECK-NEXT:        %[[EXT1:.*]] = arith.constant 3 : i64
+// CHECK-NEXT:        %[[EXTENTS:.*]] = tensor.from_elements %[[EXT0]], %[[EXT1]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.compute_yield %[[EXTENTS]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      } : tensor<2xi64, #hipsr.mem<host>>{{$}}
+// CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]], %[[EXTENTS_INIT]] : tensor<?x3xf16, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[EXPANDED:.*]] = hipsr.expand(%[[CTX]]) ins(%[[INPUT]], %[[RESULT]] : tensor<?x3xf16, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) outs(%[[INIT]] : tensor<?x?xf16, #hipsr.mem<device>>) : tensor<?x?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      return %[[EXPANDED]] : tensor<?x?xf16, #hipsr.mem<device>>
+func.func @extents_feed_an_expand(%ctx: !hipsr.context,
+                                  %input: tensor<?x3xf16>) -> tensor<?x?xf16> {
+  %0 = "onnx.Shape"(%input)
+      : (tensor<?x3xf16>) -> tensor<2xi64, #hipsr.mem<host>>
+  %1 = "onnx.Expand"(%input, %0)
+      : (tensor<?x3xf16>, tensor<2xi64, #hipsr.mem<host>>) -> tensor<?x?xf16>
+  return %1 : tensor<?x?xf16>
+}


### PR DESCRIPTION
## Summary

Convert `onnx.Shape` to a `hipsr.compute` that reads the input's extents into a host-space i64 tensor, and fill the destination placeholder's shape region during the conversion.

## Why

- No hipsr operation matches `onnx.Shape`. The work is a few tensor and arith operations rather than a library call, so it belongs in a `hipsr.compute` body.
- The extents are read on the host, which is also the space `hipsr.expand` takes its `shape` operand from, so the pattern names `#hipsr.mem<host>` for its own result. Data keeps the `#hipsr.mem<device>` the pass gives a tensor that names no space.
- `hipsr-populate-shape-region` cannot fill the region. It derives a shape from the placeholder's consumer, and a compute's result shape follows whatever its body does, so there is nothing to dispatch on. The conversion fills the region while it builds the body, and that pass already skips a region that is not empty.

## What

- New `ShapeConversion.cpp`: resolves the optional `start`/`end` attributes against the input rank, clamping into `[0, rank]` as the spec defines; emits a `normal` placeholder with a constant shape region, since the rank fixes the result length; builds the body as one `tensor.dim` per dynamic axis and an `arith.constant` per static one, packed with `tensor.from_elements`.
- `deviceTensorType` becomes `tensorTypeInSpace(type, space)`, one `RankedTensorType::cloneWithEncoding` for either space.
- `createPlaceholderShapeBlock` moves out of `PopulateShapeRegionPass.cpp` into `HipsrShapeRegionPopulationUtils.h`, since both callers build the same entry block.
- Helper operations are now legal in a placeholder's shape region as well as in a compute body, so the `shape.from_extents` this conversion emits no longer rolls the rewrite back.
- New `shape.mlir` checks every line each case produces; new `shape-invalid.mlir` covers the seven forms the pattern rejects.

## Notes for reviewers

- A graph whose extents are read has to name `#hipsr.mem<host>` on the ONNX result. A consumer pattern that carries the pass converter asks for each operand in `convertType(...)`, which is device for a tensor naming no space, and the pass then ends with an unresolved host-to-device materialization. Letting consumers take the space their producer chose is a follow-up.
- The destination the placeholder allocates is never written, because the body yields a fresh `tensor.from_elements`. Both buffers are host, so the result is correct, but bufferization allocates twice. Making the body store into its destination is a separate change.
- No HipsrToLLVM lowering yet, as for every operation in this series, so `--hipsr-pipeline` still cannot run this end to end.

## AI assistance

Cursor (Claude Opus 5) assisted with the conversion and the tests, and ran the build, the LIT suites and `pre-commit`. I reviewed the result and understand it.
