### PR TITLE
feat(hipsr): convert onnx.Reshape to a hipsr.compute

### DIFF
--- a/include/hip/Conversion/OnnxToHipsr/OnnxToHipsr.h
+++ b/include/hip/Conversion/OnnxToHipsr/OnnxToHipsr.h
@@ -46,8 +46,9 @@ void populateShapeConversionPatterns(const ::mlir::TypeConverter &typeConverter,
                                      ::mlir::RewritePatternSet &patterns,
                                      ::mlir::MLIRContext *ctx);
 
-void populateReturnConversionPatterns(::mlir::RewritePatternSet &patterns,
-                                      ::mlir::MLIRContext *ctx);
+void populateReturnConversionPatterns(
+    const ::mlir::TypeConverter &typeConverter,
+    ::mlir::RewritePatternSet &patterns, ::mlir::MLIRContext *ctx);
 
 } // namespace hipsr
 } // namespace mlir

--- a/include/hip/Conversion/OnnxToHipsr/OnnxToHipsr.h
+++ b/include/hip/Conversion/OnnxToHipsr/OnnxToHipsr.h
@@ -46,6 +46,10 @@ void populateShapeConversionPatterns(const ::mlir::TypeConverter &typeConverter,
                                      ::mlir::RewritePatternSet &patterns,
                                      ::mlir::MLIRContext *ctx);
 
+void populateReshapeConversionPatterns(
+    const ::mlir::TypeConverter &typeConverter,
+    ::mlir::RewritePatternSet &patterns, ::mlir::MLIRContext *ctx);
+
 void populateReturnConversionPatterns(
     const ::mlir::TypeConverter &typeConverter,
     ::mlir::RewritePatternSet &patterns, ::mlir::MLIRContext *ctx);

--- a/lib/Conversion/OnnxToHipsr/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHipsr/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(OnnxToHipsr STATIC
   MatMulConversion.cpp
   ExpandConversion.cpp
   ShapeConversion.cpp
+  ReshapeConversion.cpp
   ReturnConversion.cpp
 )
 

--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
@@ -19,7 +19,6 @@
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/Func/Transforms/FuncConversions.h"
 #include "mlir/Dialect/Shape/IR/Shape.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -120,10 +119,9 @@ struct ConvertOnnxToHipsrPass
     populateMatMulConversionPatterns(converter, patterns, &getContext());
     populateExpandConversionPatterns(converter, patterns, &getContext());
     populateShapeConversionPatterns(converter, patterns, &getContext());
-    populateReturnConversionPatterns(patterns, &getContext());
+    populateReturnConversionPatterns(converter, patterns, &getContext());
     populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(patterns,
                                                                    converter);
