### PR TITLE
fix(host-scratch): namespace storage by function site

### DIFF
--- a/docs/design/compiler-runtime-contract.md
+++ b/docs/design/compiler-runtime-contract.md
@@ -178,6 +178,11 @@ Pool planning is the canonical example:
 - `site_id` is the deterministic top-level function ordinal and `domain_id` is
   local to that function. The explicit pair prevents caller/outlined-helper
   pool collisions without relying on symbol-name hashes.
+- Each `hip.get_host_scratch` lowers to
+  `hipdnn_ep_get_host_scratch_base(state, site_id, needed_size)`. Distinct
+  function sites own distinct host-mapped allocations; production outlined
+  helpers are non-recursive and execute under the single-inference-per-state
+  contract.
 - None of the `hipdnn.pool_*` or `hipdnn.buffer_*` attributes are fields in the
   FlatBuffers schema or the JSON mirror.
 
@@ -185,8 +190,8 @@ The generated LLVM IR plus `RuntimeState` therefore carry pool behavior. See
 [pool-allocs-memory-planning.md](pool-allocs-memory-planning.md) for the
 attribute, lowering, grow-on-demand runtime contract, and stale-artifact
 invalidation requirement. Because the generated call ABI changed, cached model
-artifacts compiled against the old three-argument pool helper must be deleted
-and rebuilt with the matching runtime bitcode.
+artifacts compiled against the old pool helper or two-argument host-scratch
+helper must be deleted and rebuilt with the matching runtime bitcode.
 
 Input staging is another generated-code-only contract. `generate-interface`
 queries `hipdnn_ep_tensor_buffer_storage_words` and constructs every opaque

--- a/docs/design/pool-allocs-memory-planning.md
+++ b/docs/design/pool-allocs-memory-planning.md
@@ -253,7 +253,26 @@ the new runtime.
 
 `hip-materialize-host-scalars` selects static-shape integer/index allocations of at most 16 elements with host reads or writes, including accesses reachable through supported view/alias operations. Accepted descriptor-only and terminal users include memref dimension/deallocation operations, supported views, memref copies, reshape shape operands, and HIP operations.
 
-All selected allocations in a function share one `hip.get_host_scratch` buffer. Their offsets are aligned to 64 bytes, independently of PoolAllocs' default 256-byte alignment.
+All selected allocations in a function share one `hip.get_host_scratch` buffer.
+Their offsets are aligned to 64 bytes, independently of PoolAllocs' default
+256-byte alignment. The op carries the same deterministic top-level function
+ordinal used for pool sites, and lowers to:
+
+```c
+void *hipdnn_ep_get_host_scratch_base(RuntimeState *state,
+                                      int site_id,
+                                      size_t needed_size);
+```
+
+Each site owns distinct host-mapped storage. Caller and outlined-helper local
+offset zero therefore cannot collide, and growing a helper site synchronizes
+the stream before replacing only that site's allocation.
+
+`RuntimeState` supports one inference at a time. Recursive or reentrant entry
+into the same compiled function reuses that function's site and is unsupported;
+current production outlined helpers are non-recursive and execute serially.
+The changed generated-call ABI also requires stale cached model artifacts to be
+deleted and rebuilt.
 
 Functions without `!hip.context` as argument zero are skipped.
 

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -288,15 +288,20 @@ def Hip_GetHostScratchOp : Hip_Op<"get_host_scratch",
     GPU-readable. Used by hip-materialize-host-scalars to redirect tiny
     host-fed memref.alloc ops away from the GPU pool (which on some targets
     is real device memory and SEGVs on host stores). Grow-on-demand semantics
-    mirror hip.get_pool.
+    mirror hip.get_pool. The optional `site_id` is the deterministic
+    module-local ordinal of the containing function. Distinct sites have
+    distinct backing allocations, so an outlined helper cannot overwrite or
+    grow its caller's live scratch.
 
     Example:
     ```mlir
-    %scratch = hip.get_host_scratch(%ctx, %size) : memref<?xi8>
+    %scratch = hip.get_host_scratch(%ctx, %size)
+        {site_id = 4 : i64} : memref<?xi8>
     ```
   }];
 
