### PR TITLE
fix(pool-alloc): size i1 buffers by physical bytes

### DIFF
--- a/include/hip/Dialect/Transforms/BufferUtils.h
+++ b/include/hip/Dialect/Transforms/BufferUtils.h
@@ -20,9 +20,12 @@
 namespace mlir {
 namespace hip {
 
-/// Byte size for a fully-static memref type; returns 0 when any dim is dynamic.
-/// Uses llvm::divideCeil to correctly handle sub-byte element types (e.g. i1).
-int64_t getStaticByteSize(MemRefType type);
+/// Physical bytes used by one HIP memref element.
+int64_t getElementByteWidth(MemRefType type);
+
+/// Byte size for a fully-static memref type. Fails for dynamic shapes or when
+/// the physical byte size does not fit in int64_t.
+FailureOr<int64_t> getStaticByteSize(MemRefType type);
 
 /// Emit arith ops for: llvm::alignTo(value, alignment).
 /// Produces: ((value + alignment - 1) / alignment) * alignment.

--- a/lib/Dialect/Transforms/BufferUtils.cpp
+++ b/lib/Dialect/Transforms/BufferUtils.cpp
@@ -17,11 +17,20 @@
 
 using namespace mlir;
 
-int64_t mlir::hip::getStaticByteSize(MemRefType type) {
+int64_t mlir::hip::getElementByteWidth(MemRefType type) {
+  return static_cast<int64_t>(
+      llvm::divideCeil(type.getElementTypeBitWidth(), 8));
+}
+
+FailureOr<int64_t> mlir::hip::getStaticByteSize(MemRefType type) {
   if (!type.hasStaticShape())
-    return 0;
-  int64_t totalBits = type.getNumElements() * type.getElementTypeBitWidth();
-  return static_cast<int64_t>(llvm::divideCeil(totalBits, 8));
+    return failure();
+
+  int64_t byteSize = getElementByteWidth(type);
+  for (int64_t dim : type.getShape())
+    if (llvm::MulOverflow(byteSize, dim, byteSize))
+      return failure();
+  return byteSize;
 }
 
 Value mlir::hip::emitAlignUp(OpBuilder &builder, Location loc, Value value,

--- a/lib/Dialect/Transforms/OptimizeMemRefs.cpp
+++ b/lib/Dialect/Transforms/OptimizeMemRefs.cpp
@@ -107,13 +107,14 @@ static bool canReuse(const Slot &slot, MemRefType neededType,
   if (slot.type.getMemorySpace() != neededType.getMemorySpace())
     return false;
 
-  int64_t slotBytes = getStaticByteSize(slot.type);
-  int64_t neededBytes = getStaticByteSize(neededType);
+  FailureOr<int64_t> slotBytes = getStaticByteSize(slot.type);
+  FailureOr<int64_t> neededBytes = getStaticByteSize(neededType);
 
-  if (slotBytes > 0 && neededBytes > 0)
-    return slotBytes >= neededBytes;
+  if (succeeded(slotBytes) && succeeded(neededBytes))
+    return *slotBytes >= *neededBytes;
 
-  if (slotBytes == 0 && neededBytes == 0 && slot.type == neededType) {
+  if (!slot.type.hasStaticShape() && !neededType.hasStaticShape() &&
+      slot.type == neededType) {
     if (slot.dynamicSizes.size() != static_cast<size_t>(neededDynSizes.size()))
       return false;
     for (auto [slotDyn, neededDyn] :
@@ -203,8 +204,10 @@ void OptimizeMemRefsPass::runOnOperation() {
         continue;
       if (!canReuse(slot, neededType, neededDynSizes))
         continue;
+      FailureOr<int64_t> slotBytes = getStaticByteSize(slot.type);
+      FailureOr<int64_t> neededBytes = getStaticByteSize(neededType);
       int64_t waste =
-          getStaticByteSize(slot.type) - getStaticByteSize(neededType);
+          succeeded(slotBytes) ? *slotBytes - *neededBytes : int64_t{0};
       if (waste < bestWaste) {
         bestWaste = waste;
         bestSlot = &slot;

--- a/lib/Dialect/Transforms/PoolAllocs.cpp
+++ b/lib/Dialect/Transforms/PoolAllocs.cpp
@@ -93,9 +93,10 @@ namespace {
 
 struct AllocInfo {
   memref::AllocOp allocOp;
-  unsigned defIndex;      ///< sequential index of the alloc op in the block
-  unsigned lastUseIndex;  ///< highest index of any (transitive) user
-  int64_t staticByteSize; ///< >0 for static shapes, 0 for dynamic
+  unsigned defIndex;        ///< sequential index of the alloc op in the block
+  unsigned lastUseIndex;    ///< highest index of any (transitive) user
+  int64_t staticByteSize;   ///< >0 for static shapes, 0 for dynamic
+  int64_t staticByteFactor; ///< element bytes times all static dimensions
 };
 
 /// True when two allocs' [def, lastUse] intervals overlap.
@@ -103,16 +104,14 @@ static bool lifetimesOverlap(const AllocInfo &a, const AllocInfo &b) {
   return !(a.lastUseIndex < b.defIndex || b.lastUseIndex < a.defIndex);
 }
 
-/// Compile-time byte coefficient: element bytes times all static dimensions.
-/// For dynamic memrefs, multiplying this coefficient by the ordered dynamic
-/// size operands yields the runtime byte size.
-static int64_t staticFactorBytes(MemRefType type) {
-  int64_t staticElems = 1;
+/// Compile-time byte coefficient for a possibly-dynamic memref.
+static FailureOr<int64_t> getStaticByteFactor(MemRefType type) {
+  int64_t factor = getElementByteWidth(type);
   for (int64_t dim : type.getShape())
     if (!ShapedType::isDynamic(dim))
-      staticElems *= dim;
-  return static_cast<int64_t>(
-      llvm::divideCeil(staticElems * type.getElementTypeBitWidth(), 8));
+      if (llvm::MulOverflow(factor, dim, factor))
+        return failure();
+  return factor;
 }
 
 /// Max-load lower bound: the peak sum of `sizeOf` over members live at a single
@@ -516,7 +515,7 @@ static DynPacking packDynamicAllocs(MutableArrayRef<AllocInfo> dynamics,
   auto computeKey = [](AllocInfo &info) {
     MemRefType type = info.allocOp.getType();
     auto dynSizes = info.allocOp.getDynamicSizes();
-    int64_t staticFactor = staticFactorBytes(type);
+    int64_t staticFactor = info.staticByteFactor;
     SmallVector<Value, 2> dynOperands;
     unsigned dynIdx = 0;
     for (int64_t dim : type.getShape())
@@ -732,7 +731,23 @@ void PoolAllocsPass::runOnOperation() {
     info.defIndex = opIndex[&op];
     info.lastUseIndex = findLastAliasedUseIndex(result, aliasAnalysis, block,
                                                 opIndex, blockSize);
-    info.staticByteSize = getStaticByteSize(allocOp.getType());
+    MemRefType type = allocOp.getType();
+    FailureOr<int64_t> staticFactor = getStaticByteFactor(type);
+    if (failed(staticFactor)) {
+      allocOp.emitError("HIP pool byte-size coefficient overflows int64");
+      return signalPassFailure();
+    }
+    info.staticByteFactor = *staticFactor;
+    if (type.hasStaticShape()) {
+      FailureOr<int64_t> staticByteSize = getStaticByteSize(type);
+      if (failed(staticByteSize)) {
+        allocOp.emitError("HIP pool byte size overflows int64");
+        return signalPassFailure();
+      }
+      info.staticByteSize = *staticByteSize;
+    } else {
+      info.staticByteSize = 0;
+    }
     LLVM_DEBUG(llvm::dbgs() << "  alloc " << allocOp << " [" << info.defIndex
                             << ", " << info.lastUseIndex << "] "
                             << info.staticByteSize << " bytes\n");
@@ -894,10 +909,8 @@ void PoolAllocsPass::runOnOperation() {
       for (const DynGroup &g : groups)
         for (const auto &[info, unitOffset] : g.assignments)
           members.push_back(info);
-      int64_t dynLbUnits = maxConcurrentLoad(members, [](const AllocInfo *i) {
-        memref::AllocOp op = i->allocOp; // copy handle to drop constness
-        return staticFactorBytes(op.getType());
-      });
+      int64_t dynLbUnits = maxConcurrentLoad(
+          members, [](const AllocInfo *i) { return i->staticByteFactor; });
       int64_t dynFrag = coefficientComparable ? dynPoolUnits - dynLbUnits : 0;
       if (!groups.empty()) {
         if (coefficientComparable) {

--- a/test/lit/Dialect/hip-pool-allocs-i1-byte-sizing.mlir
+++ b/test/lit/Dialect/hip-pool-allocs-i1-byte-sizing.mlir
@@ -1,0 +1,50 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+// RUN: hip-mlir-opt --hip-pool-allocs='alignment=1' %s | FileCheck %s
+
+// HIP kernels address i1 storage as one byte per element. This allocation is
+// larger than the default pool alignment so a packed-bit size cannot hide.
+// CHECK-LABEL: func.func @static_i1
+// CHECK: %[[BYTES:.*]] = arith.constant 300 : index
+// CHECK: %[[POOL:.*]] = hip.get_pool(%{{.*}}, %[[BYTES]]) : memref<?xi8>
+// CHECK: memref.view %[[POOL]]{{.*}} to memref<300xi1>
+func.func @static_i1(
+    %ctx: !hip.context, %input: memref<300xi1>) -> memref<300xi1> {
+  %temporary = memref.alloc() : memref<300xi1>
+  hip.not(%ctx) ins(%input : memref<300xi1>)
+                outs(%temporary : memref<300xi1>)
+  return %temporary : memref<300xi1>
+}
+
+// A dynamic i1 shape multiplies its runtime extent by the four-element static
+// suffix, not by a packed-bit fraction.
+// CHECK-LABEL: func.func @dynamic_i1_static_suffix
+// CHECK-SAME: %[[N:[a-zA-Z0-9_]+]]: index
+// CHECK: %[[COEFF:.*]] = arith.constant 4 : index
+// CHECK: %[[BYTES:.*]] = arith.muli %[[N]], %[[COEFF]] : index
+// CHECK: hip.get_pool(%{{.*}}, %[[BYTES]]) : memref<?xi8>
+func.func @dynamic_i1_static_suffix(
+    %ctx: !hip.context, %input: memref<?x4xi1>,
+    %n: index) -> memref<?x4xi1> {
+  %temporary = memref.alloc(%n) : memref<?x4xi1>
+  hip.not(%ctx) ins(%input : memref<?x4xi1>)
+                outs(%temporary : memref<?x4xi1>)
+  return %temporary : memref<?x4xi1>
+}
+
+// Non-i1 element sizing is unchanged: 4xf32 contributes 16 bytes per dynamic
+// element.
+// CHECK-LABEL: func.func @dynamic_f32_static_suffix
+// CHECK-SAME: %[[N:[a-zA-Z0-9_]+]]: index
+// CHECK: %[[COEFF:.*]] = arith.constant 16 : index
+// CHECK: %[[BYTES:.*]] = arith.muli %[[N]], %[[COEFF]] : index
+// CHECK: hip.get_pool(%{{.*}}, %[[BYTES]]) : memref<?xi8>
+func.func @dynamic_f32_static_suffix(
+    %ctx: !hip.context, %input: memref<?x4xf32>,
+    %n: index) -> memref<?x4xf32> {
+  %temporary = memref.alloc(%n) : memref<?x4xf32>
+  hip.miopen.softmax(%ctx) ins(%input : memref<?x4xf32>)
+                           outs(%temporary : memref<?x4xf32>)
+  return %temporary : memref<?x4xf32>
+}


### PR DESCRIPTION
## Why

HIP kernels address each `i1` memref element as one physical byte, but pool sizing previously rounded the aggregate bit count to bytes. A static `memref<300xi1>` could therefore reserve only 38 bytes, and dynamic shapes inherited the same packed-bit assumption in their runtime coefficients. The undersized pool could let a valid kernel access storage beyond the allocation.

Pool sizing also multiplied static dimensions without checking for `int64_t` overflow, so an unrepresentable size could silently wrap before allocation.

## IR example

The new sizing rule preserves one physical byte per `i1` element for both static and dynamic allocations. This is the static case covered by the added pass test:

```mlir
func.func @static_i1(
    %ctx: !hip.context, %input: memref<300xi1>) -> memref<300xi1> {
  %temporary = memref.alloc() : memref<300xi1>
  hip.not(%ctx) ins(%input : memref<300xi1>)
                outs(%temporary : memref<300xi1>)
  return %temporary : memref<300xi1>
}

// After hip-pool-allocs with alignment=1:
%c300 = arith.constant 300 : index
%pool = hip.get_pool(%ctx, %c300) : memref<?xi8>
%temporary = memref.view %pool[%c0][]
    : memref<?xi8> to memref<300xi1>
```

## What changes

- Define the physical element byte width once and use it for static and dynamic pool sizing.
- Compute `i1` allocations as one byte per element instead of packed bits.
- Detect overflow while multiplying dimensions and fail the pass with a diagnostic.
- Keep static slot-reuse comparisons explicit through `FailureOr` rather than overloading zero as a dynamic/error sentinel.
- Add focused LIT coverage for static `i1`, dynamic `i1`, and unchanged `f32` sizing.

## Stack

1. [#688 — Constant carrier](https://github.com/ROCm/hip-ep/pull/688)
2. [#754 — i1 pool bytes](https://github.com/ROCm/hip-ep/pull/754) ← this PR
3. [#756 — ORT error propagation](https://github.com/ROCm/hip-ep/pull/756)
4. [#758 — output view contract](https://github.com/ROCm/hip-ep/pull/758)
5. [#755 — pool namespaces](https://github.com/ROCm/hip-ep/pull/755)
6. [#757 — host scratch namespaces](https://github.com/ROCm/hip-ep/pull/757)
7. [#724 — symbolic transport](https://github.com/ROCm/hip-ep/pull/724)
8. [#759 — artifact ABI](https://github.com/ROCm/hip-ep/pull/759)
9. [#639 — shape foundation](https://github.com/ROCm/hip-ep/pull/639)
10. [#681 — reshape provenance](https://github.com/ROCm/hip-ep/pull/681)
11. [#725 — broadcast activation](https://github.com/ROCm/hip-ep/pull/725)
12. [#763 — Softmax reuse](https://github.com/ROCm/hip-ep/pull/763)
13. [#640 — MatMul runtime](https://github.com/ROCm/hip-ep/pull/640)
14. [#734 — MatMul shapes](https://github.com/ROCm/hip-ep/pull/734)
15. [#641 — broadcast contracts](https://github.com/ROCm/hip-ep/pull/641)
16. [#735 — reduction conversion](https://github.com/ROCm/hip-ep/pull/735)
17. [#736 — reduction contracts](https://github.com/ROCm/hip-ep/pull/736)
18. [#689 — loop frame](https://github.com/ROCm/hip-ep/pull/689)
19. [#737 — shape-changing loops](https://github.com/ROCm/hip-ep/pull/737)
20. [#762 — loop bank recycling](https://github.com/ROCm/hip-ep/pull/762)
21. [#642 — grouped readback](https://github.com/ROCm/hip-ep/pull/642)
22. [#727 — payload shapes](https://github.com/ROCm/hip-ep/pull/727)
23. [#728 — Tile/Range](https://github.com/ROCm/hip-ep/pull/728)
24. [#729 — Slice normalization](https://github.com/ROCm/hip-ep/pull/729)
25. [#731 — Slice ABI](https://github.com/ROCm/hip-ep/pull/731)
26. [#733 — loop payload](https://github.com/ROCm/hip-ep/pull/733)
27. [#643 — Conv](https://github.com/ROCm/hip-ep/pull/643)
28. [#738 — Pool](https://github.com/ROCm/hip-ep/pull/738)
29. [#742 — CausalConv](https://github.com/ROCm/hip-ep/pull/742)
30. [#644 — Gather](https://github.com/ROCm/hip-ep/pull/644)
31. [#739 — GBQ](https://github.com/ROCm/hip-ep/pull/739)
32. [#645 — norm](https://github.com/ROCm/hip-ep/pull/645)
33. [#740 — attention](https://github.com/ROCm/hip-ep/pull/740)
34. [#741 — GQA capacity](https://github.com/ROCm/hip-ep/pull/741)
35. [#743 — GQA rejection](https://github.com/ROCm/hip-ep/pull/743)
36. [#646 — DPS contracts](https://github.com/ROCm/hip-ep/pull/646)
37. [#730 — inventory audit](https://github.com/ROCm/hip-ep/pull/730)
38. [#732 — converter audit](https://github.com/ROCm/hip-ep/pull/732)
39. [#647 — refinement](https://github.com/ROCm/hip-ep/pull/647)
40. [#761 — headers](https://github.com/ROCm/hip-ep/pull/761)
41. [#764 — cleanup](https://github.com/ROCm/hip-ep/pull/764)

## AI assistance

AI tools assisted with the implementation and description. The contributor reviewed the resulting code and tests.

Made-with: Cursor