### PR TITLE
testing PR700 + PR599 on latest main

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -362,7 +362,7 @@ jobs:
           # OGA is built against the patched ort-install, so the key folds in
           # the fork ref, optional OGA_PR_PATCHES, and ONNXRUNTIME_PR_PATCHES.
           # The mm<N> token bumps when the OGA artifact set changes shape.
-          key: oga-dml-mm3-${{ env.OGA_REPO }}-${{ env.OGA_REF }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
+          key: oga-dml-mm3-${{ env.OGA_REPO }}-${{ env.OGA_REF }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}-1
 
       # OGA is built from cliu1003/onnxruntime-genai sliding_window_support_amdgpu
       # (AMDGPU MorphiZen integration + sliding_window). Optional OGA_PR_PATCHES

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -362,7 +362,7 @@ jobs:
           # OGA is built against the patched ort-install, so the key folds in
           # the fork ref, optional OGA_PR_PATCHES, and ONNXRUNTIME_PR_PATCHES.
           # The mm<N> token bumps when the OGA artifact set changes shape.
-          key: oga-dml-mm3-${{ env.OGA_REPO }}-${{ env.OGA_REF }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}-1
+          key: oga-dml-mm3-${{ env.OGA_REPO }}-${{ env.OGA_REF }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}-2
 
       # OGA is built from cliu1003/onnxruntime-genai sliding_window_support_amdgpu
       # (AMDGPU MorphiZen integration + sliding_window). Optional OGA_PR_PATCHES

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -51,11 +51,14 @@ jobs:
       ONNXRUNTIME_PR_PATCHES: ""
       SCCACHE_GHA_ENABLED: "true"
       SCCACHE_GHA_RW_MODE: ${{ github.ref_name == 'main' && 'READ_WRITE' || 'READ_ONLY' }}
-      OGA_VERSION: "0.14.0"
-      # Space-separated microsoft/onnxruntime-genai PR numbers fetched from
-      # pull/<n>.patch and `git apply` on top of v<OGA_VERSION>. Part of the OGA
-      # cache key. Remove a PR once it lands in the pinned OGA release.
-      OGA_PR_PATCHES: "2194"
+      # Fork branch carrying AMDGPU MorphiZen integration (former PR 2194) plus
+      # sliding_window support.
+      OGA_REPO: "amd-genmingz/onnxruntime-genai"
+      OGA_REF: "test_0_3"
+      # Optional space-separated microsoft/onnxruntime-genai PR numbers applied
+      # on top of the fork checkout via pull/<n>.patch + git am. Empty when the
+      # fork branch already carries the needed integration.
+      OGA_PR_PATCHES: ""
       # ilammy/msvc-dev-cmd and mozilla-actions/sccache-action have no
       # Node.js 24 releases yet; allow Node.js 20 until they are updated.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
@@ -357,22 +360,19 @@ jobs:
         with:
           path: ${{ runner.workspace }}/oga-artifacts
           # OGA is built against the patched ort-install, so the key folds in
-          # both OGA's own PR list and ONNXRUNTIME_PR_PATCHES; editing either
-          # forces a rebuild. The mm<N> token bumps when the OGA artifact set
-          # changes shape, or when a PR's branch content changes under the same
-          # number (mm2: PR 2194 now carries the AMDGPU OGA integration).
-          key: oga-dml-mm2-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
+          # the fork ref, optional OGA_PR_PATCHES, and ONNXRUNTIME_PR_PATCHES.
+          # The mm<N> token bumps when the OGA artifact set changes shape.
+          key: oga-dml-mm3-${{ env.OGA_REPO }}-${{ env.OGA_REF }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
 
-      # OGA is built from upstream microsoft/onnxruntime-genai + PR patches
-      # (OGA_PR_PATCHES). PR 2194 (the dynamic-shape-morphizen branch) now also
-      # carries the AMDGPU umbrella integration, so the patched upstream build
-      # is the AMDGPU-targeted OGA -- no fork checkout needed.
+      # OGA is built from cliu1003/onnxruntime-genai sliding_window_support_amdgpu
+      # (AMDGPU MorphiZen integration + sliding_window). Optional OGA_PR_PATCHES
+      # apply extra upstream PRs on top of the fork checkout.
       - name: Checkout OGA
         if: steps.cache-oga.outputs.cache-hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: microsoft/onnxruntime-genai
-          ref: v${{ env.OGA_VERSION }}
+          repository: ${{ env.OGA_REPO }}
+          ref: ${{ env.OGA_REF }}
           path: source-oga
           submodules: true
           fetch-depth: 1
@@ -832,9 +832,9 @@ jobs:
           exit /b %RC%
 
       # ----------------------------------------------------------------------
-      # EPContext export + import perf test (PR #132 constants-file-in-tar path).
+      # EPContext export + import perf test (PR #132 sidecar-in-tar path).
       # Limited to full_model_seq128 to bound runtime: each model triggers
-      # one export pass (~60 s + N GB constants-file write) plus one import perf
+      # one export pass (~60 s + N GB sidecar write) plus one import perf
       # pass (-t 30). The _ctx.onnx + _MORPHIZEN.bin are deleted right after
       # import to keep runner disk usage bounded.
       # ----------------------------------------------------------------------

--- a/lib/Conversion/OnnxToHip/ReshapeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ReshapeConversion.cpp
@@ -51,51 +51,124 @@ validateSqueezeUnsqueezeOp(mlir::Operation *op, mlir::PatternRewriter &rewriter,
   return mlir::success();
 }
 
-/// Build output shape for expand_shape operations.
+/// Count the dynamic output dims a reassociation group covers.
+static int64_t countDynOutDims(mlir::RankedTensorType outputType,
+                               const mlir::ReassociationIndices &group) {
+  return llvm::count_if(
+      group, [&](int64_t idx) { return outputType.isDynamicDim(idx); });
+}
+
+/// Resolve output dim \p outDim's extent from a Reshape's `shape` operand.
+///
+/// Only a host-visible shape vector is honoured, i.e. the
+/// `tensor.from_elements` that ReshapeShapeFold leaves behind for the
+/// `Reshape(_, Shape(x))` idiom, whose elements are already host SSA values. A
+/// shape tensor that is still device-resident yields nullopt instead of paying
+/// for a readback; the caller then falls back to `tensor.reshape`, which
+/// consumes the runtime shape vector directly.
+///
+/// Resolution is per-dim rather than whole-vector because ONNX's `-1` ("infer")
+/// and `0` ("keep the input dim") are not usable as extents but normally sit on
+/// the feature dim -- a position the result type already pins as static, so the
+/// caller never asks about it. Resolving the whole vector up front would let a
+/// `-1` at such a position veto a split that is otherwise fully determined,
+/// which is the usual spelling of `[bs*ss, H] -> [bs, ss, -1]`.
+static std::optional<mlir::OpFoldResult>
+resolveShapeOperandExtent(mlir::PatternRewriter &rewriter, mlir::Location loc,
+                          mlir::Value shapeOperand, int64_t outDim,
+                          int64_t outputRank) {
+  if (!shapeOperand)
+    return std::nullopt;
+  // Shape-refining casts do not change the elements.
+  while (auto castOp = shapeOperand.getDefiningOp<mlir::tensor::CastOp>())
+    shapeOperand = castOp.getSource();
+
+  auto fromElements =
+      shapeOperand.getDefiningOp<mlir::tensor::FromElementsOp>();
+  if (!fromElements ||
+      static_cast<int64_t>(fromElements.getElements().size()) != outputRank)
+    return std::nullopt;
+
+  mlir::Value element = fromElements.getElements()[outDim];
+  // ReshapeShapeFold emits `arith.index_cast %tensor.dim`. Reusing the pre-cast
+  // index keeps the extent on the same SSA value the rest of the conversion
+  // derives dims from, instead of a round trip through i64.
+  if (auto castOp = element.getDefiningOp<mlir::arith::IndexCastOp>();
+      castOp && mlir::isa<mlir::IndexType>(castOp.getIn().getType()))
+    return mlir::OpFoldResult(castOp.getIn());
+  if (std::optional<int64_t> known = mlir::getConstantIntValue(element)) {
+    if (*known <= 0)
+      return std::nullopt;
+    return mlir::OpFoldResult(rewriter.getIndexAttr(*known));
+  }
+  return mlir::OpFoldResult(mlir::arith::IndexCastOp::create(
+      rewriter, loc, rewriter.getIndexType(), element));
+}
+
+/// Build the `output_shape` operand list for a `tensor.expand_shape`.
 /// Used by both Reshape and Unsqueeze when expanding dimensions.
 ///
-/// For static dimensions: use compile-time size from outputType.
-/// For dynamic dimensions: extract from input via DimOp, dividing out any
-/// static dimensions in the same reassociation group.
-llvm::SmallVector<mlir::OpFoldResult> buildExpandShapeOutputShape(
-    mlir::PatternRewriter &rewriter, mlir::Location loc, mlir::Value data,
-    mlir::RankedTensorType outputType,
-    llvm::ArrayRef<mlir::ReassociationIndices> reassoc) {
+/// Extents that follow from the source type are computed by
+/// `tensor::ExpandShapeOp::inferOutputShape`: static dims come from
+/// \p outputType, and a group's single dynamic dim is the source extent divided
+/// by the group's static dims. That upstream helper is called rather than
+/// reimplemented because it also *declines* when a group covers more than one
+/// dynamic output dim -- the case with no solution in the source type, since
+/// the source dim holds only the PRODUCT of those dims. An in-tree copy of the
+/// derivation missing that bail-out is what turned
+/// `[bs*ss, 2816] -> [bs, ss, 2816]` into `[ss, ss, 2816]` and dispatched every
+/// Gemma-4 layer's input norm over ss^2 rows.
+///
+/// A multi-dynamic group's extents exist only in the Reshape's `shape` operand,
+/// so they are read from \p shapeOperand. Returns nullopt when that is not
+/// readable, letting the caller fall back to `tensor.reshape` instead of
+/// emitting an `output_shape` it cannot justify.
+std::optional<llvm::SmallVector<mlir::OpFoldResult>>
+buildExpandShapeOutputShape(mlir::PatternRewriter &rewriter, mlir::Location loc,
+                            mlir::Value data, mlir::RankedTensorType outputType,
+                            llvm::ArrayRef<mlir::ReassociationIndices> reassoc,
+                            mlir::Value shapeOperand = {}) {
+  auto inputType = mlir::cast<mlir::RankedTensorType>(data.getType());
+  bool hasMultiDynGroup =
+      llvm::any_of(reassoc, [&](const mlir::ReassociationIndices &group) {
+        return countDynOutDims(outputType, group) > 1;
+      });
+
+  if (!hasMultiDynGroup) {
+    // inferOutputShape reads a group's source extent as an SSA value, which
+    // holds whenever a group covering a dynamic output dim has a dynamic source
+    // dim. The opposite pairing describes an inconsistent source/result type
+    // pair; decline rather than trip the cast inside the helper.
+    for (auto [g, group] : llvm::enumerate(reassoc))
+      if (countDynOutDims(outputType, group) == 1 && !inputType.isDynamicDim(g))
+        return std::nullopt;
+    auto inferred = mlir::tensor::ExpandShapeOp::inferOutputShape(
+        rewriter, loc, outputType, reassoc,
+        mlir::tensor::getMixedSizes(rewriter, loc, data));
+    if (mlir::failed(inferred))
+      return std::nullopt;
+    return *inferred;
+  }
+
+  // Some group splits one dynamic source dim into several dynamic output dims.
+  // Statics still come from the result type, but every dynamic extent is taken
+  // from the shape operand: within such a group the source dim says nothing
+  // about the split, and sourcing the whole shape from one operand keeps the
+  // dynamic extents mutually consistent instead of mixing two derivations.
   int64_t outputRank = outputType.getRank();
-
-  llvm::SmallVector<int64_t> outDimToInDim(outputRank, -1);
-  for (auto [g, group] : llvm::enumerate(reassoc))
-    for (int64_t idx : group)
-      outDimToInDim[idx] = g;
-
   llvm::SmallVector<mlir::OpFoldResult> outputShape;
+  outputShape.reserve(outputRank);
   for (int64_t i : llvm::seq<int64_t>(outputRank)) {
     if (!outputType.isDynamicDim(i)) {
       outputShape.push_back(rewriter.getIndexAttr(outputType.getDimSize(i)));
       continue;
     }
-
-    int64_t srcDim = outDimToInDim[i];
-    const auto &group = reassoc[srcDim];
-
-    int64_t staticProduct = 1;
-    for (int64_t idx : group)
-      if (!outputType.isDynamicDim(idx))
-        staticProduct *= outputType.getDimSize(idx);
-
-    mlir::Value inputSize =
-        mlir::tensor::DimOp::create(rewriter, loc, data, srcDim);
-    if (staticProduct == 1) {
-      outputShape.push_back(inputSize);
-    } else {
-      mlir::Value divisor =
-          mlir::arith::ConstantIndexOp::create(rewriter, loc, staticProduct);
-      mlir::Value dynSize =
-          mlir::arith::DivUIOp::create(rewriter, loc, inputSize, divisor);
-      outputShape.push_back(dynSize);
-    }
+    auto extent =
+        resolveShapeOperandExtent(rewriter, loc, shapeOperand, i, outputRank);
+    if (!extent)
+      return std::nullopt;
+    outputShape.push_back(*extent);
   }
-
   return outputShape;
 }
 
@@ -194,17 +267,27 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
       if (auto reassocOpt =
               mlir::getReassociationIndicesForReshape(inputType, outputType)) {
         if (outputRank > inputRank) {
-          auto outputShape = buildExpandShapeOutputShape(
-              rewriter, loc, data, outputType, *reassocOpt);
-          auto expandOp = mlir::tensor::ExpandShapeOp::create(
-              rewriter, loc, outputType, data, *reassocOpt, outputShape);
-          rewriter.replaceOp(op, expandOp.getResult());
+          // The `shape` operand is the only place a multi-dynamic split's
+          // per-dim extents exist; ReshapeShapeFold has already folded
+          // `Shape(x)` into a host-visible tensor.from_elements for it.
+          mlir::Value shapeOperand =
+              op->getNumOperands() >= 2 ? op->getOperand(1) : mlir::Value();
+          if (auto outputShape = buildExpandShapeOutputShape(
+                  rewriter, loc, data, outputType, *reassocOpt, shapeOperand)) {
+            auto expandOp = mlir::tensor::ExpandShapeOp::create(
+                rewriter, loc, outputType, data, *reassocOpt, *outputShape);
+            rewriter.replaceOp(op, expandOp.getResult());
+            return mlir::success();
+          }
+          // Multi-dynamic split with an unreadable shape operand: fall through
+          // to the tensor.reshape fallback, which takes the runtime shape
+          // vector verbatim.
         } else {
           auto collapseOp = mlir::tensor::CollapseShapeOp::create(
               rewriter, loc, outputType, data, *reassocOpt);
           rewriter.replaceOp(op, collapseOp.getResult());
+          return mlir::success();
         }
-        return mlir::success();
       }
       // Fall through to tensor.reshape fallback (no structured reassoc).
     }
@@ -344,16 +427,22 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
             mlir::RankedTensorType::get(intShape, inputType.getElementType());
 
         // (d) Reuse the existing helper to compute output_shape values for the
-        // expand. It emits tensor.dim for dynamic dims and arith.divui when a
-        // dynamic input dim is split into (dyn, static_factor) — exactly the
-        // combine direction here. (PoolAllocs's hoistable whitelist must
-        // include arith.divui for the resulting dim arithmetic to survive
-        // pool-base hoisting.)
+        // expand. It emits tensor.dim for dynamic dims and an integer division
+        // when a dynamic input dim is split into (dyn, static_factor) — exactly
+        // the combine direction here. The divisor is a positive constant, so
+        // the division is speculatable and --hip-hoist-alloc-size-arith (which
+        // gates on mlir::isPure, not an op-name list) can still hoist the
+        // resulting dim arithmetic above the allocs --hip-pool-allocs absorbs.
+        //
+        // Each group here pairs one dynamic extent with the static factor K,
+        // so no group is multi-dynamic and the shape operand is never needed.
         auto intOutShape = buildExpandShapeOutputShape(rewriter, loc, data,
                                                        intType, expandReassoc);
+        if (!intOutShape)
+          break; // fall through to tensor.reshape fallback
 
         auto expanded = mlir::tensor::ExpandShapeOp::create(
-            rewriter, loc, intType, data, expandReassoc, intOutShape);
+            rewriter, loc, intType, data, expandReassoc, *intOutShape);
 
         // (e) Collapse: the OUTPUT dim that absorbs the factor pair maps to the
         // two intermediate dims; everything else is identity.
@@ -578,10 +667,15 @@ struct UnsqueezeToStdTensor : public mlir::RewritePattern {
           op, "cannot compute unsqueeze reassociation");
 
     mlir::Location loc = op->getLoc();
+    // Unsqueeze only inserts unit dims, so every group keeps at most one
+    // dynamic dim and no shape operand is needed.
     auto outputShape = buildExpandShapeOutputShape(rewriter, loc, data,
                                                    outputType, *reassocOpt);
+    if (!outputShape)
+      return rewriter.notifyMatchFailure(
+          op, "unsqueeze: multi-dynamic reassociation group");
     auto expandOp = mlir::tensor::ExpandShapeOp::create(
-        rewriter, loc, outputType, data, *reassocOpt, outputShape);
+        rewriter, loc, outputType, data, *reassocOpt, *outputShape);
     rewriter.replaceOp(op, expandOp.getResult());
     return mlir::success();
   }

