### PR TITLE
fix(hipsr): keep a graph output's memory space at the function boundary

### DIFF
--- a/include/hip/Conversion/OnnxToHipsr/OnnxToHipsr.h
+++ b/include/hip/Conversion/OnnxToHipsr/OnnxToHipsr.h
@@ -46,8 +46,9 @@ void populateShapeConversionPatterns(const ::mlir::TypeConverter &typeConverter,
                                      ::mlir::RewritePatternSet &patterns,
                                      ::mlir::MLIRContext *ctx);
 
-void populateReturnConversionPatterns(::mlir::RewritePatternSet &patterns,
-                                      ::mlir::MLIRContext *ctx);
+void populateReturnConversionPatterns(
+    const ::mlir::TypeConverter &typeConverter,
+    ::mlir::RewritePatternSet &patterns, ::mlir::MLIRContext *ctx);
 
 } // namespace hipsr
 } // namespace mlir

--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
@@ -19,7 +19,6 @@
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/Func/Transforms/FuncConversions.h"
 #include "mlir/Dialect/Shape/IR/Shape.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -120,10 +119,9 @@ struct ConvertOnnxToHipsrPass
     populateMatMulConversionPatterns(converter, patterns, &getContext());
     populateExpandConversionPatterns(converter, patterns, &getContext());
     populateShapeConversionPatterns(converter, patterns, &getContext());
-    populateReturnConversionPatterns(patterns, &getContext());
+    populateReturnConversionPatterns(converter, patterns, &getContext());
     populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(patterns,
                                                                    converter);
