### PR TITLE
feat(hipsr): add hipsr.alloc_output op

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/HipsrAllocOutputOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrAllocOutputOp.td
@@ -1,0 +1,30 @@
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+
+def Hipsr_AllocOutputOp : Hipsr_Op<"alloc_output",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+  let summary = "Obtain a graph-output buffer from the EP output allocator";
+  let description = [{
+    Allocates the buffer for graph output `out_idx` via the EP-supplied output
+    allocator, at the point in the graph where the output shape is known.
+    Operands: runtime context + one Index per dynamic dim of the result memref
+    (same operand convention as hip.alloc). The `out_idx` attribute identifies
+    which graph output this buffer is.
+
+
+    Example:
+    ```mlir
+    %out = hipsr.alloc_output(%ctx, %M, %N) {out_idx = 0 : i64} : memref<?x?xf16>
+    ```
+  }];
+
+  let arguments = (ins Hipsr_ContextType:$ctx, Variadic<Index>:$dynamicSizes,
+                       I64Attr:$out_idx);
+  let results = (outs AnyMemRef:$memref);
+  let assemblyFormat = [{
+    `(` $ctx (`,` $dynamicSizes^ )? `)` attr-dict `:` type($memref)
+  }];
+  let hasVerifier = 1;
+}

--- a/include/hip/Dialect/Hipsr/IR/HipsrOps.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrOps.td
@@ -51,5 +51,6 @@ include "hip/Dialect/Hipsr/IR/HipsrMulOp.td"
 include "hip/Dialect/Hipsr/IR/HipsrConstantOp.td"
 include "hip/Dialect/Hipsr/IR/HipsrGetPoolOp.td"
 include "hip/Dialect/Hipsr/IR/HipsrPreserveShapeOp.td"
+include "hip/Dialect/Hipsr/IR/HipsrAllocOutputOp.td"
 
 #endif // HIPSR_OPS

--- a/lib/Dialect/Hipsr/IR/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/IR/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(HipsrDialectIR STATIC
   HipsrDialect.cpp
   HipsrShapeYieldOp.cpp
   HipsrOps.cpp
+  HipsrAllocOutputOp.cpp
   HipsrPoolDomainYieldOp.cpp
   HipsrPoolDomainOp.cpp
   HipsrComputeYieldOp.cpp

--- a/lib/Dialect/Hipsr/IR/HipsrAllocOutputOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrAllocOutputOp.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip/Dialect/Hipsr/IR/HipsrOps.h"
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+namespace mlir {
+namespace hipsr {
+
+void AllocOutputOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(),
+                       SideEffects::DefaultResource::get());
+}
+
+LogicalResult AllocOutputOp::verify() {
+  auto memrefTy = cast<MemRefType>(getMemref().getType());
+  if (static_cast<int64_t>(getDynamicSizes().size()) !=
+      memrefTy.getNumDynamicDims())
+    return emitOpError("expected ")
+           << memrefTy.getNumDynamicDims() << " dynamic size operand(s), got "
+           << getDynamicSizes().size();
+  return success();
+}
+
+} // namespace hipsr
+} // namespace mlir

--- a/test/lit/Dialect/Hipsr/IR/alloc_output.mlir
+++ b/test/lit/Dialect/Hipsr/IR/alloc_output.mlir
@@ -1,0 +1,18 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s | FileCheck %s
+
+// A dynamic graph output round-trips: one Index per dynamic result dim plus
+// the out_idx attribute.
+// CHECK-LABEL: func.func @alloc_output_dynamic(
+// CHECK-SAME: %[[CTX:.+]]: !hipsr.context, %[[M:.+]]: index, %[[N:.+]]: index
+// CHECK-NEXT: %[[OUT:.+]] = hipsr.alloc_output(%[[CTX]], %[[M]], %[[N]]) {out_idx = 0 : i64} : memref<?x?xf16, #hipsr.mem<device>>
+// CHECK-NEXT: return %[[OUT]] : memref<?x?xf16, #hipsr.mem<device>>
+func.func @alloc_output_dynamic(
+    %ctx: !hipsr.context, %m: index, %n: index)
+    -> memref<?x?xf16, #hipsr.mem<device>> {
+  %out = hipsr.alloc_output(%ctx, %m, %n) {out_idx = 0 : i64}
+      : memref<?x?xf16, #hipsr.mem<device>>
+  return %out : memref<?x?xf16, #hipsr.mem<device>>
+}


### PR DESCRIPTION
## Summary
Register the `hipsr.alloc_output` operation. It obtains a graph-output
buffer from the EP output allocator at the point in the graph where the
output shape is known, so output buffers are owned by the EP/runtime
instead of being pooled or deallocated by the graph

## What
- Add `HipsrAllocOutputOp.td` defining `hipsr.alloc_output`:
  - operands: `!hipsr.context` + one `Index` per dynamic result dim
    (same operand convention as `hip.alloc`)
  - `out_idx` attribute identifying which graph output this buffer is
  - result: `AnyMemRef`
  - assembly format: `(%ctx, %d0, %d1) {out_idx = N} : memref<...>`
- Add `HipsrAllocOutputOp.cpp`:
  - `getEffects` reports only a `MemoryEffects::Write` (the EP owns the
    buffer, so it is not modeled as an allocation)
  - `verify` checks the dynamic-size operand count matches the number of
    dynamic dims in the result memref
- Register the op in `HipsrOps.td` and build it in the IR `CMakeLists.txt`.
This only adds the op. The pass that rewrites graph-output `memref.alloc`
into `hipsr.alloc_output` lands separately.

Made with Cursor