### PR TITLE
perf(gqa): move KV cache append/concat 16 B per lane (-15.4% decode ms/token at 12K)

### DIFF
--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -341,6 +341,23 @@ __global__ void transpose_mid_dims_kernel(
 // Ref: onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h (ConcatStateChunkGQA)
 // -------------------------------------------------------------------------
 
+// Widest copy unit for the KV data-movement kernels. Both append and concat are
+// pure relocation, so the element type only matters for indexing -- the payload
+// can move as opaque 16 B chunks. One fp16 per lane leaves the copy issue-rate
+// limited well short of the memory roofline (measured ~99 GB/s of 256 GB/s at
+// 12K context); eight per lane is what closes that gap.
+struct __align__(16) KvVec16 {
+  uint32_t x, y, z, w;
+};
+
+// The vectorised path indexes in KvVec16 units, which is only valid when the
+// head dim divides evenly and every buffer is 16 B aligned. Element offsets are
+// then automatically aligned too: each is (multiple of d) + (multiple of VEC),
+// and d % VEC == 0. Callers fall back to the scalar kernel when this fails.
+static inline bool kv_is_16b_aligned(const void* p) {
+  return (reinterpret_cast<uintptr_t>(p) & 15u) == 0;
+}
+
 template <typename T>
 __global__ void kv_cache_append_kernel(
     const T* __restrict__ src,
@@ -363,6 +380,35 @@ __global__ void kv_cache_append_kernel(
   int src_idx = ((batch_idx * sq + s) * G + g) * d + di;
   int dst_idx = ((batch_idx * G + g) * present_seq + (eff_past_len + s)) * d + di;
   cache[dst_idx] = src[src_idx];
+}
+
+// 16 B-per-lane form of kv_cache_append_kernel. VEC elements of T are moved as
+// one KvVec16, so the thread count drops by VEC and each lane issues a single
+// dwordx4. Indexing is identical, just in vector units along d.
+template <typename T, int VEC>
+__global__ void kv_cache_append_vec_kernel(
+    const T* __restrict__ src,
+    T* __restrict__ cache,
+    int sq, int G, int d, int present_seq, int past_len,
+    const int* __restrict__ seqlens_k) {
+  const int batch_idx = __builtin_amdgcn_readfirstlane(blockIdx.y);
+  int eff_past_len = seqlens_k ? (seqlens_k[batch_idx] + 1 - sq) : past_len;
+  if (eff_past_len < 0 || eff_past_len + sq > present_seq) return;
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int dv = d / VEC;
+  int total_per_batch = sq * G * dv;
+  if (idx >= total_per_batch) return;
+
+  int dvi = idx % dv;
+  int remaining = idx / dv;
+  int g = remaining % G;
+  int s = remaining / G;
+
+  int src_idx = ((batch_idx * sq + s) * G + g) * d + dvi * VEC;
+  int dst_idx =
+      ((batch_idx * G + g) * present_seq + (eff_past_len + s)) * d + dvi * VEC;
+  *reinterpret_cast<KvVec16*>(cache + dst_idx) =
+      *reinterpret_cast<const KvVec16*>(src + src_idx);
 }
 
 // -------------------------------------------------------------------------
@@ -410,6 +456,42 @@ __global__ void kv_cache_concat_kernel(
     int cs = s - past_len;
     int src_idx = ((batch_idx * sq + cs) * G + g) * d + di;
     present[dst_idx] = current[src_idx];
+  }
+}
+
+// 16 B-per-lane form of kv_cache_concat_kernel. A VEC-wide chunk never straddles
+// the past/new boundary (the split is along s, the chunk runs along d), so the
+// source branch stays uniform per lane exactly as in the scalar kernel.
+template <typename T, int VEC>
+__global__ void kv_cache_concat_vec_kernel(
+    const T* __restrict__ past,
+    const T* __restrict__ current,
+    T* __restrict__ present,
+    int past_len, int sq, int G, int d,
+    int past_seq, int present_seq) {
+  const int batch_idx = __builtin_amdgcn_readfirstlane(blockIdx.y);
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int dv = d / VEC;
+  int total_seq = past_len + sq;
+  int total_per_batch = total_seq * G * dv;
+  if (idx >= total_per_batch) return;
+
+  int dvi = idx % dv;
+  int remaining = idx / dv;
+  int g = remaining % G;
+  int s = remaining / G;
+
+  int dst_idx = ((batch_idx * G + g) * present_seq + s) * d + dvi * VEC;
+
+  if (s < past_len) {
+    int src_idx = ((batch_idx * G + g) * past_seq + s) * d + dvi * VEC;
+    *reinterpret_cast<KvVec16*>(present + dst_idx) =
+        *reinterpret_cast<const KvVec16*>(past + src_idx);
+  } else {
+    int cs = s - past_len;
+    int src_idx = ((batch_idx * sq + cs) * G + g) * d + dvi * VEC;
+    *reinterpret_cast<KvVec16*>(present + dst_idx) =
+        *reinterpret_cast<const KvVec16*>(current + src_idx);
   }
 }
 
@@ -748,6 +830,16 @@ static void launch_kv_cache_append(
     hipStream_t stream, const void* src, void* cache,
     int batch_size, int sq, int G, int d, int present_seq, int past_len,
     const void* seqlens_k) {
+  constexpr int VEC = 16 / sizeof(T);
+  if ((d % VEC) == 0 && kv_is_16b_aligned(src) && kv_is_16b_aligned(cache)) {
+    int total = sq * G * (d / VEC);
+    int blocks = (total + GQA_THREADS - 1) / GQA_THREADS;
+    kv_cache_append_vec_kernel<T, VEC><<<dim3(blocks, batch_size), GQA_THREADS,
+                                         0, stream>>>(
+        static_cast<const T*>(src), static_cast<T*>(cache),
+        sq, G, d, present_seq, past_len, static_cast<const int*>(seqlens_k));
+    return;
+  }
   int total = sq * G * d;
   int blocks = (total + GQA_THREADS - 1) / GQA_THREADS;
   kv_cache_append_kernel<T><<<dim3(blocks, batch_size), GQA_THREADS, 0,
@@ -762,6 +854,17 @@ static void launch_kv_cache_concat(
     int batch_size, int past_len, int sq, int G, int d,
     int past_seq, int present_seq) {
   int total_seq = past_len + sq;
+  constexpr int VEC = 16 / sizeof(T);
+  if ((d % VEC) == 0 && kv_is_16b_aligned(past) && kv_is_16b_aligned(current) &&
+      kv_is_16b_aligned(present)) {
+    int total = total_seq * G * (d / VEC);
+    int blocks = (total + GQA_THREADS - 1) / GQA_THREADS;
+    kv_cache_concat_vec_kernel<T, VEC><<<dim3(blocks, batch_size), GQA_THREADS,
+                                         0, stream>>>(
+        static_cast<const T*>(past), static_cast<const T*>(current),
+        static_cast<T*>(present), past_len, sq, G, d, past_seq, present_seq);
+    return;
+  }
   int total = total_seq * G * d;
   int blocks = (total + GQA_THREADS - 1) / GQA_THREADS;
   kv_cache_concat_kernel<T><<<dim3(blocks, batch_size), GQA_THREADS, 0,


### PR DESCRIPTION
## Summary

Two commits on top of `main`:

1. **`perf(gqa)`** — the actual change. Both KV data-movement kernels moved one element per lane, so on fp16 each lane issued a 2 B copy, leaving `kv_cache_concat` issue-rate limited at ~99 GB/s against a 256 GB/s roofline (100% occupancy, 8 VGPRs, no LDS — no occupancy lever left, only vector width). Adds `KvVec16` forms of append and concat that move 16 B per lane as a single `dwordx4`, cutting thread count 8x.
2. **`ci(windows)`** — points the OGA checkout at the AMDGPU fork branch carrying MorphiZen integration + `sliding_window`, which Gemma-4 unified needs. Taken from #599 so this PR can be tested against gemma4-unified without depending on that PR landing first.

## Measurements

Gemma-4 26B-A4B, 12K context (12276-token prompt), 64 generated tokens x 3 reps after 1 warmup, no EP profiling enabled:

| metric | base | this PR | delta |
|---|---|---|---|
| avg ms/token | 263.39 | 222.74 | **-15.4%** |
| p50 ms/token | 250.33 | 203.43 | **-18.7%** |
| p90 ms/token | 310.49 | 274.88 | -11.5% |
| peak memory | 16229 MB | 16232 MB | flat |

`hipgpu.dll` was byte-identical across the A/B, so the delta is attributable to `custom_kernels` alone. Harness repeatability on this model is ~0.3 ms/token between independent runs, so the deltas are far outside noise.

This is substantially larger than the -3.2% the original commit claimed at 12K. That earlier number was measured on a different tree and harness.

## Safety of the vector path

Guarded on `d % VEC == 0` plus a 16 B alignment check on **every** buffer, re-evaluated per call:

- Gemma-4's head dims are 256 and 512, both divisible by 8, so there is no tail case.
- A pooled buffer that happens to be misaligned falls back to the scalar kernel rather than faulting. This matters because a separate in-flight branch changes the allocator to hand out pooled (rather than fresh) KV output buffers.
- A vector chunk never straddles the past/new boundary: the split runs along the sequence dim while the chunk runs along the contiguous head dim, so the source branch stays uniform per lane exactly as in the scalar kernel.

## Test plan

- [x] 12K decode A/B, 3 reps + warmup, profiling env cleared (numbers above)
- [x] Peak memory checked for regression
- [ ] **Numerical correctness not yet validated** — see below

:warning: I could not validate numerics. The usual generated-text diff cannot discriminate on this stack: the *same binary* produced two different completions across runs, and one of them matched the baseline exactly, so decode here is non-deterministic. The standalone GQA kernel tests would be the deterministic check, but they currently fail to launch (`STATUS_ENTRYPOINT_NOT_FOUND`) for reasons unrelated to this change. Both kernels are pure relocation and should be bit-exact, but that is an argument, not a measurement — reviewer input welcome on the right correctness gate.

## Note on #599

Only #599's intended OGA change is carried over. Two unrelated deletions in that branch are deliberately **not** included, as both look like merge-resolution accidents:

- it drops `SCCACHE_GHA_RW_MODE`
- its merge resolution reverts the `sidecar` -> `constants file` rename from #513

Its comment also names a different fork (`cliu1003/...sliding_window_support_amdgpu`) than the ref it actually checks out, so I refer to `OGA_REPO` generically instead.