-  let arguments = (ins Hip_ContextType:$ctx, Index:$scratch_size);
+  let arguments = (ins Hip_ContextType:$ctx, Index:$scratch_size,
+                       DefaultValuedAttr<I64Attr, "0">:$site_id);
   let results = (outs AnyMemRef:$scratch);
   let assemblyFormat = "`(` $ctx `,` $scratch_size `)` attr-dict `:` type($scratch)";
 }

--- a/lib/Conversion/HipToLLVM/MemoryLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MemoryLowering.cpp
@@ -188,8 +188,10 @@ struct GetPoolOpLowering : public ConvertOpToLLVMPattern<GetPoolOp> {
   }
 };
 
-// --- GetHostScratchOp: hip.get_host_scratch(%ctx, %scratch_size) :memref<?xi8>
-//     -> llvm.call @hipdnn_ep_get_host_scratch_base(state, size) + descriptor.
+// --- GetHostScratchOp:
+//     hip.get_host_scratch(%ctx, %scratch_size) {site_id = S} : memref<?xi8>
+//       -> llvm.call @hipdnn_ep_get_host_scratch_base(state, S, size)
+//          + descriptor.
 // The runtime returns hipHostMalloc(hipHostMallocMapped) memory, which is
 // accessible from both host and device. The result memref uses the default
 // address space (AS 0) — so host stores from materialized scalars work, and
@@ -205,19 +207,24 @@ struct GetHostScratchOpLowering
     Location loc = op.getLoc();
     ModuleOp module = op->getParentOfType<ModuleOp>();
     Type ptrType = getPtrType();
+    Type i32Type = rewriter.getI32Type();
     Type i64Type = rewriter.getI64Type();
     MemRefType memRefType = cast<MemRefType>(op.getScratch().getType());
 
-    FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
-        rewriter, module, kHipGetHostScratch, {ptrType, i64Type}, ptrType);
+    FailureOr<LLVM::LLVMFuncOp> funcOp =
+        LLVM::lookupOrCreateFn(rewriter, module, kHipGetHostScratch,
+                               {ptrType, i32Type, i64Type}, ptrType);
     if (failed(funcOp))
       return failure();
 
     Value scratchSize = adaptor.getScratchSize();
-    Value rawPtr =
-        LLVM::CallOp::create(rewriter, loc, *funcOp,
-                             ValueRange{adaptor.getCtx(), scratchSize})
-            .getResult();
+    Value siteIdVal = LLVM::ConstantOp::create(
+        rewriter, loc, i32Type,
+        rewriter.getI32IntegerAttr(static_cast<int32_t>(op.getSiteId())));
+    Value rawPtr = LLVM::CallOp::create(
+                       rewriter, loc, *funcOp,
+                       ValueRange{adaptor.getCtx(), siteIdVal, scratchSize})
+                       .getResult();
 
     FailureOr<unsigned> addrSpace =
         getTypeConverter()->getMemRefAddressSpace(memRefType);

--- a/lib/Dialect/Transforms/MaterializeHostScalars.cpp
+++ b/lib/Dialect/Transforms/MaterializeHostScalars.cpp
@@ -8,7 +8,7 @@
 // host-fed scalar staging buffers -- small static-shape, integer-or-index
 // memrefs that have at least one host I/O user (memref.store / load) --
 // away from the GPU pool.  Each candidate is replaced by a `memref.view`
-// over a single per-function `hip.get_host_scratch(%ctx, %total)` buffer
+// over a single per-function-site `hip.get_host_scratch(%ctx, %total)` buffer
 // (host-mapped via `hipHostMalloc(hipHostMallocMapped)`, GPU-readable at
 // the same VA on UMA targets, runtime-owned, grow-on-demand).
 //
@@ -34,7 +34,8 @@
 // After (alloc replaced by a view into the per-function host scratch buffer):
 //
 //   %total   = arith.constant 8 : index              // 1 elem * 8 bytes (i64)
