### PR TITLE
refactor(hip): clarify shape destination authority

### DIFF
--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -4564,6 +4564,7 @@ def Hip_ResizeOp :
     `outs` `(` $output `:` type($output) `)`
     attr-dict (`:` type($result_tensors)^)?
   }];
+
   let hasVerifier = 1;
 }
 

--- a/lib/Conversion/OnnxToHip/AndConversion.cpp
+++ b/lib/Conversion/OnnxToHip/AndConversion.cpp
@@ -12,9 +12,8 @@ namespace {
 /// onnx.And -> hip.and
 ///
 /// Element-wise logical AND of two boolean tensors with NumPy-style
-/// broadcasting. Dynamic output dims are resolved via
-/// `createBroadcastEmptyTensor` so each axis picks the non-broadcasting operand
-/// (e.g. `[?x1] & [1x?] -> [?x?]`).
+/// broadcasting. Dynamic output dimensions use the shared exact broadcast
+/// selection, including when both aligned operand dimensions are dynamic.
 struct AndToHip : public mlir::RewritePattern {
   AndToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.And", /*benefit=*/1, ctx) {}
@@ -47,7 +46,7 @@ struct AndToHip : public mlir::RewritePattern {
         createOnnxBroadcastEmptyTensor(rewriter, loc, resultType, {a, b}, op);
     if (mlir::failed(initOrFailure))
       return rewriter.notifyMatchFailure(
-          op, "And: no ranked operand spans dynamic result dim");
+          op, "And: result type is incompatible with the broadcast shape");
 
     auto hipOp =
         mlir::hip::AndOp::create(rewriter, loc, context, a, b, *initOrFailure);

--- a/lib/Conversion/OnnxToHip/ExpandConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ExpandConversion.cpp
@@ -84,7 +84,7 @@ struct ExpandToHip : public mlir::RewritePattern {
       if (mlir::failed(inferredShape))
         return rewriter.notifyMatchFailure(
             op, "constant Expand shape is not broadcast-compatible");
-      if (!isResultTypeCompatibleWithPayloadShape(resultType, *inferredShape))
+      if (!isResultTypeCompatibleWithInferredShape(resultType, *inferredShape))
         return rewriter.notifyMatchFailure(
             op, "Expand result type contradicts constant shape");
     }

--- a/lib/Conversion/OnnxToHip/OnnxDimParams.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxDimParams.cpp
@@ -8,7 +8,6 @@
 
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Value.h"
-#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringSet.h"
 
@@ -16,12 +15,14 @@ namespace mlir::hip {
 namespace {
 
 bool isBroadcastOp(Operation *op) {
+  static constexpr llvm::StringLiteral kBroadcastOpNames[] = {
+      "onnx.Add",   "onnx.And",         "onnx.Div",
+      "onnx.Equal", "onnx.Greater",     "onnx.GreaterOrEqual",
+      "onnx.Less",  "onnx.LessOrEqual", "onnx.Mod",
+      "onnx.Mul",   "onnx.Or",          "onnx.Sub",
+      "onnx.Where"};
   llvm::StringRef name = op->getName().getStringRef();
-  return llvm::is_contained({"onnx.Add", "onnx.And", "onnx.Div", "onnx.Equal",
-                             "onnx.Greater", "onnx.GreaterOrEqual", "onnx.Less",
-                             "onnx.LessOrEqual", "onnx.Mod", "onnx.Mul",
-                             "onnx.Or", "onnx.Sub", "onnx.Where"},
-                            name);
+  return llvm::is_contained(kBroadcastOpNames, name);
 }
 
 std::optional<std::string> getValueName(Value value) {

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.cpp
@@ -52,11 +52,6 @@ bool extractConstantIntVector(Value value,
   return extractConstantIntTensor(value, out, /*expectedRank=*/1);
 }
 
-bool isResultTypeCompatibleWithPayloadShape(
-    mlir::RankedTensorType resultType, llvm::ArrayRef<int64_t> inferredShape) {
-  return isResultTypeCompatibleWithInferredShape(resultType, inferredShape);
-}
-
 static std::optional<llvm::ArrayRef<int64_t>>
 resolveReductionAxes(Operation *op, Value data, int64_t noopWithEmptyAxes,
                      llvm::SmallVectorImpl<int64_t> &storage) {

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -133,12 +133,6 @@ bool extractConstantIntTensor(
 bool extractConstantIntVector(mlir::Value value,
                               llvm::SmallVectorImpl<int64_t> &out);
 
-/// Compatibility check for a pure payload shape. A dynamic imported or
-/// inferred extent is compatible with its counterpart; unequal static extents
-/// are contradictions.
-bool isResultTypeCompatibleWithPayloadShape(
-    mlir::RankedTensorType resultType, llvm::ArrayRef<int64_t> inferredShape);
-
 /// Map an MLIR element type onto the HIPDNN_EP_DATATYPE_* enum that runtime
 /// wrappers take as an `input_data_type` argument. Only the subset needed by
 /// the converters that scan a raw buffer (hip.nonzero, and the Compress

--- a/lib/Conversion/OnnxToHip/OrConversion.cpp
+++ b/lib/Conversion/OnnxToHip/OrConversion.cpp
@@ -12,9 +12,8 @@ namespace {
 /// onnx.Or -> hip.or
 ///
 /// Element-wise logical OR of two boolean tensors with NumPy-style
-/// broadcasting. Dynamic output dims are resolved via
-/// `createBroadcastEmptyTensor` so each axis picks the non-broadcasting
-/// operand.
+/// broadcasting. Dynamic output dimensions use the shared exact broadcast
+/// selection, including when both aligned operand dimensions are dynamic.
 struct OrToHip : public mlir::RewritePattern {
   OrToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Or", /*benefit=*/1, ctx) {}
@@ -47,7 +46,7 @@ struct OrToHip : public mlir::RewritePattern {
         createOnnxBroadcastEmptyTensor(rewriter, loc, resultType, {a, b}, op);
     if (mlir::failed(initOrFailure))
       return rewriter.notifyMatchFailure(
-          op, "Or: no ranked operand spans dynamic result dim");
+          op, "Or: result type is incompatible with the broadcast shape");
 
     auto hipOp =
         mlir::hip::OrOp::create(rewriter, loc, context, a, b, *initOrFailure);

--- a/lib/Conversion/OnnxToHip/PadConversion.cpp
+++ b/lib/Conversion/OnnxToHip/PadConversion.cpp
@@ -231,7 +231,7 @@ struct PadToHip : public mlir::RewritePattern {
       if (mlir::failed(inferredShape))
         return rewriter.notifyMatchFailure(
             op, "constant Pad parameters are invalid for the data shape");
-      if (!isResultTypeCompatibleWithPayloadShape(resultType, *inferredShape))
+      if (!isResultTypeCompatibleWithInferredShape(resultType, *inferredShape))
         return rewriter.notifyMatchFailure(
             op, "Pad result type contradicts constant parameters");
     }

--- a/lib/Conversion/OnnxToHip/RangeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/RangeConversion.cpp
@@ -279,13 +279,12 @@ struct RangeToHip : public RewritePattern {
                       .Default([&](Type) { return Value(); });
       if (!len)
         return failure();
-      init = resultType.isDynamicDim(0)
-                 ? Value(tensor::EmptyOp::create(rewriter, loc,
-                                                 resultType.getShape(), elemTy,
-                                                 ValueRange{len}))
-                 : Value(tensor::EmptyOp::create(rewriter, loc,
-                                                 resultType.getShape(), elemTy,
-                                                 ValueRange{}));
+      SmallVector<OpFoldResult> exactShape = {len};
+      auto exactInit = createEmptyTensorFromReifiedShape(
+          rewriter, loc, resultType, exactShape);
+      if (failed(exactInit))
+        return failure();
+      init = *exactInit;
     }
 
     auto rangeOp = mlir::hip::RangeOp::create(rewriter, loc, ctx, startS,

--- a/lib/Conversion/OnnxToHip/TileConversion.cpp
+++ b/lib/Conversion/OnnxToHip/TileConversion.cpp
@@ -62,7 +62,7 @@ struct TileToHip : public mlir::RewritePattern {
       if (failed(inferredShape))
         return rewriter.notifyMatchFailure(
             op, "Tile repeats must match input rank and be non-negative");
-      if (!isResultTypeCompatibleWithPayloadShape(resultType, *inferredShape))
+      if (!isResultTypeCompatibleWithInferredShape(resultType, *inferredShape))
         return rewriter.notifyMatchFailure(
             op, "Tile result type contradicts constant repeats");
       if (failed(reifyTileShape(rewriter, loc, input, repeats,


### PR DESCRIPTION
## Why

The shape-contract inventory had accumulated both the leaf classification ledger and detailed implementation guidance, while converter code used several equivalent-looking destination construction forms. That made it less clear which shape source is authoritative and when a direct local `tensor.empty` is intentional.

This PR is a non-functional change (NFC). It clarifies and enforces the existing ownership policy without changing inferred extents, accepted shapes, generated destinations, or runtime behavior.

## IR example

Range and Slice already compute validated exact mixed extents. Routing those extents through the shared destination helper still materializes the same IR:

```mlir
%init = tensor.empty(%len) : tensor<?xf32>
```

The destination extent remains `%len`; the cleanup changes which C++ helper constructs the operation, not the shape semantics.

## What changes

- Keep the contract inventory focused on HIP DPS leaves and move contract meanings, implementation policy, and authoring guidance to the shape-inference design document.
- State the authority rule directly: compute-family destinations come from their shared contract rule, not an unrelated same-shape or positional builder.
- Permit direct local destinations only for exact payload, control-flow, or standard-tensor intermediate shapes outside HIP compute-family results, after structural and static validation.
- Use `createEmptyTensorFromReifiedShape` when such a local path already has a validated mixed shape; retain a narrow reviewed local builder when it remains the actual authority.
- Canonicalize Range and Slice destination construction through that helper and remove their reviewed direct-empty exemptions.
- Reuse the general inferred-shape compatibility check instead of a payload-only alias.
- Clarify that loop body signature synchronization follows the conservative joined loop result rather than re-narrowing from `v_init`.
- Preserve shape semantics and generated IR unchanged (NFC).

## Stack

Merged prerequisite plus the 22 active shape PRs:

1. [#688 — refactor(hip): externalize constants after ONNX conversion](https://github.com/ROCm/hip-ep/pull/688)
2. [#724 — feat(shape): preserve symbolic compiler inputs](https://github.com/ROCm/hip-ep/pull/724)
3. [#639 — refactor(hip): establish shared shape-rule foundation](https://github.com/ROCm/hip-ep/pull/639)
4. [#681 — fix(shape): canonicalize host reshape provenance](https://github.com/ROCm/hip-ep/pull/681)
5. [#725 — fix(shape): activate exact broadcasts with symbolic proofs](https://github.com/ROCm/hip-ep/pull/725)
6. [#734 — fix(shape): share MatMul and Gemm contracts](https://github.com/ROCm/hip-ep/pull/734)
7. [#641 — fix(shape): enforce shared broadcast contracts](https://github.com/ROCm/hip-ep/pull/641)
8. [#735 — refactor(conversion): share ONNX reduction conversion](https://github.com/ROCm/hip-ep/pull/735)
9. [#736 — fix(shape): normalize reduction contracts](https://github.com/ROCm/hip-ep/pull/736)
10. [#643 — fix(shape): share convolution contracts](https://github.com/ROCm/hip-ep/pull/643)
11. [#742 — fix(shape): share causal convolution contracts](https://github.com/ROCm/hip-ep/pull/742)
12. [#645 — fix(shape): share normalization contracts](https://github.com/ROCm/hip-ep/pull/645)
13. [#740 — fix(shape): share attention contracts](https://github.com/ROCm/hip-ep/pull/740)
14. [#741 — fix(shape): share GQA capacity contracts](https://github.com/ROCm/hip-ep/pull/741)
15. [#644 — fix(shape): share gather and tensor contracts](https://github.com/ROCm/hip-ep/pull/644)
16. [#727 — feat(shape): consume constant payload shapes directly](https://github.com/ROCm/hip-ep/pull/727)
17. [#728 — feat(shape): add exact Tile and Range destinations](https://github.com/ROCm/hip-ep/pull/728)
18. [#646 — refactor(hip): declare explicit DPS shape contracts](https://github.com/ROCm/hip-ep/pull/646)
19. [#730 — test(hip): audit explicit DPS contract inventory](https://github.com/ROCm/hip-ep/pull/730)
20. [#732 — test(hip): audit ONNX converter deduplication](https://github.com/ROCm/hip-ep/pull/732)
21. [#647 — fix(hip): harden shape refinement failure handling](https://github.com/ROCm/hip-ep/pull/647)
22. [#761 — refactor(hip): split shape utility headers by family](https://github.com/ROCm/hip-ep/pull/761)
23. [#764 — refactor(hip): clarify shape destination authority](https://github.com/ROCm/hip-ep/pull/764) ← this PR

## AI assistance

AI tools assisted with the review-driven policy cleanup and PR description. The contributor reviewed the resulting changes.

Made-with: Cursor