-    populateReturnOpTypeConversionPattern(patterns, converter);
 
     if (failed(applyFullConversion(module, target, std::move(patterns)))) {
       signalPassFailure();

--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
@@ -119,6 +119,7 @@ struct ConvertOnnxToHipsrPass
     populateMatMulConversionPatterns(converter, patterns, &getContext());
     populateExpandConversionPatterns(converter, patterns, &getContext());
     populateShapeConversionPatterns(converter, patterns, &getContext());
+    populateReshapeConversionPatterns(converter, patterns, &getContext());
     populateReturnConversionPatterns(converter, patterns, &getContext());
     populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(patterns,
                                                                    converter);

--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsrUtils.h
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsrUtils.h
@@ -14,10 +14,15 @@
 #define HIP_CONVERSION_ONNXTOHIPSR_UTILS_H
 
 #include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
+#include "hip/Dialect/Hipsr/IR/HipsrOps.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Shape/IR/Shape.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/PatternMatch.h"
+
+#include "llvm/ADT/SmallVector.h"
 
 namespace mlir {
 namespace hipsr {
@@ -27,6 +32,40 @@ inline ::mlir::RankedTensorType tensorTypeInSpace(::mlir::RankedTensorType type,
                                                   MemorySpace space) {
   return type.cloneWithEncoding(
       ::mlir::hipsr::MemorySpaceAttr::get(type.getContext(), space));
+}
+
+/// Creates `compute`'s entry block and leaves `builder` inserting at its
+/// start. The ODS builder only reserves the region, so every conversion that
+/// emits a compute has to fill it.
+inline ::mlir::Block &createComputeBodyBlock(::mlir::OpBuilder &builder,
+                                             ComputeOp compute) {
+  // The body's arguments are the operands: ctx, then the inputs, then the
+  // outputs.
+  ::mlir::TypeRange argTypes = compute->getOperandTypes();
+  ::llvm::SmallVector<::mlir::Location> argLocs(argTypes.size(),
+                                                compute.getLoc());
+  ::mlir::Block *block =
+      builder.createBlock(&compute.getBody(), {}, argTypes, argLocs);
+  builder.setInsertionPointToStart(block);
+  return *block;
+}
+
+/// Returns `compute`'s entry-block argument for input `index`, skipping the
+/// leading `ctx` argument.
+inline ::mlir::Value computeBodyInput(::mlir::Block &body, unsigned index) {
+  return body.getArgument(1 + index);
+}
+
+/// Terminates a placeholder's shape region with `extents`. The region yields
+/// one `!shape.shape` however it was computed, so only the extents differ
+/// between the conversions that fill one.
+inline void yieldShapeFromExtents(::mlir::OpBuilder &builder,
+                                  ::mlir::Location loc,
+                                  ::mlir::ValueRange extents) {
+  ::mlir::Value shape = ::mlir::shape::FromExtentsOp::create(
+      builder, loc, ::mlir::shape::ShapeType::get(builder.getContext()),
+      extents);
+  ShapeYieldOp::create(builder, loc, ::mlir::ValueRange{shape});
 }
 
 /// Gets the `!hipsr.context` from function argument 0. The ONNX phase adds it

--- a/lib/Conversion/OnnxToHipsr/ReshapeConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/ReshapeConversion.cpp
@@ -6,23 +6,36 @@
 //
 // onnx.Reshape regroups extents in row-major order without moving data. The
 // conversion emits a tensor.collapse_shape and a tensor.expand_shape through
-// the 1-D form, inside a hipsr.compute. Both ops bufferize to memrefs that
-// alias their source, so nothing runs on the device, and canonicalization
-// composes the pair into a single op when one can express the regroup.
+// the 1-D form, inside a hipsr.compute. Both bufferize to memrefs that alias
+// their source, so nothing runs on the device, and canonicalization composes
+// the pair into one op when a single op can express the regroup.
 //
-// The destination has to be known one of two ways; nothing else is supported.
+// The target shape operand is not simply a list of extents. With allowzero
+// clear, ONNX gives two entries a meaning of their own: 0 copies the input's
+// extent at that axis, and -1 asks for the one extent that the preserved
+// element count can recover. Resolving those two is most of the work here.
 //
-// Compile time. The result type gives its static extents and a target shape
-// operand that folds to a constant gives the rest. One extent may still be
-// unknown: a reshape preserves the element count, so it is that count divided
-// by the others. The shape region only needs the input's shape here, so a
-// normal placeholder is enough.
+// The destination's shape then comes from one of two places.
 //
-// Runtime. Otherwise the extents are only in the target shape operand, which
-// must be a host tensor the shape region can read. That needs a barrier
-// placeholder, whose shape region takes the operands rather than their shapes.
-// A shape operand anywhere else is rejected; nothing here copies it to the
-// host.
+// Derived. Every extent follows from the result type's static dims, a target
+// shape operand that folds to a constant, and the input's shape. Nothing has
+// to be read out of memory, so a normal placeholder is enough.
+//
+// Host. Otherwise two or more extents are left inferred, and the element count
+// recovers only one, so the shape region has to read the target shape operand
+// itself. That is a host read: the operand must be in host memory and the
+// placeholder a barrier. A shape operand anywhere else is rejected; nothing
+// here copies it to the host.
+//
+// The pattern runs in the order below, and the helpers are grouped to match:
+//
+//   1. Reject the unsupported forms and put the result type in the input's
+//      memory space, since the result aliases the input.
+//   2. Classify every result extent. That refines the result type and picks
+//      which of the two destinations follows.
+//   3. Drop the reshape when the refined type is the input's own.
+//   4. Build the placeholder whose shape region resolves the destination.
+//   5. Build the hipsr.compute whose body regroups the input into it.
 //
 // Before:
 //   %r = "onnx.Reshape"(%x, %shape)
@@ -74,6 +87,7 @@
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SmallVector.h"
 
+#include <cassert>
 #include <functional>
 #include <optional>
 
@@ -82,12 +96,12 @@ namespace hipsr {
 namespace {
 
 //===----------------------------------------------------------------------===//
-// Naming the result extents at compile time
+// Classifying the result extents
 //===----------------------------------------------------------------------===//
 
-// Where a result extent comes from when the target shape needs no runtime
-// read. ONNX allows one -1 entry, which `Inferred` marks; the rest are either
-// known outright or copied from the input.
+// Where one result extent comes from. The three kinds are the three meanings a
+// target shape entry can have: an extent, a copy of the input's, or the -1 the
+// element count has to recover.
 struct TargetExtent {
   enum class Kind { Constant, CopiesInput, Inferred };
   Kind kind = Kind::Inferred;
@@ -107,78 +121,79 @@ auto isKind(TargetExtent::Kind kind) {
   return [kind](const TargetExtent &extent) { return extent.kind == kind; };
 }
 
-// Names every result extent without reading the target shape operand at
-// runtime. A static result dim gives its own extent. For a dynamic one, a
-// target shape operand that folds to a constant decides: with allowzero clear,
-// a positive entry is the extent, a 0 copies the input's extent at that axis,
-// and a -1 says nothing. Fails when more than one extent is left unnamed,
-// since the preserved element count recovers only one.
-FailureOr<SmallVector<TargetExtent>>
-nameTargetExtents(RankedTensorType resultType, RankedTensorType inputType,
-                  Value shape) {
-  SmallVector<int64_t> stated;
-  DenseIntElementsAttr entries;
-  if (matchPattern(shape, m_Constant(&entries)) &&
-      entries.getNumElements() == resultType.getRank()) {
-    stated =
-        llvm::map_to_vector(entries.getValues<APInt>(), [](const APInt &entry) {
+// Classifies every result extent without reading the target shape operand at
+// runtime. A static result dim gives its own extent; for a dynamic one, an
+// operand that folds to a constant decides.
+//
+// Nothing means two or more extents are left inferred, which the element count
+// cannot recover. That is not an error but the choice of destination: those
+// extents have to be read on the host instead.
+std::optional<SmallVector<TargetExtent>>
+classifyTargetExtents(RankedTensorType resultType, RankedTensorType inputType,
+                      Value shape) {
+  SmallVector<int64_t> entries;
+  DenseIntElementsAttr folded;
+  if (matchPattern(shape, m_Constant(&folded)) &&
+      folded.getNumElements() == resultType.getRank()) {
+    entries =
+        llvm::map_to_vector(folded.getValues<APInt>(), [](const APInt &entry) {
           return entry.getSExtValue();
         });
   }
 
-  SmallVector<TargetExtent> named;
-  named.reserve(resultType.getRank());
+  SmallVector<TargetExtent> classified;
+  classified.reserve(resultType.getRank());
   for (int64_t axis : llvm::seq<int64_t>(0, resultType.getRank())) {
     if (!resultType.isDynamicDim(axis)) {
-      named.push_back(TargetExtent::constant(resultType.getDimSize(axis)));
+      classified.push_back(TargetExtent::constant(resultType.getDimSize(axis)));
       continue;
     }
     // An operand that stayed a runtime value says nothing about any axis,
     // which is what a -1 entry already means to ONNX.
-    int64_t entry = stated.empty() ? -1 : stated[axis];
+    int64_t entry = entries.empty() ? -1 : entries[axis];
     if (entry > 0) {
-      named.push_back(TargetExtent::constant(entry));
+      classified.push_back(TargetExtent::constant(entry));
     } else if (entry == 0 && axis < inputType.getRank()) {
-      named.push_back(inputType.isDynamicDim(axis)
-                          ? TargetExtent::copiesInput(axis)
-                          : TargetExtent::constant(inputType.getDimSize(axis)));
+      classified.push_back(
+          inputType.isDynamicDim(axis)
+              ? TargetExtent::copiesInput(axis)
+              : TargetExtent::constant(inputType.getDimSize(axis)));
     } else {
-      named.push_back(TargetExtent::inferred());
+      classified.push_back(TargetExtent::inferred());
     }
   }
 
-  if (llvm::count_if(named, isKind(TargetExtent::Kind::Inferred)) > 1) {
-    return failure();
+  if (llvm::count_if(classified, isKind(TargetExtent::Kind::Inferred)) > 1) {
+    return std::nullopt;
   }
-  return named;
+  return classified;
 }
 
 // The axes whose extent the result copies from the input.
-llvm::SmallDenseSet<int64_t> copiedInputAxes(ArrayRef<TargetExtent> named) {
-  auto copies =
-      llvm::make_filter_range(named, isKind(TargetExtent::Kind::CopiesInput));
+llvm::SmallDenseSet<int64_t>
+copiedInputAxes(ArrayRef<TargetExtent> classified) {
+  auto copies = llvm::make_filter_range(
+      classified, isKind(TargetExtent::Kind::CopiesInput));
   llvm::SmallDenseSet<int64_t> copied;
   copied.insert_range(
       llvm::map_range(copies, std::mem_fn(&TargetExtent::value)));
   return copied;
 }
 
-// The product of the known extents. The inferred extent is the element count
-// divided by this.
-int64_t statedProduct(ArrayRef<TargetExtent> named) {
-  auto stated =
-      llvm::make_filter_range(named, isKind(TargetExtent::Kind::Constant));
+// The divisor for an inferred extent, which is the element count over this.
+int64_t constantExtentProduct(ArrayRef<TargetExtent> classified) {
+  auto constants =
+      llvm::make_filter_range(classified, isKind(TargetExtent::Kind::Constant));
   return llvm::product_of(
-      llvm::map_range(stated, std::mem_fn(&TargetExtent::value)));
+      llvm::map_range(constants, std::mem_fn(&TargetExtent::value)));
 }
 
-// Returns the inferred extent when nothing it divides is dynamic. A copied
-// axis appears in the element count and in the divisor, so the two cancel and
-// only the input's other extents are left over the divisor. That is how a
-// dynamic axis beside an inferred one still folds.
+// Folds the inferred extent when every axis it divides is static. A copied
+// axis cancels between the element count and the divisor, which is how a
+// dynamic input axis beside an inferred extent still folds.
 std::optional<int64_t> foldInferredExtent(RankedTensorType inputType,
-                                          ArrayRef<TargetExtent> named) {
-  llvm::SmallDenseSet<int64_t> copied = copiedInputAxes(named);
+                                          ArrayRef<TargetExtent> classified) {
+  llvm::SmallDenseSet<int64_t> copied = copiedInputAxes(classified);
   auto axes = llvm::seq<int64_t>(0, inputType.getRank());
   auto divided = llvm::make_filter_range(
       axes, [&](int64_t axis) { return !copied.contains(axis); });
@@ -187,7 +202,7 @@ std::optional<int64_t> foldInferredExtent(RankedTensorType inputType,
       })) {
     return std::nullopt;
   }
-  int64_t divisor = statedProduct(named);
+  int64_t divisor = constantExtentProduct(classified);
   if (divisor == 0) {
     return std::nullopt;
   }
@@ -196,20 +211,20 @@ std::optional<int64_t> foldInferredExtent(RankedTensorType inputType,
   return llvm::product_of(extents) / divisor;
 }
 
-// Puts the named extents into the result type. Everything downstream takes
-// that type, so an extent recovered here is one no consumer has to rediscover.
+// Writes the classified extents back into the result type, so that no consumer
+// has to rediscover one the target shape operand already gave away.
 RankedTensorType refineResultType(RankedTensorType resultType,
                                   RankedTensorType inputType,
-                                  ArrayRef<TargetExtent> named) {
-  SmallVector<int64_t> refined =
-      llvm::map_to_vector(named, [&](const TargetExtent &extent) -> int64_t {
+                                  ArrayRef<TargetExtent> classified) {
+  SmallVector<int64_t> refined = llvm::map_to_vector(
+      classified, [&](const TargetExtent &extent) -> int64_t {
         switch (extent.kind) {
         case TargetExtent::Kind::Constant:
           return extent.value;
         case TargetExtent::Kind::CopiesInput:
           return inputType.getDimSize(extent.value);
         case TargetExtent::Kind::Inferred:
-          return foldInferredExtent(inputType, named)
+          return foldInferredExtent(inputType, classified)
               .value_or(ShapedType::kDynamic);
         }
         llvm_unreachable("unhandled target extent kind");
@@ -259,34 +274,35 @@ Value buildElementCount(OpBuilder &builder, Location loc,
 }
 
 //===----------------------------------------------------------------------===//
-// Destination whose extents are named at compile time
+// Destination whose shape is derived from the input's
 //===----------------------------------------------------------------------===//
 
-// Extents of a `!shape.shape` are `!shape.size`, which carries an error state
-// that arith has no room for, so reading one means converting it to index.
-Value getShapeExtent(OpBuilder &builder, Location loc, Value shape,
-                     int64_t axis) {
+// `!shape.size` carries an error state that arith has no room for, so an
+// extent read off a `!shape.shape` has to be converted to index.
+Value buildShapeExtent(OpBuilder &builder, Location loc, Value shape,
+                       int64_t axis) {
   Value size = shape::GetExtentOp::create(builder, loc, shape, axis);
   return shape::SizeToIndexOp::create(builder, loc, builder.getIndexType(),
                                       size);
 }
 
-// Returns one extent per result axis, reading the input's dynamic extents out
-// of `inputShape`.
+// One extent per result axis. Every one is a constant or comes out of
+// `inputShape`, so the extents can still be dynamic even though the
+// classification is complete.
 SmallVector<Value> buildResultExtents(OpBuilder &builder, Location loc,
                                       RankedTensorType inputType,
-                                      ArrayRef<TargetExtent> named,
+                                      ArrayRef<TargetExtent> classified,
                                       Value inputShape) {
-  SmallVector<Value> extents(named.size());
+  SmallVector<Value> extents(classified.size());
   std::optional<int64_t> inferredAxis;
-  for (auto [axis, extent] : llvm::enumerate(named)) {
+  for (auto [axis, extent] : llvm::enumerate(classified)) {
     switch (extent.kind) {
     case TargetExtent::Kind::Constant:
       extents[axis] =
           arith::ConstantIndexOp::create(builder, loc, extent.value);
       break;
     case TargetExtent::Kind::CopiesInput:
-      extents[axis] = getShapeExtent(builder, loc, inputShape, extent.value);
+      extents[axis] = buildShapeExtent(builder, loc, inputShape, extent.value);
       break;
     case TargetExtent::Kind::Inferred:
       inferredAxis = axis;
@@ -298,10 +314,10 @@ SmallVector<Value> buildResultExtents(OpBuilder &builder, Location loc,
   }
 
   Value elementCount = buildElementCount(
-      builder, loc, inputType, copiedInputAxes(named), [&](int64_t axis) {
-        return getShapeExtent(builder, loc, inputShape, axis);
+      builder, loc, inputType, copiedInputAxes(classified), [&](int64_t axis) {
+        return buildShapeExtent(builder, loc, inputShape, axis);
       });
-  if (int64_t divisor = statedProduct(named); divisor != 1) {
+  if (int64_t divisor = constantExtentProduct(classified); divisor != 1) {
     Value divisorValue = arith::ConstantIndexOp::create(builder, loc, divisor);
     elementCount =
         arith::DivUIOp::create(builder, loc, elementCount, divisorValue);
@@ -310,40 +326,39 @@ SmallVector<Value> buildResultExtents(OpBuilder &builder, Location loc,
   return extents;
 }
 
-void populateKnownShapeRegion(OpBuilder &builder, PlaceholderOp placeholder,
-                              RankedTensorType inputType,
-                              ArrayRef<TargetExtent> named) {
+void populateDerivedShapeRegion(OpBuilder &builder, PlaceholderOp placeholder,
+                                RankedTensorType inputType,
+                                ArrayRef<TargetExtent> classified) {
   OpBuilder::InsertionGuard guard(builder);
   Block &block = createPlaceholderShapeBlock(builder, placeholder);
   builder.setInsertionPointToStart(&block);
 
   Location loc = placeholder.getLoc();
-  SmallVector<Value> extents = buildResultExtents(
-      builder, loc, inputType, named, PlaceholderShapeRegionArgs{block}.in(0));
+  SmallVector<Value> extents =
+      buildResultExtents(builder, loc, inputType, classified,
+                         PlaceholderShapeRegionArgs{block}.in(0));
   yieldShapeFromExtents(builder, loc, extents);
 }
 
-// Every extent is named at compile time, so the shape region needs nothing but
-// the input's shape and the placeholder stays normal.
-PlaceholderOp createKnownShapePlaceholder(OpBuilder &builder, Location loc,
-                                          Value ctx, Value input,
-                                          RankedTensorType inputType,
-                                          RankedTensorType destType,
-                                          ArrayRef<TargetExtent> named) {
+// The region needs only the input's shape, so a normal placeholder does.
+PlaceholderOp createDerivedShapePlaceholder(OpBuilder &builder, Location loc,
+                                            Value ctx, Value input,
+                                            RankedTensorType inputType,
+                                            RankedTensorType destType,
+                                            ArrayRef<TargetExtent> classified) {
   auto init = PlaceholderOp::create(builder, loc, TypeRange{destType}, ctx,
                                     ValueRange{input}, PlaceholderType::Normal);
-  populateKnownShapeRegion(builder, init, inputType, named);
+  populateDerivedShapeRegion(builder, init, inputType, classified);
   return init;
 }
 
 //===----------------------------------------------------------------------===//
-// Destination whose extents are read on the host
+// Destination whose shape is read on the host
 //===----------------------------------------------------------------------===//
 
-// Reads one extent per result axis out of the target shape operand. An entry
-// is not always the extent: with allowzero clear a 0 copies the input's extent
-// at that axis, and a -1 is the element count divided by the rest. Both are
-// resolved here, against values only the runtime has.
+// One extent per result axis, read out of the target shape operand. Resolving
+// the 0 and -1 entries falls to the region here, since only the runtime holds
+// the values they depend on.
 void populateHostShapeRegion(OpBuilder &builder, PlaceholderOp placeholder,
                              RankedTensorType inputType, int64_t resultRank) {
   OpBuilder::InsertionGuard guard(builder);
@@ -357,8 +372,8 @@ void populateHostShapeRegion(OpBuilder &builder, PlaceholderOp placeholder,
   Value input = args.in(0);
   Value target = args.in(1);
 
-  // The region holds the input tensor here, not a `!shape.shape`, so a dynamic
-  // extent comes from tensor.dim. A static one is already known.
+  // The region holds the input tensor, not a `!shape.shape`, so a dynamic
+  // extent comes from tensor.dim.
   auto inputExtent = [&](int64_t axis) -> Value {
     if (inputType.isDynamicDim(axis)) {
       return tensor::DimOp::create(builder, loc, input, axis);
@@ -372,6 +387,8 @@ void populateHostShapeRegion(OpBuilder &builder, PlaceholderOp placeholder,
   Value count =
       buildElementCount(builder, loc, inputType, /*skipped=*/{}, inputExtent);
 
+  // An inferred axis contributes 1 to the divisor rather than its entry, so
+  // the element count divides by the extents that are actually stated.
   SmallVector<Value> stated(resultRank);
   SmallVector<Value> isInferred(resultRank);
   SmallVector<Value> divisorFactors;
@@ -404,9 +421,8 @@ void populateHostShapeRegion(OpBuilder &builder, PlaceholderOp placeholder,
   yieldShapeFromExtents(builder, loc, extents);
 }
 
-// More than one extent is left unnamed, so the shape region has to read the
-// shape operand. That is a host read, which needs the operand in host memory
-// and a barrier placeholder to order it.
+// The region has to read the shape operand, which is a host read: the operand
+// must be in host memory and the placeholder a barrier to order it.
 FailureOr<PlaceholderOp>
 createHostShapePlaceholder(onnx::ReshapeOp op, Value target,
                            ConversionPatternRewriter &rewriter, Value ctx,
@@ -440,80 +456,73 @@ createHostShapePlaceholder(onnx::ReshapeOp op, Value target,
 // The compute body
 //===----------------------------------------------------------------------===//
 
-// Returns the 1-D form `type` flattens to, dynamic when the element count is
-// not a compile-time constant.
+// The 1-D form `type` flattens to, dynamic when the element count is not a
+// compile-time constant.
 RankedTensorType flatTensorType(RankedTensorType type, Attribute space) {
   int64_t count =
       type.hasStaticShape() ? type.getNumElements() : ShapedType::kDynamic;
   return RankedTensorType::get({count}, type.getElementType(), space);
 }
 
-// The grouping the 1-D form uses on both sides: every axis in one group.
-SmallVector<ReassociationIndices> wholeRank(int64_t rank) {
+// Every axis in one group: the grouping that reaches the 1-D form.
+SmallVector<ReassociationIndices> flatReassociation(int64_t rank) {
   return {llvm::to_vector<2>(llvm::seq<int64_t>(0, rank))};
 }
 
-// Regroups a rank-0 side, the one case with no 1-D form to go through. A
-// collapse takes its extents from the grouping, but an expansion splits one
+// A rank-0 side has no axis to collapse, so one op covers the whole reshape.
+// A collapse takes its extents from the grouping; an expansion splits one
 // source extent over a group, so it carries the target extents instead.
-FailureOr<Value> createRegroup(OpBuilder &builder, Location loc, Value source,
-                               RankedTensorType sourceType,
-                               RankedTensorType targetType,
-                               ArrayRef<ReassociationIndices> reassociation) {
+FailureOr<Value> createRank0Regroup(OpBuilder &builder, Location loc,
+                                    Value source, RankedTensorType sourceType,
+                                    RankedTensorType targetType) {
+  std::optional<SmallVector<ReassociationIndices>> reassociation =
+      getReassociationIndicesForReshape(sourceType, targetType);
+  if (!reassociation) {
+    return failure();
+  }
   if (sourceType.getRank() > targetType.getRank()) {
     return tensor::CollapseShapeOp::create(builder, loc, targetType, source,
-                                           reassociation)
+                                           *reassociation)
         .getResult();
   }
   FailureOr<SmallVector<OpFoldResult>> outputShape =
       tensor::ExpandShapeOp::inferOutputShape(
-          builder, loc, targetType, reassociation,
+          builder, loc, targetType, *reassociation,
           tensor::getMixedSizes(builder, loc, source));
   if (failed(outputShape)) {
     return failure();
   }
   return tensor::ExpandShapeOp::create(builder, loc, targetType, source,
-                                       reassociation, *outputShape)
+                                       *reassociation, *outputShape)
       .getResult();
 }
 
-// Every regroup goes the same way through the 1-D form: one group collapses
-// every input axis, one expands the result out of it. Some regroups would fit
-// a single collapse or expand instead, but `ComposeExpandOfCollapseOp` finds
-// those, so looking for them here would repeat its work. Both halves alias
-// either way.
+// Every regroup goes through the 1-D form: one group collapses every input
+// axis, one expands the result out of it. A single collapse or expand would
+// fit some regroups, but `ComposeExpandOfCollapseOp` already finds those.
 //
-// A rank-0 side has no axis to collapse, so it regroups directly.
-//
-// `dest` is the placeholder, typed as `resultType`, so an expansion reads the
-// extents it resolved back off it.
+// `dest` is the placeholder, so an expansion reads the extents it resolved.
 FailureOr<Value> createReshape(OpBuilder &builder, Location loc, Value input,
                                RankedTensorType inputType,
                                RankedTensorType resultType, Value dest) {
-  if (inputType == resultType) {
-    return input;
-  }
+  assert(inputType != resultType &&
+         "an identity reshape is dropped before it is given a body");
   if (inputType.getRank() == 0 || resultType.getRank() == 0) {
-    std::optional<SmallVector<ReassociationIndices>> reassociation =
-        getReassociationIndicesForReshape(inputType, resultType);
-    if (!reassociation) {
-      return failure();
-    }
-    return createRegroup(builder, loc, input, inputType, resultType,
-                         *reassociation);
+    return createRank0Regroup(builder, loc, input, inputType, resultType);
   }
 
+  // Both sides share a space: the result took the input's, and only rank 0
+  // names none.
   Attribute space = resultType.getEncoding();
   RankedTensorType flatType = flatTensorType(inputType, space);
   Value flat = input;
   if (inputType.getRank() > 1) {
-    flat = tensor::CollapseShapeOp::create(builder, loc, flatType, input,
-                                           wholeRank(inputType.getRank()));
+    flat = tensor::CollapseShapeOp::create(
+        builder, loc, flatType, input, flatReassociation(inputType.getRank()));
   }
 
-  // One side can pin the element count down while the other leaves it dynamic.
   // A collapsed extent has to agree with its group on being dynamic, so the
-  // collapse cannot carry the refinement itself and a cast follows it.
+  // collapse cannot pin down an element count only the result side knows.
   if (RankedTensorType resultFlatType = flatTensorType(resultType, space);
       flatType != resultFlatType) {
     flat = tensor::CastOp::create(builder, loc, resultFlatType, flat);
@@ -524,14 +533,14 @@ FailureOr<Value> createReshape(OpBuilder &builder, Location loc, Value input,
   }
 
   return tensor::ExpandShapeOp::create(
-             builder, loc, resultType, flat, wholeRank(resultType.getRank()),
+             builder, loc, resultType, flat,
+             flatReassociation(resultType.getRank()),
              tensor::getMixedSizes(builder, loc, dest))
       .getResult();
 }
 
-// The refined type is what the compute and the destination both carry, so an
-// expansion reads its extents off `dest` and the body needs no widening back
-// to the type ONNX declared.
+// The compute and the destination both carry the refined type, so the body
+// never widens back to the type ONNX declared.
 LogicalResult populateComputeBody(OpBuilder &builder, ComputeOp computeOp,
                                   RankedTensorType inputType,
                                   RankedTensorType refinedType) {
@@ -539,9 +548,11 @@ LogicalResult populateComputeBody(OpBuilder &builder, ComputeOp computeOp,
   Location loc = computeOp.getLoc();
   Block &body = createComputeBodyBlock(builder, computeOp);
   Value input = computeBodyInput(body, 0);
+  // The lone output argument, which is the placeholder the compute writes to.
+  Value dest = body.getArguments().back();
 
-  FailureOr<Value> reshaped = createReshape(
-      builder, loc, input, inputType, refinedType, body.getArguments().back());
+  FailureOr<Value> reshaped =
+      createReshape(builder, loc, input, inputType, refinedType, dest);
   if (failed(reshaped)) {
     return failure();
   }
@@ -553,11 +564,11 @@ LogicalResult populateComputeBody(OpBuilder &builder, ComputeOp computeOp,
 // The pattern
 //===----------------------------------------------------------------------===//
 
-// Rejects the forms the conversion does not handle and returns the result type
-// in the memory space the data will actually live in.
+// The result aliases the input, so it lives in the input's space whatever ONNX
+// declared. Rejects the forms that would need a copy or a layout change.
 FailureOr<RankedTensorType>
-resolveResultType(onnx::ReshapeOp op, RankedTensorType inputType,
-                  ConversionPatternRewriter &rewriter) {
+resultTypeInInputSpace(onnx::ReshapeOp op, RankedTensorType inputType,
+                       ConversionPatternRewriter &rewriter) {
   auto resultType = dyn_cast<RankedTensorType>(op.getReshaped().getType());
   if (!resultType) {
     return rewriter.notifyMatchFailure(op, "expected ranked tensor types");
@@ -566,10 +577,8 @@ resolveResultType(onnx::ReshapeOp op, RankedTensorType inputType,
     return rewriter.notifyMatchFailure(
         op, "expected matching input and result element types");
   }
-  // The result aliases the input, so it lives wherever the input does. Only a
-  // rank-0 input names no space, since the type converter leaves scalar host
-  // roots alone, and the tensor it expands to has to live somewhere: device.
-  // A result naming a different space would need a copy this does not emit.
+  // Only a rank-0 input names no space: the type converter leaves scalar host
+  // roots alone so that arith.constant stays legal. Default those to device.
   Attribute space = inputType.getEncoding();
   if (!space) {
     space = MemorySpaceAttr::get(rewriter.getContext(), MemorySpace::Device);
@@ -583,15 +592,16 @@ resolveResultType(onnx::ReshapeOp op, RankedTensorType inputType,
 }
 
 struct ReshapeToHipsr : public OpConversionPattern<onnx::ReshapeOp> {
-  // Takes the pass converter to match the other patterns.
+  // The converter goes unused: the result type depends on the target shape
+  // operand, which a type conversion never sees. Taken so that the pass adds
+  // every pattern the same way.
   ReshapeToHipsr(const TypeConverter &typeConverter, MLIRContext *ctx)
       : OpConversionPattern(ctx) {}
 
   LogicalResult
   matchAndRewrite(onnx::ReshapeOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // With allowzero set, a 0 in the target shape is a literal extent instead
-    // of a copy of the input's, which gives a different result shape.
+    // allowzero flips what a 0 entry means, giving a different result shape.
     if (op.getAllowzero() != 0) {
       return rewriter.notifyMatchFailure(op, "expected allowzero = 0");
     }
@@ -601,28 +611,26 @@ struct ReshapeToHipsr : public OpConversionPattern<onnx::ReshapeOp> {
       return rewriter.notifyMatchFailure(op, "expected ranked tensor types");
     }
     FailureOr<RankedTensorType> resultType =
-        resolveResultType(op, inputType, rewriter);
+        resultTypeInInputSpace(op, inputType, rewriter);
     if (failed(resultType)) {
       return failure();
     }
 
-    // Naming the extents both refines the type everything downstream takes and
-    // decides which of the two destinations the reshape gets.
-    FailureOr<SmallVector<TargetExtent>> named =
-        nameTargetExtents(*resultType, inputType, adaptor.getShape());
+    // The classification refines the result type and picks the destination.
+    std::optional<SmallVector<TargetExtent>> classified =
+        classifyTargetExtents(*resultType, inputType, adaptor.getShape());
     RankedTensorType refinedType =
-        succeeded(named) ? refineResultType(*resultType, inputType, *named)
-                         : *resultType;
+        classified ? refineResultType(*resultType, inputType, *classified)
+                   : *resultType;
 
-    // An identity reshape reinterprets nothing, so it needs no destination.
-    // Refining first also catches the ones only the target shape operand shows
-    // to be identities.
+    // An identity reshape needs no destination. Refining first also catches
+    // the ones only the target shape operand reveals to be identities.
     if (inputType == refinedType) {
       rewriter.replaceOp(op, input);
       return success();
     }
-    // A reshape preserves the element count, so two static shapes that
-    // disagree on it cannot describe the same data.
+    // Two static shapes that disagree on the element count cannot describe the
+    // same data.
     if (inputType.hasStaticShape() && refinedType.hasStaticShape() &&
         inputType.getNumElements() != refinedType.getNumElements()) {
       return rewriter.notifyMatchFailure(
@@ -635,9 +643,9 @@ struct ReshapeToHipsr : public OpConversionPattern<onnx::ReshapeOp> {
 
     Location loc = op.getLoc();
     FailureOr<PlaceholderOp> init =
-        succeeded(named)
-            ? createKnownShapePlaceholder(rewriter, loc, *ctx, input, inputType,
-                                          refinedType, *named)
+        classified
+            ? createDerivedShapePlaceholder(rewriter, loc, *ctx, input,
+                                            inputType, refinedType, *classified)
             : createHostShapePlaceholder(op, adaptor.getShape(), rewriter, *ctx,
                                          input, inputType, refinedType);
     if (failed(init)) {

--- a/lib/Conversion/OnnxToHipsr/ReshapeConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/ReshapeConversion.cpp
@@ -1,0 +1,668 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- ReshapeConversion.cpp - Convert onnx.Reshape to hipsr.compute -----===//
+//
+// onnx.Reshape regroups extents in row-major order without moving data. The
+// conversion emits a tensor.collapse_shape and a tensor.expand_shape through
+// the 1-D form, inside a hipsr.compute. Both ops bufferize to memrefs that
+// alias their source, so nothing runs on the device, and canonicalization
+// composes the pair into a single op when one can express the regroup.
+//
+// The destination has to be known one of two ways; nothing else is supported.
+//
+// Compile time. The result type gives its static extents and a target shape
+// operand that folds to a constant gives the rest. One extent may still be
+// unknown: a reshape preserves the element count, so it is that count divided
+// by the others. The shape region only needs the input's shape here, so a
+// normal placeholder is enough.
+//
+// Runtime. Otherwise the extents are only in the target shape operand, which
+// must be a host tensor the shape region can read. That needs a barrier
+// placeholder, whose shape region takes the operands rather than their shapes.
+// A shape operand anywhere else is rejected; nothing here copies it to the
+// host.
+//
+// Before:
+//   %r = "onnx.Reshape"(%x, %shape)
+//       : (tensor<?x?x4xf16, #hipsr.mem<device>>,
+//          tensor<2xi64, #hipsr.mem<host>>)
+//       -> tensor<?x?xf16, #hipsr.mem<device>>
+//
+// After, with the types inside the regions left out:
+//   %init = hipsr.placeholder(%ctx) ins(%x, %shape)
+//       {placeholder_type = #hipsr.placeholder_type<barrier>}
+//       : tensor<?x?xf16, #hipsr.mem<device>> shape_region {
+//   ^bb0(%shape_ctx, %x_arg, %shape_arg):
+//     %n = arith.muli ...            // the input's element count
+//     %e0 = arith.index_cast tensor.extract %shape_arg[0]
+//     %e1 = arith.index_cast tensor.extract %shape_arg[1]
+//     ...                            // resolve a 0 or a -1 entry
+//     %s = shape.from_extents %e0, %e1
+//     hipsr.shape_yield %s
+//   }
+//   %r = hipsr.compute(%ctx) ins(%x) outs(%init) {
+//   ^bb0(%body_ctx, %in, %dest):
+//     %flat = tensor.collapse_shape %in [[0, 1, 2]]
+//     %d0 = tensor.dim %dest, 0      // the extents the placeholder resolved
+//     %d1 = tensor.dim %dest, 1
+//     %out = tensor.expand_shape %flat [[0, 1]] output_shape [%d0, %d1]
+//     hipsr.compute_yield %out
+//   } : tensor<?x?xf16, #hipsr.mem<device>>
+//
+//===----------------------------------------------------------------------===//
+
+#include "OnnxToHipsrUtils.h"
+
+#include "hip/Conversion/OnnxToHipsr/OnnxToHipsr.h"
+#include "hip/Dialect/Hipsr/IR/HipsrOps.h"
+#include "hip/Dialect/Hipsr/IR/HipsrShapeRegionPopulationUtils.h"
+#include "hip/Dialect/Onnx/IR/OnnxOps.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Shape/IR/Shape.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Sequence.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <functional>
+#include <optional>
+
+namespace mlir {
+namespace hipsr {
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Naming the result extents at compile time
+//===----------------------------------------------------------------------===//
+
+// Where a result extent comes from when the target shape needs no runtime
+// read. ONNX allows one -1 entry, which `Inferred` marks; the rest are either
+// known outright or copied from the input.
+struct TargetExtent {
+  enum class Kind { Constant, CopiesInput, Inferred };
+  Kind kind = Kind::Inferred;
+  // The extent for Constant, the input axis copied for CopiesInput.
+  int64_t value = 0;
+
+  static TargetExtent constant(int64_t extent) {
+    return {Kind::Constant, extent};
+  }
+  static TargetExtent copiesInput(int64_t axis) {
+    return {Kind::CopiesInput, axis};
+  }
+  static TargetExtent inferred() { return {}; }
+};
+
+auto isKind(TargetExtent::Kind kind) {
+  return [kind](const TargetExtent &extent) { return extent.kind == kind; };
+}
+
+// Names every result extent without reading the target shape operand at
+// runtime. A static result dim gives its own extent. For a dynamic one, a
+// target shape operand that folds to a constant decides: with allowzero clear,
+// a positive entry is the extent, a 0 copies the input's extent at that axis,
+// and a -1 says nothing. Fails when more than one extent is left unnamed,
+// since the preserved element count recovers only one.
+FailureOr<SmallVector<TargetExtent>>
+nameTargetExtents(RankedTensorType resultType, RankedTensorType inputType,
+                  Value shape) {
+  SmallVector<int64_t> stated;
+  DenseIntElementsAttr entries;
+  if (matchPattern(shape, m_Constant(&entries)) &&
+      entries.getNumElements() == resultType.getRank()) {
+    stated =
+        llvm::map_to_vector(entries.getValues<APInt>(), [](const APInt &entry) {
+          return entry.getSExtValue();
+        });
+  }
+
+  SmallVector<TargetExtent> named;
+  named.reserve(resultType.getRank());
+  for (int64_t axis : llvm::seq<int64_t>(0, resultType.getRank())) {
+    if (!resultType.isDynamicDim(axis)) {
+      named.push_back(TargetExtent::constant(resultType.getDimSize(axis)));
+      continue;
+    }
+    // An operand that stayed a runtime value says nothing about any axis,
+    // which is what a -1 entry already means to ONNX.
+    int64_t entry = stated.empty() ? -1 : stated[axis];
+    if (entry > 0) {
+      named.push_back(TargetExtent::constant(entry));
+    } else if (entry == 0 && axis < inputType.getRank()) {
+      named.push_back(inputType.isDynamicDim(axis)
+                          ? TargetExtent::copiesInput(axis)
+                          : TargetExtent::constant(inputType.getDimSize(axis)));
+    } else {
+      named.push_back(TargetExtent::inferred());
+    }
+  }
+
+  if (llvm::count_if(named, isKind(TargetExtent::Kind::Inferred)) > 1) {
+    return failure();
+  }
+  return named;
+}
+
+// The axes whose extent the result copies from the input.
+llvm::SmallDenseSet<int64_t> copiedInputAxes(ArrayRef<TargetExtent> named) {
+  auto copies =
+      llvm::make_filter_range(named, isKind(TargetExtent::Kind::CopiesInput));
+  llvm::SmallDenseSet<int64_t> copied;
+  copied.insert_range(
+      llvm::map_range(copies, std::mem_fn(&TargetExtent::value)));
+  return copied;
+}
+
+// The product of the known extents. The inferred extent is the element count
+// divided by this.
+int64_t statedProduct(ArrayRef<TargetExtent> named) {
+  auto stated =
+      llvm::make_filter_range(named, isKind(TargetExtent::Kind::Constant));
+  return llvm::product_of(
+      llvm::map_range(stated, std::mem_fn(&TargetExtent::value)));
+}
+
+// Returns the inferred extent when nothing it divides is dynamic. A copied
+// axis appears in the element count and in the divisor, so the two cancel and
+// only the input's other extents are left over the divisor. That is how a
+// dynamic axis beside an inferred one still folds.
+std::optional<int64_t> foldInferredExtent(RankedTensorType inputType,
+                                          ArrayRef<TargetExtent> named) {
+  llvm::SmallDenseSet<int64_t> copied = copiedInputAxes(named);
+  auto axes = llvm::seq<int64_t>(0, inputType.getRank());
+  auto divided = llvm::make_filter_range(
+      axes, [&](int64_t axis) { return !copied.contains(axis); });
+  if (llvm::any_of(divided, [&](int64_t axis) {
+        return inputType.isDynamicDim(axis);
+      })) {
+    return std::nullopt;
+  }
+  int64_t divisor = statedProduct(named);
+  if (divisor == 0) {
+    return std::nullopt;
+  }
+  auto extents = llvm::map_range(
+      divided, [&](int64_t axis) { return inputType.getDimSize(axis); });
+  return llvm::product_of(extents) / divisor;
+}
+
+// Puts the named extents into the result type. Everything downstream takes
+// that type, so an extent recovered here is one no consumer has to rediscover.
+RankedTensorType refineResultType(RankedTensorType resultType,
+                                  RankedTensorType inputType,
+                                  ArrayRef<TargetExtent> named) {
+  SmallVector<int64_t> refined =
+      llvm::map_to_vector(named, [&](const TargetExtent &extent) -> int64_t {
+        switch (extent.kind) {
+        case TargetExtent::Kind::Constant:
+          return extent.value;
+        case TargetExtent::Kind::CopiesInput:
+          return inputType.getDimSize(extent.value);
+        case TargetExtent::Kind::Inferred:
+          return foldInferredExtent(inputType, named)
+              .value_or(ShapedType::kDynamic);
+        }
+        llvm_unreachable("unhandled target extent kind");
+      });
+  return resultType.clone(refined);
+}
+
+//===----------------------------------------------------------------------===//
+// Element-count arithmetic, emitted by both shape regions
+//===----------------------------------------------------------------------===//
+
+// Multiplies `factors`. An empty list gives 1.
+Value buildProduct(OpBuilder &builder, Location loc, ArrayRef<Value> factors) {
+  if (factors.empty()) {
+    return arith::ConstantIndexOp::create(builder, loc, 1);
+  }
+  Value product = factors.front();
+  for (Value factor : factors.drop_front()) {
+    product = arith::MulIOp::create(builder, loc, product, factor);
+  }
+  return product;
+}
+
+// The product of the input's extents outside `skipped`. The static ones fold
+// into a single constant, leaving one multiply per dynamic extent.
+Value buildElementCount(OpBuilder &builder, Location loc,
+                        RankedTensorType inputType,
+                        const llvm::SmallDenseSet<int64_t> &skipped,
+                        function_ref<Value(int64_t)> extentAt) {
+  int64_t staticCount = 1;
+  SmallVector<Value> factors;
+  for (int64_t axis : llvm::seq<int64_t>(0, inputType.getRank())) {
+    if (skipped.contains(axis)) {
+      continue;
+    }
+    if (!inputType.isDynamicDim(axis)) {
+      staticCount *= inputType.getDimSize(axis);
+      continue;
+    }
+    factors.push_back(extentAt(axis));
+  }
+  if (staticCount != 1) {
+    factors.push_back(
+        arith::ConstantIndexOp::create(builder, loc, staticCount));
+  }
+  return buildProduct(builder, loc, factors);
+}
+
+//===----------------------------------------------------------------------===//
+// Destination whose extents are named at compile time
+//===----------------------------------------------------------------------===//
+
+// Extents of a `!shape.shape` are `!shape.size`, which carries an error state
+// that arith has no room for, so reading one means converting it to index.
+Value getShapeExtent(OpBuilder &builder, Location loc, Value shape,
+                     int64_t axis) {
+  Value size = shape::GetExtentOp::create(builder, loc, shape, axis);
+  return shape::SizeToIndexOp::create(builder, loc, builder.getIndexType(),
+                                      size);
+}
+
+// Returns one extent per result axis, reading the input's dynamic extents out
+// of `inputShape`.
+SmallVector<Value> buildResultExtents(OpBuilder &builder, Location loc,
+                                      RankedTensorType inputType,
+                                      ArrayRef<TargetExtent> named,
+                                      Value inputShape) {
+  SmallVector<Value> extents(named.size());
+  std::optional<int64_t> inferredAxis;
+  for (auto [axis, extent] : llvm::enumerate(named)) {
+    switch (extent.kind) {
+    case TargetExtent::Kind::Constant:
+      extents[axis] =
+          arith::ConstantIndexOp::create(builder, loc, extent.value);
+      break;
+    case TargetExtent::Kind::CopiesInput:
+      extents[axis] = getShapeExtent(builder, loc, inputShape, extent.value);
+      break;
+    case TargetExtent::Kind::Inferred:
+      inferredAxis = axis;
+      break;
+    }
+  }
+  if (!inferredAxis) {
+    return extents;
+  }
+
+  Value elementCount = buildElementCount(
+      builder, loc, inputType, copiedInputAxes(named), [&](int64_t axis) {
+        return getShapeExtent(builder, loc, inputShape, axis);
+      });
+  if (int64_t divisor = statedProduct(named); divisor != 1) {
+    Value divisorValue = arith::ConstantIndexOp::create(builder, loc, divisor);
+    elementCount =
+        arith::DivUIOp::create(builder, loc, elementCount, divisorValue);
+  }
+  extents[*inferredAxis] = elementCount;
+  return extents;
+}
+
+void populateKnownShapeRegion(OpBuilder &builder, PlaceholderOp placeholder,
+                              RankedTensorType inputType,
+                              ArrayRef<TargetExtent> named) {
+  OpBuilder::InsertionGuard guard(builder);
+  Block &block = createPlaceholderShapeBlock(builder, placeholder);
+  builder.setInsertionPointToStart(&block);
+
+  Location loc = placeholder.getLoc();
+  SmallVector<Value> extents = buildResultExtents(
+      builder, loc, inputType, named, PlaceholderShapeRegionArgs{block}.in(0));
+  yieldShapeFromExtents(builder, loc, extents);
+}
+
+// Every extent is named at compile time, so the shape region needs nothing but
+// the input's shape and the placeholder stays normal.
+PlaceholderOp createKnownShapePlaceholder(OpBuilder &builder, Location loc,
+                                          Value ctx, Value input,
+                                          RankedTensorType inputType,
+                                          RankedTensorType destType,
+                                          ArrayRef<TargetExtent> named) {
+  auto init = PlaceholderOp::create(builder, loc, TypeRange{destType}, ctx,
+                                    ValueRange{input}, PlaceholderType::Normal);
+  populateKnownShapeRegion(builder, init, inputType, named);
+  return init;
+}
+
+//===----------------------------------------------------------------------===//
+// Destination whose extents are read on the host
+//===----------------------------------------------------------------------===//
+
+// Reads one extent per result axis out of the target shape operand. An entry
+// is not always the extent: with allowzero clear a 0 copies the input's extent
+// at that axis, and a -1 is the element count divided by the rest. Both are
+// resolved here, against values only the runtime has.
+void populateHostShapeRegion(OpBuilder &builder, PlaceholderOp placeholder,
+                             RankedTensorType inputType, int64_t resultRank) {
+  OpBuilder::InsertionGuard guard(builder);
+  Block &block = createPlaceholderShapeBlock(builder, placeholder);
+  builder.setInsertionPointToStart(&block);
+
+  Location loc = placeholder.getLoc();
+  // A barrier region takes the operands themselves rather than their shapes,
+  // which is what makes the target extents readable at all.
+  PlaceholderShapeRegionArgs args{block};
+  Value input = args.in(0);
+  Value target = args.in(1);
+
+  // The region holds the input tensor here, not a `!shape.shape`, so a dynamic
+  // extent comes from tensor.dim. A static one is already known.
+  auto inputExtent = [&](int64_t axis) -> Value {
+    if (inputType.isDynamicDim(axis)) {
+      return tensor::DimOp::create(builder, loc, input, axis);
+    }
+    return arith::ConstantIndexOp::create(builder, loc,
+                                          inputType.getDimSize(axis));
+  };
+
+  Value zero = arith::ConstantIndexOp::create(builder, loc, 0);
+  Value one = arith::ConstantIndexOp::create(builder, loc, 1);
+  Value count =
+      buildElementCount(builder, loc, inputType, /*skipped=*/{}, inputExtent);
+
+  SmallVector<Value> stated(resultRank);
+  SmallVector<Value> isInferred(resultRank);
+  SmallVector<Value> divisorFactors;
+  for (int64_t axis : llvm::seq<int64_t>(0, resultRank)) {
+    Value position = arith::ConstantIndexOp::create(builder, loc, axis);
+    Value entry =
+        tensor::ExtractOp::create(builder, loc, target, ValueRange{position});
+    Value extent =
+        arith::IndexCastOp::create(builder, loc, builder.getIndexType(), entry);
+    if (axis < inputType.getRank()) {
+      Value copies = arith::CmpIOp::create(
+          builder, loc, arith::CmpIPredicate::eq, extent, zero);
+      extent = arith::SelectOp::create(builder, loc, copies, inputExtent(axis),
+                                       extent);
+    }
+    stated[axis] = extent;
+    isInferred[axis] = arith::CmpIOp::create(
+        builder, loc, arith::CmpIPredicate::slt, extent, zero);
+    divisorFactors.push_back(
+        arith::SelectOp::create(builder, loc, isInferred[axis], one, extent));
+  }
+
+  Value inferred = arith::DivUIOp::create(
+      builder, loc, count, buildProduct(builder, loc, divisorFactors));
+  SmallVector<Value> extents = llvm::map_to_vector(
+      llvm::seq<int64_t>(0, resultRank), [&](int64_t axis) -> Value {
+        return arith::SelectOp::create(builder, loc, isInferred[axis], inferred,
+                                       stated[axis]);
+      });
+  yieldShapeFromExtents(builder, loc, extents);
+}
+
+// More than one extent is left unnamed, so the shape region has to read the
+// shape operand. That is a host read, which needs the operand in host memory
+// and a barrier placeholder to order it.
+FailureOr<PlaceholderOp>
+createHostShapePlaceholder(onnx::ReshapeOp op, Value target,
+                           ConversionPatternRewriter &rewriter, Value ctx,
+                           Value input, RankedTensorType inputType,
+                           RankedTensorType destType) {
+  auto targetType = dyn_cast<RankedTensorType>(target.getType());
+  if (!targetType || targetType.getRank() != 1 ||
+      !targetType.getElementType().isInteger(64)) {
+    return rewriter.notifyMatchFailure(
+        op, "expected a rank-1 i64 target shape operand");
+  }
+  if (targetType.getDimSize(0) != destType.getRank()) {
+    return rewriter.notifyMatchFailure(
+        op, "expected one target shape entry per result axis");
+  }
+  auto space = dyn_cast_if_present<MemorySpaceAttr>(targetType.getEncoding());
+  if (!space || space.getValue() != MemorySpace::Host) {
+    return rewriter.notifyMatchFailure(
+        op, "expected the target shape operand in host memory");
+  }
+
+  Location loc = op.getLoc();
+  auto init = PlaceholderOp::create(rewriter, loc, TypeRange{destType}, ctx,
+                                    ValueRange{input, target},
+                                    PlaceholderType::Barrier);
+  populateHostShapeRegion(rewriter, init, inputType, destType.getRank());
+  return init;
+}
+
+//===----------------------------------------------------------------------===//
+// The compute body
+//===----------------------------------------------------------------------===//
+
+// Returns the 1-D form `type` flattens to, dynamic when the element count is
+// not a compile-time constant.
+RankedTensorType flatTensorType(RankedTensorType type, Attribute space) {
+  int64_t count =
+      type.hasStaticShape() ? type.getNumElements() : ShapedType::kDynamic;
+  return RankedTensorType::get({count}, type.getElementType(), space);
+}
+
+// The grouping the 1-D form uses on both sides: every axis in one group.
+SmallVector<ReassociationIndices> wholeRank(int64_t rank) {
+  return {llvm::to_vector<2>(llvm::seq<int64_t>(0, rank))};
+}
+
+// Regroups a rank-0 side, the one case with no 1-D form to go through. A
+// collapse takes its extents from the grouping, but an expansion splits one
+// source extent over a group, so it carries the target extents instead.
+FailureOr<Value> createRegroup(OpBuilder &builder, Location loc, Value source,
+                               RankedTensorType sourceType,
+                               RankedTensorType targetType,
+                               ArrayRef<ReassociationIndices> reassociation) {
+  if (sourceType.getRank() > targetType.getRank()) {
+    return tensor::CollapseShapeOp::create(builder, loc, targetType, source,
+                                           reassociation)
+        .getResult();
+  }
+  FailureOr<SmallVector<OpFoldResult>> outputShape =
+      tensor::ExpandShapeOp::inferOutputShape(
+          builder, loc, targetType, reassociation,
+          tensor::getMixedSizes(builder, loc, source));
+  if (failed(outputShape)) {
+    return failure();
+  }
+  return tensor::ExpandShapeOp::create(builder, loc, targetType, source,
+                                       reassociation, *outputShape)
+      .getResult();
+}
+
+// Every regroup goes the same way through the 1-D form: one group collapses
+// every input axis, one expands the result out of it. Some regroups would fit
+// a single collapse or expand instead, but `ComposeExpandOfCollapseOp` finds
+// those, so looking for them here would repeat its work. Both halves alias
+// either way.
+//
+// A rank-0 side has no axis to collapse, so it regroups directly.
+//
+// `dest` is the placeholder, typed as `resultType`, so an expansion reads the
+// extents it resolved back off it.
+FailureOr<Value> createReshape(OpBuilder &builder, Location loc, Value input,
+                               RankedTensorType inputType,
+                               RankedTensorType resultType, Value dest) {
+  if (inputType == resultType) {
+    return input;
+  }
+  if (inputType.getRank() == 0 || resultType.getRank() == 0) {
+    std::optional<SmallVector<ReassociationIndices>> reassociation =
+        getReassociationIndicesForReshape(inputType, resultType);
+    if (!reassociation) {
+      return failure();
+    }
+    return createRegroup(builder, loc, input, inputType, resultType,
+                         *reassociation);
+  }
+
+  Attribute space = resultType.getEncoding();
+  RankedTensorType flatType = flatTensorType(inputType, space);
+  Value flat = input;
+  if (inputType.getRank() > 1) {
+    flat = tensor::CollapseShapeOp::create(builder, loc, flatType, input,
+                                           wholeRank(inputType.getRank()));
+  }
+
+  // One side can pin the element count down while the other leaves it dynamic.
+  // A collapsed extent has to agree with its group on being dynamic, so the
+  // collapse cannot carry the refinement itself and a cast follows it.
+  if (RankedTensorType resultFlatType = flatTensorType(resultType, space);
+      flatType != resultFlatType) {
+    flat = tensor::CastOp::create(builder, loc, resultFlatType, flat);
+    flatType = resultFlatType;
+  }
+  if (flatType == resultType) {
+    return flat;
+  }
+
+  return tensor::ExpandShapeOp::create(
+             builder, loc, resultType, flat, wholeRank(resultType.getRank()),
+             tensor::getMixedSizes(builder, loc, dest))
+      .getResult();
+}
+
+// The refined type is what the compute and the destination both carry, so an
+// expansion reads its extents off `dest` and the body needs no widening back
+// to the type ONNX declared.
+LogicalResult populateComputeBody(OpBuilder &builder, ComputeOp computeOp,
+                                  RankedTensorType inputType,
+                                  RankedTensorType refinedType) {
+  OpBuilder::InsertionGuard guard(builder);
+  Location loc = computeOp.getLoc();
+  Block &body = createComputeBodyBlock(builder, computeOp);
+  Value input = computeBodyInput(body, 0);
+
+  FailureOr<Value> reshaped = createReshape(
+      builder, loc, input, inputType, refinedType, body.getArguments().back());
+  if (failed(reshaped)) {
+    return failure();
+  }
+  ComputeYieldOp::create(builder, loc, ValueRange{*reshaped});
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// The pattern
+//===----------------------------------------------------------------------===//
+
+// Rejects the forms the conversion does not handle and returns the result type
+// in the memory space the data will actually live in.
+FailureOr<RankedTensorType>
+resolveResultType(onnx::ReshapeOp op, RankedTensorType inputType,
+                  ConversionPatternRewriter &rewriter) {
+  auto resultType = dyn_cast<RankedTensorType>(op.getReshaped().getType());
+  if (!resultType) {
+    return rewriter.notifyMatchFailure(op, "expected ranked tensor types");
+  }
+  if (inputType.getElementType() != resultType.getElementType()) {
+    return rewriter.notifyMatchFailure(
+        op, "expected matching input and result element types");
+  }
+  // The result aliases the input, so it lives wherever the input does. Only a
+  // rank-0 input names no space, since the type converter leaves scalar host
+  // roots alone, and the tensor it expands to has to live somewhere: device.
+  // A result naming a different space would need a copy this does not emit.
+  Attribute space = inputType.getEncoding();
+  if (!space) {
+    space = MemorySpaceAttr::get(rewriter.getContext(), MemorySpace::Device);
+  }
+  if (Attribute declared = resultType.getEncoding();
+      declared && declared != space) {
+    return rewriter.notifyMatchFailure(
+        op, "expected the result in the input's memory space");
+  }
+  return resultType.cloneWithEncoding(space);
+}
+
+struct ReshapeToHipsr : public OpConversionPattern<onnx::ReshapeOp> {
+  // Takes the pass converter to match the other patterns.
+  ReshapeToHipsr(const TypeConverter &typeConverter, MLIRContext *ctx)
+      : OpConversionPattern(ctx) {}
+
+  LogicalResult
+  matchAndRewrite(onnx::ReshapeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // With allowzero set, a 0 in the target shape is a literal extent instead
+    // of a copy of the input's, which gives a different result shape.
+    if (op.getAllowzero() != 0) {
+      return rewriter.notifyMatchFailure(op, "expected allowzero = 0");
+    }
+    Value input = adaptor.getData();
+    auto inputType = dyn_cast<RankedTensorType>(input.getType());
+    if (!inputType) {
+      return rewriter.notifyMatchFailure(op, "expected ranked tensor types");
+    }
+    FailureOr<RankedTensorType> resultType =
+        resolveResultType(op, inputType, rewriter);
+    if (failed(resultType)) {
+      return failure();
+    }
+
+    // Naming the extents both refines the type everything downstream takes and
+    // decides which of the two destinations the reshape gets.
+    FailureOr<SmallVector<TargetExtent>> named =
+        nameTargetExtents(*resultType, inputType, adaptor.getShape());
+    RankedTensorType refinedType =
+        succeeded(named) ? refineResultType(*resultType, inputType, *named)
+                         : *resultType;
+
+    // An identity reshape reinterprets nothing, so it needs no destination.
+    // Refining first also catches the ones only the target shape operand shows
+    // to be identities.
+    if (inputType == refinedType) {
+      rewriter.replaceOp(op, input);
+      return success();
+    }
+    // A reshape preserves the element count, so two static shapes that
+    // disagree on it cannot describe the same data.
+    if (inputType.hasStaticShape() && refinedType.hasStaticShape() &&
+        inputType.getNumElements() != refinedType.getNumElements()) {
+      return rewriter.notifyMatchFailure(
+          op, "expected the element count to be preserved");
+    }
+    FailureOr<Value> ctx = getHipsrContextArg(op, rewriter);
+    if (failed(ctx)) {
+      return failure();
+    }
+
+    Location loc = op.getLoc();
+    FailureOr<PlaceholderOp> init =
+        succeeded(named)
+            ? createKnownShapePlaceholder(rewriter, loc, *ctx, input, inputType,
+                                          refinedType, *named)
+            : createHostShapePlaceholder(op, adaptor.getShape(), rewriter, *ctx,
+                                         input, inputType, refinedType);
+    if (failed(init)) {
+      return failure();
+    }
+
+    auto computeOp =
+        ComputeOp::create(rewriter, loc, TypeRange{refinedType}, *ctx,
+                          ValueRange{input}, ValueRange{init->getResult(0)});
+    if (failed(
+            populateComputeBody(rewriter, computeOp, inputType, refinedType))) {
+      return failure();
+    }
+    rewriter.replaceOp(op, computeOp.getResult(0));
+    return success();
+  }
+};
+
+} // namespace
+
+void populateReshapeConversionPatterns(const TypeConverter &typeConverter,
+                                       RewritePatternSet &patterns,
+                                       MLIRContext *ctx) {
+  patterns.add<ReshapeToHipsr>(typeConverter, ctx);
+}
+
+} // namespace hipsr
+} // namespace mlir

--- a/lib/Conversion/OnnxToHipsr/ReturnConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/ReturnConversion.cpp
@@ -7,6 +7,10 @@
 // onnx.Return carries graph structure rather than a computation, so it lowers
 // to func.return instead of to a hipsr operation.
 //
+// The conversion also retypes the enclosing function's results. A pattern does
+// not carry the pass converter, so an operand keeps the memory space its
+// producer chose and the signature follows it.
+//
 //===----------------------------------------------------------------------===//
 
 #include "hip/Conversion/OnnxToHipsr/OnnxToHipsr.h"
@@ -14,27 +18,39 @@
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir {
 namespace hipsr {
 namespace {
 
-struct ReturnToFunc : public ::mlir::OpRewritePattern<::mlir::onnx::ReturnOp> {
-  using OpRewritePattern::OpRewritePattern;
+struct ReturnToFunc
+    : public ::mlir::OpConversionPattern<::mlir::onnx::ReturnOp> {
+  ReturnToFunc(const ::mlir::TypeConverter &typeConverter,
+               ::mlir::MLIRContext *ctx)
+      : OpConversionPattern(ctx) {}
 
   ::mlir::LogicalResult
-  matchAndRewrite(::mlir::onnx::ReturnOp op,
-                  ::mlir::PatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<::mlir::func::ReturnOp>(op, op.getOperands());
+  matchAndRewrite(::mlir::onnx::ReturnOp op, OpAdaptor adaptor,
+                  ::mlir::ConversionPatternRewriter &rewriter) const override {
+    ::mlir::ValueRange operands = adaptor.getOperands();
+    // onnx.Return carries HasParent<func::FuncOp>.
+    auto funcOp = ::mlir::cast<::mlir::func::FuncOp>(op->getParentOp());
+    rewriter.modifyOpInPlace(funcOp, [&] {
+      funcOp.setFunctionType(rewriter.getFunctionType(
+          funcOp.getFunctionType().getInputs(), operands.getTypes()));
+    });
+    rewriter.replaceOpWithNewOp<::mlir::func::ReturnOp>(op, operands);
     return ::mlir::success();
   }
 };
 
 } // namespace
 
-void populateReturnConversionPatterns(::mlir::RewritePatternSet &patterns,
-                                      ::mlir::MLIRContext *ctx) {
-  patterns.add<ReturnToFunc>(ctx);
+void populateReturnConversionPatterns(
+    const ::mlir::TypeConverter &typeConverter,
+    ::mlir::RewritePatternSet &patterns, ::mlir::MLIRContext *ctx) {
+  patterns.add<ReturnToFunc>(typeConverter, ctx);
 }
 
 } // namespace hipsr

--- a/lib/Conversion/OnnxToHipsr/ShapeConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/ShapeConversion.cpp
@@ -53,7 +53,6 @@
 #include "hip/Dialect/Onnx/IR/OnnxOps.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/Dialect/Shape/IR/Shape.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -99,10 +98,7 @@ void populateShapeRegion(OpBuilder &builder, PlaceholderOp placeholder,
 
   Location loc = placeholder.getLoc();
   Value extent = arith::ConstantIndexOp::create(builder, loc, numExtents);
-  Value shape = shape::FromExtentsOp::create(
-      builder, loc, shape::ShapeType::get(builder.getContext()),
-      ValueRange{extent});
-  ShapeYieldOp::create(builder, loc, ValueRange{shape});
+  yieldShapeFromExtents(builder, loc, ValueRange{extent});
 }
 
 // A static axis becomes a constant, so only a dynamic one needs a tensor.dim.
@@ -112,16 +108,9 @@ void populateComputeBody(OpBuilder &builder, ComputeOp computeOp,
                          int64_t end) {
   OpBuilder::InsertionGuard guard(builder);
   Location loc = computeOp.getLoc();
+  Block &body = createComputeBodyBlock(builder, computeOp);
 
-  // The body's arguments are the operands: ctx, then the inputs, then the
-  // outputs.
-  TypeRange argTypes = computeOp->getOperandTypes();
-  SmallVector<Location> argLocs(argTypes.size(), loc);
-  Block *body =
-      builder.createBlock(&computeOp.getBody(), {}, argTypes, argLocs);
-  builder.setInsertionPointToStart(body);
-
-  Value input = body->getArgument(1);
+  Value input = computeBodyInput(body, 0);
   auto extentOf = [&](int64_t axis) -> Value {
     if (!inputType.isDynamicDim(axis)) {
       return arith::ConstantOp::create(

--- a/test/lit/Conversion/onnx-to-hipsr/cast.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/cast.mlir
@@ -22,5 +22,5 @@ func.func @cast_chain(
     %ctx: !hipsr.context, %input: tensor<?x8xf32>) -> tensor<?x8xf32> {
   %0 = "onnx.Cast"(%input) {to = f16} : (tensor<?x8xf32>) -> tensor<?x8xf16>
   %1 = "onnx.Cast"(%0) {to = f32} : (tensor<?x8xf16>) -> tensor<?x8xf32>
-  return %1 : tensor<?x8xf32>
+  "onnx.Return"(%1) : (tensor<?x8xf32>) -> ()
 }

--- a/test/lit/Conversion/onnx-to-hipsr/constant.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/constant.mlir
@@ -8,7 +8,7 @@ func.func @scalar_const() -> tensor<f32> {
   // CHECK: arith.constant dense<3.000000e+00> : tensor<f32>
   // CHECK-NOT: hipsr.constant
   %0 = "onnx.Constant"() {value = dense<3.0> : tensor<f32>} : () -> tensor<f32>
-  return %0 : tensor<f32>
+  "onnx.Return"(%0) : (tensor<f32>) -> ()
 }
 
 // -----
@@ -17,7 +17,7 @@ func.func @scalar_const() -> tensor<f32> {
 func.func @inline_const() -> tensor<4xf32> {
   // CHECK: hipsr.constant {value = dense<[1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00]> : tensor<4xf32>} : tensor<4xf32, #hipsr.mem<device>>
   %0 = "onnx.Constant"() {value = dense<[1.0, 2.0, 3.0, 4.0]> : tensor<4xf32>} : () -> tensor<4xf32>
-  return %0 : tensor<4xf32>
+  "onnx.Return"(%0) : (tensor<4xf32>) -> ()
 }
 
 // -----
@@ -26,7 +26,7 @@ func.func @inline_const() -> tensor<4xf32> {
 func.func @mem_resource_const() -> tensor<2x4xf32> {
   // CHECK: hipsr.constant {value = dense_resource<"mem|0x7ff620910000"> : tensor<2x4xf32, #hipsr.mem<device>>} : tensor<2x4xf32, #hipsr.mem<device>>
   %0 = "onnx.Constant"() {location = "*/_ORT_MEM_ADDR_/*", offset = 140695085056000 : i64, size = 32 : i64} : () -> tensor<2x4xf32>
-  return %0 : tensor<2x4xf32>
+  "onnx.Return"(%0) : (tensor<2x4xf32>) -> ()
 }
 
 // -----
@@ -35,5 +35,5 @@ func.func @mem_resource_const() -> tensor<2x4xf32> {
 func.func @file_resource_const() -> tensor<4xi8> {
   // CHECK: hipsr.constant {value = dense_resource<"file|w.bin|4"> : tensor<4xi8, #hipsr.mem<device>>} : tensor<4xi8, #hipsr.mem<device>>
   %0 = "onnx.Constant"() {location = "w.bin", offset = 4 : i64, size = 4 : i64} : () -> tensor<4xi8>
-  return %0 : tensor<4xi8>
+  "onnx.Return"(%0) : (tensor<4xi8>) -> ()
 }

--- a/test/lit/Conversion/onnx-to-hipsr/expand-invalid.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/expand-invalid.mlir
@@ -86,5 +86,5 @@ func.func @shape_argument_names_no_space(%ctx: !hipsr.context,
   // expected-error @+1 {{operand #2 must be ranked host tensor or host memref}}
   %0 = "onnx.Expand"(%input, %shape)
       : (tensor<?x3xf16>, tensor<2xi64>) -> tensor<?x?xf16>
-  return %0 : tensor<?x?xf16>
+  "onnx.Return"(%0) : (tensor<?x?xf16>) -> ()
 }

--- a/test/lit/Conversion/onnx-to-hipsr/expand.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/expand.mlir
@@ -25,7 +25,7 @@ func.func @expand(%ctx: !hipsr.context, %input: tensor<?x3xf16>,
                   %shape: tensor<2xi64, #hipsr.mem<host>>) -> tensor<?x?xf16> {
   %0 = "onnx.Expand"(%input, %shape)
       : (tensor<?x3xf16>, tensor<2xi64, #hipsr.mem<host>>) -> tensor<?x?xf16>
-  return %0 : tensor<?x?xf16>
+  "onnx.Return"(%0) : (tensor<?x?xf16>) -> ()
 }
 
 // -----
@@ -45,5 +45,5 @@ func.func @expand_broadcast_rank(%ctx: !hipsr.context,
     -> tensor<?x?x?x?xf16> {
   %0 = "onnx.Expand"(%input, %shape)
       : (tensor<2x3xf16>, tensor<4xi64, #hipsr.mem<host>>) -> tensor<?x?x?x?xf16>
-  return %0 : tensor<?x?x?x?xf16>
+  "onnx.Return"(%0) : (tensor<?x?x?x?xf16>) -> ()
 }

--- a/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/matmul.mlir
@@ -22,7 +22,7 @@ func.func @matmul_2d(%ctx: !hipsr.context, %a: tensor<?x4096xf16>,
                      %b: tensor<4096x1024xf16>) -> tensor<?x1024xf16> {
   %0 = "onnx.MatMul"(%a, %b) : (tensor<?x4096xf16>, tensor<4096x1024xf16>)
       -> tensor<?x1024xf16>
-  return %0 : tensor<?x1024xf16>
+  "onnx.Return"(%0) : (tensor<?x1024xf16>) -> ()
 }
 
 // -----
@@ -40,5 +40,5 @@ func.func @matmul_1d_rhs(%ctx: !hipsr.context, %a: tensor<?x4096xf16>,
                          %b: tensor<4096xf16>) -> tensor<?xf16> {
   %0 = "onnx.MatMul"(%a, %b) : (tensor<?x4096xf16>, tensor<4096xf16>)
       -> tensor<?xf16>
-  return %0 : tensor<?xf16>
+  "onnx.Return"(%0) : (tensor<?xf16>) -> ()
 }

--- a/test/lit/Conversion/onnx-to-hipsr/no-value.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/no-value.mlir
@@ -16,5 +16,5 @@
 // CHECK-NEXT:    return %[[INPUT]] : tensor<2x3xf16, #hipsr.mem<device>>
 func.func @dead_placeholder(%input: tensor<2x3xf16>) -> tensor<2x3xf16> {
   %none = "onnx.NoValue"() {value} : () -> none
-  return %input : tensor<2x3xf16>
+  "onnx.Return"(%input) : (tensor<2x3xf16>) -> ()
 }

--- a/test/lit/Conversion/onnx-to-hipsr/reshape-compose.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/reshape-compose.mlir
@@ -1,0 +1,74 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+//===----------------------------------------------------------------------===//
+// The reshape conversion sends every regroup through the 1-D form instead of
+// looking for the single grouping that would express it, because
+// ComposeExpandOfCollapseOp already finds that grouping. These check it does,
+// and that it leaves the pair alone when no single grouping exists.
+//
+// reshape.mlir checks what the conversion emits before canonicalization.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt %s --onnx-dialect=modeled --split-input-file -allow-unregistered-dialect -convert-onnx-to-hipsr --canonicalize | FileCheck %s
+
+// The copied axis and the inferred one nest into [[0], [1, 2]], so the pair
+// composes away. This is the flatten-all-but-batch shape ONNX graphs use most,
+// and the hardest case to compose because one extent stays dynamic. Nothing is
+// left but the single collapse.
+// CHECK-LABEL: func.func @copy_and_infer_composes(
+// CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
+// CHECK-SAME:    %[[INPUT:.*]]: tensor<?x8x4xf16, #hipsr.mem<device>>) -> tensor<?x32xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x8x4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x32xf16, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:    ^bb0(%[[IN_SHAPE:.*]]: !shape.shape):
+// CHECK-NEXT:      %[[COLS:.*]] = arith.constant 32 : index
+// CHECK-NEXT:      %[[AXIS:.*]] = shape.const_size 0
+// CHECK-NEXT:      %[[SIZE:.*]] = shape.get_extent %[[IN_SHAPE]], %[[AXIS]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:      %[[ROWS:.*]] = shape.size_to_index %[[SIZE]] : !shape.size
+// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[ROWS]], %[[COLS]] : index, index
+// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x8x4xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x32xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x8x4xf16, #hipsr.mem<device>>, %{{.*}}: tensor<?x32xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:      %[[OUT:.*]] = tensor.collapse_shape %[[IN]] {{\[}}[0], [1, 2]] : tensor<?x8x4xf16, #hipsr.mem<device>> into tensor<?x32xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.compute_yield %[[OUT]] : tensor<?x32xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    } : tensor<?x32xf16, #hipsr.mem<device>>{{$}}
+// CHECK-NEXT:    return %[[RESULT]] : tensor<?x32xf16, #hipsr.mem<device>>
+func.func @copy_and_infer_composes(%ctx: !hipsr.context,
+                                   %input: tensor<?x8x4xf16>) -> tensor<?x?xf16> {
+  %shape = "onnx.Constant"() {value = dense<[0, -1]> : tensor<2xi64>}
+      : () -> tensor<2xi64>
+  %0 = "onnx.Reshape"(%input, %shape) {allowzero = 0 : si64}
+      : (tensor<?x8x4xf16>, tensor<2xi64>) -> tensor<?x?xf16>
+  "onnx.Return"(%0) : (tensor<?x?xf16>) -> ()
+}
+
+// -----
+
+// 4x3 into 2x6 cuts the row-major order at 3, 6 and 9 on one side and at 6 on
+// the other, so no single grouping merges and splits at once. The pair is the
+// answer here and canonicalization leaves it alone, folding only the static
+// extents in the shape region.
+// CHECK-LABEL: func.func @interleaved_stays_paired(
+// CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
+// CHECK-SAME:    %[[INPUT:.*]]: tensor<4x3xf16, #hipsr.mem<device>>,
+// CHECK-SAME:    %{{.*}}: tensor<2xi64, #hipsr.mem<device>>) -> tensor<2x6xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<4x3xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2x6xf16, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:    ^bb0(%{{.*}}: !shape.shape):
+// CHECK-NEXT:      %[[SHAPE:.*]] = shape.const_shape [2, 6] : !shape.shape
+// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<4x3xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<2x6xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<4x3xf16, #hipsr.mem<device>>, %{{.*}}: tensor<2x6xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:      %[[FLAT:.*]] = tensor.collapse_shape %[[IN]] {{\[}}[0, 1]] : tensor<4x3xf16, #hipsr.mem<device>> into tensor<12xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[OUT:.*]] = tensor.expand_shape %[[FLAT]] {{\[}}[0, 1]] output_shape [2, 6] : tensor<12xf16, #hipsr.mem<device>> into tensor<2x6xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.compute_yield %[[OUT]] : tensor<2x6xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    } : tensor<2x6xf16, #hipsr.mem<device>>{{$}}
+// CHECK-NEXT:    return %[[RESULT]] : tensor<2x6xf16, #hipsr.mem<device>>
+func.func @interleaved_stays_paired(%ctx: !hipsr.context,
+                                    %input: tensor<4x3xf16>,
+                                    %shape: tensor<2xi64>) -> tensor<2x6xf16> {
+  %0 = "onnx.Reshape"(%input, %shape)
+      : (tensor<4x3xf16>, tensor<2xi64>) -> tensor<2x6xf16>
+  "onnx.Return"(%0) : (tensor<2x6xf16>) -> ()
+}

--- a/test/lit/Conversion/onnx-to-hipsr/reshape-invalid.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/reshape-invalid.mlir
@@ -1,0 +1,116 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+//===----------------------------------------------------------------------===//
+// onnx.Reshape forms the conversion rejects.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --onnx-dialect=modeled --convert-onnx-to-hipsr --split-input-file --verify-diagnostics %s
+
+// With allowzero set, a 0 in the target shape is a literal extent instead of a
+// copy of the input's, which the result type alone does not distinguish.
+func.func @allowzero(%ctx: !hipsr.context, %input: tensor<2x3xf16>,
+                     %shape: tensor<1xi64>) -> tensor<6xf16> {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Reshape'}}
+  %0 = "onnx.Reshape"(%input, %shape) {allowzero = 1 : si64}
+      : (tensor<2x3xf16>, tensor<1xi64>) -> tensor<6xf16>
+  return %0 : tensor<6xf16>
+}
+
+// -----
+
+// Two unnamed extents are one equation with two unknowns, so they have to come
+// from the target shape operand. This one is in device memory, which the shape
+// region cannot read and nothing here copies to the host. @constant_shape and
+// @host_shape in reshape.mlir are the same reshape with operands that do work.
+func.func @device_shape(%ctx: !hipsr.context, %input: tensor<?x?x4xf16>,
+                        %shape: tensor<2xi64>) -> tensor<?x?xf16> {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Reshape'}}
+  %0 = "onnx.Reshape"(%input, %shape)
+      : (tensor<?x?x4xf16>, tensor<2xi64>) -> tensor<?x?xf16>
+  return %0 : tensor<?x?xf16>
+}
+
+// -----
+
+// The shape region reads one entry per result axis, so a host operand without
+// one for each cannot be read that way.
+func.func @short_host_shape(%ctx: !hipsr.context, %input: tensor<?x?x4xf16>,
+                            %shape: tensor<1xi64, #hipsr.mem<host>>)
+    -> tensor<?x?xf16> {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Reshape'}}
+  %0 = "onnx.Reshape"(%input, %shape)
+      : (tensor<?x?x4xf16>, tensor<1xi64, #hipsr.mem<host>>) -> tensor<?x?xf16>
+  return %0 : tensor<?x?xf16>
+}
+
+// -----
+
+// Entries are read one index at a time, so the host operand has to be 1-D.
+func.func @host_shape_rank2(%ctx: !hipsr.context, %input: tensor<?x?x4xf16>,
+                            %shape: tensor<1x2xi64, #hipsr.mem<host>>)
+    -> tensor<?x?xf16> {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Reshape'}}
+  %0 = "onnx.Reshape"(%input, %shape)
+      : (tensor<?x?x4xf16>, tensor<1x2xi64, #hipsr.mem<host>>)
+      -> tensor<?x?xf16>
+  return %0 : tensor<?x?xf16>
+}
+
+// -----
+
+// A reshape preserves the element count, so 6 elements cannot become 7 by
+// regrouping them.
+func.func @count_mismatch(%ctx: !hipsr.context, %input: tensor<2x3xf16>,
+                          %shape: tensor<1xi64>) -> tensor<7xf16> {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Reshape'}}
+  %0 = "onnx.Reshape"(%input, %shape)
+      : (tensor<2x3xf16>, tensor<1xi64>) -> tensor<7xf16>
+  return %0 : tensor<7xf16>
+}
+
+// -----
+
+// The 1-D form is built from the input's extents, so the input must be ranked.
+func.func @unranked_input(%ctx: !hipsr.context, %input: tensor<*xf16>,
+                          %shape: tensor<1xi64>) -> tensor<6xf16> {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Reshape'}}
+  %0 = "onnx.Reshape"(%input, %shape)
+      : (tensor<*xf16>, tensor<1xi64>) -> tensor<6xf16>
+  return %0 : tensor<6xf16>
+}
+
+// -----
+
+// Reshape reinterprets extents; it does not convert elements.
+func.func @element_type_mismatch(%ctx: !hipsr.context,
+                                 %input: tensor<2x3xf16>,
+                                 %shape: tensor<1xi64>) -> tensor<6xf32> {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Reshape'}}
+  %0 = "onnx.Reshape"(%input, %shape)
+      : (tensor<2x3xf16>, tensor<1xi64>) -> tensor<6xf32>
+  return %0 : tensor<6xf32>
+}
+
+// -----
+
+// The result aliases the input, so it cannot cross memory spaces. A result
+// naming a space the input does not have would need a copy.
+func.func @space_mismatch(%ctx: !hipsr.context, %input: tensor<2x3xi64>,
+                          %shape: tensor<1xi64>) {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Reshape'}}
+  %0 = "onnx.Reshape"(%input, %shape)
+      : (tensor<2x3xi64>, tensor<1xi64>) -> tensor<6xi64, #hipsr.mem<host>>
+  return
+}
+
+// -----
+
+// Every hipsr op threads the context from function argument 0.
+func.func @missing_context(%input: tensor<2x3xf16>,
+                           %shape: tensor<1xi64>) -> tensor<6xf16> {
+  // expected-error @+1 {{failed to legalize operation 'onnx.Reshape'}}
+  %0 = "onnx.Reshape"(%input, %shape)
+      : (tensor<2x3xf16>, tensor<1xi64>) -> tensor<6xf16>
+  return %0 : tensor<6xf16>
+}

--- a/test/lit/Conversion/onnx-to-hipsr/reshape.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/reshape.mlir
@@ -1,0 +1,373 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+//===----------------------------------------------------------------------===//
+// onnx.Reshape becomes a hipsr.compute holding a tensor.collapse_shape and a
+// tensor.expand_shape, with the placeholder's shape region filled in as the
+// body is built. Rejected forms are in reshape-invalid.mlir.
+//
+// The conversion does not look for the single grouping that would express a
+// regroup on its own. reshape-compose.mlir checks that canonicalization
+// recovers it where one exists.
+//
+// The destination comes either from the result type plus a target shape operand
+// that folds to a constant, or at runtime from a host operand the shape region
+// reads.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt %s --onnx-dialect=modeled --split-input-file -allow-unregistered-dialect -convert-onnx-to-hipsr | FileCheck %s
+
+// A shape operand left as a runtime value goes unread: the result type already
+// carries the extents, and a dynamic one follows from the preserved element
+// count.
+// CHECK-LABEL: func.func @collapse_dynamic(
+// CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
+// CHECK-SAME:    %[[INPUT:.*]]: tensor<?x4096xf16, #hipsr.mem<device>>,
+// CHECK-SAME:    %{{.*}}: tensor<1xi64, #hipsr.mem<device>>) -> tensor<?xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?xf16, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:    ^bb0(%[[IN_SHAPE:.*]]: !shape.shape):
+// CHECK-NEXT:      %[[AXIS:.*]] = shape.const_size 0
+// CHECK-NEXT:      %[[SIZE:.*]] = shape.get_extent %[[IN_SHAPE]], %[[AXIS]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:      %[[EXTENT:.*]] = shape.size_to_index %[[SIZE]] : !shape.size
+// CHECK-NEXT:      %[[COLS:.*]] = arith.constant 4096 : index
+// CHECK-NEXT:      %[[COUNT:.*]] = arith.muli %[[EXTENT]], %[[COLS]] : index
+// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[COUNT]] : index
+// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x4096xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x4096xf16, #hipsr.mem<device>>, %{{.*}}: tensor<?xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:      %[[FLAT:.*]] = tensor.collapse_shape %[[IN]] {{\[}}[0, 1]] : tensor<?x4096xf16, #hipsr.mem<device>> into tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.compute_yield %[[FLAT]] : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    } : tensor<?xf16, #hipsr.mem<device>>{{$}}
+// CHECK-NEXT:    return %[[RESULT]] : tensor<?xf16, #hipsr.mem<device>>
+func.func @collapse_dynamic(%ctx: !hipsr.context, %input: tensor<?x4096xf16>,
+                            %shape: tensor<1xi64>) -> tensor<?xf16> {
+  %0 = "onnx.Reshape"(%input, %shape) {allowzero = 0 : si64}
+      : (tensor<?x4096xf16>, tensor<1xi64>) -> tensor<?xf16>
+  "onnx.Return"(%0) : (tensor<?xf16>) -> ()
+}
+
+// -----
+
+// Static shapes need no extent arithmetic, so the region is two constants. The
+// body is the 1-D pair, the same as every other regroup.
+// CHECK-LABEL: func.func @static_regroup(
+// CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
+// CHECK-SAME:    %[[INPUT:.*]]: tensor<2x3x4xf16, #hipsr.mem<device>>,
+// CHECK-SAME:    %{{.*}}: tensor<2xi64, #hipsr.mem<device>>) -> tensor<6x4xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<2x3x4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<6x4xf16, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:    ^bb0(%{{.*}}: !shape.shape):
+// CHECK-NEXT:      %[[ROWS:.*]] = arith.constant 6 : index
+// CHECK-NEXT:      %[[COLS:.*]] = arith.constant 4 : index
+// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[ROWS]], %[[COLS]] : index, index
+// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<2x3x4xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<6x4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<2x3x4xf16, #hipsr.mem<device>>, %{{.*}}: tensor<6x4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:      %[[FLAT:.*]] = tensor.collapse_shape %[[IN]] {{\[}}[0, 1, 2]] : tensor<2x3x4xf16, #hipsr.mem<device>> into tensor<24xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[OUT:.*]] = tensor.expand_shape %[[FLAT]] {{\[}}[0, 1]] output_shape [6, 4] : tensor<24xf16, #hipsr.mem<device>> into tensor<6x4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.compute_yield %[[OUT]] : tensor<6x4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    } : tensor<6x4xf16, #hipsr.mem<device>>{{$}}
+// CHECK-NEXT:    return %[[RESULT]] : tensor<6x4xf16, #hipsr.mem<device>>
+func.func @static_regroup(%ctx: !hipsr.context, %input: tensor<2x3x4xf16>,
+                          %shape: tensor<2xi64>) -> tensor<6x4xf16> {
+  %0 = "onnx.Reshape"(%input, %shape)
+      : (tensor<2x3x4xf16>, tensor<2xi64>) -> tensor<6x4xf16>
+  "onnx.Return"(%0) : (tensor<6x4xf16>) -> ()
+}
+
+// -----
+
+// Expanding splits one input extent over a group, which the input type cannot
+// pin down. The destination already carries what the shape region resolved, so
+// output_shape reads the extent off it rather than dividing for it again. A
+// rank-1 input is already flat, so no collapse comes first.
+// CHECK-LABEL: func.func @expand_dynamic(
+// CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
+// CHECK-SAME:    %[[INPUT:.*]]: tensor<?xf16, #hipsr.mem<device>>,
+// CHECK-SAME:    %{{.*}}: tensor<2xi64, #hipsr.mem<device>>) -> tensor<?x4096xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x4096xf16, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:    ^bb0(%[[IN_SHAPE:.*]]: !shape.shape):
+// CHECK-NEXT:      %[[COLS:.*]] = arith.constant 4096 : index
+// CHECK-NEXT:      %[[AXIS:.*]] = shape.const_size 0
+// CHECK-NEXT:      %[[SIZE:.*]] = shape.get_extent %[[IN_SHAPE]], %[[AXIS]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:      %[[COUNT:.*]] = shape.size_to_index %[[SIZE]] : !shape.size
+// CHECK-NEXT:      %[[DIVISOR:.*]] = arith.constant 4096 : index
+// CHECK-NEXT:      %[[ROWS:.*]] = arith.divui %[[COUNT]], %[[DIVISOR]] : index
+// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[ROWS]], %[[COLS]] : index, index
+// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x4096xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?xf16, #hipsr.mem<device>>, %[[DEST:.*]]: tensor<?x4096xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:      %[[C0:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[DEST_ROWS:.*]] = tensor.dim %[[DEST]], %[[C0]] : tensor<?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[OUT:.*]] = tensor.expand_shape %[[IN]] {{\[}}[0, 1]] output_shape {{\[}}%[[DEST_ROWS]], 4096] : tensor<?xf16, #hipsr.mem<device>> into tensor<?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.compute_yield %[[OUT]] : tensor<?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    } : tensor<?x4096xf16, #hipsr.mem<device>>{{$}}
+// CHECK-NEXT:    return %[[RESULT]] : tensor<?x4096xf16, #hipsr.mem<device>>
+func.func @expand_dynamic(%ctx: !hipsr.context, %input: tensor<?xf16>,
+                          %shape: tensor<2xi64>) -> tensor<?x4096xf16> {
+  %0 = "onnx.Reshape"(%input, %shape)
+      : (tensor<?xf16>, tensor<2xi64>) -> tensor<?x4096xf16>
+  "onnx.Return"(%0) : (tensor<?x4096xf16>) -> ()
+}
+
+// -----
+
+// The input leaves the element count dynamic while the result pins it down.
+// Neither reshape op takes that mismatch across a group, so a cast refines the
+// flat form first. The result is already 1-D, so no expansion follows.
+// CHECK-LABEL: func.func @regroup_refined(
+// CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
+// CHECK-SAME:    %[[INPUT:.*]]: tensor<?x4xf16, #hipsr.mem<device>>,
+// CHECK-SAME:    %{{.*}}: tensor<1xi64, #hipsr.mem<device>>) -> tensor<24xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<24xf16, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:    ^bb0(%{{.*}}: !shape.shape):
+// CHECK-NEXT:      %[[COUNT:.*]] = arith.constant 24 : index
+// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[COUNT]] : index
+// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x4xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<24xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x4xf16, #hipsr.mem<device>>, %{{.*}}: tensor<24xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:      %[[FLAT:.*]] = tensor.collapse_shape %[[IN]] {{\[}}[0, 1]] : tensor<?x4xf16, #hipsr.mem<device>> into tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[REFINED:.*]] = tensor.cast %[[FLAT]] : tensor<?xf16, #hipsr.mem<device>> to tensor<24xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.compute_yield %[[REFINED]] : tensor<24xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    } : tensor<24xf16, #hipsr.mem<device>>{{$}}
+// CHECK-NEXT:    return %[[RESULT]] : tensor<24xf16, #hipsr.mem<device>>
+func.func @regroup_refined(%ctx: !hipsr.context, %input: tensor<?x4xf16>,
+                           %shape: tensor<1xi64>) -> tensor<24xf16> {
+  %0 = "onnx.Reshape"(%input, %shape)
+      : (tensor<?x4xf16>, tensor<1xi64>) -> tensor<24xf16>
+  "onnx.Return"(%0) : (tensor<24xf16>) -> ()
+}
+
+// -----
+
+// A rank-0 input has no axis to collapse, so there is no 1-D form to go through
+// and the expansion regroups it on its own. Such an input also names no memory
+// space, so the result falls back to device.
+// CHECK-LABEL: func.func @rank0_input(
+// CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
+// CHECK-SAME:    %[[INPUT:.*]]: tensor<f16>) -> tensor<1xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:    %{{.*}} = hipsr.constant {value = dense<1> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<f16>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<1xf16, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:    ^bb0(%{{.*}}: !shape.shape):
+// CHECK-NEXT:      %[[EXTENT:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[EXTENT]] : index
+// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<f16>) outs(%[[INIT]] : tensor<1xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<f16>, %{{.*}}: tensor<1xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:      %[[OUT:.*]] = tensor.expand_shape %[[IN]] [] output_shape [1] : tensor<f16> into tensor<1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.compute_yield %[[OUT]] : tensor<1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    } : tensor<1xf16, #hipsr.mem<device>>{{$}}
+// CHECK-NEXT:    return %[[RESULT]] : tensor<1xf16, #hipsr.mem<device>>
+func.func @rank0_input(%ctx: !hipsr.context,
+                       %input: tensor<f16>) -> tensor<1xf16> {
+  %shape = "onnx.Constant"() {value = dense<1> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+  %0 = "onnx.Reshape"(%input, %shape) {allowzero = 0 : si64}
+      : (tensor<f16>, tensor<1xi64>) -> tensor<1xf16>
+  "onnx.Return"(%0) : (tensor<1xf16>) -> ()
+}
+
+// -----
+
+// Shape inference does not always fold a constant shape operand into the result
+// type, which leaves both extents dynamic here. The operand still names the
+// first one, and without it the expansion would have two unknowns in one group.
+// That refinement is the type the compute carries, so it reaches the signature
+// instead of being widened back to the one ONNX declared.
+// CHECK-LABEL: func.func @constant_shape(
+// CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
+// CHECK-SAME:    %[[INPUT:.*]]: tensor<?x?x4xf16, #hipsr.mem<device>>) -> tensor<2x?xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:    %{{.*}} = hipsr.constant {value = dense<[2, -1]> : tensor<2xi64>} : tensor<2xi64, #hipsr.mem<device>>
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2x?xf16, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:    ^bb0(%[[IN_SHAPE:.*]]: !shape.shape):
+// CHECK-NEXT:      %[[ROWS:.*]] = arith.constant 2 : index
+// CHECK-NEXT:      %[[AXIS0:.*]] = shape.const_size 0
+// CHECK-NEXT:      %[[SIZE0:.*]] = shape.get_extent %[[IN_SHAPE]], %[[AXIS0]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:      %[[D0:.*]] = shape.size_to_index %[[SIZE0]] : !shape.size
+// CHECK-NEXT:      %[[AXIS1:.*]] = shape.const_size 1
+// CHECK-NEXT:      %[[SIZE1:.*]] = shape.get_extent %[[IN_SHAPE]], %[[AXIS1]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:      %[[D1:.*]] = shape.size_to_index %[[SIZE1]] : !shape.size
+// CHECK-NEXT:      %[[D2:.*]] = arith.constant 4 : index
+// CHECK-NEXT:      %[[PARTIAL:.*]] = arith.muli %[[D0]], %[[D1]] : index
+// CHECK-NEXT:      %[[COUNT:.*]] = arith.muli %[[PARTIAL]], %[[D2]] : index
+// CHECK-NEXT:      %[[DIVISOR:.*]] = arith.constant 2 : index
+// CHECK-NEXT:      %[[COLS:.*]] = arith.divui %[[COUNT]], %[[DIVISOR]] : index
+// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[ROWS]], %[[COLS]] : index, index
+// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<2x?xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x?x4xf16, #hipsr.mem<device>>, %[[DEST:.*]]: tensor<2x?xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:      %[[FLAT:.*]] = tensor.collapse_shape %[[IN]] {{\[}}[0, 1, 2]] : tensor<?x?x4xf16, #hipsr.mem<device>> into tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[C1:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[DEST_COLS:.*]] = tensor.dim %[[DEST]], %[[C1]] : tensor<2x?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[OUT:.*]] = tensor.expand_shape %[[FLAT]] {{\[}}[0, 1]] output_shape [2, %[[DEST_COLS]]] : tensor<?xf16, #hipsr.mem<device>> into tensor<2x?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.compute_yield %[[OUT]] : tensor<2x?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    } : tensor<2x?xf16, #hipsr.mem<device>>{{$}}
+// CHECK-NEXT:    return %[[RESULT]] : tensor<2x?xf16, #hipsr.mem<device>>
+func.func @constant_shape(%ctx: !hipsr.context,
+                          %input: tensor<?x?x4xf16>) -> tensor<?x?xf16> {
+  %shape = "onnx.Constant"() {value = dense<[2, -1]> : tensor<2xi64>}
+      : () -> tensor<2xi64>
+  %0 = "onnx.Reshape"(%input, %shape) {allowzero = 0 : si64}
+      : (tensor<?x?x4xf16>, tensor<2xi64>) -> tensor<?x?xf16>
+  "onnx.Return"(%0) : (tensor<?x?xf16>) -> ()
+}
+
+// -----
+
+// A 0 keeps the input's extent and a -1 takes the rest, which is how ONNX
+// graphs flatten everything but the batch. The copied axis cancels out of the
+// element count, so the inferred extent folds to a constant even though the
+// axis beside it stays dynamic, and no division survives.
+// CHECK-LABEL: func.func @copy_and_infer(
+// CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
+// CHECK-SAME:    %[[INPUT:.*]]: tensor<?x8x4xf16, #hipsr.mem<device>>) -> tensor<?x32xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:    %{{.*}} = hipsr.constant {value = dense<[0, -1]> : tensor<2xi64>} : tensor<2xi64, #hipsr.mem<device>>
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x8x4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x32xf16, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:    ^bb0(%[[IN_SHAPE:.*]]: !shape.shape):
+// CHECK-NEXT:      %[[AXIS:.*]] = shape.const_size 0
+// CHECK-NEXT:      %[[SIZE:.*]] = shape.get_extent %[[IN_SHAPE]], %[[AXIS]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:      %[[ROWS:.*]] = shape.size_to_index %[[SIZE]] : !shape.size
+// CHECK-NEXT:      %[[COLS:.*]] = arith.constant 32 : index
+// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[ROWS]], %[[COLS]] : index, index
+// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x8x4xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x32xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x8x4xf16, #hipsr.mem<device>>, %[[DEST:.*]]: tensor<?x32xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:      %[[FLAT:.*]] = tensor.collapse_shape %[[IN]] {{\[}}[0, 1, 2]] : tensor<?x8x4xf16, #hipsr.mem<device>> into tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[C0:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[DEST_ROWS:.*]] = tensor.dim %[[DEST]], %[[C0]] : tensor<?x32xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[OUT:.*]] = tensor.expand_shape %[[FLAT]] {{\[}}[0, 1]] output_shape {{\[}}%[[DEST_ROWS]], 32] : tensor<?xf16, #hipsr.mem<device>> into tensor<?x32xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.compute_yield %[[OUT]] : tensor<?x32xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    } : tensor<?x32xf16, #hipsr.mem<device>>{{$}}
+// CHECK-NEXT:    return %[[RESULT]] : tensor<?x32xf16, #hipsr.mem<device>>
+func.func @copy_and_infer(%ctx: !hipsr.context,
+                          %input: tensor<?x8x4xf16>) -> tensor<?x?xf16> {
+  %shape = "onnx.Constant"() {value = dense<[0, -1]> : tensor<2xi64>}
+      : () -> tensor<2xi64>
+  %0 = "onnx.Reshape"(%input, %shape) {allowzero = 0 : si64}
+      : (tensor<?x8x4xf16>, tensor<2xi64>) -> tensor<?x?xf16>
+  "onnx.Return"(%0) : (tensor<?x?xf16>) -> ()
+}
+
+// -----
+
+// The identity check runs on the refined type, so it covers both a declared
+// type that already matches the input and this one, where only the operand
+// shows it: [0, -1] against a rank-2 input names the extents back to the
+// input's own. The reshape is replaced by its input, leaving no destination.
+// CHECK-LABEL: func.func @refines_to_input(
+// CHECK-SAME:    %{{.*}}: !hipsr.context,
+// CHECK-SAME:    %[[INPUT:.*]]: tensor<?x32xf16, #hipsr.mem<device>>) -> tensor<?x32xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:    %{{.*}} = hipsr.constant {value = dense<[0, -1]> : tensor<2xi64>} : tensor<2xi64, #hipsr.mem<device>>
+// CHECK-NEXT:    return %[[INPUT]] : tensor<?x32xf16, #hipsr.mem<device>>
+func.func @refines_to_input(%ctx: !hipsr.context,
+                            %input: tensor<?x32xf16>) -> tensor<?x?xf16> {
+  %shape = "onnx.Constant"() {value = dense<[0, -1]> : tensor<2xi64>}
+      : () -> tensor<2xi64>
+  %0 = "onnx.Reshape"(%input, %shape) {allowzero = 0 : si64}
+      : (tensor<?x32xf16>, tensor<2xi64>) -> tensor<?x?xf16>
+  "onnx.Return"(%0) : (tensor<?x?xf16>) -> ()
+}
+
+// -----
+
+// Two extents nothing names leave the target shape operand as the only place
+// they are, so the shape region reads it. That is a host read, hence the
+// barrier layout, which hands the region the operands themselves rather than
+// their shapes. A 0 still copies the input's extent and a -1 is still the
+// element count divided by the rest, only now against runtime values. The
+// destination carries what the region resolved, so the body reads the extents
+// off it rather than resolving them a second time.
+// CHECK-LABEL: func.func @host_shape(
+// CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
+// CHECK-SAME:    %[[INPUT:.*]]: tensor<?x?x4xf16, #hipsr.mem<device>>,
+// CHECK-SAME:    %[[TARGET:.*]]: tensor<2xi64, #hipsr.mem<host>>) -> tensor<?x?xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]], %[[TARGET]] : tensor<?x?x4xf16, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x?xf16, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x?x4xf16, #hipsr.mem<device>>, %[[SHAPE_IN:.*]]: tensor<2xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:      %[[ZERO:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[ONE:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[AXIS0:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[D0:.*]] = tensor.dim %[[IN]], %[[AXIS0]] : tensor<?x?x4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[AXIS1:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[D1:.*]] = tensor.dim %[[IN]], %[[AXIS1]] : tensor<?x?x4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[D2:.*]] = arith.constant 4 : index
+// CHECK-NEXT:      %[[PARTIAL:.*]] = arith.muli %[[D0]], %[[D1]] : index
+// CHECK-NEXT:      %[[COUNT:.*]] = arith.muli %[[PARTIAL]], %[[D2]] : index
+// CHECK-NEXT:      %[[ENTRY0:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[RAW0:.*]] = tensor.extract %[[SHAPE_IN]]{{\[}}%[[ENTRY0]]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      %[[E0:.*]] = arith.index_cast %[[RAW0]] : i64 to index
+// CHECK-NEXT:      %[[COPIES0:.*]] = arith.cmpi eq, %[[E0]], %[[ZERO]] : index
+// CHECK-NEXT:      %[[SRC0:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[IN_D0:.*]] = tensor.dim %[[IN]], %[[SRC0]] : tensor<?x?x4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[STATED0:.*]] = arith.select %[[COPIES0]], %[[IN_D0]], %[[E0]] : index
+// CHECK-NEXT:      %[[INFERS0:.*]] = arith.cmpi slt, %[[STATED0]], %[[ZERO]] : index
+// CHECK-NEXT:      %[[FACTOR0:.*]] = arith.select %[[INFERS0]], %[[ONE]], %[[STATED0]] : index
+// CHECK-NEXT:      %[[ENTRY1:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[RAW1:.*]] = tensor.extract %[[SHAPE_IN]]{{\[}}%[[ENTRY1]]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      %[[E1:.*]] = arith.index_cast %[[RAW1]] : i64 to index
+// CHECK-NEXT:      %[[COPIES1:.*]] = arith.cmpi eq, %[[E1]], %[[ZERO]] : index
+// CHECK-NEXT:      %[[SRC1:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[IN_D1:.*]] = tensor.dim %[[IN]], %[[SRC1]] : tensor<?x?x4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[STATED1:.*]] = arith.select %[[COPIES1]], %[[IN_D1]], %[[E1]] : index
+// CHECK-NEXT:      %[[INFERS1:.*]] = arith.cmpi slt, %[[STATED1]], %[[ZERO]] : index
+// CHECK-NEXT:      %[[FACTOR1:.*]] = arith.select %[[INFERS1]], %[[ONE]], %[[STATED1]] : index
+// CHECK-NEXT:      %[[DIVISOR:.*]] = arith.muli %[[FACTOR0]], %[[FACTOR1]] : index
+// CHECK-NEXT:      %[[INFERRED:.*]] = arith.divui %[[COUNT]], %[[DIVISOR]] : index
+// CHECK-NEXT:      %[[EXTENT0:.*]] = arith.select %[[INFERS0]], %[[INFERRED]], %[[STATED0]] : index
+// CHECK-NEXT:      %[[EXTENT1:.*]] = arith.select %[[INFERS1]], %[[INFERRED]], %[[STATED1]] : index
+// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[EXTENT0]], %[[EXTENT1]] : index, index
+// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x?xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[BODY_IN:.*]]: tensor<?x?x4xf16, #hipsr.mem<device>>, %[[DEST:.*]]: tensor<?x?xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:      %[[FLAT:.*]] = tensor.collapse_shape %[[BODY_IN]] {{\[}}[0, 1, 2]] : tensor<?x?x4xf16, #hipsr.mem<device>> into tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[C0:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[DEST_D0:.*]] = tensor.dim %[[DEST]], %[[C0]] : tensor<?x?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[C1:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[DEST_D1:.*]] = tensor.dim %[[DEST]], %[[C1]] : tensor<?x?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[OUT:.*]] = tensor.expand_shape %[[FLAT]] {{\[}}[0, 1]] output_shape {{\[}}%[[DEST_D0]], %[[DEST_D1]]] : tensor<?xf16, #hipsr.mem<device>> into tensor<?x?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.compute_yield %[[OUT]] : tensor<?x?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    } : tensor<?x?xf16, #hipsr.mem<device>>{{$}}
+// CHECK-NEXT:    return %[[RESULT]] : tensor<?x?xf16, #hipsr.mem<device>>
+func.func @host_shape(%ctx: !hipsr.context, %input: tensor<?x?x4xf16>,
+                      %shape: tensor<2xi64, #hipsr.mem<host>>)
+    -> tensor<?x?xf16> {
+  %0 = "onnx.Reshape"(%input, %shape) {allowzero = 0 : si64}
+      : (tensor<?x?x4xf16>, tensor<2xi64, #hipsr.mem<host>>)
+      -> tensor<?x?xf16>
+  "onnx.Return"(%0) : (tensor<?x?xf16>) -> ()
+}
+
+// -----
+
+// The result aliases the input, so a host input keeps the whole chain in
+// #hipsr.mem<host>. An ONNX result naming no space follows the input rather
+// than defaulting to device.
+// CHECK-LABEL: func.func @host_input(
+// CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
+// CHECK-SAME:    %[[INPUT:.*]]: tensor<2x3xi64, #hipsr.mem<host>>,
+// CHECK-SAME:    %{{.*}}: tensor<1xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<2x3xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<6xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:    ^bb0(%{{.*}}: !shape.shape):
+// CHECK-NEXT:      %[[COUNT:.*]] = arith.constant 6 : index
+// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[COUNT]] : index
+// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %{{.*}} = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<2x3xi64, #hipsr.mem<host>>) outs(%[[INIT]] : tensor<6xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<2x3xi64, #hipsr.mem<host>>, %{{.*}}: tensor<6xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:      %[[FLAT:.*]] = tensor.collapse_shape %[[IN]] {{\[}}[0, 1]] : tensor<2x3xi64, #hipsr.mem<host>> into tensor<6xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      hipsr.compute_yield %[[FLAT]] : tensor<6xi64, #hipsr.mem<host>>
+// CHECK-NEXT:    } : tensor<6xi64, #hipsr.mem<host>>{{$}}
+// CHECK-NEXT:    return{{$}}
+func.func @host_input(%ctx: !hipsr.context,
+                      %input: tensor<2x3xi64, #hipsr.mem<host>>,
+                      %shape: tensor<1xi64>) {
+  %0 = "onnx.Reshape"(%input, %shape)
+      : (tensor<2x3xi64, #hipsr.mem<host>>, tensor<1xi64>) -> tensor<6xi64>
+  "onnx.Return"() : () -> ()
+}

--- a/test/lit/Conversion/onnx-to-hipsr/reshape.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/reshape.mlir
@@ -17,67 +17,6 @@
 
 // RUN: hip-mlir-opt %s --onnx-dialect=modeled --split-input-file -allow-unregistered-dialect -convert-onnx-to-hipsr | FileCheck %s
 
-// A shape operand left as a runtime value goes unread: the result type already
-// carries the extents, and a dynamic one follows from the preserved element
-// count.
-// CHECK-LABEL: func.func @collapse_dynamic(
-// CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
-// CHECK-SAME:    %[[INPUT:.*]]: tensor<?x4096xf16, #hipsr.mem<device>>,
-// CHECK-SAME:    %{{.*}}: tensor<1xi64, #hipsr.mem<device>>) -> tensor<?xf16, #hipsr.mem<device>> {
-// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?xf16, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:    ^bb0(%[[IN_SHAPE:.*]]: !shape.shape):
-// CHECK-NEXT:      %[[AXIS:.*]] = shape.const_size 0
-// CHECK-NEXT:      %[[SIZE:.*]] = shape.get_extent %[[IN_SHAPE]], %[[AXIS]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:      %[[EXTENT:.*]] = shape.size_to_index %[[SIZE]] : !shape.size
-// CHECK-NEXT:      %[[COLS:.*]] = arith.constant 4096 : index
-// CHECK-NEXT:      %[[COUNT:.*]] = arith.muli %[[EXTENT]], %[[COLS]] : index
-// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[COUNT]] : index
-// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
-// CHECK-NEXT:    }
-// CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x4096xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x4096xf16, #hipsr.mem<device>>, %{{.*}}: tensor<?xf16, #hipsr.mem<device>>):
-// CHECK-NEXT:      %[[FLAT:.*]] = tensor.collapse_shape %[[IN]] {{\[}}[0, 1]] : tensor<?x4096xf16, #hipsr.mem<device>> into tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.compute_yield %[[FLAT]] : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:    } : tensor<?xf16, #hipsr.mem<device>>{{$}}
-// CHECK-NEXT:    return %[[RESULT]] : tensor<?xf16, #hipsr.mem<device>>
-func.func @collapse_dynamic(%ctx: !hipsr.context, %input: tensor<?x4096xf16>,
-                            %shape: tensor<1xi64>) -> tensor<?xf16> {
-  %0 = "onnx.Reshape"(%input, %shape) {allowzero = 0 : si64}
-      : (tensor<?x4096xf16>, tensor<1xi64>) -> tensor<?xf16>
-  "onnx.Return"(%0) : (tensor<?xf16>) -> ()
-}
-
-// -----
-
-// Static shapes need no extent arithmetic, so the region is two constants. The
-// body is the 1-D pair, the same as every other regroup.
-// CHECK-LABEL: func.func @static_regroup(
-// CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
-// CHECK-SAME:    %[[INPUT:.*]]: tensor<2x3x4xf16, #hipsr.mem<device>>,
-// CHECK-SAME:    %{{.*}}: tensor<2xi64, #hipsr.mem<device>>) -> tensor<6x4xf16, #hipsr.mem<device>> {
-// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<2x3x4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<6x4xf16, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:    ^bb0(%{{.*}}: !shape.shape):
-// CHECK-NEXT:      %[[ROWS:.*]] = arith.constant 6 : index
-// CHECK-NEXT:      %[[COLS:.*]] = arith.constant 4 : index
-// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[ROWS]], %[[COLS]] : index, index
-// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
-// CHECK-NEXT:    }
-// CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<2x3x4xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<6x4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<2x3x4xf16, #hipsr.mem<device>>, %{{.*}}: tensor<6x4xf16, #hipsr.mem<device>>):
-// CHECK-NEXT:      %[[FLAT:.*]] = tensor.collapse_shape %[[IN]] {{\[}}[0, 1, 2]] : tensor<2x3x4xf16, #hipsr.mem<device>> into tensor<24xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[OUT:.*]] = tensor.expand_shape %[[FLAT]] {{\[}}[0, 1]] output_shape [6, 4] : tensor<24xf16, #hipsr.mem<device>> into tensor<6x4xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.compute_yield %[[OUT]] : tensor<6x4xf16, #hipsr.mem<device>>
-// CHECK-NEXT:    } : tensor<6x4xf16, #hipsr.mem<device>>{{$}}
-// CHECK-NEXT:    return %[[RESULT]] : tensor<6x4xf16, #hipsr.mem<device>>
-func.func @static_regroup(%ctx: !hipsr.context, %input: tensor<2x3x4xf16>,
-                          %shape: tensor<2xi64>) -> tensor<6x4xf16> {
-  %0 = "onnx.Reshape"(%input, %shape)
-      : (tensor<2x3x4xf16>, tensor<2xi64>) -> tensor<6x4xf16>
-  "onnx.Return"(%0) : (tensor<6x4xf16>) -> ()
-}
-
-// -----
-
 // Expanding splits one input extent over a group, which the input type cannot
 // pin down. The destination already carries what the shape region resolved, so
 // output_shape reads the extent off it rather than dividing for it again. A
@@ -348,6 +287,10 @@ func.func @host_shape(%ctx: !hipsr.context, %input: tensor<?x?x4xf16>,
 // The result aliases the input, so a host input keeps the whole chain in
 // #hipsr.mem<host>. An ONNX result naming no space follows the input rather
 // than defaulting to device.
+//
+// Static extents on both sides also make this the plainest regroup: constants
+// in the region, and a body that flattens and stops, with no extent to refine
+// and no group to expand back out.
 // CHECK-LABEL: func.func @host_input(
 // CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:    %[[INPUT:.*]]: tensor<2x3xi64, #hipsr.mem<host>>,

--- a/test/lit/Conversion/onnx-to-hipsr/return.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/return.mlir
@@ -2,7 +2,8 @@
 // Licensed under the MIT License.
 
 //===----------------------------------------------------------------------===//
-// onnx.Return becomes func.return. Rejected forms live in return-invalid.mlir.
+// onnx.Return becomes func.return, and the function's result types follow the
+// operands it carries. Rejected forms live in return-invalid.mlir.
 //===----------------------------------------------------------------------===//
 
 // RUN: hip-mlir-opt --onnx-dialect=modeled --convert-onnx-to-hipsr --split-input-file %s | FileCheck %s
@@ -13,6 +14,7 @@
 // CHECK-SAME:    %{{.*}}: !hipsr.context,
 // CHECK-SAME:    %[[INPUT:.*]]: tensor<?x4096xf16, #hipsr.mem<device>>) -> tensor<?x4096xf16, #hipsr.mem<device>> {
 // CHECK-NEXT:    return %[[INPUT]] : tensor<?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:  }
 func.func @imported_graph(%ctx: !hipsr.context, %input: tensor<?x4096xf16>)
     -> tensor<?x4096xf16> {
   "onnx.Return"(%input) : (tensor<?x4096xf16>) -> ()
@@ -22,7 +24,9 @@ func.func @imported_graph(%ctx: !hipsr.context, %input: tensor<?x4096xf16>)
 
 // A graph with no results returns nothing.
 // CHECK-LABEL: func.func @return_no_operands(
+// CHECK-SAME:    %{{.*}}: !hipsr.context) {
 // CHECK-NEXT:    return
+// CHECK-NEXT:  }
 func.func @return_no_operands(%ctx: !hipsr.context) {
   "onnx.Return"() : () -> ()
 }

--- a/test/lit/Conversion/onnx-to-hipsr/shape.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/shape.mlir
@@ -190,25 +190,18 @@ func.func @result_names_no_space(%ctx: !hipsr.context,
 
 // -----
 
-// Neither ONNX type names a space, and the expand still reads its shape operand
-// in the host memory this conversion picks: an operation pattern does not carry
-// the pass converter, so an operand keeps the space its producer gave it.
-//
-// The extents feed the shape graph as well as the data graph, and each takes a
-// different value: the barrier placeholder's input names the buffer holding
-// them, which is the compute's destination, while the expand reads what the
-// compute wrote. Reading host extents says nothing about where the expand keeps
-// its own data, which stays in the #hipsr.mem<device> its input and init
-// require.
-// CHECK-LABEL:   func.func @extents_feed_an_expand(
+// Returning the extents carries the host space to the function boundary, so a
+// graph declaring a bare tensor comes back with the space this conversion
+// picked.
+// CHECK-LABEL:   func.func @extents_leave_the_function(
 // CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
-// CHECK-SAME:      %[[INPUT:.*]]: tensor<?x3xf16, #hipsr.mem<device>>) -> tensor<?x?xf16, #hipsr.mem<device>> {
-// CHECK-NEXT:      %[[EXTENTS_INIT:.*]] = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
+// CHECK-SAME:      %[[INPUT:.*]]: tensor<?x3xf16, #hipsr.mem<device>>) -> tensor<2xi64, #hipsr.mem<host>> {
+// CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
 // CHECK-NEXT:        %[[LEN:.*]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[SHAPE:.*]] = shape.from_extents %[[LEN]] : index
 // CHECK-NEXT:        hipsr.shape_yield %[[SHAPE]] : !shape.shape
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x3xf16, #hipsr.mem<device>>) outs(%[[EXTENTS_INIT]] : tensor<2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:      %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x3xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<2xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:      ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x3xf16, #hipsr.mem<device>>, %{{.*}}: tensor<2xi64, #hipsr.mem<host>>):
 // CHECK-NEXT:        %[[C0:.*]] = arith.constant 0 : index
 // CHECK-NEXT:        %[[DIM0:.*]] = tensor.dim %[[IN]], %[[C0]] : tensor<?x3xf16, #hipsr.mem<device>>
@@ -217,13 +210,10 @@ func.func @result_names_no_space(%ctx: !hipsr.context,
 // CHECK-NEXT:        %[[EXTENTS:.*]] = tensor.from_elements %[[EXT0]], %[[EXT1]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        hipsr.compute_yield %[[EXTENTS]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:      } : tensor<2xi64, #hipsr.mem<host>>{{$}}
-// CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]], %[[EXTENTS_INIT]] : tensor<?x3xf16, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[EXPANDED:.*]] = hipsr.expand(%[[CTX]]) ins(%[[INPUT]], %[[RESULT]] : tensor<?x3xf16, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) outs(%[[INIT]] : tensor<?x?xf16, #hipsr.mem<device>>) : tensor<?x?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      return %[[EXPANDED]] : tensor<?x?xf16, #hipsr.mem<device>>
-func.func @extents_feed_an_expand(%ctx: !hipsr.context,
-                                  %input: tensor<?x3xf16>) -> tensor<?x?xf16> {
+// CHECK-NEXT:      return %[[RESULT]] : tensor<2xi64, #hipsr.mem<host>>
+func.func @extents_leave_the_function(%ctx: !hipsr.context,
+                                      %input: tensor<?x3xf16>)
+    -> tensor<2xi64> {
   %0 = "onnx.Shape"(%input) : (tensor<?x3xf16>) -> tensor<2xi64>
-  %1 = "onnx.Expand"(%input, %0)
-      : (tensor<?x3xf16>, tensor<2xi64>) -> tensor<?x?xf16>
-  return %1 : tensor<?x?xf16>
+  "onnx.Return"(%0) : (tensor<2xi64>) -> ()
 }


### PR DESCRIPTION
## Summary

Converts `onnx.Reshape` into a `hipsr.compute` whose body is a
`tensor.collapse_shape`, a `tensor.expand_shape`, or both, with the placeholder's
shape region populated inline. Also lifts the compute-body and shape-yield
helpers into `OnnxToHipsrUtils.h` so `ShapeConversion.cpp` shares them.

Both reshape operations bufferize to memrefs that alias their source, so the
whole thing costs nothing at runtime.

## Why

The target shape operand is not a list of extents. With `allowzero` clear, a `0`
copies the input's extent at that axis and a `-1` asks for the one extent the
preserved element count can recover. Resolving those two is most of the work.

## What

The destination's shape comes from one of two places, and nothing else is
supported.

- **Derived.** Every extent follows from the result type, a shape operand that
  folds to a constant, and the input's shape. Nothing is read out of memory, so
  a normal placeholder is enough. A copied axis cancels between the element
  count and the divisor, which is what makes `[0, -1]` fold to a static extent
  even beside a dynamic axis.
- **Host.** Past one unstated extent the values are only in the shape operand,
  so the region has to read it. That needs the operand in `#hipsr.mem<host>` and
  a barrier placeholder. An operand anywhere else is rejected.

Every regroup goes through the 1-D form instead of searching for a single
reassociation, because `ComposeExpandOfCollapseOp` already finds that grouping.

The result aliases its source, so it lives in the input's memory space, and the
refined result type reaches the function signature rather than being widened
back to what the graph declared.

## Notes for reviewers

Stacked on #779, which the refined return type depends on. Review that first;
this rebases onto `main` once it lands.

Read the commits in order. The first is the conversion. The second is a review
pass that changes no behavior: renames for accuracy, shorter comments, and two
LIT cases dropped that no longer covered a path of their own.

Coverage is in `reshape.mlir`, `reshape-compose.mlir` for the canonicalization
claim, and `reshape-invalid.mlir` for the rejections.

No HipsrToLLVM lowering yet, so `--hipsr-pipeline` cannot run this end to end.

Cursor (Claude Opus 5) assisted with the conversion, the shared helpers and the
tests. I reviewed the result and understand it.
