### PR TITLE
perf(loop): recycle carrier banks across frames

### DIFF
--- a/docs/design/loop-carrier-descriptor-abi.md
+++ b/docs/design/loop-carrier-descriptor-abi.md
@@ -51,14 +51,29 @@ element_size)`.
 
 ## Ownership and allocation
 
-Each invocation owns two high-water device banks per carrier. Current is
-read-only to the body; next is writable and may grow. Exact logical sizes and
-contiguous strides live in the returned memref descriptor and are independent
-of retained bank capacity. Checked multiplication rejects negative extents and
-byte-size overflow. A zero-element descriptor has null data and zero logical
-bytes; publishing it advances the logical bank without allocating, freeing, or
-discarding retained bank capacity. A later nonzero iteration resumes normal
-bank reuse or growth. Null remains an allocation failure for nonzero bytes.
+Each invocation checks out two independent device-bank blocks per carrier as
+needed. Checkout is exclusive until frame destruction, so current remains
+read-only, next remains writable, nested/concurrent frames cannot share a
+pointer, and a checked-out block never relocates. The generic two-bank
+ping-pong contract is unchanged. Exact logical sizes and contiguous strides
+live in the returned memref descriptor and are independent of block capacity.
+Checked multiplication rejects negative extents and byte-size overflow. A
+zero-element descriptor has null data and zero logical bytes; publishing it
+advances the logical bank without checking out, freeing, or discarding a
+retained block. A later nonzero iteration resumes normal bank reuse or growth.
+Null remains an allocation failure for nonzero bytes.
+
+The RuntimeState owns a mutex-protected best-fit cache of independent blocks.
+Checkout takes the smallest cached capacity at least as large as the request.
+A miss allocates one block. Frame destruction and bank growth return blocks to
+the cache only after successful stream synchronization; a synchronization
+failure quarantines the owning frame and its blocks until a later successful
+graph sync. Uncertain in-flight memory is never offered to another frame.
+The cache keeps the largest useful blocks up to the observed concurrent block
+high-water; undersized blocks displaced by synchronized growth are released,
+while retained blocks live across inferences and are freed exactly once during
+normal RuntimeState teardown. This cache is separate from relocatable compiler
+pools and deliberately is not one contiguous arena.
 
 `hip.loop_alloc` deliberately has no Allocate memory effect. Carrier banks are
 therefore excluded from PoolAllocs and ownership-based deallocation. Ordinary
@@ -68,8 +83,9 @@ body `memref.alloc` operations remain poolable.
 carrier descriptor use and after any graph-output copy. An escaping nested
 carrier transfers its child frame to the enclosing parent frame; explicit child
 destruction unlinks it. Normal invocations therefore retain no per-run frame.
-If synchronization fails during destruction, only that frame is quarantined
-for a later successful synchronization or state cleanup.
+Their drained bank blocks remain in the RuntimeState cache. If synchronization
+fails during destruction or growth, only that frame is quarantined for a later
+successful synchronization or state cleanup.
 
 Lifetime analysis follows conditional zero-trip/pass-through aliases
 transitively through later loop `v_init` edges and view chains. Therefore
@@ -91,7 +107,24 @@ token. Every failure sets the existing generated-graph runtime error flag.
 
 ## Concurrency and nesting
 
-Iteration storage, condition storage, events, descriptor sets, and carrier
-banks are frame-local. Nested loops and simultaneous driver invocations on one
-runtime state therefore do not share loop slots. Only the failed-destruction
-quarantine list is shared and mutex-protected.
+Iteration storage, condition storage, events, descriptor sets, and checked-out
+carrier banks are frame-local. Nested loops and simultaneous driver
+invocations on one runtime state therefore do not share loop slots or bank
+pointers. The
+available-block cache and failed-synchronization quarantine list are shared and
+mutex-protected.
+
+## Diagnostics and retention estimate
+
+`HIPDNN_EP_LOOP_BANK_TRACE=1` enables low-overhead cache event lines with
+best-fit hits/misses, successful allocation/free counts, active/cached/peak
+bytes, quarantine bytes, and synchronization/quarantine reason. The variable
+is read once when loop state is initialized; no cache diagnostics are emitted
+by default.
+
+For 27 sequential equivalent Loop frames whose two final bank capacities are
+`A` and `B`, the cache retains `A + B` bytes and avoids up to 52 repeated
+allocations after the first frame. Relative to allocating/finally freeing two
+blocks per frame, the estimated cumulative allocation traffic recovered is
+`26 * (A + B)` bytes. This is an allocation-volume estimate, not a Windows VRAM
+measurement; peak/process VRAM must be reported only after CI reruns it.

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -504,6 +504,45 @@ set(RUNTIME_BC_PATH ${CMAKE_CURRENT_BINARY_DIR}/runtime.bc PARENT_SCOPE)
 
 add_custom_target(RuntimeBitcode DEPENDS HipRuntime)
 
+# Keep runtime.bc within the symbol surface that LlvmIrJit can resolve in the
+# EP process. In particular, std::nothrow allocation introduces MSVC CRT
+# symbols that are unavailable to Windows JIT artifacts.
+if(TARGET llvm-nm)
+    set(RUNTIME_LLVM_NM "$<TARGET_FILE:llvm-nm>")
+    set(RUNTIME_LLVM_NM_DEPENDS llvm-nm)
+else()
+    find_program(RUNTIME_LLVM_NM NAMES llvm-nm
+        PATHS
+            ${LLVM_BINARY_DIR}/bin
+            ${LLVM_TOOLS_BINARY_DIR}
+    )
+    if(NOT RUNTIME_LLVM_NM)
+        message(FATAL_ERROR
+            "llvm-nm not found (required for runtime bitcode ABI audit)")
+    endif()
+    set(RUNTIME_LLVM_NM_DEPENDS "")
+endif()
+
+set(RUNTIME_BITCODE_ABI_STAMP
+    ${CMAKE_CURRENT_BINARY_DIR}/runtime_bitcode_jit_abi.stamp)
+add_custom_command(
+    OUTPUT ${RUNTIME_BITCODE_ABI_STAMP}
+    COMMAND ${CMAKE_COMMAND}
+            -DLLVM_NM_EXECUTABLE=${RUNTIME_LLVM_NM}
+            -DRUNTIME_BITCODE=${CMAKE_CURRENT_BINARY_DIR}/runtime.bc
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/check_runtime_bitcode_symbols.cmake
+    COMMAND ${CMAKE_COMMAND} -E touch ${RUNTIME_BITCODE_ABI_STAMP}
+    DEPENDS
+            ${CMAKE_CURRENT_BINARY_DIR}/runtime.bc
+            ${CMAKE_CURRENT_SOURCE_DIR}/check_runtime_bitcode_symbols.cmake
+            ${RUNTIME_LLVM_NM_DEPENDS}
+    COMMENT "Auditing runtime bitcode JIT symbol compatibility"
+    VERBATIM
+)
+add_custom_target(RuntimeBitcodeJitAbiCheck ALL
+    DEPENDS ${RUNTIME_BITCODE_ABI_STAMP})
+add_dependencies(RuntimeBitcodeJitAbiCheck RuntimeBitcode)
+
 # ============================================================================
 # STEP 6: Native current-stream accessor (NOT bitcode)
 # ============================================================================

--- a/lib/Runtime/check_runtime_bitcode_symbols.cmake
+++ b/lib/Runtime/check_runtime_bitcode_symbols.cmake
@@ -1,0 +1,32 @@
+##
+# ** Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# ** Licensed under the MIT License.
+##
+
+if(NOT DEFINED LLVM_NM_EXECUTABLE OR NOT DEFINED RUNTIME_BITCODE)
+  message(FATAL_ERROR
+    "LLVM_NM_EXECUTABLE and RUNTIME_BITCODE are required")
+endif()
+
+execute_process(
+  COMMAND "${LLVM_NM_EXECUTABLE}" --undefined-only "${RUNTIME_BITCODE}"
+  RESULT_VARIABLE llvm_nm_result
+  OUTPUT_VARIABLE undefined_symbols
+  ERROR_VARIABLE llvm_nm_error
+)
+
+if(NOT llvm_nm_result EQUAL 0)
+  message(FATAL_ERROR
+    "Failed to inspect runtime bitcode with llvm-nm: ${llvm_nm_error}")
+endif()
+
+# The default model artifact JIT-links runtime.bc inside the EP process. The
+# Windows host does not export the MSVC std::nothrow object or its allocation
+# overload, so either reference makes every model fail during global_ctors.
+string(REGEX MATCHALL "[^\n]*nothrow[^\n]*" nothrow_symbols
+  "${undefined_symbols}")
+if(nothrow_symbols)
+  message(FATAL_ERROR
+    "runtime.bc references unsupported std::nothrow symbols:\n"
+    "${nothrow_symbols}")
+endif()

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -1692,11 +1692,32 @@ int hipdnn_ep_run_loop(RuntimeState *state, HipdnnEpLoopBodyFn body_fn,
                        HipdnnEpLoopFrame *parent_frame, void ***final_descs,
                        HipdnnEpLoopFrame **frame_out);
 
-// Retry cleanup only for frames quarantined by a failed explicit destroy.
-// Successful frames are released through their compiler-visible token.
+// Recycle frames quarantined by a failed explicit destroy after the caller has
+// successfully synchronized the RuntimeState stream. Successful frames are
+// released through their compiler-visible token.
 void hipdnn_ep_loop_cleanup_quarantined_frames(RuntimeState *state);
 int hipdnn_ep_loop_state_init(RuntimeState *state);
 void hipdnn_ep_loop_state_cleanup(RuntimeState *state);
+
+#ifdef HIPDNN_EP_RUNTIME_TESTING
+typedef struct HipdnnEpLoopBankStats {
+  uint64_t hits;
+  uint64_t misses;
+  uint64_t allocations;
+  uint64_t frees;
+  size_t active_bytes;
+  size_t cached_bytes;
+  size_t peak_bytes;
+  size_t quarantined_bytes;
+} HipdnnEpLoopBankStats;
+
+void hipdnn_ep_test_fail_next_loop_sync(void);
+void hipdnn_ep_test_fail_next_loop_alloc(void);
+void hipdnn_ep_test_get_loop_bank_stats(RuntimeState *state,
+                                        HipdnnEpLoopBankStats *stats);
+void hipdnn_ep_test_get_last_cleaned_loop_bank_stats(
+    HipdnnEpLoopBankStats *stats);
+#endif
 
 // ONNX If driver. Dispatches to exactly one of the two branch trampolines
 // based on `cond`. Each trampoline writes branch outputs into the shared

--- a/lib/Runtime/hipdnn_ep_runtime_loop.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_loop.cpp
@@ -60,12 +60,18 @@
 #include <cstring>
 #include <limits>
 #include <mutex>
+#include <new>
 #include <utility>
+
+struct HipdnnEpLoopBankBlock {
+  void *data;
+  size_t capacity;
+  HipdnnEpLoopBankBlock *next;
+};
 
 struct HipdnnEpLoopFrame {
   struct CarrierBanks {
-    void *data[2];
-    size_t capacity[2];
+    HipdnnEpLoopBankBlock *bank[2];
     const void *current_data;
     int current_bank;
     int allocated_bank;
@@ -87,13 +93,32 @@ struct HipdnnEpLoopFrame {
   HipdnnEpLoopFrame *first_child;
   HipdnnEpLoopFrame *next_sibling;
   HipdnnEpLoopFrame *quarantine_next;
+  size_t quarantined_bytes;
+  const char *quarantine_reason;
 };
 
 namespace {
 
+struct LoopBankCache {
+  HipdnnEpLoopBankBlock *available = nullptr;
+  uint64_t hits = 0;
+  uint64_t misses = 0;
+  uint64_t allocations = 0;
+  uint64_t frees = 0;
+  size_t active_blocks = 0;
+  size_t peak_active_blocks = 0;
+  size_t total_blocks = 0;
+  size_t active_bytes = 0;
+  size_t cached_bytes = 0;
+  size_t peak_bytes = 0;
+  size_t quarantined_bytes = 0;
+  bool trace = false;
+};
+
 #ifdef HIPDNN_EP_RUNTIME_TESTING
 bool failNextLoopSync = false;
 bool failNextLoopAlloc = false;
+HipdnnEpLoopBankStats lastCleanedLoopBankStats{};
 #endif
 
 hipError_t synchronizeLoopStream(hipStream_t stream) {
@@ -110,7 +135,40 @@ std::mutex *getFrameMutex(RuntimeState *state) {
   return static_cast<std::mutex *>(state ? state->loop_frames_mutex : nullptr);
 }
 
-void destroyFrame(HipdnnEpLoopFrame *frame) {
+LoopBankCache *getBankCache(RuntimeState *state) {
+  return static_cast<LoopBankCache *>(state ? state->loop_bank_cache : nullptr);
+}
+
+void traceCacheLocked(const LoopBankCache &cache, const char *event,
+                      const char *reason, size_t bytes) {
+  if (!cache.trace)
+    return;
+  std::fprintf(
+      stderr,
+      "[HIPDNN_EP_LOOP_BANK_TRACE] event=%s reason=%s bytes=%zu hits=%llu "
+      "misses=%llu allocations=%llu frees=%llu active_blocks=%zu "
+      "cached_blocks=%zu active_bytes=%zu cached_bytes=%zu peak_bytes=%zu "
+      "quarantined_bytes=%zu\n",
+      event, reason ? reason : "none", bytes,
+      static_cast<unsigned long long>(cache.hits),
+      static_cast<unsigned long long>(cache.misses),
+      static_cast<unsigned long long>(cache.allocations),
+      static_cast<unsigned long long>(cache.frees), cache.active_blocks,
+      cache.total_blocks - cache.active_blocks, cache.active_bytes,
+      cache.cached_bytes, cache.peak_bytes, cache.quarantined_bytes);
+}
+
+void traceCache(RuntimeState *state, const char *event, const char *reason,
+                size_t bytes) {
+  std::mutex *mutex = getFrameMutex(state);
+  LoopBankCache *cache = getBankCache(state);
+  if (!mutex || !cache)
+    return;
+  std::lock_guard<std::mutex> lock(*mutex);
+  traceCacheLocked(*cache, event, reason, bytes);
+}
+
+void destroyFrameMetadata(HipdnnEpLoopFrame *frame) {
   if (!frame)
     return;
   if (frame->event)
@@ -121,20 +179,151 @@ void destroyFrame(HipdnnEpLoopFrame *frame) {
     hipFree(frame->iter_dev);
   if (frame->cond_host)
     hipHostFree(frame->cond_host);
-  if (frame->carriers) {
-    for (int32_t i = 0; i < frame->num_carriers; ++i)
-      for (int bank = 0; bank < 2; ++bank)
-        if (frame->carriers[i].data[bank])
-          hipFree(frame->carriers[i].data[bank]);
+  if (frame->carriers)
     std::free(frame->carriers);
-  }
   while (frame->first_child) {
     HipdnnEpLoopFrame *child = frame->first_child;
     frame->first_child = child->next_sibling;
     child->parent = nullptr;
-    destroyFrame(child);
+    destroyFrameMetadata(child);
   }
   std::free(frame);
+}
+
+size_t frameBankBytes(const HipdnnEpLoopFrame *frame) {
+  if (!frame)
+    return 0;
+  size_t bytes = 0;
+  for (int32_t i = 0; i < frame->num_carriers; ++i)
+    for (int bank = 0; bank < 2; ++bank)
+      if (frame->carriers[i].bank[bank])
+        bytes += frame->carriers[i].bank[bank]->capacity;
+  for (HipdnnEpLoopFrame *child = frame->first_child; child;
+       child = child->next_sibling)
+    bytes += frameBankBytes(child);
+  return bytes;
+}
+
+void trimCacheLocked(LoopBankCache &cache) {
+  while (cache.total_blocks > cache.peak_active_blocks && cache.available) {
+    HipdnnEpLoopBankBlock **smallestLink = &cache.available;
+    for (HipdnnEpLoopBankBlock **link = &cache.available; *link;
+         link = &(*link)->next)
+      if ((*link)->capacity < (*smallestLink)->capacity)
+        smallestLink = link;
+    HipdnnEpLoopBankBlock *block = *smallestLink;
+    if (hipFree(block->data) != hipSuccess) {
+      traceCacheLocked(cache, "free", "high-water-trim-failure",
+                       block->capacity);
+      return;
+    }
+    *smallestLink = block->next;
+    cache.cached_bytes -= block->capacity;
+    --cache.total_blocks;
+    ++cache.frees;
+    traceCacheLocked(cache, "free", "high-water-trim", block->capacity);
+    std::free(block);
+  }
+}
+
+HipdnnEpLoopBankBlock *checkoutBank(RuntimeState *state, size_t bytes) {
+  std::mutex *mutex = getFrameMutex(state);
+  LoopBankCache *cache = getBankCache(state);
+  if (!mutex || !cache)
+    return nullptr;
+  std::lock_guard<std::mutex> lock(*mutex);
+
+  HipdnnEpLoopBankBlock **bestLink = nullptr;
+  for (HipdnnEpLoopBankBlock **link = &cache->available; *link;
+       link = &(*link)->next) {
+    if ((*link)->capacity < bytes)
+      continue;
+    if (!bestLink || (*link)->capacity < (*bestLink)->capacity)
+      bestLink = link;
+  }
+  if (bestLink) {
+    HipdnnEpLoopBankBlock *block = *bestLink;
+    *bestLink = block->next;
+    block->next = nullptr;
+    ++cache->hits;
+    ++cache->active_blocks;
+    if (cache->active_blocks > cache->peak_active_blocks)
+      cache->peak_active_blocks = cache->active_blocks;
+    cache->cached_bytes -= block->capacity;
+    cache->active_bytes += block->capacity;
+    if (cache->active_bytes > cache->peak_bytes)
+      cache->peak_bytes = cache->active_bytes;
+    traceCacheLocked(*cache, "checkout", "best-fit-hit", block->capacity);
+    return block;
+  }
+
+  ++cache->misses;
+#ifdef HIPDNN_EP_RUNTIME_TESTING
+  if (failNextLoopAlloc) {
+    failNextLoopAlloc = false;
+    traceCacheLocked(*cache, "checkout", "allocation-injected-failure", bytes);
+    return nullptr;
+  }
+#endif
+  void *data = nullptr;
+  if (hipMalloc(&data, bytes) != hipSuccess) {
+    traceCacheLocked(*cache, "checkout", "allocation-failure", bytes);
+    return nullptr;
+  }
+  auto *block = static_cast<HipdnnEpLoopBankBlock *>(
+      std::calloc(1, sizeof(HipdnnEpLoopBankBlock)));
+  if (!block) {
+    ++cache->allocations;
+    if (hipFree(data) == hipSuccess)
+      ++cache->frees;
+    traceCacheLocked(*cache, "checkout", "metadata-allocation-failure", bytes);
+    return nullptr;
+  }
+  block->data = data;
+  block->capacity = bytes;
+  ++cache->allocations;
+  ++cache->active_blocks;
+  ++cache->total_blocks;
+  if (cache->active_blocks > cache->peak_active_blocks)
+    cache->peak_active_blocks = cache->active_blocks;
+  cache->active_bytes += bytes;
+  if (cache->active_bytes > cache->peak_bytes)
+    cache->peak_bytes = cache->active_bytes;
+  traceCacheLocked(*cache, "checkout", "cache-miss", bytes);
+  trimCacheLocked(*cache);
+  return block;
+}
+
+void recycleBank(RuntimeState *state, HipdnnEpLoopBankBlock *block,
+                 const char *reason) {
+  if (!block)
+    return;
+  std::mutex *mutex = getFrameMutex(state);
+  LoopBankCache *cache = getBankCache(state);
+  if (!mutex || !cache)
+    return;
+  std::lock_guard<std::mutex> lock(*mutex);
+  --cache->active_blocks;
+  cache->active_bytes -= block->capacity;
+  cache->cached_bytes += block->capacity;
+  block->next = cache->available;
+  cache->available = block;
+  traceCacheLocked(*cache, "recycle", reason, block->capacity);
+}
+
+void recycleFrameBanks(RuntimeState *state, HipdnnEpLoopFrame *frame,
+                       const char *reason) {
+  if (!frame)
+    return;
+  for (int32_t i = 0; i < frame->num_carriers; ++i) {
+    for (int bank = 0; bank < 2; ++bank) {
+      recycleBank(state, frame->carriers[i].bank[bank], reason);
+      frame->carriers[i].bank[bank] = nullptr;
+    }
+  }
+  for (HipdnnEpLoopFrame *child = frame->first_child; child;
+       child = child->next_sibling)
+    recycleFrameBanks(state, child, reason);
 }
 
 HipdnnEpLoopFrame *createFrame(RuntimeState *state, int32_t num_carriers,
@@ -150,7 +339,7 @@ HipdnnEpLoopFrame *createFrame(RuntimeState *state, int32_t num_carriers,
         std::calloc(static_cast<size_t>(num_carriers),
                     sizeof(HipdnnEpLoopFrame::CarrierBanks)));
     if (!frame->carriers) {
-      destroyFrame(frame);
+      destroyFrameMetadata(frame);
       return nullptr;
     }
     for (int32_t i = 0; i < num_carriers; ++i) {
@@ -164,7 +353,7 @@ HipdnnEpLoopFrame *createFrame(RuntimeState *state, int32_t num_carriers,
     if (count > std::numeric_limits<size_t>::max() / sizeof(int64_t) ||
         hipHostMalloc(&frame->iter_cpu_buf, count * sizeof(int64_t),
                       hipHostMallocDefault) != hipSuccess) {
-      destroyFrame(frame);
+      destroyFrameMetadata(frame);
       return nullptr;
     }
     auto *iters = static_cast<int64_t *>(frame->iter_cpu_buf);
@@ -176,28 +365,32 @@ HipdnnEpLoopFrame *createFrame(RuntimeState *state, int32_t num_carriers,
           hipSuccess ||
       hipHostGetDevicePointer(&frame->cond_dev, frame->cond_host, 0) !=
           hipSuccess) {
-    destroyFrame(frame);
+    destroyFrameMetadata(frame);
     return nullptr;
   }
   hipEvent_t event = nullptr;
   if (hipEventCreateWithFlags(&event, hipEventDisableTiming) != hipSuccess) {
-    destroyFrame(frame);
+    destroyFrameMetadata(frame);
     return nullptr;
   }
   frame->event = static_cast<void *>(event);
   return frame;
 }
 
-void quarantineFrame(RuntimeState *state, HipdnnEpLoopFrame *frame) {
+void quarantineFrame(RuntimeState *state, HipdnnEpLoopFrame *frame,
+                     const char *reason) {
   std::mutex *mutex = getFrameMutex(state);
-  if (!mutex) {
-    destroyFrame(frame);
+  LoopBankCache *cache = getBankCache(state);
+  if (!mutex || !cache)
     return;
-  }
   std::lock_guard<std::mutex> lock(*mutex);
+  frame->quarantined_bytes = frameBankBytes(frame);
+  frame->quarantine_reason = reason;
+  cache->quarantined_bytes += frame->quarantined_bytes;
   frame->quarantine_next =
       static_cast<HipdnnEpLoopFrame *>(state->quarantined_loop_frames);
   state->quarantined_loop_frames = frame;
+  traceCacheLocked(*cache, "quarantine", reason, frame->quarantined_bytes);
 }
 
 void unlinkFromParent(HipdnnEpLoopFrame *frame) {
@@ -361,10 +554,14 @@ int runLoopImpl(RuntimeState *state, HipdnnEpLoopBodyFn body_fn,
     // after complete success, so final_descs still names the prior set.
     (void)hipdnn_ep_state_set_error_flag(state);
     *final_descs = initial_descs;
-    if (synchronizeLoopStream(stream) == hipSuccess)
-      destroyFrame(frame);
-    else
-      quarantineFrame(state, frame);
+    if (frame->quarantine_reason) {
+      quarantineFrame(state, frame, frame->quarantine_reason);
+    } else if (synchronizeLoopStream(stream) == hipSuccess) {
+      recycleFrameBanks(state, frame, "failed-frame-drained");
+      destroyFrameMetadata(frame);
+    } else {
+      quarantineFrame(state, frame, "failed-frame-sync");
+    }
     return rc;
   }
   frame->parent = parent_frame;
@@ -384,6 +581,26 @@ extern "C" void hipdnn_ep_test_fail_next_loop_sync() {
 }
 extern "C" void hipdnn_ep_test_fail_next_loop_alloc() {
   failNextLoopAlloc = true;
+}
+extern "C" void
+hipdnn_ep_test_get_loop_bank_stats(RuntimeState *state,
+                                   HipdnnEpLoopBankStats *stats) {
+  if (!stats)
+    return;
+  *stats = {};
+  std::mutex *mutex = getFrameMutex(state);
+  LoopBankCache *cache = getBankCache(state);
+  if (!mutex || !cache)
+    return;
+  std::lock_guard<std::mutex> lock(*mutex);
+  *stats = {cache->hits,       cache->misses,           cache->allocations,
+            cache->frees,      cache->active_bytes,     cache->cached_bytes,
+            cache->peak_bytes, cache->quarantined_bytes};
+}
+extern "C" void
+hipdnn_ep_test_get_last_cleaned_loop_bank_stats(HipdnnEpLoopBankStats *stats) {
+  if (stats)
+    *stats = lastCleanedLoopBankStats;
 }
 #endif
 
@@ -444,32 +661,27 @@ extern "C" void *hipdnn_ep_loop_frame_alloc(HipdnnEpLoopFrame *frame,
     carrier.allocation_valid = true;
     return nullptr;
   }
-  if (bytes > carrier.capacity[bank]) {
-    if (carrier.data[bank]) {
+  HipdnnEpLoopBankBlock *block = carrier.bank[bank];
+  if (!block || bytes > block->capacity) {
+    if (block) {
       if (synchronizeLoopStream(
-              static_cast<hipStream_t>(frame->state->stream)) != hipSuccess ||
-          hipFree(carrier.data[bank]) != hipSuccess) {
+              static_cast<hipStream_t>(frame->state->stream)) != hipSuccess) {
+        frame->quarantine_reason = "growth-sync";
         frame->status = -1;
         return nullptr;
       }
-      carrier.data[bank] = nullptr;
-      carrier.capacity[bank] = 0;
+      recycleBank(frame->state, block, "growth");
+      carrier.bank[bank] = nullptr;
     }
-#ifdef HIPDNN_EP_RUNTIME_TESTING
-    if (failNextLoopAlloc) {
-      failNextLoopAlloc = false;
+    block = checkoutBank(frame->state, bytes);
+    if (!block) {
       frame->status = -1;
       return nullptr;
     }
-#endif
-    if (hipMalloc(&carrier.data[bank], bytes) != hipSuccess) {
-      frame->status = -1;
-      return nullptr;
-    }
-    carrier.capacity[bank] = bytes;
+    carrier.bank[bank] = block;
   }
   carrier.allocation_valid = true;
-  return carrier.data[bank];
+  return block->data;
 }
 
 extern "C" int hipdnn_ep_loop_frame_status(HipdnnEpLoopFrame *frame) {
@@ -496,9 +708,10 @@ extern "C" int hipdnn_ep_loop_frame_publish(HipdnnEpLoopFrame *frame,
     bool validZeroSize = carrier.allocation_valid &&
                          carrier.allocated_bytes == 0 &&
                          published_data == nullptr;
-    bool validAllocated =
-        carrier.allocation_valid && carrier.allocated_bytes > 0 &&
-        published_data != nullptr && published_data == carrier.data[bank];
+    bool validAllocated = carrier.allocation_valid &&
+                          carrier.allocated_bytes > 0 &&
+                          published_data != nullptr && carrier.bank[bank] &&
+                          published_data == carrier.bank[bank]->data;
     if (validZeroSize || validAllocated) {
       carrier.published_bank = bank;
       return 0;
@@ -523,18 +736,29 @@ extern "C" int hipdnn_ep_loop_frame_destroy(RuntimeState *state,
   unlinkFromParent(frame);
   if (synchronizeLoopStream(static_cast<hipStream_t>(state->stream)) !=
       hipSuccess) {
-    quarantineFrame(state, frame);
+    quarantineFrame(state, frame, "destroy-sync");
     (void)hipdnn_ep_state_set_error_flag(state);
     return -1;
   }
-  destroyFrame(frame);
+  recycleFrameBanks(state, frame, "frame-destroy");
+  destroyFrameMetadata(frame);
   return 0;
 }
 
 extern "C" int hipdnn_ep_loop_state_init(RuntimeState *state) {
   if (!state)
     return -1;
-  state->loop_frames_mutex = new std::mutex();
+  auto *mutex = new (std::nothrow) std::mutex();
+  auto *cache = new (std::nothrow) LoopBankCache();
+  if (!mutex || !cache) {
+    delete mutex;
+    delete cache;
+    return -1;
+  }
+  const char *trace = std::getenv("HIPDNN_EP_LOOP_BANK_TRACE");
+  cache->trace = trace && trace[0] != '\0' && std::strcmp(trace, "0") != 0;
+  state->loop_frames_mutex = mutex;
+  state->loop_bank_cache = cache;
   state->quarantined_loop_frames = nullptr;
   return 0;
 }
@@ -554,7 +778,15 @@ extern "C" void hipdnn_ep_loop_cleanup_quarantined_frames(RuntimeState *state) {
   }
   while (frames) {
     HipdnnEpLoopFrame *next = frames->quarantine_next;
-    destroyFrame(frames);
+    LoopBankCache *cache = getBankCache(state);
+    if (mutex && cache) {
+      std::lock_guard<std::mutex> lock(*mutex);
+      cache->quarantined_bytes -= frames->quarantined_bytes;
+      traceCacheLocked(*cache, "quarantine-cleanup", frames->quarantine_reason,
+                       frames->quarantined_bytes);
+    }
+    recycleFrameBanks(state, frames, "quarantine-drained");
+    destroyFrameMetadata(frames);
     frames = next;
   }
 }
@@ -562,9 +794,41 @@ extern "C" void hipdnn_ep_loop_cleanup_quarantined_frames(RuntimeState *state) {
 extern "C" void hipdnn_ep_loop_state_cleanup(RuntimeState *state) {
   if (!state)
     return;
-  if (synchronizeLoopStream(static_cast<hipStream_t>(state->stream)) ==
-      hipSuccess)
+  bool streamDrained =
+      synchronizeLoopStream(static_cast<hipStream_t>(state->stream)) ==
+      hipSuccess;
+  if (streamDrained)
     hipdnn_ep_loop_cleanup_quarantined_frames(state);
-  delete getFrameMutex(state);
+  else
+    traceCache(state, "state-cleanup", "sync-failure", 0);
+
+  std::mutex *mutex = getFrameMutex(state);
+  LoopBankCache *cache = getBankCache(state);
+  if (mutex && cache) {
+    std::lock_guard<std::mutex> lock(*mutex);
+    while (cache->available) {
+      HipdnnEpLoopBankBlock *block = cache->available;
+      cache->available = block->next;
+      cache->cached_bytes -= block->capacity;
+      --cache->total_blocks;
+      if (hipFree(block->data) == hipSuccess) {
+        ++cache->frees;
+        traceCacheLocked(*cache, "free", "state-teardown", block->capacity);
+      } else {
+        traceCacheLocked(*cache, "free", "state-teardown-failure",
+                         block->capacity);
+      }
+      std::free(block);
+    }
+#ifdef HIPDNN_EP_RUNTIME_TESTING
+    lastCleanedLoopBankStats = {cache->hits,         cache->misses,
+                                cache->allocations,  cache->frees,
+                                cache->active_bytes, cache->cached_bytes,
+                                cache->peak_bytes,   cache->quarantined_bytes};
+#endif
+  }
+  delete cache;
+  state->loop_bank_cache = nullptr;
+  delete mutex;
   state->loop_frames_mutex = nullptr;
 }

--- a/lib/Runtime/hipdnn_ep_runtime_loop.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_loop.cpp
@@ -54,6 +54,7 @@
 #include "runtime_state_internal.h"
 #include "runtime_types.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -61,6 +62,7 @@
 #include <limits>
 #include <mutex>
 #include <new>
+#include <type_traits>
 #include <utility>
 
 struct HipdnnEpLoopBankBlock {
@@ -118,8 +120,33 @@ struct LoopBankCache {
 #ifdef HIPDNN_EP_RUNTIME_TESTING
 bool failNextLoopSync = false;
 bool failNextLoopAlloc = false;
+int failNextLoopStateAllocation = -1;
 HipdnnEpLoopBankStats lastCleanedLoopBankStats{};
 #endif
+
+// Runtime bitcode cannot use std::nothrow allocation on Windows, while this C
+// entry point must report allocation failure as status. Use malloc-backed,
+// statically nonthrowing construction so partial initialization can roll back.
+template <typename T> T *createLoopStateObject(int allocationIndex) noexcept {
+  static_assert(std::is_nothrow_default_constructible_v<T>);
+  static_assert(std::is_nothrow_destructible_v<T>);
+  static_assert(alignof(T) <= alignof(std::max_align_t));
+#ifdef HIPDNN_EP_RUNTIME_TESTING
+  if (failNextLoopStateAllocation == allocationIndex) {
+    failNextLoopStateAllocation = -1;
+    return nullptr;
+  }
+#endif
+  void *storage = std::malloc(sizeof(T));
+  return storage ? ::new (storage) T() : nullptr;
+}
+
+template <typename T> void destroyLoopStateObject(T *object) noexcept {
+  if (!object)
+    return;
+  object->~T();
+  std::free(object);
+}
 
 hipError_t synchronizeLoopStream(hipStream_t stream) {
 #ifdef HIPDNN_EP_RUNTIME_TESTING
@@ -582,6 +609,9 @@ extern "C" void hipdnn_ep_test_fail_next_loop_sync() {
 extern "C" void hipdnn_ep_test_fail_next_loop_alloc() {
   failNextLoopAlloc = true;
 }
+extern "C" void hipdnn_ep_test_fail_loop_state_allocation(int allocation) {
+  failNextLoopStateAllocation = allocation;
+}
 extern "C" void
 hipdnn_ep_test_get_loop_bank_stats(RuntimeState *state,
                                    HipdnnEpLoopBankStats *stats) {
@@ -748,11 +778,12 @@ extern "C" int hipdnn_ep_loop_frame_destroy(RuntimeState *state,
 extern "C" int hipdnn_ep_loop_state_init(RuntimeState *state) {
   if (!state)
     return -1;
-  auto *mutex = new (std::nothrow) std::mutex();
-  auto *cache = new (std::nothrow) LoopBankCache();
-  if (!mutex || !cache) {
-    delete mutex;
-    delete cache;
+  auto *mutex = createLoopStateObject<std::mutex>(0);
+  if (!mutex)
+    return -1;
+  auto *cache = createLoopStateObject<LoopBankCache>(1);
+  if (!cache) {
+    destroyLoopStateObject(mutex);
     return -1;
   }
   const char *trace = std::getenv("HIPDNN_EP_LOOP_BANK_TRACE");
@@ -827,8 +858,8 @@ extern "C" void hipdnn_ep_loop_state_cleanup(RuntimeState *state) {
                                 cache->peak_bytes,   cache->quarantined_bytes};
 #endif
   }
-  delete cache;
+  destroyLoopStateObject(cache);
   state->loop_bank_cache = nullptr;
-  delete mutex;
+  destroyLoopStateObject(mutex);
   state->loop_frames_mutex = nullptr;
 }

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -184,6 +184,7 @@ static int initialize_state_handles(RuntimeState **out_state) {
   state->seqlens_k_cached_valid = false;
   state->seqlens_k_cached_val = 0;
   state->seqlens_k_cached_ptr = nullptr;
+  state->loop_bank_cache = nullptr;
   state->quarantined_loop_frames = nullptr;
   state->loop_frames_mutex = nullptr;
   state->op_states = nullptr;

--- a/lib/Runtime/runtime_state_internal.h
+++ b/lib/Runtime/runtime_state_internal.h
@@ -231,10 +231,12 @@ struct RuntimeState {
   int32_t seqlens_k_cached_val;
   const void *seqlens_k_cached_ptr;
 
-  // Frames whose explicit destroy encountered a stream-sync failure are
-  // quarantined here. A later successful graph sync or state cleanup retries
-  // them; active/successful frames are never swept globally. The list and mutex
-  // are opaque to keep C++ runtime types out of this C-layout header.
+  // Independent loop-carrier bank blocks are checked out exclusively from a
+  // synchronized best-fit cache and retained to the RuntimeState high-water.
+  // Frames whose explicit destroy encountered a stream-sync failure remain
+  // quarantined until a later successful graph sync proves their blocks safe
+  // to recycle. These C++ implementation types stay opaque here.
+  void *loop_bank_cache;
   void *quarantined_loop_frames;
   void *loop_frames_mutex;
 

--- a/test/runtime/test_loop_frame.cpp
+++ b/test/runtime/test_loop_frame.cpp
@@ -42,10 +42,21 @@ struct Scenario {
   bool runNested = false;
   RuntimeState *state = nullptr;
   std::vector<std::vector<void *>> allocations;
+  void *nestedAllocation = nullptr;
 };
 
 thread_local Scenario *activeScenario = nullptr;
 thread_local int specialIteration = 0;
+
+struct ConcurrentScenario {
+  RuntimeState *state;
+  int64_t extent;
+  std::atomic<int> *ready;
+  std::atomic<bool> *release;
+  void *allocation = nullptr;
+};
+
+thread_local ConcurrentScenario *activeConcurrentScenario = nullptr;
 
 extern "C" void hipdnn_ep_test_fail_next_loop_sync();
 extern "C" void hipdnn_ep_test_fail_next_loop_alloc();
@@ -96,6 +107,8 @@ int body(RuntimeState *state, HipdnnEpLoopFrame *frame, void *, void *cond,
     activeScenario = saved;
     CHECK(rc == 0);
     CHECK(static_cast<Rank1Desc *>(final[0])->sizes[0] == 3);
+    if (!nested.allocations.empty() && !nested.allocations[0].empty())
+      scenario.nestedAllocation = nested.allocations[0][0];
   }
 
   // Dynamic-loop tests stop after the second successful body.
@@ -104,15 +117,56 @@ int body(RuntimeState *state, HipdnnEpLoopFrame *frame, void *, void *cond,
   return 0;
 }
 
+int concurrentBody(RuntimeState *, HipdnnEpLoopFrame *frame, void *, void *,
+                   void **current, void **, void **next) {
+  ConcurrentScenario &scenario = *activeConcurrentScenario;
+  auto *in = static_cast<Rank1Desc *>(current[0]);
+  CHECK(hipdnn_ep_loop_frame_set_current(frame, 0, in->aligned) == 0);
+  scenario.allocation =
+      hipdnn_ep_loop_frame_alloc(frame, 0, &scenario.extent, 1, sizeof(float));
+  auto *out = static_cast<Rank1Desc *>(next[0]);
+  *out = {scenario.allocation, scenario.allocation, 0, {scenario.extent}, {1}};
+  CHECK(hipdnn_ep_loop_frame_publish(frame, 0, scenario.allocation) == 0);
+  ++*scenario.ready;
+  while (!scenario.release->load())
+    std::this_thread::yield();
+  return hipdnn_ep_loop_frame_status(frame);
+}
+
 RuntimeState makeState() {
   RuntimeState state{};
   CHECK(hipdnn_ep_loop_state_init(&state) == 0);
   return state;
 }
 
-void cleanup(RuntimeState &state) {
-  hipdnn_ep_loop_cleanup_quarantined_frames(&state);
-  hipdnn_ep_loop_state_cleanup(&state);
+void cleanup(RuntimeState &state) { hipdnn_ep_loop_state_cleanup(&state); }
+
+HipdnnEpLoopBankStats getStats(RuntimeState &state) {
+  HipdnnEpLoopBankStats stats{};
+  hipdnn_ep_test_get_loop_bank_stats(&state, &stats);
+  return stats;
+}
+
+std::vector<void *> runCarrierFrame(RuntimeState &state,
+                                    const std::vector<int64_t> &extents) {
+  Rank1Desc seed{nullptr, nullptr, 0, {0}, {1}};
+  Rank1Desc scratchA{}, scratchB{};
+  void *initial[] = {&seed};
+  void *nextA[] = {&scratchA};
+  void *nextB[] = {&scratchB};
+  void **final = nullptr;
+  HipdnnEpLoopFrame *frame = nullptr;
+  Scenario scenario{{extents}, 0, -1, false, &state};
+  activeScenario = &scenario;
+  CHECK(hipdnn_ep_run_counted_loop(
+            &state, body, static_cast<int64_t>(extents.size()), true, 1, 0,
+            initial, nextA, nextB, nullptr, nullptr, &final, &frame) == 0);
+  CHECK(frame != nullptr);
+  if (frame)
+    CHECK(hipdnn_ep_loop_frame_destroy(&state, frame) == 0);
+  if (scenario.allocations.empty())
+    return {};
+  return scenario.allocations[0];
 }
 
 void testZeroTripAliasesSeed() {
@@ -134,6 +188,58 @@ void testZeroTripAliasesSeed() {
   CHECK(final[0] == &seed);
   CHECK(frame == nullptr);
   cleanup(state);
+}
+
+void testZeroSizeDoesNotCheckoutBank() {
+  RuntimeState state = makeState();
+  std::vector<void *> allocations = runCarrierFrame(state, {0});
+  CHECK(allocations.size() == 1);
+  if (allocations.size() == 1)
+    CHECK(allocations[0] == nullptr);
+  HipdnnEpLoopBankStats stats = getStats(state);
+  CHECK(stats.hits == 0);
+  CHECK(stats.misses == 0);
+  CHECK(stats.allocations == 0);
+  CHECK(stats.active_bytes == 0);
+  CHECK(stats.cached_bytes == 0);
+  cleanup(state);
+}
+
+void testSequentialGrowingFramesReuseTwoBlocks() {
+  RuntimeState state = makeState();
+  std::vector<void *> first = runCarrierFrame(state, {4, 16, 8, 32});
+  CHECK(first.size() == 4);
+  if (first.size() == 4) {
+    CHECK(first[0] != first[2]);
+    CHECK(first[1] != first[3]);
+    CHECK(first[2] != first[3]);
+  }
+  for (int frame = 1; frame < 27; ++frame) {
+    std::vector<void *> current = runCarrierFrame(state, {4, 16, 8, 32});
+    CHECK(current.size() == 4);
+    if (current.size() == 4 && first.size() == 4) {
+      CHECK(current[0] == first[2]);
+      CHECK(current[1] == first[3]);
+      CHECK(current[2] == first[2]);
+      CHECK(current[3] == first[3]);
+    }
+  }
+  HipdnnEpLoopBankStats stats = getStats(state);
+  CHECK(stats.hits == 52);
+  CHECK(stats.misses == 4);
+  CHECK(stats.allocations == 4);
+  CHECK(stats.frees == 2);
+  CHECK(stats.active_bytes == 0);
+  CHECK(stats.cached_bytes == 160);
+  CHECK(stats.peak_bytes == 160);
+  cleanup(state);
+
+  HipdnnEpLoopBankStats cleaned{};
+  hipdnn_ep_test_get_last_cleaned_loop_bank_stats(&cleaned);
+  CHECK(cleaned.allocations == 4);
+  CHECK(cleaned.frees == 4);
+  CHECK(cleaned.active_bytes == 0);
+  CHECK(cleaned.cached_bytes == 0);
 }
 
 void testGrowShrinkRegrowAndMultipleCarriers() {
@@ -274,6 +380,24 @@ int allocationFailureAfterEvolution(RuntimeState *, HipdnnEpLoopFrame *frame,
   return 0;
 }
 
+thread_local int growthSyncDispatches = 0;
+int growthSyncFailure(RuntimeState *, HipdnnEpLoopFrame *frame, void *, void *,
+                      void **current, void **, void **next) {
+  auto *in = static_cast<Rank1Desc *>(current[0]);
+  CHECK(hipdnn_ep_loop_frame_set_current(frame, 0, in->aligned) == 0);
+  const int64_t extents[] = {2, 3, 9};
+  int64_t extent = extents[growthSyncDispatches];
+  if (growthSyncDispatches == 2)
+    hipdnn_ep_test_fail_next_loop_sync();
+  void *data = hipdnn_ep_loop_frame_alloc(frame, 0, &extent, 1, sizeof(float));
+  if (hipdnn_ep_loop_frame_status(frame) != 0)
+    return hipdnn_ep_loop_frame_status(frame);
+  ++growthSyncDispatches;
+  *static_cast<Rank1Desc *>(next[0]) = {data, data, 0, {extent}, {1}};
+  CHECK(hipdnn_ep_loop_frame_publish(frame, 0, data) == 0);
+  return 0;
+}
+
 void testAllocationOverflow() {
   RuntimeState state = makeState();
   Rank1Desc seed{nullptr, nullptr, 0, {0}, {1}};
@@ -302,27 +426,42 @@ void testNestedAndConcurrentFrames() {
   CHECK(hipdnn_ep_run_counted_loop(&state, body, 1, true, 1, 0, initial, next,
                                    next, nullptr, nullptr, &final,
                                    &frame) == 0);
+  CHECK(!outer.allocations.empty());
+  CHECK(outer.nestedAllocation != nullptr);
+  if (!outer.allocations.empty() && !outer.allocations[0].empty())
+    CHECK(outer.allocations[0][0] != outer.nestedAllocation);
 
-  auto run = [&state](int64_t extent) {
+  std::atomic<int> ready{0};
+  std::atomic<bool> release{false};
+  void *concurrentAllocations[2] = {};
+  auto run = [&state, &ready, &release,
+              &concurrentAllocations](int index, int64_t extent) {
     Rank1Desc localSeed{nullptr, nullptr, 0, {0}, {1}};
     Rank1Desc localScratch{};
     void *localInitial[] = {&localSeed};
     void *localNext[] = {&localScratch};
     void **localFinal = nullptr;
     HipdnnEpLoopFrame *localFrame = nullptr;
-    Scenario scenario{{{extent}}, 0, -1, false, &state};
-    activeScenario = &scenario;
+    ConcurrentScenario scenario{&state, extent, &ready, &release};
+    activeConcurrentScenario = &scenario;
     int rc = hipdnn_ep_run_counted_loop(
-        &state, body, 1, true, 1, 0, localInitial, localNext, localNext,
-        nullptr, nullptr, &localFinal, &localFrame);
+        &state, concurrentBody, 1, true, 1, 0, localInitial, localNext,
+        localNext, nullptr, nullptr, &localFinal, &localFrame);
     CHECK(rc == 0);
     CHECK(static_cast<Rank1Desc *>(localFinal[0])->sizes[0] == extent);
+    concurrentAllocations[index] = scenario.allocation;
     CHECK(hipdnn_ep_loop_frame_destroy(&state, localFrame) == 0);
   };
-  std::thread first(run, 11);
-  std::thread second(run, 13);
+  std::thread first(run, 0, 11);
+  std::thread second(run, 1, 13);
+  while (ready.load() != 2)
+    std::this_thread::yield();
+  release = true;
   first.join();
   second.join();
+  CHECK(concurrentAllocations[0] != nullptr);
+  CHECK(concurrentAllocations[1] != nullptr);
+  CHECK(concurrentAllocations[0] != concurrentAllocations[1]);
   CHECK(hipdnn_ep_loop_frame_destroy(&state, frame) == 0);
   cleanup(state);
 }
@@ -384,8 +523,19 @@ void testEarlyExitAndSyncFailureCleanup() {
   hipdnn_ep_test_fail_next_loop_sync();
   CHECK(hipdnn_ep_loop_frame_destroy(&state, frame) != 0);
   CHECK(recordedErrors.load() > 0);
-  // The failed destroy quarantines only this frame. State cleanup retries a
-  // successful sync and releases it without touching any active invocation.
+  HipdnnEpLoopBankStats quarantined = getStats(state);
+  CHECK(quarantined.active_bytes == 28);
+  CHECK(quarantined.cached_bytes == 0);
+  CHECK(quarantined.quarantined_bytes == 28);
+  // The failed destroy quarantines only this frame. A later successful graph
+  // sync proves its banks safe to recycle without touching active invocations.
+  CHECK(hipStreamSynchronize(static_cast<hipStream_t>(state.stream)) ==
+        hipSuccess);
+  hipdnn_ep_loop_cleanup_quarantined_frames(&state);
+  HipdnnEpLoopBankStats recycled = getStats(state);
+  CHECK(recycled.active_bytes == 0);
+  CHECK(recycled.cached_bytes == 28);
+  CHECK(recycled.quarantined_bytes == 0);
   cleanup(state);
 }
 
@@ -405,7 +555,48 @@ void testInjectedAllocationFailureAfterEvolution() {
   CHECK(allocationDispatches == 1);
   CHECK(final == initial);
   CHECK(frame == nullptr);
+  HipdnnEpLoopBankStats stats = getStats(state);
+  CHECK(stats.misses == 2);
+  CHECK(stats.allocations == 1);
+  CHECK(stats.active_bytes == 0);
+  CHECK(stats.cached_bytes == 8);
   cleanup(state);
+}
+
+void testGrowthSyncFailureQuarantinesBanks() {
+  RuntimeState state = makeState();
+  Rank1Desc seed{nullptr, nullptr, 0, {0}, {1}};
+  Rank1Desc scratchA{}, scratchB{};
+  void *initial[] = {&seed};
+  void *nextA[] = {&scratchA};
+  void *nextB[] = {&scratchB};
+  void **final = nullptr;
+  HipdnnEpLoopFrame *frame = nullptr;
+  growthSyncDispatches = 0;
+  CHECK(hipdnn_ep_run_counted_loop(&state, growthSyncFailure, 3, true, 1, 0,
+                                   initial, nextA, nextB, nullptr, nullptr,
+                                   &final, &frame) != 0);
+  CHECK(growthSyncDispatches == 2);
+  CHECK(final == initial);
+  CHECK(frame == nullptr);
+  HipdnnEpLoopBankStats quarantined = getStats(state);
+  CHECK(quarantined.allocations == 2);
+  CHECK(quarantined.active_bytes == 20);
+  CHECK(quarantined.cached_bytes == 0);
+  CHECK(quarantined.quarantined_bytes == 20);
+
+  CHECK(hipStreamSynchronize(static_cast<hipStream_t>(state.stream)) ==
+        hipSuccess);
+  hipdnn_ep_loop_cleanup_quarantined_frames(&state);
+  HipdnnEpLoopBankStats recycled = getStats(state);
+  CHECK(recycled.active_bytes == 0);
+  CHECK(recycled.cached_bytes == 20);
+  CHECK(recycled.quarantined_bytes == 0);
+  cleanup(state);
+  HipdnnEpLoopBankStats cleaned{};
+  hipdnn_ep_test_get_last_cleaned_loop_bank_stats(&cleaned);
+  CHECK(cleaned.allocations == 2);
+  CHECK(cleaned.frees == 2);
 }
 
 } // namespace
@@ -417,6 +608,8 @@ extern "C" int hipdnn_ep_state_set_error_flag(RuntimeState *) {
 
 int main() {
   testZeroTripAliasesSeed();
+  testZeroSizeDoesNotCheckoutBank();
+  testSequentialGrowingFramesReuseTwoBlocks();
   testGrowShrinkRegrowAndMultipleCarriers();
   testZeroSizePublicationAndBankReuse();
   testFailureIsTransactional();
@@ -425,6 +618,7 @@ int main() {
   testPassThroughThenAllocateAndAtomicFailure();
   testEarlyExitAndSyncFailureCleanup();
   testInjectedAllocationFailureAfterEvolution();
+  testGrowthSyncFailureQuarantinesBanks();
   if (failures == 0) {
     std::printf("loop frame unit test: ALL PASS\n");
     return 0;

--- a/test/runtime/test_loop_frame.cpp
+++ b/test/runtime/test_loop_frame.cpp
@@ -60,6 +60,7 @@ thread_local ConcurrentScenario *activeConcurrentScenario = nullptr;
 
 extern "C" void hipdnn_ep_test_fail_next_loop_sync();
 extern "C" void hipdnn_ep_test_fail_next_loop_alloc();
+extern "C" void hipdnn_ep_test_fail_loop_state_allocation(int allocation);
 
 int body(RuntimeState *state, HipdnnEpLoopFrame *frame, void *, void *cond,
          void **current, void **, void **next) {
@@ -145,6 +146,22 @@ HipdnnEpLoopBankStats getStats(RuntimeState &state) {
   HipdnnEpLoopBankStats stats{};
   hipdnn_ep_test_get_loop_bank_stats(&state, &stats);
   return stats;
+}
+
+void testStateInitAllocationFailureIsAtomic() {
+  for (int allocation = 0; allocation < 2; ++allocation) {
+    RuntimeState state{};
+    hipdnn_ep_test_fail_loop_state_allocation(allocation);
+    CHECK(hipdnn_ep_loop_state_init(&state) != 0);
+    CHECK(state.loop_frames_mutex == nullptr);
+    CHECK(state.loop_bank_cache == nullptr);
+    CHECK(state.quarantined_loop_frames == nullptr);
+  }
+
+  RuntimeState state = makeState();
+  CHECK(state.loop_frames_mutex != nullptr);
+  CHECK(state.loop_bank_cache != nullptr);
+  cleanup(state);
 }
 
 std::vector<void *> runCarrierFrame(RuntimeState &state,
@@ -607,6 +624,7 @@ extern "C" int hipdnn_ep_state_set_error_flag(RuntimeState *) {
 }
 
 int main() {
+  testStateInitAllocationFailureIsAtomic();
   testZeroTripAliasesSeed();
   testZeroSizeDoesNotCheckoutBank();
   testSequentialGrowingFramesReuseTwoBlocks();


### PR DESCRIPTION
## Why

Each Loop frame currently owns and frees its carrier banks at frame destruction. Sequential Loop sites with equivalent carrier sizes therefore repeat device allocations even though the prior frame has synchronized and its banks are safe to reuse.

A RuntimeState-scoped best-fit cache can retain synchronized high-water blocks across frames while preserving exclusive frame ownership. The generic two-bank ping-pong design remains unchanged. Windows recovery requires telemetry confirmation; allocation-volume estimates alone are not evidence of lower process or peak VRAM.

## IR example

Before runtime bank recycling, two sequential frames execute the same carrier allocation and each frame obtains fresh device storage:

```mlir
func.func private @body0(%frame: !hip.loop_frame) -> memref<4096xf32> {
  %next = hip.loop_alloc(%frame) {carrier_index = 0 : i32}
      : memref<4096xf32> // fresh bank checkout
  return %next : memref<4096xf32>
}

