### PR TITLE
fix(pool-alloc): namespace pools by function site

### DIFF
--- a/docs/design/compiler-runtime-contract.md
+++ b/docs/design/compiler-runtime-contract.md
@@ -174,13 +174,19 @@ Pool planning is the canonical example:
   `hipdnn_ep_pool_init` only when all three are present and
   `hipdnn.pool_size > 0`.
 - Each `hip.get_pool` lowers directly to
-  `hipdnn_ep_get_pool_base(state, domain_id, needed_size)`.
+  `hipdnn_ep_get_pool_base(state, site_id, domain_id, needed_size)`.
+- `site_id` is the deterministic top-level function ordinal and `domain_id` is
+  local to that function. The explicit pair prevents caller/outlined-helper
+  pool collisions without relying on symbol-name hashes.
 - None of the `hipdnn.pool_*` or `hipdnn.buffer_*` attributes are fields in the
   FlatBuffers schema or the JSON mirror.
 
 The generated LLVM IR plus `RuntimeState` therefore carry pool behavior. See
 [pool-allocs-memory-planning.md](pool-allocs-memory-planning.md) for the
-attribute, lowering, and grow-on-demand runtime contract.
+attribute, lowering, grow-on-demand runtime contract, and stale-artifact
+invalidation requirement. Because the generated call ABI changed, cached model
+artifacts compiled against the old three-argument pool helper must be deleted
+and rebuilt with the matching runtime bitcode.
 
 Input staging is another generated-code-only contract. `generate-interface`
 queries `hipdnn_ep_tensor_buffer_storage_words` and constructs every opaque

--- a/docs/design/output-allocator-design.md
+++ b/docs/design/output-allocator-design.md
@@ -264,7 +264,8 @@ MlirCustomOp::Compute(context)
    │     ├─ hipdnn_ep_state_reset_error_flag(state)
    │     ├─ main_graph(state, inputs)            thin wrapper: unpacks input descriptors,
    │     │  └─ main_graph_internal(...)          calls body, DISCARDS its returned descriptor
-   │     │     ├─ hipdnn_ep_get_pool_base(state, domain_id, size)   grow-on-demand GPU pool
+   │     │     ├─ hipdnn_ep_get_pool_base(state, site_id, domain_id, size)
+   │     │     │                                                    grow-on-demand GPU pool
    │     │     ├─ <compute ops> (e.g. wrap_hipblasLtMatmul, wrap_miopen*) -> pool slots
    │     │     ├─ hipdnn_ep_alloc_output(state, out_idx, shape, rank, elem)   <-- OUTPUT ALLOC
    │     │     │  └─ output_allocator.cpp: forwards to alloc.allocate(self, ...)

--- a/docs/design/pool-allocs-memory-planning.md
+++ b/docs/design/pool-allocs-memory-planning.md
@@ -24,13 +24,22 @@ When all dynamic sizes can be computed before the earliest pooled allocation, th
 ## Ownership model
 
 - Pool memory belongs to `RuntimeState`, not to an inference call.
-- `hip.get_pool(%ctx, %size) {domain_id = N}` obtains the backing buffer for a domain.
+- `hip.get_pool(%ctx, %size) {site_id = S, domain_id = N}` obtains the backing
+  buffer for a function-local domain.
 - Pool buffers grow on demand and are freed during session cleanup.
 - Pooled `memref.alloc` operations become `memref.view` operations; matching per-allocation deallocations are removed.
 - Graph outputs are not pooled. `hip-use-output-allocator` rewrites them to `hip.alloc_output`.
 - Tiny host-written shape buffers are not pooled. `hip-materialize-host-scalars` redirects them to session-owned host-mapped scratch.
 
-The default domain ID is zero and is omitted from textual IR. Additional domains print an explicit `domain_id`.
+`site_id` is the function's ordinal in top-level module symbol order. This
+deterministic module-level assignment is collision-free and independent of
+symbol spelling; no string hash is used. `domain_id` remains local to the
+function, preserving existing per-domain packing.
+
+The runtime keys storage by `(site_id, domain_id)`. A caller's local domain zero
+and an outlined helper's local domain zero therefore have distinct backing
+allocations while both are live; growing the helper cannot invalidate the
+caller's pool.
 
 ## Pipeline relationship
 
@@ -206,22 +215,35 @@ PoolAllocs writes MLIR module attributes:
 | `hipdnn.domain_count` | Number of domains; emitted only for multi-domain functions |
 | `hipdnn.pool_sizes` | Per-domain static prefixes |
 | `hipdnn.buffer_domains` | Domain ID for each pooled allocation |
+| `hipdnn.pool_site_id` | Function site owning legacy eager domain-zero metadata |
 
 The pool attributes are MLIR code-generation inputs, not fields in `schemas/model_metadata.fbs`. `generate-interface` emits `hipdnn_ep_pool_init` only when all three legacy attributes are present and `hipdnn.pool_size > 0`. Dynamic contributions are handled by the size operands on `hip.get_pool` during `inference_compute`.
 
-Pool behavior is therefore carried by generated LLVM IR plus `RuntimeState`, not by the FlatBuffers metadata blob. The optional multi-domain attributes are diagnostic/code-generation metadata; runtime domain selection comes from each lowered `hip.get_pool` call's `domain_id`.
+Pool behavior is therefore carried by generated LLVM IR plus `RuntimeState`,
+not by the FlatBuffers metadata blob. Runtime selection comes from each lowered
+`hip.get_pool` call's `(site_id, domain_id)` pair.
 
 Each `hip.get_pool` lowers to:
 
 ```c
 void *hipdnn_ep_get_pool_base(RuntimeState *state,
+                              int site_id,
                               int domain_id,
                               size_t needed_size);
 ```
 
-The runtime maintains grow-on-demand arrays of pool bases and capacities. Domain 0 is initialized eagerly when it has a static prefix; higher domains allocate lazily on first use. A zero-byte request is promoted to one byte before calling HIP.
+The runtime maintains a grow-on-demand function-site table whose entries own
+grow-on-demand arrays of domain bases and capacities. A zero-byte request is
+promoted to one byte before calling HIP.
 
-When a domain grows, the runtime synchronizes the session stream, frees that domain's old buffer, allocates the new capacity, and leaves other domains untouched. Pools never shrink.
+When one site/domain grows, the runtime synchronizes the session stream, frees
+that pool's old buffer, allocates the new capacity, and leaves every other pool
+untouched. Pools never shrink.
+
+This generated-call ABI is internal but not backwards compatible. Delete and
+rebuild stale cached model bitcode/native artifacts after upgrading; artifacts
+compiled against the former three-argument pool helper cannot be mixed with
+the new runtime.
 
 `hipdnn_ep_get_buffer_from_pool(state, index)` remains the legacy domain-zero accessor for compile-time offsets. Multi-domain dynamic paths use `hipdnn_ep_get_pool_base`.
 

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -257,22 +257,23 @@ def Hip_GetPoolOp : Hip_Op<"get_pool",
     If the current pool is smaller, the runtime grows it (realloc)
     transparently.
 
-    The optional `domain_id` attribute selects which pool to access (default
-    0).  hip-pool-allocs partitions a function's pooled allocs into
-    independent dominance domains and emits one hip.get_pool per domain;
-    domains are independent so growing one does not affect any other.  Old
-    single-pool textual MLIR (without the attribute) parses as
-    `domain_id = 0`, and the printer omits the attribute when it equals the
-    default — single-domain output is bit-identical to pre-multi-domain IR.
+    The optional `site_id` attribute identifies the containing compiled
+    function (default 0), and `domain_id` identifies a dominance domain within
+    that function (default 0). hip-pool-allocs assigns deterministic,
+    module-unique site IDs from top-level function order. The runtime keys pool
+    storage by the collision-free `(site_id, domain_id)` pair, so a caller and
+    an outlined helper may both use local domain zero without sharing storage.
 
     Example:
     ```mlir
-    %pool0 = hip.get_pool(%ctx, %size_a) : memref<?xi8>
-    %pool1 = hip.get_pool(%ctx, %size_b) {domain_id = 1 : i64} : memref<?xi8>
+    %pool0 = hip.get_pool(%ctx, %size_a) {site_id = 4 : i64} : memref<?xi8>
+    %pool1 = hip.get_pool(%ctx, %size_b)
+        {site_id = 4 : i64, domain_id = 1 : i64} : memref<?xi8>
     ```
   }];
 
   let arguments = (ins Hip_ContextType:$ctx, Index:$pool_size,
+                       DefaultValuedAttr<I64Attr, "0">:$site_id,
                        DefaultValuedAttr<I64Attr, "0">:$domain_id);
   let results = (outs AnyMemRef:$pool);
   let assemblyFormat = "`(` $ctx `,` $pool_size `)` attr-dict `:` type($pool)";

--- a/lib/Conversion/HipToLLVM/MemoryLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MemoryLowering.cpp
@@ -127,13 +127,11 @@ struct FreeOpLowering : public ConvertOpToLLVMPattern<FreeOp> {
 };
 
 // --- GetPoolOp:
-//     hip.get_pool(%ctx, %pool_size) {domain_id = N} : memref<?xi8>
-//       -> llvm.call @hipdnn_ep_get_pool_base(state, N, size) + memref desc.
+//     hip.get_pool(%ctx, %pool_size) {site_id = S, domain_id = N}
+//       -> llvm.call @hipdnn_ep_get_pool_base(state, S, N, size) + descriptor.
 //
-// The domain_id attribute (default 0) is materialized as an i32 constant
-// argument so the runtime can select the right per-domain pool slot.
-// Single-domain models emit `domain_id = 0` and round-trip identically to
-// the pre-multi-domain IR (printer elides the default).
+// site_id is a deterministic module-local function ordinal; domain_id remains
+// local to that function. The pair prevents caller/helper pool collisions.
 struct GetPoolOpLowering : public ConvertOpToLLVMPattern<GetPoolOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
@@ -147,21 +145,24 @@ struct GetPoolOpLowering : public ConvertOpToLLVMPattern<GetPoolOp> {
     Type i64Type = rewriter.getI64Type();
     MemRefType memRefType = cast<MemRefType>(op.getPool().getType());
 
-    // Runtime ABI: hipdnn_ep_get_pool_base(state: ptr, domain_id: i32,
-    // needed_size: i64) -> ptr.
+    // Runtime ABI: hipdnn_ep_get_pool_base(state: ptr, site_id: i32,
+    // domain_id: i32, needed_size: i64) -> ptr.
     FailureOr<LLVM::LLVMFuncOp> funcOp =
         LLVM::lookupOrCreateFn(rewriter, module, kHipGetPoolBase,
-                               {ptrType, i32Type, i64Type}, ptrType);
+                               {ptrType, i32Type, i32Type, i64Type}, ptrType);
     if (failed(funcOp))
       return failure();
 
     Value poolSize = adaptor.getPoolSize();
+    Value siteIdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i32Type,
+        rewriter.getI32IntegerAttr(static_cast<int32_t>(op.getSiteId())));
     Value domainIdVal = LLVM::ConstantOp::create(
         rewriter, loc, i32Type,
         rewriter.getI32IntegerAttr(static_cast<int32_t>(op.getDomainId())));
-    Value rawPtr = LLVM::CallOp::create(
-                       rewriter, loc, *funcOp,
-                       ValueRange{adaptor.getCtx(), domainIdVal, poolSize})
+    Value rawPtr = LLVM::CallOp::create(rewriter, loc, *funcOp,
+                                        ValueRange{adaptor.getCtx(), siteIdVal,
+                                                   domainIdVal, poolSize})
                        .getResult();
 
     FailureOr<unsigned> addrSpace =

--- a/lib/Dialect/Transforms/GenerateInterface.cpp
+++ b/lib/Dialect/Transforms/GenerateInterface.cpp
@@ -443,7 +443,7 @@ private:
         {"wrap_hipMemcpyD2H", i32, {ptr, ptr, i64, ptr}},
         {"wrap_hipStreamSynchronize", i32, {ptr}},
         {"hipdnn_ep_state_get_stream", ptr, {ptr}},
-        {"hipdnn_ep_pool_init", i32, {ptr, i64, ptr, i64}},
+        {"hipdnn_ep_pool_init", i32, {ptr, i32, i64, ptr, i64}},
         {"hipdnn_ep_get_buffer_from_pool", ptr, {ptr, i64}},
         {"hipdnn_ep_tensor_buffer_storage_words", i64, {}},
         {"hipdnn_ep_tensor_buffer_construct", vd, {ptr}},
@@ -609,6 +609,8 @@ private:
         module->getAttrOfType<ArrayAttr>("hipdnn.buffer_offsets");
     auto bufferCountAttr =
         module->getAttrOfType<IntegerAttr>("hipdnn.buffer_count");
+    auto poolSiteIdAttr =
+        module->getAttrOfType<IntegerAttr>("hipdnn.pool_site_id");
 
     // Buffer offsets and count are optional — if absent, pool is managed at
     // runtime via hip.get_pool / hipdnn_ep_get_pool_base (no static offsets).
@@ -646,6 +648,7 @@ private:
       if (hasPoolInit) {
         size_t poolSize = poolSizeAttr.getInt();
         size_t numBuffers = bufferCountAttr.getInt();
+        int32_t poolSiteId = poolSiteIdAttr ? poolSiteIdAttr.getInt() : 0;
         auto offsetsAttrArray = bufferOffsetsAttr.getValue();
         Value numBuffersVal = LLVM::ConstantOp::create(
             builder, loc, i64Type, builder.getI64IntegerAttr(numBuffers));
@@ -666,9 +669,12 @@ private:
             module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_pool_init");
         Value poolSizeVal = LLVM::ConstantOp::create(
             builder, loc, i64Type, builder.getI64IntegerAttr(poolSize));
+        Value poolSiteIdVal = LLVM::ConstantOp::create(
+            builder, loc, i32Type, builder.getI32IntegerAttr(poolSiteId));
         auto poolInitCall = LLVM::CallOp::create(
             builder, loc, poolInitFunc,
-            ValueRange{statePtr, poolSizeVal, offsetsArrayPtr, numBuffersVal});
+            ValueRange{statePtr, poolSiteIdVal, poolSizeVal, offsetsArrayPtr,
+                       numBuffersVal});
         Value poolFailed =
             LLVM::ICmpOp::create(builder, loc, LLVM::ICmpPredicate::ne,
                                  poolInitCall.getResult(), zero_i32);