--- a/lib/Conversion/OnnxToHip/ReshapeShapeFold.cpp
+++ b/lib/Conversion/OnnxToHip/ReshapeShapeFold.cpp
@@ -50,8 +50,9 @@
 //
 // This fold rewrites the shape operand BEFORE ConvertOnnxToHip so the
 // resulting `tensor.from_elements` is exactly what ReshapeConversion's
-// existing multi-dyn-per-group branch picks up.  Bug fix is structural
-// at the operand level; no change to ReshapeConversion required.
+// multi-dyn-per-group branch picks up.  That branch is the other half of
+// the fix and lives in `buildExpandShapeOutputShape`; without it this fold
+// has no effect, because the conversion otherwise never reads operand 1.
 //
 // Implementation notes
 // --------------------

--- a/test/lit/Conversion/onnx-to-hip/test_reshape.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_reshape.mlir
@@ -77,6 +77,45 @@ module {
     %result = "onnx.Reshape"(%data, %shape) {allowzero = 0 : si64} : (tensor<f16>, tensor<3xi64>) -> tensor<1x1x1xf16>
     return %result : tensor<1x1x1xf16>
   }
+
+  // --- Multi-dynamic expand: [bs*ss, H] -> [bs, ss, H] ---
+  // The source dim only holds the PRODUCT bs*ss, so the split has to come from
+  // the shape operand.  Deriving both extents positionally from the source
+  // yields [bs*ss, bs*ss, H], which is how every Gemma-4 decoder layer's input
+  // norm ended up dispatched over ss^2 rows.
+  func.func @test_reshape_expand_multi_dyn(%data: tensor<?x2816xf16>,
+                                           %ref: tensor<?x?x2816xf16>)
+      -> tensor<?x?x2816xf16> {
+    %shape = "onnx.Shape"(%ref) : (tensor<?x?x2816xf16>) -> tensor<3xi64>
+    %result = "onnx.Reshape"(%data, %shape) {allowzero = 0 : si64} : (tensor<?x2816xf16>, tensor<3xi64>) -> tensor<?x?x2816xf16>
+    return %result : tensor<?x?x2816xf16>
+  }
+
+  // --- Multi-dynamic expand, `-1` on the static output dim ---
+  // The most common ONNX spelling of this reshape. The `-1` ("infer") entry is
+  // not usable as an extent, but it sits on the dim the result type already
+  // pins as 2816, so it is never consulted: extents resolve per-dim, not
+  // whole-vector, and the split still comes from the shape operand.
+  func.func @test_reshape_expand_multi_dyn_infer_static_dim(
+      %data: tensor<?x2816xf16>, %bs: index, %ss: index)
+      -> tensor<?x?x2816xf16> {
+    %bs_i64 = arith.index_cast %bs : index to i64
+    %ss_i64 = arith.index_cast %ss : index to i64
+    %minus_one = arith.constant -1 : i64
+    %shape = tensor.from_elements %bs_i64, %ss_i64, %minus_one : tensor<3xi64>
+    %result = "onnx.Reshape"(%data, %shape) {allowzero = 0 : si64} : (tensor<?x2816xf16>, tensor<3xi64>) -> tensor<?x?x2816xf16>
+    return %result : tensor<?x?x2816xf16>
+  }
+
+  // --- Multi-dynamic expand with an opaque shape operand ---
+  // Nothing here reveals the split, so the conversion must decline to build an
+  // expand_shape and hand the runtime shape vector to tensor.reshape instead.
+  func.func @test_reshape_expand_multi_dyn_opaque(%data: tensor<?x2816xf16>,
+                                                  %shape: tensor<3xi64>)
+      -> tensor<?x?x2816xf16> {
+    %result = "onnx.Reshape"(%data, %shape) {allowzero = 0 : si64} : (tensor<?x2816xf16>, tensor<3xi64>) -> tensor<?x?x2816xf16>
+    return %result : tensor<?x?x2816xf16>
+  }
 }
 
 // CHECK-LABEL: func.func @test_reshape_expand
