### PR TITLE
feat(onnx-to-hip): axis-0 Gather extract_slice + Transpose-MatMul fusion

### DIFF
--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -791,8 +791,11 @@ def Hip_MatmulOp : Hip_DpsOp<"matmul", /*traits=*/[OpStateOpInterface],
     [docs/design/hip-shape-inference.md](docs/design/hip-shape-inference.md)
     for the dim-source contract and the consuming pipeline.
 
-    Unlike hip.gemm, this has no alpha/beta/transA/transB/bias — it maps
-    directly to onnx.MatMul semantics.
+    Optional `transA` / `transB` (0/1) apply a last-dimension swap on the
+    corresponding operand before multiply — the compile-time fusion of
+    `Transpose(perm=[..,r,r-2])` into MatMul for attention Q @ K^T. When
+    unset they default to 0 (standard onnx.MatMul layout: A [...,M,K],
+    B [...,K,N]).
 
     Example (2D):
     ```mlir
@@ -813,7 +816,9 @@ def Hip_MatmulOp : Hip_DpsOp<"matmul", /*traits=*/[OpStateOpInterface],
     Hip_ContextType:$ctx,
     Hip_TensorOrMemRef:$A,
     Hip_TensorOrMemRef:$B,
-    Hip_TensorOrMemRef:$output
+    Hip_TensorOrMemRef:$output,
+    DefaultValuedAttr<I64Attr, "0">:$transA,
+    DefaultValuedAttr<I64Attr, "0">:$transB
   );
 
   let assemblyFormat = [{

--- a/include/hip/Dialect/IR/HipShapeUtils.h
+++ b/include/hip/Dialect/IR/HipShapeUtils.h
@@ -18,9 +18,10 @@ namespace mlir {
 namespace hip {
 
 /// Compute the shape of `A @ B` for matmul with NumPy-style batch broadcast
-/// over the leading dims. Last two dims of `aShape` are `[M, K]`; last two
-/// dims of `bShape` are `[K, N]`. Leading dims are broadcast (right-aligned,
-/// missing dims treated as 1).
+/// over the leading dims. By default last two dims of `aShape` are `[M, K]`
+/// and last two dims of `bShape` are `[K, N]`. When `transA` / `transB` are
+/// set the corresponding operand's last two dims are swapped before the
+/// contraction (compile-time fusion of `Transpose(perm=[..,r,r-2])`).
 ///
 /// Returns the inferred shape on success. Returns an empty `SmallVector` and
 /// emits a diagnostic via `emitError` on rank-, K-, or batch-broadcast
@@ -39,7 +40,8 @@ namespace hip {
 ///         -> error.
 SmallVector<int64_t>
 inferMatmulShape(ArrayRef<int64_t> aShape, ArrayRef<int64_t> bShape,
-                 function_ref<InFlightDiagnostic()> emitError);
+                 function_ref<InFlightDiagnostic()> emitError,
+                 int64_t transA = 0, int64_t transB = 0);
 
 /// Verify that the actual `outs` operand shapes of a DPS HIP op match the
 /// shapes returned by `computeExpected`. `op` must implement

--- a/lib/Conversion/HipToLLVM/MatmulLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MatmulLowering.cpp
@@ -44,18 +44,24 @@ struct MatmulOpLowering : public ConvertOpToLLVMPattern<MatmulOp> {
     auto BType = cast<MemRefType>(op.getB().getType());
     int64_t ARank = AType.getRank();
     int64_t BRank = BType.getRank();
+    int64_t transA = op.getTransA();
+    int64_t transB = op.getTransB();
 
     // === DYNAMIC SHAPE SUPPORT ===
     // For dynamic shapes, we compute dimensions at runtime
     MemRefDescriptor ADesc(adaptor.getA());
     MemRefDescriptor BDesc(adaptor.getB());
 
-    // Compute M, K, N from runtime dimensions
-    // A: [..., M, K], B: [..., K, N] or B: [K, N]
-    Value M =
-        (ARank >= 2) ? ADesc.size(rewriter, loc, ARank - 2) : createI64Const(1);
-    Value K = ADesc.size(rewriter, loc, ARank - 1);
-    Value N = BDesc.size(rewriter, loc, BRank - 1);
+    // Compute logical M, K, N from runtime dimensions.
+    // A: [..., M, K] or [..., K, M] when transA; B: [..., K, N] or [..., N, K]
+    // when transB.
+    Value M = (ARank >= 2) ? (transA ? ADesc.size(rewriter, loc, ARank - 1)
+                                     : ADesc.size(rewriter, loc, ARank - 2))
+                           : createI64Const(1);
+    Value K = transA ? ADesc.size(rewriter, loc, ARank - 2)
+                     : ADesc.size(rewriter, loc, ARank - 1);
+    Value N = transB ? BDesc.size(rewriter, loc, BRank - 2)
+                     : BDesc.size(rewriter, loc, BRank - 1);
 
     // Compute batch count from leading dimensions of A
     Value batchCount;
@@ -139,8 +145,9 @@ struct MatmulOpLowering : public ConvertOpToLLVMPattern<MatmulOp> {
     //                          const void* A, const void* B, void* output,
     //                          int64_t M, int64_t N, int64_t K,
     //                          int64_t batch_count, int64_t elem_size,
-    //                          int64_t b_batch_stride, int op_state_slot)
-    SmallVector<Type, 11> paramTypes = {
+    //                          int64_t b_batch_stride, int64_t transA,
+    //                          int64_t transB, int op_state_slot)
+    SmallVector<Type, 13> paramTypes = {
         ptrType, // state
         i32Type, // op_state_slot
         ptrType, // A
@@ -151,7 +158,9 @@ struct MatmulOpLowering : public ConvertOpToLLVMPattern<MatmulOp> {
         i64Type, // K
         i64Type, // batch_count
         i64Type, // elem_size
-        i64Type  // b_batch_stride
+        i64Type, // b_batch_stride
+        i64Type, // transA
+        i64Type  // transB
     };
 
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
@@ -159,13 +168,19 @@ struct MatmulOpLowering : public ConvertOpToLLVMPattern<MatmulOp> {
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value, 11> args = {
-        statePtr,    getOpStateSlotValue(op, rewriter, loc),
-        APtr,        BPtr,
-        outputPtr,   M,
-        N,           K,
-        batchCount,  elemSize,
-        bBatchStride};
+    SmallVector<Value, 13> args = {statePtr,
+                                   getOpStateSlotValue(op, rewriter, loc),
+                                   APtr,
+                                   BPtr,
+                                   outputPtr,
+                                   M,
+                                   N,
+                                   K,
+                                   batchCount,
+                                   elemSize,
+                                   bBatchStride,
+                                   createI64Const(transA),
+                                   createI64Const(transB)};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(OnnxToHip STATIC
   CompressConversion.cpp
   OneHotConversion.cpp
   GatherShapeFold.cpp
+  TransposeMatMulFold.cpp
   ReshapeShapeFold.cpp
   PadShapeFold.cpp
   SliceShapeFold.cpp

--- a/lib/Conversion/OnnxToHip/GatherConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GatherConversion.cpp
@@ -5,15 +5,121 @@
 
 #include "OnnxToHipUtils.h"
 
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "llvm/ADT/Statistic.h"
+
+#define DEBUG_TYPE "gather-conversion"
+
+STATISTIC(NumGatherAxis0ExtractSlice,
+          "Number of axis-0 scalar-index onnx.Gather ops lowered to "
+          "tensor.extract_slice");
+
 namespace mlir {
 namespace hip {
 namespace {
 
-//===----------------------------------------------------------------------===//
-// ONNX Gather -> HIP Gather
-//===----------------------------------------------------------------------===//
+static bool dimsCompatible(int64_t expected, int64_t actual) {
+  if (ShapedType::isDynamic(expected) || ShapedType::isDynamic(actual))
+    return true;
+  return expected == actual;
+}
 
-struct GatherToHip : public mlir::RewritePattern {
+static bool outputMatchesAxis0Gather(RankedTensorType dataTy,
+                                     RankedTensorType indicesTy,
+                                     RankedTensorType outputTy) {
+  int64_t dataRank = dataTy.getRank();
+  int64_t indicesRank = indicesTy.getRank();
+  if (outputTy.getRank() != dataRank - 1 + indicesRank)
+    return false;
+
+  ArrayRef<int64_t> dataShape = dataTy.getShape();
+  ArrayRef<int64_t> indicesShape = indicesTy.getShape();
+  ArrayRef<int64_t> outShape = outputTy.getShape();
+
+  int64_t outDim = 0;
+  for (int64_t i = 0; i < indicesRank; ++i, ++outDim)
+    if (!dimsCompatible(indicesShape[i], outShape[outDim]))
+      return false;
+  for (int64_t i = 1; i < dataRank; ++i, ++outDim)
+    if (!dimsCompatible(dataShape[i], outShape[outDim]))
+      return false;
+  return true;
+}
+
+/// Axis-0 extract_slice requires a compile-time index so the offset folds to
+/// a static `memref.subview` (zero-copy). Dynamic offsets would bufferize to a
+/// host load from GPU-resident external constants and crash at inference.
+static std::optional<OpFoldResult>
+axisZeroStaticOffset(PatternRewriter &rewriter, Value indices) {
+  if (auto idx = getCompileTimeScalarInt(indices))
+    return OpFoldResult(rewriter.getIndexAttr(*idx));
+  return std::nullopt;
+}
+
+/// Swin-style axis=0 Gather with a single scalar (or len-1) index lowers to
+/// tensor.extract_slice when the index is known at compile time, not hip.gather.
+struct GatherAxis0ExtractSlice : public RewritePattern {
+  GatherAxis0ExtractSlice(MLIRContext *ctx)
+      : RewritePattern("onnx.Gather", /*benefit=*/2, ctx) {}
+
+  LogicalResult
+  matchAndRewrite(Operation *op, PatternRewriter &rewriter) const override {
+    int64_t axis = op->getAttrOfType<IntegerAttr>("axis").getSInt();
+    auto dataTy = cast<RankedTensorType>(op->getOperand(0).getType());
+    auto indicesTy = cast<RankedTensorType>(op->getOperand(1).getType());
+    auto outputTy = cast<RankedTensorType>(op->getResult(0).getType());
+
+    int64_t normalizedAxis = axis < 0 ? axis + dataTy.getRank() : axis;
+    if (normalizedAxis != 0)
+      return failure();
+
+    if (indicesTy.getRank() > 1)
+      return failure();
+    if (indicesTy.getRank() == 1 && indicesTy.getDimSize(0) != 1 &&
+        !indicesTy.isDynamicDim(0))
+      return failure();
+
+    if (!outputMatchesAxis0Gather(dataTy, indicesTy, outputTy))
+      return failure();
+
+    Location loc = op->getLoc();
+    Value data = op->getOperand(0);
+    Value indices = op->getOperand(1);
+
+    std::optional<OpFoldResult> axisOffset =
+        axisZeroStaticOffset(rewriter, indices);
+    if (!axisOffset)
+      return failure();
+
+    int64_t rank = dataTy.getRank();
+    SmallVector<OpFoldResult, 4> offsets(rank, rewriter.getIndexAttr(0));
+    offsets[0] = *axisOffset;
+
+    SmallVector<OpFoldResult, 4> sizes;
+    SmallVector<OpFoldResult, 4> strides(rank, rewriter.getIndexAttr(1));
+    for (int64_t i = 0; i < rank; ++i) {
+      if (i == 0) {
+        sizes.push_back(rewriter.getIndexAttr(1));
+        continue;
+      }
+      if (dataTy.isDynamicDim(i)) {
+        Value dimVal = tensor::DimOp::create(rewriter, loc, data, i);
+        sizes.push_back(dimVal);
+      } else
+        sizes.push_back(rewriter.getIndexAttr(dataTy.getDimSize(i)));
+    }
+
+    Value slice = tensor::ExtractSliceOp::create(rewriter, loc, outputTy, data,
+                                                   offsets, sizes, strides);
+
+    ++NumGatherAxis0ExtractSlice;
+    rewriter.replaceOp(op, slice);
+    return success();
+  }
+};
+
+struct GatherToHip : public RewritePattern {
   GatherToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Gather", /*benefit=*/1, ctx) {}
 
@@ -29,32 +135,25 @@ struct GatherToHip : public mlir::RewritePattern {
     mlir::Value data = op->getOperand(0);
     mlir::Value indices = op->getOperand(1);
 
-    // Get axis attribute from ONNX Gather operation
     int64_t axis = op->getAttrOfType<mlir::IntegerAttr>("axis").getSInt();
     auto axisAttr = rewriter.getI64IntegerAttr(axis);
 
-    // Get result type
     auto resultType =
         mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
     auto dataType = mlir::cast<mlir::RankedTensorType>(data.getType());
     auto indicesType = mlir::cast<mlir::RankedTensorType>(indices.getType());
 
-    // Normalize negative axis for dimension calculations only
     int64_t normalizedAxis = axis < 0 ? axis + dataType.getRank() : axis;
 
-    // Create output tensor with dynamic shape support
-    // Output shape: [data[0:axis], indices.shape, data[axis+1:]]
     llvm::SmallVector<mlir::Value> dynSizes;
     int64_t outDimIdx = 0;
 
-    // Copy dimensions before axis from data
     for (auto i : llvm::seq<int64_t>(0, normalizedAxis)) {
       if (outDimIdx < resultType.getRank() &&
           resultType.isDynamicDim(outDimIdx))
         dynSizes.push_back(mlir::tensor::DimOp::create(rewriter, loc, data, i));
       outDimIdx++;
     }
-    // Copy all dimensions from indices
     for (auto i : llvm::seq<int64_t>(0, indicesType.getRank())) {
       if (outDimIdx < resultType.getRank() &&
           resultType.isDynamicDim(outDimIdx))
@@ -62,7 +161,6 @@ struct GatherToHip : public mlir::RewritePattern {
             mlir::tensor::DimOp::create(rewriter, loc, indices, i));
       outDimIdx++;
     }
-    // Copy dimensions after axis from data
     for (auto i : llvm::seq<int64_t>(normalizedAxis + 1, dataType.getRank())) {
       if (outDimIdx < resultType.getRank() &&
           resultType.isDynamicDim(outDimIdx))
@@ -74,7 +172,6 @@ struct GatherToHip : public mlir::RewritePattern {
         mlir::tensor::EmptyOp::create(rewriter, loc, resultType.getShape(),
                                       resultType.getElementType(), dynSizes);
 
-    // Create hip.gather operation
     auto gatherOp = mlir::hip::GatherOp::create(rewriter, loc, context, data,
                                                 indices, init, axisAttr);
 
@@ -87,7 +184,7 @@ struct GatherToHip : public mlir::RewritePattern {
 
 void populateGatherConversionPatterns(RewritePatternSet &patterns,
                                       MLIRContext *ctx) {
-  patterns.add<GatherToHip>(ctx);
+  patterns.add<GatherAxis0ExtractSlice, GatherToHip>(ctx);
 }
 
 } // namespace hip

--- a/lib/Conversion/OnnxToHip/GatherConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GatherConversion.cpp
@@ -58,13 +58,14 @@ axisZeroStaticOffset(PatternRewriter &rewriter, Value indices) {
 }
 
 /// Swin-style axis=0 Gather with a single scalar (or len-1) index lowers to
-/// tensor.extract_slice when the index is known at compile time, not hip.gather.
+/// tensor.extract_slice when the index is known at compile time, not
+/// hip.gather.
 struct GatherAxis0ExtractSlice : public RewritePattern {
   GatherAxis0ExtractSlice(MLIRContext *ctx)
       : RewritePattern("onnx.Gather", /*benefit=*/2, ctx) {}
 
-  LogicalResult
-  matchAndRewrite(Operation *op, PatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const override {
     int64_t axis = op->getAttrOfType<IntegerAttr>("axis").getSInt();
     auto dataTy = cast<RankedTensorType>(op->getOperand(0).getType());
     auto indicesTy = cast<RankedTensorType>(op->getOperand(1).getType());
@@ -111,7 +112,7 @@ struct GatherAxis0ExtractSlice : public RewritePattern {
     }
 
     Value slice = tensor::ExtractSliceOp::create(rewriter, loc, outputTy, data,
-                                                   offsets, sizes, strides);
+                                                 offsets, sizes, strides);
 
     ++NumGatherAxis0ExtractSlice;
     rewriter.replaceOp(op, slice);

--- a/lib/Conversion/OnnxToHip/MatMulConversion.cpp
+++ b/lib/Conversion/OnnxToHip/MatMulConversion.cpp
@@ -33,17 +33,30 @@ MatMulToHip::matchAndRewrite(mlir::Operation *op,
   auto resultType =
       mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
 
+  int64_t transA = 0;
+  int64_t transB = 0;
+  if (auto attr = op->getAttrOfType<mlir::IntegerAttr>("hipdnn.transA"))
+    transA = attr.getSInt();
+  if (auto attr = op->getAttrOfType<mlir::IntegerAttr>("hipdnn.transB"))
+    transB = attr.getSInt();
+
   // MatMul: result[..., M, N] = A[..., M, K] @ B[..., K, N].
   // Batch and M dims come from A; N comes from B's last dim.
   llvm::SmallVector<mlir::Value> dynSizes;
   const int64_t rank = resultType.getRank();
+  const auto aType = mlir::cast<mlir::RankedTensorType>(a.getType());
   const auto bType = mlir::cast<mlir::RankedTensorType>(b.getType());
+  const int64_t aRank = aType.getRank();
+  const int64_t bRank = bType.getRank();
   for (int64_t dimIdx : llvm::seq<int64_t>(rank)) {
     if (!resultType.isDynamicDim(dimIdx))
       continue;
     if (dimIdx == rank - 1) {
-      dynSizes.push_back(
-          mlir::tensor::DimOp::create(rewriter, loc, b, bType.getRank() - 1));
+      int64_t bDim = transB ? bRank - 2 : bRank - 1;
+      dynSizes.push_back(mlir::tensor::DimOp::create(rewriter, loc, b, bDim));
+    } else if (dimIdx == rank - 2) {
+      int64_t aDim = transA ? aRank - 1 : aRank - 2;
+      dynSizes.push_back(mlir::tensor::DimOp::create(rewriter, loc, a, aDim));
     } else {
       dynSizes.push_back(mlir::tensor::DimOp::create(rewriter, loc, a, dimIdx));
     }
@@ -52,14 +65,14 @@ MatMulToHip::matchAndRewrite(mlir::Operation *op,
   mlir::Value init =
       mlir::tensor::EmptyOp::create(rewriter, loc, resultType.getShape(),
                                     resultType.getElementType(), dynSizes);
-  // Inferred-type Op::create overload: result type is read from the typed
-  // outs operand via the auto-emitted MatmulOp::inferReturnTypes (HipOps.td
-  // base, autoInfer=1). Equivalent to passing `resultType` explicitly --
-  // outs.getType() == resultType by construction here -- but keeps the DPS
-  // contract `result_type == outs_operand_type` closed by ODS rather than
-  // restated at the callsite.
-  auto hipOp = mlir::hip::MatmulOp::create(rewriter, loc, context, a, b, init);
-  rewriter.replaceOp(op, hipOp->getResult(0));
+  llvm::SmallVector<mlir::NamedAttribute> attrs;
+  attrs.push_back(
+      rewriter.getNamedAttr("transA", rewriter.getI64IntegerAttr(transA)));
+  attrs.push_back(
+      rewriter.getNamedAttr("transB", rewriter.getI64IntegerAttr(transB)));
+  llvm::SmallVector<mlir::Value> operands = {context, a, b, init};
+  auto hipOp = mlir::hip::MatmulOp::create(rewriter, loc, operands, attrs);
+  rewriter.replaceOp(op, hipOp.getResult(0));
   return mlir::success();
 }
 

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -417,6 +417,7 @@ void ConvertOnnxToHipPass::runOnOperation() {
       for (int round = 0; round < kMaxRounds; ++round) {
         mlir::RewritePatternSet preLoweringPatterns(ctx);
         populateGatherShapeFoldPatterns(preLoweringPatterns, ctx);
+        populateTransposeMatMulFoldPatterns(preLoweringPatterns, ctx);
         populateGatherBlockQuantizedPreparePatterns(preLoweringPatterns, ctx);
         populateReshapeShapeFoldPatterns(preLoweringPatterns, ctx);
         populatePadShapeFoldPatterns(preLoweringPatterns, ctx);

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -489,6 +489,13 @@ void populateGlobalPoolConversionPatterns(RewritePatternSet &patterns,
 void populateFlattenConversionPatterns(RewritePatternSet &patterns,
                                        MLIRContext *ctx);
 
+/// Pre-lowering pattern set: fold `Transpose(perm=[..,r,r-2])` into a
+/// consuming `onnx.MatMul` as `hipdnn.transA` / `hipdnn.transB` so the
+/// runtime can apply the swap inside hipBLASLt. Sibling of GatherShapeFold;
+/// must run while ONNX ops are still present. See TransposeMatMulFold.cpp.
+void populateTransposeMatMulFoldPatterns(RewritePatternSet &patterns,
+                                         MLIRContext *ctx);
+
 /// Pre-lowering pattern set: collapse the Gather(Shape(x), const_idx)
 /// idiom into tensor.from_elements over a tensor.dim of x. Must run
 /// BEFORE lowerOnnxConstants so this ONNX-rooted matcher still sees the

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -46,6 +46,62 @@ namespace hip {
 // Helpers
 //===----------------------------------------------------------------------===//
 
+/// Attribute on extern `memref.global` ops recording a single-element integer
+/// constant's value at compile time (data may live only in constants.bin/GPU).
+inline constexpr llvm::StringLiteral kCompileTimeScalarAttr =
+    "hip.compile_time_scalar";
+
+/// Return the integer value of a 0-D (or 1-element) index tensor when known at
+/// compile time: inline dense constants, hip.constant carriers, globals with
+/// initial_value, or extern globals tagged with `hip.compile_time_scalar`.
+inline std::optional<int64_t> getCompileTimeScalarInt(mlir::Value value) {
+  auto scalarFromDense = [](mlir::DenseElementsAttr dense)
+      -> std::optional<int64_t> {
+    if (!dense || dense.getNumElements() != 1)
+      return std::nullopt;
+    mlir::Type elemTy = dense.getElementType();
+    if (!elemTy.isInteger(32) && !elemTy.isInteger(64))
+      return std::nullopt;
+    return (*dense.getValues<mlir::APInt>().begin()).getSExtValue();
+  };
+
+  if (mlir::DenseElementsAttr dense = getConstantDense(value))
+    if (auto v = scalarFromDense(dense))
+      return v;
+
+  if (auto constant = value.getDefiningOp<mlir::hip::ConstantOp>())
+    if (auto valueAttr = mlir::dyn_cast_or_null<mlir::DenseElementsAttr>(
+            constant.getValueAttr()))
+      if (auto v = scalarFromDense(valueAttr))
+        return v;
+
+  mlir::Operation *defOp = value.getDefiningOp();
+  if (!defOp)
+    return std::nullopt;
+
+  if (auto toTensor = mlir::dyn_cast<mlir::bufferization::ToTensorOp>(defOp)) {
+    auto bufDef =
+        toTensor.getBuffer().getDefiningOp<mlir::memref::GetGlobalOp>();
+    if (!bufDef)
+      return std::nullopt;
+    auto module = bufDef->getParentOfType<mlir::ModuleOp>();
+    if (!module)
+      return std::nullopt;
+    auto global =
+        module.lookupSymbol<mlir::memref::GlobalOp>(bufDef.getNameAttr());
+    if (!global)
+      return std::nullopt;
+    if (auto initial = mlir::dyn_cast_or_null<mlir::DenseElementsAttr>(
+            global.getInitialValueAttr()))
+      if (auto v = scalarFromDense(initial))
+        return v;
+    if (auto scalarAttr =
+            global->getAttrOfType<mlir::IntegerAttr>(kCompileTimeScalarAttr))
+      return scalarAttr.getInt();
+  }
+  return std::nullopt;
+}
+
 /// Create a tensor.empty for a DPS init operand.  Dynamic dimension sizes
 /// are extracted from \p source using tensor.dim at each dynamic index.
 /// Suitable for ops where the output shape aligns positionally with one input

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -55,8 +55,8 @@ inline constexpr llvm::StringLiteral kCompileTimeScalarAttr =
 /// compile time: inline dense constants, hip.constant carriers, globals with
 /// initial_value, or extern globals tagged with `hip.compile_time_scalar`.
 inline std::optional<int64_t> getCompileTimeScalarInt(mlir::Value value) {
-  auto scalarFromDense = [](mlir::DenseElementsAttr dense)
-      -> std::optional<int64_t> {
+  auto scalarFromDense =
+      [](mlir::DenseElementsAttr dense) -> std::optional<int64_t> {
     if (!dense || dense.getNumElements() != 1)
       return std::nullopt;
     mlir::Type elemTy = dense.getElementType();

--- a/lib/Conversion/OnnxToHip/TransposeMatMulFold.cpp
+++ b/lib/Conversion/OnnxToHip/TransposeMatMulFold.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- TransposeMatMulFold.cpp - Fold Transpose into MatMul --------------===//
+//
+// Pre-lowering pattern that recognizes the common attention idiom
+//
+//   %kt = onnx.Transpose(%k) {perm = [0, 1, ..., r-1, r, r-2]}
+//   %scores = onnx.MatMul(%q, %kt)
+//
+// and folds it to
+//
+//   %scores = onnx.MatMul(%q, %k) {hipdnn.transB = 1}
+//
+// Only the last-two-dimension swap is matched (Q @ K^T in transformers).
+// MatMulConversion passes the stamped attributes through to hip.matmul, which
+// applies the transpose inside hipBLASLt instead of a separate transpose
+// kernel.
+//
+//===----------------------------------------------------------------------===//
+
+#include "OnnxToHipUtils.h"
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "llvm/ADT/Statistic.h"
+
+#define DEBUG_TYPE "transpose-matmul-fold"
+
+STATISTIC(NumTransposeMatMulFolds,
+          "Number of Transpose(last-two-swap) -> MatMul folds");
+
+namespace mlir {
+namespace hip {
+
+namespace {
+
+static bool isLastTwoDimSwap(ArrayRef<int64_t> perm) {
+  int64_t r = perm.size();
+  if (r < 2)
+    return false;
+  for (int64_t i = 0; i < r - 2; ++i) {
+    if (perm[i] != i)
+      return false;
+  }
+  return perm[r - 2] == r - 1 && perm[r - 1] == r - 2;
+}
+
+static std::optional<SmallVector<int64_t>>
+getExplicitTransposePerm(mlir::Operation *transposeOp) {
+  if (!transposeOp || transposeOp->getName().getStringRef() != "onnx.Transpose")
+    return std::nullopt;
+  SmallVector<int64_t> perm;
+  if (auto permAttr =
+          transposeOp->getAttrOfType<mlir::DenseIntElementsAttr>("perm")) {
+    perm.reserve(permAttr.size());
+    for (mlir::APInt v : permAttr.getValues<mlir::APInt>())
+      perm.push_back(v.getSExtValue());
+    return perm;
+  }
+  if (auto permAttr = transposeOp->getAttrOfType<mlir::ArrayAttr>("perm")) {
+    perm.reserve(permAttr.size());
+    for (mlir::Attribute elem : permAttr) {
+      auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(elem);
+      if (!intAttr)
+        return std::nullopt;
+      perm.push_back(intAttr.getSInt());
+    }
+    return perm;
+  }
+  return std::nullopt;
+}
+
+static bool isFoldableLastTwoSwap(mlir::Operation *transposeOp) {
+  auto permOpt = getExplicitTransposePerm(transposeOp);
+  if (!permOpt)
+    return false;
+  if (!isLastTwoDimSwap(*permOpt))
+    return false;
+  if (!transposeOp->getResult(0).hasOneUse())
+    return false;
+  return true;
+}
+
+struct FoldTransposeIntoMatMul : public mlir::RewritePattern {
+  FoldTransposeIntoMatMul(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.MatMul", /*benefit=*/2, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *matmulOp,
+                  mlir::PatternRewriter &rewriter) const override {
+    mlir::Value a = matmulOp->getOperand(0);
+    mlir::Value b = matmulOp->getOperand(1);
+    int64_t transA = 0;
+    int64_t transB = 0;
+
+    if (mlir::Operation *trA = a.getDefiningOp()) {
+      if (isFoldableLastTwoSwap(trA)) {
+        a = trA->getOperand(0);
+        transA = 1;
+      }
+    }
+    if (mlir::Operation *trB = b.getDefiningOp()) {
+      if (isFoldableLastTwoSwap(trB)) {
+        b = trB->getOperand(0);
+        transB = 1;
+      }
+    }
+    if (transA == 0 && transB == 0)
+      return rewriter.notifyMatchFailure(matmulOp, "no foldable transpose");
+
+    mlir::Location loc = matmulOp->getLoc();
+    mlir::OperationState state(loc, "onnx.MatMul");
+    state.addOperands({a, b});
+    state.addTypes(matmulOp->getResultTypes());
+    for (mlir::NamedAttribute attr : matmulOp->getAttrs()) {
+      if (attr.getName() == "hipdnn.transA" ||
+          attr.getName() == "hipdnn.transB")
+        continue;
+      state.addAttribute(attr.getName(), attr.getValue());
+    }
+    if (transA)
+      state.addAttribute("hipdnn.transA", rewriter.getI64IntegerAttr(transA));
+    if (transB)
+      state.addAttribute("hipdnn.transB", rewriter.getI64IntegerAttr(transB));
+
+    mlir::Operation *newMatmul = rewriter.create(state);
+    rewriter.replaceOp(matmulOp, newMatmul->getResults());
+    ++NumTransposeMatMulFolds;
+    return mlir::success();
+  }
+};
+
+} // namespace
+
+void populateTransposeMatMulFoldPatterns(RewritePatternSet &patterns,
+                                         MLIRContext *ctx) {
+  patterns.add<FoldTransposeIntoMatMul>(ctx);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
@@ -201,16 +201,16 @@ struct MatMulLowering : ConvertOpToLLVMPattern<MatMulOp> {
     int64_t elementSize = aType.getElementType().getIntOrFloatBitWidth() / 8;
     using MatMulCall =
         RuntimeFunc<i32, hostPtr, slotIndex, devicePtr, devicePtr, devicePtr,
-                    i64, i64, i64, i64, i64, i64>;
+                    i64, i64, i64, i64, i64, i64, i64, i64>;
     auto matMulFunc = MatMulCall::lookupOrCreateFn(rewriter, loc, module,
                                                    kWrapHipblasLtMatmul);
     if (failed(matMulFunc)) {
       return failure();
     }
-    if (failed(matMulFunc->call(adaptor.getCtx(), SlotIndex{op.getOperation()},
-                                adaptor.getA(), adaptor.getB(),
-                                adaptor.getInit(), m, n, k, batchCount,
-                                elementSize, bBatchStride))) {
+    if (failed(matMulFunc->call(
+            adaptor.getCtx(), SlotIndex{op.getOperation()}, adaptor.getA(),
+            adaptor.getB(), adaptor.getInit(), m, n, k, batchCount, elementSize,
+            bBatchStride, static_cast<int64_t>(0), static_cast<int64_t>(0)))) {
       return failure();
     }
     rewriter.eraseOp(op);

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -680,9 +680,9 @@ LogicalResult MatmulOp::verify() {
   // mismatch (in which case it has already issued a diagnostic on `*this`).
   return mlir::hip::verifyHipOpShape(
       *this, [&]() -> SmallVector<SmallVector<int64_t>> {
-        SmallVector<int64_t> outShape =
-            mlir::hip::inferMatmulShape(getShapeOf(getA()), getShapeOf(getB()),
-                                        [&]() { return this->emitOpError(); });
+        SmallVector<int64_t> outShape = mlir::hip::inferMatmulShape(
+            getShapeOf(getA()), getShapeOf(getB()),
+            [&]() { return this->emitOpError(); }, getTransA(), getTransB());
         if (outShape.empty())
           return {};
         return {std::move(outShape)};

--- a/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
+++ b/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
@@ -74,7 +74,8 @@ MatmulOp::reifyResultShapes(OpBuilder &b,
   // Re-run the matmul-shape helper. verify() has already passed by reify
   // time, but bail on empty() in case a pre-verify call sneaks in.
   SmallVector<int64_t> outShape = mlir::hip::inferMatmulShape(
-      aShape, bShape, [&]() { return this->emitOpError(); });
+      aShape, bShape, [&]() { return this->emitOpError(); }, getTransA(),
+      getTransB());
   if (outShape.empty())
     return failure();
 
@@ -93,16 +94,18 @@ MatmulOp::reifyResultShapes(OpBuilder &b,
   SmallVector<OpFoldResult> dims;
   dims.reserve(outRank);
   for (size_t i : llvm::seq<size_t>(0, outRank)) {
-    // M dim: A[-2].
+    // M dim: A[-2], or A[-1] when transA.
     if (i + 2 == outRank) {
+      size_t aDim = getTransA() ? aRank - 1 : aRank - 2;
       dims.push_back(
-          mlir::hip::reifyDimOrConstant(b, loc, outShape[i], A, aRank - 2));
+          mlir::hip::reifyDimOrConstant(b, loc, outShape[i], A, aDim));
       continue;
     }
-    // N dim: B[-1].
+    // N dim: B[-1], or B[-2] when transB.
     if (i + 1 == outRank) {
+      size_t bDim = getTransB() ? bRank - 2 : bRank - 1;
       dims.push_back(
-          mlir::hip::reifyDimOrConstant(b, loc, outShape[i], B, bRank - 1));
+          mlir::hip::reifyDimOrConstant(b, loc, outShape[i], B, bDim));
       continue;
     }
     // Batch dim: prefer the side that contributes the size (in range, not 1).

--- a/lib/Dialect/IR/HipShapeUtils.cpp
+++ b/lib/Dialect/IR/HipShapeUtils.cpp
@@ -54,7 +54,8 @@ std::string formatShape(ArrayRef<int64_t> shape) {
 
 SmallVector<int64_t>
 mlir::hip::inferMatmulShape(ArrayRef<int64_t> aShape, ArrayRef<int64_t> bShape,
-                            function_ref<InFlightDiagnostic()> emitError) {
+                            function_ref<InFlightDiagnostic()> emitError,
+                            int64_t transA, int64_t transB) {
   if (aShape.size() < 2) {
     emitError() << "matmul A must have rank >= 2, got rank " << aShape.size();
     return {};
@@ -64,10 +65,10 @@ mlir::hip::inferMatmulShape(ArrayRef<int64_t> aShape, ArrayRef<int64_t> bShape,
     return {};
   }
 
-  int64_t M = aShape[aShape.size() - 2];
-  int64_t Ka = aShape.back();
-  int64_t Kb = bShape[bShape.size() - 2];
-  int64_t N = bShape.back();
+  int64_t M = transA ? aShape.back() : aShape[aShape.size() - 2];
+  int64_t Ka = transA ? aShape[aShape.size() - 2] : aShape.back();
+  int64_t Kb = transB ? bShape.back() : bShape[bShape.size() - 2];
+  int64_t N = transB ? bShape[bShape.size() - 2] : bShape.back();
 
   // Contraction K must agree (kDynamic on either side is a wildcard).
   if (!ShapedType::isDynamic(Ka) && !ShapedType::isDynamic(Kb) && Ka != Kb) {

--- a/lib/Dialect/Transforms/ExternalizeConstants.cpp
+++ b/lib/Dialect/Transforms/ExternalizeConstants.cpp
@@ -81,10 +81,10 @@ static void attachCompileTimeScalarAttr(memref::GlobalOp global,
   if (!intTy || !intTy.isSignlessInteger() ||
       (intTy.getWidth() != 32 && intTy.getWidth() != 64))
     return;
-  int64_t value = intTy.getWidth() == 64
-                      ? *reinterpret_cast<const int64_t *>(hostBytes)
-                      : static_cast<int64_t>(
-                            *reinterpret_cast<const int32_t *>(hostBytes));
+  int64_t value =
+      intTy.getWidth() == 64
+          ? *reinterpret_cast<const int64_t *>(hostBytes)
+          : static_cast<int64_t>(*reinterpret_cast<const int32_t *>(hostBytes));
   global->setAttr(
       "hip.compile_time_scalar",
       IntegerAttr::get(IntegerType::get(global.getContext(), 64), value));

--- a/lib/Dialect/Transforms/ExternalizeConstants.cpp
+++ b/lib/Dialect/Transforms/ExternalizeConstants.cpp
@@ -68,6 +68,28 @@ namespace {
 
 constexpr int64_t kConstantAlignment = 64;
 
+/// For single-element signless-integer extern constants, stash the host-visible
+/// value on the global so compile-time folds (e.g. axis-0 Gather ->
+/// tensor.extract_slice) can emit static subview offsets instead of a runtime
+/// host load from GPU-resident constants.bin.
+static void attachCompileTimeScalarAttr(memref::GlobalOp global,
+                                        RankedTensorType tensorType,
+                                        const void *hostBytes) {
+  if (!hostBytes || tensorType.getNumElements() != 1)
+    return;
+  auto intTy = dyn_cast<IntegerType>(tensorType.getElementType());
+  if (!intTy || !intTy.isSignlessInteger() ||
+      (intTy.getWidth() != 32 && intTy.getWidth() != 64))
+    return;
+  int64_t value = intTy.getWidth() == 64
+                      ? *reinterpret_cast<const int64_t *>(hostBytes)
+                      : static_cast<int64_t>(
+                            *reinterpret_cast<const int32_t *>(hostBytes));
+  global->setAttr(
+      "hip.compile_time_scalar",
+      IntegerAttr::get(IntegerType::get(global.getContext(), 64), value));
+}
+
 using SourceKind = hip::ConstantOp::SourceKind;
 
 struct ConstantPlan {
@@ -694,6 +716,7 @@ private:
         /*initial_value=*/nullptr, /*constant=*/false,
         moduleBuilder.getI64IntegerAttr(kConstantAlignment));
     global->setAttr("hip.external_data", externalData);
+    attachCompileTimeScalarAttr(global, plan.type, plan.data());
 
     OpBuilder builder(plan.op);
     auto getGlobal = memref::GetGlobalOp::create(builder, plan.op.getLoc(),

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -833,16 +833,18 @@ int wrap_hipblasLtGemm(void *handle, // hipBLASLt handle
 // at compile time when B's leading dims are static, else at runtime.
 int wrap_hipblasLtMatmul(
     RuntimeState *state,
-    int op_state_slot,       // per-instance op-state slot (shared algo table)
-    const void *A,           // Matrix A GPU pointer
-    const void *B,           // Matrix B GPU pointer
-    void *output,            // Output GPU pointer
-    int64_t M,               // Rows of A (per batch)
-    int64_t N,               // Columns of B
-    int64_t K,               // Columns of A / Rows of B
-    int64_t batch_count,     // Number of batches
-    int64_t elem_size,       // Element size in bytes (2=f16, 4=f32)
-    int64_t b_batch_stride); // 0 = broadcast (any rank); K*N = per-batch
+    int op_state_slot,      // per-instance op-state slot (shared algo table)
+    const void *A,          // Matrix A GPU pointer
+    const void *B,          // Matrix B GPU pointer
+    void *output,           // Output GPU pointer
+    int64_t M,              // Rows of A (per batch)
+    int64_t N,              // Columns of B
+    int64_t K,              // Columns of A / Rows of B
+    int64_t batch_count,    // Number of batches
+    int64_t elem_size,      // Element size in bytes (2=f16, 4=f32)
+    int64_t b_batch_stride, // 0 = broadcast (any rank); K*N = per-batch
+    int64_t transA,         // 1 = swap A's last two dims before multiply
+    int64_t transB);        // 1 = swap B's last two dims before multiply
 
 // GroupQueryAttention operation wrapper (Full MS spec)
 // Called by generated IR for onnx.Custom(GroupQueryAttention) lowering

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -597,8 +597,11 @@ int wrap_hipblasLtGemm(void *handle, void *stream, int64_t m, int64_t n,
 int wrap_hipblasLtMatmul(RuntimeState *state, int op_state_slot, const void *A,
                          const void *B, void *output, int64_t M, int64_t N,
                          int64_t K, int64_t batch_count, int64_t elem_size,
-                         int64_t b_batch_stride) {
+                         int64_t b_batch_stride, int64_t transA,
+                         int64_t transB) {
   (void)b_batch_stride;
+  (void)transA;
+  (void)transB;
   (void)op_state_slot;
   if (!state) {
     fprintf(stderr, "Invalid state in wrap_hipblasLtMatmul\n");
@@ -606,9 +609,9 @@ int wrap_hipblasLtMatmul(RuntimeState *state, int op_state_slot, const void *A,
   }
 
   MOCK_PRINT("[MOCK] wrap_hipblasLtMatmul(M=%lld, N=%lld, K=%lld, "
-             "batch=%lld, elem_size=%lld)\n",
+             "batch=%lld, elem_size=%lld, transA=%lld, transB=%lld)\n",
              (long long)M, (long long)N, (long long)K, (long long)batch_count,
-             (long long)elem_size);
+             (long long)elem_size, (long long)transA, (long long)transB);
 
   return 0;
 }

--- a/lib/Runtime/real/matmul.cpp
+++ b/lib/Runtime/real/matmul.cpp
@@ -44,23 +44,11 @@ static bool autotune_enabled() {
 }
 
 struct MatmulCacheKey {
-  int64_t M, N, K, batch_count, elem_size;
-  // hipBLASLt's STRIDED_BATCH_OFFSET on layA, in elements. Two distinct
-  // values reach this site at the same (M,N,K,batch,elem_size):
-  //   * 0   — B is a broadcast weight (rank-2 [K,N], or rank-N
-  //           [1,...,1,K,N] whose leading-dim product is 1).
-  //   * K*N — B is per-batch (leading-dim product > 1; the buffer holds
-  //           multiple [K,N] matrices laid out contiguously).
-  // Part of the cache key because the layout descriptor is parameterised
-  // by the stride: mixing the two would silently route one path through
-  // the other's stride and read past the end of a broadcast weight buffer.
-  // Keyed on the actual int stride (not a 0/1 bool) so any future site
-  // that legitimately uses a stride other than {0, K*N} also gets its
-  // own cache entry rather than aliasing one of these two.
-  int64_t b_batch_stride;
+  int64_t M, N, K, batch_count, elem_size, b_batch_stride, transA, transB;
   bool operator==(const MatmulCacheKey &o) const {
     return M == o.M && N == o.N && K == o.K && batch_count == o.batch_count &&
-           elem_size == o.elem_size && b_batch_stride == o.b_batch_stride;
+           elem_size == o.elem_size && b_batch_stride == o.b_batch_stride &&
+           transA == o.transA && transB == o.transB;
   }
 };
 
@@ -73,6 +61,8 @@ struct MatmulCacheKeyHash {
     hash_combine_val(h, k.batch_count);
     hash_combine_val(h, k.elem_size);
     hash_combine_val(h, k.b_batch_stride);
+    hash_combine_val(h, k.transA);
+    hash_combine_val(h, k.transB);
     return h;
   }
 };
@@ -163,6 +153,8 @@ static MatmulCacheEntry *queryOrCreateMatmul(MatmulAlgoTable &table,
 
   hipDataType dt = (key.elem_size == 2) ? HIP_R_16F : HIP_R_32F;
   int64_t M = key.M, N = key.N, K = key.K;
+  int64_t transA = key.transA;
+  int64_t transB = key.transB;
 
   auto entryPtr = std::make_unique<MatmulCacheEntry>();
   MatmulCacheEntry &entry = *entryPtr;
@@ -184,16 +176,41 @@ static MatmulCacheEntry *queryOrCreateMatmul(MatmulAlgoTable &table,
       hipblasLtMatmulDescCreate(&entry.desc, HIPBLAS_COMPUTE_32F, HIP_R_32F));
 
   {
-    hipblasOperation_t opN = HIPBLAS_OP_N;
+    hipblasOperation_t opA = transB ? HIPBLAS_OP_T : HIPBLAS_OP_N;
+    hipblasOperation_t opB = transA ? HIPBLAS_OP_T : HIPBLAS_OP_N;
     MATMUL_CACHE_CHECK(hipblasLtMatmulDescSetAttribute(
-        entry.desc, HIPBLASLT_MATMUL_DESC_TRANSA, &opN, sizeof(opN)));
+        entry.desc, HIPBLASLT_MATMUL_DESC_TRANSA, &opA, sizeof(opA)));
     MATMUL_CACHE_CHECK(hipblasLtMatmulDescSetAttribute(
-        entry.desc, HIPBLASLT_MATMUL_DESC_TRANSB, &opN, sizeof(opN)));
+        entry.desc, HIPBLASLT_MATMUL_DESC_TRANSB, &opB, sizeof(opB)));
   }
 
-  // Row-major -> col-major trick: BLAS sees m=N, k=K, n=M with ld = first dim
-  MATMUL_CACHE_CHECK(hipblasLtMatrixLayoutCreate(&entry.layA, dt, N, K, N));
-  MATMUL_CACHE_CHECK(hipblasLtMatrixLayoutCreate(&entry.layB, dt, K, M, K));
+  // Row-major -> col-major trick (see wrap_hipblasLtMatmul banner). Layouts
+  // follow the same transA/transB rules as wrap_gemm, with hipBLASLt "A" =
+  // user's B and "B" = user's A.
+  int64_t hblA_rows, hblA_cols, hblA_ld;
+  if (!transB) {
+    hblA_rows = N;
+    hblA_cols = K;
+    hblA_ld = N;
+  } else {
+    hblA_rows = K;
+    hblA_cols = N;
+    hblA_ld = K;
+  }
+  int64_t hblB_rows, hblB_cols, hblB_ld;
+  if (!transA) {
+    hblB_rows = K;
+    hblB_cols = M;
+    hblB_ld = K;
+  } else {
+    hblB_rows = M;
+    hblB_cols = K;
+    hblB_ld = M;
+  }
+  MATMUL_CACHE_CHECK(hipblasLtMatrixLayoutCreate(&entry.layA, dt, hblA_rows,
+                                                 hblA_cols, hblA_ld));
+  MATMUL_CACHE_CHECK(hipblasLtMatrixLayoutCreate(&entry.layB, dt, hblB_rows,
+                                                 hblB_cols, hblB_ld));
   MATMUL_CACHE_CHECK(hipblasLtMatrixLayoutCreate(&entry.layC, dt, N, M, N));
 
   if (key.batch_count > 1) {
@@ -435,7 +452,8 @@ static void autotuneMatmul(hipblasLtHandle_t handle, hipStream_t stream,
 int wrap_hipblasLtMatmul(RuntimeState *state, int op_state_slot, const void *A,
                          const void *B, void *output, int64_t M, int64_t N,
                          int64_t K, int64_t batch_count, int64_t elem_size,
-                         int64_t b_batch_stride) {
+                         int64_t b_batch_stride, int64_t transA,
+                         int64_t transB) {
   OP_PROFILE(
       "matmul",
       [&] {
@@ -468,12 +486,12 @@ int wrap_hipblasLtMatmul(RuntimeState *state, int op_state_slot, const void *A,
 
   const char *type_name = (elem_size == 2) ? "f16" : "f32";
   RUNTIME_DEBUG_LOG("[REAL] wrap_hipblasLtMatmul: M=%lld, N=%lld, K=%lld, "
-                    "batch=%lld, b_batch_stride=%lld, elem_size=%lld (%s), "
-                    "total_bytes=%lld\n",
+                    "batch=%lld, b_batch_stride=%lld, transA=%lld, "
+                    "transB=%lld, elem_size=%lld (%s), total_bytes=%lld\n",
                     (long long)M, (long long)N, (long long)K,
                     (long long)batch_count, (long long)b_batch_stride,
-                    (long long)elem_size, type_name,
-                    (long long)(batch_count * M * N * elem_size));
+                    (long long)transA, (long long)transB, (long long)elem_size,
+                    type_name, (long long)(batch_count * M * N * elem_size));
 
   MatmulState *ms = MatmulState::get_op_state(state, op_state_slot);
   if (!ms || !ms->table) {
@@ -482,7 +500,8 @@ int wrap_hipblasLtMatmul(RuntimeState *state, int op_state_slot, const void *A,
     return -1;
   }
 
-  MatmulCacheKey key{M, N, K, batch_count, elem_size, b_batch_stride};
+  MatmulCacheKey key{M,      N,     K, batch_count, elem_size, b_batch_stride,
+                     transA, transB};
   MatmulCacheEntry *cached = queryOrCreateMatmul(*ms->table, handle, key);
   if (!cached) {
     fprintf(stderr,

--- a/test/lit/Conversion/hip-to-llvm/test_matmul.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_matmul.mlir
@@ -24,7 +24,7 @@ module {
 // CHECK-LABEL: llvm.func @test_matmul_rank2_b
 // CHECK-NOT: llvm.icmp
 // CHECK-NOT: llvm.select
-// CHECK: llvm.call @wrap_hipblasLtMatmul({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64) -> i32
+// CHECK: llvm.call @wrap_hipblasLtMatmul({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
 // Verify 11 parameters:
 // - 4 pointers: state, A, B, output
 // - 6 i64: M=128, N=1024, K=4096, batch_count=1, elem_size=2, b_batch_stride=0
@@ -54,4 +54,22 @@ module {
 // CHECK-LABEL: llvm.func @test_matmul_rank3_leading_one_b
 // CHECK-NOT: llvm.icmp
 // CHECK-NOT: llvm.select
-// CHECK: llvm.call @wrap_hipblasLtMatmul({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64) -> i32
+// CHECK: llvm.call @wrap_hipblasLtMatmul({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
+
+// ----- transB=1 (fused Q @ K^T) ----------------------------------------------
+module {
+  func.func @test_matmul_trans_b(%ctx: !hip.context,
+                                  %A: memref<2x3x8x16xf16, 1>,
+                                  %B: memref<2x3x8x16xf16, 1>,
+                                  %output: memref<2x3x8x8xf16, 1>) {
+    hip.matmul(%ctx)
+        ins(%A, %B : memref<2x3x8x16xf16, 1>, memref<2x3x8x16xf16, 1>)
+        outs(%output : memref<2x3x8x8xf16, 1>)
+        {transB = 1 : i64}
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @test_matmul_trans_b
+// CHECK: llvm.mlir.constant(1 : i64)
+// CHECK: llvm.call @wrap_hipblasLtMatmul({{.*}}) : (!llvm.ptr, i32, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64) -> i32

--- a/test/lit/Conversion/hipsr-to-llvm/matmul.mlir
+++ b/test/lit/Conversion/hipsr-to-llvm/matmul.mlir
@@ -15,7 +15,7 @@
 // CHECK-NEXT:  %[[B_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
 // CHECK-NEXT:  %[[OUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
 // CHECK-NEXT:  %[[ELEM_SIZE:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-NEXT:  llvm.call @wrap_hipblasLtMatmul(%[[CTX]], %[[SLOT]], %[[A_PTR]], %[[B_PTR]], %[[OUT_PTR]], %[[M]], %[[N]], %[[K]], %[[BATCH]], %[[ELEM_SIZE]], %[[B_STRIDE]]) : (!llvm.ptr, i32, !llvm.ptr<1>, !llvm.ptr<1>, !llvm.ptr<1>, i64, i64, i64, i64, i64, i64) -> i32
+// CHECK-NEXT:  llvm.call @wrap_hipblasLtMatmul(%[[CTX]], %[[SLOT]], %[[A_PTR]], %[[B_PTR]], %[[OUT_PTR]], %[[M]], %[[N]], %[[K]], %[[BATCH]], %[[ELEM_SIZE]], %[[B_STRIDE]], {{.*}}, {{.*}}) : (!llvm.ptr, i32, !llvm.ptr<1>, !llvm.ptr<1>, !llvm.ptr<1>, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
 // CHECK-NEXT:  llvm.return
 func.func @matmul_rank2(
     %ctx: !hipsr.context,
@@ -49,7 +49,7 @@ func.func @matmul_rank2(
 // CHECK-NEXT:  %[[DYN_B_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
 // CHECK-NEXT:  %[[DYN_OUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
 // CHECK-NEXT:  %[[DYN_ELEM_SIZE:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-NEXT:  llvm.call @wrap_hipblasLtMatmul(%[[DYN_CTX]], %[[DYN_SLOT]], %[[DYN_A_PTR]], %[[DYN_B_PTR]], %[[DYN_OUT_PTR]], %[[DYN_M]], %[[DYN_N]], %[[DYN_K]], %[[DYN_BATCH]], %[[DYN_ELEM_SIZE]], %[[DYN_B_STRIDE]]) : (!llvm.ptr, i32, !llvm.ptr<1>, !llvm.ptr<1>, !llvm.ptr<1>, i64, i64, i64, i64, i64, i64) -> i32
+// CHECK-NEXT:  llvm.call @wrap_hipblasLtMatmul(%[[DYN_CTX]], %[[DYN_SLOT]], %[[DYN_A_PTR]], %[[DYN_B_PTR]], %[[DYN_OUT_PTR]], %[[DYN_M]], %[[DYN_N]], %[[DYN_K]], %[[DYN_BATCH]], %[[DYN_ELEM_SIZE]], %[[DYN_B_STRIDE]], {{.*}}, {{.*}}) : (!llvm.ptr, i32, !llvm.ptr<1>, !llvm.ptr<1>, !llvm.ptr<1>, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
 // CHECK-NEXT:  llvm.return
 func.func @matmul_dynamic_batch(
     %ctx: !hipsr.context,

--- a/test/lit/Conversion/hipsr-to-llvm/matmul.mlir
+++ b/test/lit/Conversion/hipsr-to-llvm/matmul.mlir
@@ -15,6 +15,8 @@
 // CHECK-NEXT:  %[[B_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
 // CHECK-NEXT:  %[[OUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
 // CHECK-NEXT:  %[[ELEM_SIZE:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK-NEXT:  llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:  llvm.mlir.constant(0 : i64) : i64
 // CHECK-NEXT:  llvm.call @wrap_hipblasLtMatmul(%[[CTX]], %[[SLOT]], %[[A_PTR]], %[[B_PTR]], %[[OUT_PTR]], %[[M]], %[[N]], %[[K]], %[[BATCH]], %[[ELEM_SIZE]], %[[B_STRIDE]], {{.*}}, {{.*}}) : (!llvm.ptr, i32, !llvm.ptr<1>, !llvm.ptr<1>, !llvm.ptr<1>, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
 // CHECK-NEXT:  llvm.return
 func.func @matmul_rank2(
@@ -49,6 +51,8 @@ func.func @matmul_rank2(
 // CHECK-NEXT:  %[[DYN_B_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
 // CHECK-NEXT:  %[[DYN_OUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
 // CHECK-NEXT:  %[[DYN_ELEM_SIZE:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK-NEXT:  llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:  llvm.mlir.constant(0 : i64) : i64
 // CHECK-NEXT:  llvm.call @wrap_hipblasLtMatmul(%[[DYN_CTX]], %[[DYN_SLOT]], %[[DYN_A_PTR]], %[[DYN_B_PTR]], %[[DYN_OUT_PTR]], %[[DYN_M]], %[[DYN_N]], %[[DYN_K]], %[[DYN_BATCH]], %[[DYN_ELEM_SIZE]], %[[DYN_B_STRIDE]], {{.*}}, {{.*}}) : (!llvm.ptr, i32, !llvm.ptr<1>, !llvm.ptr<1>, !llvm.ptr<1>, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
 // CHECK-NEXT:  llvm.return
 func.func @matmul_dynamic_batch(

--- a/test/lit/Conversion/onnx-to-hip/test_gather_axis0_extract_slice.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_gather_axis0_extract_slice.mlir
@@ -11,8 +11,10 @@ module {
   memref.global "private" @hip_ext_constant_k_idx : memref<i64> {hip.external_data = {index = 1 : i64, offset = 8 : i64, size = 8 : i64}, hip.compile_time_scalar = 1 : i64}
 
   func.func @main_graph(%arg0: !hip.context, %data: tensor<3x4x2xf16>) -> (tensor<4x2xf16>, tensor<4x2xf16>) {
-    %q_idx = bufferization.to_tensor @hip_ext_constant_q_idx restrict : memref<i64> to tensor<i64>
-    %k_idx = bufferization.to_tensor @hip_ext_constant_k_idx restrict : memref<i64> to tensor<i64>
+    %q_buf = memref.get_global @hip_ext_constant_q_idx : memref<i64>
+    %k_buf = memref.get_global @hip_ext_constant_k_idx : memref<i64>
+    %q_idx = bufferization.to_tensor %q_buf restrict : memref<i64> to tensor<i64>
+    %k_idx = bufferization.to_tensor %k_buf restrict : memref<i64> to tensor<i64>
 
     %q = "onnx.Gather"(%data, %q_idx) {axis = 0 : si64} : (tensor<3x4x2xf16>, tensor<i64>) -> tensor<4x2xf16>
     %k = "onnx.Gather"(%data, %k_idx) {axis = 0 : si64} : (tensor<3x4x2xf16>, tensor<i64>) -> tensor<4x2xf16>

--- a/test/lit/Conversion/onnx-to-hip/test_gather_axis0_extract_slice.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_gather_axis0_extract_slice.mlir
@@ -1,0 +1,28 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// Axis-0 scalar Gather with a compile-time index lowers to tensor.extract_slice
+// (zero-copy subview), including when the index was externalized to a global.
+
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip | FileCheck %s
+
+module {
+  memref.global "private" @hip_ext_constant_q_idx : memref<i64> {hip.external_data = {index = 0 : i64, offset = 0 : i64, size = 8 : i64}, hip.compile_time_scalar = 0 : i64}
+  memref.global "private" @hip_ext_constant_k_idx : memref<i64> {hip.external_data = {index = 1 : i64, offset = 8 : i64, size = 8 : i64}, hip.compile_time_scalar = 1 : i64}
+
+  func.func @main_graph(%arg0: !hip.context, %data: tensor<3x4x2xf16>) -> (tensor<4x2xf16>, tensor<4x2xf16>) {
+    %q_idx = bufferization.to_tensor @hip_ext_constant_q_idx restrict : memref<i64> to tensor<i64>
+    %k_idx = bufferization.to_tensor @hip_ext_constant_k_idx restrict : memref<i64> to tensor<i64>
+
+    %q = "onnx.Gather"(%data, %q_idx) {axis = 0 : si64} : (tensor<3x4x2xf16>, tensor<i64>) -> tensor<4x2xf16>
+    %k = "onnx.Gather"(%data, %k_idx) {axis = 0 : si64} : (tensor<3x4x2xf16>, tensor<i64>) -> tensor<4x2xf16>
+
+    // CHECK: tensor.extract_slice {{.*}}[0, 0, 0] [1, 4, 2] [1, 1, 1]
+    // CHECK: tensor.extract_slice {{.*}}[1, 0, 0] [1, 4, 2] [1, 1, 1]
+    // CHECK-NOT: hip.gather
+    // CHECK-NOT: tensor.extract
+    // CHECK-NOT: memref.load
+
+    return %q, %k : tensor<4x2xf16>, tensor<4x2xf16>
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_gather_shape_fold.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_gather_shape_fold.mlir
@@ -140,9 +140,10 @@ module {
 
 // CHECK-LABEL: func.func @test_no_fold_non_shape_source
 // CHECK-NOT: onnx.Gather
-// Without onnx.Shape as the Gather source, the fold doesn't fire and the
-// generic Gather lowering (hip.gather) handles the op.
-// CHECK: hip.gather
+// GatherShapeFold does not fire (source is not onnx.Shape), but axis-0
+// Gather with a compile-time len-1 index still lowers to extract_slice.
+// CHECK: tensor.extract_slice {{.*}}[1] [1] [1]
+// CHECK-NOT: hip.gather
 
 // CHECK-LABEL: func.func @test_fold_shape_start_negative_k
 // CHECK-NOT: onnx.Shape

--- a/test/lit/Conversion/onnx-to-hip/test_transpose_matmul_fusion.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_transpose_matmul_fusion.mlir
@@ -1,0 +1,78 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify the pre-lowering Transpose(last-two-swap) -> MatMul fold and the
+// resulting hip.matmul transB attribute for attention Q @ K^T patterns.
+// ============================================================================
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<1x1xf16>) -> tensor<1x1xf16> {
+    return %arg0 : tensor<1x1xf16>
+  }
+
+  // Swin-style 4D batched attention: Q @ K^T with perm=[0,1,3,2].
+  func.func @attention_qk(%q: tensor<2x3x8x16xf16>, %k: tensor<2x3x8x16xf16>)
+      -> tensor<2x3x8x8xf16> {
+    %kt = "onnx.Transpose"(%k) {perm = dense<[0, 1, 3, 2]> : tensor<4xi64>}
+        : (tensor<2x3x8x16xf16>) -> tensor<2x3x16x8xf16>
+    %scores = "onnx.MatMul"(%q, %kt)
+        : (tensor<2x3x8x16xf16>, tensor<2x3x16x8xf16>) -> tensor<2x3x8x8xf16>
+    return %scores : tensor<2x3x8x8xf16>
+  }
+
+  // CHECK-LABEL: func.func @attention_qk
+  // CHECK-NOT: onnx.Transpose
+  // CHECK-NOT: onnx.MatMul
+  // CHECK: hip.matmul(%{{.*}}) ins(%{{.*}}, %{{.*}} : tensor<2x3x8x16xf16>, tensor<2x3x8x16xf16>)
+  // CHECK-SAME: transB = 1
+  // CHECK-NOT: hip.transpose
+
+  // Same fold when perm is an ArrayAttr (MorphiZen / ONNX importer form).
+  func.func @attention_qk_array_perm(%q: tensor<2x3x8x16xf16>,
+                                     %k: tensor<2x3x8x16xf16>)
+      -> tensor<2x3x8x8xf16> {
+    %kt = "onnx.Transpose"(%k) {perm = [0, 1, 3, 2]}
+        : (tensor<2x3x8x16xf16>) -> tensor<2x3x16x8xf16>
+    %scores = "onnx.MatMul"(%q, %kt)
+        : (tensor<2x3x8x16xf16>, tensor<2x3x16x8xf16>) -> tensor<2x3x8x8xf16>
+    return %scores : tensor<2x3x8x8xf16>
+  }
+
+  // CHECK-LABEL: func.func @attention_qk_array_perm
+  // CHECK-NOT: onnx.Transpose
+  // CHECK: hip.matmul
+  // CHECK-SAME: transB = 1
+
+  // transA on the left operand.
+  func.func @matmul_trans_a(%a: tensor<4x8xf16>, %b: tensor<4x16xf16>)
+      -> tensor<8x16xf16> {
+    %at = "onnx.Transpose"(%a) {perm = dense<[1, 0]> : tensor<2xi64>}
+        : (tensor<4x8xf16>) -> tensor<8x4xf16>
+    %y = "onnx.MatMul"(%at, %b)
+        : (tensor<8x4xf16>, tensor<4x16xf16>) -> tensor<8x16xf16>
+    return %y : tensor<8x16xf16>
+  }
+
+  // CHECK-LABEL: func.func @matmul_trans_a
+  // CHECK-NOT: onnx.Transpose
+  // CHECK: hip.matmul
+  // CHECK-SAME: transA = 1
+
+  // Non-matching perm (full reverse on rank 3) must survive.
+  func.func @no_fold_full_reverse(%a: tensor<2x3x4xf16>, %b: tensor<2x3x4xf16>)
+      -> tensor<2x3x3xf16> {
+    %bt = "onnx.Transpose"(%b) {perm = dense<[2, 1, 0]> : tensor<3xi64>}
+        : (tensor<2x3x4xf16>) -> tensor<2x4x3xf16>
+    %y = "onnx.MatMul"(%a, %bt)
+        : (tensor<2x3x4xf16>, tensor<2x4x3xf16>) -> tensor<2x3x3xf16>
+    return %y : tensor<2x3x3xf16>
+  }
+
+  // CHECK-LABEL: func.func @no_fold_full_reverse
+  // CHECK: onnx.Transpose
+  // CHECK: onnx.MatMul
+}

--- a/test/lit/Conversion/onnx-to-hip/test_transpose_matmul_fusion.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_transpose_matmul_fusion.mlir
@@ -73,6 +73,8 @@ module {
   }
 
   // CHECK-LABEL: func.func @no_fold_full_reverse
-  // CHECK: onnx.Transpose
-  // CHECK: onnx.MatMul
+  // CHECK: hip.transpose
+  // CHECK: hip.matmul
+  // CHECK-NOT: transB = 1
+  // CHECK-NOT: transA = 1
 }


### PR DESCRIPTION
## Summary
- Lower compile-time scalar axis-0 `Gather` to `tensor.extract_slice` instead of `hip.gather`, enabling zero-copy subviews for Swin-style indexing patterns.
- Externalize single-element integer constants with `hip.compile_time_scalar` so indices fold at compile time rather than triggering host loads from GPU-resident memory.
- Fuse `Transpose(last-two-swap) + MatMul` into `hip.matmul` via new `transA`/`transB` attributes, wiring through shape inference, LLVM lowering, and hipBLASLt runtime layouts (attention Q @ K^T idiom).

## Test plan
- [ ] `test/lit/Conversion/onnx-to-hip/test_gather_axis0_extract_slice.mlir`
- [ ] `test/lit/Conversion/onnx-to-hip/test_gather_shape_fold.mlir`
- [ ] `test/lit/Conversion/onnx-to-hip/test_transpose_matmul_fusion.mlir`
- [ ] `test/lit/Conversion/hip-to-llvm/test_matmul.mlir`
- [ ] `test/lit/Conversion/hipsr-to-llvm/matmul.mlir`
- [ ] Full LIT suite on Windows CI