### PR TITLE
ci(cache): make sccache read-only outside main

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -22,6 +22,7 @@ concurrency:
 env:
   # Route sccache through the GitHub Actions cache.
   SCCACHE_GHA_ENABLED: "true"
+  SCCACHE_GHA_RW_MODE: ${{ github.ref_name == 'main' && 'READ_WRITE' || 'READ_ONLY' }}
   # Pins (kept in lockstep with cmake/deps.txt).
   # LLVM/MLIR/LLD are built from source at this upstream release tag; bumping it
   # only invalidates the llvm-install cache.

--- a/.github/workflows/windows-build-mock.yml
+++ b/.github/workflows/windows-build-mock.yml
@@ -38,6 +38,7 @@ jobs:
       # ort-install cache key and drives the same patch set.
       ONNXRUNTIME_PR_PATCHES: ""
       SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_RW_MODE: ${{ github.ref_name == 'main' && 'READ_WRITE' || 'READ_ONLY' }}
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
 
     steps:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -50,6 +50,7 @@ jobs:
       # Remove a PR number once its fix is in the pinned ONNXRUNTIME_VERSION.
       ONNXRUNTIME_PR_PATCHES: ""
       SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_RW_MODE: ${{ github.ref_name == 'main' && 'READ_WRITE' || 'READ_ONLY' }}
       OGA_VERSION: "0.14.0"
       # Space-separated microsoft/onnxruntime-genai PR numbers fetched from
       # pull/<n>.patch and `git apply` on top of v<OGA_VERSION>. Part of the OGA


### PR DESCRIPTION
## Summary

sccache writes to the GitHub Actions cache only on `main` runs; every other run reads. This stops PR runs from exhausting the repository-wide cache upload budget, which had been degrading their own cache restores into multi-hour from-source LLVM rebuilds.

## Related issue or design

None

## Why

GitHub limits a repository to 200 cache entry uploads per minute, and sccache's GHA backend stores one entry per compiled object, so a single cold build uploads thousands. Those uploads buy a PR nothing: a `pull_request` run's entries are scoped to `refs/pull/N/merge`, which no sibling PR and no base branch can restore. A PR run already reads the default branch scope, so dropping the write path costs no hit rate.

The cost is real and measured. The repository currently holds 9.74 GB of its 10 GB quota across 18980 entries, of which seven byte-identical 1.13 GB copies of `linux-llvm-llvmorg-22.1.0` sit in seven separate PR scopes and account for 7.9 GB, while `refs/heads/main` holds no copy at all. When 19 runs started within 45 seconds on 2026-08-17, each one missed the LLVM cache, rebuilt LLVM from source for 1 to 3.3 hours, and saw its restores rejected:

```
Warning: Failed to restore: Failed to GetCacheEntryDownloadURL: Rate limited: Failed request: (429) Too Many Requests: rate limit exceeded
Cache not found for input keys: linux-llvm-llvmorg-22.1.0
```

## What

- `SCCACHE_GHA_RW_MODE` is added next to the existing `SCCACHE_GHA_ENABLED` in `windows-build.yml`, `windows-build-mock.yml` and `linux-build.yml`.
- The mode is keyed on `github.ref_name` rather than `github.event_name`, so `merge_group` (`gh-readonly-queue/...`), `pull_request` (`N/merge`) and a `workflow_dispatch` on a feature branch are all read-only: their scopes are equally unreadable by anyone else.
- Nothing else changes. The dependency prefix caches keep their current read-write `actions/cache` steps.

## Test plan

- [ ] The post-merge `main` run populates the default branch scope: `gh cache list --repo ROCm/hip-ep` shows `dep-llvm-*` and `linux-llvm-*` on `refs/heads/main`.
- [ ] A PR run opened after that restores the LLVM cache and skips `Build LLVM/MLIR/LLD from source`.
- [ ] That PR run reports zero sccache cache writes and logs no rate-limit warning.

## Notes for reviewers

The first `main` run after merge still builds LLVM from source, since the default branch scope currently holds no copy; PR runs benefit from the one after it.

`release/**` branches become read-only too. They still read the default branch scope, and their dependency prefix caches are untouched by this change, so a release branch only loses sccache acceleration on the first build after it pins a dependency differently from `main`.

The dependency prefix caches are deliberately left read-write here. A PR that misses them still writes a 1.13 GB `llvm-install` copy into its own unreadable scope, so the quota can fill up again. If it does, the follow-up is splitting those steps into `actions/cache/restore` plus an `actions/cache/save` gated on `main`.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