@@ -118,4 +157,27 @@ module {
 // CHECK: hip.readback_scalar
 // CHECK: tensor.from_elements
 // CHECK: tensor.expand_shape
+// CHECK-NOT: onnx.Reshape
+
+// The two dynamic output extents must be DISTINCT dims of the rank-3 reference,
+// never the same source dim twice.
+// CHECK-LABEL: func.func @test_reshape_expand_multi_dyn
+// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+// CHECK: %[[BS:.*]] = tensor.dim %[[REF:.*]], %[[C0]] : tensor<?x?x2816xf16>
+// CHECK: %[[SS:.*]] = tensor.dim %[[REF]], %[[C1]] : tensor<?x?x2816xf16>
+// CHECK: tensor.expand_shape %{{.*}} {{\[\[}}0, 1], [2]] output_shape [%[[BS]], %[[SS]], 2816]
+// CHECK-NOT: onnx.Reshape
+
+// A `-1` on an output dim the result type pins as static must not block the
+// expand: the split still comes from the two resolvable entries.
+// CHECK-LABEL: func.func @test_reshape_expand_multi_dyn_infer_static_dim
+// CHECK-SAME: %[[BS:[^:]*]]: index, %[[SS:[^:]*]]: index
+// CHECK: tensor.expand_shape %{{.*}} {{\[\[}}0, 1], [2]] output_shape [%[[BS]], %[[SS]], 2816]
+// CHECK-NOT: tensor.reshape
+// CHECK-NOT: onnx.Reshape
+
+// CHECK-LABEL: func.func @test_reshape_expand_multi_dyn_opaque
+// CHECK-NOT: tensor.expand_shape
+// CHECK: tensor.reshape
 // CHECK-NOT: onnx.Reshape


### PR DESCRIPTION
Testing branch: latest main + PR #599 + PR #700. Do not merge.

Built by cherry-picking each PR onto main (6683d2a5, which now includes PR #675), so CI exercises the two together on current main.

## Contents

| Commit | Source | What it does |
| --- | --- | --- |
| d134ca8b, a8ff85e4, a28b3282 | PR #599 | Points the OGA build at the `amd-genmingz/onnxruntime-genai` fork (ref `test_0_3`) instead of upstream v0.14.0 + PR 2194, and bumps the OGA cache key to `-2`. |
| 90b64c4c | PR #700 | Takes multi-dynamic `expand_shape` extents from the shape operand. |

PR #700's commit is byte-identical to its head (`3a0b2b8f`), verified with `git range-diff`.

## One conflict resolution

PR #599's first commit replaces the `OGA_VERSION` block in the workflow `env:` map, and main's PR #768 added `SCCACHE_GHA_RW_MODE` in that same spot. Both are kept: main's sccache gating stays, and the fork pin applies. No `OGA_VERSION` references remain anywhere in the workflow.

Side effect worth knowing: because this branch is not `main`, PR #768 makes sccache `READ_ONLY` here, so the Windows build will be slower than it was on the older test branch.

## Note on PR #599

PR #599 is `CONFLICTING` against main on its own branch, and its history interleaves the three real commits with four merges from main. This branch carries only the three real commits, replayed linearly on current main.