func.func private @body1(%frame: !hip.loop_frame) -> memref<4096xf32> {
  %next = hip.loop_alloc(%frame) {carrier_index = 0 : i32}
      : memref<4096xf32> // another fresh bank checkout
  return %next : memref<4096xf32>
}
```

After runtime bank recycling, the MLIR ABI stays unchanged while the second frame checks out the synchronized best-fit block returned by the first:

```mlir
func.func private @body0(%frame: !hip.loop_frame) -> memref<4096xf32> {
  %next = hip.loop_alloc(%frame) {carrier_index = 0 : i32}
      : memref<4096xf32> // cache miss, retained after frame destroy
  return %next : memref<4096xf32>
}

func.func private @body1(%frame: !hip.loop_frame) -> memref<4096xf32> {
  %next = hip.loop_alloc(%frame) {carrier_index = 0 : i32}
      : memref<4096xf32> // best-fit cache hit
  return %next : memref<4096xf32>
}
```

## What changes

- Add a mutex-protected RuntimeState cache that checks out the smallest available carrier block meeting each request.
- Recycle banks only after successful stream synchronization and quarantine uncertain in-flight banks after synchronization failures.
- Retain the useful concurrent high-water, trim undersized displaced blocks, and free cached blocks exactly once at state teardown.
- Preserve exclusive bank ownership for nested and concurrent frames and preserve generic ping-pong semantics within every frame.
- Treat zero-byte carrier publication as valid without checking out or discarding retained storage.
- Add opt-in `HIPDNN_EP_LOOP_BANK_TRACE=1` hit, miss, byte, allocation, free, and quarantine telemetry.
- Cover sequential reuse, growth, zero-size publication, concurrency, quarantine, and teardown behavior.

## Stack

1. [#688 — constant externalization](https://github.com/ROCm/hip-ep/pull/688)
2. [#754 — i1 pool sizing](https://github.com/ROCm/hip-ep/pull/754)
3. [#756 — ORT error propagation](https://github.com/ROCm/hip-ep/pull/756)
4. [#758 — exact output views](https://github.com/ROCm/hip-ep/pull/758)
5. [#755 — pool namespaces](https://github.com/ROCm/hip-ep/pull/755)
6. [#757 — host-scratch namespaces](https://github.com/ROCm/hip-ep/pull/757)
7. [#724 — symbolic transport](https://github.com/ROCm/hip-ep/pull/724)
8. [#759 — artifact ABI guard](https://github.com/ROCm/hip-ep/pull/759)
9. [#639 — shape-rule foundation](https://github.com/ROCm/hip-ep/pull/639)
10. [#681 — reshape provenance](https://github.com/ROCm/hip-ep/pull/681)
11. [#725 — broadcast activation](https://github.com/ROCm/hip-ep/pull/725)
12. [#763 — Softmax buffer reuse](https://github.com/ROCm/hip-ep/pull/763)
13. [#640 — MatMul/Gemm runtime](https://github.com/ROCm/hip-ep/pull/640)
14. [#734 — MatMul/Gemm shapes](https://github.com/ROCm/hip-ep/pull/734)
15. [#641 — broadcast contracts](https://github.com/ROCm/hip-ep/pull/641)
16. [#735 — reduction conversion](https://github.com/ROCm/hip-ep/pull/735)
17. [#736 — reduction contracts](https://github.com/ROCm/hip-ep/pull/736)
18. [#689 — loop frame ABI](https://github.com/ROCm/hip-ep/pull/689)
19. [#737 — shape-changing loops](https://github.com/ROCm/hip-ep/pull/737)
20. [#762 — loop bank recycling](https://github.com/ROCm/hip-ep/pull/762) ← this PR
21. [#642 — grouped readback](https://github.com/ROCm/hip-ep/pull/642)
22. [#727 — payload shapes](https://github.com/ROCm/hip-ep/pull/727)
23. [#728 — Tile/Range destinations](https://github.com/ROCm/hip-ep/pull/728)
24. [#729 — Slice normalization](https://github.com/ROCm/hip-ep/pull/729)
25. [#731 — exact Slice ABI](https://github.com/ROCm/hip-ep/pull/731)
26. [#733 — loop payload integration](https://github.com/ROCm/hip-ep/pull/733)
27. [#643 — convolution contracts](https://github.com/ROCm/hip-ep/pull/643)
28. [#738 — pooling contracts](https://github.com/ROCm/hip-ep/pull/738)
29. [#742 — causal convolution contracts](https://github.com/ROCm/hip-ep/pull/742)
30. [#644 — gather/tensor contracts](https://github.com/ROCm/hip-ep/pull/644)
31. [#739 — block-quantized Gather](https://github.com/ROCm/hip-ep/pull/739)
32. [#645 — normalization contracts](https://github.com/ROCm/hip-ep/pull/645)
33. [#740 — attention contracts](https://github.com/ROCm/hip-ep/pull/740)
34. [#741 — GQA capacity](https://github.com/ROCm/hip-ep/pull/741)
35. [#743 — GQA feature rejection](https://github.com/ROCm/hip-ep/pull/743)
36. [#646 — explicit DPS contracts](https://github.com/ROCm/hip-ep/pull/646)
37. [#730 — contract inventory audit](https://github.com/ROCm/hip-ep/pull/730)
38. [#732 — converter dedup audit](https://github.com/ROCm/hip-ep/pull/732)
39. [#647 — refinement hardening](https://github.com/ROCm/hip-ep/pull/647)
40. [#761 — split shape utilities](https://github.com/ROCm/hip-ep/pull/761)
41. [#764 — destination authority](https://github.com/ROCm/hip-ep/pull/764)

## AI assistance

AI tools assisted with the implementation and PR drafting. The contributor reviewed the resulting changes.

Made-with: Cursor