@@ -692,6 +698,7 @@ private:
     if (hasPoolAttrs && poolSizeAttr.getInt() > 0) {
       size_t poolSize = poolSizeAttr.getInt();
       size_t numBuffers = bufferCountAttr.getInt();
+      int32_t poolSiteId = poolSiteIdAttr ? poolSiteIdAttr.getInt() : 0;
       auto offsetsAttrArray = bufferOffsetsAttr.getValue();
 
       Value zero_i32 = LLVM::ConstantOp::create(builder, loc, i32Type,
@@ -735,9 +742,12 @@ private:
           module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_pool_init");
       Value poolSizeVal = LLVM::ConstantOp::create(
           builder, loc, i64Type, builder.getI64IntegerAttr(poolSize));
-      auto poolInitCall = LLVM::CallOp::create(
-          builder, loc, poolInitFunc,
-          ValueRange{statePtr, poolSizeVal, offsetsArrayPtr, numBuffersVal});
+      Value poolSiteIdVal = LLVM::ConstantOp::create(
+          builder, loc, i32Type, builder.getI32IntegerAttr(poolSiteId));
+      auto poolInitCall =
+          LLVM::CallOp::create(builder, loc, poolInitFunc,
+                               ValueRange{statePtr, poolSiteIdVal, poolSizeVal,
+                                          offsetsArrayPtr, numBuffersVal});
 
       LLVM::ReturnOp::create(builder, loc, poolInitCall.getResult());
     } else {

--- a/lib/Dialect/Transforms/PoolAllocs.cpp
+++ b/lib/Dialect/Transforms/PoolAllocs.cpp
@@ -87,6 +87,27 @@ namespace hip {
 
 namespace {
 
+/// Return this function's deterministic module-local runtime site ID.
+///
+/// Symbol-table order is stable for a compiled module and function symbols are
+/// unique, so the ordinal is collision-free without relying on string hashes.
+/// Pool domains remain local to the function and are paired with this ID by the
+/// runtime. Reading the parent module is safe when FuncOp passes execute in
+/// parallel because this helper does not mutate module structure.
+static FailureOr<int64_t> getFunctionSiteId(func::FuncOp funcOp) {
+  ModuleOp moduleOp = funcOp->getParentOfType<ModuleOp>();
+  if (!moduleOp)
+    return failure();
+
+  int64_t siteId = 0;
+  for (func::FuncOp candidate : moduleOp.getOps<func::FuncOp>()) {
+    if (candidate == funcOp)
+      return siteId;
+    ++siteId;
+  }
+  return failure();
+}
+
 //===----------------------------------------------------------------------===//
 // AllocInfo - per-alloc metadata collected in Phase 1
 //===----------------------------------------------------------------------===//
@@ -686,6 +707,12 @@ struct PoolAllocsPass : public impl::PoolAllocsPassBase<PoolAllocsPass> {
 
 void PoolAllocsPass::runOnOperation() {
   func::FuncOp funcOp = getOperation();
+  FailureOr<int64_t> functionSiteId = getFunctionSiteId(funcOp);
+  if (failed(functionSiteId)) {
+    funcOp.emitError(
+        "hip-pool-allocs: function must be a top-level module symbol");
+    return signalPassFailure();
+  }
 
   if (alignment <= 0 || (alignment & (alignment - 1)) != 0) {
     funcOp.emitError("hip-pool-allocs: alignment must be a positive power of 2"
@@ -774,6 +801,8 @@ void PoolAllocsPass::runOnOperation() {
     moduleOp->setAttr("hipdnn.buffer_count", zeroBuilder.getI64IntegerAttr(0));
     moduleOp->setAttr("hipdnn.buffer_offsets",
                       zeroBuilder.getArrayAttr(SmallVector<Attribute>{}));
+    moduleOp->setAttr("hipdnn.pool_site_id",
+                      zeroBuilder.getI64IntegerAttr(*functionSiteId));
     return;
   }
 
@@ -1082,12 +1111,12 @@ void PoolAllocsPass::runOnOperation() {
           builder.createOrFold<arith::AddIOp>(loc, poolSize, contribution);
     }
 
-    // Tag the get_pool with this domain's id so the runtime grows the right
-    // backing buffer. domain_id == 0 round-trips as the default attribute and
-    // is elided by the printer, keeping single-domain output bit-identical to
-    // the pre-multi-domain IR.
+    // The module-local function ordinal and function-local domain ID form a
+    // collision-free runtime identity. An outlined helper's domain 0 therefore
+    // cannot reuse or grow its caller's live domain 0 pool.
     Value pool = hip::GetPoolOp::create(
         builder, loc, poolType, ctx, poolSize,
+        builder.getI64IntegerAttr(*functionSiteId),
         builder.getI64IntegerAttr(static_cast<int64_t>(domainId)));
 
     // Per-alloc offsets in this domain's pool. Static offsets are emitted
@@ -1219,6 +1248,8 @@ void PoolAllocsPass::runOnOperation() {
     offsetAttrs.push_back(builder.getI64IntegerAttr(off));
   moduleOp->setAttr("hipdnn.buffer_offsets",
                     ArrayAttr::get(mlirCtx, offsetAttrs));
+  moduleOp->setAttr("hipdnn.pool_site_id",
+                    builder.getI64IntegerAttr(*functionSiteId));
 
   if (domains.size() > 1) {
     moduleOp->setAttr(

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -339,26 +339,21 @@ void *hipdnn_ep_get_buffer_from_pool(RuntimeState *state, size_t index);
 // if needed. Called from PoolAllocs-generated code, once per emitted
 // hip.get_pool, at the start of each inference.
 //
-// `domain_id` selects which pool to access: hip-pool-allocs partitions the
-// function's pooled allocs into independent dominance domains and emits one
-// hip.get_pool per domain (id starts at 0). Domain 0 inherits the legacy
-// single-pool semantics — its pool was eagerly sized by hipdnn_ep_pool_init
-// using the static buffer offsets, so single-domain models are bit-identical
-// to the pre-multi-domain runtime. Domains 1..N start with size 0 and grow
-// lazily on their first call here.
+// `site_id` is the deterministic module-local ordinal of the compiled function.
+// `domain_id` selects a dominance domain within that function. The runtime keys
+// storage by the pair, so a caller and outlined helper may both use local
+// domain zero while their buffers are simultaneously live.
 //
 // When `needed_size` exceeds the selected domain's current allocation, that
 // pool is grown via stream-sync + hipFree + hipMalloc. Pools never shrink and
 // are independent across domains: growing domain N does not touch domain M.
 //
-// There is no compile-time cap on `domain_id`: the per-domain arrays are
-// themselves grown on demand the first time a higher id is seen (a cold-path
-// event on the first inference). A negative `domain_id` returns NULL with a
-// stderr diagnostic (it would indicate a compiler bug — ids start at 0).
+// There is no compile-time cap on either ID: both table levels grow on demand.
+// Negative IDs return NULL with a diagnostic.
 //
 // Returns: GPU base pointer for the selected domain (NULL on bad domain_id
 //          or allocation failure).
-void *hipdnn_ep_get_pool_base(RuntimeState *state, int domain_id,
+void *hipdnn_ep_get_pool_base(RuntimeState *state, int site_id, int domain_id,
                               size_t needed_size);
 
 // Get the host-mapped scratch buffer base, growing it if needed. Called from
@@ -498,11 +493,12 @@ void hipdnn_ep_runtime_add_cpu_profile(RuntimeState *state, const char *name,
 // Called by generated inference_init after creating RuntimeState
 // Parameters:
 //   state: Runtime state to initialize pool in
+//   site_id: Module-local function site owning domain zero
 //   pool_size: Total size of memory pool in bytes
 //   buffer_offsets: Array of offsets for each buffer
 //   num_buffers: Number of buffers
 // Returns: 0=success, non-zero=error
-int hipdnn_ep_pool_init(RuntimeState *state, size_t pool_size,
+int hipdnn_ep_pool_init(RuntimeState *state, int site_id, size_t pool_size,
                         const size_t *buffer_offsets, size_t num_buffers);
 
 //===----------------------------------------------------------------------===//

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -3,19 +3,26 @@
  * Licensed under the MIT License.
  */
 #include "debug_log.h"
+#ifndef HIPDNN_EP_POOL_UNIT_TEST
 #include "hip/timing.h"
+#endif
 #include "hip_cleanup.h"
 #include "hipdnn_ep_runtime.h"
+#ifndef HIPDNN_EP_POOL_UNIT_TEST
 #include "op_profile.h"
+#endif
 #include "runtime_state_internal.h"
 
+#ifndef HIPDNN_EP_POOL_UNIT_TEST
 #include "model_metadata_generated.h"
 #include "morphizen-foundation/file_io.hpp"
+#endif
 
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 
+#ifndef HIPDNN_EP_POOL_UNIT_TEST
 // Forward decl of static helpers defined later in this file.
 static int initialize_state_handles(RuntimeState **out_state);
 static int prepare_constants_array(RuntimeState *state,
@@ -142,10 +149,11 @@ static int initialize_state_handles(RuntimeState **out_state) {
   state->gpu_constants_blob = nullptr;
   state->gpu_constants = nullptr;
   state->num_constants = 0;
-  // Per-domain pool arrays start empty; grown on demand (no compile-time cap).
-  state->num_pool_domains = 0;
-  state->pool_base = nullptr;
-  state->pool_size = nullptr;
+  // Per-function pool sites start empty; both site and domain tables grow on
+  // demand without a compile-time cap.
+  state->num_pool_sites = 0;
+  state->pool_sites = nullptr;
+  state->legacy_pool_site_id = -1;
   state->buffer_offsets = nullptr;
   state->num_buffers = 0;
   state->workspace = nullptr;
@@ -770,22 +778,22 @@ int hipdnn_ep_state_cleanup(RuntimeState *state) {
     HIP_CLEANUP(hipHostFree(state->host_scratch_base));
   }
 
-  // Free memory pools (if allocated) — one hipFree per non-null domain — then
-  // the per-domain arrays themselves.
-  if (state->pool_base) {
-    for (int i = 0; i < state->num_pool_domains; ++i) {
-      if (state->pool_base[i]) {
-        HIP_CLEANUP(hipFree(state->pool_base[i]));
+  // Free every module-site/function-domain pool and then both table levels.
+  if (state->pool_sites) {
+    for (int site_id = 0; site_id < state->num_pool_sites; ++site_id) {
+      RuntimePoolSite &site = state->pool_sites[site_id];
+      for (int domain_id = 0; domain_id < site.num_domains; ++domain_id) {
+        if (site.pool_base[domain_id])
+          HIP_CLEANUP(hipFree(site.pool_base[domain_id]));
       }
+      free(site.pool_base);
+      free(site.pool_size);
     }
-    free(state->pool_base);
-    state->pool_base = nullptr;
+    free(state->pool_sites);
+    state->pool_sites = nullptr;
   }
-  if (state->pool_size) {
-    free(state->pool_size);
-    state->pool_size = nullptr;
-  }
-  state->num_pool_domains = 0;
+  state->num_pool_sites = 0;
+  state->legacy_pool_site_id = -1;
   if (state->buffer_offsets) {
     free(state->buffer_offsets);
   }
@@ -939,78 +947,102 @@ extern "C"
   op_profile_add_cpu_total(static_cast<OpProfileState *>(state->op_profile),
                            name, cpu_start_us, cpu_ms);
 }
+#endif
 
 //===----------------------------------------------------------------------===//
 // Memory Pooling Support
 //===----------------------------------------------------------------------===//
 
-// Grow the per-domain pool arrays so that index [needed_count - 1] is valid.
-// New slots are zero-filled (null base, size 0) so they behave exactly like the
-// fresh inline entries the fixed-size array used to provide. Mirrors the
-// grow-on-demand contract of the individual pools: never shrinks, and at steady
-// state (every domain already seen) this is a no-op. Returns false on OOM,
-// leaving the existing arrays intact. realloc-move is safe — callers re-derive
-// pool_base[domain_id] from state on every access, never caching element ptrs.
-static bool ensure_pool_domains(RuntimeState *state, int needed_count) {
-  if (needed_count <= state->num_pool_domains) {
+// Grow the module-local function-site table so [needed_count - 1] is valid.
+// New sites start with no domain table. Runtime site IDs are dense function
+// ordinals, so direct indexing is collision-free and O(1).
+static bool ensure_pool_sites(RuntimeState *state, int needed_count) {
+  if (needed_count <= state->num_pool_sites)
     return true;
+
+  auto *new_sites = static_cast<RuntimePoolSite *>(
+      realloc(state->pool_sites, sizeof(RuntimePoolSite) * needed_count));
+  if (!new_sites) {
+    fprintf(stderr, "Failed to grow pool site array to %d sites\n",
+            needed_count);
+    return false;
   }
+  state->pool_sites = new_sites;
+  for (int i = state->num_pool_sites; i < needed_count; ++i) {
+    state->pool_sites[i].num_domains = 0;
+    state->pool_sites[i].pool_base = nullptr;
+    state->pool_sites[i].pool_size = nullptr;
+  }
+  state->num_pool_sites = needed_count;
+  return true;
+}
+
+// Grow one function site's domain table. Existing domain backing allocations
+// are untouched, so growing a child site/domain cannot invalidate a live
+// pointer from its caller.
+static bool ensure_pool_domains(RuntimePoolSite &site, int needed_count) {
+  if (needed_count <= site.num_domains)
+    return true;
+
   auto *new_base = static_cast<void **>(
-      realloc(state->pool_base, sizeof(void *) * needed_count));
+      realloc(site.pool_base, sizeof(void *) * needed_count));
   if (!new_base) {
-    fprintf(stderr, "Failed to grow pool_base array to %d domains\n",
+    fprintf(stderr, "Failed to grow pool base array to %d domains\n",
             needed_count);
     return false;
   }
-  state->pool_base = new_base;
+  site.pool_base = new_base;
   auto *new_size = static_cast<size_t *>(
-      realloc(state->pool_size, sizeof(size_t) * needed_count));
+      realloc(site.pool_size, sizeof(size_t) * needed_count));
   if (!new_size) {
-    // pool_base already grew; leaving it larger than num_pool_domains is safe
-    // because num_pool_domains (updated below) still bounds every loop.
-    fprintf(stderr, "Failed to grow pool_size array to %d domains\n",
+    // pool_base already grew; leaving it larger than num_domains is safe
+    // because num_domains still bounds every access and cleanup loop.
+    fprintf(stderr, "Failed to grow pool size array to %d domains\n",
             needed_count);
     return false;
   }
-  state->pool_size = new_size;
-  for (int i = state->num_pool_domains; i < needed_count; ++i) {
-    state->pool_base[i] = nullptr;
-    state->pool_size[i] = 0;
+  site.pool_size = new_size;
+  for (int i = site.num_domains; i < needed_count; ++i) {
+    site.pool_base[i] = nullptr;
+    site.pool_size[i] = 0;
   }
-  state->num_pool_domains = needed_count;
+  site.num_domains = needed_count;
   return true;
 }
 
 extern "C" {
 
-int hipdnn_ep_pool_init(RuntimeState *state, size_t pool_size,
+int hipdnn_ep_pool_init(RuntimeState *state, int site_id, size_t pool_size,
                         const size_t *buffer_offsets, size_t num_buffers) {
   if (!state) {
     fprintf(stderr, "Invalid state parameter to hipdnn_ep_pool_init\n");
     return 1;
   }
-
-  // Ensure domain 0's array slot exists before we write it. Lazy domains 1..N
-  // grow their slots on first hipdnn_ep_get_pool_base call.
-  if (!ensure_pool_domains(state, 1)) {
+  if (site_id < 0) {
+    fprintf(stderr, "hipdnn_ep_pool_init: negative site_id %d\n", site_id);
     return 1;
   }
 
-  // Eagerly size domain 0's pool from the static metadata baked at compile
-  // time. Multi-domain functions leave domains 1..N empty here; those are grown
-  // on first hip.get_pool call (lazy init).
+  if (!ensure_pool_sites(state, site_id + 1))
+    return 1;
+  RuntimePoolSite &site = state->pool_sites[site_id];
+  if (!ensure_pool_domains(site, 1))
+    return 1;
+
+  // Eagerly size this function site's domain zero from static metadata.
   if (pool_size > 0) {
-    if (hipMalloc(&state->pool_base[0], pool_size) != hipSuccess) {
+    if (hipMalloc(&site.pool_base[0], pool_size) != hipSuccess) {
       fprintf(stderr, "Failed to allocate memory pool of size %zu bytes\n",
               pool_size);
       return 2; // Pool allocation failed
     }
   } else {
-    state->pool_base[0] = nullptr;
+    site.pool_base[0] = nullptr;
   }
 
   // Store pool metadata
-  state->pool_size[0] = pool_size;
+  site.pool_size[0] = pool_size;
+  state->legacy_pool_site_id = site_id;
   state->num_buffers = num_buffers;
 
   // Copy buffer offsets array
@@ -1018,9 +1050,9 @@ int hipdnn_ep_pool_init(RuntimeState *state, size_t pool_size,
     state->buffer_offsets = (size_t *)malloc(sizeof(size_t) * num_buffers);
     if (!state->buffer_offsets) {
       fprintf(stderr, "Failed to allocate buffer offsets array\n");
-      if (state->pool_base[0]) {
-        HIP_CLEANUP(hipFree(state->pool_base[0]));
-        state->pool_base[0] = nullptr;
+      if (site.pool_base[0]) {
+        HIP_CLEANUP(hipFree(site.pool_base[0]));
+        site.pool_base[0] = nullptr;
       }
       return 1; // Allocation failed
     }
@@ -1033,15 +1065,13 @@ int hipdnn_ep_pool_init(RuntimeState *state, size_t pool_size,
 }
 
 void *hipdnn_ep_get_buffer_from_pool(RuntimeState *state, size_t index) {
-  // Static buffers always live in domain 0 (the legacy single-pool case).
-  // Multi-domain functions only use the dynamic hip.get_pool path; this entry
-  // is kept for the eager-static-offset path.
-  // pool_base is a lazily-allocated heap array (null until pool_init or the
-  // first ensure_pool_domains). Check the array pointer and that domain 0 has
-  // a slot BEFORE indexing [0] — otherwise calling this before pool_init (or
-  // on a pool_size==0 model whose arrays were never grown) is a null deref.
-  if (!state || !state->pool_base || state->num_pool_domains < 1 ||
-      !state->pool_base[0]) {
+  if (!state || state->legacy_pool_site_id < 0 ||
+      state->legacy_pool_site_id >= state->num_pool_sites) {
+    fprintf(stderr, "Invalid state or pool not initialized\n");
+    return nullptr;
+  }
+  RuntimePoolSite &site = state->pool_sites[state->legacy_pool_site_id];
+  if (site.num_domains < 1 || !site.pool_base[0]) {
     fprintf(stderr, "Invalid state or pool not initialized\n");
     return nullptr;
   }
@@ -1052,31 +1082,29 @@ void *hipdnn_ep_get_buffer_from_pool(RuntimeState *state, size_t index) {
     return nullptr;
   }
 
-  char *pool_ptr = static_cast<char *>(state->pool_base[0]);
+  char *pool_ptr = static_cast<char *>(site.pool_base[0]);
   size_t offset = state->buffer_offsets[index];
   return pool_ptr + offset;
 }
 
-void *hipdnn_ep_get_pool_base(RuntimeState *state, int domain_id,
+void *hipdnn_ep_get_pool_base(RuntimeState *state, int site_id, int domain_id,
                               size_t needed_size) {
   if (!state) {
     fprintf(stderr, "Invalid state parameter to hipdnn_ep_get_pool_base\n");
     return nullptr;
   }
-  if (domain_id < 0) {
+  if (site_id < 0 || domain_id < 0) {
     fprintf(stderr,
-            "hipdnn_ep_get_pool_base: negative domain_id %d — this is a "
-            "compiler bug (hip-pool-allocs assigns domain ids starting at 0)\n",
-            domain_id);
+            "hipdnn_ep_get_pool_base: negative site/domain id (%d, %d)\n",
+            site_id, domain_id);
     return nullptr;
   }
-  // Grow the per-domain arrays the first time this domain_id is seen. There is
-  // no compile-time cap: the array grows to whatever the compiled function's
-  // hip.get_pool ids require, which is a cold-path event on the first
-  // inference.
-  if (!ensure_pool_domains(state, domain_id + 1)) {
+  if (!ensure_pool_sites(state, site_id + 1))
     return nullptr;
-  }
+  RuntimePoolSite &site = state->pool_sites[site_id];
+  if (!ensure_pool_domains(site, domain_id + 1))
+    return nullptr;
+
   // Zero-byte pool requests arise when a dynamic temp has no elements (e.g.
   // embedding NonZero count=0 → transpose/scatter scratch). hipMalloc(0) is
   // invalid and an unallocated domain slot is nullptr, which poisons every
@@ -1088,7 +1116,7 @@ void *hipdnn_ep_get_pool_base(RuntimeState *state, int domain_id,
   // intermediates than the current allocation for this domain, reallocate
   // its pool. Pools never shrink, and other domains are untouched —
   // growing domain N is independent of domain M.
-  if (needed_size > state->pool_size[domain_id]) {
+  if (needed_size > site.pool_size[domain_id]) {
     // Sync the stream before freeing: the previous inference may have
     // dispatched async kernels that still hold pointers into THIS domain's
     // pool. hipFree on an in-flight buffer is undefined behavior. Other
@@ -1096,32 +1124,35 @@ void *hipdnn_ep_get_pool_base(RuntimeState *state, int domain_id,
     // is independent — but we still need a single stream sync because all
     // domains share the runtime's compute stream. Grow events are rare so
     // the cost is amortized.
-    if (state->pool_base[domain_id]) {
+    if (site.pool_base[domain_id]) {
       if (state->stream)
         HIP_CLEANUP(hipStreamSynchronize(state->stream));
       fprintf(stderr,
-              "hipdnn_ep_get_pool_base: growing pool[%d] %zu -> %zu bytes "
+              "hipdnn_ep_get_pool_base: growing pool[%d,%d] %zu -> %zu bytes "
               "(rare; first time this large input shape was seen)\n",
-              domain_id, state->pool_size[domain_id], needed_size);
+              site_id, domain_id, site.pool_size[domain_id], needed_size);
       fflush(stderr);
-      HIP_CLEANUP(hipFree(state->pool_base[domain_id]));
+      HIP_CLEANUP(hipFree(site.pool_base[domain_id]));
     }
     void *new_base = nullptr;
     if (hipMalloc(&new_base, needed_size) != hipSuccess) {
       fprintf(stderr,
-              "hipdnn_ep_get_pool_base: hipMalloc failed for pool[%d] grow "
+              "hipdnn_ep_get_pool_base: hipMalloc failed for pool[%d,%d] grow "
               "(%zu -> %zu bytes)\n",
-              domain_id, state->pool_size[domain_id], needed_size);
-      state->pool_base[domain_id] = nullptr;
-      state->pool_size[domain_id] = 0;
+              site_id, domain_id, site.pool_size[domain_id], needed_size);
+      site.pool_base[domain_id] = nullptr;
+      site.pool_size[domain_id] = 0;
       return nullptr;
     }
-    state->pool_base[domain_id] = new_base;
-    state->pool_size[domain_id] = needed_size;
+    site.pool_base[domain_id] = new_base;
+    site.pool_size[domain_id] = needed_size;
   }
-  return state->pool_base[domain_id];
+  return site.pool_base[domain_id];
 }
 
+#ifdef HIPDNN_EP_POOL_UNIT_TEST
+} // extern "C"
+#else
 void *hipdnn_ep_get_host_scratch_base(RuntimeState *state, size_t needed_size) {
   if (!state) {
     fprintf(stderr,
@@ -1474,3 +1505,4 @@ int hipdnn_ep_state_ensure_la_scratch(RuntimeState *state, size_t needed_size) {
 }
 
 } // extern "C"
+#endif

--- a/lib/Runtime/runtime_state_internal.h
+++ b/lib/Runtime/runtime_state_internal.h
@@ -27,6 +27,12 @@
 // is acyclic.
 #include "op_state.h"
 
+struct RuntimePoolSite {
+  int num_domains;
+  void **pool_base;
+  size_t *pool_size;
+};
+
 // Internal runtime state structure
 // This struct is opaque to generated code (passed as void*)
 struct RuntimeState {
@@ -42,31 +48,20 @@ struct RuntimeState {
   void **gpu_constants;
   size_t num_constants;
 
-  // Memory pooling support — multi-domain.
+  // Memory pooling support — module sites containing function-local domains.
   //
-  // hip-pool-allocs partitions a function's pooled allocs into independent
-  // dominance domains; each domain owns one contiguous GPU pool that grows on
-  // demand. Domain 0 carries the legacy single-pool semantics (eagerly sized
-  // by hipdnn_ep_pool_init using static offsets) so single-domain models are
-  // bit-identical to the pre-multi-domain runtime. Domains 1..N start empty
-  // and grow lazily on the first hipdnn_ep_get_pool_base(state, domain_id, ...)
-  // call.
+  // hip-pool-allocs assigns each top-level function a deterministic module
+  // ordinal (site_id), then partitions that function's allocs into local
+  // dominance domains. Runtime identity is the pair (site_id, domain_id), so
+  // caller and outlined-helper domain zero never share a backing allocation.
   //
-  // The per-domain pool arrays are themselves grown on demand: there is no
-  // compile-time cap on the domain count. pool_base/pool_size are heap arrays
-  // of num_pool_domains entries, reallocated (zero-filling new slots) the first
-  // time a higher domain_id is observed — by hipdnn_ep_get_pool_base for the
-  // lazy domains and by hipdnn_ep_pool_init for domain 0. Every domain_id is
-  // first seen on the cold first inference, so num_pool_domains stabilises
-  // after that and no further array realloc happens at steady state — mirroring
-  // the grow-on-demand contract of the individual pools. realloc-move is safe
-  // because nothing caches &pool_base[i] across calls; pool_base[domain_id] is
-  // re-derived from state on every access.
-  int num_pool_domains;   // Number of slots currently allocated in the arrays
-  void **pool_base;       // [num_pool_domains] per-domain GPU pool base ptrs
-  size_t *pool_size;      // [num_pool_domains] per-domain pool size in bytes
-  size_t *buffer_offsets; // Offsets for static buffers in domain 0
-  size_t num_buffers;     // Static buffer count in domain 0
+  // Both dimensions grow lazily without a compile-time cap and stabilize after
+  // the first inference. No generated code caches addresses of table entries.
+  int num_pool_sites;
+  RuntimePoolSite *pool_sites;
+  int legacy_pool_site_id; // Site initialized by hipdnn_ep_pool_init
+  size_t *buffer_offsets;  // Offsets for static buffers in domain 0
+  size_t num_buffers;      // Static buffer count in domain 0
 
   // Shared workspace for operator temp buffers (MatMul GEMM ws, GQA pipeline).
   // Lazily grown via hipdnn_ep_state_ensure_workspace(); never shrinks.

--- a/test/lit/Dialect/hip-pool-allocs-i1-byte-sizing.mlir
+++ b/test/lit/Dialect/hip-pool-allocs-i1-byte-sizing.mlir
@@ -7,7 +7,7 @@
 // larger than the default pool alignment so a packed-bit size cannot hide.
 // CHECK-LABEL: func.func @static_i1
 // CHECK: %[[BYTES:.*]] = arith.constant 300 : index
-// CHECK: %[[POOL:.*]] = hip.get_pool(%{{.*}}, %[[BYTES]]) : memref<?xi8>
+// CHECK: %[[POOL:.*]] = hip.get_pool(%{{.*}}, %[[BYTES]]){{.*}} : memref<?xi8>
 // CHECK: memref.view %[[POOL]]{{.*}} to memref<300xi1>
 func.func @static_i1(
     %ctx: !hip.context, %input: memref<300xi1>) -> memref<300xi1> {
@@ -23,7 +23,7 @@ func.func @static_i1(
 // CHECK-SAME: %[[N:[a-zA-Z0-9_]+]]: index
 // CHECK: %[[COEFF:.*]] = arith.constant 4 : index
 // CHECK: %[[BYTES:.*]] = arith.muli %[[N]], %[[COEFF]] : index
-// CHECK: hip.get_pool(%{{.*}}, %[[BYTES]]) : memref<?xi8>
+// CHECK: hip.get_pool(%{{.*}}, %[[BYTES]]){{.*}} : memref<?xi8>
 func.func @dynamic_i1_static_suffix(
     %ctx: !hip.context, %input: memref<?x4xi1>,
     %n: index) -> memref<?x4xi1> {
@@ -39,7 +39,7 @@ func.func @dynamic_i1_static_suffix(
 // CHECK-SAME: %[[N:[a-zA-Z0-9_]+]]: index
 // CHECK: %[[COEFF:.*]] = arith.constant 16 : index
 // CHECK: %[[BYTES:.*]] = arith.muli %[[N]], %[[COEFF]] : index
-// CHECK: hip.get_pool(%{{.*}}, %[[BYTES]]) : memref<?xi8>
+// CHECK: hip.get_pool(%{{.*}}, %[[BYTES]]){{.*}} : memref<?xi8>
 func.func @dynamic_f32_static_suffix(
     %ctx: !hip.context, %input: memref<?x4xf32>,
     %n: index) -> memref<?x4xf32> {

--- a/test/lit/Dialect/hip-pool-allocs-module-sites.mlir
+++ b/test/lit/Dialect/hip-pool-allocs-module-sites.mlir
@@ -1,0 +1,24 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+// RUN: hip-mlir-opt --hip-pool-allocs %s | FileCheck %s
+//
+// Both functions use local domain zero. Their deterministic module-site IDs
+// must differ so an outlined helper cannot share its caller's live pool.
+
+// CHECK-LABEL: func.func @caller
+// CHECK: hip.get_pool({{.*}}) : memref<?xi8>
+func.func @caller(%ctx: !hip.context, %in: memref<8xf32>) -> memref<8xf32> {
+  %tmp = memref.alloc() : memref<8xf32>
+  hip.miopen.softmax(%ctx) ins(%in : memref<8xf32>) outs(%tmp : memref<8xf32>)
+  return %tmp : memref<8xf32>
+}
+
+// CHECK-LABEL: func.func @outlined_helper
+// CHECK: hip.get_pool({{.*}}) {site_id = 1 : i64} : memref<?xi8>
+func.func @outlined_helper(
+    %ctx: !hip.context, %in: memref<16xf32>) -> memref<16xf32> {
+  %tmp = memref.alloc() : memref<16xf32>
+  hip.miopen.softmax(%ctx) ins(%in : memref<16xf32>) outs(%tmp : memref<16xf32>)
+  return %tmp : memref<16xf32>
+}

--- a/test/lit/Dialect/hip-pool-allocs.mlir
+++ b/test/lit/Dialect/hip-pool-allocs.mlir
@@ -54,7 +54,7 @@ func.func @static_two_allocs(
 // Pool size depends on alignment and overlap analysis.
 //
 // CHECK-LABEL: func.func @static_three_allocs_overlap
-// CHECK:         %[[POOL:.*]] = hip.get_pool({{.*}}) : memref<?xi8>
+// CHECK:         %[[POOL:.*]] = hip.get_pool({{.*}}){{.*}} : memref<?xi8>
 // CHECK-COUNT-3: memref.view %[[POOL]]
 // CHECK:         return
 func.func @static_three_allocs_overlap(
@@ -76,7 +76,7 @@ func.func @static_three_allocs_overlap(
 // Both go into the same i8 pool (type-agnostic via memref.view).
 //
 // CHECK-LABEL: func.func @mixed_element_types
-// CHECK:         %[[POOL:.*]] = hip.get_pool({{.*}}) : memref<?xi8>
+// CHECK:         %[[POOL:.*]] = hip.get_pool({{.*}}){{.*}} : memref<?xi8>
 // CHECK:         memref.view %[[POOL]]{{.*}} : memref<?xi8> to memref<8x8xf32>
 // CHECK:         memref.view %[[POOL]]{{.*}} : memref<?xi8> to memref<8x8xf16>
 // CHECK:         return
@@ -97,7 +97,7 @@ func.func @mixed_element_types(
 // through to an out-param) =====
 //
 // CHECK-LABEL: func.func @single_alloc_pooled
-// CHECK:         %[[POOL:.*]] = hip.get_pool({{.*}}) : memref<?xi8>
+// CHECK:         %[[POOL:.*]] = hip.get_pool({{.*}}){{.*}} : memref<?xi8>
 // CHECK:         memref.view %[[POOL]]{{.*}} : memref<?xi8> to memref<8x8xf32>
 // CHECK:         return
 func.func @single_alloc_pooled(
@@ -128,7 +128,7 @@ func.func @no_allocs_noop(
 // Both memref<?x8xf32> allocs use %n. Pool comes from hip.get_pool.
 //
 // CHECK-LABEL: func.func @dynamic_two_allocs_same_size
-// CHECK:         %[[POOL:.*]] = hip.get_pool({{.*}}) : memref<?xi8>
+// CHECK:         %[[POOL:.*]] = hip.get_pool({{.*}}){{.*}} : memref<?xi8>
 // CHECK:         memref.view %[[POOL]]{{.*}} : memref<?xi8> to memref<?x8xf32>
 // CHECK:         memref.view %[[POOL]]{{.*}} : memref<?xi8> to memref<?x8xf32>
 // CHECK:         return
@@ -150,7 +150,7 @@ func.func @dynamic_two_allocs_same_size(
 // Pool comes from hip.get_pool.
 //
 // CHECK-LABEL: func.func @mixed_static_dynamic
-// CHECK:         %[[POOL:.*]] = hip.get_pool({{.*}}) : memref<?xi8>
+// CHECK:         %[[POOL:.*]] = hip.get_pool({{.*}}){{.*}} : memref<?xi8>
 // CHECK:         memref.view %[[POOL]]{{.*}} : memref<?xi8> to memref<8x8xf32>
 // CHECK:         memref.view %[[POOL]]{{.*}} : memref<?xi8> to memref<?x8xf32>
 // CHECK:         return
@@ -175,7 +175,7 @@ func.func @mixed_static_dynamic(
 // CHECK-LABEL: func.func @alignment_256
 // CHECK-SAME:    (%[[CTX:.*]]: !hip.context,
 // CHECK:         %[[SIZE:.*]] = arith.constant 512 : index
-// CHECK:         %[[POOL:.*]] = hip.get_pool(%[[CTX]], %[[SIZE]]) : memref<?xi8>
+// CHECK:         %[[POOL:.*]] = hip.get_pool(%[[CTX]], %[[SIZE]]){{.*}} : memref<?xi8>
 // CHECK-DAG:     arith.constant 0 : index
 // CHECK-DAG:     arith.constant 256 : index
 // CHECK:         memref.view %[[POOL]]
@@ -185,7 +185,7 @@ func.func @mixed_static_dynamic(
 // With --alignment=64, each 4-byte alloc rounds to 64 bytes -> pool = 128xi8.
 // ALIGN64-LABEL: func.func @alignment_256
 // ALIGN64:         arith.constant 128 : index
-// ALIGN64:         hip.get_pool({{.*}}) : memref<?xi8>
+// ALIGN64:         hip.get_pool({{.*}}){{.*}} : memref<?xi8>
 func.func @alignment_256(
     %ctx: !hip.context,
     %in: memref<1xf32>) -> memref<1xf32> {
@@ -210,7 +210,7 @@ func.func @alignment_256(
 // CHECK:         %[[ADJUSTED:.*]] = arith.addi %[[WIDTH]], %[[C255]] : index
 // CHECK:         %[[QUOTIENT:.*]] = arith.divui %[[ADJUSTED]], %[[C256]] : index
 // CHECK:         %[[ALIGNED:.*]] = arith.muli %[[QUOTIENT]], %[[C256]] : index
-// CHECK:         %[[POOL:.*]] = hip.get_pool(%{{.*}}, %[[ALIGNED]]) : memref<?xi8>
+// CHECK:         %[[POOL:.*]] = hip.get_pool(%{{.*}}, %[[ALIGNED]]){{.*}} : memref<?xi8>
 // CHECK:         memref.view %[[POOL]][%[[OFF:[a-zA-Z0-9_]+]]]
 // CHECK-SAME:      : memref<?xi8> to memref<?x8xf32>
 // CHECK:         memref.view %[[POOL]][%[[OFF]]]
@@ -237,7 +237,7 @@ func.func @dynamic_disjoint_share(
 // CHECK-LABEL: func.func @metadata_attributes
 // CHECK-NOT:     hipdnn.pool_size
 // CHECK-NOT:     hipdnn.buffer_offsets
-// CHECK:         hip.get_pool({{.*}}) : memref<?xi8>
+// CHECK:         hip.get_pool({{.*}}){{.*}} : memref<?xi8>
 func.func @metadata_attributes(
     %ctx: !hip.context,
     %a: memref<8x8xf32, strided<[?, ?], offset: ?>>,
@@ -256,7 +256,7 @@ func.func @metadata_attributes(
 // No pool dealloc is inserted — the pool is owned by the runtime.
 //
 // CHECK-LABEL: func.func @preexisting_deallocs
-// CHECK:         %[[POOL:.*]] = hip.get_pool({{.*}}) : memref<?xi8>
+// CHECK:         %[[POOL:.*]] = hip.get_pool({{.*}}){{.*}} : memref<?xi8>
 // CHECK:         memref.view %[[POOL]]
 // CHECK:         memref.view %[[POOL]]
 // CHECK-NOT:     memref.dealloc
@@ -278,7 +278,7 @@ func.func @preexisting_deallocs(
 //
 // CHECK-LABEL: func.func @dynamic_metadata
 // CHECK-NOT:     hipdnn.buffer_offsets
-// CHECK:         hip.get_pool({{.*}}) : memref<?xi8>
+// CHECK:         hip.get_pool({{.*}}){{.*}} : memref<?xi8>
 func.func @dynamic_metadata(
     %ctx: !hip.context,
     %a: memref<?x8xf32>,
@@ -319,7 +319,7 @@ func.func @dynamic_metadata(
 // CHECK-LABEL: func.func @dim_of_collapse
 // CHECK:         memref.collapse_shape
 // CHECK:         memref.dim
-// CHECK:         hip.get_pool({{.*}}) : memref<?xi8>
+// CHECK:         hip.get_pool({{.*}}){{.*}} : memref<?xi8>
 // CHECK-COUNT-2: memref.view %{{.*}} : memref<?xi8> to memref<?x8xf32>
 // CHECK:         return
 func.func @dim_of_collapse(
@@ -345,7 +345,7 @@ func.func @dim_of_collapse(
 // CHECK-LABEL: func.func @dim_of_cast
 // CHECK:         memref.cast
 // CHECK:         memref.dim
-// CHECK:         hip.get_pool({{.*}}) : memref<?xi8>
+// CHECK:         hip.get_pool({{.*}}){{.*}} : memref<?xi8>
 // CHECK:         memref.view %{{.*}} : memref<?xi8> to memref<?x16xf32>
 // CHECK:         return
 func.func @dim_of_cast(
@@ -371,7 +371,7 @@ func.func @dim_of_cast(
 // CHECK-LABEL: func.func @dim_of_view
 // CHECK:         memref.view
 // CHECK:         memref.dim
-// CHECK:         hip.get_pool({{.*}}) : memref<?xi8>
+// CHECK:         hip.get_pool({{.*}}){{.*}} : memref<?xi8>
 // CHECK:         return
 func.func @dim_of_view(
     %ctx: !hip.context,
@@ -398,7 +398,7 @@ func.func @dim_of_view(
 // CHECK-LABEL: func.func @dim_of_subview
 // CHECK:         memref.subview
 // CHECK:         memref.dim
-// CHECK:         hip.get_pool({{.*}}) : memref<?xi8>
+// CHECK:         hip.get_pool({{.*}}){{.*}} : memref<?xi8>
 // CHECK:         return
 func.func @dim_of_subview(
     %ctx: !hip.context,
@@ -428,7 +428,7 @@ func.func @dim_of_subview(
 // CHECK-LABEL: func.func @dim_of_reshape
 // CHECK:         memref.reshape
 // CHECK:         memref.dim
-// CHECK:         hip.get_pool({{.*}}) : memref<?xi8>
+// CHECK:         hip.get_pool({{.*}}){{.*}} : memref<?xi8>
 // CHECK:         return
 func.func @dim_of_reshape(
     %ctx: !hip.context,
@@ -463,7 +463,7 @@ func.func @dim_of_reshape(
 // CHECK-LABEL: func.func @dim_from_host_scratch
 // CHECK:         memref.store
 // CHECK:         memref.load
-// CHECK:         hip.get_pool({{.*}}) : memref<?xi8>
+// CHECK:         hip.get_pool({{.*}}){{.*}} : memref<?xi8>
 // CHECK:         return
 func.func @dim_from_host_scratch(
     %ctx: !hip.context,
@@ -498,12 +498,11 @@ func.func @dim_from_host_scratch(
 // CHECK-LABEL: func.func @multi_domain_two_pools
 // CHECK-SAME:    (%[[CTX:.*]]: !hip.context,
 // CHECK:         memref.dim %{{.*}}, %{{.*}}
-// CHECK:         %[[POOL0:.*]] = hip.get_pool(%[[CTX]], %{{.*}}) : memref<?xi8>
-// CHECK-NOT:     domain_id
+// CHECK:         %[[POOL0:.*]] = hip.get_pool(%[[CTX]], %{{.*}}) {site_id = 18 : i64} : memref<?xi8>
 // CHECK:         %[[V0:.*]] = memref.view %[[POOL0]]{{.*}} to memref<?x16xf32>
 // CHECK:         hip.miopen.softmax{{.*}}outs(%[[V0]] :
 // CHECK:         memref.load
-// CHECK:         %[[POOL1:.*]] = hip.get_pool(%[[CTX]], %{{.*}}) {domain_id = 1 : i64} : memref<?xi8>
+// CHECK:         %[[POOL1:.*]] = hip.get_pool(%[[CTX]], %{{.*}}) {domain_id = 1 : i64, site_id = 18 : i64} : memref<?xi8>
 // CHECK:         %[[V1:.*]] = memref.view %[[POOL1]]{{.*}} to memref<?x16xf32>
 // CHECK:         hip.miopen.softmax{{.*}}outs(%[[V1]] :
 // CHECK:         return %[[V1]]
@@ -527,12 +526,11 @@ func.func @multi_domain_two_pools(
 // BELOW the previous alloc, so each alloc opens a new domain.
 //
 // CHECK-LABEL: func.func @multi_domain_three_pools
-// CHECK:         hip.get_pool({{.*}}) : memref<?xi8>
-// CHECK-NOT:     domain_id
+// CHECK:         hip.get_pool({{.*}}) {site_id = 19 : i64} : memref<?xi8>
 // CHECK:         memref.load
-// CHECK:         hip.get_pool({{.*}}) {domain_id = 1 : i64} : memref<?xi8>
+// CHECK:         hip.get_pool({{.*}}) {domain_id = 1 : i64, site_id = 19 : i64} : memref<?xi8>
 // CHECK:         memref.load
-// CHECK:         hip.get_pool({{.*}}) {domain_id = 2 : i64} : memref<?xi8>
+// CHECK:         hip.get_pool({{.*}}) {domain_id = 2 : i64, site_id = 19 : i64} : memref<?xi8>
 // CHECK:         return
 func.func @multi_domain_three_pools(
     %ctx: !hip.context,

--- a/test/lit/Pipeline/pipeline-onnx-pool.mlir
+++ b/test/lit/Pipeline/pipeline-onnx-pool.mlir
@@ -19,7 +19,7 @@
 // CHECK-LABEL: func.func @main_graph
 // CHECK-SAME:    (%[[CTX:.*]]: !hip.context,
 // CHECK:         %[[SIZE:.*]] = arith.constant 8192 : index
-// CHECK:         %[[POOL:.*]] = hip.get_pool(%[[CTX]], %[[SIZE]]) : memref<?xi8>
+// CHECK:         %[[POOL:.*]] = hip.get_pool(%[[CTX]], %[[SIZE]]){{.*}} : memref<?xi8>
 // CHECK-DAG:     %[[OFF0:.*]] = arith.constant 0 : index
 // CHECK-DAG:     %[[OFF1:.*]] = arith.constant 4096 : index
 // CHECK:         memref.view %[[POOL]][%[[OFF0]]][] : memref<?xi8> to memref<1x16x8x8xf32>

--- a/test/lit/Pipeline/pipeline-pool-lower.mlir
+++ b/test/lit/Pipeline/pipeline-pool-lower.mlir
@@ -19,8 +19,9 @@
 // CHECK-LABEL: llvm.func @static_pool_to_llvm
 // CHECK-SAME:    (%[[CTX:[a-z0-9]+]]: !llvm.ptr,
 // CHECK:         %[[POOL_SIZE:.*]] = llvm.mlir.constant(512 : index) : i64
+// CHECK:         %[[SITE:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:         %[[DOM:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK:         llvm.call @hipdnn_ep_get_pool_base(%[[CTX]], %[[DOM]], %[[POOL_SIZE]]) : (!llvm.ptr, i32, i64) -> !llvm.ptr
+// CHECK:         llvm.call @hipdnn_ep_get_pool_base(%[[CTX]], %[[SITE]], %[[DOM]], %[[POOL_SIZE]]) : (!llvm.ptr, i32, i32, i64) -> !llvm.ptr
 // CHECK:         llvm.mlir.constant(256 : index) : i64
 // CHECK:         llvm.call @wrap_hipblasLtMatmul(%[[CTX]],
 // CHECK:         llvm.call @hip_miopen_softmax(%[[CTX]],
@@ -45,8 +46,9 @@ func.func @static_pool_to_llvm(
 // CHECK-SAME:    (%[[CTX2:[a-z0-9]+]]: !llvm.ptr,
 // CHECK:         %[[C32:[a-z0-9_]+]] = llvm.mlir.constant(32 : index) : i64
 // CHECK:         llvm.mul %arg15, %[[C32]] : i64
+// CHECK:         %[[SITE2:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK:         %[[DOM2:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK:         llvm.call @hipdnn_ep_get_pool_base(%[[CTX2]], %[[DOM2]], %{{[0-9]+}}) : (!llvm.ptr, i32, i64) -> !llvm.ptr
+// CHECK:         llvm.call @hipdnn_ep_get_pool_base(%[[CTX2]], %[[SITE2]], %[[DOM2]], %{{[0-9]+}}) : (!llvm.ptr, i32, i32, i64) -> !llvm.ptr
 // CHECK:         llvm.call @wrap_hipblasLtMatmul(%[[CTX2]],
 // CHECK:         llvm.call @hip_miopen_softmax(%[[CTX2]],
 // CHECK:         llvm.return

--- a/test/runtime/CMakeLists.txt
+++ b/test/runtime/CMakeLists.txt
@@ -37,6 +37,30 @@ add_test(NAME OutputAllocatorUnitTest COMMAND test-output-allocator)
 
 set_target_properties(test-output-allocator PROPERTIES FOLDER "runtime-tests")
 
+# Compiles only the pool-site portion of runtime_state.cpp against tiny mock HIP
+# allocation functions. This directly proves that caller/helper local domain
+# zero map to distinct pointers and child growth leaves the parent live.
+add_executable(test-pool-sites
+    test_pool_sites.cpp
+    ${CMAKE_SOURCE_DIR}/lib/Runtime/hipdnn_ep_runtime_state.cpp
+)
+
+target_compile_features(test-pool-sites PRIVATE cxx_std_17)
+
+target_include_directories(test-pool-sites PRIVATE
+    ${CMAKE_SOURCE_DIR}/lib/Runtime
+    ${CMAKE_SOURCE_DIR}/lib/Runtime/mock
+)
+
+target_compile_definitions(test-pool-sites PRIVATE
+    HIPDNN_EP_POOL_UNIT_TEST
+    HIPDNN_EP_RT_NO_EXPORT
+)
+
+add_test(NAME PoolSitesUnitTest COMMAND test-pool-sites)
+
+set_target_properties(test-pool-sites PROPERTIES FOLDER "runtime-tests")
+
 # Exercises the void CustomOp ABI's exception-to-OrtStatus boundary with a
 # generated-compute failure seam. The fake OrtApi needs only CreateStatus, so
 # this test executes without loading HIP or an ORT session.

--- a/test/runtime/test_pool_sites.cpp
+++ b/test/runtime/test_pool_sites.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hipdnn_ep_runtime.h"
+#include "runtime_state_internal.h"
+
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+
+static int sync_count = 0;
+
+extern "C" hipError_t hipMalloc(void **ptr, size_t size) {
+  *ptr = std::malloc(size);
+  return *ptr ? hipSuccess : -1;
+}
+
+extern "C" hipError_t hipFree(void *ptr) {
+  std::free(ptr);
+  return hipSuccess;
+}
+
+extern "C" hipError_t hipStreamSynchronize(hipStream_t) {
+  ++sync_count;
+  return hipSuccess;
+}
+
+int main() {
+  RuntimeState state{};
+  state.stream = reinterpret_cast<hipStream_t>(1);
+  state.legacy_pool_site_id = -1;
+
+  void *parent = hipdnn_ep_get_pool_base(&state, 0, 0, 64);
+  void *child = hipdnn_ep_get_pool_base(&state, 1, 0, 32);
+  assert(parent != nullptr);
+  assert(child != nullptr);
+  assert(parent != child);
+
+  std::memset(parent, 0x5a, 64);
+  void *grown_child = hipdnn_ep_get_pool_base(&state, 1, 0, 128);
+  assert(grown_child != nullptr);
+  assert(state.pool_sites[0].pool_base[0] == parent);
+  for (size_t i = 0; i < 64; ++i)
+    assert(static_cast<unsigned char *>(parent)[i] == 0x5a);
+  assert(sync_count == 1);
+
+  for (int site_id = 0; site_id < state.num_pool_sites; ++site_id) {
+    RuntimePoolSite &site = state.pool_sites[site_id];
+    for (int domain_id = 0; domain_id < site.num_domains; ++domain_id)
+      std::free(site.pool_base[domain_id]);
+    std::free(site.pool_base);
+    std::free(site.pool_size);
+  }
+  std::free(state.pool_sites);
+  return 0;
+}


### PR DESCRIPTION
## Why

Pool domains are numbered locally within each compiled function, but the runtime previously treated a domain ID as model-global. A caller and an outlined helper could therefore both use domain zero and receive the same backing allocation. If the helper grew that allocation while the caller still held a live view, the caller's pointer could be invalidated.

Pool identity needs both the deterministic function site and the function-local domain. Keeping those coordinates explicit avoids collisions without depending on symbol-name hashes and preserves live caller storage while helpers execute.

## IR example

The focused pass test contains two functions whose first transient allocation is local domain zero:

```mlir
func.func @caller(%ctx: !hip.context, %in: memref<8xf32>) -> memref<8xf32> {
  %tmp = memref.alloc() : memref<8xf32>
  hip.miopen.softmax(%ctx) ins(%in : memref<8xf32>) outs(%tmp : memref<8xf32>)
  return %tmp : memref<8xf32>
}

func.func @outlined_helper(
    %ctx: !hip.context, %in: memref<16xf32>) -> memref<16xf32> {
  %tmp = memref.alloc() : memref<16xf32>
  hip.miopen.softmax(%ctx) ins(%in : memref<16xf32>) outs(%tmp : memref<16xf32>)
  return %tmp : memref<16xf32>
}
```

After `hip-pool-allocs`, the caller uses the default site zero while the helper carries its distinct module-function site:

```mlir
// @caller
%caller_pool = hip.get_pool(%ctx, %caller_size) : memref<?xi8>

// @outlined_helper
%helper_pool = hip.get_pool(%ctx, %helper_size)
    {site_id = 1 : i64} : memref<?xi8>
```

## What changes

- Add a deterministic module-function `site_id` to `hip.get_pool` while retaining function-local domain IDs.
- Carry both coordinates through HIP-to-LLVM lowering and the generated runtime call ABI.
- Store runtime pools in a per-site, per-domain table so helper growth cannot replace a caller's live pool.
- Release every site/domain allocation and its bookkeeping during runtime cleanup.
- Cover distinct caller/helper sites, growth isolation, lowering, byte sizing, and pipeline behavior in focused LIT and GPU-free runtime tests.
- Document the namespaced pool contract and the requirement to regenerate stale compiled artifacts after the generated-call ABI change.

## Stack

1. [#688 — Constant carrier](https://github.com/ROCm/hip-ep/pull/688)
2. [#754 — i1 pool bytes](https://github.com/ROCm/hip-ep/pull/754)
3. [#756 — ORT error propagation](https://github.com/ROCm/hip-ep/pull/756)
4. [#758 — output view contract](https://github.com/ROCm/hip-ep/pull/758)
5. [#755 — pool namespaces](https://github.com/ROCm/hip-ep/pull/755) ← this PR
6. [#757 — host scratch namespaces](https://github.com/ROCm/hip-ep/pull/757)
7. [#724 — symbolic transport](https://github.com/ROCm/hip-ep/pull/724)
8. [#759 — artifact ABI](https://github.com/ROCm/hip-ep/pull/759)
9. [#639 — shape foundation](https://github.com/ROCm/hip-ep/pull/639)
10. [#681 — reshape provenance](https://github.com/ROCm/hip-ep/pull/681)
11. [#725 — broadcast activation](https://github.com/ROCm/hip-ep/pull/725)
12. [#763 — Softmax reuse](https://github.com/ROCm/hip-ep/pull/763)
13. [#640 — MatMul runtime](https://github.com/ROCm/hip-ep/pull/640)
14. [#734 — MatMul shapes](https://github.com/ROCm/hip-ep/pull/734)
15. [#641 — broadcast contracts](https://github.com/ROCm/hip-ep/pull/641)
16. [#735 — reduction conversion](https://github.com/ROCm/hip-ep/pull/735)
17. [#736 — reduction contracts](https://github.com/ROCm/hip-ep/pull/736)
18. [#689 — loop frame](https://github.com/ROCm/hip-ep/pull/689)
19. [#737 — shape-changing loops](https://github.com/ROCm/hip-ep/pull/737)
20. [#762 — loop bank recycling](https://github.com/ROCm/hip-ep/pull/762)
21. [#642 — grouped readback](https://github.com/ROCm/hip-ep/pull/642)
22. [#727 — payload shapes](https://github.com/ROCm/hip-ep/pull/727)
23. [#728 — Tile/Range](https://github.com/ROCm/hip-ep/pull/728)
24. [#729 — Slice normalization](https://github.com/ROCm/hip-ep/pull/729)
25. [#731 — Slice ABI](https://github.com/ROCm/hip-ep/pull/731)
26. [#733 — loop payload](https://github.com/ROCm/hip-ep/pull/733)
27. [#643 — Conv](https://github.com/ROCm/hip-ep/pull/643)
28. [#738 — Pool](https://github.com/ROCm/hip-ep/pull/738)
29. [#742 — CausalConv](https://github.com/ROCm/hip-ep/pull/742)
30. [#644 — Gather](https://github.com/ROCm/hip-ep/pull/644)
31. [#739 — GBQ](https://github.com/ROCm/hip-ep/pull/739)
32. [#645 — norm](https://github.com/ROCm/hip-ep/pull/645)
33. [#740 — attention](https://github.com/ROCm/hip-ep/pull/740)
34. [#741 — GQA capacity](https://github.com/ROCm/hip-ep/pull/741)
35. [#743 — GQA rejection](https://github.com/ROCm/hip-ep/pull/743)
36. [#646 — DPS contracts](https://github.com/ROCm/hip-ep/pull/646)
37. [#730 — inventory audit](https://github.com/ROCm/hip-ep/pull/730)
38. [#732 — converter audit](https://github.com/ROCm/hip-ep/pull/732)
39. [#647 — refinement](https://github.com/ROCm/hip-ep/pull/647)
40. [#761 — headers](https://github.com/ROCm/hip-ep/pull/761)
41. [#764 — cleanup](https://github.com/ROCm/hip-ep/pull/764)

## AI assistance

AI tools assisted with the implementation and PR description. The contributor reviewed the resulting code and description.

Made-with: Cursor