-//   %scratch = hip.get_host_scratch(%ctx, %total) : memref<?xi8>
+//   %scratch = hip.get_host_scratch(%ctx, %total)
+//                  {site_id = <module function ordinal>} : memref<?xi8>
 //   %c0      = arith.constant 0 : index
 //   %view    = memref.view %scratch[%c0][] : memref<?xi8> to memref<i64>
 //   %c0_i64  = arith.constant 0 : i64
@@ -99,10 +100,12 @@
 //     Utility functions and pre-context-arg passes don't have access to
 //     the runtime scratch handle; the pass is a best-effort mitigation,
 //     not a correctness requirement on every function.
-//   - Cross-function scratch coalescing: each function gets its own
-//     `hip.get_host_scratch` allocation.  The runtime pool is
-//     grow-on-demand and amortizes over the model's lifetime;
-//     cross-function pooling would need a different mechanism.
+//   - Cross-function scratch coalescing: each function gets a deterministic
+//     site ID and distinct runtime storage. This is required while outlined
+//     helpers execute with caller scratch still live.
+//   - Recursive/reentrant execution of the SAME compiled function: a site is
+//     reused by design. Production outlined helpers are non-recursive and
+//     RuntimeState permits one inference at a time.
 //   - Pipeline placement after `hip-pool-allocs`: this pass MUST run
 //     before `hip-pool-allocs`, otherwise candidates have already been
 //     rewritten as views into the GPU pool and the host-mapping rewrite
