### PR TITLE
feat(tools): optimize merged convert — remove redundant fp16 Casts and pack LoRA weights at export

### DIFF
--- a/tools/onnx-merged-convert/README.md
+++ b/tools/onnx-merged-convert/README.md
@@ -73,7 +73,7 @@ model-bundle/
 | File | Purpose |
 |------|---------|
 | `genai_config.json` | Source for model metadata and search settings. If missing, a default config is generated from the merged graph and bundle metadata (see below). |
-| `adapter.safetensors` | LoRA adapter weights; copied to the output when present. |
+| `adapter.safetensors` | Raw int8 LoRA weights in input-dir; exported as packed uint8 in output. |
 | `tokenizer/` | Not read by the converter; copy manually for inference. |
 | `tokenizer/config.json` or `config.json` | Hugging Face model config; used for `vocab_size`, `context_length`, and decoder architecture fields when the source genai config omits them. |
 | `tokenizer/tokenizer_config.json` or `tokenizer_config.json` | Tokenizer settings; used for pad/EOS token ids when inferring model metadata. |
@@ -103,7 +103,7 @@ Pipeline **type** is inferred from the decoder prefill graph:
 
 | Detected pattern | Behavior |
 |------------------|----------|
-| Quantized linear (MatMulNBits) | Standard QDQ removal and merge. |
+| Quantized linear (MatMulNBits) | Standard QDQ removal and merge; LoRA weights are packed into `adapter.safetensors` with uint8 `weight_quantized` graph inputs. |
 | Many Gemm nodes, few MatMulNBits | Treats weights as folded Gemm (pure-Gemm / adapter path); may emit `lora_dequant.json`. |
 | GroupQueryAttention with 8-bit KV cache | Preserves int8 KV I/O and GQA quant attrs; rewrites activations to pure fp16 (including RoPE cos/sin at GQA inputs 7–8) for hip-ep. |
 | Many 2-bit MatMulNBits nodes | Low-bit decoder path. |
@@ -116,7 +116,7 @@ Pipeline **type** is inferred from the decoder prefill graph:
 | `{decoder_stem}_merged.data` | External weight blob (when weights are externalized). |
 | `genai_config.json` | GenAI runtime configuration (pipeline stages point at the merged file). |
 | `lora_dequant.json` | Present only for folded-Gemm / adapter bundles. |
-| `adapter.safetensors` | Copied from input when present and needed. |
+| `adapter.safetensors` | Packed uint8 LoRA weights (same keys as `weight_quantized` graph inputs). |
 
 The merged `genai_config.json` is adjusted for a single merged graph:
 

--- a/tools/onnx-merged-convert/README.md
+++ b/tools/onnx-merged-convert/README.md
@@ -104,7 +104,7 @@ Pipeline **type** is inferred from the decoder prefill graph:
 | Detected pattern | Behavior |
 |------------------|----------|
 | Quantized linear (MatMulNBits) | Standard QDQ removal and merge; LoRA weights are packed into `adapter.safetensors` with uint8 `weight_quantized` graph inputs. |
-| Many Gemm nodes, few MatMulNBits | Treats weights as folded Gemm (pure-Gemm / adapter path); may emit `lora_dequant.json`. |
+| Many Gemm nodes, few MatMulNBits | Treats weights as folded Gemm; LoRA adapter exported as fp16 `weight_fp16` tensors. |
 | GroupQueryAttention with 8-bit KV cache | Preserves int8 KV I/O and GQA quant attrs; rewrites activations to pure fp16 (including RoPE cos/sin at GQA inputs 7–8) for hip-ep. |
 | Many 2-bit MatMulNBits nodes | Low-bit decoder path. |
 
@@ -115,8 +115,7 @@ Pipeline **type** is inferred from the decoder prefill graph:
 | `{decoder_stem}_merged.onnx` | Merged model (graph only or with inline weights). |
 | `{decoder_stem}_merged.data` | External weight blob (when weights are externalized). |
 | `genai_config.json` | GenAI runtime configuration (pipeline stages point at the merged file). |
-| `lora_dequant.json` | Present only for folded-Gemm / adapter bundles. |
-| `adapter.safetensors` | Packed uint8 LoRA weights (same keys as `weight_quantized` graph inputs). |
+| `adapter.safetensors` | LoRA adapter weights: fp16 (`weight_fp16` keys) for folded Gemm, or packed uint8 (`weight_quantized` keys) for MatMulNBits. |
 
 The merged `genai_config.json` is adjusted for a single merged graph:
 

--- a/tools/onnx-merged-convert/merged_convert/cli.py
+++ b/tools/onnx-merged-convert/merged_convert/cli.py
@@ -9,7 +9,7 @@ import argparse
 from pathlib import Path
 
 from .bundle import DEFAULT_OUTPUT_DIR_NAME, detect_bundle
-from .pipeline import _default_output_dir, convert_bundle
+from .pipeline import INTERMEDIATES_DIR_NAME, _default_output_dir, convert_bundle
 
 __all__ = ["main"]
 
@@ -29,9 +29,17 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help=f"Output directory (default: <input-dir>/{DEFAULT_OUTPUT_DIR_NAME})",
     )
+    parser.add_argument(
+        "--keep-intermediates",
+        action="store_true",
+        help=(
+            f"Keep step-by-step ONNX artifacts under <output-dir>/{INTERMEDIATES_DIR_NAME}/ "
+            "(decoder weights in model.data; default: temp dir, deleted when done)"
+        ),
+    )
     args = parser.parse_args(argv)
 
     bundle = detect_bundle(args.input_dir)
     out = args.output_dir or _default_output_dir(bundle)
-    convert_bundle(bundle, out)
+    convert_bundle(bundle, out, keep_intermediates=args.keep_intermediates)
     return 0

