### PR TITLE
fix(windows): accept 7.11/7.14 ROCm library names, layernorm layout, and debug log gating

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -565,13 +565,13 @@ jobs:
 
           THEROCK_DIR="../build/$(basename "$PWD")/_therock"
           for pat in amdhip64_7.dll MIOpen.dll 'amd_comgr*.dll' rocblas.dll \
-                     hipblaslt.dll 'hiprtc*.dll'; do
-            cp $THEROCK_DIR/bin/$pat staging/bin/
+                     hipblaslt.dll libhipblaslt.dll 'hiprtc*.dll'; do
+            cp $THEROCK_DIR/bin/$pat staging/bin/ 2>/dev/null || true
           done
-          cp -r "$THEROCK_DIR/bin/hipblaslt" staging/bin/
-          cp -r "$THEROCK_DIR/bin/rocblas" staging/bin/
-          for pat in 'amdhip64*.lib' MIOpen.lib hipblaslt.lib; do
-            cp $THEROCK_DIR/lib/$pat staging/lib/
+          cp -r "$THEROCK_DIR/bin/hipblaslt" staging/bin/ 2>/dev/null || true
+          cp -r "$THEROCK_DIR/bin/rocblas" staging/bin/ 2>/dev/null || true
+          for pat in 'amdhip64*.lib' MIOpen.lib hipblaslt.lib libhipblaslt.dll.a; do
+            cp $THEROCK_DIR/lib/$pat staging/lib/ 2>/dev/null || true
           done
 
           # MorphiZen EP config

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -569,6 +569,7 @@ jobs:
             cp $THEROCK_DIR/bin/$pat staging/bin/
           done
           cp -r "$THEROCK_DIR/bin/hipblaslt" staging/bin/
+          cp -r "$THEROCK_DIR/bin/rocblas" staging/bin/
           for pat in 'amdhip64*.lib' MIOpen.lib hipblaslt.lib; do
             cp $THEROCK_DIR/lib/$pat staging/lib/
           done

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -564,16 +564,13 @@ jobs:
           cp "${{ runner.workspace }}/install/lib/"*.lib staging/lib/ 2>/dev/null || true
 
           THEROCK_DIR="../build/$(basename "$PWD")/_therock"
-          for dll in amdhip64_7.dll MIOpen.dll amd_comgr0702.dll rocblas.dll \
-                     libhipblaslt.dll hiprtc0702.dll hiprtc-builtins0702.dll \
-                     hipdnn_backend.dll; do
-            cp "$THEROCK_DIR/bin/$dll" staging/bin/
+          for pat in amdhip64_7.dll MIOpen.dll 'amd_comgr*.dll' rocblas.dll \
+                     hipblaslt.dll 'hiprtc*.dll'; do
+            cp $THEROCK_DIR/bin/$pat staging/bin/
           done
-          for data in hipblaslt rocblas; do
-            cp -r "$THEROCK_DIR/bin/$data" staging/bin/
-          done
-          for lib in amdhip64.lib MIOpen.lib libhipblaslt.dll.a; do
-            cp "$THEROCK_DIR/lib/$lib" staging/lib/
+          cp -r "$THEROCK_DIR/bin/hipblaslt" staging/bin/
+          for pat in 'amdhip64*.lib' MIOpen.lib hipblaslt.lib; do
+            cp $THEROCK_DIR/lib/$pat staging/lib/
           done
 
           # MorphiZen EP config