@@ -134,6 +137,23 @@ namespace hip {
 #include "hip/Dialect/Transforms/Passes.h.inc"
 
 namespace {
+
+/// Return this function's deterministic ordinal among top-level module
+/// functions. Symbol-table order is stable and function symbols are unique, so
+/// the ordinal is collision-free without hashing names.
+static FailureOr<int64_t> getFunctionSiteId(func::FuncOp funcOp) {
+  ModuleOp moduleOp = funcOp->getParentOfType<ModuleOp>();
+  if (!moduleOp)
+    return failure();
+
+  int64_t siteId = 0;
+  for (func::FuncOp candidate : moduleOp.getOps<func::FuncOp>()) {
+    if (candidate == funcOp)
+      return siteId;
+    ++siteId;
+  }
+  return failure();
+}
 
 // Round \p x up to a multiple of \p align (align must be a power of two).
 static int64_t roundUp(int64_t x, int64_t align) {
@@ -223,6 +243,13 @@ void MaterializeHostScalarsPass::runOnOperation() {
   func::FuncOp funcOp = getOperation();
   if (funcOp.empty())
     return;
+  FailureOr<int64_t> functionSiteId = getFunctionSiteId(funcOp);
+  if (failed(functionSiteId)) {
+    funcOp.emitError(
+        "hip-materialize-host-scalars: function must be a top-level module "
+        "symbol");
+    return signalPassFailure();
+  }
 
   // Need !hip.context as arg 0 to call hip.get_host_scratch. If absent (e.g.
   // utility funcs or pre-context-arg passes), silently skip — we're a
@@ -275,7 +302,8 @@ void MaterializeHostScalarsPass::runOnOperation() {
   auto scratchType =
       MemRefType::get({ShapedType::kDynamic}, builder.getIntegerType(8));
   Value scratch =
-      GetHostScratchOp::create(builder, loc, scratchType, ctx, totalSize);
+      GetHostScratchOp::create(builder, loc, scratchType, ctx, totalSize,
+                               builder.getI64IntegerAttr(*functionSiteId));
 
   // Replace each candidate with a memref.view over the scratch buffer.
   // Deallocs of the candidate are erased — the scratch buffer is owned by

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -356,15 +356,19 @@ void *hipdnn_ep_get_buffer_from_pool(RuntimeState *state, size_t index);
 void *hipdnn_ep_get_pool_base(RuntimeState *state, int site_id, int domain_id,
                               size_t needed_size);
 
-// Get the host-mapped scratch buffer base, growing it if needed. Called from
-// hip.get_host_scratch (emitted by hip-materialize-host-scalars) once per
-// inference for tiny host-fed scalar memrefs that would otherwise land in the
-// GPU pool. Memory is hipHostMalloc(hipHostMallocMapped) - host-writable AND
-// GPU-readable via the device pointer mapping. Grow semantics mirror
-// hipdnn_ep_get_pool_base: stream-synced hipHostFree + hipHostMalloc; never
-// shrinks.
+// Get one compiled function site's host-mapped scratch base, growing it if
+// needed. `site_id` is the deterministic module-local function ordinal emitted
+// by hip-materialize-host-scalars. Distinct sites own distinct allocations, so
+// caller/helper offset zero cannot collide and helper growth cannot invalidate
+// the caller. Memory is hipHostMalloc(hipHostMallocMapped), host-writable and
+// GPU-readable. Growth remains stream-synchronized and never shrinks.
+//
+// RuntimeState is not thread-safe, and recursive/reentrant entry into the same
+// compiled function reuses that function's site. Production outlined helpers
+// are non-recursive and execute serially; same-site recursion is unsupported.
 // Returns: host-mapped base pointer (NULL on allocation failure)
-void *hipdnn_ep_get_host_scratch_base(RuntimeState *state, size_t needed_size);
+void *hipdnn_ep_get_host_scratch_base(RuntimeState *state, int site_id,
+                                      size_t needed_size);
 
 // Shared workspace management (lazily grown, reused across MatMul/GQA/Conv)
 void *hipdnn_ep_state_get_workspace(RuntimeState *state);

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -158,8 +158,8 @@ static int initialize_state_handles(RuntimeState **out_state) {
   state->num_buffers = 0;
   state->workspace = nullptr;
   state->workspace_size = 0;
-  state->host_scratch_base = nullptr;
-  state->host_scratch_size = 0;
+  state->num_host_scratch_sites = 0;
+  state->host_scratch_sites = nullptr;
   // Start with no output allocator (null context + callback). The EP installs
   // one via hipdnn_ep_set_output_allocator before the first inference_compute,
   // and hipdnn_ep_alloc_output then forwards each graph-output request to it.
@@ -773,10 +773,16 @@ int hipdnn_ep_state_cleanup(RuntimeState *state) {
     HIP_CLEANUP(hipFree(state->device_error_flag));
   }
 
-  // Free host-mapped scratch buffer (if allocated)
-  if (state->host_scratch_base) {
-    HIP_CLEANUP(hipHostFree(state->host_scratch_base));
+  // Free each function site's host-mapped scratch buffer and the site table.
+  if (state->host_scratch_sites) {
+    for (int site_id = 0; site_id < state->num_host_scratch_sites; ++site_id) {
+      if (state->host_scratch_sites[site_id].base)
+        HIP_CLEANUP(hipHostFree(state->host_scratch_sites[site_id].base));
+    }
+    free(state->host_scratch_sites);
+    state->host_scratch_sites = nullptr;
   }
+  state->num_host_scratch_sites = 0;
 
   // Free every module-site/function-domain pool and then both table levels.
   if (state->pool_sites) {
@@ -1150,51 +1156,71 @@ void *hipdnn_ep_get_pool_base(RuntimeState *state, int site_id, int domain_id,
   return site.pool_base[domain_id];
 }
 
-#ifdef HIPDNN_EP_POOL_UNIT_TEST
-} // extern "C"
-#else
-void *hipdnn_ep_get_host_scratch_base(RuntimeState *state, size_t needed_size) {
+void *hipdnn_ep_get_host_scratch_base(RuntimeState *state, int site_id,
+                                      size_t needed_size) {
   if (!state) {
     fprintf(stderr,
             "Invalid state parameter to hipdnn_ep_get_host_scratch_base\n");
     return nullptr;
   }
-  // Mirrors hipdnn_ep_get_pool_base growth semantics for the host-mapped
-  // scratch buffer that backs hip.get_host_scratch. One allocation per
-  // function for all tiny host-fed scalars routed away from the GPU pool by
-  // hip-materialize-host-scalars; grown only when shape changes increase the
-  // total demand; never shrinks. hipHostMalloc(hipHostMallocMapped) memory is
-  // host-writable AND GPU-readable via the device pointer mapping, so the
-  // same pointer can be stored into from host code and then read by
-  // subsequent GPU kernels.
-  if (needed_size > state->host_scratch_size) {
-    if (state->host_scratch_base) {
+  if (site_id < 0) {
+    fprintf(stderr, "hipdnn_ep_get_host_scratch_base: negative site_id %d\n",
+            site_id);
+    return nullptr;
+  }
+  if (site_id >= state->num_host_scratch_sites) {
+    int needed_count = site_id + 1;
+    auto *new_sites = static_cast<RuntimeHostScratchSite *>(
+        realloc(state->host_scratch_sites,
+                sizeof(RuntimeHostScratchSite) * needed_count));
+    if (!new_sites) {
+      fprintf(stderr, "Failed to grow host scratch site array to %d sites\n",
+              needed_count);
+      return nullptr;
+    }
+    state->host_scratch_sites = new_sites;
+    for (int i = state->num_host_scratch_sites; i < needed_count; ++i) {
+      state->host_scratch_sites[i].base = nullptr;
+      state->host_scratch_sites[i].size = 0;
+    }
+    state->num_host_scratch_sites = needed_count;
+  }
+
+  RuntimeHostScratchSite &site = state->host_scratch_sites[site_id];
+  if (needed_size == 0)
+    needed_size = 1;
+  if (needed_size > site.size) {
+    if (site.base) {
       if (state->stream)
         HIP_CLEANUP(hipStreamSynchronize(state->stream));
       fprintf(stderr,
-              "hipdnn_ep_get_host_scratch_base: growing host scratch "
+              "hipdnn_ep_get_host_scratch_base: growing host scratch[%d] "
               "%zu -> %zu bytes (rare; first time this large)\n",
-              state->host_scratch_size, needed_size);
+              site_id, site.size, needed_size);
       fflush(stderr);
-      HIP_CLEANUP(hipHostFree(state->host_scratch_base));
+      HIP_CLEANUP(hipHostFree(site.base));
     }
     void *new_base = nullptr;
     if (hipHostMalloc(&new_base, needed_size, hipHostMallocMapped) !=
         hipSuccess) {
       fprintf(stderr,
-              "hipdnn_ep_get_host_scratch_base: hipHostMalloc failed "
+              "hipdnn_ep_get_host_scratch_base: hipHostMalloc failed for "
+              "site[%d] "
               "(%zu -> %zu bytes)\n",
-              state->host_scratch_size, needed_size);
-      state->host_scratch_base = nullptr;
-      state->host_scratch_size = 0;
+              site_id, site.size, needed_size);
+      site.base = nullptr;
+      site.size = 0;
       return nullptr;
     }
-    state->host_scratch_base = new_base;
-    state->host_scratch_size = needed_size;
+    site.base = new_base;
+    site.size = needed_size;
   }
-  return state->host_scratch_base;
+  return site.base;
 }
 
+#ifdef HIPDNN_EP_POOL_UNIT_TEST
+} // extern "C"
+#else
 //===----------------------------------------------------------------------===//
 // Shared Workspace Support
 //===----------------------------------------------------------------------===//

--- a/lib/Runtime/runtime_state_internal.h
+++ b/lib/Runtime/runtime_state_internal.h
@@ -33,6 +33,11 @@ struct RuntimePoolSite {
   size_t *pool_size;
 };
 
+struct RuntimeHostScratchSite {
+  void *base;
+  size_t size;
+};
+
 // Internal runtime state structure
 // This struct is opaque to generated code (passed as void*)
 struct RuntimeState {
@@ -68,16 +73,15 @@ struct RuntimeState {
   void *workspace;
   size_t workspace_size;
 
-  // Host-mapped scratch buffer for tiny host-fed scalars routed away from the
-  // GPU pool by hip-materialize-host-scalars.
+  // Per-function-site host-mapped scratch buffers for tiny host-fed scalars
+  // routed away from the GPU pool by hip-materialize-host-scalars.
   // hipHostMalloc(hipHostMallocMapped): host-writable AND GPU-readable.
   // Grow-on-demand via hipdnn_ep_get_host_scratch_base(); never shrinks.
-  // hipHostFree'd in cleanup. Why: on some targets the regular GPU pool is
-  // real device memory; host stores into it SEGV. Other targets silently
-  // worked because hipMalloc returned UMA-mapped host memory there, masking
-  // the bug.
-  void *host_scratch_base;
-  size_t host_scratch_size;
+  // Distinct compiled functions have disjoint storage, so a helper cannot
+  // invalidate its caller's live offset-zero scalar while growing. The table
+  // is hipHostFree'd in cleanup.
+  int num_host_scratch_sites;
+  RuntimeHostScratchSite *host_scratch_sites;
 
   // Output allocator installed by the EP before inference_compute via
   // hipdnn_ep_set_output_allocator. hipdnn_ep_alloc_output forwards to

--- a/test/lit/Dialect/hip-host-scratch-module-sites.mlir
+++ b/test/lit/Dialect/hip-host-scratch-module-sites.mlir
@@ -1,0 +1,35 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+// RUN: hip-mlir-opt --hip-materialize-host-scalars %s | FileCheck %s
+// RUN: hip-mlir-opt --hip-materialize-host-scalars --convert-hip-to-llvm %s \
+// RUN:   | FileCheck %s --check-prefix=LLVM
+//
+// Both functions use local scratch offset zero. Their module-site identities
+// must differ so an outlined helper cannot overwrite its caller's live scalar.
+
+// CHECK-LABEL: func.func @caller
+// CHECK: %[[CALLER:.*]] = hip.get_host_scratch({{.*}}) : memref<?xi8>
+// CHECK: memref.view %[[CALLER]][%{{.*}}][] : memref<?xi8> to memref<i64>
+// LLVM-LABEL: llvm.func @caller
+// LLVM: %[[SITE0:.*]] = llvm.mlir.constant(0 : i32) : i32
+// LLVM: llvm.call @hipdnn_ep_get_host_scratch_base({{.*}}, %[[SITE0]], {{.*}}) : (!llvm.ptr, i32, i64) -> !llvm.ptr
+func.func @caller(%ctx: !hip.context, %x: i64) -> i64 {
+  %tmp = memref.alloc() : memref<i64>
+  memref.store %x, %tmp[] : memref<i64>
+  %value = memref.load %tmp[] : memref<i64>
+  return %value : i64
+}
+
+// CHECK-LABEL: func.func @outlined_helper
+// CHECK: %[[HELPER:.*]] = hip.get_host_scratch({{.*}}) {site_id = 1 : i64} : memref<?xi8>
+// CHECK: memref.view %[[HELPER]][%{{.*}}][] : memref<?xi8> to memref<i64>
+// LLVM-LABEL: llvm.func @outlined_helper
+// LLVM: %[[SITE1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// LLVM: llvm.call @hipdnn_ep_get_host_scratch_base({{.*}}, %[[SITE1]], {{.*}}) : (!llvm.ptr, i32, i64) -> !llvm.ptr
+func.func @outlined_helper(%ctx: !hip.context, %x: i64) -> i64 {
+  %tmp = memref.alloc() : memref<i64>
+  memref.store %x, %tmp[] : memref<i64>
+  %value = memref.load %tmp[] : memref<i64>
+  return %value : i64
+}

--- a/test/runtime/CMakeLists.txt
+++ b/test/runtime/CMakeLists.txt
@@ -37,9 +37,9 @@ add_test(NAME OutputAllocatorUnitTest COMMAND test-output-allocator)
 
 set_target_properties(test-output-allocator PROPERTIES FOLDER "runtime-tests")
 
-# Compiles only the pool-site portion of runtime_state.cpp against tiny mock HIP
-# allocation functions. This directly proves that caller/helper local domain
-# zero map to distinct pointers and child growth leaves the parent live.
+# Compiles only the pool/host-scratch site portion of runtime_state.cpp against
+# tiny mock HIP allocation functions. This directly proves caller/helper local
+# zero identities map to distinct pointers and child growth leaves parents live.
 add_executable(test-pool-sites
     test_pool_sites.cpp
     ${CMAKE_SOURCE_DIR}/lib/Runtime/hipdnn_ep_runtime_state.cpp

--- a/test/runtime/test_pool_sites.cpp
+++ b/test/runtime/test_pool_sites.cpp
@@ -22,6 +22,16 @@ extern "C" hipError_t hipFree(void *ptr) {
   return hipSuccess;
 }
 
+extern "C" hipError_t hipHostMalloc(void **ptr, size_t size, unsigned int) {
+  *ptr = std::malloc(size);
+  return *ptr ? hipSuccess : -1;
+}
+
+extern "C" hipError_t hipHostFree(void *ptr) {
+  std::free(ptr);
+  return hipSuccess;
+}
+
 extern "C" hipError_t hipStreamSynchronize(hipStream_t) {
   ++sync_count;
   return hipSuccess;
@@ -46,6 +56,20 @@ int main() {
     assert(static_cast<unsigned char *>(parent)[i] == 0x5a);
   assert(sync_count == 1);
 
+  void *parent_scratch = hipdnn_ep_get_host_scratch_base(&state, 0, 64);
+  void *child_scratch = hipdnn_ep_get_host_scratch_base(&state, 1, 32);
+  assert(parent_scratch != nullptr);
+  assert(child_scratch != nullptr);
+  assert(parent_scratch != child_scratch);
+
+  std::memset(parent_scratch, 0xa5, 64);
+  void *grown_child_scratch = hipdnn_ep_get_host_scratch_base(&state, 1, 128);
+  assert(grown_child_scratch != nullptr);
+  assert(state.host_scratch_sites[0].base == parent_scratch);
+  for (size_t i = 0; i < 64; ++i)
+    assert(static_cast<unsigned char *>(parent_scratch)[i] == 0xa5);
+  assert(sync_count == 2);
+
   for (int site_id = 0; site_id < state.num_pool_sites; ++site_id) {
     RuntimePoolSite &site = state.pool_sites[site_id];
     for (int domain_id = 0; domain_id < site.num_domains; ++domain_id)
@@ -54,5 +78,8 @@ int main() {
     std::free(site.pool_size);
   }
   std::free(state.pool_sites);
+  for (int site_id = 0; site_id < state.num_host_scratch_sites; ++site_id)
+    std::free(state.host_scratch_sites[site_id].base);
+  std::free(state.host_scratch_sites);
   return 0;
 }


### PR DESCRIPTION
## Why

`hip-materialize-host-scalars` coalesces each function's tiny host-fed allocations into local offsets within one scratch view, but the runtime previously exposed one model-global host-scratch allocation. A caller and an outlined helper could both use offset zero, so the helper could overwrite the caller's live scalar. Growing the helper's scratch could also free and replace the backing allocation beneath the caller.

Host scratch must be namespaced by the same deterministic function-site identity as transient pools. Each function can then retain local offset packing without aliasing another function's live storage.

## IR example

The focused test uses local scratch offset zero in both the caller and helper:

```mlir
func.func @caller(%ctx: !hip.context, %x: i64) -> i64 {
  %tmp = memref.alloc() : memref<i64>
  memref.store %x, %tmp[] : memref<i64>
  %value = memref.load %tmp[] : memref<i64>
  return %value : i64
}

func.func @outlined_helper(%ctx: !hip.context, %x: i64) -> i64 {
  %tmp = memref.alloc() : memref<i64>
  memref.store %x, %tmp[] : memref<i64>
  %value = memref.load %tmp[] : memref<i64>
  return %value : i64
}
```

After materialization, their scratch requests carry distinct module-function sites before lowering to the three-argument runtime helper:

```mlir
// @caller: default site 0
%caller = hip.get_host_scratch(%ctx, %caller_size) : memref<?xi8>

// @outlined_helper: site 1
%helper = hip.get_host_scratch(%ctx, %helper_size)
    {site_id = 1 : i64} : memref<?xi8>
```

## What changes

- Add a deterministic module-function `site_id` to `hip.get_host_scratch` and assign it during host-scalar materialization.
- Lower scratch requests to `hipdnn_ep_get_host_scratch_base(state, site_id, needed_size)`.
- Maintain one grow-on-demand host-mapped allocation per function site and synchronize only when replacing that site's storage.
- Clean up every per-site scratch allocation and its table during runtime teardown.
- Cover distinct caller/helper pointers and helper-growth isolation in focused LIT and GPU-free runtime tests.
- Document the single-inference, non-recursive function-site contract and stale-artifact implications of the generated-call ABI change.

## Stack

1. [#688 — Constant carrier](https://github.com/ROCm/hip-ep/pull/688)
2. [#754 — i1 pool bytes](https://github.com/ROCm/hip-ep/pull/754)
3. [#756 — ORT error propagation](https://github.com/ROCm/hip-ep/pull/756)
4. [#758 — output view contract](https://github.com/ROCm/hip-ep/pull/758)
5. [#755 — pool namespaces](https://github.com/ROCm/hip-ep/pull/755)
6. [#757 — host scratch namespaces](https://github.com/ROCm/hip-ep/pull/757) ← this PR
7. [#724 — symbolic transport](https://github.com/ROCm/hip-ep/pull/724)
8. [#759 — artifact ABI](https://github.com/ROCm/hip-ep/pull/759)
9. [#639 — shape foundation](https://github.com/ROCm/hip-ep/pull/639)
10. [#681 — reshape provenance](https://github.com/ROCm/hip-ep/pull/681)
11. [#725 — broadcast activation](https://github.com/ROCm/hip-ep/pull/725)
12. [#763 — Softmax reuse](https://github.com/ROCm/hip-ep/pull/763)
13. [#640 — MatMul runtime](https://github.com/ROCm/hip-ep/pull/640)
14. [#734 — MatMul shapes](https://github.com/ROCm/hip-ep/pull/734)
15. [#641 — broadcast contracts](https://github.com/ROCm/hip-ep/pull/641)
16. [#735 — reduction conversion](https://github.com/ROCm/hip-ep/pull/735)
17. [#736 — reduction contracts](https://github.com/ROCm/hip-ep/pull/736)
18. [#689 — loop frame](https://github.com/ROCm/hip-ep/pull/689)
19. [#737 — shape-changing loops](https://github.com/ROCm/hip-ep/pull/737)
20. [#762 — loop bank recycling](https://github.com/ROCm/hip-ep/pull/762)
21. [#642 — grouped readback](https://github.com/ROCm/hip-ep/pull/642)
22. [#727 — payload shapes](https://github.com/ROCm/hip-ep/pull/727)
23. [#728 — Tile/Range](https://github.com/ROCm/hip-ep/pull/728)
24. [#729 — Slice normalization](https://github.com/ROCm/hip-ep/pull/729)
25. [#731 — Slice ABI](https://github.com/ROCm/hip-ep/pull/731)
26. [#733 — loop payload](https://github.com/ROCm/hip-ep/pull/733)
27. [#643 — Conv](https://github.com/ROCm/hip-ep/pull/643)
28. [#738 — Pool](https://github.com/ROCm/hip-ep/pull/738)
29. [#742 — CausalConv](https://github.com/ROCm/hip-ep/pull/742)
30. [#644 — Gather](https://github.com/ROCm/hip-ep/pull/644)
31. [#739 — GBQ](https://github.com/ROCm/hip-ep/pull/739)
32. [#645 — norm](https://github.com/ROCm/hip-ep/pull/645)
33. [#740 — attention](https://github.com/ROCm/hip-ep/pull/740)
34. [#741 — GQA capacity](https://github.com/ROCm/hip-ep/pull/741)
35. [#743 — GQA rejection](https://github.com/ROCm/hip-ep/pull/743)
36. [#646 — DPS contracts](https://github.com/ROCm/hip-ep/pull/646)
37. [#730 — inventory audit](https://github.com/ROCm/hip-ep/pull/730)
38. [#732 — converter audit](https://github.com/ROCm/hip-ep/pull/732)
39. [#647 — refinement](https://github.com/ROCm/hip-ep/pull/647)
40. [#761 — headers](https://github.com/ROCm/hip-ep/pull/761)
41. [#764 — cleanup](https://github.com/ROCm/hip-ep/pull/764)

## AI assistance

AI tools assisted with the implementation and PR description. The contributor reviewed the resulting code and description.

Made-with: Cursor
