### PR TITLE
fix(runtime): propagate generated failures to ORT

### DIFF
--- a/backend-mlir-compiler/custom-op-mlir/CMakeLists.txt
+++ b/backend-mlir-compiler/custom-op-mlir/CMakeLists.txt
@@ -115,6 +115,7 @@ target_include_directories(${LIB_NAME} PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/src
   ${CMAKE_CURRENT_BINARY_DIR}/..  # For generated protobuf headers (metadata.pb.h)
   ${CMAKE_SOURCE_DIR}/include     # Shared project headers (timing.h, etc.)
+  ${CMAKE_SOURCE_DIR}/morphizen/ort-bridge/src
   ${LLVM_INCLUDE_DIRS}            # LLVM ORC headers consumed by LlvmIrJit.cpp
 )
 

--- a/backend-mlir-compiler/custom-op-mlir/src/InferenceState.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/InferenceState.cpp
@@ -12,6 +12,7 @@
 #include <cstddef>
 #include <cstdlib>
 #include <glog/logging.h>
+#include <stdexcept>
 #include <utility>
 
 // Environment parameters (global scope, before namespace)
@@ -177,14 +178,12 @@ void InferenceState::set_output_allocator(
     const output_allocator_t *allocator) const {
   if (!set_output_allocator_fn_) {
     // Installing an allocator on a DLL that cannot accept it would leave
-    // hip.alloc_output returning null -> guaranteed crash. Fail loudly with an
-    // actionable message instead. Clearing (nullptr) on such a DLL is a no-op.
-    if (allocator) {
-      LOG(FATAL) << "Loaded model.dll does not export "
-                    "hipdnn_ep_set_output_allocator. The DLL is stale; delete "
-                    "%TEMP%/morphizen_mlir_* (or regenerate the EPContext) and "
-                    "rebuild so the linked runtime exports the setter.";
-    }
+    // hip.alloc_output returning null. Clearing on such a DLL remains a no-op.
+    if (allocator)
+      throw std::runtime_error(
+          "Loaded model artifact does not export "
+          "hipdnn_ep_set_output_allocator; regenerate the EPContext and "
+          "rebuild it with the current runtime");
     return;
   }
   if (state_) {

--- a/backend-mlir-compiler/custom-op-mlir/src/InferenceState.h
+++ b/backend-mlir-compiler/custom-op-mlir/src/InferenceState.h
@@ -71,9 +71,9 @@ public:
 
   // Install (allocator != nullptr) or clear (nullptr) the output allocator on
   // the loaded artifact's RuntimeState before compute(). Resolved once in the
-  // ctor. Fatal if called with a non-null allocator but the artifact does not
-  // export the setter (a stale artifact would otherwise crash with a null
-  // output buffer).
+  // ctor. Installing on a stale artifact that lacks the setter throws so the
+  // CustomOp boundary can return an OrtStatus; clearing is always a no-op-safe
+  // cleanup operation.
   void set_output_allocator(const output_allocator_t *allocator) const;
 
   // Invokes the optional `hipdnn_ep_runtime_begin_compute` hook to invalidate

--- a/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
@@ -4,6 +4,12 @@
  */
 #include "MlirCustomOp.h"
 
+// HIP must precede LLVM headers on MSVC. LLVM's __has_attribute fallback
+// otherwise makes HIP select its GNU vector implementation.
+#ifdef HIPDNN_EP_LINK_HIP_HOST
+#include <hip/hip_runtime_api.h>
+#endif
+
 // CRITICAL: morphizen.hpp must be included before other morphizen headers
 #include "custom-op-compute-status.hpp"
 #include "morphizen/env_config.hpp"
@@ -21,10 +27,6 @@
 #include "InferenceState.h"
 #include "hip/env.h" // shared cross-platform env reader (single Win32 call)
 
-// HIPDNN_EP_PERF instrumentation dependencies
-#ifdef HIPDNN_EP_LINK_HIP_HOST
-#include <hip/hip_runtime_api.h>
-#endif
 #include <algorithm>
 #include <chrono>
 #include <cstddef>

--- a/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
@@ -11,6 +11,8 @@
 #include "morphizen/onnxruntime_api.hpp"
 #include <glog/logging.h>
 
+#include "llvm/ADT/ScopeExit.h"
+
 // Protobuf headers
 #include "google/protobuf/util/json_util.h"
 #include "metadata.pb.h"
@@ -25,10 +27,14 @@
 #endif
 #include <algorithm>
 #include <chrono>
+#include <cstddef>
 #include <cstdio>
 #include <cstdlib>
+#include <limits>
 #include <mutex>
 #include <optional>
+#include <stdexcept>
+#include <string>
 #include <vector>
 
 // Environment parameters (global scope, before namespace)
@@ -537,58 +543,113 @@ struct PendingD2H {
 // inference_compute; the allocator is cleared on the RuntimeState before it
 // goes out of scope so `self` can never dangle.
 struct OutputAllocatorCtx {
-  Ort::KernelContext *ctx = nullptr;
-  const google::protobuf::RepeatedPtrField<mlir_metadata::Output> *outputs =
-      nullptr;
-  const std::vector<int> *output_index_map = nullptr;
-  // Borrowed from the MlirCustomOp instance (grow-on-demand, reused across
-  // Compute()): one GPU scratch buffer per output index for host outputs.
-  std::vector<HostOutputScratch> *host_out_scratch = nullptr;
+  OutputAllocatorCtx(
+      Ort::KernelContext &ctx,
+      const google::protobuf::RepeatedPtrField<mlir_metadata::Output> &outputs,
+      const std::vector<int> &outputIndexMap,
+      std::vector<HostOutputScratch> &hostOutputScratch)
+      : ctx(ctx), outputs(outputs), output_index_map(outputIndexMap),
+        host_out_scratch(hostOutputScratch), allocated(outputs.size(), false) {
+    if (output_index_map.size() != static_cast<size_t>(outputs.size()))
+      throw std::runtime_error(
+          "output allocator: metadata/output index map size mismatch");
+  }
+
+  Ort::KernelContext &ctx;
+  const google::protobuf::RepeatedPtrField<mlir_metadata::Output> &outputs;
+  const std::vector<int> &output_index_map;
+  // Session-owned grow-on-demand GPU scratch, one slot per host output.
+  std::vector<HostOutputScratch> &host_out_scratch;
   std::vector<PendingD2H> pending_d2h; // filled during compute, consumed after
   // Output-completeness guard: which metadata outputs received an alloc call.
   std::vector<bool> allocated;
+  morphizen::detail::DeferredComputeException callback_error;
 };
 
+static size_t checked_output_byte_size(const std::vector<int64_t> &shape,
+                                       int64_t elem_size, int64_t out_idx) {
+  if (elem_size <= 0)
+    throw std::runtime_error(
+        "output allocator: non-positive element size for output " +
+        std::to_string(out_idx));
+
+  size_t nbytes = static_cast<size_t>(elem_size);
+  for (size_t axis = 0; axis < shape.size(); ++axis) {
+    int64_t dim = shape[axis];
+    if (dim < 0)
+      throw std::runtime_error("output allocator: negative extent at axis " +
+                               std::to_string(axis) + " for output " +
+                               std::to_string(out_idx));
+    size_t extent = static_cast<size_t>(dim);
+    if (extent != 0 && nbytes > std::numeric_limits<size_t>::max() / extent)
+      throw std::overflow_error("output allocator: byte size overflow for "
+                                "output " +
+                                std::to_string(out_idx));
+    nbytes *= extent;
+  }
+  return nbytes;
+}
+
 #ifdef HIPDNN_EP_LINK_HIP_HOST
-// Ensure scratch[idx] holds at least nbytes of device memory. Grows by
-// hipFree + hipMalloc (never shrinks). Safe within a Compute(): each output
-// index is allocated exactly once, so a grow here cannot invalidate a pointer
-// the DLL is still about to write this pass (distinct indices = distinct
-// buffers). LOG(FATAL) on failure -- never returns null.
+// Grow one persistent scratch slot without discarding the usable old allocation
+// until its replacement exists.
 static void *ensure_host_out_slot(std::vector<HostOutputScratch> &scratch,
                                   size_t idx, size_t nbytes) {
   if (idx >= scratch.size())
     scratch.resize(idx + 1);
   HostOutputScratch &slot = scratch[idx];
-  if (slot.capacity < nbytes) {
-    if (slot.ptr)
-      (void)hipFree(slot.ptr);
-    void *p = nullptr;
-    hipError_t e = hipMalloc(&p, nbytes ? nbytes : 1);
-    if (e != hipSuccess || !p)
-      LOG(FATAL) << "hipMalloc(" << nbytes
-                 << ") for output-allocator host scratch failed: "
-                 << hipGetErrorString(e);
-    slot.ptr = p;
-    slot.capacity = nbytes;
+  const size_t requiredBytes = std::max(nbytes, size_t{1});
+  if (slot.ptr && slot.capacity >= requiredBytes)
+    return slot.ptr;
+
+  void *replacement = nullptr;
+  hipError_t error = hipMalloc(&replacement, requiredBytes);
+  llvm::scope_exit releaseReplacement([&] {
+    if (replacement)
+      (void)hipFree(replacement);
+  });
+  if (error != hipSuccess || !replacement)
+    throw std::runtime_error(
+        "output allocator: hipMalloc(" + std::to_string(requiredBytes) +
+        ") for host scratch failed: " + hipGetErrorString(error));
+
+  // Publish the known-valid replacement before retiring the old pointer. If
+  // hipFree reports an error, its disposition is uncertain; retaining it for
+  // reuse would be unsafe, so leave the replacement live and abandon the old
+  // allocation rather than risk a stale-pointer reuse.
+  void *retired = slot.ptr;
+  slot.ptr = replacement;
+  slot.capacity = requiredBytes;
+  replacement = nullptr;
+  if (retired) {
+    error = hipFree(retired);
+    if (error != hipSuccess)
+      throw std::runtime_error(
+          "output allocator: hipFree of replaced host scratch failed: " +
+          std::string(hipGetErrorString(error)));
   }
   return slot.ptr;
 }
 #endif // HIPDNN_EP_LINK_HIP_HOST
 
 // C callback installed on the RuntimeState (output_allocator_t.allocate).
-// noexcept: invoked from C (the model.dll runtime); a C++ exception crossing
-// that boundary is UB. Any failure aborts via LOG(FATAL) with a clear message
-// rather than returning null (a null would be written by the DLL -> segfault
-// with no diagnostic).
+// It cannot unwind through the model's C ABI. Preserve the first exception and
+// rethrow it after inference_compute returns and runs generated cleanup.
 void *output_allocate_cb(void *self, int64_t out_idx, const int64_t *shape,
                          int64_t rank, int64_t elem_size) noexcept {
   auto *octx = static_cast<OutputAllocatorCtx *>(self);
+  if (!octx || octx->callback_error.hasValue())
+    return nullptr;
+
   try {
-    if (out_idx < 0 || out_idx >= static_cast<int64_t>(octx->outputs->size())) {
-      LOG(FATAL) << "output allocator: out_idx " << out_idx << " out of range ("
-                 << octx->outputs->size() << " outputs)";
-    }
+    if (out_idx < 0 || out_idx >= static_cast<int64_t>(octx->outputs.size()))
+      throw std::runtime_error("output allocator: out_idx " +
+                               std::to_string(out_idx) + " out of range (" +
+                               std::to_string(octx->outputs.size()) +
+                               " outputs)");
+    if (rank < 0 || (rank > 0 && !shape))
+      throw std::runtime_error("output allocator: invalid shape for output " +
+                               std::to_string(out_idx));
     // Use the DLL's in-graph shape verbatim -- the EP never reshapes an output
     // here. The shape is computed in-graph by hip.alloc_output from its
     // producer's operands; when a dynamic output dim is sized from a graph
@@ -597,20 +658,44 @@ void *output_allocate_cb(void *self, int64_t out_idx, const int64_t *shape,
     // (IO-bound) buffer rather than allocating a fresh one, so when an input
     // and output are bound to the same buffer that identity is preserved with
     // no EP-side override.
-    std::vector<int64_t> out_shape(shape, shape + rank);
+    std::vector<int64_t> out_shape;
+    if (rank > 0)
+      out_shape.assign(shape, shape + rank);
+    size_t nbytes = checked_output_byte_size(out_shape, elem_size, out_idx);
 
-    int ort_idx = (*octx->output_index_map)[static_cast<int>(out_idx)];
-    auto out_tensor = octx->ctx->GetOutput(ort_idx, out_shape);
+    const size_t outputIndex = static_cast<size_t>(out_idx);
+    int ort_idx = octx->output_index_map[outputIndex];
+    if (ort_idx < 0)
+      throw std::runtime_error("output allocator: negative ORT output index");
+    auto out_tensor = octx->ctx.GetOutput(ort_idx, out_shape);
     int mem_type =
         static_cast<int>(out_tensor.GetTensorMemoryInfo().GetDeviceType());
     void *ort_ptr = out_tensor.GetTensorMutableRawData();
 
-    octx->allocated[static_cast<size_t>(out_idx)] = true;
+    if (!ort_ptr) {
+      if (nbytes != 0)
+        throw std::runtime_error(
+            "output allocator: ORT returned null for non-empty output " +
+            std::to_string(out_idx));
+#ifdef HIPDNN_EP_LINK_HIP_HOST
+      // Some allocators represent an empty OrtValue with null. Generated code
+      // still requires a non-null descriptor even though it performs no writes.
+      void *sentinel =
+          ensure_host_out_slot(octx->host_out_scratch, outputIndex, 0);
+      octx->allocated[outputIndex] = true;
+      return sentinel;
+#else
+      static std::byte emptyOutputSentinel;
+      octx->allocated[outputIndex] = true;
+      return &emptyOutputSentinel;
+#endif
+    }
 
     if (mem_type == TENSOR_MEMORY_GPU) {
       // Zero-copy: ORT buffer is already GPU-accessible (e.g. the EP's
       // host-mapped allocator, or caller-provided device memory). The DLL
       // writes into it directly.
+      octx->allocated[outputIndex] = true;
       return ort_ptr;
     }
 
@@ -618,27 +703,21 @@ void *output_allocate_cb(void *self, int64_t out_idx, const int64_t *shape,
     // D2H-copies into ort_ptr after inference_compute returns (the 2-arg
     // interface already stream-synced).
 #ifdef HIPDNN_EP_LINK_HIP_HOST
-    size_t nelem = 1;
-    for (int64_t d : out_shape)
-      nelem *= static_cast<size_t>(d);
-    size_t nbytes = nelem * static_cast<size_t>(elem_size);
-    void *gpu = ensure_host_out_slot(*octx->host_out_scratch,
-                                     static_cast<size_t>(out_idx), nbytes);
+    void *gpu =
+        ensure_host_out_slot(octx->host_out_scratch, outputIndex, nbytes);
     octx->pending_d2h.push_back({gpu, ort_ptr, nbytes});
+    octx->allocated[outputIndex] = true;
     return gpu;
 #else
     // Mock runtime writes host memory directly; no GPU staging needed.
     (void)elem_size;
+    octx->allocated[outputIndex] = true;
     return ort_ptr;
 #endif
-  } catch (const std::exception &e) {
-    LOG(FATAL) << "output allocator callback failed for out_idx " << out_idx
-               << ": " << e.what();
   } catch (...) {
-    LOG(FATAL) << "output allocator callback failed for out_idx " << out_idx
-               << " (unknown exception)";
+    octx->callback_error.captureCurrent();
+    return nullptr;
   }
-  return nullptr; // unreachable: LOG(FATAL) aborts. Silences -Wreturn-type.
 }
 
 } // anonymous namespace
@@ -723,33 +802,34 @@ void MlirCustomOp::compute_with_output_allocator(
 #endif
 
   Ort::KernelContext ort_ctx(context);
-  OutputAllocatorCtx octx;
-  octx.ctx = &ort_ctx;
-  octx.outputs = &metadata_.outputs();
-  octx.output_index_map = &output_index_map_;
-  octx.host_out_scratch = &host_out_scratch_;
-  octx.allocated.assign(metadata_.outputs().size(), false);
+  OutputAllocatorCtx octx(ort_ctx, metadata_.outputs(), output_index_map_,
+                          host_out_scratch_);
 
   output_allocator_t alloc;
   alloc.self = &octx;
   alloc.allocate = &output_allocate_cb;
-  inference_state_->set_output_allocator(&alloc);
+  int ret = 0;
+  {
+    inference_state_->set_output_allocator(&alloc);
+    llvm::scope_exit clearAllocator(
+        [&] { inference_state_->set_output_allocator(nullptr); });
 
 #ifdef HIPDNN_EP_LINK_HIP_HOST
-  if (perf)
-    timer->record_start();
+    if (perf)
+      timer->record_start();
 #endif
 
-  int ret = inference_state_->compute(&inputs.span);
+    ret = inference_state_->compute(&inputs.span);
 
 #ifdef HIPDNN_EP_LINK_HIP_HOST
-  if (perf)
-    timer->record_stop();
+    if (perf)
+      timer->record_stop();
 #endif
+  }
 
-  // Clear before octx leaves scope so a stale self pointer can never be used by
-  // a later call (e.g. the next Compute() before it reinstalls its own ctx).
-  inference_state_->set_output_allocator(nullptr);
+  // The callback cannot throw through C. Surface its precise failure only
+  // after inference_compute has completed its generated cleanup.
+  octx.callback_error.rethrow();
 
   if (ret != 0) {
     // Do not validate, copy, profile, or report successful outputs after a
@@ -764,25 +844,27 @@ void MlirCustomOp::compute_with_output_allocator(
   // Fail loudly rather than hand ORT an uninitialized buffer (which can
   // silently pass a CPU-vs-CPU comparison).
   for (size_t i = 0; i < octx.allocated.size(); ++i) {
-    if (!octx.allocated[i]) {
-      LOG(FATAL) << "output allocator: output '"
-                 << metadata_.outputs()[static_cast<int>(i)].name() << "' (idx "
-                 << i
-                 << ") was never allocated by the model.dll. Passthrough / "
-                    "aliased outputs are not supported yet.";
-    }
+    if (!octx.allocated[i])
+      throw std::runtime_error(
+          "output allocator: output '" +
+          metadata_.outputs()[static_cast<int>(i)].name() + "' (idx " +
+          std::to_string(i) +
+          ") was never allocated by the model artifact; passthrough and "
+          "aliased outputs are not supported yet");
   }
 
 #ifdef HIPDNN_EP_LINK_HIP_HOST
   // Deferred host-output copies. The 2-arg interface already stream-synced, so
   // the GPU scratch holds final data; a blocking hipMemcpy is safe.
   for (const auto &p : octx.pending_d2h) {
+    if (p.nbytes == 0)
+      continue;
     hipError_t e =
         hipMemcpy(p.host_dst, p.gpu_src, p.nbytes, hipMemcpyDeviceToHost);
-    if (e != hipSuccess) {
-      LOG(FATAL) << "output allocator: D2H copy of " << p.nbytes
-                 << " bytes failed: " << hipGetErrorString(e);
-    }
+    if (e != hipSuccess)
+      throw std::runtime_error("output allocator: D2H copy of " +
+                               std::to_string(p.nbytes) +
+                               " bytes failed: " + hipGetErrorString(e));
   }
 
   if (perf) {

--- a/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
@@ -5,6 +5,7 @@
 #include "MlirCustomOp.h"
 
 // CRITICAL: morphizen.hpp must be included before other morphizen headers
+#include "custom-op-compute-status.hpp"
 #include "morphizen/env_config.hpp"
 #include "morphizen/morphizen.hpp"
 #include "morphizen/onnxruntime_api.hpp"
@@ -751,7 +752,10 @@ void MlirCustomOp::compute_with_output_allocator(
   inference_state_->set_output_allocator(nullptr);
 
   if (ret != 0) {
-    LOG(ERROR) << "inference_compute (allocator) failed with code: " << ret;
+    // Do not validate, copy, profile, or report successful outputs after a
+    // generated/runtime failure. The stable void CustomOp ABI carries this to
+    // the ORT callback as an exception, where it becomes a non-null OrtStatus.
+    morphizen::detail::throwComputeFailure("inference_compute", ret);
   }
 
   // Output-completeness guard. Every declared output must be produced in-graph

--- a/build.py
+++ b/build.py
@@ -352,7 +352,7 @@ def run_tests(args, build_dir):
             "-C",
             args.config,
             "-R",
-            "StaticPlugins|OutputAllocator|CustomOpComputeStatus",
+            "StaticPlugins|OutputAllocator|CustomOpComputeStatus|TensorBufferLifecycle",
             "--output-on-failure",
         ]
     )

--- a/build.py
+++ b/build.py
@@ -326,7 +326,8 @@ def build_targets(args, build_dir):
 def run_tests(args, build_dir):
     """Run the GPU-free test suites (no device needed, so they run on the build
     machine in every CI job): the MLIR LIT pass-verification suite plus the
-    compiler-plugin registrar and output-allocator ctest unit tests."""
+    compiler-plugin registrar, output-allocator, and custom-op status ctest
+    unit tests."""
     step("Test (check-hip-mlir-lit)")
     run_subprocess(
         [
@@ -351,7 +352,7 @@ def run_tests(args, build_dir):
             "-C",
             args.config,
             "-R",
-            "StaticPlugins|OutputAllocator",
+            "StaticPlugins|OutputAllocator|CustomOpComputeStatus",
             "--output-on-failure",
         ]
     )

--- a/docs/design/compiler-runtime-contract.md
+++ b/docs/design/compiler-runtime-contract.md
@@ -182,6 +182,13 @@ The generated LLVM IR plus `RuntimeState` therefore carry pool behavior. See
 [pool-allocs-memory-planning.md](pool-allocs-memory-planning.md) for the
 attribute, lowering, and grow-on-demand runtime contract.
 
+Input staging is another generated-code-only contract. `generate-interface`
+queries `hipdnn_ep_tensor_buffer_storage_words` and constructs every opaque
+`TensorBuffer` before the first fallible prepare call. It commits a prepared
+count after each success, so shared error cleanup releases exactly that prefix
+through one runtime batch helper. The runtime, not generated LLVM, owns the
+record layout and release loop.
+
 ---
 
 ## Consumers

--- a/docs/design/compiler-runtime-contract.md
+++ b/docs/design/compiler-runtime-contract.md
@@ -189,6 +189,13 @@ count after each success, so shared error cleanup releases exactly that prefix
 through one runtime batch helper. The runtime, not generated LLVM, owns the
 record layout and release loop.
 
+Operation runtime calls use one status contract. After HIP-to-LLVM conversion,
+every status-bearing call records its nonzero `i32` in the shared runtime error
+flag. The generated interface reads and clears that flag after stream
+synchronization and returns it through `inference_compute`. Conversion fails
+closed if any `i32` call result is left unused; scalar data-return calls must
+consume their value explicitly.
+
 ---
 
 ## Consumers

--- a/docs/design/output-allocator-design.md
+++ b/docs/design/output-allocator-design.md
@@ -257,7 +257,7 @@ MlirCustomOp::Compute(context)
    ├─ build OutputAllocatorCtx octx{ctx, outputs, output_index_map, host_out_scratch, allocated[]}
    ├─ output_allocator_t alloc{ self=&octx, allocate=&output_allocate_cb }
    ├─ inference_state_->set_output_allocator(&alloc)
-   │     └─ hipdnn_ep_set_output_allocator(state, &alloc)   FATAL if the DLL lacks the export
+   │     └─ hipdnn_ep_set_output_allocator(state, &alloc)   throws if the DLL lacks the export
    ├─ inference_state_->compute(&inputs.span)
    │  └─ inference_compute(state, inputs)        2-arg ABI, NO outputs span
    │     ├─ hipdnn_ep_tensor_prepare_input(...) x N   -> input memref descriptors
@@ -278,8 +278,9 @@ MlirCustomOp::Compute(context)
    │     ├─ hipdnn_ep_stream_sync(state)         all GPU writes complete on return
    │     ├─ hipdnn_ep_state_read_and_clear_error_flag(state)
    │     └─ hipdnn_ep_tensor_free_input(state, ...) x N
-   ├─ inference_state_->set_output_allocator(nullptr)   clear before octx leaves scope
-   ├─ output-completeness guard: every allocated[i] true else LOG(FATAL)
+   ├─ scope-exit clears the allocator before octx leaves scope
+   ├─ rethrow any exception captured by the noexcept callback
+   ├─ output-completeness guard: every allocated[i] true else OrtStatus failure
    └─ #ifndef BUILD_MOCK_RUNTIME: pending_d2h -> blocking hipMemcpy(host <- GPU scratch)
 ```
 
@@ -298,7 +299,7 @@ Note the `main_graph` / `main_graph_internal` split (from `convert-hip-to-llvm`)
 
 **Key design points (as built):**
 
-1. **The callback is `noexcept` across the C ABI.** `output_allocate_cb` is invoked from the model.dll's C runtime; a C++ exception unwinding through those frames is UB. The body is wrapped in `try/catch`, and any failure (out-of-range `out_idx`, an ORT throw, a scratch `hipMalloc` failure) ends in `LOG(FATAL)` — it never returns null, because the lowering builds a memref from the returned pointer and a null write would segfault with no diagnostic. This does **not** contradict the DLL-side `hipdnn_ep_alloc_output` forwarder returning null (above): the forwarder returns null only when *no* callback was installed — which never happens in a real session. Once the EP installs `output_allocate_cb`, the callback always returns a valid pointer.
+1. **The callback is `noexcept` across the C ABI.** `output_allocate_cb` is invoked from the model artifact's C runtime, so unwinding a C++ exception through those frames would be undefined behavior. The callback captures its first exception and returns null. The alloc-output lowering tests that pointer before constructing its memref descriptor; null records shared runtime failure and returns from the generated graph, so no downstream operation can consume it. After `inference_compute` runs generated input cleanup, the EP clears the borrowed callback with `llvm::scope_exit` and rethrows the precise exception. MorphiZen's CustomOp boundary converts it to a non-null `OrtStatus`. No output validation, D2H copy, or success reporting occurs on that path.
 
 2. **Allocator returns a GPU device pointer** (Phase 3 contract). GPU outputs (EP `hipHostMalloc` allocator or OGA device memory: `memory_type == TENSOR_MEMORY_GPU`) zero-copy ORT's buffer. Host (CPU) outputs get an EP-owned GPU scratch pointer; the DLL writes there and the EP D2H-copies into ORT's host buffer after compute.
 
@@ -306,6 +307,8 @@ Note the `main_graph` / `main_graph_internal` split (from `convert-hip-to-llvm`)
 
 4. **KV cache share-buffer needs no special case in the callback.** `output_allocate_cb` passes the DLL's in-graph `shape` to `GetOutput` verbatim — every output is acquired the same way. The shape is already right because `hip.alloc_output`'s dynamic dims come from its producer's operands: a `present.*` output is sized from `memref.dim %past_key` (the past input buffer's actual extent), which under OGA `past_present_share_buffer` already **is** the `max_length` capacity buffer. So `GetOutput` returns the pre-bound shared `OrtValue` and the `past == present` pointer identity is preserved. Pinned by `test/lit/e2e/test_gqa_output_allocator_present_dim.mlir`. (`build_metadata_json` emits each output shape verbatim — static extent or `-1`.)
 
-5. **Output-completeness guard.** Every declared output must be created in-graph, so each one should trigger exactly one `hip.alloc_output` → callback. Right after the inference call returns, the EP checks that every output index in the metadata was served; if one was skipped it `LOG(FATAL)`s and names it. This catches the two graph shapes we don't support yet — an output that just passes a graph input straight through, and two outputs that share (alias) one buffer — and turns them into a clear error instead of handing ORT an unfilled buffer. None of the target models have either shape.
+5. **Output-completeness guard.** Every declared output must be created in-graph, so each one should trigger exactly one `hip.alloc_output` → callback. Right after a successful inference call, the EP checks that every output index in the metadata was served. A missing output throws a named runtime error that becomes `OrtStatus`, rather than exposing an uninitialized buffer or terminating the host. #758 owns support or compile-time rejection for pass-through and duplicated output slots.
 
-6. **Per-Compute allocator install/clear.** The `OutputAllocatorCtx` lives on `MlirCustomOp::compute_with_output_allocator`'s stack; the allocator is installed (with `self = &ctx`) before `InferenceState::compute` and cleared (`set_output_allocator(nullptr)`) immediately after, so `self` can never dangle into a later `Compute()`.
+6. **Per-Compute allocator install/clear.** The `OutputAllocatorCtx` lives on `MlirCustomOp::compute_with_output_allocator`'s stack. A scope-exit guard clears the installed allocator on success and on every exception path, so its borrowed `self` pointer cannot dangle into a later `Compute()`.
+
+7. **Scratch growth is failure-atomic.** Host-output scratch allocates and installs the replacement before retiring the old slot. Allocation failure preserves the reusable old buffer. If freeing the old pointer fails, its disposition is uncertain, so the runtime abandons that pointer (and may leak it) rather than risk reuse; the known-valid replacement remains live. Zero-byte outputs retain a valid one-byte device sentinel and skip the zero-byte D2H call. Shape and byte-size arithmetic is validated before ORT or scratch allocation.

--- a/lib/Conversion/HipToLLVM/ActivationLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ActivationLowering.cpp
@@ -363,14 +363,14 @@ struct MiopenSoftmaxOpLowering
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
     ModuleOp module = op->getParentOfType<ModuleOp>();
-    Type voidType = getVoidType();
     Type ptrType = getPtrType();
+    Type i32Type = rewriter.getI32Type();
     Type indexType = getIndexType();
 
     SmallVector<Type> paramTypes = {ptrType,   ptrType,   ptrType,
                                     indexType, indexType, indexType};
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
-        rewriter, module, kMiopenSoftmax, paramTypes, voidType);
+        rewriter, module, kMiopenSoftmax, paramTypes, i32Type);
     if (failed(funcOp))
       return failure();
 

--- a/lib/Conversion/HipToLLVM/CMakeLists.txt
+++ b/lib/Conversion/HipToLLVM/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 add_library(HipToLLVM STATIC
   HipToLLVM.cpp
+  RuntimeStatus.cpp
   MemoryLowering.cpp
   ConvLowering.cpp
   ConvTransposeLowering.cpp

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "HipToLLVMUtils.h"
+#include "RuntimeStatus.h"
 
 #include "mlir/Conversion/ConvertToLLVM/ToLLVMInterface.h"
 #include "mlir/IR/Dialect.h"
@@ -46,26 +47,26 @@ private:
       auto ptrTy = cast<LLVM::LLVMPointerType>(ptr.getType());
       if (ptrTy.getAddressSpace() == 0)
         return ptr;
-      return builder.create<LLVM::AddrSpaceCastOp>(loc, as0PtrType, ptr);
+      return LLVM::AddrSpaceCastOp::create(builder, loc, as0PtrType, ptr);
     };
 
-    Value allocPtr = builder.create<LLVM::ExtractValueOp>(
-        loc, memrefStruct, ArrayRef<int64_t>{kAllocPtrIdx});
+    Value allocPtr = LLVM::ExtractValueOp::create(
+        builder, loc, memrefStruct, ArrayRef<int64_t>{kAllocPtrIdx});
     args.push_back(castToAs0(allocPtr));
 
-    Value alignedPtr = builder.create<LLVM::ExtractValueOp>(
-        loc, memrefStruct, ArrayRef<int64_t>{kAlignedPtrIdx});
+    Value alignedPtr = LLVM::ExtractValueOp::create(
+        builder, loc, memrefStruct, ArrayRef<int64_t>{kAlignedPtrIdx});
     args.push_back(castToAs0(alignedPtr));
 
-    args.push_back(builder.create<LLVM::ExtractValueOp>(
-        loc, memrefStruct, ArrayRef<int64_t>{kOffsetIdx}));
+    args.push_back(LLVM::ExtractValueOp::create(builder, loc, memrefStruct,
+                                                ArrayRef<int64_t>{kOffsetIdx}));
 
     for (int64_t dim : llvm::seq<int64_t>(0, rank))
-      args.push_back(builder.create<LLVM::ExtractValueOp>(
-          loc, memrefStruct, ArrayRef<int64_t>{kSizesIdx, dim}));
+      args.push_back(LLVM::ExtractValueOp::create(
+          builder, loc, memrefStruct, ArrayRef<int64_t>{kSizesIdx, dim}));
     for (int64_t dim : llvm::seq<int64_t>(0, rank))
-      args.push_back(builder.create<LLVM::ExtractValueOp>(
-          loc, memrefStruct, ArrayRef<int64_t>{kStridesIdx, dim}));
+      args.push_back(LLVM::ExtractValueOp::create(
+          builder, loc, memrefStruct, ArrayRef<int64_t>{kStridesIdx, dim}));
   }
 
   // Split @main_graph into two functions so the runtime's simple (ctx, inputs)
@@ -168,7 +169,7 @@ private:
     // Create the (ctx, inputs) wrapper.
     builder.setInsertionPoint(mainFunc);
     auto newMainFunc =
-        builder.create<LLVM::LLVMFuncOp>(loc, "main_graph", newFuncType);
+        LLVM::LLVMFuncOp::create(builder, loc, "main_graph", newFuncType);
     newMainFunc.setLinkage(LLVM::Linkage::Private);
 
     newMainFunc->setAttr(
@@ -186,15 +187,15 @@ private:
 
     for (int64_t i : llvm::seq<int64_t>(0, inputCount)) {
       int64_t rank = cast<DenseI64ArrayAttr>(inputShapesAttr[i]).size();
-      Value inputIdxVal = builder.create<LLVM::ConstantOp>(
-          loc, i32Type, builder.getI32IntegerAttr(i));
-      Value inputSlotPtr = builder.create<LLVM::GEPOp>(
-          loc, ptrType, ptrType, inputsArg, ValueRange{inputIdxVal});
+      Value inputIdxVal = LLVM::ConstantOp::create(
+          builder, loc, i32Type, builder.getI32IntegerAttr(i));
+      Value inputSlotPtr = LLVM::GEPOp::create(
+          builder, loc, ptrType, ptrType, inputsArg, ValueRange{inputIdxVal});
       Value inputStructPtr =
-          builder.create<LLVM::LoadOp>(loc, ptrType, inputSlotPtr);
+          LLVM::LoadOp::create(builder, loc, ptrType, inputSlotPtr);
       Type memrefStructType = getMemRefStructType(builder, rank, 1);
       Value inputMemref =
-          builder.create<LLVM::LoadOp>(loc, memrefStructType, inputStructPtr);
+          LLVM::LoadOp::create(builder, loc, memrefStructType, inputStructPtr);
       unpackMemRefStructWithAddrCast(builder, loc, inputMemref, rank,
                                      mainInternalArgs);
     }
@@ -204,10 +205,10 @@ private:
     // any returned descriptor is ignored (the output reaches the EP through the
     // callback). A zero-output graph returns void, so there is nothing to
     // ignore.
-    builder.create<LLVM::CallOp>(loc, mainFunc, mainInternalArgs);
-    Value zero = builder.create<LLVM::ConstantOp>(loc, i32Type,
-                                                  builder.getI32IntegerAttr(0));
-    builder.create<LLVM::ReturnOp>(loc, zero);
+    LLVM::CallOp::create(builder, loc, mainFunc, mainInternalArgs);
+    Value zero = LLVM::ConstantOp::create(builder, loc, i32Type,
+                                          builder.getI32IntegerAttr(0));
+    LLVM::ReturnOp::create(builder, loc, zero);
 
     COMPILER_DEBUG_LOG("[HipToLLVM] Transformed @main_graph signature: "
                        << actualParams << " params -> " << newParamTypes.size()
@@ -357,11 +358,20 @@ void ConvertHipToLLVMPass::runOnOperation() {
     });
   }
 
-  if (failed(applyPartialConversion(module, target, std::move(patterns))))
+  if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
     signalPassFailure();
+    return;
+  }
 
-  if (failed(transformMainFunction(module)))
+  if (failed(recordAndVerifyRuntimeStatuses(module))) {
     signalPassFailure();
+    return;
+  }
+
+  if (failed(transformMainFunction(module))) {
+    signalPassFailure();
+    return;
+  }
 }
 
 } // namespace

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -42,6 +42,7 @@ inline constexpr const char *kHipGetPoolBase = "hipdnn_ep_get_pool_base";
 inline constexpr const char *kHipGetHostScratch =
     "hipdnn_ep_get_host_scratch_base";
 inline constexpr const char *kHipAllocOutput = "hipdnn_ep_alloc_output";
+inline constexpr const char *kHipRecordStatus = "hipdnn_ep_state_record_status";
 
 inline constexpr const char *kWrapHipMemcpyAsync = "wrap_hipMemcpyAsync";
 inline constexpr const char *kWrapHipMemcpy2DAsync = "wrap_hipMemcpy2DAsync";

--- a/lib/Conversion/HipToLLVM/MemoryLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MemoryLowering.cpp
@@ -276,9 +276,29 @@ struct AllocOutputOpLowering : public ConvertOpToLLVMPattern<AllocOutputOp> {
     Location loc = op.getLoc();
     ModuleOp module = op->getParentOfType<ModuleOp>();
     MemRefType memRefType = cast<MemRefType>(op.getMemref().getType());
+    auto parentFunc = op->getParentOfType<func::FuncOp>();
+    auto parentLLVMFunc = op->getParentOfType<LLVM::LLVMFuncOp>();
 
     if (!isConvertibleAndHasIdentityMaps(memRefType))
       return rewriter.notifyMatchFailure(op, "incompatible memref type");
+    if (!parentFunc && !parentLLVMFunc)
+      return rewriter.notifyMatchFailure(op, "expected a function parent");
+
+    // A null callback result returns from the graph before any consumer can
+    // dereference it. Precompute the converted failure-return type before
+    // emitting IR so a conversion failure cannot leave a partially split CFG.
+    Type failureReturnType;
+    if (parentFunc && parentFunc.getNumResults() != 0) {
+      failureReturnType =
+          getTypeConverter()->packFunctionResults(parentFunc.getResultTypes());
+      if (!failureReturnType)
+        return rewriter.notifyMatchFailure(
+            op, "could not convert function results");
+    } else if (parentLLVMFunc) {
+      Type resultType = parentLLVMFunc.getFunctionType().getReturnType();
+      if (!isa<LLVM::LLVMVoidType>(resultType))
+        failureReturnType = resultType;
+    }
 
     Type ptrType = getPtrType();
     Type i64Type = rewriter.getI64Type();
@@ -404,7 +424,6 @@ struct AllocOutputOpLowering : public ConvertOpToLLVMPattern<AllocOutputOp> {
       callbackRank = rank;
     }
 
-    auto parentFunc = op->getParentOfType<func::FuncOp>();
     if (failed(verifyCallbackRankAgainstMetadata(
             module, parentFunc, op.getOutIdx(), callbackRank, loc)))
       return failure();
@@ -439,12 +458,48 @@ struct AllocOutputOpLowering : public ConvertOpToLLVMPattern<AllocOutputOp> {
         {ptrType, i64Type, ptrType, i64Type, i64Type}, ptrType);
     if (failed(funcOp))
       return failure();
+    FailureOr<LLVM::LLVMFuncOp> recorder = LLVM::lookupOrCreateFn(
+        rewriter, module, kHipRecordStatus, {ptrType, i32Type}, i32Type);
+    if (failed(recorder))
+      return failure();
 
     Value rawPtr =
         LLVM::CallOp::create(rewriter, loc, *funcOp,
                              ValueRange{adaptor.getCtx(), outIdxVal,
                                         shapeAlloca, rankVal, elemSizeVal})
             .getResult();
+
+    // The callback is a noexcept C boundary and reports failure with null.
+    // Split before replacing the op so every downstream use remains in the
+    // success block. The failure block records status and returns a poison
+    // value only to satisfy the internal function ABI; its wrapper discards
+    // graph return descriptors and the generated interface observes status.
+    Value nullPtr = LLVM::ZeroOp::create(rewriter, loc, ptrType);
+    Value hasOutput = LLVM::ICmpOp::create(
+        rewriter, loc, LLVM::ICmpPredicate::ne, rawPtr, nullPtr);
+    Block *allocationBlock = op->getBlock();
+    Block *continuationBlock =
+        rewriter.splitBlock(allocationBlock, Block::iterator(op));
+    Block *failureBlock = rewriter.createBlock(
+        continuationBlock->getParent(), Region::iterator(continuationBlock));
+
+    rewriter.setInsertionPointToEnd(allocationBlock);
+    LLVM::CondBrOp::create(rewriter, loc, hasOutput, continuationBlock,
+                           failureBlock);
+
+    rewriter.setInsertionPointToEnd(failureBlock);
+    Value failureStatus = LLVM::ConstantOp::create(
+        rewriter, loc, i32Type, rewriter.getI32IntegerAttr(-1));
+    LLVM::CallOp::create(rewriter, loc, *recorder,
+                         ValueRange{adaptor.getCtx(), failureStatus});
+    if (failureReturnType) {
+      Value poison = LLVM::PoisonOp::create(rewriter, loc, failureReturnType);
+      LLVM::ReturnOp::create(rewriter, loc, poison);
+    } else {
+      LLVM::ReturnOp::create(rewriter, loc, ValueRange{});
+    }
+
+    rewriter.setInsertionPoint(op);
 
     // The runtime returns a generic (AS 0) pointer; cast to the memref's
     // address space if it differs (mirrors GetConstant / AllocOp).

--- a/lib/Conversion/HipToLLVM/RuntimeStatus.cpp
+++ b/lib/Conversion/HipToLLVM/RuntimeStatus.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#include "RuntimeStatus.h"
+#include "HipToLLVMUtils.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringSwitch.h"
+
+#include <optional>
+#include <utility>
+
+namespace mlir::hip {
+namespace {
+
+bool isStatusReturningRuntimeSymbol(StringRef name) {
+  if (name.starts_with("wrap_"))
+    return true;
+  return llvm::StringSwitch<bool>(name)
+      .Cases({"hip_miopen_softmax", "hipdnn_graph_execute"}, true)
+      .Cases({"hipdnn_ep_run_if", "hipdnn_ep_run_counted_loop"}, true)
+      .Cases({"hipdnn_ep_run_loop", "hipdnn_ep_loop_frame_destroy"}, true)
+      .Case("hipdnn_ep_copy_output", true)
+      .Default(false);
+}
+
+bool hasStatusRecorderUse(LLVM::CallOp call) {
+  if (call.getNumResults() != 1)
+    return false;
+  return llvm::any_of(call.getResult().getUsers(), [](Operation *user) {
+    auto recorder = dyn_cast<LLVM::CallOp>(user);
+    return recorder && recorder.getCallee() &&
+           *recorder.getCallee() == kHipRecordStatus;
+  });
+}
+
+} // namespace
+
+LogicalResult recordAndVerifyRuntimeStatuses(ModuleOp module) {
+  MLIRContext *ctx = module.getContext();
+  Type i32Type = IntegerType::get(ctx, 32);
+  Type ptrType = LLVM::LLVMPointerType::get(ctx, 0);
+  SmallVector<LLVM::CallOp> statusCalls;
+
+  WalkResult validation = module.walk([&](LLVM::CallOp call) -> WalkResult {
+    std::optional<StringRef> callee = call.getCallee();
+    if (!callee || !isStatusReturningRuntimeSymbol(*callee))
+      return WalkResult::advance();
+    if (call.getNumResults() != 1 || call.getResult().getType() != i32Type ||
+        call.getArgOperands().empty() ||
+        call.getArgOperands().front().getType() != ptrType) {
+      call.emitOpError() << "status-bearing runtime call must have signature "
+                            "(state, ...) -> i32";
+      return WalkResult::interrupt();
+    }
+    statusCalls.push_back(call);
+    return WalkResult::advance();
+  });
+  if (validation.wasInterrupted())
+    return failure();
+
+  SmallVector<std::pair<ModuleOp, LLVM::LLVMFuncOp>> recorders;
+  for (LLVM::CallOp call : statusCalls) {
+    ModuleOp owner = call->getParentOfType<ModuleOp>();
+    auto existing = llvm::find_if(
+        recorders, [&](const auto &entry) { return entry.first == owner; });
+    if (existing != recorders.end())
+      continue;
+    OpBuilder declarationBuilder(ctx);
+    declarationBuilder.setInsertionPointToStart(owner.getBody());
+    FailureOr<LLVM::LLVMFuncOp> recorder =
+        LLVM::lookupOrCreateFn(declarationBuilder, owner, kHipRecordStatus,
+                               {ptrType, i32Type}, i32Type);
+    if (failed(recorder))
+      return failure();
+    recorders.emplace_back(owner, *recorder);
+  }
+
+  for (LLVM::CallOp call : statusCalls) {
+    if (hasStatusRecorderUse(call))
+      continue;
+    ModuleOp owner = call->getParentOfType<ModuleOp>();
+    auto recorder = llvm::find_if(
+        recorders, [&](const auto &entry) { return entry.first == owner; });
+    assert(recorder != recorders.end() &&
+           "recorder must exist for call module");
+    OpBuilder builder(call);
+    builder.setInsertionPointAfter(call);
+    LLVM::CallOp::create(
+        builder, call.getLoc(), recorder->second,
+        ValueRange{call.getArgOperands().front(), call.getResult()});
+  }
+
+  WalkResult audit = module.walk([&](LLVM::CallOp call) -> WalkResult {
+    if (call.getNumResults() != 1 || call.getResult().getType() != i32Type ||
+        !call.getResult().use_empty())
+      return WalkResult::advance();
+    std::optional<StringRef> callee = call.getCallee();
+    if (callee && *callee == kHipRecordStatus)
+      return WalkResult::advance();
+    InFlightDiagnostic diagnostic = call.emitOpError("unused i32 result from ");
+    if (callee)
+      diagnostic << "'" << *callee << "'";
+    else
+      diagnostic << "indirect call";
+    diagnostic << "; consume data or propagate operation status";
+    return WalkResult::interrupt();
+  });
+  return success(!audit.wasInterrupted());
+}
+
+} // namespace mlir::hip

--- a/lib/Conversion/HipToLLVM/RuntimeStatus.h
+++ b/lib/Conversion/HipToLLVM/RuntimeStatus.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#ifndef HIP_CONVERSION_HIPTOLLVM_RUNTIME_STATUS_H
+#define HIP_CONVERSION_HIPTOLLVM_RUNTIME_STATUS_H
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::hip {
+
+/// Record every operation-runtime status and reject unused i32 call results.
+LogicalResult recordAndVerifyRuntimeStatuses(ModuleOp module);
+
+} // namespace mlir::hip
+
+#endif // HIP_CONVERSION_HIPTOLLVM_RUNTIME_STATUS_H

--- a/lib/Dialect/Transforms/GenerateInterface.cpp
+++ b/lib/Dialect/Transforms/GenerateInterface.cpp
@@ -445,8 +445,10 @@ private:
         {"hipdnn_ep_state_get_stream", ptr, {ptr}},
         {"hipdnn_ep_pool_init", i32, {ptr, i64, ptr, i64}},
         {"hipdnn_ep_get_buffer_from_pool", ptr, {ptr, i64}},
+        {"hipdnn_ep_tensor_buffer_storage_words", i64, {}},
+        {"hipdnn_ep_tensor_buffer_construct", vd, {ptr}},
         {"hipdnn_ep_tensor_prepare_input", i32, {ptr, ptr, i64, i64, ptr}},
-        {"hipdnn_ep_tensor_free_input", vd, {ptr, ptr}},
+        {"hipdnn_ep_tensor_free_inputs", vd, {ptr, ptr, i64}},
         {"hipdnn_ep_tensor_buffer_get_gpu_ptr", ptr, {ptr}},
         {"hipdnn_ep_tensor_buffer_get_host_ptr", ptr, {ptr}},
         {"hipdnn_ep_tensor_buffer_get_shape_ptr", ptr, {ptr}},
@@ -743,7 +745,7 @@ private:
     }
   }
 
-  /// Generated IR overview (1 input of rank 1; outputs allocated in-graph):
+  /// Generated IR overview (N inputs; outputs allocated in-graph):
   ///   llvm.func @inference_compute(%state: !llvm.ptr, %ins: !llvm.ptr) -> i32
   ///       attributes {llvm.emit_c_interface, sym_visibility = "public"} {
   ///     // 1. Alloca input TensorBuffer structs on the stack
@@ -806,13 +808,19 @@ private:
 
     Value c0_i32 = LLVM::ConstantOp::create(builder, loc, i32Type,
                                             builder.getI32IntegerAttr(0));
+    Value c0_i64 = LLVM::ConstantOp::create(builder, loc, i64Type,
+                                            builder.getI64IntegerAttr(0));
     Value c1_i64 = LLVM::ConstantOp::create(builder, loc, i64Type,
                                             builder.getI64IntegerAttr(1));
 
     auto prepareInputFunc =
         module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_tensor_prepare_input");
-    auto freeInputFunc =
-        module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_tensor_free_input");
+    auto freeInputsFunc =
+        module.lookupSymbol<LLVM::LLVMFuncOp>("hipdnn_ep_tensor_free_inputs");
+    auto tensorBufferWordsFunc = module.lookupSymbol<LLVM::LLVMFuncOp>(
+        "hipdnn_ep_tensor_buffer_storage_words");
+    auto constructTensorBufferFunc = module.lookupSymbol<LLVM::LLVMFuncOp>(
+        "hipdnn_ep_tensor_buffer_construct");
 
     auto getGpuPtrFunc = module.lookupSymbol<LLVM::LLVMFuncOp>(
         "hipdnn_ep_tensor_buffer_get_gpu_ptr");
@@ -827,24 +835,32 @@ private:
 
     Value errorCodePtr =
         LLVM::AllocaOp::create(builder, loc, ptrType, i32Type, c1_i64, 0);
+    Value preparedCountPtr =
+        LLVM::AllocaOp::create(builder, loc, ptrType, i64Type, c1_i64, 0);
+    LLVM::StoreOp::create(builder, loc, c0_i64, preparedCountPtr);
 
     SmallVector<Value> inputBuffers;
+    Value numInputsVal = LLVM::ConstantOp::create(
+        builder, loc, i64Type, builder.getI64IntegerAttr(numInputs));
+    Value inputBufferArray =
+        LLVM::AllocaOp::create(builder, loc, ptrType, ptrType, numInputsVal, 0);
 
-    // sizeof(TensorBuffer) in the runtime (6 fields, 48 bytes on 64-bit).
-    // TODO: Replace with sizeof(TensorBuffer) or a runtime query once the
-    // runtime is ported into this repo.
-    constexpr int64_t kTensorBufferSizeBytes = 48;
-
-    Type i8Type = builder.getI8Type();
-    Value tensorBufferSize = LLVM::ConstantOp::create(
-        builder, loc, i64Type,
-        builder.getI64IntegerAttr(kTensorBufferSizeBytes));
+    Value tensorBufferWords =
+        LLVM::CallOp::create(builder, loc, tensorBufferWordsFunc, ValueRange{})
+            .getResult();
 
     for (auto i : llvm::seq<size_t>(0, numInputs)) {
       (void)i;
-      Value bufferPtr = LLVM::AllocaOp::create(builder, loc, ptrType, i8Type,
-                                               tensorBufferSize, 0);
+      Value bufferPtr = LLVM::AllocaOp::create(builder, loc, ptrType, i64Type,
+                                               tensorBufferWords, 0);
+      LLVM::CallOp::create(builder, loc, constructTensorBufferFunc,
+                           ValueRange{bufferPtr});
       inputBuffers.push_back(bufferPtr);
+      Value index = LLVM::ConstantOp::create(builder, loc, i64Type,
+                                             builder.getI64IntegerAttr(i));
+      Value slot = LLVM::GEPOp::create(builder, loc, ptrType, ptrType,
+                                       inputBufferArray, ValueRange{index});
+      LLVM::StoreOp::create(builder, loc, bufferPtr, slot);
     }
 
     Block *errorCleanupBlock = funcOp.addBlock();
@@ -864,11 +880,12 @@ private:
           builder, loc, prepareInputFunc,
           ValueRange{state, inputsSpanPtr, indexVal, rankVal, bufferPtr},
           errorCodePtr, errorCleanupBlock, funcOp);
+      Value prepared = LLVM::ConstantOp::create(
+          builder, loc, i64Type, builder.getI64IntegerAttr(i + 1));
+      LLVM::StoreOp::create(builder, loc, prepared, preparedCountPtr);
     }
 
     // Build memref structs for @main call
-    Value numInputsVal = LLVM::ConstantOp::create(
-        builder, loc, i64Type, builder.getI64IntegerAttr(numInputs));
     Value inputMemrefArray =
         LLVM::AllocaOp::create(builder, loc, ptrType, ptrType, numInputsVal, 0);
 
@@ -933,12 +950,8 @@ private:
     emitErrorCheckedCall(builder, loc, readErrorFlagFunc, ValueRange{state},
                          errorCodePtr, errorCleanupBlock, funcOp);
 
-    // Free input tensors
-    for (auto i : llvm::seq<size_t>(0, numInputs)) {
-      Value bufferPtr = inputBuffers[i];
-      LLVM::CallOp::create(builder, loc, freeInputFunc,
-                           ValueRange{state, bufferPtr});
-    }
+    LLVM::CallOp::create(builder, loc, freeInputsFunc,
+                         ValueRange{state, inputBufferArray, numInputsVal});
 
     LLVM::ReturnOp::create(builder, loc, c0_i32);
 
@@ -947,10 +960,10 @@ private:
 
     Value errorCode = LLVM::LoadOp::create(builder, loc, i32Type, errorCodePtr);
 
-    for (auto i : llvm::seq<size_t>(0, inputBuffers.size())) {
-      LLVM::CallOp::create(builder, loc, freeInputFunc,
-                           ValueRange{state, inputBuffers[i]});
-    }
+    Value preparedCount =
+        LLVM::LoadOp::create(builder, loc, i64Type, preparedCountPtr);
+    LLVM::CallOp::create(builder, loc, freeInputsFunc,
+                         ValueRange{state, inputBufferArray, preparedCount});
 
     LLVM::ReturnOp::create(builder, loc, errorCode);
   }

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -275,6 +275,7 @@ endmacro()
 
 # Compile shared implementation files
 compile_to_bitcode(hipdnn_ep_runtime_state.cpp runtime_state.bc)
+compile_to_bitcode(runtime_error.cpp runtime_error.bc)
 compile_to_bitcode(tensor_buffer.cpp runtime_tensor_buffer.bc)
 compile_to_bitcode(hipdnn_ep_runtime_tensor.cpp runtime_tensor.bc)
 compile_to_bitcode(hipdnn_ep_runtime_loop.cpp runtime_loop.bc)
@@ -363,6 +364,7 @@ if(NOT BUILD_MOCK_RUNTIME)
 
     set(RUNTIME_BC_MODULES
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_state.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_error.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_tensor_buffer.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_tensor.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_loop.bc
@@ -454,6 +456,7 @@ else()
 
     set(RUNTIME_BC_MODULES
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_state.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_error.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_tensor_buffer.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_tensor.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_loop.bc

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -260,6 +260,7 @@ macro(compile_to_bitcode SOURCE_FILE OUTPUT_BC)
         DEPENDS ${SOURCE_FILE}
                 ${CMAKE_CURRENT_SOURCE_DIR}/hipdnn_ep_runtime.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/runtime_state_internal.h
+                ${CMAKE_CURRENT_SOURCE_DIR}/tensor_buffer_internal.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/op_state.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/op_profile.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/chrome_trace.h
@@ -274,6 +275,7 @@ endmacro()
 
 # Compile shared implementation files
 compile_to_bitcode(hipdnn_ep_runtime_state.cpp runtime_state.bc)
+compile_to_bitcode(tensor_buffer.cpp runtime_tensor_buffer.bc)
 compile_to_bitcode(hipdnn_ep_runtime_tensor.cpp runtime_tensor.bc)
 compile_to_bitcode(hipdnn_ep_runtime_loop.cpp runtime_loop.bc)
 compile_to_bitcode(hipdnn_ep_runtime_if.cpp runtime_if.bc)
@@ -361,6 +363,7 @@ if(NOT BUILD_MOCK_RUNTIME)
 
     set(RUNTIME_BC_MODULES
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_state.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_tensor_buffer.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_tensor.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_loop.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_if.bc
@@ -451,6 +454,7 @@ else()
 
     set(RUNTIME_BC_MODULES
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_state.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_tensor_buffer.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_tensor.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_loop.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_if.bc

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -573,20 +573,9 @@ typedef struct {
   size_t count;   // Number of tensors
 } span_t;
 
-// Represents a prepared tensor with GPU buffer and metadata
-// Used internally by tensor preparation helpers
-typedef struct {
-  void *gpu_ptr;      // GPU memory (allocated, from pool, or aliased)
-  void *host_ptr;     // Host memory (from tensor_t.data)
-  int64_t *shape_ptr; // Shape array (from tensor_t.shape) for memref building
-  size_t rank;        // Tensor rank (for validation)
-  size_t size_bytes;  // Buffer size
-  bool is_pooled;     // Internal: true if from pool, false if allocated
-  // Internal: true if gpu_ptr aliases caller's GPU-accessible memory
-  // (tensor_t.memory_type == TENSOR_MEMORY_GPU). When set, free_input skips
-  // pool_release/hipFree because the memory is owned by the caller, not by us.
-  bool is_aliased;
-} TensorBuffer;
+// Opaque prepared-input record. Generated code obtains its storage size and
+// starts its lifetime through the helpers below; only the runtime owns layout.
+typedef struct TensorBuffer TensorBuffer;
 
 //===----------------------------------------------------------------------===//
 // Constant Access (used by generated inference code)
@@ -610,6 +599,12 @@ void *hipdnn_ep_constant_get(RuntimeState *state, int64_t index);
 // Element size: Read from tensor_t.element_size, set by the EP caller.
 //===----------------------------------------------------------------------===//
 
+// Return the number of i64 words required for one TensorBuffer and construct
+// an empty record in that storage. Generated code constructs every record
+// before the first fallible prepare call, making common error cleanup safe.
+int64_t hipdnn_ep_tensor_buffer_storage_words(void);
+void hipdnn_ep_tensor_buffer_construct(void *storage);
+
 // Prepare input tensor: parse, validate, get/allocate GPU buffer, H2D transfer
 //
 // Parameters:
@@ -628,6 +623,12 @@ int hipdnn_ep_tensor_prepare_input(RuntimeState *state, span_t *inputs,
 //   state: Runtime state
 //   buffer: TensorBuffer from prepare_input
 void hipdnn_ep_tensor_free_input(RuntimeState *state, TensorBuffer *buffer);
+
+// Release the successfully prepared prefix of an array of TensorBuffer
+// pointers. Generated error cleanup passes the count committed after each
+// successful prepare call.
+void hipdnn_ep_tensor_free_inputs(RuntimeState *state, TensorBuffer **buffers,
+                                  size_t count);
 
 // Synchronize the GPU stream and print PERF/profile timing (if enabled).
 // Called by generated code after compute, before free_input.

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -427,11 +427,12 @@ int hipdnn_ep_state_ensure_la_scratch(RuntimeState *state, size_t needed_size);
 // walks the array via each object's deletor.
 bool hipdnn_ep_op_states_alloc(RuntimeState *state, int64_t n);
 
-// Device-side runtime error flag (set by kernels, observed by wrappers).
-// Intended for operators that detect runtime-invalid inputs on GPU (e.g. Range
-// delta==0) and need to propagate an error code back through main_graph.
+// Shared runtime error flag. Generated code records every nonzero operation
+// status here; kernels may also write the device pointer directly.
 void *hipdnn_ep_state_get_error_flag_device_ptr(RuntimeState *state);
 int hipdnn_ep_state_reset_error_flag(RuntimeState *state);
+int hipdnn_ep_state_set_error_flag(RuntimeState *state);
+int hipdnn_ep_state_record_status(RuntimeState *state, int status);
 int hipdnn_ep_state_read_and_clear_error_flag(RuntimeState *state);
 // Mark the start of a new Compute() call. Invalidates per-forward-pass
 // runtime caches -- today: the GQA seqlens_k cache (see

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -169,6 +169,7 @@ static int initialize_state_handles(RuntimeState **out_state) {
   state->la_scratch_size = 0;
   state->zp_unpack_cache = nullptr;
   state->op_profile = hipdnn_ep_perf_enabled() ? op_profile_create() : nullptr;
+  state->host_error_status = 0;
   state->device_error_flag = nullptr;
   state->hipdnn_handle = nullptr;
   state->hipdnn_graph_registry = nullptr;
@@ -1470,43 +1471,6 @@ int hipdnn_ep_state_ensure_la_scratch(RuntimeState *state, size_t needed_size) {
   }
   state->la_scratch_size = alloc_size;
   return 0;
-}
-
-void *hipdnn_ep_state_get_error_flag_device_ptr(RuntimeState *state) {
-  return state ? static_cast<void *>(state->device_error_flag) : nullptr;
-}
-
-int hipdnn_ep_state_reset_error_flag(RuntimeState *state) {
-  if (!state || !state->device_error_flag || !state->stream) {
-    fprintf(stderr, "hipdnn_ep_state_reset_error_flag: invalid state\n");
-    return -1;
-  }
-  hipError_t err =
-      hipMemsetAsync(state->device_error_flag, 0, sizeof(int), state->stream);
-  return (err == hipSuccess) ? 0 : -1;
-}
-
-int hipdnn_ep_state_read_and_clear_error_flag(RuntimeState *state) {
-  if (!state || !state->device_error_flag || !state->stream) {
-    fprintf(stderr,
-            "hipdnn_ep_state_read_and_clear_error_flag: invalid state\n");
-    return -1;
-  }
-
-  int host_error = 0;
-  hipError_t err =
-      hipMemcpyAsync(&host_error, state->device_error_flag, sizeof(int),
-                     hipMemcpyDeviceToHost, state->stream);
-  if (err != hipSuccess)
-    return -1;
-  err = hipStreamSynchronize(state->stream);
-  if (err != hipSuccess)
-    return -1;
-  if (host_error != 0)
-    return host_error;
-
-  err = hipMemsetAsync(state->device_error_flag, 0, sizeof(int), state->stream);
-  return (err == hipSuccess) ? 0 : -1;
 }
 
 } // extern "C"

--- a/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_tensor.cpp
@@ -7,6 +7,7 @@
 #include "hipdnn_ep_runtime.h"
 #include "op_profile.h"
 #include "runtime_state_internal.h"
+#include "tensor_buffer_internal.h"
 
 #include <cassert>
 #include <cstdio>
@@ -198,45 +199,17 @@ int hipdnn_ep_tensor_prepare_input(RuntimeState *state, span_t *inputs,
                                    TensorBuffer *out_buffer) {
   check_gcnarch("BEFORE prepare_input");
 
-  // VERIFICATION: Struct sizes
-  RUNTIME_DEBUG_LOG("[Runtime DEBUG] === Struct Size Verification ===\n");
-  RUNTIME_DEBUG_LOG("[Runtime DEBUG] sizeof(TensorBuffer) = %zu\n",
-                    sizeof(TensorBuffer));
-  RUNTIME_DEBUG_LOG("[Runtime DEBUG] offsetof(TensorBuffer, gpu_ptr) = %zu\n",
-                    offsetof(TensorBuffer, gpu_ptr));
-  RUNTIME_DEBUG_LOG("[Runtime DEBUG] offsetof(TensorBuffer, host_ptr) = %zu\n",
-                    offsetof(TensorBuffer, host_ptr));
-  RUNTIME_DEBUG_LOG("[Runtime DEBUG] offsetof(TensorBuffer, shape_ptr) = %zu\n",
-                    offsetof(TensorBuffer, shape_ptr));
-  RUNTIME_DEBUG_LOG("[Runtime DEBUG] offsetof(TensorBuffer, rank) = %zu\n",
-                    offsetof(TensorBuffer, rank));
-  RUNTIME_DEBUG_LOG(
-      "[Runtime DEBUG] offsetof(TensorBuffer, size_bytes) = %zu\n",
-      offsetof(TensorBuffer, size_bytes));
-  RUNTIME_DEBUG_LOG("[Runtime DEBUG] offsetof(TensorBuffer, is_pooled) = %zu\n",
-                    offsetof(TensorBuffer, is_pooled));
-
-  // VERIFICATION: tensor_t struct
-  RUNTIME_DEBUG_LOG("[Runtime DEBUG] sizeof(tensor_t) = %zu\n",
-                    sizeof(tensor_t));
-  RUNTIME_DEBUG_LOG("[Runtime DEBUG] offsetof(tensor_t, data) = %zu\n",
-                    offsetof(tensor_t, data));
-  RUNTIME_DEBUG_LOG("[Runtime DEBUG] offsetof(tensor_t, shape) = %zu\n",
-                    offsetof(tensor_t, shape));
-  RUNTIME_DEBUG_LOG("[Runtime DEBUG] offsetof(tensor_t, rank) = %zu\n",
-                    offsetof(tensor_t, rank));
-
-  // Validate arguments
+  if (!out_buffer) {
+    fprintf(stderr, "hipdnn_ep_tensor_prepare_input: null out_buffer\n");
+    return HIPDNN_EP_ERR_NULL_POINTER;
+  }
+  *out_buffer = {};
   if (!state) {
     fprintf(stderr, "hipdnn_ep_tensor_prepare_input: null state\n");
     return HIPDNN_EP_ERR_NULL_POINTER;
   }
   if (!inputs) {
     fprintf(stderr, "hipdnn_ep_tensor_prepare_input: null inputs\n");
-    return HIPDNN_EP_ERR_NULL_POINTER;
-  }
-  if (!out_buffer) {
-    fprintf(stderr, "hipdnn_ep_tensor_prepare_input: null out_buffer\n");
     return HIPDNN_EP_ERR_NULL_POINTER;
   }
 
@@ -257,37 +230,6 @@ int hipdnn_ep_tensor_prepare_input(RuntimeState *state, span_t *inputs,
 
   // Extract tensor from span
   tensor_t *tensor = &inputs->data[index];
-
-  // DUMP: Raw memory of tensor_t struct
-  RUNTIME_DEBUG_LOG(
-      "[Runtime DEBUG] tensor_t struct memory dump (address=%p):\n",
-      (void *)tensor);
-  auto *bytes = reinterpret_cast<unsigned char *>(tensor);
-  for (size_t i = 0; i < sizeof(tensor_t); i++) {
-    RUNTIME_DEBUG_LOG("  [%02zu] = 0x%02x\n", i, bytes[i]);
-  }
-
-  // DUMP: Field values
-  RUNTIME_DEBUG_LOG("[Runtime DEBUG] tensor->data = %p\n", tensor->data);
-  RUNTIME_DEBUG_LOG("[Runtime DEBUG] tensor->shape = %p\n",
-                    (void *)tensor->shape);
-  RUNTIME_DEBUG_LOG("[Runtime DEBUG] tensor->rank = %zu\n", tensor->rank);
-
-  // Validate field access doesn't corrupt memory (re-read test)
-  void *data_before = tensor->data;
-  int64_t *shape_before = tensor->shape;
-  size_t rank_before = tensor->rank;
-
-  // Re-read and compare
-  if (tensor->data != data_before || tensor->shape != shape_before ||
-      tensor->rank != rank_before) {
-    fprintf(stderr, "[Runtime ERROR] Struct fields changed on re-read!\n");
-    fprintf(stderr, "  data: %p -> %p\n", data_before, tensor->data);
-    fprintf(stderr, "  shape: %p -> %p\n", (void *)shape_before,
-            (void *)tensor->shape);
-    fprintf(stderr, "  rank: %zu -> %zu\n", rank_before, tensor->rank);
-    return HIPDNN_EP_ERR_NULL_POINTER; // Use generic error code
-  }
 
   // Shape must be present (or rank==0 for scalars).
   if (!tensor->shape && tensor->rank != 0) {
@@ -335,7 +277,6 @@ int hipdnn_ep_tensor_prepare_input(RuntimeState *state, span_t *inputs,
     out_buffer->shape_ptr = tensor->shape;
     out_buffer->rank = tensor->rank;
     out_buffer->size_bytes = 0;
-    out_buffer->is_pooled = false;
     out_buffer->is_aliased = false;
     return HIPDNN_EP_SUCCESS;
   }
@@ -461,7 +402,6 @@ int hipdnn_ep_tensor_prepare_input(RuntimeState *state, span_t *inputs,
   out_buffer->shape_ptr = tensor->shape;
   out_buffer->rank = tensor->rank;
   out_buffer->size_bytes = size_bytes;
-  out_buffer->is_pooled = false;
   out_buffer->is_aliased = alias_caller_buffer;
 
   check_gcnarch("AFTER prepare_input");
@@ -601,21 +541,16 @@ void hipdnn_ep_tensor_free_input(RuntimeState *state, TensorBuffer *buffer) {
     return;
   }
 
-  // Empty input (size_bytes == 0, e.g. KV cache with past_sequence_length==0
-  // on prefill): no pool allocation was made; nothing to release.
+  // A zero-sized or merely constructed record owns no pool allocation.
   if (buffer->size_bytes == 0) {
-    buffer->gpu_ptr = nullptr;
+    *buffer = {};
     return;
   }
 
-  // Return buffer to pool only if we own it. Aliased buffers are owned by
-  // the caller (e.g. OGA's KV cache OrtValue under path A); freeing them
-  // would corrupt the caller's allocation.
-  if (!buffer->is_aliased) {
+  // Aliased device inputs remain owned by the caller.
+  if (!buffer->is_aliased)
     pool_release(buffer->gpu_ptr, buffer->size_bytes);
-  }
-  buffer->gpu_ptr = nullptr;
-  buffer->is_aliased = false;
+  *buffer = {};
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Runtime/runtime_error.cpp
+++ b/lib/Runtime/runtime_error.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#include "hipdnn_ep_runtime.h"
+#include "runtime_state_internal.h"
+
+#include <cstdio>
+
+extern "C" {
+
+void *hipdnn_ep_state_get_error_flag_device_ptr(RuntimeState *state) {
+  return state ? static_cast<void *>(state->device_error_flag) : nullptr;
+}
+
+int hipdnn_ep_state_reset_error_flag(RuntimeState *state) {
+  if (!state || !state->device_error_flag || !state->stream) {
+    std::fprintf(stderr, "hipdnn_ep_state_reset_error_flag: invalid state\n");
+    return -1;
+  }
+  state->host_error_status = 0;
+  hipError_t err =
+      hipMemsetAsync(state->device_error_flag, 0, sizeof(int), state->stream);
+  return err == hipSuccess ? 0 : -1;
+}
+
+int hipdnn_ep_state_set_error_flag(RuntimeState *state) {
+  if (!state || !state->device_error_flag || !state->stream) {
+    std::fprintf(stderr, "hipdnn_ep_state_set_error_flag: invalid state\n");
+    return -1;
+  }
+  if (state->host_error_status == 0)
+    state->host_error_status = -1;
+  hipError_t err = hipMemsetAsync(state->device_error_flag, 0xff, sizeof(int),
+                                  state->stream);
+  return err == hipSuccess ? 0 : -1;
+}
+
+int hipdnn_ep_state_record_status(RuntimeState *state, int status) {
+  if (status != 0 && state && state->host_error_status == 0)
+    state->host_error_status = status;
+  return status;
+}
+
+int hipdnn_ep_state_read_and_clear_error_flag(RuntimeState *state) {
+  if (!state || !state->device_error_flag || !state->stream) {
+    std::fprintf(stderr,
+                 "hipdnn_ep_state_read_and_clear_error_flag: invalid state\n");
+    return -1;
+  }
+
+  int deviceError = 0;
+  hipError_t err =
+      hipMemcpyAsync(&deviceError, state->device_error_flag, sizeof(int),
+                     hipMemcpyDeviceToHost, state->stream);
+  if (err != hipSuccess)
+    return -1;
+  err = hipStreamSynchronize(state->stream);
+  if (err != hipSuccess)
+    return -1;
+  err = hipMemsetAsync(state->device_error_flag, 0, sizeof(int), state->stream);
+  if (err != hipSuccess)
+    return -1;
+
+  int result =
+      state->host_error_status != 0 ? state->host_error_status : deviceError;
+  state->host_error_status = 0;
+  return result;
+}
+
+} // extern "C"

--- a/lib/Runtime/runtime_state_internal.h
+++ b/lib/Runtime/runtime_state_internal.h
@@ -196,6 +196,10 @@ struct RuntimeState {
   // Allocated in state_init, freed in state_cleanup.
   void *op_profile;
 
+  // First host-observed operation error in the current Compute() call. This
+  // preserves wrapper failures even if queuing the mirrored device flag fails.
+  int host_error_status;
+
   // Device-side error flag used by kernels to report runtime-invalid inputs.
   // 0 = no error, non-zero = error code (currently -1).
   int *device_error_flag;

--- a/lib/Runtime/tensor_buffer.cpp
+++ b/lib/Runtime/tensor_buffer.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#include "hipdnn_ep_runtime.h"
+#include "tensor_buffer_internal.h"
+
+#include <new>
+
+extern "C" {
+
+int64_t hipdnn_ep_tensor_buffer_storage_words(void) {
+  static_assert(alignof(TensorBuffer) <= alignof(int64_t));
+  constexpr size_t wordSize = sizeof(int64_t);
+  return static_cast<int64_t>((sizeof(TensorBuffer) + wordSize - 1) / wordSize);
+}
+
+void hipdnn_ep_tensor_buffer_construct(void *storage) {
+  if (storage)
+    ::new (storage) TensorBuffer{};
+}
+
+void hipdnn_ep_tensor_free_inputs(RuntimeState *state, TensorBuffer **buffers,
+                                  size_t count) {
+  if (!buffers && count != 0)
+    return;
+  for (size_t i = 0; i < count; ++i)
+    hipdnn_ep_tensor_free_input(state, buffers[i]);
+}
+
+} // extern "C"

--- a/lib/Runtime/tensor_buffer_internal.h
+++ b/lib/Runtime/tensor_buffer_internal.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#ifndef HIPDNN_EP_RUNTIME_TENSOR_BUFFER_INTERNAL_H
+#define HIPDNN_EP_RUNTIME_TENSOR_BUFFER_INTERNAL_H
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+struct TensorBuffer {
+  void *gpu_ptr = nullptr;
+  void *host_ptr = nullptr;
+  int64_t *shape_ptr = nullptr;
+  size_t rank = 0;
+  size_t size_bytes = 0;
+  bool is_aliased = false;
+};
+
+static_assert(std::is_standard_layout_v<TensorBuffer>);
+static_assert(std::is_trivially_destructible_v<TensorBuffer>);
+
+#endif // HIPDNN_EP_RUNTIME_TENSOR_BUFFER_INTERNAL_H

--- a/morphizen/3rd-party/onnxruntime-morphizen-headers/morphizen/custom_op.h
+++ b/morphizen/3rd-party/onnxruntime-morphizen-headers/morphizen/custom_op.h
@@ -47,6 +47,9 @@ public:
   MORPHIZEN_DLL_SPEC virtual ~CustomOp();
 
 public:
+  // The void return is part of the stable plugin ABI. Implementations signal
+  // execution failure by throwing; the MorphiZen ORT callback catches every
+  // exception and returns a non-null OrtStatus to ORT.
   virtual void Compute(const OrtApi *api, OrtKernelContext *context) const = 0;
 };
 

--- a/morphizen/ort-bridge/ort-bridge.cmake
+++ b/morphizen/ort-bridge/ort-bridge.cmake
@@ -8,6 +8,7 @@ set(_ORT_BRIDGE_SOURCES
   src/api-ptrs.cpp
   src/ort-status-exception.hpp
   src/ort-status-exception.cpp
+  src/custom-op-compute-status.hpp
   src/ort-graph-wrapper.hpp
   src/ort-graph-wrapper.cpp
   src/morphizen-ep-factory.cpp

--- a/morphizen/ort-bridge/src/custom-op-compute-status.hpp
+++ b/morphizen/ort-bridge/src/custom-op-compute-status.hpp
@@ -6,11 +6,34 @@
 
 #include "onnxruntime_c_api.h"
 
+#include <exception>
 #include <stdexcept>
 #include <string>
 #include <utility>
 
 namespace morphizen::detail {
+
+// Carries the first exception out of a noexcept C callback. The owner rethrows
+// only after the foreign call returns and its generated cleanup has run.
+class DeferredComputeException {
+public:
+  void captureCurrent() noexcept {
+    if (!exception_)
+      exception_ = std::current_exception();
+  }
+
+  [[nodiscard]] bool hasValue() const noexcept {
+    return static_cast<bool>(exception_);
+  }
+
+  void rethrow() const {
+    if (exception_)
+      std::rethrow_exception(exception_);
+  }
+
+private:
+  std::exception_ptr exception_;
+};
 
 // CustomOp::Compute is a stable void-returning plugin ABI. Implementations
 // report execution failures by throwing; the ORT callback must translate every

--- a/morphizen/ort-bridge/src/custom-op-compute-status.hpp
+++ b/morphizen/ort-bridge/src/custom-op-compute-status.hpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#pragma once
+
+#include "onnxruntime_c_api.h"
+
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace morphizen::detail {
+
+// CustomOp::Compute is a stable void-returning plugin ABI. Implementations
+// report execution failures by throwing; the ORT callback must translate every
+// exception into an OrtStatus so none can cross the C ABI boundary.
+template <typename Compute>
+OrtStatus *translateComputeExceptions(const OrtApi &api,
+                                      Compute &&compute) noexcept {
+  try {
+    std::forward<Compute>(compute)();
+    return nullptr;
+  } catch (const std::exception &e) {
+    return api.CreateStatus(ORT_RUNTIME_EXCEPTION, e.what());
+  } catch (...) {
+    return api.CreateStatus(ORT_RUNTIME_EXCEPTION,
+                            "CustomOp::Compute failed with unknown exception");
+  }
+}
+
+[[noreturn]] inline void throwComputeFailure(const char *entryPoint, int code) {
+  throw std::runtime_error(std::string(entryPoint) +
+                           " failed with code: " + std::to_string(code));
+}
+
+} // namespace morphizen::detail

--- a/morphizen/ort-bridge/src/morphizen-ep.cpp
+++ b/morphizen/ort-bridge/src/morphizen-ep.cpp
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 #include "./morphizen-ep.hpp"
+#include "./custom-op-compute-status.hpp"
 #include "./ir-converter.hpp"
 #include "./morphizen-deps.hpp"
 #include "./ort-graph-wrapper.hpp"
@@ -543,9 +544,11 @@ OrtStatus *MorphiZenEP::CompileSubgraph(const morphizen::ExecutionProvider &ep,
            OrtKernelContext *kernel_context) -> OrtStatus * {
       auto self = static_cast<MorphiZenEP_ComputeInfo *>(this_ptr);
       (void)self;
-      static_cast<morphizen::CustomOp *>(compute_state)
-          ->Compute(&Ort::GetApi(), kernel_context);
-      return nullptr;
+      const OrtApi &api = Ort::GetApi();
+      return detail::translateComputeExceptions(api, [&] {
+        static_cast<morphizen::CustomOp *>(compute_state)
+            ->Compute(&api, kernel_context);
+      });
     };
     MY_LOG(2) << "CompileSubgraph: Successfully compiled subgraph";
     return nullptr;

--- a/test/lit/Conversion/hip-to-llvm/test_alloc_output.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_alloc_output.mlir
@@ -13,6 +13,8 @@
 //   dims come from the op's operands.
 // - The call signature is (state, out_idx, shape_ptr, rank, elem_size) -> ptr,
 //   with out_idx / rank / elem_size emitted as i64 constants.
+// - A null callback result records failure and returns before the descriptor is
+//   consumed.
 // - The returned generic (AS 0) pointer is addrspacecast to the memref's
 //   address space (AS 1) only when they differ; for a default-AS (AS 0) result
 //   no cast is emitted.
@@ -188,6 +190,14 @@ module {
     // CHECK-LABEL: llvm.func @alloc_then_sigmoid
     // CHECK:       %[[OUTIDX:.*]] = llvm.mlir.constant(29 : i64) : i64
     // CHECK:       %[[OUTRAW:.*]] = llvm.call @hipdnn_ep_alloc_output(%{{.*}}, %[[OUTIDX]], %{{.*}}, %{{.*}}, %{{.*}}) : (!llvm.ptr, i64, !llvm.ptr, i64, i64) -> !llvm.ptr
+    // CHECK:       %[[NULL:.*]] = llvm.mlir.zero : !llvm.ptr
+    // CHECK:       %[[HAS_OUTPUT:.*]] = llvm.icmp "ne" %[[OUTRAW]], %[[NULL]] : !llvm.ptr
+    // CHECK:       llvm.cond_br %[[HAS_OUTPUT]], ^[[SUCCESS:bb[0-9]+]], ^[[FAILURE:bb[0-9]+]]
+    // CHECK:       ^[[FAILURE]]:
+    // CHECK:       %[[FAILURE_STATUS:.*]] = llvm.mlir.constant(-1 : i32) : i32
+    // CHECK:       llvm.call @hipdnn_ep_state_record_status(%{{.*}}, %[[FAILURE_STATUS]])
+    // CHECK:       llvm.return
+    // CHECK:       ^[[SUCCESS]]:
     // CHECK:       %[[OUTCAST:.*]] = llvm.addrspacecast %[[OUTRAW]] : !llvm.ptr to !llvm.ptr<1>
     // CHECK:       llvm.insertvalue %[[OUTCAST]], %{{.*}}[1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
     // CHECK:       llvm.call @wrap_miopenActivationForward(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, i64, i64, i64) -> i32

--- a/test/lit/Conversion/hip-to-llvm/test_cast.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_cast.mlir
@@ -30,7 +30,8 @@ module {
     hip.cast(%ctx) ins(%input : memref<256x512xf32, 1>)
                    outs(%output : memref<256x512xf16, 1>) {to = 10 : i64}
 
-    // CHECK: llvm.call @wrap_cast({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64) -> i32
+    // CHECK: %[[STATUS:.*]] = llvm.call @wrap_cast({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64) -> i32
+    // CHECK-NEXT: llvm.call @hipdnn_ep_state_record_status({{.*}}, %[[STATUS]])
 
     return
   }

--- a/test/lit/Conversion/hip-to-llvm/test_gather_block_quantized.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_gather_block_quantized.mlir
@@ -90,7 +90,8 @@ module {
 }
 
 // CHECK-LABEL: llvm.func @test_gbq_static_with_zp
-// CHECK: llvm.call @wrap_gather_block_quantized({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
+// CHECK: %[[STATUS:.*]] = llvm.call @wrap_gather_block_quantized({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
+// CHECK-NEXT: llvm.call @hipdnn_ep_state_record_status({{.*}}, %[[STATUS]])
 
 // CHECK-LABEL: llvm.func @test_gbq_static_no_zp
 // CHECK: llvm.mlir.zero

--- a/test/lit/Conversion/hip-to-llvm/test_hipdnn_graph.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_hipdnn_graph.mlir
@@ -52,7 +52,8 @@ module {
     // CHECK:       llvm.store
     // CHECK:       llvm.store
 
-    // CHECK:       llvm.call @hipdnn_graph_execute({{.*}}) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i32
+    // CHECK:       %[[STATUS:.*]] = llvm.call @hipdnn_graph_execute({{.*}}) : (!llvm.ptr, i32, i32, !llvm.ptr, !llvm.ptr) -> i32
+    // CHECK-NEXT:  llvm.call @hipdnn_ep_state_record_status({{.*}}, %[[STATUS]])
 
     return
   }

--- a/test/lit/Conversion/hip-to-llvm/test_matmul_nbits.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_matmul_nbits.mlir
@@ -36,9 +36,10 @@ module {
   }
 
   // CHECK-LABEL: llvm.func @test_matmul_nbits_basic
-  // CHECK: llvm.call @wrap_matmul_nbits({{.*}}) :
+  // CHECK: %[[STATUS:.*]] = llvm.call @wrap_matmul_nbits({{.*}}) :
   // CHECK-SAME: (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
   // CHECK-SAME:  i64, i64, i64, i64, i64, i64, i64, i64) -> i32
+  // CHECK-NEXT: llvm.call @hipdnn_ep_state_record_status({{.*}}, %[[STATUS]])
   // Verify 17 parameters:
   // - 1 i32: op_state_slot (2nd arg; per-instance MatmulNbitsState; threaded by
   //          --assign-op-state-slots, replaces shared RuntimeState::zp_unpack_cache)

--- a/test/lit/Conversion/hip-to-llvm/test_memref_copy.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_memref_copy.mlir
@@ -26,7 +26,8 @@
 // identity-layout dense memrefs -> single `wrap_hipMemcpyAsync` call.
 //
 // CHECK-LABEL: llvm.func @copy_dense_2d
-// CHECK:         llvm.call @wrap_hipMemcpyAsync({{.*}}) :
+// CHECK:         %[[STATUS:.*]] = llvm.call @wrap_hipMemcpyAsync({{.*}}) :
+// CHECK-NEXT:    llvm.call @hipdnn_ep_state_record_status({{.*}}, %[[STATUS]])
 // CHECK-NOT:     llvm.call @memrefCopy
 // CHECK-NOT:     llvm.call @wrap_hipMemcpy2DAsync
 func.func @copy_dense_2d(%ctx: !hip.context,

--- a/test/lit/Conversion/hip-to-llvm/test_runtime_status_audit.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_runtime_status_audit.mlir
@@ -1,0 +1,18 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: not hip-mlir-opt --convert-hip-to-llvm %s 2>&1 | FileCheck %s
+
+// A future direct runtime call cannot bypass the shared status policy by
+// silently discarding an external i32 result.
+// CHECK: unused i32 result from 'unconsumed_status'
+
+module {
+  llvm.func @unconsumed_status(!llvm.ptr) -> i32
+
+  llvm.func @main_graph(%state: !llvm.ptr, %inputs: !llvm.ptr) -> i32 {
+    %unused = llvm.call @unconsumed_status(%state) : (!llvm.ptr) -> i32
+    %zero = llvm.mlir.constant(0 : i32) : i32
+    llvm.return %zero : i32
+  }
+}

--- a/test/lit/Conversion/hip-to-llvm/test_runtime_status_policy.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_runtime_status_policy.mlir
@@ -1,0 +1,48 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --convert-hip-to-llvm %s | FileCheck %s
+
+module {
+  llvm.func @wrap_already_recorded(!llvm.ptr) -> i32
+  llvm.func @hipdnn_ep_state_record_status(!llvm.ptr, i32) -> i32
+  llvm.func @read_scalar_i32(!llvm.ptr) -> i32
+  llvm.func @hipdnn_ep_loop_frame_destroy(!llvm.ptr) -> i32
+  llvm.func @hipdnn_ep_copy_output(!llvm.ptr) -> i32
+
+  // An existing recorder use remains singular.
+  // CHECK-LABEL: llvm.func @already_recorded
+  // CHECK: %[[STATUS:.*]] = llvm.call @wrap_already_recorded
+  // CHECK-NEXT: llvm.call @hipdnn_ep_state_record_status({{.*}}, %[[STATUS]])
+  // CHECK-NEXT: llvm.return
+  llvm.func @already_recorded(%state: !llvm.ptr) {
+    %status = llvm.call @wrap_already_recorded(%state) : (!llvm.ptr) -> i32
+    %recorded = llvm.call @hipdnn_ep_state_record_status(%state, %status)
+        : (!llvm.ptr, i32) -> i32
+    llvm.return
+  }
+
+  // A consumed i32 data value is not a status and remains untouched.
+  // CHECK-LABEL: llvm.func @consumed_data
+  // CHECK: %[[VALUE:.*]] = llvm.call @read_scalar_i32
+  // CHECK-NEXT: %{{.*}} = llvm.zext %[[VALUE]] : i32 to i64
+  llvm.func @consumed_data(%state: !llvm.ptr) -> i64 {
+    %value = llvm.call @read_scalar_i32(%state) : (!llvm.ptr) -> i32
+    %wide = llvm.zext %value : i32 to i64
+    llvm.return %wide : i64
+  }
+
+  // Later stack layers add these non-wrap status calls. They are part of the
+  // policy before those layers rebase onto this prerequisite.
+  // CHECK-LABEL: llvm.func @future_status_calls
+  // CHECK: %[[DESTROY:.*]] = llvm.call @hipdnn_ep_loop_frame_destroy
+  // CHECK-NEXT: llvm.call @hipdnn_ep_state_record_status({{.*}}, %[[DESTROY]])
+  // CHECK: %[[COPY:.*]] = llvm.call @hipdnn_ep_copy_output
+  // CHECK-NEXT: llvm.call @hipdnn_ep_state_record_status({{.*}}, %[[COPY]])
+  llvm.func @future_status_calls(%state: !llvm.ptr) {
+    %destroy =
+        llvm.call @hipdnn_ep_loop_frame_destroy(%state) : (!llvm.ptr) -> i32
+    %copy = llvm.call @hipdnn_ep_copy_output(%state) : (!llvm.ptr) -> i32
+    llvm.return
+  }
+}

--- a/test/lit/Conversion/hip-to-llvm/test_softmax.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_softmax.mlir
@@ -1,0 +1,21 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --convert-hip-to-llvm %s | FileCheck %s
+
+// The standalone Softmax runtime returns status. Its lowering must preserve
+// that i32 ABI and route the result through the shared recorder.
+// CHECK-LABEL: llvm.func @softmax_f16
+// CHECK: %[[STATUS:.*]] = llvm.call @hip_miopen_softmax({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64) -> i32
+// CHECK-NEXT: llvm.call @hipdnn_ep_state_record_status({{.*}}, %[[STATUS]])
+
+module {
+  func.func @softmax_f16(%ctx: !hip.context,
+                         %input: memref<2x4xf16, 1>,
+                         %output: memref<2x4xf16, 1>) {
+    hip.miopen.softmax(%ctx)
+        ins(%input : memref<2x4xf16, 1>)
+        outs(%output : memref<2x4xf16, 1>)
+    return
+  }
+}

--- a/test/lit/Transforms/GenerateInterface/test_basic_interface.mlir
+++ b/test/lit/Transforms/GenerateInterface/test_basic_interface.mlir
@@ -34,10 +34,28 @@
 // --- inference_compute stages inputs and calls main_graph (2-arg ABI) ---
 // CHECK-LABEL: llvm.func @inference_compute
 // CHECK-SAME:  -> i32
+// CHECK:   %[[ZERO64:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK:   %[[ONE64:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK:   %[[PREPARED_COUNT:.*]] = llvm.alloca %[[ONE64]] x i64
+// CHECK:   llvm.store %[[ZERO64]], %[[PREPARED_COUNT]]
+// CHECK:   %[[BUFFER_WORDS:.*]] = llvm.call @hipdnn_ep_tensor_buffer_storage_words() : () -> i64
+// CHECK:   llvm.alloca %[[BUFFER_WORDS]] x i64
+// CHECK-COUNT-3: llvm.call @hipdnn_ep_tensor_buffer_construct
 // CHECK:   llvm.call @hipdnn_ep_tensor_prepare_input
+// CHECK:   %[[ERROR_COUNT:.*]] = llvm.load %[[PREPARED_COUNT]]
+// CHECK:   llvm.call @hipdnn_ep_tensor_free_inputs({{.*}}, {{.*}}, %[[ERROR_COUNT]])
+// CHECK:   %[[PREPARED1:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK:   llvm.store %[[PREPARED1]], %[[PREPARED_COUNT]]
+// CHECK:   llvm.call @hipdnn_ep_tensor_prepare_input
+// CHECK:   %[[PREPARED2:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK:   llvm.store %[[PREPARED2]], %[[PREPARED_COUNT]]
+// CHECK:   llvm.call @hipdnn_ep_tensor_prepare_input
+// CHECK:   %[[PREPARED3:.*]] = llvm.mlir.constant(3 : i64) : i64
+// CHECK:   llvm.store %[[PREPARED3]], %[[PREPARED_COUNT]]
 // CHECK:   llvm.call @main_graph
 // CHECK:   llvm.call @hipdnn_ep_stream_sync
 // CHECK:   llvm.call @hipdnn_ep_state_read_and_clear_error_flag
+// CHECK:   llvm.call @hipdnn_ep_tensor_free_inputs
 
 // --- inference_cleanup calls state cleanup ---
 // CHECK-LABEL: llvm.func @inference_cleanup
@@ -49,9 +67,9 @@
 // CHECK:   llvm.mlir.addressof @__metadata_json
 
 module attributes {
-  hipdnn.input_count = 1 : i64,
-  hipdnn.input_shapes = [array<i64: 8>],
-  hipdnn.input_element_sizes = array<i64: 4>,
+  hipdnn.input_count = 3 : i64,
+  hipdnn.input_shapes = [array<i64: 8>, array<i64: 8>, array<i64: 8>],
+  hipdnn.input_element_sizes = array<i64: 4, 4, 4>,
   hipdnn.output_count = 1 : i64,
   hipdnn.output_shapes = [array<i64: 8>],
   hipdnn.output_element_sizes = array<i64: 4>,
@@ -60,7 +78,9 @@ module attributes {
   hipdnn.buffer_count = 0 : i64
 } {
   func.func @main_graph(%ctx: !hip.context,
-                        %in: memref<8xf32>) -> memref<8xf32> {
+                        %in0: memref<8xf32>,
+                        %in1: memref<8xf32>,
+                        %in2: memref<8xf32>) -> memref<8xf32> {
     %out = hip.alloc_output(%ctx) {out_idx = 0 : i64} : memref<8xf32>
     return %out : memref<8xf32>
   }

--- a/test/lit/Transforms/GenerateInterface/test_zero_input_cleanup.mlir
+++ b/test/lit/Transforms/GenerateInterface/test_zero_input_cleanup.mlir
@@ -1,0 +1,34 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --hip-to-llvm-pipeline %s | FileCheck %s
+
+// A zero-input graph constructs and prepares no TensorBuffer records. The
+// common cleanup call receives the zero prepared count and must not dereference
+// its zero-length pointer array.
+// CHECK-LABEL: llvm.func @inference_compute
+// CHECK: %[[PREPARED_ZERO:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK: llvm.store %[[PREPARED_ZERO]], %{{.*}}
+// CHECK: %[[ZERO:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT: %{{.*}} = llvm.alloca %[[ZERO]] x !llvm.ptr
+// CHECK-NOT: llvm.call @hipdnn_ep_tensor_buffer_construct
+// CHECK-NOT: llvm.call @hipdnn_ep_tensor_prepare_input
+// CHECK: llvm.call @main_graph
+// CHECK: llvm.call @hipdnn_ep_tensor_free_inputs({{.*}}, {{.*}}, %[[ZERO]])
+
+module attributes {
+  hipdnn.input_count = 0 : i64,
+  hipdnn.input_shapes = [],
+  hipdnn.input_element_sizes = array<i64>,
+  hipdnn.output_count = 1 : i64,
+  hipdnn.output_shapes = [array<i64: 1>],
+  hipdnn.output_element_sizes = array<i64: 4>,
+  hipdnn.pool_size = 0 : i64,
+  hipdnn.buffer_offsets = [],
+  hipdnn.buffer_count = 0 : i64
+} {
+  func.func @main_graph(%ctx: !hip.context) -> memref<1xf32> {
+    %out = hip.alloc_output(%ctx) {out_idx = 0 : i64} : memref<1xf32>
+    return %out : memref<1xf32>
+  }
+}

--- a/test/lit/e2e/test_output_allocator_model.mlir
+++ b/test/lit/e2e/test_output_allocator_model.mlir
@@ -14,9 +14,21 @@
 
 // RUN: hip-mlir-opt %s --hipdnn-pipeline 2>&1 | FileCheck %s
 
-// In-graph output allocation + 2-arg compute ABI.
-// CHECK: llvm.call @hipdnn_ep_alloc_output
-// CHECK: llvm.func @inference_compute(%{{[a-zA-Z0-9_]+}}: !llvm.ptr, %{{[a-zA-Z0-9_]+}}: !llvm.ptr) -> i32
+// A null callback result cannot reach the Sigmoid consumer. It records shared
+// status and returns from the internal graph; inference_compute observes that
+// status and still releases prepared inputs.
+// CHECK-LABEL: llvm.func private @main_graph_internal
+// CHECK: %[[OUTPUT:.*]] = llvm.call @hipdnn_ep_alloc_output
+// CHECK: %[[HAS_OUTPUT:.*]] = llvm.icmp "ne" %[[OUTPUT]], %{{.*}} : !llvm.ptr
+// CHECK: llvm.cond_br %[[HAS_OUTPUT]]
+// CHECK: llvm.call @hipdnn_ep_state_record_status
+// CHECK: llvm.return
+
+// CHECK-LABEL: llvm.func @inference_compute(%{{[a-zA-Z0-9_]+}}: !llvm.ptr, %{{[a-zA-Z0-9_]+}}: !llvm.ptr) -> i32
+// CHECK: llvm.call @hipdnn_ep_state_reset_error_flag
+// CHECK: llvm.call @main_graph
+// CHECK: llvm.call @hipdnn_ep_state_read_and_clear_error_flag
+// CHECK: llvm.call @hipdnn_ep_tensor_free_inputs
 
 module {
   func.func @main_graph(%arg0: tensor<4x8xf16> {onnx.name = "input"}) -> (tensor<4x8xf16> {onnx.name = "output"}) {

--- a/test/runtime/CMakeLists.txt
+++ b/test/runtime/CMakeLists.txt
@@ -36,3 +36,26 @@ target_compile_definitions(test-output-allocator PRIVATE HIPDNN_EP_RT_NO_EXPORT)
 add_test(NAME OutputAllocatorUnitTest COMMAND test-output-allocator)
 
 set_target_properties(test-output-allocator PROPERTIES FOLDER "runtime-tests")
+
+# Exercises the void CustomOp ABI's exception-to-OrtStatus boundary with a
+# generated-compute failure seam. The fake OrtApi needs only CreateStatus, so
+# this test executes without loading HIP or an ORT session.
+add_executable(test-custom-op-compute-status
+    test_custom_op_compute_status.cpp
+)
+
+target_compile_features(test-custom-op-compute-status PRIVATE cxx_std_17)
+
+target_include_directories(test-custom-op-compute-status PRIVATE
+    ${CMAKE_SOURCE_DIR}/morphizen/ort-bridge/src
+)
+
+target_link_libraries(test-custom-op-compute-status PRIVATE
+    onnxruntime::onnxruntime
+)
+
+add_test(NAME CustomOpComputeStatusUnitTest
+    COMMAND test-custom-op-compute-status)
+
+set_target_properties(test-custom-op-compute-status
+    PROPERTIES FOLDER "runtime-tests")

--- a/test/runtime/CMakeLists.txt
+++ b/test/runtime/CMakeLists.txt
@@ -59,3 +59,22 @@ add_test(NAME CustomOpComputeStatusUnitTest
 
 set_target_properties(test-custom-op-compute-status
     PROPERTIES FOLDER "runtime-tests")
+
+# Pins the opaque TensorBuffer storage/initialization ABI used by generated
+# inference cleanup. This source has no HIP dependency.
+add_executable(test-tensor-buffer-lifecycle
+    test_tensor_buffer_lifecycle.cpp
+    ${CMAKE_SOURCE_DIR}/lib/Runtime/tensor_buffer.cpp
+)
+
+target_compile_features(test-tensor-buffer-lifecycle PRIVATE cxx_std_17)
+
+target_include_directories(test-tensor-buffer-lifecycle PRIVATE
+    ${CMAKE_SOURCE_DIR}/lib/Runtime
+)
+
+add_test(NAME TensorBufferLifecycleUnitTest
+    COMMAND test-tensor-buffer-lifecycle)
+
+set_target_properties(test-tensor-buffer-lifecycle
+    PROPERTIES FOLDER "runtime-tests")

--- a/test/runtime/test_custom_op_compute_status.cpp
+++ b/test/runtime/test_custom_op_compute_status.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// GPU-free unit test for the CustomOp::Compute -> OrtStatus boundary.
+
+#include "custom-op-compute-status.hpp"
+
+#include <cstdio>
+#include <string>
+
+namespace {
+
+int gFailures = 0;
+
+#define CHECK(cond)                                                            \
+  do {                                                                         \
+    if (!(cond)) {                                                             \
+      std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);     \
+      ++gFailures;                                                             \
+    }                                                                          \
+  } while (0)
+
+struct FakeStatus {
+  OrtErrorCode code;
+  std::string message;
+};
+
+OrtStatus *ORT_API_CALL createStatus(OrtErrorCode code,
+                                     const char *message) noexcept {
+  return reinterpret_cast<OrtStatus *>(new FakeStatus{code, message});
+}
+
+FakeStatus *unwrap(OrtStatus *status) {
+  return reinterpret_cast<FakeStatus *>(status);
+}
+
+void release(OrtStatus *status) { delete unwrap(status); }
+
+OrtApi makeApi() {
+  OrtApi api{};
+  api.CreateStatus = &createStatus;
+  return api;
+}
+
+void testSuccessReturnsNull() {
+  const OrtApi api = makeApi();
+  bool called = false;
+  OrtStatus *status = morphizen::detail::translateComputeExceptions(
+      api, [&] { called = true; });
+  CHECK(called);
+  CHECK(status == nullptr);
+}
+
+void testGeneratedFailureReturnsStatus() {
+  const OrtApi api = makeApi();
+  OrtStatus *status = morphizen::detail::translateComputeExceptions(api, [] {
+    morphizen::detail::throwComputeFailure("inference_compute", 37);
+  });
+  CHECK(status != nullptr);
+  if (status) {
+    CHECK(unwrap(status)->code == ORT_RUNTIME_EXCEPTION);
+    CHECK(unwrap(status)->message == "inference_compute failed with code: 37");
+    release(status);
+  }
+}
+
+void testUnknownExceptionReturnsStatus() {
+  const OrtApi api = makeApi();
+  OrtStatus *status =
+      morphizen::detail::translateComputeExceptions(api, [] { throw 42; });
+  CHECK(status != nullptr);
+  if (status) {
+    CHECK(unwrap(status)->code == ORT_RUNTIME_EXCEPTION);
+    CHECK(unwrap(status)->message ==
+          "CustomOp::Compute failed with unknown exception");
+    release(status);
+  }
+}
+
+} // namespace
+
+int main() {
+  testSuccessReturnsNull();
+  testGeneratedFailureReturnsStatus();
+  testUnknownExceptionReturnsStatus();
+
+  if (gFailures != 0) {
+    std::fprintf(stderr, "%d check(s) failed\n", gFailures);
+    return 1;
+  }
+  std::puts("CustomOp compute status tests passed");
+  return 0;
+}

--- a/test/runtime/test_custom_op_compute_status.cpp
+++ b/test/runtime/test_custom_op_compute_status.cpp
@@ -79,12 +79,43 @@ void testUnknownExceptionReturnsStatus() {
   }
 }
 
+void testDeferredCallbackFailureReturnsStatusAfterCleanup() {
+  const OrtApi api = makeApi();
+  morphizen::detail::DeferredComputeException deferred;
+  bool cleanupRan = false;
+
+  try {
+    throw std::runtime_error("output allocator failed");
+  } catch (...) {
+    deferred.captureCurrent();
+  }
+  // The first callback failure is authoritative if later callbacks also fail.
+  try {
+    throw std::runtime_error("secondary failure");
+  } catch (...) {
+    deferred.captureCurrent();
+  }
+
+  OrtStatus *status = morphizen::detail::translateComputeExceptions(api, [&] {
+    cleanupRan = true;
+    deferred.rethrow();
+  });
+  CHECK(cleanupRan);
+  CHECK(status != nullptr);
+  if (status) {
+    CHECK(unwrap(status)->code == ORT_RUNTIME_EXCEPTION);
+    CHECK(unwrap(status)->message == "output allocator failed");
+    release(status);
+  }
+}
+
 } // namespace
 
 int main() {
   testSuccessReturnsNull();
   testGeneratedFailureReturnsStatus();
   testUnknownExceptionReturnsStatus();
+  testDeferredCallbackFailureReturnsStatusAfterCleanup();
 
   if (gFailures != 0) {
     std::fprintf(stderr, "%d check(s) failed\n", gFailures);

--- a/test/runtime/test_tensor_buffer_lifecycle.cpp
+++ b/test/runtime/test_tensor_buffer_lifecycle.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#include "hipdnn_ep_runtime.h"
+#include "tensor_buffer_internal.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+
+namespace {
+
+int failures = 0;
+TensorBuffer *released[3] = {};
+size_t releasedCount = 0;
+
+void check(bool condition, const char *message) {
+  if (!condition) {
+    std::fprintf(stderr, "FAIL: %s\n", message);
+    ++failures;
+  }
+}
+
+} // namespace
+
+extern "C" void hipdnn_ep_tensor_free_input(RuntimeState *,
+                                            TensorBuffer *buffer) {
+  released[releasedCount++] = buffer;
+}
+
+int main() {
+  const int64_t storageWords = hipdnn_ep_tensor_buffer_storage_words();
+  const int64_t expectedWords = static_cast<int64_t>(
+      (sizeof(TensorBuffer) + sizeof(int64_t) - 1) / sizeof(int64_t));
+  check(storageWords == expectedWords,
+        "runtime storage words must cover TensorBuffer");
+
+  auto storage = std::make_unique<int64_t[]>(static_cast<size_t>(storageWords));
+  std::memset(storage.get(), 0xa5,
+              static_cast<size_t>(storageWords) * sizeof(int64_t));
+  hipdnn_ep_tensor_buffer_construct(storage.get());
+
+  auto *buffer = reinterpret_cast<TensorBuffer *>(storage.get());
+  check(buffer->gpu_ptr == nullptr, "gpu_ptr must start null");
+  check(buffer->host_ptr == nullptr, "host_ptr must start null");
+  check(buffer->shape_ptr == nullptr, "shape_ptr must start null");
+  check(buffer->rank == 0, "rank must start zero");
+  check(buffer->size_bytes == 0, "size_bytes must start zero");
+  check(!buffer->is_aliased, "constructed buffer must own no alias");
+
+  TensorBuffer prefix[3] = {};
+  TensorBuffer *prefixPtrs[] = {&prefix[0], &prefix[1], &prefix[2]};
+  for (size_t count = 0; count <= 3; ++count) {
+    releasedCount = 0;
+    hipdnn_ep_tensor_free_inputs(nullptr, prefixPtrs, count);
+    check(releasedCount == count, "batch cleanup must release exact prefix");
+    for (size_t i = 0; i < count; ++i)
+      check(released[i] == prefixPtrs[i],
+            "batch cleanup must preserve prefix order");
+  }
+
+  releasedCount = 0;
+  hipdnn_ep_tensor_free_inputs(nullptr, nullptr, 0);
+  check(releasedCount == 0, "empty cleanup must not dereference its array");
+
+  return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Why

Generated `inference_compute` already returns an `i32` failure code, but the custom-op implementation previously only logged a nonzero result and continued through output validation, copying, profiling, and success reporting. The MorphiZen callback then returned a null `OrtStatus`, so ONNX Runtime could observe a failed generated invocation as successful execution.

`CustomOp::Compute` has a stable void-returning plugin ABI. Failures therefore need an explicit exception boundary that converts generated/runtime failures into a non-null ORT status without allowing an exception to cross the C callback ABI.

## IR example

The generated interface exposes the status that the runtime layer must preserve. The existing interface shape exercised by this change is:

```mlir
llvm.func @inference_compute(%state: !llvm.ptr, %inputs: !llvm.ptr) -> i32 {
  // Stage inputs and invoke the generated graph.
  llvm.call @main_graph(%state, %inputs) : (!llvm.ptr, !llvm.ptr) -> ()
  llvm.call @hipdnn_ep_stream_sync(%state) : (!llvm.ptr) -> ()
  %status = llvm.call @hipdnn_ep_state_read_and_clear_error_flag(%state)
      : (!llvm.ptr) -> i32
  llvm.return %status : i32
}
```

A nonzero `%status` now stops output processing, becomes a C++ failure at the stable void `Compute` boundary, and is translated into `ORT_RUNTIME_EXCEPTION` for ONNX Runtime.

## What changes

- Throw immediately when generated `inference_compute` returns a failure code.
- Catch both standard and unknown exceptions at the MorphiZen ORT compute callback.
- Convert every caught exception into a non-null `OrtStatus` with `ORT_RUNTIME_EXCEPTION`.
- Keep successful computes on the existing null-status path.
- Document the void custom-op ABI failure contract.
- Add a GPU-free unit test for success, generated failures, and unknown exceptions, and include it in the default test selection.

## Stack

1. [#688 — Constant carrier](https://github.com/ROCm/hip-ep/pull/688)
2. [#754 — i1 pool bytes](https://github.com/ROCm/hip-ep/pull/754)
3. [#756 — ORT error propagation](https://github.com/ROCm/hip-ep/pull/756) ← this PR
4. [#758 — output view contract](https://github.com/ROCm/hip-ep/pull/758)
5. [#755 — pool namespaces](https://github.com/ROCm/hip-ep/pull/755)
6. [#757 — host scratch namespaces](https://github.com/ROCm/hip-ep/pull/757)
7. [#724 — symbolic transport](https://github.com/ROCm/hip-ep/pull/724)
8. [#759 — artifact ABI](https://github.com/ROCm/hip-ep/pull/759)
9. [#639 — shape foundation](https://github.com/ROCm/hip-ep/pull/639)
10. [#681 — reshape provenance](https://github.com/ROCm/hip-ep/pull/681)
11. [#725 — broadcast activation](https://github.com/ROCm/hip-ep/pull/725)
12. [#763 — Softmax reuse](https://github.com/ROCm/hip-ep/pull/763)
13. [#640 — MatMul runtime](https://github.com/ROCm/hip-ep/pull/640)
14. [#734 — MatMul shapes](https://github.com/ROCm/hip-ep/pull/734)
15. [#641 — broadcast contracts](https://github.com/ROCm/hip-ep/pull/641)
16. [#735 — reduction conversion](https://github.com/ROCm/hip-ep/pull/735)
17. [#736 — reduction contracts](https://github.com/ROCm/hip-ep/pull/736)
18. [#689 — loop frame](https://github.com/ROCm/hip-ep/pull/689)
19. [#737 — shape-changing loops](https://github.com/ROCm/hip-ep/pull/737)
20. [#762 — loop bank recycling](https://github.com/ROCm/hip-ep/pull/762)
21. [#642 — grouped readback](https://github.com/ROCm/hip-ep/pull/642)
22. [#727 — payload shapes](https://github.com/ROCm/hip-ep/pull/727)
23. [#728 — Tile/Range](https://github.com/ROCm/hip-ep/pull/728)
24. [#729 — Slice normalization](https://github.com/ROCm/hip-ep/pull/729)
25. [#731 — Slice ABI](https://github.com/ROCm/hip-ep/pull/731)
26. [#733 — loop payload](https://github.com/ROCm/hip-ep/pull/733)
27. [#643 — Conv](https://github.com/ROCm/hip-ep/pull/643)
28. [#738 — Pool](https://github.com/ROCm/hip-ep/pull/738)
29. [#742 — CausalConv](https://github.com/ROCm/hip-ep/pull/742)
30. [#644 — Gather](https://github.com/ROCm/hip-ep/pull/644)
31. [#739 — GBQ](https://github.com/ROCm/hip-ep/pull/739)
32. [#645 — norm](https://github.com/ROCm/hip-ep/pull/645)
33. [#740 — attention](https://github.com/ROCm/hip-ep/pull/740)
34. [#741 — GQA capacity](https://github.com/ROCm/hip-ep/pull/741)
35. [#743 — GQA rejection](https://github.com/ROCm/hip-ep/pull/743)
36. [#646 — DPS contracts](https://github.com/ROCm/hip-ep/pull/646)
37. [#730 — inventory audit](https://github.com/ROCm/hip-ep/pull/730)
38. [#732 — converter audit](https://github.com/ROCm/hip-ep/pull/732)
39. [#647 — refinement](https://github.com/ROCm/hip-ep/pull/647)
40. [#761 — headers](https://github.com/ROCm/hip-ep/pull/761)
41. [#764 — cleanup](https://github.com/ROCm/hip-ep/pull/764)

## AI assistance

AI tools assisted with the implementation and description. The contributor reviewed the resulting code and tests.

Made-with: Cursor