--- a/backend-mlir-compiler/custom-op-mlir/src/LlvmIrJit.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/LlvmIrJit.cpp
@@ -297,6 +297,7 @@ bool installSearchGenerators(llvm::orc::LLJIT &jit) {
   const char *const rocm_libs[] = {
 #ifdef _WIN32
       "MIOpen.dll",
+      "hipblaslt.dll",
       "libhipblaslt.dll",
       "hipdnn_backend.dll",
 #else

--- a/backend-mlir-compiler/custom-op-mlir/src/LlvmIrJit.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/LlvmIrJit.cpp
@@ -31,6 +31,7 @@
 // pluginLibraryPaths). Provided by LibHipCompiler, which every host linking
 // this lib also links (see this dir's CMakeLists).
 #include "hip/Compiler/PluginRegistry.h"
+#include "hip/env.h" // shared cross-platform env reader (single Win32 call)
 
 #include <glog/logging.h>
 
@@ -327,9 +328,11 @@ bool installSearchGenerators(llvm::orc::LLJIT &jit) {
         tried += ", ";
       tried += lib;
     }
-    LOG(WARNING) << "LlvmIrJit: Load(" << tried
-                 << ") failed: " << last_load_error
-                 << "; models needing it will fail at lookup.";
+    if (hipdnn_ep::env_enabled("HIPDNN_EP_DEBUG")) {
+      LOG(WARNING) << "LlvmIrJit: Load(" << tried
+                   << ") failed: " << last_load_error
+                   << "; models needing it will fail at lookup.";
+    }
   }
 
 #ifdef _WIN32
@@ -338,9 +341,11 @@ bool installSearchGenerators(llvm::orc::LLJIT &jit) {
   const char *const kHipdnnBackend = "libhipdnn_backend.so";
 #endif
   if (!loadFirst({kHipdnnBackend})) {
-    LOG(INFO) << "LlvmIrJit: Load(" << kHipdnnBackend
-              << ") failed: " << last_load_error
-              << "; hipDNN graph models will fail at lookup.";
+    if (hipdnn_ep::env_enabled("HIPDNN_EP_DEBUG")) {
+      LOG(INFO) << "LlvmIrJit: Load(" << kHipdnnBackend
+                << ") failed: " << last_load_error
+                << "; hipDNN graph models will fail at lookup.";
+    }
   }
 
 #ifdef HIPDNN_EP_LOAD_KERNEL_DLLS

--- a/backend-mlir-compiler/custom-op-mlir/src/LlvmIrJit.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/LlvmIrJit.cpp
@@ -292,30 +292,55 @@ bool installSearchGenerators(llvm::orc::LLJIT &jit) {
   auto &jd = jit.getMainJITDylib();
   const char global_prefix = jit.getDataLayout().getGlobalPrefix();
 
+  std::string last_load_error;
+  auto loadFirst = [&](llvm::ArrayRef<const char *> names) {
+    for (const char *lib : names) {
+      auto gen =
+          llvm::orc::DynamicLibrarySearchGenerator::Load(lib, global_prefix);
+      if (!gen) {
+        last_load_error = llvm::toString(gen.takeError());
+        continue;
+      }
+      jd.addGenerator(std::move(*gen));
+      return true;
+    }
+    return false;
+  };
+
   // ROCm libs the runtime calls into (the EP only imports amdhip64 directly).
   // A missing lib is tolerated: a model that never touches it still JITs.
-  const char *const rocm_libs[] = {
+  const std::vector<std::vector<const char *>> rocm_libs = {
 #ifdef _WIN32
-      "MIOpen.dll",
-      "hipblaslt.dll",
-      "libhipblaslt.dll",
-      "hipdnn_backend.dll",
+      {"MIOpen.dll"},
+      {"hipblaslt.dll", "libhipblaslt.dll"},
 #else
-      "libMIOpen.so",
-      "libhipblaslt.so",
-      "libhipdnn_backend.so",
+      {"libMIOpen.so"},
+      {"libhipblaslt.so"},
 #endif
   };
-  for (const char *lib : rocm_libs) {
-    auto gen =
-        llvm::orc::DynamicLibrarySearchGenerator::Load(lib, global_prefix);
-    if (!gen) {
-      LOG(WARNING) << "LlvmIrJit: Load(" << lib
-                   << ") failed: " << llvm::toString(gen.takeError())
-                   << "; models needing it will fail at lookup.";
+  for (const std::vector<const char *> &names : rocm_libs) {
+    if (loadFirst(names))
       continue;
+    std::string tried;
+    for (const char *lib : names) {
+      if (!tried.empty())
+        tried += ", ";
+      tried += lib;
     }
-    jd.addGenerator(std::move(*gen));
+    LOG(WARNING) << "LlvmIrJit: Load(" << tried
+                 << ") failed: " << last_load_error
+                 << "; models needing it will fail at lookup.";
+  }
+
+#ifdef _WIN32
+  const char *const kHipdnnBackend = "hipdnn_backend.dll";
+#else
+  const char *const kHipdnnBackend = "libhipdnn_backend.so";
+#endif
+  if (!loadFirst({kHipdnnBackend})) {
+    LOG(INFO) << "LlvmIrJit: Load(" << kHipdnnBackend
+              << ") failed: " << last_load_error
+              << "; hipDNN graph models will fail at lookup.";
   }
 
 #ifdef HIPDNN_EP_LOAD_KERNEL_DLLS

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -17,5 +17,5 @@ flatbuffers;https://github.com/google/flatbuffers.git;v25.12.19
 ## Crash-backtrace helper (always FetchContent; no find_package path).
 cpptrace;https://github.com/jeremy-rifkin/cpptrace.git;v0.8.3
 ##
-therock_windows;https://github.com/ROCm/hip-ep/releases/download/v0.3.0;therock-dist-windows-gfx115X-all-7.14.0
+therock_windows;https://github.com/ROCm/hip-ep/releases/download/v0.3.0;therock-dist-windows-gfx115X-all-7.11.0
 therock_linux;https://repo.amd.com/rocm/tarball;7.11.0

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -17,5 +17,5 @@ flatbuffers;https://github.com/google/flatbuffers.git;v25.12.19
 ## Crash-backtrace helper (always FetchContent; no find_package path).
 cpptrace;https://github.com/jeremy-rifkin/cpptrace.git;v0.8.3
 ##
-therock_windows;https://github.com/ROCm/hip-ep/releases/download/v0.3.0;therock-dist-windows-gfx115X-all-7.11.0
+therock_windows;https://github.com/ROCm/hip-ep/releases/download/v0.3.0;therock-dist-windows-gfx115X-all-7.14.0
 therock_linux;https://repo.amd.com/rocm/tarball;7.11.0

--- a/lib/Compiler/CompilerDriver.cpp
+++ b/lib/Compiler/CompilerDriver.cpp
@@ -536,7 +536,12 @@ void CompilerDriver::discoverInTreeLibraries(
   COMPILER_DEBUG_LOG("THEROCK_DIST detected: " << dist << "\n");
   COMPILER_DEBUG_LOG("  Adding library path: " << lib_dir << "\n");
 
-  libraries.push_back("amdhip64");
+  if (!llvm::sys::fs::exists(lib_dir + "/amdhip64.lib") &&
+      llvm::sys::fs::exists(lib_dir + "/amdhip64_7.lib")) {
+    libraries.push_back("amdhip64_7");
+  } else {
+    libraries.push_back("amdhip64");
+  }
 
   // Skip -lMIOpen/-lhipblaslt when the vendor BLAS/DNN backends are disabled;
   // the runtime's vendor wrappers are then error-returning stubs that reference

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -1098,11 +1098,10 @@ void *hipdnn_ep_get_pool_base(RuntimeState *state, int domain_id,
     if (state->pool_base[domain_id]) {
       if (state->stream)
         HIP_CLEANUP(hipStreamSynchronize(state->stream));
-      fprintf(stderr,
-              "hipdnn_ep_get_pool_base: growing pool[%d] %zu -> %zu bytes "
-              "(rare; first time this large input shape was seen)\n",
-              domain_id, state->pool_size[domain_id], needed_size);
-      fflush(stderr);
+      RUNTIME_DEBUG_LOG(
+          "hipdnn_ep_get_pool_base: growing pool[%d] %zu -> %zu bytes "
+          "(rare; first time this large input shape was seen)\n",
+          domain_id, state->pool_size[domain_id], needed_size);
       HIP_CLEANUP(hipFree(state->pool_base[domain_id]));
     }
     void *new_base = nullptr;

--- a/lib/Runtime/real/simplified_layer_norm.cpp
+++ b/lib/Runtime/real/simplified_layer_norm.cpp
@@ -123,18 +123,17 @@ static const T5NormCacheEntry *queryOrCreateT5Norm(T5NormTable &table,
   T5_CACHE_CHECK(miopenCreateTensorDescriptor(&e.rstdDesc));
 
   {
-    int x_dims[] = {static_cast<int>(key.num_rows),
+    int x_dims[] = {1, 1, static_cast<int>(key.num_rows),
                     static_cast<int>(key.hidden_dim)};
-    int x_strides[] = {static_cast<int>(key.hidden_dim), 1};
     int w_dims[] = {static_cast<int>(key.hidden_dim)};
     int w_strides[] = {1};
     int rstd_dims[] = {static_cast<int>(key.num_rows)};
     int rstd_strides[] = {1};
 
-    T5_CACHE_CHECK(miopenSetTensorDescriptor(e.xDesc, key.data_type, 2, x_dims,
-                                             x_strides));
-    T5_CACHE_CHECK(miopenSetTensorDescriptor(e.yDesc, key.data_type, 2, x_dims,
-                                             x_strides));
+    T5_CACHE_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        e.xDesc, key.data_type, miopenTensorNCHW, x_dims, 4));
+    T5_CACHE_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        e.yDesc, key.data_type, miopenTensorNCHW, x_dims, 4));
     T5_CACHE_CHECK(miopenSetTensorDescriptor(e.weightDesc, key.data_type, 1,
                                              w_dims, w_strides));
     T5_CACHE_CHECK(miopenSetTensorDescriptor(e.rstdDesc, miopenFloat, 1,

--- a/lib/Runtime/real/skip_simplified_layer_norm.cpp
+++ b/lib/Runtime/real/skip_simplified_layer_norm.cpp
@@ -134,7 +134,8 @@ queryOrCreateSkipT5Norm(SkipT5NormTable &table, const SkipT5NormCacheKey &key) {
   }
 
   {
-    // T5LayerNorm: 2D [num_rows, hidden_dim]
+    int norm_dims[] = {1, 1, static_cast<int>(key.num_rows),
+                       static_cast<int>(key.hidden_dim)};
     int x_dims[] = {static_cast<int>(key.num_rows),
                     static_cast<int>(key.hidden_dim)};
     int x_strides[] = {static_cast<int>(key.hidden_dim), 1};
@@ -145,10 +146,10 @@ queryOrCreateSkipT5Norm(SkipT5NormTable &table, const SkipT5NormCacheKey &key) {
     int bias_dims[] = {1, static_cast<int>(key.hidden_dim)};
     int bias_strides[] = {static_cast<int>(key.hidden_dim), 1};
 
-    SKIP_CACHE_CHECK(miopenSetTensorDescriptor(e.xDesc, key.data_type, 2,
-                                               x_dims, x_strides));
-    SKIP_CACHE_CHECK(miopenSetTensorDescriptor(e.yDesc, key.data_type, 2,
-                                               x_dims, x_strides));
+    SKIP_CACHE_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        e.xDesc, key.data_type, miopenTensorNCHW, norm_dims, 4));
+    SKIP_CACHE_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        e.yDesc, key.data_type, miopenTensorNCHW, norm_dims, 4));
     SKIP_CACHE_CHECK(miopenSetTensorDescriptor(e.weightDesc, key.data_type, 1,
                                                w_dims, w_strides));
     SKIP_CACHE_CHECK(miopenSetTensorDescriptor(e.rstdDesc, miopenFloat, 1,


### PR DESCRIPTION
## Summary

Land forward-compatible Windows ROCm library naming (JIT dlopen, native link, gpu-test staging), T5 layernorm NCHW descriptors, and HIPDNN_EP_DEBUG-gated cold-path diagnostics. TheRock Windows dist stays at 7.11.0; the 7.14 dist bump and VLM gpu-test gate are deferred (VLM landed separately in #817).

## Related issue or design

None

## Why

ROCm 7.14 renames several libraries the EP loads and links (hipBLASLt, amdhip64 import lib, comgr/hiprtc suffixes) and drops hipdnn_backend.dll. Rather than hardcoding one spelling, this PR accepts either name so CI and local builds keep working on the pinned 7.11 dist while a future deps.txt bump needs only a one-line change.

Separately, MIOpen T5 layernorm logs `Failed to convert layout string 'UNKNOWN'` on rank-2 descriptors, and unconditional JIT/pool-grow diagnostics leak internal noise to stderr on every run.

## What

- `LlvmIrJit.cpp`: grouped dlopen with load-first resolution (`hipblaslt.dll` / `libhipblaslt.dll`); hipdnn_backend probed separately; load warnings gated behind `HIPDNN_EP_DEBUG`.
- `CompilerDriver.cpp`: link `amdhip64_7` when `amdhip64.lib` is absent from `THEROCK_DIST/lib`.
- `simplified_layer_norm.cpp` / `skip_simplified_layer_norm.cpp`: explicit NCHW 4D descriptors for T5 norm x/y (`[1, 1, num_rows, hidden_dim]`).
- `hipdnn_ep_runtime_state.cpp`: pool-grow notice routed through `RUNTIME_DEBUG_LOG`.
- `windows-build.yml`: gpu-test-package staging uses dual 7.11/7.14 DLL/lib patterns with tolerant copy; stages rocBLAS Tensile data explicitly. VLM benchmark unchanged from main (#817).

**Not in this PR:** `cmake/deps.txt` remains `therock-dist-windows-gfx115X-all-7.11.0`. TheRock 7.14 dist pin will follow in a separate PR.

## Test plan

- [ ] `pre-commit run --all-files` clean after rebase
- [ ] `build-windows` green on cold cache (7.11 dist)
- [ ] `gpu-test` green: staging step succeeds with 7.11 DLL names; perf / native smoke / EPContext paths pass

## Notes for reviewers

- #817 already cherry-picked the VLM benchmark commit off this branch; rebase drops the duplicate.
- Staging patterns use `2>/dev/null || true` so missing 7.14-only artifacts do not fail the job while CI still pins 7.11.
- Linux `therock_linux` untouched.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [ ] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
