### PR TITLE
perf(onnx-attention): size present KV to buffer capacity so shared-buffer KV cache works

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -362,7 +362,7 @@ jobs:
           # OGA is built against the patched ort-install, so the key folds in
           # the fork ref, optional OGA_PR_PATCHES, and ONNXRUNTIME_PR_PATCHES.
           # The mm<N> token bumps when the OGA artifact set changes shape.
-          key: oga-dml-mm3-${{ env.OGA_REPO }}-${{ env.OGA_REF }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
+          key: oga-dml-mm3-${{ env.OGA_REPO }}-${{ env.OGA_REF }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}-1
 
       # OGA is built from cliu1003/onnxruntime-genai sliding_window_support_amdgpu
       # (AMDGPU MorphiZen integration + sliding_window). Optional OGA_PR_PATCHES

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -362,7 +362,7 @@ jobs:
           # OGA is built against the patched ort-install, so the key folds in
           # the fork ref, optional OGA_PR_PATCHES, and ONNXRUNTIME_PR_PATCHES.
           # The mm<N> token bumps when the OGA artifact set changes shape.
-          key: oga-dml-mm3-${{ env.OGA_REPO }}-${{ env.OGA_REF }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}-1
+          key: oga-dml-mm3-${{ env.OGA_REPO }}-${{ env.OGA_REF }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}-2
 
       # OGA is built from cliu1003/onnxruntime-genai sliding_window_support_amdgpu
       # (AMDGPU MorphiZen integration + sliding_window). Optional OGA_PR_PATCHES

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -51,11 +51,14 @@ jobs:
       ONNXRUNTIME_PR_PATCHES: ""
       SCCACHE_GHA_ENABLED: "true"
       SCCACHE_GHA_RW_MODE: ${{ github.ref_name == 'main' && 'READ_WRITE' || 'READ_ONLY' }}
-      OGA_VERSION: "0.14.0"
-      # Space-separated microsoft/onnxruntime-genai PR numbers fetched from
-      # pull/<n>.patch and `git apply` on top of v<OGA_VERSION>. Part of the OGA
-      # cache key. Remove a PR once it lands in the pinned OGA release.
-      OGA_PR_PATCHES: "2194"
+      # Fork branch carrying AMDGPU MorphiZen integration (former PR 2194) plus
+      # sliding_window support.
+      OGA_REPO: "amd-genmingz/onnxruntime-genai"
+      OGA_REF: "test_0_3"
+      # Optional space-separated microsoft/onnxruntime-genai PR numbers applied
+      # on top of the fork checkout via pull/<n>.patch + git am. Empty when the
+      # fork branch already carries the needed integration.
+      OGA_PR_PATCHES: ""
       # ilammy/msvc-dev-cmd and mozilla-actions/sccache-action have no
       # Node.js 24 releases yet; allow Node.js 20 until they are updated.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
@@ -357,22 +360,19 @@ jobs:
         with:
           path: ${{ runner.workspace }}/oga-artifacts
           # OGA is built against the patched ort-install, so the key folds in
-          # both OGA's own PR list and ONNXRUNTIME_PR_PATCHES; editing either
-          # forces a rebuild. The mm<N> token bumps when the OGA artifact set
-          # changes shape, or when a PR's branch content changes under the same
-          # number (mm2: PR 2194 now carries the AMDGPU OGA integration).
-          key: oga-dml-mm2-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
+          # the fork ref, optional OGA_PR_PATCHES, and ONNXRUNTIME_PR_PATCHES.
+          # The mm<N> token bumps when the OGA artifact set changes shape.
+          key: oga-dml-mm3-${{ env.OGA_REPO }}-${{ env.OGA_REF }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
 
-      # OGA is built from upstream microsoft/onnxruntime-genai + PR patches
-      # (OGA_PR_PATCHES). PR 2194 (the dynamic-shape-morphizen branch) now also
-      # carries the AMDGPU umbrella integration, so the patched upstream build
-      # is the AMDGPU-targeted OGA -- no fork checkout needed.
+      # OGA is built from cliu1003/onnxruntime-genai sliding_window_support_amdgpu
+      # (AMDGPU MorphiZen integration + sliding_window). Optional OGA_PR_PATCHES
+      # apply extra upstream PRs on top of the fork checkout.
       - name: Checkout OGA
         if: steps.cache-oga.outputs.cache-hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: microsoft/onnxruntime-genai
-          ref: v${{ env.OGA_VERSION }}
+          repository: ${{ env.OGA_REPO }}
+          ref: ${{ env.OGA_REF }}
           path: source-oga
           submodules: true
           fetch-depth: 1
@@ -832,9 +832,9 @@ jobs:
           exit /b %RC%
 
       # ----------------------------------------------------------------------
-      # EPContext export + import perf test (PR #132 constants-file-in-tar path).
+      # EPContext export + import perf test (PR #132 sidecar-in-tar path).
       # Limited to full_model_seq128 to bound runtime: each model triggers
-      # one export pass (~60 s + N GB constants-file write) plus one import perf
+      # one export pass (~60 s + N GB sidecar write) plus one import perf
       # pass (-t 30). The _ctx.onnx + _MORPHIZEN.bin are deleted right after
       # import to keep runner disk usage bounded.
       # ----------------------------------------------------------------------

--- a/lib/Conversion/OnnxToHip/NormConversion.cpp
+++ b/lib/Conversion/OnnxToHip/NormConversion.cpp
@@ -51,6 +51,51 @@ inline mlir::Value getOptionalResult(mlir::Operation *op, unsigned idx) {
   return v;
 }
 
+/// Reject a norm whose `axis` does not select exactly the trailing block that
+/// the scale operand covers.
+///
+/// The runtime wrappers flatten the input to `[num_rows, hidden_dim]` with
+/// `hidden_dim` taken from the scale's element count and `num_rows` recovered
+/// by dividing the input's total element count. That is only the requested
+/// reduction when normalization spans `dims[axis:]` and those dims multiply to
+/// the scale's size; the wrappers cannot check it themselves because the ABI
+/// carries element counts rather than shapes. Rank is known here, so check it
+/// here -- an unnoticed mismatch normalizes over the wrong axis and returns
+/// plausible-looking numbers.
+///
+/// Dynamic trailing extents are not checkable and are accepted; in practice the
+/// normalized axes are the static feature dims.
+mlir::LogicalResult verifyNormAxisMatchesScale(mlir::Operation *op,
+                                               mlir::Value input,
+                                               mlir::Value scale,
+                                               int64_t axis) {
+  auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(input.getType());
+  auto scaleType = mlir::dyn_cast<mlir::RankedTensorType>(scale.getType());
+  if (!inputType || !scaleType || !scaleType.hasStaticShape())
+    return mlir::success();
+
+  int64_t rank = inputType.getRank();
+  int64_t normAxis = axis < 0 ? axis + rank : axis;
+  if (normAxis < 0 || normAxis >= rank)
+    return op->emitError("norm axis ")
+           << axis << " is out of range for a rank-" << rank << " input";
+
+  int64_t normalizedExtent = 1;
+  for (int64_t d = normAxis; d < rank; ++d) {
+    if (inputType.isDynamicDim(d))
+      return mlir::success();
+    normalizedExtent *= inputType.getDimSize(d);
+  }
+  if (normalizedExtent != scaleType.getNumElements())
+    return op->emitError("norm axis ")
+           << axis << " spans " << normalizedExtent
+           << " element(s) of the rank-" << rank << " input, but scale has "
+           << scaleType.getNumElements()
+           << "; the runtime flattens to [rows, scale_num_elements] and would "
+              "normalize over the wrong axis";
+  return mlir::success();
+}
+
 /// onnx.Custom(SimplifiedLayerNormalization) -> hip.rms_norm
 struct SimplifiedLayerNormToHip : public mlir::RewritePattern {
   SimplifiedLayerNormToHip(mlir::MLIRContext *ctx)
@@ -97,6 +142,10 @@ mlir::LogicalResult SimplifiedLayerNormToHip::matchAndRewrite(
   auto stashTypeAttr = op->getAttrOfType<mlir::IntegerAttr>("stash_type");
   if (!stashTypeAttr)
     return rewriter.notifyMatchFailure(op, "missing stash_type attribute");
+
+  if (mlir::failed(
+          verifyNormAxisMatchesScale(op, input, scale, axisAttr.getSInt())))
+    return mlir::failure();
 
   // Convert axis to i64
   auto axisI64Attr = rewriter.getI64IntegerAttr(axisAttr.getSInt());
@@ -152,6 +201,9 @@ RMSNormalizationToHip::matchAndRewrite(mlir::Operation *op,
   int64_t axis = -1;
   if (auto axisAttr = op->getAttrOfType<mlir::IntegerAttr>("axis"))
     axis = axisAttr.getSInt();
+
+  if (mlir::failed(verifyNormAxisMatchesScale(op, input, scale, axis)))
+    return mlir::failure();
 
   llvm::APFloat epsValue(9.99999974E-6f);
   if (auto epsilonAttr = op->getAttrOfType<mlir::FloatAttr>("epsilon"))

--- a/lib/Conversion/OnnxToHip/OnnxAttentionConversion.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxAttentionConversion.cpp
@@ -71,22 +71,37 @@ namespace {
 ///
 /// After:
 ///   %cur       = tensor.dim %q, %c1        // current KV tokens (== query seq)
-///   %past      = tensor.dim %past_k, %c2   // valid past KV length (0 prefill)
-///   %tot       = arith.addi %past, %cur    // present seq = past + current
+///   %past      = tensor.dim %past_k, %c2   // past buffer EXTENT (see below)
+///   %tot       = tensor.dim %mask, %c3     // valid total KV, else %past + %cur
+///   %cap       = arith.maxsi %past, %tot   // present buffer capacity
 ///   %seqlens_k = tensor.from_elements (%tot - 1)  : tensor<1xi32>
-///   %total_seq = tensor.from_elements %tot        : tensor<i32>
-///   %pk_init   = tensor.empty(%B, %tot)    // present sized to %tot, NOT %past
+///   %total_seq = tensor.from_elements %cap        : tensor<i32>
+///   %pk_init   = tensor.empty(%B, %cap)    // present sized to capacity
 ///   %y, %pk, %pv = hip.gqa(%ctx)
 ///       ins(%q, %k, %v, %past_k, %past_v, %seqlens_k, %total_seq, %mask)
 ///       outs(%y_init, %pk_init, %pv_init)
 ///       {num_heads = 16, kv_num_heads = 8, scale = 1.0, no_causal = true}
 ///
-/// present KV is concat(past, current) along the seq axis, so its seq extent is
-/// past_seq + current_seq.  A fresh prefill arrives with an EMPTY past
-/// (past_seq == 0): sizing present from dim(past_key, 2) alone would collapse
-/// it to a zero-length buffer, the output allocator would then hand the runtime
-/// a null present_key/present_value, and wrap_group_query_attention would
-/// reject the call and leave the attention output zero-filled.
+/// Buffer capacity vs valid length. These coincide only when the caller
+/// allocates a fresh, exactly-sized present every step, and separating them is
+/// what lets this op reach the in-place append path:
+///
+///   - Valid total KV length drives seqlens_k, and comes from the mask's kv
+///     extent when a mask is present. dim(past_key, 2) cannot serve here: under
+///     a shared past/present buffer it is the max_length capacity, so past +
+///     current would overshoot the real length and attend to stale cache.
+///   - Capacity drives the present DPS init, and is max(past extent, total).
+///     Requesting exactly the bound buffer's shape is what makes ORT's
+///     GetOutput return the pre-bound OrtValue instead of allocating a fresh
+///     one, so past_key == present_key and update_kv_cache takes the cheap
+///     append branch rather than re-materialising the whole cache every step.
+///
+/// The max() also preserves the property the previous past + current form was
+/// protecting: a fresh prefill arrives with an EMPTY past (past_seq == 0), and
+/// sizing present from dim(past_key, 2) alone would collapse it to a
+/// zero-length buffer, after which the output allocator hands the runtime a
+/// null present_key/present_value and wrap_group_query_attention rejects the
+/// call, leaving the attention output zero-filled.
 struct OnnxAttentionToHip : public mlir::RewritePattern {
   OnnxAttentionToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Attention", /*benefit=*/1, ctx) {}
@@ -339,8 +354,36 @@ OnnxAttentionToHip::matchAndRewrite(mlir::Operation *op,
       pastKey
           ? mlir::tensor::DimOp::create(rewriter, loc, pastKey, 2).getResult()
           : mlir::arith::ConstantIndexOp::create(rewriter, loc, 0).getResult();
+
+  // Valid total KV length. dim(past_key, 2) is the past buffer's EXTENT, which
+  // equals the valid past length only when the caller grows a fresh present
+  // every step. Under a shared past/present buffer it is the max_length
+  // capacity, so past + current would overshoot. The additive mask carries the
+  // true length: its kv extent is the total past+current KV length (see the
+  // mask-extent contract above), so prefer it whenever a mask is present.
+  mlir::Value maskKvIdx;
+  if (attnMask) {
+    auto maskType = mlir::dyn_cast<mlir::RankedTensorType>(attnMask.getType());
+    if (maskType && maskType.getRank() >= 2)
+      maskKvIdx = mlir::tensor::DimOp::create(rewriter, loc, attnMask,
+                                              maskType.getRank() - 1)
+                      .getResult();
+  }
   mlir::Value totalKvIdx =
-      mlir::arith::AddIOp::create(rewriter, loc, pastSeqIdx, curSeqIdx)
+      maskKvIdx ? maskKvIdx
+                : mlir::arith::AddIOp::create(rewriter, loc, pastSeqIdx,
+                                              curSeqIdx)
+                      .getResult();
+
+  // present buffer capacity, which is NOT the same as the valid length above.
+  // Taking the max keeps both callers correct: with a separately allocated
+  // present it collapses to past + current (the past extent is the valid past
+  // length, which is smaller), while with a shared buffer it yields the
+  // max_length capacity so the requested output shape matches the buffer ORT
+  // already bound -- which is what makes past_key == present_key, and hence the
+  // in-place append path, reachable at all.
+  mlir::Value presentCapIdx =
+      mlir::arith::MaxSIOp::create(rewriter, loc, pastSeqIdx, totalKvIdx)
           .getResult();
 
   // seqlens_k[b] = total_seq - 1 (ORT GQA convention total_seq = seqlens_k + 1;
@@ -440,7 +483,7 @@ OnnxAttentionToHip::matchAndRewrite(mlir::Operation *op,
     totalSeqLen = mlir::arith::ConstantOp::create(rewriter, loc, attr);
   } else {
     mlir::Value totalKvI32 =
-        mlir::arith::IndexCastOp::create(rewriter, loc, i32Ty, totalKvIdx);
+        mlir::arith::IndexCastOp::create(rewriter, loc, i32Ty, presentCapIdx);
     totalSeqLen = mlir::tensor::FromElementsOp::create(
         rewriter, loc, totalSeqLenType, mlir::ValueRange{totalKvI32});
   }
@@ -455,7 +498,7 @@ OnnxAttentionToHip::matchAndRewrite(mlir::Operation *op,
       if (!t.isDynamicDim(dimIdx))
         continue;
       if (dimIdx == 2)
-        dynSizes.push_back(totalKvIdx);
+        dynSizes.push_back(presentCapIdx);
       else if (dimIdx == 0)
         dynSizes.push_back(
             mlir::tensor::DimOp::create(rewriter, loc, query, 0).getResult());

--- a/lib/Conversion/OnnxToHip/OnnxAttentionConversion.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxAttentionConversion.cpp
@@ -72,7 +72,7 @@ namespace {
 /// After:
 ///   %cur       = tensor.dim %q, %c1        // current KV tokens (== query seq)
 ///   %past      = tensor.dim %past_k, %c2   // past buffer EXTENT (see below)
-///   %tot       = tensor.dim %mask, %c3     // valid total KV, else %past + %cur
+///   %tot       = tensor.dim %mask, %c3     // valid total KV, else %past+%cur
 ///   %cap       = arith.maxsi %past, %tot   // present buffer capacity
 ///   %seqlens_k = tensor.from_elements (%tot - 1)  : tensor<1xi32>
 ///   %total_seq = tensor.from_elements %cap        : tensor<i32>
@@ -370,10 +370,10 @@ OnnxAttentionToHip::matchAndRewrite(mlir::Operation *op,
                       .getResult();
   }
   mlir::Value totalKvIdx =
-      maskKvIdx ? maskKvIdx
-                : mlir::arith::AddIOp::create(rewriter, loc, pastSeqIdx,
-                                              curSeqIdx)
-                      .getResult();
+      maskKvIdx
+          ? maskKvIdx
+          : mlir::arith::AddIOp::create(rewriter, loc, pastSeqIdx, curSeqIdx)
+                .getResult();
 
   // present buffer capacity, which is NOT the same as the valid length above.
   // Taking the max keeps both callers correct: with a separately allocated

--- a/lib/Conversion/OnnxToHip/ReshapeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ReshapeConversion.cpp
@@ -52,9 +52,8 @@ validateSqueezeUnsqueezeOp(mlir::Operation *op, mlir::PatternRewriter &rewriter,
 }
 
 /// Count the dynamic output dims a reassociation group covers.
-static int64_t
-countDynOutDims(mlir::RankedTensorType outputType,
-                const mlir::ReassociationIndices &group) {
+static int64_t countDynOutDims(mlir::RankedTensorType outputType,
+                               const mlir::ReassociationIndices &group) {
   return llvm::count_if(
       group, [&](int64_t idx) { return outputType.isDynamicDim(idx); });
 }
@@ -131,11 +130,10 @@ resolveShapeOperandExtents(mlir::PatternRewriter &rewriter, mlir::Location loc,
 /// `[bs*ss, 2816] -> [bs, ss, 2816]` became `[ss, ss, 2816]` and dispatched
 /// every Gemma-4 layer's input norm over ss^2 rows.
 std::optional<llvm::SmallVector<mlir::OpFoldResult>>
-buildExpandShapeOutputShape(
-    mlir::PatternRewriter &rewriter, mlir::Location loc, mlir::Value data,
-    mlir::RankedTensorType outputType,
-    llvm::ArrayRef<mlir::ReassociationIndices> reassoc,
-    mlir::Value shapeOperand = {}) {
+buildExpandShapeOutputShape(mlir::PatternRewriter &rewriter, mlir::Location loc,
+                            mlir::Value data, mlir::RankedTensorType outputType,
+                            llvm::ArrayRef<mlir::ReassociationIndices> reassoc,
+                            mlir::Value shapeOperand = {}) {
   int64_t outputRank = outputType.getRank();
 
   llvm::SmallVector<int64_t> outDimToInDim(outputRank, -1);
@@ -289,9 +287,8 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
           // `Shape(x)` into a host-visible tensor.from_elements for it.
           mlir::Value shapeOperand =
               op->getNumOperands() >= 2 ? op->getOperand(1) : mlir::Value();
-          if (auto outputShape =
-                  buildExpandShapeOutputShape(rewriter, loc, data, outputType,
-                                              *reassocOpt, shapeOperand)) {
+          if (auto outputShape = buildExpandShapeOutputShape(
+                  rewriter, loc, data, outputType, *reassocOpt, shapeOperand)) {
             auto expandOp = mlir::tensor::ExpandShapeOp::create(
                 rewriter, loc, outputType, data, *reassocOpt, *outputShape);
             rewriter.replaceOp(op, expandOp.getResult());

--- a/lib/Conversion/OnnxToHip/ReshapeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ReshapeConversion.cpp
@@ -51,22 +51,107 @@ validateSqueezeUnsqueezeOp(mlir::Operation *op, mlir::PatternRewriter &rewriter,
   return mlir::success();
 }
 
+/// Count the dynamic output dims a reassociation group covers.
+static int64_t
+countDynOutDims(mlir::RankedTensorType outputType,
+                const mlir::ReassociationIndices &group) {
+  return llvm::count_if(
+      group, [&](int64_t idx) { return outputType.isDynamicDim(idx); });
+}
+
+/// Resolve a Reshape's `shape` operand into one extent per output dim.
+///
+/// Only a host-visible shape vector is honoured, i.e. the
+/// `tensor.from_elements` that ReshapeShapeFold leaves behind for the
+/// `Reshape(_, Shape(x))` idiom. A shape tensor that is still device-resident
+/// yields nullopt instead of paying for a readback; the caller then falls back
+/// to `tensor.reshape`, which consumes the runtime shape vector directly.
+static std::optional<llvm::SmallVector<mlir::OpFoldResult>>
+resolveShapeOperandExtents(mlir::PatternRewriter &rewriter, mlir::Location loc,
+                           mlir::Value shapeOperand, int64_t outputRank) {
+  if (!shapeOperand)
+    return std::nullopt;
+  auto fromElements =
+      shapeOperand.getDefiningOp<mlir::tensor::FromElementsOp>();
+  if (!fromElements ||
+      static_cast<int64_t>(fromElements.getElements().size()) != outputRank)
+    return std::nullopt;
+
+  // Resolve every element before building anything, so a late unresolvable
+  // entry cannot leave a half-materialized cast behind in the IR.
+  llvm::SmallVector<mlir::OpFoldResult> extents;
+  llvm::SmallVector<mlir::Value> needsCast(outputRank);
+  extents.reserve(outputRank);
+  for (auto [i, element] : llvm::enumerate(fromElements.getElements())) {
+    // ReshapeShapeFold emits `arith.index_cast %tensor.dim`. Reusing the
+    // pre-cast index keeps the extent on the same SSA value the rest of the
+    // conversion derives dims from, instead of a round trip through i64.
+    if (auto cast = element.getDefiningOp<mlir::arith::IndexCastOp>();
+        cast && mlir::isa<mlir::IndexType>(cast.getIn().getType())) {
+      extents.push_back(cast.getIn());
+      continue;
+    }
+    if (auto constant = element.getDefiningOp<mlir::arith::ConstantOp>()) {
+      auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(constant.getValue());
+      // ONNX gives 0 ("keep the input dim") and -1 ("infer") meanings that
+      // this helper does not resolve; neither is usable as an extent.
+      if (!intAttr || intAttr.getInt() <= 0)
+        return std::nullopt;
+      extents.push_back(rewriter.getIndexAttr(intAttr.getInt()));
+      continue;
+    }
+    needsCast[i] = element;
+    extents.push_back(mlir::OpFoldResult{});
+  }
+
+  for (int64_t i : llvm::seq<int64_t>(outputRank)) {
+    if (!needsCast[i])
+      continue;
+    mlir::Value asIndex = mlir::arith::IndexCastOp::create(
+        rewriter, loc, rewriter.getIndexType(), needsCast[i]);
+    extents[i] = asIndex;
+  }
+  return extents;
+}
+
 /// Build output shape for expand_shape operations.
 /// Used by both Reshape and Unsqueeze when expanding dimensions.
 ///
 /// For static dimensions: use compile-time size from outputType.
 /// For dynamic dimensions: extract from input via DimOp, dividing out any
 /// static dimensions in the same reassociation group.
-llvm::SmallVector<mlir::OpFoldResult> buildExpandShapeOutputShape(
+///
+/// That derivation only holds while a group covers at most ONE dynamic output
+/// dim. When a group splits one dynamic source dim into several dynamic output
+/// dims, the source extent is their PRODUCT and says nothing about the split,
+/// so those extents have to come from \p shapeOperand (the Reshape's `shape`
+/// input). Returns nullopt when that is needed but unreadable, letting the
+/// caller fall back to `tensor.reshape` instead of emitting an expand_shape
+/// that claims each dynamic output dim is the whole product -- which is how
+/// `[bs*ss, 2816] -> [bs, ss, 2816]` became `[ss, ss, 2816]` and dispatched
+/// every Gemma-4 layer's input norm over ss^2 rows.
+std::optional<llvm::SmallVector<mlir::OpFoldResult>>
+buildExpandShapeOutputShape(
     mlir::PatternRewriter &rewriter, mlir::Location loc, mlir::Value data,
     mlir::RankedTensorType outputType,
-    llvm::ArrayRef<mlir::ReassociationIndices> reassoc) {
+    llvm::ArrayRef<mlir::ReassociationIndices> reassoc,
+    mlir::Value shapeOperand = {}) {
   int64_t outputRank = outputType.getRank();
 
   llvm::SmallVector<int64_t> outDimToInDim(outputRank, -1);
   for (auto [g, group] : llvm::enumerate(reassoc))
     for (int64_t idx : group)
       outDimToInDim[idx] = g;
+
+  std::optional<llvm::SmallVector<mlir::OpFoldResult>> shapeExtents;
+  if (llvm::any_of(reassoc, [&](const mlir::ReassociationIndices &group) {
+        return countDynOutDims(outputType, group) > 1;
+      })) {
+    shapeExtents =
+        resolveShapeOperandExtents(rewriter, loc, shapeOperand, outputRank);
+    if (!shapeExtents)
+      return std::nullopt;
+  }
 
   llvm::SmallVector<mlir::OpFoldResult> outputShape;
   for (int64_t i : llvm::seq<int64_t>(outputRank)) {
@@ -77,6 +162,11 @@ llvm::SmallVector<mlir::OpFoldResult> buildExpandShapeOutputShape(
 
     int64_t srcDim = outDimToInDim[i];
     const auto &group = reassoc[srcDim];
+
+    if (countDynOutDims(outputType, group) > 1) {
+      outputShape.push_back((*shapeExtents)[i]);
+      continue;
+    }
 
     int64_t staticProduct = 1;
     for (int64_t idx : group)
@@ -194,17 +284,28 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
       if (auto reassocOpt =
               mlir::getReassociationIndicesForReshape(inputType, outputType)) {
         if (outputRank > inputRank) {
-          auto outputShape = buildExpandShapeOutputShape(
-              rewriter, loc, data, outputType, *reassocOpt);
-          auto expandOp = mlir::tensor::ExpandShapeOp::create(
-              rewriter, loc, outputType, data, *reassocOpt, outputShape);
-          rewriter.replaceOp(op, expandOp.getResult());
+          // The `shape` operand is the only place a multi-dynamic split's
+          // per-dim extents exist; ReshapeShapeFold has already folded
+          // `Shape(x)` into a host-visible tensor.from_elements for it.
+          mlir::Value shapeOperand =
+              op->getNumOperands() >= 2 ? op->getOperand(1) : mlir::Value();
+          if (auto outputShape =
+                  buildExpandShapeOutputShape(rewriter, loc, data, outputType,
+                                              *reassocOpt, shapeOperand)) {
+            auto expandOp = mlir::tensor::ExpandShapeOp::create(
+                rewriter, loc, outputType, data, *reassocOpt, *outputShape);
+            rewriter.replaceOp(op, expandOp.getResult());
+            return mlir::success();
+          }
+          // Multi-dynamic split with an unreadable shape operand: fall through
+          // to the tensor.reshape fallback, which takes the runtime shape
+          // vector verbatim.
         } else {
           auto collapseOp = mlir::tensor::CollapseShapeOp::create(
               rewriter, loc, outputType, data, *reassocOpt);
           rewriter.replaceOp(op, collapseOp.getResult());
+          return mlir::success();
         }
-        return mlir::success();
       }
       // Fall through to tensor.reshape fallback (no structured reassoc).
     }
@@ -349,11 +450,15 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
         // combine direction here. (PoolAllocs's hoistable whitelist must
         // include arith.divui for the resulting dim arithmetic to survive
         // pool-base hoisting.)
+        // Each group here pairs one dynamic extent with the static factor K,
+        // so no group is multi-dynamic and the shape operand is never needed.
         auto intOutShape = buildExpandShapeOutputShape(rewriter, loc, data,
                                                        intType, expandReassoc);
+        if (!intOutShape)
+          break; // fall through to tensor.reshape fallback
 
         auto expanded = mlir::tensor::ExpandShapeOp::create(
-            rewriter, loc, intType, data, expandReassoc, intOutShape);
+            rewriter, loc, intType, data, expandReassoc, *intOutShape);
 
         // (e) Collapse: the OUTPUT dim that absorbs the factor pair maps to the
         // two intermediate dims; everything else is identity.
@@ -578,10 +683,15 @@ struct UnsqueezeToStdTensor : public mlir::RewritePattern {
           op, "cannot compute unsqueeze reassociation");
 
     mlir::Location loc = op->getLoc();
+    // Unsqueeze only inserts unit dims, so every group keeps at most one
+    // dynamic dim and no shape operand is needed.
     auto outputShape = buildExpandShapeOutputShape(rewriter, loc, data,
                                                    outputType, *reassocOpt);
+    if (!outputShape)
+      return rewriter.notifyMatchFailure(
+          op, "unsqueeze: multi-dynamic reassociation group");
     auto expandOp = mlir::tensor::ExpandShapeOp::create(
-        rewriter, loc, outputType, data, *reassocOpt, outputShape);
+        rewriter, loc, outputType, data, *reassocOpt, *outputShape);
     rewriter.replaceOp(op, expandOp.getResult());
     return mlir::success();
   }

--- a/lib/Conversion/OnnxToHip/ReshapeShapeFold.cpp
+++ b/lib/Conversion/OnnxToHip/ReshapeShapeFold.cpp
@@ -50,8 +50,9 @@
 //
 // This fold rewrites the shape operand BEFORE ConvertOnnxToHip so the
 // resulting `tensor.from_elements` is exactly what ReshapeConversion's
-// existing multi-dyn-per-group branch picks up.  Bug fix is structural
-// at the operand level; no change to ReshapeConversion required.
+// multi-dyn-per-group branch picks up.  That branch is the other half of
+// the fix and lives in `buildExpandShapeOutputShape`; without it this fold
+// has no effect, because the conversion otherwise never reads operand 1.
 //
 // Implementation notes
 // --------------------

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -77,6 +77,11 @@ extern "C" hipError_t hipStreamSynchronize(hipStream_t stream) {
   return hipSuccess;
 }
 
+extern "C" hipError_t hipDeviceSynchronize(void) {
+  MOCK_PRINT("[MOCK] hipDeviceSynchronize()\n");
+  return hipSuccess;
+}
+
 extern "C" hipError_t hipEventCreate(hipEvent_t *event) {
   *event = malloc(sizeof(void *));
   return hipSuccess;

--- a/lib/Runtime/mock/mock_types.h
+++ b/lib/Runtime/mock/mock_types.h
@@ -51,6 +51,7 @@ extern "C" hipError_t hipGetDeviceProperties(hipDeviceProp_t *prop, int device);
 extern "C" hipError_t hipStreamCreate(hipStream_t *stream);
 extern "C" hipError_t hipStreamDestroy(hipStream_t stream);
 extern "C" hipError_t hipStreamSynchronize(hipStream_t stream);
+extern "C" hipError_t hipDeviceSynchronize(void);
 extern "C" hipError_t hipMalloc(void **ptr, size_t size);
 extern "C" hipError_t hipFree(void *ptr);
 extern "C" hipError_t hipHostMalloc(void **ptr, size_t size,

--- a/lib/Runtime/op_profile.cpp
+++ b/lib/Runtime/op_profile.cpp
@@ -6,12 +6,61 @@
 #include "op_profile.h"
 #include "chrome_trace.h"
 #include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <map>
 #include <string>
 #include <vector>
+
+// One-shot RGP capture fence -- see op_profile.h for the rationale. Pure host
+// code (no kernel launch): drains the GPU and sleeps so RGP arms on the next
+// dispatch. All env reads are latched on first call; when RGP_FENCE is unset
+// the very first check returns and the whole thing compiles down to one load.
+void rgp_capture_fence(const char *opname) {
+  static const std::string target = hipdnn_ep::env_string("RGP_FENCE");
+  if (target.empty())
+    return;
+  static const int skip = [] {
+    const std::string s = hipdnn_ep::env_string("RGP_FENCE_SKIP");
+    return s.empty() ? 0 : std::atoi(s.c_str());
+  }();
+  static const int sleep_ms = [] {
+    const std::string s = hipdnn_ep::env_string("RGP_FENCE_MS");
+    return s.empty() ? 200 : std::atoi(s.c_str());
+  }();
+  static std::atomic<bool> fired{false};
+  static std::atomic<int> matches{0};
+
+  if (fired.load(std::memory_order_acquire))
+    return;
+  if (!opname || target != opname)
+    return;
+  // Arm only on the (skip)-th matching instance so callers can pick, e.g., a
+  // full-attention layer rather than the first (sliding) one.
+  int idx = matches.fetch_add(1, std::memory_order_acq_rel);
+  if (idx < skip)
+    return;
+  bool expected = false;
+  if (!fired.compare_exchange_strong(expected, true, std::memory_order_acq_rel))
+    return;
+  // Drain all outstanding GPU work, THEN announce the idle window and hold. The
+  // marker is emitted BEFORE the wait so the capture orchestrator has the full
+  // window to detect it and trigger RGP; the GPU stays quiescent for the whole
+  // wait, so RGP arms cleanly and this op's kernels are the first dispatches
+  // after the gap. Busy-wait on the steady clock (no threading headers, no GPU
+  // work).
+  (void)hipDeviceSynchronize();
+  fprintf(stderr, "[RGP_FENCE_ARMED] op=%s instance=%d idling sleep_ms=%d\n",
+          opname, idx, sleep_ms);
+  fflush(stderr);
+  const auto until =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(sleep_ms);
+  while (std::chrono::steady_clock::now() < until) { /* spin */
+  }
+}
 
 struct OpProfileState {
   struct ShapeEntry {

--- a/lib/Runtime/op_profile.h
+++ b/lib/Runtime/op_profile.h
@@ -52,6 +52,18 @@ void op_profile_add_cpu_total(OpProfileState *ps, const std::string &name,
                               double cpuStartUs, double cpuMs);
 bool op_profile_is_active(OpProfileState *ps);
 
+// One-shot RGP capture fence. Gated on the RGP_FENCE env var; a no-op (single
+// cached check) when unset, so it costs nothing on normal runs. When RGP_FENCE
+// names this op, the fence drains the GPU (hipDeviceSynchronize) and sleeps
+// RGP_FENCE_MS ms to manufacture an idle window, so an RGP dispatch-mode
+// auto-capture arms deterministically on THIS op's first dispatch after the gap
+// (dispatch-index positioning is unreliable in this build). RGP_FENCE_SKIP=N
+// arms on the (N+1)-th matching instance instead of the first (e.g. to target a
+// full-attention layer rather than layer-0 sliding attention). Fires once per
+// process and emits a "[RGP_FENCE_ARMED]" stderr marker the orchestrator waits
+// on before triggering the capture.
+void rgp_capture_fence(const char *opname);
+
 // Absolute microseconds on the shared steady_clock axis. A plain time
 // conversion tied to no session: the trace axis is process-global, so all
 // sessions and inferences land on it without any captured baseline.
@@ -125,6 +137,7 @@ struct OpProfileScope {
 // [PERF] table can report achieved GB/s and % of the memory roofline. bytes_fn
 // is a callable returning int64_t, invoked only when profiling is active.
 #define OP_PROFILE_BYTES(opname, shape_fn, bytes_fn, state_arg)                \
+  rgp_capture_fence(opname);                                                   \
   std::optional<OpProfileScope> _opProf;                                       \
   if (hipdnn_ep_perf_enabled()) {                                              \
     auto *_ps = static_cast<OpProfileState *>(                                 \
@@ -140,6 +153,7 @@ struct OpProfileScope {
   }
 
 #define OP_PROFILE_CPU(opname, state_arg)                                      \
+  rgp_capture_fence(opname);                                                   \
   std::optional<OpProfileCpuScope> _opProfCpu;                                 \
   if (hipdnn_ep_perf_enabled()) {                                              \
     auto *_ps = static_cast<OpProfileState *>(                                 \

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -1480,6 +1480,13 @@ static int gqa_forward_hipblaslt(
   if (past_len < 0)
     past_len = 0;
 
+  RUNTIME_DEBUG_LOG(
+      "[REAL] decomposed GQA lengths: sq=%lld total_seq=%lld past_len=%lld "
+      "present_seq=%lld past_buf_seq=%lld aliased=%d\n",
+      (long long)sq, (long long)total_seq, (long long)past_len,
+      (long long)present_seq, (long long)past_buf_seq,
+      static_cast<int>(past_key == present_key));
+
   bool packed_qkv = (key == nullptr && value == nullptr);
 
   //===--------------------------------------------------------------------===//

--- a/lib/Runtime/real/simplified_layer_norm.cpp
+++ b/lib/Runtime/real/simplified_layer_norm.cpp
@@ -212,6 +212,25 @@ int wrap_miopenT5LayerNormForward(RuntimeState *state, int op_state_slot,
     return -1;
   }
 
+  // The [num_rows, hidden_dim] flattening below is only meaningful while the
+  // caller's element counts agree; matches the checks in
+  // wrap_layer_normalization. The axis-vs-scale agreement cannot be rechecked
+  // here (the ABI carries element counts, not shapes) and is enforced at
+  // conversion time by verifyNormAxisMatchesScale.
+  if (scale_num_elements <= 0) {
+    fprintf(stderr,
+            "[REAL] wrap_miopenT5LayerNormForward: scale_num_elements=%lld\n",
+            (long long)scale_num_elements);
+    return -1;
+  }
+  if (input_num_elements % scale_num_elements != 0) {
+    fprintf(stderr,
+            "[REAL] wrap_miopenT5LayerNormForward: input_num(%lld) not "
+            "divisible by scale_num(%lld)\n",
+            (long long)input_num_elements, (long long)scale_num_elements);
+    return -1;
+  }
+
   int64_t hidden_dim = scale_num_elements;
   int64_t num_rows = input_num_elements / hidden_dim;
 

--- a/lib/Runtime/real/skip_simplified_layer_norm.cpp
+++ b/lib/Runtime/real/skip_simplified_layer_norm.cpp
@@ -240,6 +240,22 @@ int wrap_skip_simplified_layer_norm(RuntimeState *state, int op_state_slot,
     return -1;
   }
 
+  // Same flattening precondition as wrap_layer_normalization: without it a
+  // caller whose element counts disagree silently gets a truncated row count.
+  if (gamma_num_elements <= 0) {
+    fprintf(stderr,
+            "[REAL] wrap_skip_simplified_layer_norm: gamma_num_elements=%lld\n",
+            (long long)gamma_num_elements);
+    return -1;
+  }
+  if (input_num_elements % gamma_num_elements != 0) {
+    fprintf(stderr,
+            "[REAL] wrap_skip_simplified_layer_norm: input_num(%lld) not "
+            "divisible by gamma_num(%lld)\n",
+            (long long)input_num_elements, (long long)gamma_num_elements);
+    return -1;
+  }
+
   int64_t hidden_dim = gamma_num_elements;
   int64_t num_rows = input_num_elements / hidden_dim;
 

--- a/test/lit/Conversion/hip-to-llvm/test_rms_norm.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_rms_norm.mlir
@@ -113,6 +113,39 @@ func.func @rms_norm_dynamic(%ctx: !hip.context, %input: memref<?x512xf16, 1>) {
   return
 }
 
+// Rank-3 [batch, seq, hidden] with both leading extents dynamic: the shape a
+// decoder layer's input norm actually has. input_num_elements must be the
+// product of THREE distinct descriptor reads -- if dim 0 and dim 1 resolve to
+// the same value the norm is dispatched over seq^2 rows.
+// CHECK-LABEL: @rms_norm_dynamic_batch_seq_3d
+func.func @rms_norm_dynamic_batch_seq_3d(%ctx: !hip.context,
+                                         %input: memref<?x?x2816xf16, 1>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2816 = arith.constant 2816 : index
+  %dim0 = memref.dim %input, %c0 : memref<?x?x2816xf16, 1>
+  %dim1 = memref.dim %input, %c1 : memref<?x?x2816xf16, 1>
+  %scale = memref.alloc(%c2816) : memref<?xf16, 1>
+  %output = memref.alloc(%dim0, %dim1) : memref<?x?x2816xf16, 1>
+
+  // Batch and sequence come from separate descriptor slots.
+  // CHECK: llvm.extractvalue {{.*}}[3, 0]
+  // CHECK: llvm.extractvalue {{.*}}[3, 1]
+
+  // input_num_elements = dim0 * dim1 * 2816
+  // CHECK: llvm.mul {{.*}}, {{.*}} : i64
+  // CHECK: llvm.mul {{.*}}, {{.*}} : i64
+  // CHECK: llvm.mul {{.*}}, {{.*}} : i64
+
+  // CHECK: llvm.call @wrap_miopenT5LayerNormForward({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, f32, i64) -> i32
+  hip.rms_norm(%ctx)
+      ins(%input, %scale : memref<?x?x2816xf16, 1>, memref<?xf16, 1>)
+      outs(%output : memref<?x?x2816xf16, 1>)
+      {axis = -1 : i64, epsilon = 9.99999997e-07 : f32, stash_type = 1 : i64}
+
+  return
+}
+
 // CHECK-LABEL: @rms_norm_fully_dynamic
 func.func @rms_norm_fully_dynamic(%ctx: !hip.context, %input: memref<?x?xf16, 1>) {
   %c0 = arith.constant 0 : index

--- a/test/lit/Conversion/onnx-to-hip/test_onnx_attention.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_onnx_attention.mlir
@@ -9,9 +9,15 @@
 //   - is_causal=1 WITH an external attn_mask -> no_causal=false AND the mask
 //     threaded as attention_bias (runtime adds the mask, then the built-in
 //     causal triangle applies on top -- both, mirroring the ONNX reference)
-//   - present KV seq extent = past_seq + current_seq (concat semantics),
-//     and seqlens_k = total_seq - 1 (ORT convention total_seq = seqlens_k + 1)
-//   - present_key/value DPS inits sized to the past+current total
+//   - valid total KV length taken from the mask's kv extent when a mask is
+//     present (dim(past_key, 2) is the past buffer EXTENT, which equals the
+//     valid past length only when present is freshly allocated each step), and
+//     seqlens_k = total_seq - 1 (ORT convention total_seq = seqlens_k + 1)
+//   - present_key/value DPS inits sized to CAPACITY = max(past extent, total),
+//     which collapses to past+current for a separately allocated present and
+//     yields the max_length capacity under past_present_share_buffer -- the
+//     latter is what makes past_key == present_key, and hence the in-place
+//     append path, reachable
 //
 // Cases: a static-shape decode (16 query heads, 8 KV heads), a dynamic-shape
 // prefill with an EMPTY past (the case that previously sized present from
@@ -55,9 +61,9 @@ module {
         -> (tensor<1x1x2048xf16>, tensor<1x8x128x128xf16>,
             tensor<1x8x128x128xf16>)
 
-    // present KV seq = past_seq (127) + current_seq (1); seqlens_k = total - 1.
-    // CHECK: tensor.dim %{{.*}}, %c2
-    // CHECK: arith.addi
+    // Total KV (128) comes from the mask's kv extent; seqlens_k = total - 1.
+    // present is statically 128 here, so the capacity max() folds away.
+    // CHECK: tensor.dim %{{.*}}, %c3
     // CHECK: arith.subi
     // CHECK: tensor.from_elements %{{.*}} : tensor<1xi32>
     // CHECK: tensor.empty() : tensor<1x1x2048xf16>
@@ -108,14 +114,16 @@ module {
         -> (tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>,
             tensor<?x8x?x256xf16>)
 
-    // present seq extent = past + current, materialised as arith.addi and fed
-    // into the present tensor.empty (dynamic seq dim), NOT dim(past_key, 2).
-    // CHECK: %[[CUR:.*]] = tensor.dim %{{.*}}, %c1
+    // Valid total KV comes from the mask kv extent and drives seqlens_k, while
+    // the present tensor.empty is sized to max(past extent, total). The two
+    // differ only under a shared past/present buffer; here past is the valid
+    // past length, so the max() picks the mask total.
     // CHECK: %[[PAST:.*]] = tensor.dim %{{.*}}, %c2
-    // CHECK: %[[TOT:.*]] = arith.addi %[[PAST]], %[[CUR]]
-    // CHECK: arith.subi %[[TOT]], %{{.*}}
+    // CHECK: %[[MASKKV:.*]] = tensor.dim %{{.*}}, %c3
+    // CHECK: %[[CAP:.*]] = arith.maxsi %[[PAST]], %[[MASKKV]]
+    // CHECK: arith.subi %[[MASKKV]], %{{.*}}
     // CHECK: tensor.from_elements %{{.*}} : tensor<1xi32>
-    // CHECK: tensor.empty(%{{.*}}, %[[TOT]]) : tensor<?x8x?x256xf16>
+    // CHECK: tensor.empty(%{{.*}}, %[[CAP]]) : tensor<?x8x?x256xf16>
     // CHECK: hip.gqa(%[[CTX2]])
     // CHECK-SAME: no_causal = true
     // CHECK-NOT: onnx.Attention
@@ -161,13 +169,14 @@ module {
         -> (tensor<?x?x2048xf16>, tensor<?x1x?x256xf16>,
             tensor<?x1x?x256xf16>)
 
-    // present seq extent = past + current; mask threaded as attention_bias (8
-    // hip.gqa ins: q, k, v, past_k, past_v, seqlens_k, total_seq, mask).
-    // CHECK: %[[CURG:.*]] = tensor.dim %{{.*}}, %c1
+    // present sized to max(past extent, mask total); mask threaded as
+    // attention_bias (8 hip.gqa ins: q, k, v, past_k, past_v, seqlens_k,
+    // total_seq, mask).
     // CHECK: %[[PASTG:.*]] = tensor.dim %{{.*}}, %c2
-    // CHECK: %[[TOTG:.*]] = arith.addi %[[PASTG]], %[[CURG]]
+    // CHECK: %[[MASKKVG:.*]] = tensor.dim %{{.*}}, %c3
+    // CHECK: %[[CAPG:.*]] = arith.maxsi %[[PASTG]], %[[MASKKVG]]
     // CHECK: tensor.from_elements %{{.*}} : tensor<1xi32>
-    // CHECK: tensor.empty(%{{.*}}, %[[TOTG]]) : tensor<?x1x?x256xf16>
+    // CHECK: tensor.empty(%{{.*}}, %[[CAPG]]) : tensor<?x1x?x256xf16>
     // CHECK: hip.gqa(%[[CTXG]])
     // Mask is threaded as the final hip.gqa input (attention_bias).
     // CHECK-SAME: ins({{.*}}tensor<?x1x?x?xf16>) outs

--- a/test/lit/Conversion/onnx-to-hip/test_reshape.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_reshape.mlir
@@ -77,6 +77,29 @@ module {
     %result = "onnx.Reshape"(%data, %shape) {allowzero = 0 : si64} : (tensor<f16>, tensor<3xi64>) -> tensor<1x1x1xf16>
     return %result : tensor<1x1x1xf16>
   }
+
+  // --- Multi-dynamic expand: [bs*ss, H] -> [bs, ss, H] ---
+  // The source dim only holds the PRODUCT bs*ss, so the split has to come from
+  // the shape operand.  Deriving both extents positionally from the source
+  // yields [bs*ss, bs*ss, H], which is how every Gemma-4 decoder layer's input
+  // norm ended up dispatched over ss^2 rows.
+  func.func @test_reshape_expand_multi_dyn(%data: tensor<?x2816xf16>,
+                                           %ref: tensor<?x?x2816xf16>)
+      -> tensor<?x?x2816xf16> {
+    %shape = "onnx.Shape"(%ref) : (tensor<?x?x2816xf16>) -> tensor<3xi64>
+    %result = "onnx.Reshape"(%data, %shape) {allowzero = 0 : si64} : (tensor<?x2816xf16>, tensor<3xi64>) -> tensor<?x?x2816xf16>
+    return %result : tensor<?x?x2816xf16>
+  }
+
+  // --- Multi-dynamic expand with an opaque shape operand ---
+  // Nothing here reveals the split, so the conversion must decline to build an
+  // expand_shape and hand the runtime shape vector to tensor.reshape instead.
+  func.func @test_reshape_expand_multi_dyn_opaque(%data: tensor<?x2816xf16>,
+                                                  %shape: tensor<3xi64>)
+      -> tensor<?x?x2816xf16> {
+    %result = "onnx.Reshape"(%data, %shape) {allowzero = 0 : si64} : (tensor<?x2816xf16>, tensor<3xi64>) -> tensor<?x?x2816xf16>
+    return %result : tensor<?x?x2816xf16>
+  }
 }
 
 // CHECK-LABEL: func.func @test_reshape_expand
@@ -118,4 +141,19 @@ module {
 // CHECK: hip.readback_scalar
 // CHECK: tensor.from_elements
 // CHECK: tensor.expand_shape
+// CHECK-NOT: onnx.Reshape
+
+// The two dynamic output extents must be DISTINCT dims of the rank-3 reference,
+// never the same source dim twice.
+// CHECK-LABEL: func.func @test_reshape_expand_multi_dyn
+// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+// CHECK: %[[BS:.*]] = tensor.dim %[[REF:.*]], %[[C0]] : tensor<?x?x2816xf16>
+// CHECK: %[[SS:.*]] = tensor.dim %[[REF]], %[[C1]] : tensor<?x?x2816xf16>
+// CHECK: tensor.expand_shape %{{.*}} {{\[\[}}0, 1], [2]] output_shape [%[[BS]], %[[SS]], 2816]
+// CHECK-NOT: onnx.Reshape
+
+// CHECK-LABEL: func.func @test_reshape_expand_multi_dyn_opaque
+// CHECK-NOT: tensor.expand_shape
+// CHECK: tensor.reshape
 // CHECK-NOT: onnx.Reshape


### PR DESCRIPTION
## Problem

The ONNX `Attention` lowering sized the `present` KV tensor as `dim(past_key, 2) + dim(query, 1)`, and reused that same value for `seqlens_k`. That conflates two different quantities. Under `past_present_share_buffer: true`, `dim(past_key, 2)` is the buffer *capacity* (`max_length`), so `past + current` overshoots and the requested `present` shape never matches the buffer ORT has already bound. ORT therefore allocated a fresh `present` buffer on every step, `past_key != present_key`, and the runtime fell into `kv_cache_concat_kernel`, which re-materialises the entire KV cache for every generated token instead of taking the cheap in-place `kv_cache_append_kernel`.

This is also why `past_present_share_buffer: true` previously failed outright rather than merely running slowly: the computed present shape `{1,8,24565,256}` did not match the bound `{1,8,16384,256}`.

## Fix

Separate valid length from buffer capacity.

Valid total KV length now comes from the additive mask's kv extent (`tensor.dim %attn_mask, rank-1`) when a mask is present, falling back to `past + current` when there is no mask. That value drives `seqlens_k`.

Capacity is `arith.maxsi(dim(past_key, 2), total)` and drives the `present` DPS init and `total_seq_len`. When `present` is separately allocated, `dim(past_key, 2)` is the true past length, so the `max()` collapses to `past + current` and the legacy path is bit-for-bit unchanged. Under a shared buffer the `max()` yields the `max_length` capacity, the requested shape matches, ORT hands back the pre-bound `OrtValue`, and `past_key == present_key`.

The `max()` also preserves the property the old expression was implicitly providing: on a fresh prefill the past is empty, and sizing capacity from the past extent alone would collapse `present` to zero length and zero-fill the attention output.

## Why the mask is a valid length signal

This was verified empirically rather than assumed. With `past_present_share_buffer: true` the runtime reported `total_seq=2049` while `present_seq=16384` and `past_buf_seq=16384`. In other words OGA feeds a mask whose kv extent is the true `past + current` length, not the padded capacity. The graph input is declared `attention_mask: ['batch', 'past_seq_len + seq_len']`, which is consistent with that. The same debug output reported `aliased=1` (`past_key == present_key`) on all 180 GQA calls, confirming the in-place append path is now taken.

## Files

- `lib/Conversion/OnnxToHip/OnnxAttentionConversion.cpp` -- the length/capacity split, plus updated header contract documentation.
- `test/lit/Conversion/onnx-to-hip/test_onnx_attention.mlir` -- updated CHECK lines and TEST PURPOSE.
- `lib/Runtime/real/gqa.cpp` -- one `RUNTIME_DEBUG_LOG` line on the decomposed path printing `sq`, `total_seq`, `past_len`, `present_seq`, `past_buf_seq` and `aliased`. This is a deliberate, debug-gated diagnostic: it is what made the mask-semantics claim above checkable rather than assumed. Reviewers may want to weigh in on whether it stays.

## Measurements

Gemma-4 26B-A4B (`google-gemma-4-26B-A4B-it-FP16W4-qmoe`), decode P50 from alternating A/B runs of `vlm_benchmark.py`. Baseline is `share_buffer=false`; branch is `share_buffer=true`.

| Context | Baseline | Branch | Delta |
| --- | --- | --- | --- |
| 12K | 581.91 ms/token (1.72 TPS) | 166.99 ms/token (5.99 TPS) | 3.48x |
| 2K | 33.94 ms/token | 28.15 ms/token | -17% |

Two caveats on how to read these numbers. First, enabling the branch requires flipping `past_present_share_buffer` to `true` in the model's `genai_config.json`, and that config flag is not part of this diff. Second, the comparison necessarily conflates the lowering change with the shared-buffer mode, because the baseline cannot run in shared-buffer mode at all -- that is the bug being fixed. There is no configuration in which both sides differ only by this patch.

## Correctness and test status

The full lit suite passes: 382 passed, 0 failed.

With `share_buffer=false` the branch reproduces the baseline generated text exactly, which confirms the change is a no-op in the legacy mode. Qwen3.5-9B, which already uses `share_buffer=true` and reaches the runtime through the separate GQA conversion path, produces byte-identical text. A Qwen3.6-35B regression run was still in flight when this was written, so treat it as pending rather than passed.

Under `share_buffer=true` on Gemma-4 the generated text differs from baseline by a word or two ("Siberian Husky" instead of "white Pomeranian"; "grassy setting" instead of "grassy area"). This is a numerics shift, not bit-exactness: the `present_seq` stride changes from the exact length to 16384, which changes GEMM tiling and accumulation order, and that flips near-tie greedy argmax decisions. The output stays coherent and on-topic, but this path is explicitly not bit-exact against baseline.

## Base branch note

This PR is based on `test/pr700-on-main` because the local staging base (`test/pr700-on-main` plus one commit) is not pushed. The diff therefore contains two commits: the branch work, and one preceding commit `test(profile): add env-gated RGP capture fence` which adds `lib/Runtime/op_profile.{cpp,h}` and small mock-runtime additions. That fence commit is not part of the change under review here.

## Notes for reviewers

While working on this, Gemma-4 26B turned out to be a 5:1 hybrid attention model. 25 layers use 8 KV heads at head_dim 256 with a 1024-token sliding window folded into the additive mask, while layers 5, 11, 17, 23 and 29 use 2 KV heads at head_dim 512 with full causal attention.

The sliding window means those 25 layers only ever need 1024 keys, no matter how long the context grows. Capping their KV cache accordingly looks like a promising follow-up, but it is out of scope for this PR.