--- a/tools/onnx-merged-convert/merged_convert/int8kv.py
+++ b/tools/onnx-merged-convert/merged_convert/int8kv.py
@@ -24,7 +24,6 @@ from .qdq_ext import (
     convert_matmul_int8_weight_dq,
     fold_weight_dq_q,
     fuse_conv_transpose_to_matmul_nbits_q,
-    infer_decoder_external_data_name_q,
     prune_initializers_q,
     promote_model_to_fp16_q,
     rewrite_gqa_past_seq_len_to_seqlens_k_q,
@@ -256,7 +255,7 @@ def convert_decoder_int8kv(
     assert_qdq_removed(graph, context=dst.name)
     assert_int8_kv_io(model, context=dst.name)
     assert_gqa_int8_quant(model, context=dst.name)
-    ext_name = infer_decoder_external_data_name_q(src, bundle_root)
+    ext_name = f"{dst.stem}.data"
     save_decoder_model_q(
         model, dst, external_data_name=ext_name, keep_inline=inline_at_load
     )

--- a/tools/onnx-merged-convert/merged_convert/int8kv.py
+++ b/tools/onnx-merged-convert/merged_convert/int8kv.py
@@ -205,7 +205,14 @@ def ensure_gqa_rope_weights_fp16(model: onnx.ModelProto) -> dict[str, int]:
 
 
 def convert_decoder_int8kv(
-    src: Path, dst: Path, *, bundle_root: Path, gqa_seqlens_rewrite: bool = True
+    src: Path,
+    dst: Path,
+    *,
+    bundle_root: Path,
+    external_data_name: str | None = None,
+    reuse_external_data: bool = False,
+    external_data_ref: Path | None = None,
+    gqa_seqlens_rewrite: bool = True,
 ) -> dict[str, int]:
     """Q/DQ strip + Conv/MNB + fp16 activations; preserve int8 KV GQA."""
     profile = CONVERT_PROFILE_LITE
@@ -255,9 +262,16 @@ def convert_decoder_int8kv(
     assert_qdq_removed(graph, context=dst.name)
     assert_int8_kv_io(model, context=dst.name)
     assert_gqa_int8_quant(model, context=dst.name)
-    ext_name = f"{dst.stem}.data"
+    from .step1_qdq_fp16 import DECODER_WORK_EXTERNAL_DATA
+
+    ext_name = external_data_name or DECODER_WORK_EXTERNAL_DATA
     save_decoder_model_q(
-        model, dst, external_data_name=ext_name, keep_inline=inline_at_load
+        model,
+        dst,
+        external_data_name=ext_name,
+        keep_inline=inline_at_load,
+        reuse_external_data=reuse_external_data,
+        external_data_ref=external_data_ref,
     )
     return stats
 

--- a/tools/onnx-merged-convert/merged_convert/lora_weight_pack.py
+++ b/tools/onnx-merged-convert/merged_convert/lora_weight_pack.py
@@ -1,0 +1,134 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+"""LoRA MatMulNBits adapter weight packing at export time.
+
+``weight_quantized`` graph inputs are uint8 ``[N,K]``; adapter weights are
+written to ``adapter.safetensors`` in the same packed layout.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import onnx
+from onnx import TensorProto
+
+
+def pack_lora_weight_mnbits_int8(raw: np.ndarray) -> np.ndarray:
+    """Pack raw signed int8 ``[K, N]`` into MatMulNBits uint8 ``[N, K]``."""
+    if raw.ndim != 2:
+        raise ValueError(f"expected rank-2 [K,N] weight, got shape {raw.shape}")
+    return (raw.astype(np.int16) + 128).astype(np.uint8).T
+
+
+def load_adapter_int8_tensors(adapter_path: Path) -> dict[str, np.ndarray]:
+    """Load raw ``adapter.safetensors`` int8 LoRA weights keyed by ONNX input name."""
+    try:
+        from safetensors import safe_open
+    except ImportError as exc:
+        raise ImportError(
+            "safetensors is required for LoRA adapter export; pip install safetensors"
+        ) from exc
+
+    tensors: dict[str, np.ndarray] = {}
+    with safe_open(str(adapter_path), framework="numpy") as f:
+        for key in f.keys():
+            arr = np.asarray(f.get_tensor(key))
+            if arr.dtype != np.int8:
+                raise ValueError(
+                    f"adapter tensor {key!r}: expected int8 raw weight, got {arr.dtype}"
+                )
+            tensors[key] = arr
+    if not tensors:
+        raise ValueError(f"no tensors in adapter file: {adapter_path}")
+    return tensors
+
+
+def export_packed_adapter_safetensors(
+    src: Path,
+    dst: Path,
+    *,
+    port_names: Iterable[str] | None = None,
+) -> int:
+    """Pack raw int8 ``[K,N]`` adapter tensors into uint8 ``[N,K]``, same keys."""
+    try:
+        from safetensors.numpy import save_file
+    except ImportError as exc:
+        raise ImportError("safetensors is required; pip install safetensors") from exc
+
+    raw = load_adapter_int8_tensors(src)
+    if port_names is not None:
+        allowed = set(port_names)
+        raw = {k: v for k, v in raw.items() if k in allowed}
+        missing = allowed - set(raw)
+        if missing:
+            raise KeyError(
+                f"adapter missing {len(missing)} requested ports, e.g. {next(iter(missing))!r}"
+            )
+
+    packed = {name: pack_lora_weight_mnbits_int8(arr) for name, arr in raw.items()}
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    save_file(packed, str(dst))
+    return len(packed)
+
+
+def retarget_weight_quantized_graph_input(
+    graph: onnx.GraphProto, port_name: str, k: int, n: int
+) -> str:
+    """Keep ``weight_quantized`` name; change type/shape to packed uint8 ``[N,K]``."""
+    for vi in graph.input:
+        if vi.name != port_name:
+            continue
+        elem = vi.type.tensor_type
+        elem.elem_type = TensorProto.UINT8
+        del elem.shape.dim[:]
+        elem.shape.dim.add().dim_value = n
+        elem.shape.dim.add().dim_value = k
+        return port_name
+    raise KeyError(f"graph input not found: {port_name!r}")
+
+
+def collect_packed_weight_quantized_specs(
+    graph: onnx.GraphProto,
+) -> list[tuple[str, tuple[int, int]]]:
+    """``weight_quantized`` ports as uint8 ``[N,K]``."""
+    specs: list[tuple[str, tuple[int, int]]] = []
+    for vi in graph.input:
+        if "weight_quantized" not in vi.name:
+            continue
+        if vi.type.tensor_type.elem_type != TensorProto.UINT8:
+            continue
+        dims = [d.dim_value for d in vi.type.tensor_type.shape.dim]
+        if len(dims) == 2 and all(dims):
+            specs.append((vi.name, (dims[0], dims[1])))
+    return specs
+
+
+def write_packed_lora_artifacts(
+    merged_path: Path,
+    adapter_src: Path,
+    output_dir: Path,
+) -> list[str]:
+    """Export packed ``adapter.safetensors`` for a merged LoRA MatMulNBits graph."""
+    model = onnx.load(str(merged_path), load_external_data=False)
+    specs = collect_packed_weight_quantized_specs(model.graph)
+    if not specs:
+        return []
+
+    if not adapter_src.is_file():
+        raise FileNotFoundError(
+            f"merged model has {len(specs)} LoRA weight_quantized ports but adapter missing: "
+            f"{adapter_src}"
+        )
+
+    port_names = [name for name, _ in specs]
+    packed_out = output_dir / "adapter.safetensors"
+    count = export_packed_adapter_safetensors(
+        adapter_src, packed_out, port_names=port_names
+    )
+    return [f"adapter.safetensors ({count} packed tensors)"]

--- a/tools/onnx-merged-convert/merged_convert/lora_weight_pack.py
+++ b/tools/onnx-merged-convert/merged_convert/lora_weight_pack.py
@@ -3,10 +3,13 @@
 # Licensed under the MIT License.
 #
 
-"""LoRA MatMulNBits adapter weight packing at export time.
+"""LoRA adapter export helpers for merged convert.
 
-``weight_quantized`` graph inputs are uint8 ``[N,K]``; adapter weights are
-written to ``adapter.safetensors`` in the same packed layout.
+MatMulNBits graphs: pack int8 ``[K,N]`` weights to uint8 ``[N,K]`` for
+``weight_quantized`` inputs.
+
+Folded Gemm graphs: dequantize int8 adapter weights to fp16 ``weight_fp16``
+inputs at export time.
 """
 
 from __future__ import annotations
@@ -24,6 +27,69 @@ def pack_lora_weight_mnbits_int8(raw: np.ndarray) -> np.ndarray:
     if raw.ndim != 2:
         raise ValueError(f"expected rank-2 [K,N] weight, got shape {raw.shape}")
     return (raw.astype(np.int16) + 128).astype(np.uint8).T
+
+
+def dequant_lora_weight_int8_to_fp16(
+    raw: np.ndarray, *, scale: float, zero_point: int
+) -> np.ndarray:
+    """Dequantize signed int8 LoRA weights to fp16 (matches runtime DQ formula)."""
+    fp32 = (raw.astype(np.float32) - np.float32(zero_point)) * np.float32(scale)
+    return fp32.astype(np.float16)
+
+
+def export_dequant_adapter_safetensors(
+    src: Path,
+    dst: Path,
+    port_meta: dict[str, dict],
+) -> int:
+    """Dequantize int8 adapter tensors to fp16, keyed by graph ``onnx_input`` names."""
+    try:
+        from safetensors.numpy import save_file
+    except ImportError as exc:
+        raise ImportError("safetensors is required; pip install safetensors") from exc
+
+    if not port_meta:
+        return 0
+
+    raw = load_adapter_int8_tensors(src)
+    missing = set(port_meta) - set(raw)
+    if missing:
+        raise KeyError(
+            f"adapter missing {len(missing)} requested ports, e.g. {next(iter(missing))!r}"
+        )
+
+    dequantized: dict[str, np.ndarray] = {}
+    for weight_quantized, meta in port_meta.items():
+        onnx_input = meta["onnx_input"]
+        dequantized[onnx_input] = dequant_lora_weight_int8_to_fp16(
+            raw[weight_quantized],
+            scale=float(meta["scale"]),
+            zero_point=int(meta["zero_point"]),
+        )
+
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    save_file(dequantized, str(dst))
+    return len(dequantized)
+
+
+def write_dequant_lora_artifacts(
+    adapter_src: Path,
+    output_dir: Path,
+    port_meta: dict[str, dict],
+) -> list[str]:
+    """Export fp16 ``adapter.safetensors`` for folded Gemm LoRA graphs."""
+    if not port_meta:
+        return []
+
+    if not adapter_src.is_file():
+        raise FileNotFoundError(
+            f"merged Gemm LoRA graph has {len(port_meta)} adapter ports but adapter missing: "
+            f"{adapter_src}"
+        )
+
+    packed_out = output_dir / "adapter.safetensors"
+    count = export_dequant_adapter_safetensors(adapter_src, packed_out, port_meta)
+    return [f"adapter.safetensors ({count} fp16 tensors)"]
 
 
 def load_adapter_int8_tensors(adapter_path: Path) -> dict[str, np.ndarray]:

--- a/tools/onnx-merged-convert/merged_convert/pipeline.py
+++ b/tools/onnx-merged-convert/merged_convert/pipeline.py
@@ -17,7 +17,7 @@ from .bundle import (
     _find_genai_config_source,
 )
 from .int8kv import convert_decoder_int8kv
-from .lora_weight_pack import write_packed_lora_artifacts
+from .lora_weight_pack import write_dequant_lora_artifacts, write_packed_lora_artifacts
 from .pipeline_aliases import (
     CONVERT_PROFILE_LOW_BIT,
     convert_head_quantized,
@@ -338,22 +338,24 @@ def convert_bundle(bundle: ModelBundle, output_dir: Path) -> Path:
     )
 
     extras: list[str] = []
-    if lora_dequant_meta:
-        meta_path = output_dir / "lora_dequant.json"
-        meta_path.write_text(json.dumps(lora_dequant_meta, indent=2), encoding="utf-8")
-        extras.append(f"lora_dequant.json ({len(lora_dequant_meta)} adapter ports)")
-
     adapter_src = bundle.input_dir / "adapter.safetensors"
-    try:
-        extras.extend(write_packed_lora_artifacts(merged_path, adapter_src, output_dir))
-    except FileNotFoundError as exc:
-        if (
-            bundle.pipeline is PipelineKind.QUANTIZED_LINEAR
-            and not bundle.fold_gemm_weights
-        ):
-            raise RuntimeError(
-                "LoRA MatMulNBits export requires raw adapter.safetensors in input-dir"
-            ) from exc
+    if lora_dequant_meta:
+        extras.extend(
+            write_dequant_lora_artifacts(adapter_src, output_dir, lora_dequant_meta)
+        )
+    else:
+        try:
+            extras.extend(
+                write_packed_lora_artifacts(merged_path, adapter_src, output_dir)
+            )
+        except FileNotFoundError as exc:
+            if (
+                bundle.pipeline is PipelineKind.QUANTIZED_LINEAR
+                and not bundle.fold_gemm_weights
+            ):
+                raise RuntimeError(
+                    "LoRA MatMulNBits export requires raw adapter.safetensors in input-dir"
+                ) from exc
 
     extra_msg = f" + {', '.join(extras)}" if extras else ""
     print(

--- a/tools/onnx-merged-convert/merged_convert/pipeline.py
+++ b/tools/onnx-merged-convert/merged_convert/pipeline.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import json
-import shutil
 import tempfile
 from pathlib import Path
 
@@ -18,6 +17,7 @@ from .bundle import (
     _find_genai_config_source,
 )
 from .int8kv import convert_decoder_int8kv
+from .lora_weight_pack import write_packed_lora_artifacts
 from .pipeline_aliases import (
     CONVERT_PROFILE_LOW_BIT,
     convert_head_quantized,
@@ -116,7 +116,6 @@ def _convert_quantized_linear(
         dynamic,
         static_seq_lens=(1, bundle.prefill_seq_len),
     )
-    _apply_pure_fp16(dec_decode, dec_prefill, dynamic)
 
     print("  [4/5] Merge emb + dynamic decoder + lm_head ...")
     data_name = f"{bundle.merged_stem}.data"
@@ -164,7 +163,6 @@ def _convert_int8_kv(bundle: ModelBundle, work: Path, merged_path: Path) -> None
         dynamic,
         static_seq_lens=(1, bundle.prefill_seq_len),
     )
-    _apply_pure_fp16(dynamic)
 
     print("  [3/5] QDQ removal + fp16 (emb / lm_head) ...")
     patch_emb_quantized(
@@ -270,7 +268,6 @@ def _convert_low_bit(bundle: ModelBundle, work: Path, merged_path: Path) -> None
         dynamic,
         static_seq_lens=(1, bundle.prefill_seq_len),
     )
-    _apply_pure_fp16(dec_decode, dec_prefill, dynamic)
 
     print("  [4/5] Merge emb + dynamic decoder + lm_head (pruned logits) ...")
     data_name = f"{bundle.merged_stem}.data"
@@ -347,9 +344,16 @@ def convert_bundle(bundle: ModelBundle, output_dir: Path) -> Path:
         extras.append(f"lora_dequant.json ({len(lora_dequant_meta)} adapter ports)")
 
     adapter_src = bundle.input_dir / "adapter.safetensors"
-    if adapter_src.is_file():
-        shutil.copy2(adapter_src, output_dir / "adapter.safetensors")
-        extras.append("adapter.safetensors")
+    try:
+        extras.extend(write_packed_lora_artifacts(merged_path, adapter_src, output_dir))
+    except FileNotFoundError as exc:
+        if (
+            bundle.pipeline is PipelineKind.QUANTIZED_LINEAR
+            and not bundle.fold_gemm_weights
+        ):
+            raise RuntimeError(
+                "LoRA MatMulNBits export requires raw adapter.safetensors in input-dir"
+            ) from exc
 
     extra_msg = f" + {', '.join(extras)}" if extras else ""
     print(

--- a/tools/onnx-merged-convert/merged_convert/pipeline.py
+++ b/tools/onnx-merged-convert/merged_convert/pipeline.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import tempfile
 from pathlib import Path
 
@@ -29,6 +30,7 @@ from .pipeline_aliases import (
 )
 from .qdq_ext import CONVERT_PROFILE_LITE
 from .step1_qdq_fp16 import (
+    DECODER_WORK_EXTERNAL_DATA,
     ShapeFixConfig,
     convert_decoder_model,
     convert_lm_head_model,
@@ -38,6 +40,7 @@ from .step2_fp16_cleanup import patch_model_file
 from .step4_unfix_seq_len import unfix_seq_len
 
 DEFAULT_MAX_SEQ_LEN = 16384
+INTERMEDIATES_DIR_NAME = "work"
 
 
 def _apply_pure_fp16(*paths: Path) -> None:
@@ -77,6 +80,7 @@ def _convert_quantized_linear(
         dec_prefill,
         shape_fix=shape_prefill,
         bundle_root=bundle.input_dir,
+        external_data_name=DECODER_WORK_EXTERNAL_DATA,
         gqa_seqlens_rewrite=False,
         pure_gemm=bundle.fold_gemm_weights,
         lora_dequant_meta=lora_dequant_meta if bundle.fold_gemm_weights else None,
@@ -86,6 +90,9 @@ def _convert_quantized_linear(
         dec_decode,
         shape_fix=shape_decode,
         bundle_root=bundle.input_dir,
+        external_data_name=DECODER_WORK_EXTERNAL_DATA,
+        reuse_external_data=True,
+        external_data_ref=dec_prefill,
         gqa_seqlens_rewrite=False,
         pure_gemm=bundle.fold_gemm_weights,
         lora_dequant_meta=lora_dequant_meta if bundle.fold_gemm_weights else None,
@@ -146,12 +153,16 @@ def _convert_int8_kv(bundle: ModelBundle, work: Path, merged_path: Path) -> None
         bundle.dec_prefill,
         dec_prefill,
         bundle_root=bundle.input_dir,
+        external_data_name=DECODER_WORK_EXTERNAL_DATA,
         gqa_seqlens_rewrite=False,
     )
     convert_decoder_int8kv(
         bundle.dec_decode,
         dec_decode,
         bundle_root=bundle.input_dir,
+        external_data_name=DECODER_WORK_EXTERNAL_DATA,
+        reuse_external_data=True,
+        external_data_ref=dec_prefill,
         gqa_seqlens_rewrite=False,
     )
 
@@ -224,6 +235,7 @@ def _convert_low_bit(bundle: ModelBundle, work: Path, merged_path: Path) -> None
         bundle_root=bundle.input_dir,
         head_data_dir=work,
         rewrite_head_data=False,
+        external_data_name=DECODER_WORK_EXTERNAL_DATA,
         profile=profile,
     )
     process_one_onnx(
@@ -234,6 +246,9 @@ def _convert_low_bit(bundle: ModelBundle, work: Path, merged_path: Path) -> None
         bundle_root=bundle.input_dir,
         head_data_dir=work,
         rewrite_head_data=False,
+        external_data_name=DECODER_WORK_EXTERNAL_DATA,
+        reuse_external_data=True,
+        external_data_ref=dec_prefill,
         profile=profile,
     )
 
@@ -283,7 +298,33 @@ def _convert_low_bit(bundle: ModelBundle, work: Path, merged_path: Path) -> None
     _apply_pure_fp16(merged_path)
 
 
-def convert_bundle(bundle: ModelBundle, output_dir: Path) -> Path:
+def _reset_work_dir(work_dir: Path) -> Path:
+    if work_dir.exists():
+        shutil.rmtree(work_dir)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    return work_dir
+
+
+def _run_pipeline(
+    bundle: ModelBundle, work: Path, merged_path: Path
+) -> dict[str, dict] | None:
+    if bundle.pipeline is PipelineKind.QUANTIZED_LINEAR:
+        return _convert_quantized_linear(bundle, work, merged_path)
+    if bundle.pipeline is PipelineKind.INT8_KV:
+        _convert_int8_kv(bundle, work, merged_path)
+        return None
+    if bundle.pipeline is PipelineKind.LOW_BIT:
+        _convert_low_bit(bundle, work, merged_path)
+        return None
+    raise ValueError(f"Unsupported pipeline: {bundle.pipeline}")
+
+
+def convert_bundle(
+    bundle: ModelBundle,
+    output_dir: Path,
+    *,
+    keep_intermediates: bool = False,
+) -> Path:
     output_dir = output_dir.resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -303,18 +344,15 @@ def convert_bundle(bundle: ModelBundle, output_dir: Path) -> Path:
     )
 
     lora_dequant_meta: dict[str, dict] | None = None
-    with tempfile.TemporaryDirectory(
-        prefix=f"merged_convert_{bundle.decoder_stem}_"
-    ) as tmp:
-        work = Path(tmp)
-        if bundle.pipeline is PipelineKind.QUANTIZED_LINEAR:
-            lora_dequant_meta = _convert_quantized_linear(bundle, work, merged_path)
-        elif bundle.pipeline is PipelineKind.INT8_KV:
-            _convert_int8_kv(bundle, work, merged_path)
-        elif bundle.pipeline is PipelineKind.LOW_BIT:
-            _convert_low_bit(bundle, work, merged_path)
-        else:
-            raise ValueError(f"Unsupported pipeline: {bundle.pipeline}")
+    if keep_intermediates:
+        work = _reset_work_dir(output_dir / INTERMEDIATES_DIR_NAME)
+        lora_dequant_meta = _run_pipeline(bundle, work, merged_path)
+        print(f"  Kept intermediate artifacts in {work}")
+    else:
+        with tempfile.TemporaryDirectory(
+            prefix=f"merged_convert_{bundle.decoder_stem}_"
+        ) as tmp:
+            lora_dequant_meta = _run_pipeline(bundle, Path(tmp), merged_path)
 
     if not merged_path.exists():
         raise RuntimeError(

--- a/tools/onnx-merged-convert/merged_convert/qdq_ext.py
+++ b/tools/onnx-merged-convert/merged_convert/qdq_ext.py
@@ -1126,7 +1126,11 @@ def save_decoder_model_q(
     *,
     external_data_name: str = DECODER_EXT_DATA,
     keep_inline: set[str] | None = None,
+    reuse_external_data: bool = False,
+    external_data_ref: Path | None = None,
 ) -> None:
+    from .step1_qdq_fp16 import _save_decoder_graph_reusing_external_data
+
     if not model.graph.name:
         model.graph.name = f"{dst.stem}_graph"
     if keep_inline:
@@ -1135,6 +1139,22 @@ def save_decoder_model_q(
     data_path = dst.parent / external_data_name
     if dst.exists():
         dst.unlink()
+    if reuse_external_data:
+        if external_data_ref is None:
+            raise ValueError(
+                "external_data_ref is required when reuse_external_data=True"
+            )
+        if not data_path.is_file():
+            raise RuntimeError(
+                f"Expected shared external weights at {data_path} before reusing them"
+            )
+        _save_decoder_graph_reusing_external_data(
+            model,
+            dst,
+            external_data_ref=external_data_ref,
+            external_data_name=external_data_name,
+        )
+        return
     if data_path.exists():
         data_path.unlink()
     onnx.save_model(
@@ -1327,6 +1347,8 @@ def convert_decoder_model_q(
     shape_fix: ShapeFixConfig_q,
     bundle_root: Path,
     external_data_name: str | None = None,
+    reuse_external_data: bool = False,
+    external_data_ref: Path | None = None,
     runtime_ep: bool = DEFAULT_RUNTIME_EP,
     profile: ConvertProfile = CONVERT_PROFILE_FULL,
 ) -> dict[str, int]:
@@ -1414,14 +1436,16 @@ def convert_decoder_model_q(
     )
     if profile.strip_qdq:
         assert_qdq_removed(graph, context=dst.name)
-    ext_name = external_data_name or infer_decoder_external_data_name_q(
-        src, bundle_root
-    )
+    from .step1_qdq_fp16 import DECODER_WORK_EXTERNAL_DATA
+
+    ext_name = external_data_name or DECODER_WORK_EXTERNAL_DATA
     save_decoder_model_q(
         model,
         dst,
-        external_data_name=ext_name or DECODER_EXTERNAL_DATA_q,
+        external_data_name=ext_name,
         keep_inline=inline_at_load,
+        reuse_external_data=reuse_external_data,
+        external_data_ref=external_data_ref,
     )
     return stats
 
@@ -1446,6 +1470,9 @@ def process_one_onnx_q(
     bundle_root: Path,
     head_data_dir: Path,
     rewrite_head_data: bool,
+    external_data_name: str | None = None,
+    reuse_external_data: bool = False,
+    external_data_ref: Path | None = None,
     runtime_ep: bool = DEFAULT_RUNTIME_EP,
     gather_unsqueeze: bool = False,
     profile: ConvertProfile = CONVERT_PROFILE_FULL,
@@ -1477,6 +1504,9 @@ def process_one_onnx_q(
         dst,
         shape_fix=shape_fix,
         bundle_root=bundle_root,
+        external_data_name=external_data_name,
+        reuse_external_data=reuse_external_data,
+        external_data_ref=external_data_ref,
         runtime_ep=runtime_ep,
         profile=profile,
     )

--- a/tools/onnx-merged-convert/merged_convert/step1_qdq_fp16.py
+++ b/tools/onnx-merged-convert/merged_convert/step1_qdq_fp16.py
@@ -21,6 +21,7 @@ FP64 = TensorProto.DOUBLE
 FP16__dup4 = TensorProto.FLOAT16
 INT4 = TensorProto.INT4
 DECODER_EXTERNAL_DATA = "BUNDLE.data"
+DECODER_WORK_EXTERNAL_DATA = "model.data"
 HEAD_QWEIGHT_DATA = "BUNDLE_head_qweight.data"
 HEAD_SCALE_DATA = "BUNDLE_head_scale.data"
 DEFAULT_BATCH = 1
@@ -961,11 +962,75 @@ def rewrite_gqa_past_seq_len_to_seqlens_k(model: onnx.ModelProto) -> int:
     return len(gqa_nodes)
 
 
+def _external_data_kv(init: onnx.TensorProto, key: str) -> str | None:
+    for kv in init.external_data:
+        if kv.key == key:
+            return kv.value
+    return None
+
+
+def _promote_initializer_to_shared_external_data(
+    init: onnx.TensorProto,
+    ref_init: onnx.TensorProto,
+    *,
+    location: str,
+) -> None:
+    if ref_init.data_location != TensorProto.EXTERNAL:
+        raise RuntimeError(
+            f"Reference initializer {ref_init.name!r} is not external; "
+            f"cannot reuse {location}"
+        )
+    offset_raw = _external_data_kv(ref_init, "offset")
+    length_raw = _external_data_kv(ref_init, "length")
+    if offset_raw is None or length_raw is None:
+        raise RuntimeError(
+            f"Reference initializer {ref_init.name!r} is missing external offset/length"
+        )
+    name = init.name
+    data_type = init.data_type
+    dims = list(init.dims)
+    init.Clear()
+    init.name = name
+    init.data_type = data_type
+    init.dims.extend(dims)
+    init.data_location = TensorProto.EXTERNAL
+    for kv in ref_init.external_data:
+        entry = init.external_data.add()
+        entry.key = kv.key
+        entry.value = location if kv.key == "location" else kv.value
+
+
+def _save_decoder_graph_reusing_external_data(
+    model: onnx.ModelProto,
+    dst: Path,
+    *,
+    external_data_ref: Path,
+    external_data_name: str,
+) -> None:
+    from .step2_fp16_cleanup import _save_model_graph_only
+
+    ref_model = onnx.load(str(external_data_ref), load_external_data=False)
+    ref_inits = {init.name: init for init in ref_model.graph.initializer}
+    for init in model.graph.initializer:
+        ref_init = ref_inits.get(init.name)
+        if ref_init is None:
+            raise RuntimeError(
+                f"Initializer {init.name!r} missing from reference {external_data_ref.name}"
+            )
+        if ref_init.data_location == TensorProto.EXTERNAL:
+            _promote_initializer_to_shared_external_data(
+                init, ref_init, location=external_data_name
+            )
+    _save_model_graph_only(model, dst)
+
+
 def save_decoder_model(
     model: onnx.ModelProto,
     dst: Path,
     *,
     external_data_name: str = DECODER_EXTERNAL_DATA,
+    reuse_external_data: bool = False,
+    external_data_ref: Path | None = None,
 ) -> None:
     if not model.graph.name:
         model.graph.name = f"{dst.stem}_graph"
@@ -973,6 +1038,22 @@ def save_decoder_model(
     data_path = dst.parent / external_data_name
     if dst.exists():
         dst.unlink()
+    if reuse_external_data:
+        if external_data_ref is None:
+            raise ValueError(
+                "external_data_ref is required when reuse_external_data=True"
+            )
+        if not data_path.is_file():
+            raise RuntimeError(
+                f"Expected shared external weights at {data_path} before reusing them"
+            )
+        _save_decoder_graph_reusing_external_data(
+            model,
+            dst,
+            external_data_ref=external_data_ref,
+            external_data_name=external_data_name,
+        )
+        return
     if data_path.exists():
         data_path.unlink()
     onnx.save_model(
@@ -1057,6 +1138,8 @@ def convert_decoder_model(
     shape_fix: ShapeFixConfig,
     bundle_root: Path,
     external_data_name: str | None = None,
+    reuse_external_data: bool = False,
+    external_data_ref: Path | None = None,
     lpnorm_fp32: bool = False,
     gqa_seqlens_rewrite: bool = True,
     pure_gemm: bool = False,
@@ -1111,8 +1194,14 @@ def convert_decoder_model(
     stats["gqa_seqlens_rewrite"] = (
         rewrite_gqa_past_seq_len_to_seqlens_k(model) if gqa_seqlens_rewrite else 0
     )
-    ext_name = external_data_name or f"{dst.stem}.data"
-    save_decoder_model(model, dst, external_data_name=ext_name)
+    ext_name = external_data_name or DECODER_WORK_EXTERNAL_DATA
+    save_decoder_model(
+        model,
+        dst,
+        external_data_name=ext_name,
+        reuse_external_data=reuse_external_data,
+        external_data_ref=external_data_ref,
+    )
     return stats
 
 

--- a/tools/onnx-merged-convert/merged_convert/step1_qdq_fp16.py
+++ b/tools/onnx-merged-convert/merged_convert/step1_qdq_fp16.py
@@ -14,6 +14,7 @@ from onnx import TensorProto, helper, numpy_helper
 
 from .step2_fp16_cleanup import optimize_fp16_activations
 from .step3_lm_head import rewrite_lm_head_gather_unsqueeze
+from .lora_weight_pack import retarget_weight_quantized_graph_input
 
 FP32__dup4 = TensorProto.FLOAT
 FP64 = TensorProto.DOUBLE
@@ -372,14 +373,15 @@ def convert_matmul_graph_input_int8_dq(
 ) -> int:
     """Fuse graph-input int8 ``weight_quantized -> DQ -> MatMul`` into MatMulNBits.
 
-    Keeps each ``weight_quantized`` port as a graph input (shape ``[K, N]``).
-    Inserts ``Transpose + Reshape`` so MatMulNBits receives ``[N, K/block, block]``.
+    Keep ``weight_quantized`` ports as uint8 ``[N,K]`` graph inputs and
+    wire MatMulNBits directly.
     """
     graph_inputs = {vi.name: vi for vi in graph.input}
     dq_by_out = {d.output[0]: d for d in graph.node if d.op_type == "DequantizeLinear"}
     scale_cache: dict[tuple[str, str, int, int], str] = {}
     insert_before: dict[str, list[onnx.NodeProto]] = {}
     remove_nodes: set[str] = set()
+    retargeted_ports: set[str] = set()
     converted = 0
     for mm in graph.node:
         if mm.op_type != "MatMul" or len(mm.input) < 2:
@@ -401,54 +403,11 @@ def convert_matmul_graph_input_int8_dq(
         k, n = dims
         block_size = _matmul_nbits_block_size(k)
         n_blocks = k // block_size
-        packed_shape_name = f"{mm.name}_mnbits_pack_shape"
-        new_inits[packed_shape_name] = numpy_helper.from_array(
-            np.array([n, n_blocks, block_size], dtype=np.int64), name=packed_shape_name
-        )
-        offset_name = f"{mm.name}_mnbits_signed_offset"
-        new_inits[offset_name] = numpy_helper.from_array(
-            np.array(128, dtype=np.int16), name=offset_name
-        )
-        trans_out = f"{mm.name}_mnbits_w_t"
-        trans_i16 = f"{mm.name}_mnbits_w_t_i16"
-        shifted_i16 = f"{mm.name}_mnbits_w_shifted_i16"
-        trans_u8 = f"{mm.name}_mnbits_w_t_u8"
-        packed_u8 = f"{mm.name}_mnbits_w_uint8"
-        pack_nodes = [
-            helper.make_node(
-                "Transpose",
-                [w_name],
-                [trans_out],
-                name=f"{mm.name}_mnbits_transpose",
-                perm=[1, 0],
-            ),
-            helper.make_node(
-                "Cast",
-                [trans_out],
-                [trans_i16],
-                name=f"{mm.name}_mnbits_cast_i16",
-                to=TensorProto.INT16,
-            ),
-            helper.make_node(
-                "Add",
-                [trans_i16, offset_name],
-                [shifted_i16],
-                name=f"{mm.name}_mnbits_add_offset",
-            ),
-            helper.make_node(
-                "Cast",
-                [shifted_i16],
-                [trans_u8],
-                name=f"{mm.name}_mnbits_cast_u8",
-                to=TensorProto.UINT8,
-            ),
-            helper.make_node(
-                "Reshape",
-                [trans_u8, packed_shape_name],
-                [packed_u8],
-                name=f"{mm.name}_mnbits_pack",
-            ),
-        ]
+
+        if w_name not in retargeted_ports:
+            retarget_weight_quantized_graph_input(graph, w_name, k, n)
+            retargeted_ports.add(w_name)
+
         scale_key = (dq.input[1], dq.input[2], n, n_blocks)
         if scale_key not in scale_cache:
             scale_blocks, zp_blocks = _expand_scale_zp_blocks_signed_int8(
@@ -465,7 +424,7 @@ def convert_matmul_graph_input_int8_dq(
             scale_cache[dq.input[1], dq.input[2], n, n_blocks, "zp"] = z_name
         s_name = scale_cache[scale_key]
         z_name = scale_cache[dq.input[1], dq.input[2], n, n_blocks, "zp"]
-        mnbits_inputs = [mm.input[0], packed_u8, s_name, z_name]
+        mnbits_inputs = [mm.input[0], w_name, s_name, z_name]
         mnbits = helper.make_node(
             "MatMulNBits",
             mnbits_inputs,
@@ -478,7 +437,7 @@ def convert_matmul_graph_input_int8_dq(
             block_size=block_size,
             accuracy_level=MATMUL_NBITS_ACCURACY_LEVEL,
         )
-        insert_before[mm.name] = [*pack_nodes, mnbits]
+        insert_before[mm.name] = [mnbits]
         remove_nodes.update({mm.name, dq.name})
         converted += 1
     if not converted:
@@ -1152,7 +1111,7 @@ def convert_decoder_model(
     stats["gqa_seqlens_rewrite"] = (
         rewrite_gqa_past_seq_len_to_seqlens_k(model) if gqa_seqlens_rewrite else 0
     )
-    ext_name = external_data_name or infer_decoder_external_data_name(src, bundle_root)
+    ext_name = external_data_name or f"{dst.stem}.data"
     save_decoder_model(model, dst, external_data_name=ext_name)
     return stats
 

--- a/tools/onnx-merged-convert/merged_convert/step2_fp16_cleanup.py
+++ b/tools/onnx-merged-convert/merged_convert/step2_fp16_cleanup.py
@@ -13,6 +13,14 @@ from onnx import TensorProto, shape_inference
 
 FP32 = TensorProto.FLOAT
 FP16 = TensorProto.FLOAT16
+_FLOAT_ELEM_TYPES = frozenset(
+    {
+        TensorProto.FLOAT,
+        TensorProto.FLOAT16,
+        TensorProto.DOUBLE,
+        TensorProto.BFLOAT16,
+    }
+)
 _PRE_CAST_CASTFP32_RE = re.compile(
     "(?:^getitem(?:_\\d+)?_pre_cast_castfp32$|GroupQueryAttention_output_\\d+_pre_cast_castfp32$)"
 )
@@ -36,7 +44,78 @@ def _replace_tensor_uses(graph: onnx.GraphProto, old: str, new: str) -> int:
             if name == old:
                 node.input[idx] = new
                 replacements += 1
+    for vi in list(graph.output) + list(graph.value_info):
+        if vi.name == old:
+            vi.name = new
+            replacements += 1
     return replacements
+
+
+def _build_tensor_users(
+    graph: onnx.GraphProto,
+) -> dict[str, list[tuple[onnx.NodeProto, int]]]:
+    users: dict[str, list[tuple[onnx.NodeProto, int]]] = {}
+    for node in graph.node:
+        for idx, name in enumerate(node.input):
+            if name:
+                users.setdefault(name, []).append((node, idx))
+    return users
+
+
+def _infer_activation_elem_types(graph: onnx.GraphProto) -> dict[str, int]:
+    """Best-effort elem_type map for activation tensors."""
+    types: dict[str, int] = {}
+    for init in graph.initializer:
+        types[init.name] = init.data_type
+    for vi in list(graph.input) + list(graph.output) + list(graph.value_info):
+        elem_type = vi.type.tensor_type.elem_type
+        if elem_type:
+            types[vi.name] = elem_type
+
+    changed = True
+    while changed:
+        changed = False
+        for node in graph.node:
+            if node.op_type == "Cast":
+                to_type = _cast_to(node)
+                if to_type is None or not node.output:
+                    continue
+                out = node.output[0]
+                if types.get(out) != to_type:
+                    types[out] = to_type
+                    changed = True
+                continue
+
+            in_types = [
+                types[inp]
+                for inp in node.input
+                if inp and inp in types and types[inp] in _FLOAT_ELEM_TYPES
+            ]
+            if not in_types or not node.output:
+                continue
+            if all(t == FP16 for t in in_types):
+                out_type = FP16
+            elif len(set(in_types)) == 1:
+                out_type = in_types[0]
+            else:
+                continue
+            for out in node.output:
+                if not out or types.get(out) == out_type:
+                    continue
+                types[out] = out_type
+                changed = True
+    return types
+
+
+def _is_fp16_consumer_op(node: onnx.NodeProto) -> bool:
+    """True when a downstream op consumes fp16 activations on this edge."""
+    if node.op_type == "Cast":
+        return _cast_to(node) == FP16
+    return True
+
+
+def _keep_gqa_pre_cast_fp16_cast(src: str, dst: str) -> bool:
+    return src.endswith("_pre_cast") and "GroupQueryAttention_output_" in dst
 
 
 def _remove_nodes(graph: onnx.GraphProto, names: set[str]) -> int:
@@ -198,6 +277,43 @@ def remove_redundant_mnbits_fp16_casts(model: onnx.ModelProto) -> int:
     return folded
 
 
+def remove_redundant_fp16_casts(model: onnx.ModelProto) -> int:
+    """Drop Cast(fp16) when upstream and downstream ops already use fp16."""
+    graph = model.graph
+    total = 0
+    while True:
+        elem_types = _infer_activation_elem_types(graph)
+        users = _build_tensor_users(graph)
+        remove: set[str] = set()
+        removed = 0
+        for cast in graph.node:
+            if cast.op_type != "Cast" or _cast_to(cast) != FP16:
+                continue
+            if not cast.input or not cast.output:
+                continue
+            src = cast.input[0]
+            dst = cast.output[0]
+            if elem_types.get(src) != FP16:
+                continue
+            if _emu_fp32_boundary_tensor(graph, src):
+                continue
+            if _keep_gqa_pre_cast_fp16_cast(src, dst):
+                continue
+            consumers = users.get(dst, [])
+            if not consumers or any(
+                not _is_fp16_consumer_op(node) for node, _idx in consumers
+            ):
+                continue
+            _replace_tensor_uses(graph, dst, src)
+            remove.add(cast.name)
+            removed += 1
+        _remove_nodes(graph, remove)
+        total += removed
+        if removed == 0:
+            break
+    return total
+
+
 def ensure_matmul_nbits_fp16_inputs(model: onnx.ModelProto) -> int:
     """Cast MatMulNBits activations to fp16 so ORT does not mix float/float16 on T1."""
     graph = model.graph
@@ -253,6 +369,7 @@ def optimize_fp16_activations(
         else 0,
         "mnbits_fp16_casts_folded": remove_redundant_mnbits_fp16_casts(model),
         "mnbits_fp16_inputs": ensure_matmul_nbits_fp16_inputs(model),
+        "fp16_casts_removed": remove_redundant_fp16_casts(model),
     }
     if clear_value_info:
         del model.graph.value_info[:]

--- a/tools/onnx-merged-convert/merged_convert/step2_fp16_cleanup.py
+++ b/tools/onnx-merged-convert/merged_convert/step2_fp16_cleanup.py
@@ -384,55 +384,25 @@ def promote_pure_fp16_activations(
     return optimize_fp16_activations(model, clear_value_info=clear_value_info)
 
 
-def _external_data_location__dup2(model: onnx.ModelProto) -> str | None:
-    locations = {
-        entry.value
-        for init in model.graph.initializer
-        for entry in init.external_data
-        if entry.key == "location"
-    }
-    if len(locations) == 1:
-        return locations.pop()
-    return None
-
-
-def _save_model_preserving_external_data(model: onnx.ModelProto, dst: Path) -> None:
+def _save_model_graph_only(model: onnx.ModelProto, dst: Path) -> None:
+    """Write graph protobuf only; keep existing external weight blob references."""
+    if not model.graph.name:
+        model.graph.name = f"{dst.stem}_graph"
     dst.parent.mkdir(parents=True, exist_ok=True)
     if dst.exists():
         dst.unlink()
-    ext_name = _external_data_location__dup2(model)
-    if ext_name is None:
-        data_candidates = sorted(
-            dst.parent.glob("*.data"), key=lambda p: p.stat().st_size, reverse=True
-        )
-        if data_candidates:
-            ext_name = data_candidates[0].name
-    if ext_name is not None:
-        data_path = dst.parent / ext_name
-        if not data_path.exists():
-            raise FileNotFoundError(
-                f"External weights not found for {dst.name}: {data_path}"
-            )
-        onnx.save_model(
-            model,
-            str(dst),
-            save_as_external_data=True,
-            all_tensors_to_one_file=True,
-            location=ext_name,
-            size_threshold=1024,
-        )
-        if dst.stat().st_size > 256 * 1024 * 1024:
-            raise RuntimeError(
-                f"{dst.name}: ONNX protobuf is {dst.stat().st_size} bytes after save; expected weights in {ext_name}"
-            )
-        return
     onnx.save(model, str(dst))
+    if dst.stat().st_size > 256 * 1024 * 1024:
+        raise RuntimeError(
+            f"{dst.name}: ONNX protobuf is {dst.stat().st_size} bytes after graph-only save; "
+            "load with load_external_data=False to preserve external initializers"
+        )
 
 
 def patch_model_file(
     src: Path, dst: Path, *, reinfer_shapes: bool = False
 ) -> dict[str, int]:
-    model = onnx.load(str(src), load_external_data=True)
+    model = onnx.load(str(src), load_external_data=False)
     stats = optimize_fp16_activations(model)
     if stats["fp32_casts_remaining"]:
         raise RuntimeError(
@@ -440,5 +410,5 @@ def patch_model_file(
         )
     if reinfer_shapes:
         model = shape_inference.infer_shapes(model)
-    _save_model_preserving_external_data(model, dst)
+    _save_model_graph_only(model, dst)
     return stats

--- a/tools/onnx-merged-convert/merged_convert/step4_unfix_seq_len.py
+++ b/tools/onnx-merged-convert/merged_convert/step4_unfix_seq_len.py
@@ -276,38 +276,13 @@ def _apply_seq_len_bindings(
     return changed
 
 
-def _external_data_location(model: onnx.ModelProto) -> str | None:
-    locations = {
-        entry.value
-        for init in model.graph.initializer
-        for entry in init.external_data
-        if entry.key == "location"
-    }
-    if len(locations) == 1:
-        return locations.pop()
-    return None
-
-
 def _save_unfixed_model(model: onnx.ModelProto, out_path: Path) -> None:
+    """Write graph-only ONNX; reuse the source model's external weight blob."""
     out_path.parent.mkdir(parents=True, exist_ok=True)
     if out_path.exists():
         out_path.unlink()
-    ext_name = _external_data_location(model)
-    if ext_name is not None:
-        data_path = out_path.parent / ext_name
-        if not data_path.exists():
-            raise FileNotFoundError(
-                f"External weights not found for {out_path.name}: {data_path}"
-            )
-        onnx.save_model(
-            model,
-            str(out_path),
-            save_as_external_data=True,
-            all_tensors_to_one_file=True,
-            location=ext_name,
-            size_threshold=65536,
-        )
-        return
+    if not model.graph.name:
+        model.graph.name = f"{out_path.stem}_graph"
     onnx.save(model, str(out_path))
 
 


### PR DESCRIPTION
<!--
Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
Licensed under the MIT License.
-->

<!--
Thank you for contributing. Keep the description proportional to the change
and review it for accuracy before requesting review. See CONTRIBUTING.md for
the full workflow and AI-assistance disclosure requirements.
-->

## Summary

Optimizes `onnx-merged-convert` so merged graphs drop identity `Cast(fp16)` nodes on already-fp16 activations, and LoRA weights are prepared at export time instead of being copied through or dequantized later. MatMulNBits adapters become packed uint8 `adapter.safetensors` wired as `weight_quantized` graph inputs; folded-Gemm adapters become fp16 `weight_fp16` tensors. Intermediate decoder graphs now share one `model.data` blob, and `--keep-intermediates` can retain `work/` artifacts.

## Related issue or design

None.

## Why

After QDQ removal and fp16 promotion, the merged graph still kept many `Cast -> FLOAT16` nodes whose producer and consumers were already fp16. Those nodes add graph noise, extra copies, and get in the way of a pure-fp16 activation contract (especially around MatMulNBits T1 and GQA).

LoRA handling had the same “leave it to runtime” shape: MatMulNBits still expected a pack chain, and folded Gemm emitted `lora_dequant.json` for later dequant. Packing / dequant at convert time matches how the merged model is actually loaded (uint8 `[N,K]` for MatMulNBits, fp16 weights for Gemm) and removes a runtime/export mismatch.

Decoder prefill and decode were also rewriting the same external weight blob independently. Sharing `model.data` and saving graph-only ONNX avoids duplicating large blobs when only the graph changes.

## What

- **Redundant fp16 Cast folding** (`step2_fp16_cleanup.py`):
  - `remove_redundant_fp16_casts`: drop `Cast(fp16)` when inferred src type is fp16 and all consumers already take fp16; also rename `graph.output` / `value_info` when folding uses.
  - `remove_redundant_mnbits_fp16_casts`: fold identity Casts that only feed MatMulNBits T1.
  - Guards: keep Casts at fp32 fake-quant (`_emu_*`) boundaries and GQA `*_pre_cast` → `GroupQueryAttention_output_*` edges.
- **MatMulNBits LoRA at export** (`lora_weight_pack.py`, `step1_qdq_fp16.py`):
  - Fuse `graph_input int8 weight_quantized → DQ → MatMul` into `MatMulNBits` with the same port name retargeted to packed uint8 `[N,K]`.
  - Write packed `adapter.safetensors` from raw int8 `[K,N]` (`+128`, transpose). Do not copy the raw adapter.
  - Quantized-linear convert fails if the merged graph has LoRA ports but `adapter.safetensors` is missing from `--input-dir`.
- **Folded Gemm LoRA at export**:
  - Replace `int8 → DQ → Gemm` with fp16 `weight_fp16` graph inputs.
  - Dequantize adapter tensors at convert time using the graph scale/zero-point. Stop emitting `lora_dequant.json`.
- **Graph-only saves + shared decoder weights**:
  - Intermediate decoder ONNX is saved without rewriting external blobs (`_save_model_graph_only`).
  - Prefill/decode (and later unfix) reuse one `model.data`.
- **Docs**: `tools/onnx-merged-convert/README.md` updated for packed/fp16 adapter outputs and pipeline behavior.

## Test plan

No dedicated unit tests were added in this PR. Validation is convert-tool runs plus inspection of the merged graph and `adapter.safetensors`.

- Convert a **MatMulNBits LoRA** bundle:
  - merged graph has no identity `Cast(fp16)` on already-fp16 activation edges (emu / GQA pre-cast edges may remain);
  - `weight_quantized` inputs are `UINT8` `[N,K]`;
  - output `adapter.safetensors` is packed uint8, not a copy of the int8 source;
  - `lora_dequant.json` is not written.
- Convert a **folded-Gemm LoRA** bundle:
  - `adapter.safetensors` uses fp16 `weight_fp16` keys;
  - `lora_dequant.json` is not written.
- Convert an **int8-KV** decoder and confirm GQA pre-cast / RoPE fp16 cleanup still holds (`Cast->fp32 remain` must not fire).
- Run with `--keep-intermediates` and confirm `<output-dir>/work/` has step ONNX plus a single shared `model.data`.

## Notes for reviewers

- **Breaking change for convert consumers:** `lora_dequant.json` is no longer written. Output `adapter.safetensors` is transformed (packed uint8 for MatMulNBits, or dequantized fp16 for folded Gemm), not a copy of the input file. Downstream must bind the new dtypes and shapes.
- MatMulNBits LoRA export **requires** raw int8 `adapter.safetensors` in `--input-dir`.
- `--keep-intermediates` is implemented on the CLI but is not yet listed in the README argument table.
- Cast folding is conservative around `_emu_*` fake-quant and GQA `*_pre_cast` edges; leftover Casts there are expected.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [ ] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.