### PR TITLE
fix(GatherBlockQuantized): legalize external INT4 data and zero_points for hip.constant

### DIFF
--- a/lib/Conversion/OnnxToHip/GatherBlockQuantizedConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GatherBlockQuantizedConversion.cpp
@@ -32,8 +32,13 @@ inline bool isGatherBlockQuantizedOp(Operation *op) {
 }
 
 inline int64_t getGbqIntAttr(Operation *op, StringRef name, int64_t fallback) {
-  if (auto attr = op->getAttrOfType<IntegerAttr>(name))
-    return attr.getSInt();
+  if (auto attr = op->getAttrOfType<IntegerAttr>(name)) {
+    if (attr.getType().isSignedInteger())
+      return attr.getSInt();
+    if (attr.getType().isSignlessInteger())
+      return attr.getInt();
+    return static_cast<int64_t>(attr.getUInt());
+  }
   return fallback;
 }
 
@@ -220,12 +225,6 @@ bool legalizeInt4ConstantIfNeeded(Operation *gbq, PatternRewriter &rewriter) {
   if (bits != 4 || gbq->getNumOperands() < 3)
     return false;
 
-  if (gbq->getNumOperands() >= 4) {
-    Value zeroPoints = gbq->getOperand(3);
-    if (zeroPoints && !isa<NoneType>(zeroPoints.getType()))
-      return false;
-  }
-
   Value data = gbq->getOperand(0);
   Operation *constOp = data.getDefiningOp();
   if (!constOp || constOp->getName().getStringRef() != "onnx.Constant")
@@ -256,6 +255,57 @@ bool legalizeInt4ConstantIfNeeded(Operation *gbq, PatternRewriter &rewriter) {
   return recreateExternalConstant(rewriter, constOp, packedType) != nullptr;
 }
 
+// zero_points shares scales' rank but may carry ONNX UINT4 logical shapes whose
+// external `size` is half the ui8 element count; data/scales invariants do not
+// detect that case.
+bool legalizeInt4ZeroPointsConstantIfNeeded(Operation *gbq,
+                                            PatternRewriter &rewriter) {
+  const int64_t bits = gbq::getGbqIntAttr(gbq, "bits", 0);
+  if (bits != 4 || gbq->getNumOperands() < 4)
+    return false;
+
+  Value zeroPoints = gbq->getOperand(3);
+  if (!zeroPoints || isa<NoneType>(zeroPoints.getType()))
+    return false;
+
+  Operation *constOp = zeroPoints.getDefiningOp();
+  if (!constOp || constOp->getName().getStringRef() != "onnx.Constant")
+    return false;
+  if (constOp->getAttr("value"))
+    return false;
+  auto sizeAttr = constOp->getAttrOfType<IntegerAttr>("size");
+  if (!sizeAttr || sizeAttr.getInt() <= 0)
+    return false;
+
+  auto dataType = dyn_cast<RankedTensorType>(gbq->getOperand(0).getType());
+  auto zpType = dyn_cast<RankedTensorType>(zeroPoints.getType());
+  if (!dataType || !zpType)
+    return false;
+
+  int qa = gbq::normalizeGbqAxis(gbq::getGbqIntAttr(gbq, "quantize_axis", -1),
+                                 dataType.getRank());
+  if (qa < 0 || qa >= zpType.getRank())
+    return false;
+  if (zpType.getShape()[qa] % 2 != 0)
+    return false;
+
+  int64_t numElements = 1;
+  for (int64_t dim : zpType.getShape()) {
+    if (llvm::MulOverflow(numElements, dim, numElements))
+      return false;
+  }
+  if (sizeAttr.getInt() * 2 != numElements)
+    return false;
+
+  auto shape = llvm::to_vector(zpType.getShape());
+  shape[qa] /= 2;
+  auto packedType =
+      RankedTensorType::get(shape, packedI8ElementType(rewriter.getContext()));
+
+  rewriter.setInsertionPoint(constOp);
+  return recreateExternalConstant(rewriter, constOp, packedType) != nullptr;
+}
+
 struct GatherBlockQuantizedPreparePattern : public RewritePattern {
   GatherBlockQuantizedPreparePattern(MLIRContext *ctx)
       : RewritePattern("onnx.Custom", /*benefit=*/2, ctx) {}
@@ -266,6 +316,7 @@ struct GatherBlockQuantizedPreparePattern : public RewritePattern {
       return failure();
     bool changed = annotateGbqSemantics(op, rewriter);
     changed |= legalizeInt4ConstantIfNeeded(op, rewriter);
+    changed |= legalizeInt4ZeroPointsConstantIfNeeded(op, rewriter);
     return changed ? success() : failure();
   }
 };
@@ -369,7 +420,6 @@ mlir::LogicalResult GatherBlockQuantizedToHip::matchAndRewrite(
     return rewriter.notifyMatchFailure(
         op, "missing required `block_size` attribute");
   auto gatherAxisIntAttr = op->getAttrOfType<mlir::IntegerAttr>("gather_axis");
-  auto quantAxisIntAttr = op->getAttrOfType<mlir::IntegerAttr>("quantize_axis");
 
   const int64_t bits = bitsIntAttr.getSInt();
   const int64_t blockSize = blockSizeIntAttr.getSInt();
@@ -384,8 +434,8 @@ mlir::LogicalResult GatherBlockQuantizedToHip::matchAndRewrite(
   auto scalesType = mlir::cast<mlir::RankedTensorType>(scales.getType());
 
   std::optional<int64_t> explicitQuantAxis;
-  if (quantAxisIntAttr)
-    explicitQuantAxis = quantAxisIntAttr.getSInt();
+  if (op->getAttr("quantize_axis"))
+    explicitQuantAxis = gbq::getGbqIntAttr(op, "quantize_axis", 0);
   auto quantAxisOr = gbq::resolveQuantizeAxis(dataType, scalesType, blockSize,
                                               bits, explicitQuantAxis);
   if (mlir::failed(quantAxisOr))

--- a/test/lit/Conversion/onnx-to-hip/test_gather_block_quantized.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_gather_block_quantized.mlir
@@ -27,9 +27,9 @@ module {
   // block_size=16. quantize_axis=1 (last). gather_axis=0 (rows).
 
   func.func @main_graph(%indices: tensor<8xi64>) -> tensor<8x96xf16> {
-    %data = "onnx.Constant"() {value = dense<1> : tensor<2048x96xui8>} : () -> tensor<2048x96xui8>
+    %data = "onnx.Constant"() {value = dense<1> : tensor<2048x96xi8>} : () -> tensor<2048x96xi8>
     %scales = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<2048x12xf16>} : () -> tensor<2048x12xf16>
-    %zp = "onnx.Constant"() {value = dense<8> : tensor<2048x12xui8>} : () -> tensor<2048x12xui8>
+    %zp = "onnx.Constant"() {value = dense<8> : tensor<2048x12xi8>} : () -> tensor<2048x12xi8>
     %out = "onnx.Custom"(%data, %indices, %scales, %zp) {
       function_name = "GatherBlockQuantized",
       domain_name = "com.microsoft",
@@ -37,16 +37,17 @@ module {
       block_size = 16 : si64,
       gather_axis = 0 : si64,
       quantize_axis = 1 : si64,
+      unsigned_quant_storage,
       onnx_node_name = "GatherBlockQuantized_0"
-    } : (tensor<2048x96xui8>, tensor<8xi64>, tensor<2048x12xf16>, tensor<2048x12xui8>) -> tensor<8x96xf16>
+    } : (tensor<2048x96xi8>, tensor<8xi64>, tensor<2048x12xf16>, tensor<2048x12xi8>) -> tensor<8x96xf16>
     return %out : tensor<8x96xf16>
   }
 
   // CHECK-LABEL: func.func @main_graph
   // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[IDX:.*]]: tensor<8xi64>)
   // CHECK: %[[INIT:.*]] = tensor.empty() : tensor<8x96xf16>
-  // CHECK: hip.gather_block_quantized(%[[CTX]]) ins({{.*}}, %[[IDX]], {{.*}} : tensor<2048x96xui8>, tensor<8xi64>, tensor<2048x12xf16>)
-  // CHECK-SAME: zero_points(%{{.*}} : tensor<2048x12xui8>)
+  // CHECK: hip.gather_block_quantized(%[[CTX]]) ins({{.*}}, %[[IDX]], {{.*}} : tensor<2048x96xi8>, tensor<8xi64>, tensor<2048x12xf16>)
+  // CHECK-SAME: zero_points(%{{.*}} : tensor<2048x12xi8>)
   // CHECK-SAME: outs(%[[INIT]] : tensor<8x96xf16>)
   // CHECK-SAME: bits = 4
   // CHECK-SAME: block_size = 16
@@ -58,7 +59,7 @@ module {
   // ===== Test 2: 8-bit GatherBlockQuantized without zero_points =====
 
   func.func @test_gbq_uint8_no_zp(%indices: tensor<4xi32>) -> tensor<4x64xf32> {
-    %data = "onnx.Constant"() {value = dense<1> : tensor<512x64xui8>} : () -> tensor<512x64xui8>
+    %data = "onnx.Constant"() {value = dense<1> : tensor<512x64xi8>} : () -> tensor<512x64xi8>
     %scales = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<512x2xf32>} : () -> tensor<512x2xf32>
     %out = "onnx.Custom"(%data, %indices, %scales) {
       function_name = "GatherBlockQuantized",
@@ -68,13 +69,13 @@ module {
       gather_axis = 0 : si64,
       quantize_axis = 1 : si64,
       onnx_node_name = "GatherBlockQuantized_1"
-    } : (tensor<512x64xui8>, tensor<4xi32>, tensor<512x2xf32>) -> tensor<4x64xf32>
+    } : (tensor<512x64xi8>, tensor<4xi32>, tensor<512x2xf32>) -> tensor<4x64xf32>
     return %out : tensor<4x64xf32>
   }
 
   // CHECK-LABEL: func.func @test_gbq_uint8_no_zp
   // CHECK: %[[INIT:.*]] = tensor.empty() : tensor<4x64xf32>
-  // CHECK: hip.gather_block_quantized({{.*}}) ins({{.*}}, %{{.*}}, %{{.*}} : tensor<512x64xui8>, tensor<4xi32>, tensor<512x2xf32>)
+  // CHECK: hip.gather_block_quantized({{.*}}) ins({{.*}}, %{{.*}}, %{{.*}} : tensor<512x64xi8>, tensor<4xi32>, tensor<512x2xf32>)
   // CHECK-NOT: zero_points
   // CHECK-SAME: outs(%[[INIT]] : tensor<4x64xf32>)
   // CHECK-SAME: bits = 8
@@ -87,7 +88,7 @@ module {
   // comes straight from data[1] (static).
 
   func.func @test_gbq_dynamic_indices(%indices: tensor<?xi64>) -> tensor<?x96xf16> {
-    %data = "onnx.Constant"() {value = dense<1> : tensor<2048x96xui8>} : () -> tensor<2048x96xui8>
+    %data = "onnx.Constant"() {value = dense<1> : tensor<2048x96xi8>} : () -> tensor<2048x96xi8>
     %scales = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<2048x12xf16>} : () -> tensor<2048x12xf16>
     %out = "onnx.Custom"(%data, %indices, %scales) {
       function_name = "GatherBlockQuantized",
@@ -97,7 +98,7 @@ module {
       gather_axis = 0 : si64,
       quantize_axis = 1 : si64,
       onnx_node_name = "GatherBlockQuantized_2"
-    } : (tensor<2048x96xui8>, tensor<?xi64>, tensor<2048x12xf16>) -> tensor<?x96xf16>
+    } : (tensor<2048x96xi8>, tensor<?xi64>, tensor<2048x12xf16>) -> tensor<?x96xf16>
     return %out : tensor<?x96xf16>
   }
 
@@ -106,7 +107,7 @@ module {
   // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
   // CHECK: %[[DIM0:.*]] = tensor.dim %[[IDX]], %[[C0]] : tensor<?xi64>
   // CHECK: %[[INIT:.*]] = tensor.empty(%[[DIM0]]) : tensor<?x96xf16>
-  // CHECK: hip.gather_block_quantized(%[[CTX]]) ins({{.*}}, %[[IDX]], {{.*}} : tensor<2048x96xui8>, tensor<?xi64>, tensor<2048x12xf16>) outs(%[[INIT]] : tensor<?x96xf16>)
+  // CHECK: hip.gather_block_quantized(%[[CTX]]) ins({{.*}}, %[[IDX]], {{.*}} : tensor<2048x96xi8>, tensor<?xi64>, tensor<2048x12xf16>) outs(%[[INIT]] : tensor<?x96xf16>)
   // CHECK-NOT: onnx.Custom
 
   // ===== Test 4: prepare-annotated UINT4 (signless i8 + unsigned flag) =====
@@ -139,7 +140,7 @@ module {
   // ONNX often omits quantize_axis; shape invariants identify axis 1.
 
   func.func @test_gbq_infer_quantize_axis(%indices: tensor<8xi64>) -> tensor<8x128xf16> {
-    %data = "onnx.Constant"() {value = dense<1> : tensor<512x128xui8>} : () -> tensor<512x128xui8>
+    %data = "onnx.Constant"() {value = dense<1> : tensor<512x128xi8>} : () -> tensor<512x128xi8>
     %scales = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<512x8xf16>} : () -> tensor<512x8xf16>
     %out = "onnx.Custom"(%data, %indices, %scales) {
       function_name = "GatherBlockQuantized",
@@ -147,14 +148,63 @@ module {
       bits = 4 : si64,
       block_size = 32 : si64,
       gather_axis = 0 : si64,
+      unsigned_quant_storage,
       onnx_node_name = "GatherBlockQuantized_4"
-    } : (tensor<512x128xui8>, tensor<8xi64>, tensor<512x8xf16>) -> tensor<8x128xf16>
+    } : (tensor<512x128xi8>, tensor<8xi64>, tensor<512x8xf16>) -> tensor<8x128xf16>
     return %out : tensor<8x128xf16>
   }
 
   // CHECK-LABEL: func.func @test_gbq_infer_quantize_axis
-  // CHECK: hip.gather_block_quantized({{.*}}) ins({{.*}}, {{.*}}, {{.*}} : tensor<512x128xui8>, tensor<8xi64>, tensor<512x8xf16>)
+  // CHECK: hip.gather_block_quantized({{.*}}) ins({{.*}}, {{.*}}, {{.*}} : tensor<512x128xi8>, tensor<8xi64>, tensor<512x8xf16>)
   // CHECK-SAME: quantize_axis = 1
   // CHECK-SAME: unsigned_quant_storage
+  // CHECK-NOT: onnx.Custom
+
+  // ===== Test 6: external UINT4 weights + zero_points (logical shapes) =====
+  // Logical UINT4 tensors use ui8 shapes with external byte sizes at half the
+  // element count. Prepare must halve quantize_axis on data and zero_points
+  // before hip.constant verification (packed signless i8; unsigned via attr).
+  //
+  // Shapes (bits=4, block_size=32, quantize_axis=1):
+  //   data  [128, 512] ui8, external size 32768 (= 128*512/2)
+  //   scales [128, 16] f16  (512 / 32)
+  //   zp    [128, 16] ui8, external size 1024 (= 128*16/2), offset 32768
+
+  func.func @test_gbq_external_uint4_with_zp(%indices: tensor<4xi64>)
+      -> tensor<4x512xf16> {
+    %data = "onnx.Constant"() {
+      location = "/tmp/gbq_external_weights.bin",
+      offset = 0 : i64,
+      size = 32768 : i64
+    } : () -> tensor<128x512xui8>
+    %scales = "onnx.Constant"() {
+      value = dense<1.000000e+00> : tensor<128x16xf16>
+    } : () -> tensor<128x16xf16>
+    %zp = "onnx.Constant"() {
+      location = "/tmp/gbq_external_weights.bin",
+      offset = 32768 : i64,
+      size = 1024 : i64
+    } : () -> tensor<128x16xui8>
+    %out = "onnx.Custom"(%data, %indices, %scales, %zp) {
+      function_name = "GatherBlockQuantized",
+      domain_name = "com.microsoft",
+      bits = 4 : si64,
+      block_size = 32 : si64,
+      gather_axis = 0 : si64,
+      quantize_axis = 1 : si64,
+      onnx_node_name = "GatherBlockQuantized_5"
+    } : (tensor<128x512xui8>, tensor<4xi64>, tensor<128x16xf16>,
+         tensor<128x16xui8>) -> tensor<4x512xf16>
+    return %out : tensor<4x512xf16>
+  }
+
+  // CHECK-LABEL: func.func @test_gbq_external_uint4_with_zp
+  // CHECK: hip.constant {location = "/tmp/gbq_external_weights.bin", offset = 0 : i64{{.*}}size = 32768 : i64}
+  // CHECK-SAME: tensor<128x256xi8>
+  // CHECK: hip.constant {location = "/tmp/gbq_external_weights.bin", offset = 32768 : i64{{.*}}size = 1024 : i64}
+  // CHECK-SAME: tensor<128x8xi8>
+  // CHECK: hip.gather_block_quantized
+  // CHECK-SAME: tensor<128x256xi8>
+  // CHECK-SAME: zero_points(%{{.*}} : tensor<128x8xi8>)
   // CHECK-NOT: onnx.Custom
 }


### PR DESCRIPTION
## Summary

Fix GatherBlockQuantized prepare so external UINT4 **data** and **zero_points** are legalized independently before `hip.constant` verification, and make `quantize_axis` attribute reads safe across ONNX `si64` and prepare-inferred signless `i64` attrs. Update GBQ LIT for PR688 inline-constant rules and add coverage for external logical UINT4 shapes.

## Related issue or design

- Builds on GBQ INT4/UINT4 prepare from #583 (`legalizeInt4ConstantIfNeeded`, `unsigned_quant_storage`, quantize_axis inference).
- Required after #688 (`hip.constant` strict byte-size verification): logical ONNX UINT4 tensor shapes no longer match packed external file sizes unless prepare halves `quantize_axis` on **both** weights and zero_points.
- Pipeline context: `convert-onnx-to-hip` GBQ prepare runs before the first `lowerOnnxConstants` sweep ([`docs/pipeline_pass_menu.md`](docs/pipeline_pass_menu.md)).

## Why

1. **Compile failure after #688**: When a GBQ op had `zero_points`, prepare previously skipped data halving entirely. External constants kept logical ONNX shapes while `hip.constant` expected packed byte sizes → verify error (`external size != result byte size`, typically 2×).
2. **Correctness**: Halving only data (or skipping halve) while zero_points stayed logical misaligned `(q - zp) * scale` indexing and produced garbled embeddings at runtime.
3. **Crash on inferred `quantize_axis`**: Prepare writes `quantize_axis` with signless `i64`; conversion still called `IntegerAttr::getSInt()` → debug-build assert.

## What

**Compiler (`GatherBlockQuantizedConversion.cpp`)**
- Remove the blanket “has zero_points → skip data legalize” guard.
- Add `legalizeInt4ZeroPointsConstantIfNeeded` for external `zero_points` whose file `size` is half the logical `ui8` element count; halve the `quantize_axis` dim to signless `i8`, same as data.
- Extend `getGbqIntAttr` to read signed, signless, and unsigned integer attrs; use it in prepare **and** in `GatherBlockQuantizedToHip` when reading inferred `quantize_axis`.

**Tests (`test_gather_block_quantized.mlir`)**
- Use signless `xi8` for inline dense constants plus explicit `unsigned_quant_storage` where needed (PR688 / `DenseElementsAttr` compatibility).
- Keep external weights as `ui8` (importer-faithful).
- Add Test 6: external UINT4 data + zero_points with generic small logical shapes and packed byte sizes.

## Test plan

- [x] `ctest -C Release -R MorphizenMLIRLitTests` (includes `test_gather_block_quantized.mlir`)
- [x] Manual: `hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip test_gather_block_quantized.mlir | filecheck …`
- [x] E2E: validated on a GBQ embedding model with external UINT4 weights + zero_points (compile + inference correctness)

## Notes for reviewers

- `legalizeInt4ZeroPointsConstantIfNeeded` triggers only for external constants (`size * 2 == numElements` on the logical shape); inline dense zero_points are unchanged.
- `legalizeInt4ConstantIfNeeded` still only rewrites **external** data constants (inline dense unchanged by design).
- Test 6 uses small generic shapes (128×512 data, 128×16 zp/scales) to avoid model-identifying dimensions while preserving the size/halve invariants.
- No runtime/kernel ABI change; prepare-time shape/type fix only.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.