### PR TITLE
ci(cache): pin actions/cache to v5.0.1 to keep 429 retries

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -129,7 +129,7 @@ jobs:
       # -----------------------------------------------------------------------
       - name: Cache LLVM install prefix
         id: cache-llvm
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: ${{ runner.workspace }}/llvm-install
           # Keyed only on the LLVM tag: a protobuf/ORT bump must not evict the
@@ -173,7 +173,7 @@ jobs:
       # -----------------------------------------------------------------------
       - name: Cache ONNX Runtime install prefix
         id: cache-ort
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: ${{ runner.workspace }}/ort-install
           key: linux-ort-${{ env.ONNXRUNTIME_VERSION }}-ortpr-${{ env.ONNXRUNTIME_PR_PATCHES }}-whl
@@ -287,7 +287,7 @@ jobs:
       # -----------------------------------------------------------------------
       - name: Cache OGA artifacts
         id: cache-oga
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: ${{ runner.workspace }}/oga-artifacts
           key: linux-oga-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-am-whl-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}

--- a/.github/workflows/windows-build-mock.yml
+++ b/.github/workflows/windows-build-mock.yml
@@ -58,14 +58,14 @@ jobs:
       # -----------------------------------------------------------------------
       - name: Cache ort-install
         id: cache-ort
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: ${{ runner.workspace }}/ort-install
           key: dep-ort-${{ env.ONNXRUNTIME_VERSION }}-ortpr-${{ env.ONNXRUNTIME_PR_PATCHES }}
 
       - name: Cache llvm-install
         id: cache-llvm
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: ${{ runner.workspace }}/llvm-install
           key: dep-llvm-${{ env.LLVM_TAG }}

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -87,7 +87,7 @@ jobs:
       # -----------------------------------------------------------------------
       - name: Cache ort-install
         id: cache-ort
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: ${{ runner.workspace }}/ort-install
           # `ortpr-<list>` embeds ONNXRUNTIME_PR_PATCHES verbatim so editing
@@ -96,7 +96,7 @@ jobs:
 
       - name: Cache llvm-install
         id: cache-llvm
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: ${{ runner.workspace }}/llvm-install
           key: dep-llvm-${{ env.LLVM_TAG }}
@@ -280,7 +280,7 @@ jobs:
       # -----------------------------------------------------------------------
       - name: Cache amdgpu-ep build
         id: cache-amdgpu
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: ${{ runner.workspace }}/build-amdgpu
           # amdgpu-ep/hip-backend link against the patched ort-install, so the
@@ -353,7 +353,7 @@ jobs:
       # -----------------------------------------------------------------------
       - name: Cache OGA artifacts
         id: cache-oga
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: ${{ runner.workspace }}/oga-artifacts
           # OGA is built against the patched ort-install, so the key folds in


### PR DESCRIPTION
## Summary

Pin `actions/cache` to v5.0.1 in the three build workflows so a rate-limited (HTTP 429) cache restore retries instead of reporting a miss and falling through to a multi-hour cold dependency build.

## Related issue or design

None

## Why

The repository shares a 200 cache-entry-uploads-per-minute quota. When several PRs are updated at once the concurrent jobs hit that quota, and a restore lookup that gets a 429 is treated as a cache miss, which turns a ~10 minute warm run into a 3+ hour cold LLVM rebuild.

`actions/cache` v5.0.2 removed `TooManyRequests` from the retry list of the cache service v2 client (`CacheServiceClient`) and replaced it with a `rate limiting - don't retry, just warn and exit` path. Every version from v5.0.2 through v6.x behaves that way, so the currently pinned v5.0.3 gives up on the first 429. v5.0.1 is the last version that still retries a 429 with exponential backoff (`maxAttempts=5`, base 3s, multiplier 1.5).

v5.0.1 already runs on node24 against cache service v2, so pinning back does not change how caches are keyed, restored, or saved.

## What

Replaced the action SHA in all 9 cache steps, no structural changes:

- [.github/workflows/windows-build.yml](.github/workflows/windows-build.yml): `cache-ort`, `cache-llvm`, `cache-amdgpu`, `cache-oga`
- [.github/workflows/linux-build.yml](.github/workflows/linux-build.yml): `cache-llvm`, `cache-ort`, `cache-oga`
- [.github/workflows/windows-build-mock.yml](.github/workflows/windows-build-mock.yml): `cache-ort`, `cache-llvm`

The downstream `if: steps.cache-*.outputs.cache-hit != 'true'` guards are untouched.

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] All three workflow files still parse as YAML
- [ ] build-windows, build-linux and the mock job restore their dependency caches (`cache-hit=true`) on this PR run
- [ ] No cold LLVM or ORT rebuild in the warm path

## Notes for reviewers

The retry window is roughly 24 to 35 seconds in total, while the rate limit window is a minute, so a sustained burst can still exhaust the retries. If that shows up in practice the follow-up is a workflow-level sleep-and-retry around the expensive LLVM and ORT caches.

Pinning back drops the dependency security bumps from v5.0.4 and v5.0.5 and the read-only cache handling from v5.1.0. The repository has no dependabot configuration, so this pin will not be bumped automatically; it needs to be revisited manually if upstream restores 429 retries.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
