### PR TITLE
fix(hipsr): keep an ONNX-to-hipsr operand in its producer's memory space

### DIFF
--- a/include/hip/Conversion/OnnxToHipsr/OnnxToHipsr.h
+++ b/include/hip/Conversion/OnnxToHipsr/OnnxToHipsr.h
@@ -23,6 +23,9 @@ namespace hipsr {
 #define GEN_PASS_DECL_CONVERTONNXTOHIPSRPASS
 #include "hip/Conversion/Passes.h.inc"
 
+// These patterns keep the converter out of ConversionPattern: a carried
+// converter forces every operand through convertType, which overwrites the
+// memory space its producer chose.
 void populateOnnxToHipsrConstantPatterns(
     const ::mlir::TypeConverter &typeConverter,
     ::mlir::RewritePatternSet &patterns);

--- a/lib/Conversion/OnnxToHipsr/CastConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/CastConversion.cpp
@@ -21,7 +21,7 @@ namespace {
 struct CastToHipsr : public ::mlir::ConversionPattern {
   CastToHipsr(const ::mlir::TypeConverter &typeConverter,
               ::mlir::MLIRContext *ctx)
-      : ConversionPattern(typeConverter, "onnx.Cast", /*benefit=*/1, ctx) {}
+      : ConversionPattern("onnx.Cast", /*benefit=*/1, ctx) {}
 
   ::mlir::LogicalResult
   matchAndRewrite(::mlir::Operation *op,
@@ -41,11 +41,12 @@ struct CastToHipsr : public ::mlir::ConversionPattern {
 
     ::mlir::Location loc = op->getLoc();
     ::mlir::Value input = operands[0];
-    auto resultType = ::mlir::dyn_cast_or_null<::mlir::RankedTensorType>(
-        getTypeConverter()->convertType(op->getResult(0).getType()));
+    auto resultType =
+        ::mlir::dyn_cast<::mlir::RankedTensorType>(op->getResult(0).getType());
     if (!resultType) {
       return rewriter.notifyMatchFailure(op, "expected ranked tensor result");
     }
+    resultType = tensorTypeInSpace(resultType, MemorySpace::Device);
 
     ::mlir::Value init =
         rewriter

--- a/lib/Conversion/OnnxToHipsr/ConstantConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/ConstantConversion.cpp
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+#include "OnnxToHipsrUtils.h"
+
 #include "hip/Conversion/OnnxToHipsr/OnnxToHipsr.h"
 #include "hip/Dialect/Hipsr/IR/HipsrOps.h"
 
@@ -28,8 +30,7 @@ constexpr ::llvm::StringLiteral kOrtMemAddrTag = "*/_ORT_MEM_ADDR_/*";
 struct ConstantOpLowering : public ::mlir::ConversionPattern {
   ConstantOpLowering(const ::mlir::TypeConverter &typeConverter,
                      ::mlir::MLIRContext *ctx)
-      : ::mlir::ConversionPattern(typeConverter, "onnx.Constant",
-                                  /*benefit=*/1, ctx) {}
+      : ::mlir::ConversionPattern("onnx.Constant", /*benefit=*/1, ctx) {}
 
   ::mlir::LogicalResult
   matchAndRewrite(::mlir::Operation *op,
@@ -52,11 +53,8 @@ struct ConstantOpLowering : public ::mlir::ConversionPattern {
         return ::mlir::success();
       }
 
-      auto resultType = ::llvm::dyn_cast_or_null<::mlir::RankedTensorType>(
-          getTypeConverter()->convertType(tensorType));
-      if (!resultType) {
-        return rewriter.notifyMatchFailure(op, "failed to convert result type");
-      }
+      ::mlir::RankedTensorType resultType =
+          tensorTypeInSpace(tensorType, MemorySpace::Device);
       rewriter.replaceOpWithNewOp<ConstantOp>(
           op, /*result=*/resultType, /*value=*/valueAttr,
           /*index=*/IntegerAttr(), /*offset=*/IntegerAttr(),
@@ -97,11 +95,8 @@ struct ConstantOpLowering : public ::mlir::ConversionPattern {
       data = {buf->getBufferStart() + offset, static_cast<size_t>(size)};
     }
 
-    auto resultType = ::llvm::dyn_cast_or_null<::mlir::RankedTensorType>(
-        getTypeConverter()->convertType(tensorType));
-    if (!resultType) {
-      return rewriter.notifyMatchFailure(op, "failed to convert result type");
-    }
+    ::mlir::RankedTensorType resultType =
+        tensorTypeInSpace(tensorType, MemorySpace::Device);
     auto value = DenseResourceElementsAttr::get(
         resultType, key, UnmanagedAsmResourceBlob::allocateInferAlign(data));
 

--- a/lib/Conversion/OnnxToHipsr/ExpandConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/ExpandConversion.cpp
@@ -21,7 +21,7 @@ namespace {
 struct ExpandToHipsr : public ::mlir::ConversionPattern {
   ExpandToHipsr(const ::mlir::TypeConverter &typeConverter,
                 ::mlir::MLIRContext *ctx)
-      : ConversionPattern(typeConverter, "onnx.Expand", /*benefit=*/1, ctx) {}
+      : ConversionPattern("onnx.Expand", /*benefit=*/1, ctx) {}
 
   ::mlir::LogicalResult
   matchAndRewrite(::mlir::Operation *op,
@@ -52,11 +52,12 @@ struct ExpandToHipsr : public ::mlir::ConversionPattern {
       return rewriter.notifyMatchFailure(op, "expected static shape length");
     }
 
-    auto resultType = ::mlir::dyn_cast_or_null<::mlir::RankedTensorType>(
-        getTypeConverter()->convertType(op->getResult(0).getType()));
+    auto resultType =
+        ::mlir::dyn_cast<::mlir::RankedTensorType>(op->getResult(0).getType());
     if (!resultType) {
       return rewriter.notifyMatchFailure(op, "expected ranked tensor result");
     }
+    resultType = tensorTypeInSpace(resultType, MemorySpace::Device);
     if (inputType.getElementType() != resultType.getElementType()) {
       return rewriter.notifyMatchFailure(
           op, "expected matching input and result element types");

--- a/lib/Conversion/OnnxToHipsr/MatMulConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/MatMulConversion.cpp
@@ -18,7 +18,7 @@ namespace {
 struct MatMulToHipsr : public ::mlir::ConversionPattern {
   MatMulToHipsr(const ::mlir::TypeConverter &typeConverter,
                 ::mlir::MLIRContext *ctx)
-      : ConversionPattern(typeConverter, "onnx.MatMul", /*benefit=*/1, ctx) {}
+      : ConversionPattern("onnx.MatMul", /*benefit=*/1, ctx) {}
 
   ::mlir::LogicalResult
   matchAndRewrite(::mlir::Operation *op,
@@ -39,11 +39,12 @@ struct MatMulToHipsr : public ::mlir::ConversionPattern {
     ::mlir::Location loc = op->getLoc();
     ::mlir::Value a = operands[0];
     ::mlir::Value b = operands[1];
-    auto resultType = ::mlir::dyn_cast_or_null<::mlir::RankedTensorType>(
-        getTypeConverter()->convertType(op->getResult(0).getType()));
+    auto resultType =
+        ::mlir::dyn_cast<::mlir::RankedTensorType>(op->getResult(0).getType());
     if (!resultType) {
       return rewriter.notifyMatchFailure(op, "expected ranked tensor result");
     }
+    resultType = tensorTypeInSpace(resultType, MemorySpace::Device);
 
     ::mlir::Value init = PlaceholderOp::create(
                              rewriter, loc, ::mlir::TypeRange{resultType}, *ctx,

--- a/lib/Conversion/OnnxToHipsr/ShapeConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/ShapeConversion.cpp
@@ -18,9 +18,6 @@
 // names. Data keeps the #hipsr.mem<device> the pass gives a tensor naming no
 // space.
 //
-// A graph that reads these extents has to name host on the ONNX result as well,
-// because the consumer's pattern maps that type through the pass converter.
-//
 // Before:
 //   %s = "onnx.Shape"(%x) : (tensor<?x128xf16, #hipsr.mem<device>>)
 //       -> tensor<2xi64>
@@ -149,7 +146,7 @@ struct ShapeToHipsr : public ConversionPattern {
   // Takes the pass converter to match the other patterns; converts no type
   // itself.
   ShapeToHipsr(const TypeConverter &typeConverter, MLIRContext *ctx)
-      : ConversionPattern(typeConverter, "onnx.Shape", /*benefit=*/1, ctx) {}
+      : ConversionPattern("onnx.Shape", /*benefit=*/1, ctx) {}
 
   LogicalResult
   matchAndRewrite(Operation *op, ArrayRef<Value> operands,

--- a/test/lit/Conversion/onnx-to-hipsr/expand-invalid.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/expand-invalid.mlir
@@ -83,3 +83,19 @@ func.func @missing_context(%input: tensor<2x3xf16>,
       : (tensor<2x3xf16>, tensor<2xi64>) -> tensor<2x3xf16>
   return %0 : tensor<2x3xf16>
 }
+
+// -----
+
+// A graph argument naming no space is data, so it becomes device resident, and
+// hipsr.expand reads its extents on the host. Reaching them would take a copy
+// this conversion does not emit, so the shape has to name host already. The
+// pattern builds the operation and its verifier reports the space.
+func.func @shape_argument_names_no_space(%ctx: !hipsr.context,
+                                         %input: tensor<?x3xf16>,
+                                         %shape: tensor<2xi64>)
+    -> tensor<?x?xf16> {
+  // expected-error @+1 {{operand #2 must be ranked host tensor or host memref}}
+  %0 = "onnx.Expand"(%input, %shape)
+      : (tensor<?x3xf16>, tensor<2xi64>) -> tensor<?x?xf16>
+  return %0 : tensor<?x?xf16>
+}

--- a/test/lit/Conversion/onnx-to-hipsr/shape.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/shape.mlir
@@ -165,8 +165,7 @@ func.func @shape_bounds_past_the_ends(%ctx: !hipsr.context,
 // -----
 
 // A result naming no space, as an ONNX graph writes it, still puts the extents
-// in host memory. Nothing reads them here, since a consumer carrying the type
-// converter would ask for this result in the space that converter picks.
+// in host memory.
 // CHECK-LABEL:   func.func @result_names_no_space(
 // CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:      %[[INPUT:.*]]: tensor<2x3xf16, #hipsr.mem<device>>) {
@@ -191,6 +190,10 @@ func.func @result_names_no_space(%ctx: !hipsr.context,
 
 // -----
 
+// Neither ONNX type names a space, and the expand still reads its shape operand
+// in the host memory this conversion picks: an operation pattern does not carry
+// the pass converter, so an operand keeps the space its producer gave it.
+//
 // The extents feed the shape graph as well as the data graph, and each takes a
 // different value: the barrier placeholder's input names the buffer holding
 // them, which is the compute's destination, while the expand reads what the
@@ -219,9 +222,8 @@ func.func @result_names_no_space(%ctx: !hipsr.context,
 // CHECK-NEXT:      return %[[EXPANDED]] : tensor<?x?xf16, #hipsr.mem<device>>
 func.func @extents_feed_an_expand(%ctx: !hipsr.context,
                                   %input: tensor<?x3xf16>) -> tensor<?x?xf16> {
-  %0 = "onnx.Shape"(%input)
-      : (tensor<?x3xf16>) -> tensor<2xi64, #hipsr.mem<host>>
+  %0 = "onnx.Shape"(%input) : (tensor<?x3xf16>) -> tensor<2xi64>
   %1 = "onnx.Expand"(%input, %0)
-      : (tensor<?x3xf16>, tensor<2xi64, #hipsr.mem<host>>) -> tensor<?x?xf16>
+      : (tensor<?x3xf16>, tensor<2xi64>) -> tensor<?x?xf16>
   return %1 : tensor<?x?xf16>
 }


### PR DESCRIPTION
## Summary

An ONNX-to-hipsr operand now arrives in the memory space its producer chose. No
per-operation pattern carries the pass type converter any more, and each pattern
names the space its own results need instead.

## Why

`remapValues` hands a pattern that carries a converter each operand in
`convertType(operandType)`, and that converter names `#hipsr.mem<device>` for a
tensor naming no space. The host extents `onnx.Shape` produces could not reach
`onnx.Expand`, which reads its `shape` operand on the host, so the pass ended
with an unresolved host-to-device materialization. This is the follow-up #751
named.

## What

- The cast, matmul, expand, constant and shape patterns no longer pass the
  converter to `ConversionPattern`, so each operand arrives as its producer
  built it.
- Each pattern names its result space through `tensorTypeInSpace`: device for
  cast, matmul, expand and constant, host for shape. A rank-0 result now names
  device too, which its ODS constraint required all along.
- `shape.mlir` drops the `#hipsr.mem<host>` its ONNX types had to spell;
  `expand-invalid.mlir` covers the graph argument that still has to name it.
- `OnnxToHipsr.cpp` is unchanged. The func and return patterns still use the
  converter at the graph boundary.

## AI assistance

Cursor (Claude Opus 5) assisted with the changes and the tests, and ran the
build, the LIT suites and `pre-commit`. I reviewed the result and understand it.