-    populateReturnOpTypeConversionPattern(patterns, converter);
 
     if (failed(applyFullConversion(module, target, std::move(patterns)))) {
       signalPassFailure();

--- a/lib/Conversion/OnnxToHipsr/ReturnConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/ReturnConversion.cpp
@@ -7,6 +7,10 @@
 // onnx.Return carries graph structure rather than a computation, so it lowers
 // to func.return instead of to a hipsr operation.
 //
+// The conversion also retypes the enclosing function's results. A pattern does
+// not carry the pass converter, so an operand keeps the memory space its
+// producer chose and the signature follows it.
+//
 //===----------------------------------------------------------------------===//
 
 #include "hip/Conversion/OnnxToHipsr/OnnxToHipsr.h"
@@ -14,27 +18,39 @@
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir {
 namespace hipsr {
 namespace {
 
-struct ReturnToFunc : public ::mlir::OpRewritePattern<::mlir::onnx::ReturnOp> {
-  using OpRewritePattern::OpRewritePattern;
+struct ReturnToFunc
+    : public ::mlir::OpConversionPattern<::mlir::onnx::ReturnOp> {
+  ReturnToFunc(const ::mlir::TypeConverter &typeConverter,
+               ::mlir::MLIRContext *ctx)
+      : OpConversionPattern(ctx) {}
 
   ::mlir::LogicalResult
-  matchAndRewrite(::mlir::onnx::ReturnOp op,
-                  ::mlir::PatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<::mlir::func::ReturnOp>(op, op.getOperands());
+  matchAndRewrite(::mlir::onnx::ReturnOp op, OpAdaptor adaptor,
+                  ::mlir::ConversionPatternRewriter &rewriter) const override {
+    ::mlir::ValueRange operands = adaptor.getOperands();
+    // onnx.Return carries HasParent<func::FuncOp>.
+    auto funcOp = ::mlir::cast<::mlir::func::FuncOp>(op->getParentOp());
+    rewriter.modifyOpInPlace(funcOp, [&] {
+      funcOp.setFunctionType(rewriter.getFunctionType(
+          funcOp.getFunctionType().getInputs(), operands.getTypes()));
+    });
+    rewriter.replaceOpWithNewOp<::mlir::func::ReturnOp>(op, operands);
     return ::mlir::success();
   }
 };
 
 } // namespace
 
-void populateReturnConversionPatterns(::mlir::RewritePatternSet &patterns,
-                                      ::mlir::MLIRContext *ctx) {
-  patterns.add<ReturnToFunc>(ctx);
+void populateReturnConversionPatterns(
+    const ::mlir::TypeConverter &typeConverter,
+    ::mlir::RewritePatternSet &patterns, ::mlir::MLIRContext *ctx) {
+  patterns.add<ReturnToFunc>(typeConverter, ctx);
 }
 
 } // namespace hipsr

--- a/test/lit/Conversion/onnx-to-hipsr/cast.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/cast.mlir
@@ -22,5 +22,5 @@ func.func @cast_chain(
     %ctx: !hipsr.context, %input: tensor<?x8xf32>) -> tensor<?x8xf32> {
   %0 = "onnx.Cast"(%input) {to = f16} : (tensor<?x8xf32>) -> tensor<?x8xf16>
   %1 = "onnx.Cast"(%0) {to = f32} : (tensor<?x8xf16>) -> tensor<?x8xf32>
-  return %1 : tensor<?x8xf32>
+  "onnx.Return"(%1) : (tensor<?x8xf32>) -> ()
 }

--- a/test/lit/Conversion/onnx-to-hipsr/constant.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/constant.mlir
@@ -8,7 +8,7 @@ func.func @scalar_const() -> tensor<f32> {
   // CHECK: arith.constant dense<3.000000e+00> : tensor<f32>
   // CHECK-NOT: hipsr.constant
   %0 = "onnx.Constant"() {value = dense<3.0> : tensor<f32>} : () -> tensor<f32>
-  return %0 : tensor<f32>
+  "onnx.Return"(%0) : (tensor<f32>) -> ()
 }
 
 // -----
@@ -17,7 +17,7 @@ func.func @scalar_const() -> tensor<f32> {
 func.func @inline_const() -> tensor<4xf32> {
   // CHECK: hipsr.constant {value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00]> : tensor<4xf32>} : tensor<4xf32, #hipsr.mem<device>>
   %0 = "onnx.Constant"() {value = dense<[1.0, 2.0, 3.0, 4.0]> : tensor<4xf32>} : () -> tensor<4xf32>
-  return %0 : tensor<4xf32>
+  "onnx.Return"(%0) : (tensor<4xf32>) -> ()
 }
 
 // -----
@@ -26,7 +26,7 @@ func.func @inline_const() -> tensor<4xf32> {
 func.func @mem_resource_const() -> tensor<2x4xf32> {
   // CHECK: hipsr.constant {value = dense_resource<"mem|0x7ff620910000"> : tensor<2x4xf32, #hipsr.mem<device>>} : tensor<2x4xf32, #hipsr.mem<device>>
   %0 = "onnx.Constant"() {location = "*/_ORT_MEM_ADDR_/*", offset = 140695085056000 : i64, size = 32 : i64} : () -> tensor<2x4xf32>
-  return %0 : tensor<2x4xf32>
+  "onnx.Return"(%0) : (tensor<2x4xf32>) -> ()
 }
 
 // -----
@@ -35,5 +35,5 @@ func.func @mem_resource_const() -> tensor<2x4xf32> {
 func.func @file_resource_const() -> tensor<4xi8> {
   // CHECK: hipsr.constant {value = dense_resource<"file|w.bin|4"> : tensor<4xi8, #hipsr.mem<device>>} : tensor<4xi8, #hipsr.mem<device>>
   %0 = "onnx.Constant"() {location = "w.bin", offset = 4 : i64, size = 4 : i64} : () -> tensor<4xi8>
-  return %0 : tensor<4xi8>
+  "onnx.Return"(%0) : (tensor<4xi8>) -> ()
 }

--- a/test/lit/Conversion/onnx-to-hipsr/expand-invalid.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/expand-invalid.mlir
@@ -86,5 +86,5 @@ func.func @shape_argument_names_no_space(%ctx: !hipsr.context,
   // expected-error @+1 {{operand #2 must be ranked host tensor or host memref}}
   %0 = "onnx.Expand"(%input, %shape)
       : (tensor<?x3xf16>, tensor<2xi64>) -> tensor<?x?xf16>
-  return %0 : tensor<?x?xf16>
+  "onnx.Return"(%0) : (tensor<?x?xf16>) -> ()
 }

--- a/test/lit/Conversion/onnx-to-hipsr/expand.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/expand.mlir
@@ -25,7 +25,7 @@ func.func @expand(%ctx: !hipsr.context, %input: tensor<?x3xf16>,
                   %shape: tensor<2xi64, #hipsr.mem<host>>) -> tensor<?x?xf16> {
   %0 = "onnx.Expand"(%input, %shape)
       : (tensor<?x3xf16>, tensor<2xi64, #hipsr.mem<host>>) -> tensor<?x?xf16>
-  return %0 : tensor<?x?xf16>
+  "onnx.Return"(%0) : (tensor<?x?xf16>) -> ()
 }
 
 // -----
@@ -45,5 +45,5 @@ func.func @expand_broadcast_rank(%ctx: !hipsr.context,
     -> tensor<?x?x?x?xf16> {
   %0 = "onnx.Expand"(%input, %shape)
       : (tensor<2x3xf16>, tensor<4xi64, #hipsr.mem<host>>) -> tensor<?x?x?x?xf16>
-  return %0 : tensor<?x?x?x?xf16>
+  "onnx.Return"(%0) : (tensor<?x?x?x?xf16>) -> ()
 }

--- a/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
@@ -22,7 +22,7 @@ func.func @matmul_2d(%ctx: !hipsr.context, %a: tensor<?x4096xf16>,
                      %b: tensor<4096x1024xf16>) -> tensor<?x1024xf16> {
   %0 = "onnx.MatMul"(%a, %b) : (tensor<?x4096xf16>, tensor<4096x1024xf16>)
       -> tensor<?x1024xf16>
-  return %0 : tensor<?x1024xf16>
+  "onnx.Return"(%0) : (tensor<?x1024xf16>) -> ()
 }
 
 // -----
@@ -40,5 +40,5 @@ func.func @matmul_1d_rhs(%ctx: !hipsr.context, %a: tensor<?x4096xf16>,
                          %b: tensor<4096xf16>) -> tensor<?xf16> {
   %0 = "onnx.MatMul"(%a, %b) : (tensor<?x4096xf16>, tensor<4096xf16>)
       -> tensor<?xf16>
-  return %0 : tensor<?xf16>
+  "onnx.Return"(%0) : (tensor<?xf16>) -> ()
 }

--- a/test/lit/Conversion/onnx-to-hipsr/no-value.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/no-value.mlir
@@ -16,5 +16,5 @@
 // CHECK-NEXT:    return %[[INPUT]] : tensor<2x3xf16, #hipsr.mem<device>>
 func.func @dead_placeholder(%input: tensor<2x3xf16>) -> tensor<2x3xf16> {
   %none = "onnx.NoValue"() {value} : () -> none
-  return %input : tensor<2x3xf16>
+  "onnx.Return"(%input) : (tensor<2x3xf16>) -> ()
 }

--- a/test/lit/Conversion/onnx-to-hipsr/return.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/return.mlir
@@ -2,7 +2,8 @@
 // Licensed under the MIT License.
 
 //===----------------------------------------------------------------------===//
-// onnx.Return becomes func.return. Rejected forms live in return-invalid.mlir.
+// onnx.Return becomes func.return, and the function's result types follow the
+// operands it carries. Rejected forms live in return-invalid.mlir.
 //===----------------------------------------------------------------------===//
 
 // RUN: hip-mlir-opt --onnx-dialect=modeled --convert-onnx-to-hipsr --split-input-file %s | FileCheck %s
@@ -13,6 +14,7 @@
 // CHECK-SAME:    %{{.*}}: !hipsr.context,
 // CHECK-SAME:    %[[INPUT:.*]]: tensor<?x4096xf16, #hipsr.mem<device>>) -> tensor<?x4096xf16, #hipsr.mem<device>> {
 // CHECK-NEXT:    return %[[INPUT]] : tensor<?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:  }
 func.func @imported_graph(%ctx: !hipsr.context, %input: tensor<?x4096xf16>)
     -> tensor<?x4096xf16> {
   "onnx.Return"(%input) : (tensor<?x4096xf16>) -> ()
@@ -22,7 +24,9 @@ func.func @imported_graph(%ctx: !hipsr.context, %input: tensor<?x4096xf16>)
 
 // A graph with no results returns nothing.
 // CHECK-LABEL: func.func @return_no_operands(
+// CHECK-SAME:    %{{.*}}: !hipsr.context) {
 // CHECK-NEXT:    return
+// CHECK-NEXT:  }
 func.func @return_no_operands(%ctx: !hipsr.context) {
   "onnx.Return"() : () -> ()
 }

--- a/test/lit/Conversion/onnx-to-hipsr/shape.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/shape.mlir
@@ -225,5 +225,5 @@ func.func @extents_feed_an_expand(%ctx: !hipsr.context,
   %0 = "onnx.Shape"(%input) : (tensor<?x3xf16>) -> tensor<2xi64>
   %1 = "onnx.Expand"(%input, %0)
       : (tensor<?x3xf16>, tensor<2xi64>) -> tensor<?x?xf16>
-  return %1 : tensor<?x?xf16>
+  "onnx.Return"(%1) : (tensor<?x?xf16>) -> ()
 }


### PR DESCRIPTION
## Summary

`onnx.Return` now lowers through an `OpConversionPattern` that builds `func.return` from the adaptor operands and retypes the enclosing function's results to match. A graph output keeps the memory space its producer chose all the way to the function boundary, so a graph no longer has to declare that space in its signature.


## What

- `ReturnToFunc` is an `OpConversionPattern<onnx::ReturnOp>`. It takes the pass converter without handing it to the base, sets the function type from the adapted operand types, and replaces the terminator.
- `populateReturnOpTypeConversionPattern` and the `FuncConversions.h` include are dropped. `func::ReturnOp` keeps its dynamic legality on `converter.isLegal(op)`, so the pass legalizes `onnx.Return` only: a `func.return` already naming its spaces stays legal, and one that does not is now a legalization failure instead of a converter-forced rewrite.
- The positive lit cases that ended in a plain `func.return` over an unspaced type now use `onnx.Return`, and `return.mlir` checks the exact full output IR.
