### PR TITLE
fix(onnx-to-hip): compute dynamic hip.slice extents from the slice bounds (2.2x decode TPS on Gemma-4 26B-A4B at 12K)

### DIFF
--- a/lib/Conversion/OnnxToHip/SliceConversion.cpp
+++ b/lib/Conversion/OnnxToHip/SliceConversion.cpp
@@ -35,8 +35,21 @@ namespace {
 //     steps. Produces a native `hip.slice` DPS op whose runtime function is
 //     a stub today (throws); models that hit this path are unsupported until
 //     the runtime is implemented, but the conversion / bufferization pipeline
-//     can still verify and link the IR. Dynamic output dims are sourced from
-//     `tensor.dim` on `data` (an upper bound — Slice cannot widen any axis).
+//     can still verify and link the IR. Dynamic output dims are computed from
+//     the slice bounds when those are host-resolvable, and otherwise fall back
+//     to `tensor.dim` on `data` (an upper bound — Slice cannot widen any axis).
+//
+// That fallback is only an upper bound, and an upper bound is not a safe
+// stand-in for the extent: the extent this pattern puts on the `tensor.empty`
+// init IS the output shape as far as everything downstream is concerned, since
+// `tensor.dim` of a DPS result resolves through to the init. A Slice that keeps
+// one row of a 12k-row tensor therefore hands every consumer a 12k-row shape.
+// Gemma-4 26B-A4B decode does exactly this — `Slice(CumSum(attention_mask),
+// Shape(attn)[1] - Shape(ids)[1], Shape(attn)[1])` takes the single current
+// query position — and the inflated extent turned the causal mask from
+// [1, 1, S] into [1, S, S], 60% of a decode step. Hence resolveHostIndex:
+// `ends - starts` is host arithmetic over `onnx.Shape` entries, so the true
+// extent is computable without any device readback.
 
 /// Return the dense-elements attribute backing \p value if it can be
 /// determined at compile time. Recognizes arith constants, inspectable
@@ -118,6 +131,141 @@ static mlir::Value normaliseOptional(mlir::Value v) {
   if (defOp && defOp->getName().getStringRef() == "onnx.NoValue")
     return mlir::Value();
   return v;
+}
+
+/// Producer-chain depth walked by `resolveHostIndex`. Shape arithmetic in
+/// exported graphs is a handful of ops deep; the bound only stops a
+/// pathological walk.
+static constexpr int kHostIndexMaxDepth = 8;
+
+/// Resolve element \p idx of an integer shape tensor \p v to a host `index`
+/// SSA value, materializing `arith` ops as needed. Returns a null Value when
+/// the element is not host-computable.
+///
+/// Both the pre- and post-conversion spelling of ONNX shape arithmetic are
+/// accepted, because the greedy driver gives no ordering guarantee between this
+/// pattern and the ones rewriting the producers: `onnx.Shape` may still be
+/// present, or may already be
+/// `tensor.from_elements(arith.index_cast(tensor.dim))`, and `onnx.Sub` may
+/// already be `hip.sub`.
+static mlir::Value resolveHostIndex(mlir::OpBuilder &b, mlir::Location loc,
+                                    mlir::Value v, int64_t idx, int depth) {
+  if (!v || depth > kHostIndexMaxDepth)
+    return {};
+  auto vType = mlir::dyn_cast<mlir::RankedTensorType>(v.getType());
+  if (!vType || !vType.getElementType().isSignlessInteger())
+    return {};
+
+  if (mlir::DenseElementsAttr dense = getCompileTimeConstantTensor(v)) {
+    if (idx >= dense.getNumElements())
+      return {};
+    return mlir::arith::ConstantIndexOp::create(
+        b, loc,
+        (*(dense.getValues<mlir::APInt>().begin() + idx)).getSExtValue());
+  }
+
+  mlir::Operation *def = v.getDefiningOp();
+  if (!def)
+    return {};
+
+  if (auto fromElems = mlir::dyn_cast<mlir::tensor::FromElementsOp>(def)) {
+    if (idx >= static_cast<int64_t>(fromElems.getElements().size()))
+      return {};
+    mlir::Value elem = fromElems.getElements()[idx];
+    // ShapeToTensorDims index_casts every tensor.dim to i64 to pack it; take
+    // the index back rather than casting a second time.
+    if (auto cast = elem.getDefiningOp<mlir::arith::IndexCastOp>())
+      if (cast.getIn().getType().isIndex())
+        return cast.getIn();
+    return mlir::arith::IndexCastOp::create(b, loc, b.getIndexType(), elem);
+  }
+
+  if (auto cast = mlir::dyn_cast<mlir::tensor::CastOp>(def))
+    return resolveHostIndex(b, loc, cast.getSource(), idx, depth + 1);
+
+  llvm::StringRef opName = def->getName().getStringRef();
+
+  // Unconverted onnx.Shape: element idx is dim (start + idx) of the operand.
+  // start/end normalization matches ShapeToTensorDims.
+  if (opName == "onnx.Shape") {
+    mlir::Value input = def->getOperand(0);
+    auto inType = mlir::dyn_cast<mlir::RankedTensorType>(input.getType());
+    if (!inType)
+      return {};
+    int64_t rank = inType.getRank();
+    int64_t start = 0;
+    if (auto startAttr = def->getAttrOfType<mlir::IntegerAttr>("start"))
+      start = startAttr.getSInt();
+    if (start < 0)
+      start += rank;
+    start = std::max(start, int64_t(0));
+    int64_t dimIdx = start + idx;
+    if (dimIdx < 0 || dimIdx >= rank)
+      return {};
+    if (!inType.isDynamicDim(dimIdx))
+      return mlir::arith::ConstantIndexOp::create(b, loc,
+                                                  inType.getDimSize(dimIdx));
+    return mlir::tensor::DimOp::create(b, loc, input, dimIdx);
+  }
+
+  // Binary shape arithmetic. hip elementwise ops are DPS, so their operands are
+  // (ctx, lhs, rhs, out); the ONNX forms are plain (lhs, rhs).
+  unsigned lhsPos = 0;
+  bool isHip =
+      mlir::isa<mlir::hip::SubOp, mlir::hip::AddOp, mlir::hip::MulOp>(def);
+  if (isHip)
+    lhsPos = 1;
+  else if (opName != "onnx.Sub" && opName != "onnx.Add" && opName != "onnx.Mul")
+    return {};
+
+  mlir::Value lhs = def->getOperand(lhsPos);
+  mlir::Value rhs = def->getOperand(lhsPos + 1);
+  // A rank-0 or single-element operand is broadcast against the other.
+  auto elemIdx = [&](mlir::Value operand) -> int64_t {
+    auto t = mlir::dyn_cast<mlir::RankedTensorType>(operand.getType());
+    return (t && t.hasStaticShape() && t.getNumElements() == 1) ? 0 : idx;
+  };
+  mlir::Value l = resolveHostIndex(b, loc, lhs, elemIdx(lhs), depth + 1);
+  mlir::Value r = resolveHostIndex(b, loc, rhs, elemIdx(rhs), depth + 1);
+  if (!l || !r)
+    return {};
+
+  bool isSub = isHip ? mlir::isa<mlir::hip::SubOp>(def) : opName == "onnx.Sub";
+  bool isAdd = isHip ? mlir::isa<mlir::hip::AddOp>(def) : opName == "onnx.Add";
+  if (isSub)
+    return mlir::arith::SubIOp::create(b, loc, l, r);
+  if (isAdd)
+    return mlir::arith::AddIOp::create(b, loc, l, r);
+  return mlir::arith::MulIOp::create(b, loc, l, r);
+}
+
+/// Emit the number of elements ONNX Slice produces on one axis, given runtime
+/// `start`/`end` bounds and a positive compile-time \p step. Mirrors the
+/// compile-time arithmetic in SliceDecompose; `arith` ops are needed here only
+/// because the bounds are not known until run time.
+static mlir::Value buildSliceExtent(mlir::OpBuilder &b, mlir::Location loc,
+                                    mlir::Value dim, mlir::Value start,
+                                    mlir::Value end, int64_t step) {
+  mlir::Value zero = mlir::arith::ConstantIndexOp::create(b, loc, 0);
+  // A negative bound counts from the end, and the sign is not known until run
+  // time, so both forms are computed and selected between. INT64_MAX ("to the
+  // end") stays positive and is caught by the clamp instead.
+  auto normalize = [&](mlir::Value v) -> mlir::Value {
+    mlir::Value shifted = mlir::arith::AddIOp::create(b, loc, v, dim);
+    mlir::Value isNeg = mlir::arith::CmpIOp::create(
+        b, loc, mlir::arith::CmpIPredicate::slt, v, zero);
+    mlir::Value picked =
+        mlir::arith::SelectOp::create(b, loc, isNeg, shifted, v);
+    picked = mlir::arith::MaxSIOp::create(b, loc, picked, zero);
+    return mlir::arith::MinSIOp::create(b, loc, picked, dim);
+  };
+  mlir::Value len =
+      mlir::arith::SubIOp::create(b, loc, normalize(end), normalize(start));
+  len = mlir::arith::MaxSIOp::create(b, loc, len, zero);
+  if (step == 1)
+    return len;
+  return mlir::arith::CeilDivSIOp::create(
+      b, loc, len, mlir::arith::ConstantIndexOp::create(b, loc, step));
 }
 
 struct SliceDecompose : public mlir::RewritePattern {
@@ -323,11 +471,28 @@ struct SliceToHip : public mlir::RewritePattern {
 
     auto dataType = mlir::cast<mlir::RankedTensorType>(data.getType());
 
-    // For each dynamic output dim, source an upper bound from the data
-    // dim at the same position. This is sound because ONNX Slice can
-    // never widen any axis -- output dim i is at most data dim i. The
-    // runtime stub honours `output_shape[i]` as the actual extent so the
-    // over-allocation is benign.
+    // Which axes are sliced, and with what step. Both must be known to compute
+    // an extent; a non-constant axes/steps operand leaves every dim on the
+    // conservative upper bound below.
+    llvm::SmallVector<int64_t> axesVec, stepsVec;
+    bool haveAxes = true;
+    if (axes)
+      haveAxes = mlir::succeeded(
+          extractSliceParamVector(op, "hipdnn.slice_axes", axes, axesVec));
+    if (haveAxes && axesVec.empty())
+      for (int64_t i : llvm::seq<int64_t>(dataType.getRank()))
+        axesVec.push_back(i);
+    if (steps && haveAxes)
+      haveAxes = mlir::succeeded(
+          extractSliceParamVector(op, "hipdnn.slice_steps", steps, stepsVec));
+    if (haveAxes && stepsVec.empty())
+      stepsVec.assign(axesVec.size(), 1);
+    if (stepsVec.size() != axesVec.size())
+      haveAxes = false;
+
+    // Compute each dynamic output dim from the slice bounds where possible;
+    // see the file header for why the data dim is not an acceptable substitute.
+    // Ops materialized by a resolution that then fails are pure and get DCE'd.
     llvm::SmallVector<mlir::Value> dynSizes;
     for (int64_t i = 0; i < resultType.getRank(); ++i) {
       if (!resultType.isDynamicDim(i))
@@ -335,11 +500,29 @@ struct SliceToHip : public mlir::RewritePattern {
       if (i >= dataType.getRank())
         return rewriter.notifyMatchFailure(
             op, "result rank exceeds data rank — invalid Slice");
-      if (dataType.isDynamicDim(i))
-        dynSizes.push_back(mlir::tensor::DimOp::create(rewriter, loc, data, i));
-      else
-        dynSizes.push_back(mlir::arith::ConstantIndexOp::create(
-            rewriter, loc, dataType.getDimSize(i)));
+
+      mlir::Value dim =
+          dataType.isDynamicDim(i)
+              ? mlir::tensor::DimOp::create(rewriter, loc, data, i).getResult()
+              : mlir::arith::ConstantIndexOp::create(rewriter, loc,
+                                                     dataType.getDimSize(i))
+                    .getResult();
+
+      mlir::Value extent;
+      if (haveAxes) {
+        for (size_t k = 0; k < axesVec.size(); ++k) {
+          int64_t axis =
+              axesVec[k] < 0 ? axesVec[k] + dataType.getRank() : axesVec[k];
+          if (axis != i || stepsVec[k] <= 0)
+            continue;
+          mlir::Value s = resolveHostIndex(rewriter, loc, starts, k, 0);
+          mlir::Value e = resolveHostIndex(rewriter, loc, ends, k, 0);
+          if (s && e)
+            extent = buildSliceExtent(rewriter, loc, dim, s, e, stepsVec[k]);
+          break;
+        }
+      }
+      dynSizes.push_back(extent ? extent : dim);
     }
     mlir::Value init =
         mlir::tensor::EmptyOp::create(rewriter, loc, resultType.getShape(),

--- a/lib/Conversion/OnnxToHip/SliceConversion.cpp
+++ b/lib/Conversion/OnnxToHip/SliceConversion.cpp
@@ -32,10 +32,12 @@ namespace {
 //     at compile time.
 //
 //   * SliceToHip (benefit=1) — fallback for non-constant indices or negative
-//     steps. Produces a native `hip.slice` DPS op whose runtime function is
-//     a stub today (throws); models that hit this path are unsupported until
-//     the runtime is implemented, but the conversion / bufferization pipeline
-//     can still verify and link the IR. Dynamic output dims are computed from
+//     steps. Produces a native `hip.slice` DPS op, executed by `wrap_slice` in
+//     Runtime/real/slice.cpp since #284 (this comment claimed a throwing stub
+//     long after that landed). Worth knowing when reading the extent logic
+//     below: that runtime D2Hs starts/ends/axes/steps and synchronizes the
+//     stream on every call, so this op already costs a host sync per
+//     execution. Dynamic output dims are computed from
 //     the slice bounds when those are host-resolvable, and otherwise fall back
 //     to `tensor.dim` on `data` (an upper bound — Slice cannot widen any axis).
 //
@@ -147,13 +149,24 @@ static constexpr int kHostIndexMaxDepth = 8;
 /// pattern and the ones rewriting the producers: `onnx.Shape` may still be
 /// present, or may already be
 /// `tensor.from_elements(arith.index_cast(tensor.dim))`, and `onnx.Sub` may
-/// already be `hip.sub`.
+/// already be `hip.sub`. On Gemma-4 26B-A4B it is in practice the ONNX
+/// spelling that arrives here, this pattern running first; the post-conversion
+/// spelling is covered by test 10 in test_slice.mlir rather than by a model,
+/// since nothing pins the order and losing either branch silently costs the
+/// extent.
 static mlir::Value resolveHostIndex(mlir::OpBuilder &b, mlir::Location loc,
                                     mlir::Value v, int64_t idx, int depth) {
-  if (!v || depth > kHostIndexMaxDepth)
+  if (!v || idx < 0 || depth > kHostIndexMaxDepth)
     return {};
   auto vType = mlir::dyn_cast<mlir::RankedTensorType>(v.getType());
   if (!vType || !vType.getElementType().isSignlessInteger())
+    return {};
+  // Bound the request against the value's own extent once, here, rather than in
+  // each producer branch: an out-of-range element must fail rather than resolve
+  // to something plausible. Without this an `onnx.Shape` narrowed by its `end`
+  // attribute would hand back dim(start + idx) for an element it does not have,
+  // which is the same class of silently-wrong extent this file exists to fix.
+  if (vType.hasStaticShape() && idx >= vType.getNumElements())
     return {};
 
   if (mlir::DenseElementsAttr dense = getCompileTimeConstantTensor(v)) {
@@ -186,7 +199,8 @@ static mlir::Value resolveHostIndex(mlir::OpBuilder &b, mlir::Location loc,
   llvm::StringRef opName = def->getName().getStringRef();
 
   // Unconverted onnx.Shape: element idx is dim (start + idx) of the operand.
-  // start/end normalization matches ShapeToTensorDims.
+  // `start` is normalized as ShapeToTensorDims normalizes it; `end` only bounds
+  // how many elements exist, which the caller-side extent check above covers.
   if (opName == "onnx.Shape") {
     mlir::Value input = def->getOperand(0);
     auto inType = mlir::dyn_cast<mlir::RankedTensorType>(input.getType());
@@ -248,8 +262,11 @@ static mlir::Value buildSliceExtent(mlir::OpBuilder &b, mlir::Location loc,
                                     mlir::Value end, int64_t step) {
   mlir::Value zero = mlir::arith::ConstantIndexOp::create(b, loc, 0);
   // A negative bound counts from the end, and the sign is not known until run
-  // time, so both forms are computed and selected between. INT64_MAX ("to the
-  // end") stays positive and is caught by the clamp instead.
+  // time, so both forms are computed and selected between. Neither sentinel
+  // exporters use needs special handling: INT64_MAX ("to the end") stays
+  // positive, so `v + dim` overflows but is never selected, and the clamp
+  // returns `dim`; INT64_MIN ("from the beginning") cannot overflow, since
+  // adding a non-negative `dim` only moves it toward zero.
   auto normalize = [&](mlir::Value v) -> mlir::Value {
     mlir::Value shifted = mlir::arith::AddIOp::create(b, loc, v, dim);
     mlir::Value isNeg = mlir::arith::CmpIOp::create(
@@ -493,6 +510,20 @@ struct SliceToHip : public mlir::RewritePattern {
     // Compute each dynamic output dim from the slice bounds where possible;
     // see the file header for why the data dim is not an acceptable substitute.
     // Ops materialized by a resolution that then fails are pure and get DCE'd.
+    //
+    // Where the bounds do not resolve, the fallback keeps the upper bound and
+    // therefore keeps the over-sized shape. It could be exact instead:
+    // CompressConversion solves the same shrinking-extent problem by reading
+    // the true count back from the device with `hip.ReadbackDimOp`. That is not
+    // done here, but not because a readback is unaffordable on this op --
+    // `wrap_slice` already D2Hs its own bounds and syncs the stream every call,
+    // so the sync is paid regardless. It is that a readback would add a second
+    // sync point, in the shape computation ahead of the slice, to serve a case
+    // no model in scope reaches: on Gemma-4 every sliced axis resolves from its
+    // bounds, and host arithmetic is strictly better than a readback wherever
+    // it is available. If a model does land here, revisit it -- the cost is
+    // lower than it looks. Hence the debug line below: the fallback is a known
+    // performance cliff, and it should be findable without an RGP capture.
     llvm::SmallVector<mlir::Value> dynSizes;
     for (int64_t i = 0; i < resultType.getRank(); ++i) {
       if (!resultType.isDynamicDim(i))
@@ -509,12 +540,20 @@ struct SliceToHip : public mlir::RewritePattern {
                     .getResult();
 
       mlir::Value extent;
+      // An axis `axes` does not name is not sliced at all, so the data dim is
+      // its exact extent rather than a fallback. Only an axis this op really
+      // slices can land on the upper bound, so only that is worth reporting --
+      // and if `axes` itself was unreadable, any axis might be sliced.
+      bool axisIsSliced = !haveAxes;
       if (haveAxes) {
         for (size_t k = 0; k < axesVec.size(); ++k) {
           int64_t axis =
               axesVec[k] < 0 ? axesVec[k] + dataType.getRank() : axesVec[k];
-          if (axis != i || stepsVec[k] <= 0)
+          if (axis != i)
             continue;
+          axisIsSliced = true;
+          if (stepsVec[k] <= 0)
+            break;
           mlir::Value s = resolveHostIndex(rewriter, loc, starts, k, 0);
           mlir::Value e = resolveHostIndex(rewriter, loc, ends, k, 0);
           if (s && e)
@@ -522,6 +561,13 @@ struct SliceToHip : public mlir::RewritePattern {
           break;
         }
       }
+      if (!extent && axisIsSliced)
+        LLVM_DEBUG(llvm::dbgs()
+                   << "[" DEBUG_TYPE "] slice extent for dim " << i
+                   << " falls back to the data dim: no host-resolvable bounds "
+                      "(or a non-positive step), so consumers see an upper "
+                      "bound rather than the slice length -- "
+                   << *op << "\n");
       dynSizes.push_back(extent ? extent : dim);
     }
     mlir::Value init =

--- a/test/lit/Conversion/onnx-to-hip/test_slice.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_slice.mlir
@@ -175,10 +175,12 @@ module {
         : (tensor<?x?xi64>, tensor<1xi64>, tensor<1xi64>,
            tensor<1xi64>) -> tensor<?x?xi64>
 
-    // `starts` resolves through the already-lowered shape arithmetic
-    // (hip.sub of two from_elements) to an index-domain subi of the two dims,
-    // and the extent is the clamped end minus the clamped start. Dim 0, which
-    // axes does not touch, still forwards the data dim.
+    // SliceToHip fires before the operands are rewritten, so `starts` resolves
+    // through the ONNX spelling (onnx.Sub of two onnx.Shape) and the walker
+    // emits the tensor.dim / arith.subi below itself. That is also the order
+    // Gemma-4 takes in the real pipeline, so this is the production path; test
+    // 10 covers the post-conversion spelling, which the same walk accepts
+    // because the greedy driver does not guarantee either order.
     // CHECK: %[[D0:.*]] = tensor.dim %arg1, %{{.*}} : tensor<?x?xi64>
     // CHECK: %[[D1:.*]] = tensor.dim %arg1, %{{.*}} : tensor<?x?xi64>
     // CHECK: arith.subi %{{.*}}, %{{.*}} : index
@@ -208,5 +210,51 @@ module {
     // CHECK: tensor.empty(%[[DIM]]) : tensor<?xi64>
     // CHECK: hip.slice
     return %r : tensor<?xi64>
+  }
+
+  // Test 10: the same idiom already rewritten into the post-conversion
+  // spelling, which is the other order the greedy driver may produce and which
+  // test 8 therefore does not reach. Feeding it pre-lowered pins that branch of
+  // the walk: `from_elements(index_cast(tensor.dim))` for the shapes and
+  // hip.sub for the arithmetic, with the index_cast unwrapped rather than cast
+  // a second time. Without a test here, an ordering change elsewhere would
+  // silently drop back to the data-dim upper bound and nothing would fail.
+  func.func @test_slice_native_lowered_shape_sub_extent(
+      %ctx: !hip.context, %data: tensor<?x?xi64>, %ids: tensor<?x?xi64>,
+      %attn: tensor<?x?xi64>) -> tensor<?x?xi64> {
+    // CHECK-LABEL: func.func @test_slice_native_lowered_shape_sub_extent
+    %c1 = arith.constant 1 : index
+    %axes = arith.constant dense<[1]> : tensor<1xi64>
+
+    %ids_dim = tensor.dim %ids, %c1 : tensor<?x?xi64>
+    %ids_i64 = arith.index_cast %ids_dim : index to i64
+    %ids_len = tensor.from_elements %ids_i64 : tensor<1xi64>
+
+    %attn_dim = tensor.dim %attn, %c1 : tensor<?x?xi64>
+    %attn_i64 = arith.index_cast %attn_dim : index to i64
+    %attn_len = tensor.from_elements %attn_i64 : tensor<1xi64>
+
+    %sub_init = tensor.empty() : tensor<1xi64>
+    %starts = hip.sub(%ctx) ins(%attn_len, %ids_len : tensor<1xi64>,
+        tensor<1xi64>) outs(%sub_init : tensor<1xi64>) : tensor<1xi64>
+
+    %r = "onnx.Slice"(%data, %starts, %attn_len, %axes)
+        : (tensor<?x?xi64>, tensor<1xi64>, tensor<1xi64>,
+           tensor<1xi64>) -> tensor<?x?xi64>
+
+    // The bounds resolve to the two dims the from_elements were packed from,
+    // with the index_cast unwrapped, so `starts` is an index-domain subi of
+    // them; the extent is then the clamped end minus the clamped start, not the
+    // data dim.
+    // CHECK: %[[D0:.*]] = tensor.dim %arg1, %{{.*}} : tensor<?x?xi64>
+    // CHECK: %[[D1:.*]] = tensor.dim %arg1, %{{.*}} : tensor<?x?xi64>
+    // CHECK: arith.subi %{{.*}}, %{{.*}} : index
+    // CHECK: %[[LO:.*]] = arith.minsi %{{.*}}, %[[D1]] : index
+    // CHECK: %[[HI:.*]] = arith.minsi %{{.*}}, %[[D1]] : index
+    // CHECK: %[[LEN:.*]] = arith.subi %[[HI]], %[[LO]] : index
+    // CHECK: %[[EXT:.*]] = arith.maxsi %[[LEN]], %{{.*}} : index
+    // CHECK: tensor.empty(%[[D0]], %[[EXT]]) : tensor<?x?xi64>
+    // CHECK: hip.slice
+    return %r : tensor<?x?xi64>
   }
 }

--- a/test/lit/Conversion/onnx-to-hip/test_slice.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_slice.mlir
@@ -127,8 +127,9 @@ module {
 
   // Test 7: SliceDecompose bails when a sliced axis has a dynamic
   // input dim (ONNX clamping rules need the static dim size); falls
-  // through to hip.slice. The data dim is forwarded as an upper-bound
-  // tensor.dim for the dynamic output dim.
+  // through to hip.slice. The output extent is still the slice length --
+  // clamp(end) - clamp(start) -- not the data dim, which is only an upper
+  // bound and would be handed to every consumer as the shape.
   func.func @test_slice_native_dyn_axis(%input: tensor<?xf32>) -> tensor<?xf32> {
     // CHECK-LABEL: func.func @test_slice_native_dyn_axis
     %starts = arith.constant dense<[1]> : tensor<1xi64>
@@ -140,10 +141,72 @@ module {
            tensor<1xi64>, tensor<1xi64>) -> tensor<?xf32>
 
     // CHECK-NOT: tensor.extract_slice
-    // CHECK-DAG: %[[A0:.*]] = arith.constant 0 : index
-    // CHECK-DAG: %[[DIM:.*]] = tensor.dim %{{.*}}, %[[A0]] : tensor<?xf32>
-    // CHECK: tensor.empty(%[[DIM]]) : tensor<?xf32>
+    // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+    // CHECK-DAG: %[[C3:.*]] = arith.constant 3 : index
+    // CHECK-DAG: %[[DIM:.*]] = tensor.dim %{{.*}} : tensor<?xf32>
+    // CHECK: %[[LO:.*]] = arith.minsi %{{.*}}, %[[DIM]] : index
+    // CHECK: %[[HI:.*]] = arith.minsi %{{.*}}, %[[DIM]] : index
+    // CHECK: %[[LEN:.*]] = arith.subi %[[HI]], %[[LO]] : index
+    // CHECK: %[[EXT:.*]] = arith.maxsi %[[LEN]], %{{.*}} : index
+    // CHECK: tensor.empty(%[[EXT]]) : tensor<?xf32>
     // CHECK: hip.slice({{.*}}) ins({{.*}}, {{.*}}, {{.*}} : tensor<?xf32>, tensor<1xi64>, tensor<1xi64>)
     return %r : tensor<?xf32>
+  }
+
+  // Test 8: the decode-mask idiom from Gemma-4 26B-A4B. `starts` is
+  // Shape(attn)[1] - Shape(ids)[1] and `ends` is Shape(attn)[1], so the slice
+  // keeps the current query positions only -- one row during decode. Both
+  // bounds are host arithmetic over onnx.Shape, so the extent is computable
+  // with no device readback, and the resulting empty must NOT be sized by the
+  // data dim: that is what inflated the causal mask to [1, S, S] and cost 60%
+  // of a decode step.
+  func.func @test_slice_native_shape_sub_extent(
+      %data: tensor<?x?xi64>, %ids: tensor<?x?xi64>, %attn: tensor<?x?xi64>)
+      -> tensor<?x?xi64> {
+    // CHECK-LABEL: func.func @test_slice_native_shape_sub_extent
+    %axes = arith.constant dense<[1]> : tensor<1xi64>
+    %ids_len  = "onnx.Shape"(%ids)  {start = 1 : si64, end = 2 : si64}
+        : (tensor<?x?xi64>) -> tensor<1xi64>
+    %attn_len = "onnx.Shape"(%attn) {start = 1 : si64, end = 2 : si64}
+        : (tensor<?x?xi64>) -> tensor<1xi64>
+    %starts = "onnx.Sub"(%attn_len, %ids_len)
+        : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+    %r = "onnx.Slice"(%data, %starts, %attn_len, %axes)
+        : (tensor<?x?xi64>, tensor<1xi64>, tensor<1xi64>,
+           tensor<1xi64>) -> tensor<?x?xi64>
+
+    // `starts` resolves through the already-lowered shape arithmetic
+    // (hip.sub of two from_elements) to an index-domain subi of the two dims,
+    // and the extent is the clamped end minus the clamped start. Dim 0, which
+    // axes does not touch, still forwards the data dim.
+    // CHECK: %[[D0:.*]] = tensor.dim %arg1, %{{.*}} : tensor<?x?xi64>
+    // CHECK: %[[D1:.*]] = tensor.dim %arg1, %{{.*}} : tensor<?x?xi64>
+    // CHECK: arith.subi %{{.*}}, %{{.*}} : index
+    // CHECK: %[[LO:.*]] = arith.minsi %{{.*}}, %[[D1]] : index
+    // CHECK: %[[HI:.*]] = arith.minsi %{{.*}}, %[[D1]] : index
+    // CHECK: %[[LEN:.*]] = arith.subi %[[HI]], %[[LO]] : index
+    // CHECK: %[[EXT:.*]] = arith.maxsi %[[LEN]], %{{.*}} : index
+    // CHECK: tensor.empty(%[[D0]], %[[EXT]]) : tensor<?x?xi64>
+    // CHECK: hip.slice
+    return %r : tensor<?x?xi64>
+  }
+
+  // Test 9: an opaque `starts` (a graph input, not shape arithmetic) is not
+  // host-resolvable, so the extent falls back to the data dim upper bound
+  // rather than emitting an extent that cannot be justified.
+  func.func @test_slice_native_opaque_starts(
+      %data: tensor<?xi64>, %starts: tensor<1xi64>, %ends: tensor<1xi64>)
+      -> tensor<?xi64> {
+    // CHECK-LABEL: func.func @test_slice_native_opaque_starts
+    %axes = arith.constant dense<[0]> : tensor<1xi64>
+    %r = "onnx.Slice"(%data, %starts, %ends, %axes)
+        : (tensor<?xi64>, tensor<1xi64>, tensor<1xi64>,
+           tensor<1xi64>) -> tensor<?xi64>
+
+    // CHECK-NOT: arith.minsi
+    // CHECK: %[[DIM:.*]] = tensor.dim %arg1, %{{.*}} : tensor<?xi64>
+    // CHECK: tensor.empty(%[[DIM]]) : tensor<?xi64>
+    // CHECK: hip.slice
+    return %r : tensor<?xi64>
   }
 }


### PR DESCRIPTION
## Summary

`SliceToHip` sized every dynamic output dimension of a `hip.slice` from the data
dimension at the same position, on the grounds that ONNX Slice cannot widen an
axis so the data dim is a safe upper bound. It is a safe bound, but it is not a
safe *extent*: the size placed on the `tensor.empty` init is the output shape as
far as everything downstream is concerned, because `tensor.dim` of a DPS result
resolves through to the init.

A Slice that keeps one row of a 12k-row tensor therefore handed every consumer a
12k-row shape. On Gemma-4 26B-A4B this inflated the decode causal mask from
`[1, 1, S]` to `[1, S, S]` and cost 55% of every generated token.

Two commits: the fix, and a review follow-up (a missing bound on the shape-index
walk, a test for the one branch of it nothing covered, and the rationale that was
previously only in this description). The `ci(windows)` OGA prerequisite that was
originally in this PR has been dropped from it and is tracked in #599; until that
lands CI cannot build an OGA that runs Gemma-4 unified, so every model number
below is a local run on the machine named.

## Related issue or design

None. Same bug class as #700 (`buildExpandShapeOutputShape` deriving a dynamic
extent from the wrong source), one op over.

## Why

Gemma-4's decoder builds its causal mask from the current query positions:

```mlir
%ids_len  = onnx.Shape(%input_ids)     {start = 1, end = 2}
%attn_len = onnx.Shape(%attention_mask){start = 1, end = 2}
%start    = onnx.Sub(%attn_len, %ids_len)
%pos      = onnx.Slice(onnx.CumSum(%attention_mask), %start, %attn_len, axes=[1])
```

`ends - starts` is `Shape(input_ids)[1]`, so during decode the slice keeps
exactly one element. `starts` is not a compile-time constant, so
`SliceDecompose` bails and `SliceToHip` fires and sizes the output `12277`
instead of `1`. Every consumer of the broadcast against it then ran on `S x S`.

An RGP dispatch capture, fenced onto the first op of the mask chain in the first
decode step, shows the inflation appearing in the dispatch immediately after the
slice:

| kernel | threads | duration |
|---|---:|---:|
| `hip_cumsum_kernel<i64>` | 256 | 796 us |
| `elementwise_sub_i64_kernel` | 256 | 11 us |
| `hip_slice_kernel<i64>` | 12,288 | 2.8 us |
| `hip_expand_kernel<i64>` | 150,724,864 | **6,161 us** |

150,724,864 is `12277^2`; 1.2 GB of i64 materialized in one dispatch, for a mask
that needs 98 KB. Per-op profiling puts the whole chain
(`not`/`less`/`cast`/`sub`/`and`/`or`) at 126 ms of a 210 ms decode step.

The clearest symptom in hindsight: `not` cost 27.2 ms in a 12,276-token prefill
and 27.9 ms in a *one-token* decode step. Identical, because both were building
the same square mask.

Numerics were never wrong. The runtime slice writes the correct value at element
0, garbage after it, and GQA with `sq=1` reads only row 0 -- so the output was
right and merely 12,277x overpriced. That is also why nothing downstream could
detect it: `[1, S, S]` is a legal shape and only the value is wrong, so the fix
has to be at the point the shape is constructed.

## What

- `SliceConversion.cpp`: `SliceToHip` now computes each dynamic output extent as
  `ends - starts` when both bounds are host-resolvable, applying the ONNX
  negative-index and clamping rules with `arith` select/max/min against the data
  dim and `ceildiv` by a positive constant step.
- New `resolveHostIndex` walks a shape operand to a host `index` value through
  `tensor.from_elements` / `arith.index_cast` / `tensor.dim`, `tensor.cast`,
  compile-time constants, `onnx.Shape`, and add/sub/mul. Both the pre- and
  post-conversion spelling are accepted (`onnx.Shape` or the
  `from_elements(index_cast(dim))` that `ShapeToTensorDims` leaves, `onnx.Sub`
  or `hip.sub`), because the greedy driver gives no ordering guarantee between
  this pattern and the ones rewriting its operands.
- No device readback is added: the bounds here are host arithmetic over
  `onnx.Shape` entries, so the extent is an `index` computation.
- Unresolvable bounds, a non-constant `axes`/`steps`, or a non-positive step
  keep the previous data-dim upper bound, so no currently-working model changes
  shape.

Review follow-up, no behavior change on any path that already resolved:

- `resolveHostIndex` took `idx` on trust. Every branch that indexes a list
  checked it, but the `onnx.Shape` branch computed `dim(start + idx)` and only
  bounded the *result* against the operand rank, so an element past the end of a
  shape narrowed by its `end` attribute resolved to a real but wrong dimension.
  `idx` is now bounded against the value's own extent once at entry. That is the
  same class of silently-wrong extent this PR exists to fix, so it should not be
  reachable from here.
- The data-dim fallback now emits an `LLVM_DEBUG` line naming the op and axis.
  The original bug was invisible until an RGP capture; the fallback is a known
  performance cliff and should be findable without one. It reports only axes the
  op actually slices: an axis `axes` does not name is not sliced, so the data dim
  is its exact extent and not a fallback at all. On Gemma-4 that distinction is
  the difference between four spurious warnings per compile and none.
- Two comments corrected. The file header claimed `hip.slice`'s runtime is a
  throwing stub and that models reaching this path are unsupported; it has been
  implemented in `Runtime/real/slice.cpp` since #284 and Gemma-4 executes it
  every step. And I had justified not using the `hip.ReadbackDimOp` that
  `CompressConversion` uses by the cost of a host sync per step -- which the
  runtime contradicts, since `wrap_slice` already D2Hs its own bounds and
  synchronizes the stream on every call. The narrower real reason (a readback
  would add a second sync point ahead of the slice, for a case nothing in scope
  reaches) is now in the comment, along with the note that the cost is lower
  than it looks if a model ever does land there.
- `INT64_MIN` needing no more care than `INT64_MAX` in the bound normalization
  is now written down.

## Test plan

`test/lit/Conversion/onnx-to-hip/test_slice.mlir`:

- `test_slice_native_shape_sub_extent` pins the Gemma-4 idiom: extent comes from
  the clamped bounds, and the axis `axes` does not touch still forwards the data
  dim.
- `test_slice_native_opaque_starts` pins the fallback when `starts` is a graph
  input.
- `test_slice_native_dyn_axis` previously asserted `tensor.empty(%dim)` -- it was
  pinning the bug -- and now asserts the clamped slice length.
- `test_slice_native_lowered_shape_sub_extent` (new, from the follow-up) feeds
  the same idiom already lowered, pinning the post-conversion branch of the walk.

402 lit tests: 390 passed, 12 unsupported (pre-existing Morphizen plugin tests),
0 failures.

That last test exists because the coverage claim in this PR was wrong.
Instrumenting `resolveHostIndex` to report every spelling it visits shows that
what reaches it on Gemma-4 26B-A4B is the ONNX spelling -- `onnx.Shape` six
times, `onnx.Sub` twice, and the lowered form never -- and the same
instrumentation over the lit suite shows `test_slice_native_shape_sub_extent`
takes that same ONNX path, not the `hip.sub` of two `from_elements` its comment
claimed. Both branches emit `tensor.dim` + `arith.subi`, so the CHECKs passed
either way and the lowered branch had no coverage at all, in the suite or on a
model. Nothing pins the driver's order, so it is kept and now tested rather than
deleted.

Correctness on Gemma-4 26B-A4B FP16W4-qmoe: the 48-token completion for a
12,276-token prompt plus image is byte-identical before and after.

## Performance

Gemma-4 26B-A4B FP16W4-qmoe, gfx1151 (Strix Halo, 63.6 GB shared), Release,
`vlm_benchmark.py`, no EP instrumentation. 64 tokens generated, 3 iterations
after 1 warmup at 12,276; 32 tokens, 2 iterations after 1 warmup on the sweep.

| Metric | Before | After | |
|---|---:|---:|---|
| Token generation p50 | 250.06 ms | 111.85 ms | **2.24x** (4.00 -> 8.94 tok/s) |
| Token generation avg | 266.49 ms | 127.68 ms | **2.09x** (3.75 -> 7.83 tok/s) |
| Token generation p90 | 322.51 ms | 172.80 ms | -46% |
| TTFT p50 | 25,434 ms | 25,329 ms | unchanged |
| Peak memory | 16,234 MB | 16,210 MB | unchanged |

TTFT is unchanged by design: during prefill the mask is genuinely square, so the
inflated extent cost nothing there.

The win scales quadratically with context, because the discarded work is an
`S x S` mask where `1 x S` was needed. Full sweep, p50 ms/token:

| Prompt | Before | After | | saved |
|---|---:|---:|---|---:|
| 513 | 20.70 | 20.88 | 0.99x | -0.18 |
| 1,025 | 25.66 | 24.70 | 1.04x | 0.96 |
| 2,240 | 36.93 | 32.75 | 1.13x | 4.18 |
| 4,097 | 59.74 | 45.26 | 1.32x | 14.48 |
| 8,181 | 137.92 | 71.22 | 1.94x | 66.70 |
| 12,276 | 257.08 | 106.60 | 2.41x | 150.48 |
| 16,241 | 405.37 | 169.97 | **2.38x** | 235.40 |

At 16,241 that is 2.47 -> 5.88 tok/s. Scaling the 2,240 saving by `S^2` predicts
219.7 ms at 16,241 against 235.40 measured (+7.1%), and the 8,181 saving
predicts 150.2 at 12,276 against 150.48 (+0.2%), so the quadratic model holds
across a 7.9x span of context. The endpoints bracket it rather than sitting on
it -- 4,097 -> 8,181 runs 15.5% above the prediction and 12,276 -> 16,241 runs
10.6% below -- which is the expected shape once the per-arm std reaches 12-48 ms
at the long end. The 512 arm is a wash (std 0.26 and 0.28 against a 0.18 delta),
as it should be: there is nothing to save when `S` is small.

### Is there anything left here

Two checks say no, and both are worth having on the record.

Per-op GPU profiling of a decode step at 16,241 tokens, before and after, sums
to 371.2 -> 133.5 ms (-237.7), which independently reproduces the 235.40 ms
wall-clock saving above to within 1.0%. The ops this PR was aimed at -- the
`cast`/`not`/`less`/`or`/`sub`/`and` mask chain -- go from 236.8 ms to 1.0 ms,
63.8% of the step down to 0.75%:

| op | before | after |
|---|---:|---:|
| `cast` | 49.3 | 0.7 |
| `not` | 47.5 | 0.0 |
| `less` | 47.1 | 0.1 |
| `or` | 36.2 | 0.0 |
| `sub` | 28.7 | 0.1 |
| `and` | 27.9 | 0.0 |
| **chain** | **236.8** | **1.0** |

The call counts are identical on both sides (66 casts, 3 nots, and so on): the
ops still run, they just run on `[1, 1, S]` instead of `[1, S, S]`. Removing the
chain outright would now be worth 0.75% of a decode step, so there is no
remaining headroom in it. GQA goes from 27.3% of the step to 74.5% purely by
subtraction, and all non-GQA work put together is 34.0 ms of 133.5.

The second check is whether any extent is still an upper bound, since the
fallback is where this fix stops. Instrumenting the classification and compiling
Gemma-4: every dynamic axis the op slices resolves from its bounds, four times
out of four, and the only data-dim sizings are the untouched batch axis where
the data dim is exact. So on this model the fix is not partial -- there is no
slice left whose consumers see an inflated shape, which is also why the debug
line added here prints nothing on it.

Reproducing the 16k arm needs #787's prefill tiling in the tree; on this branch
alone 16k prefill exhausts the workspace and the process fast-fails before it
generates a token. The 2,240 arms have std 0.51 and 0.39 ms against a 5.02 ms
delta, so even the smallest real win is well clear of noise, and it matches the
model: per-op profiling put the mask chain at 126 ms at `S = 12277`, and
`126 * (2270 / 12277)^2 = 4.3 ms` predicted against 5.0 ms measured.

## Notes for reviewers

- The interesting judgement call is the fallback direction. An unresolvable bound
  keeps the old upper bound, which is wrong in the same way as before but is what
  every model on this path already runs with. `CompressConversion` solves the
  same problem exactly with a `hip.ReadbackDimOp`, and I originally justified not
  copying it on cost grounds -- wrongly, as it turns out: `wrap_slice` already
  D2Hs its bounds and syncs the stream every call, so this op pays a host sync
  per execution no matter what this pattern does. The honest position is that a
  readback would add a *second* sync point, ahead of the slice, to serve a case
  no model in scope reaches, and that host arithmetic beats a readback wherever
  it is available. If you would rather have the exact extent unconditionally,
  that is a smaller change than I first claimed and I am happy to make it. The
  fallback is also now visible under `-debug-only=convert-onnx-to-hip`.
- `resolveHostIndex` accepting both dialect spellings of the same arithmetic is
  the part I would still most like a second opinion on, but it is no longer a
  guess: measured on the model, the ONNX spelling is what fires, and the lowered
  spelling is now held up by a lit test rather than by an assumption. The
  alternative is to force an ordering between this pattern and
  `ShapeToTensorDims`, which still seems worse.
- Ops materialized by a resolution attempt that then fails are pure and left for
  DCE rather than tracked and erased.
- Peak memory does not improve because prefill, where the mask really is square,
  sets the high-water mark.
- Where the earlier note about GQA went. This PR made GQA 70% of the decode step,
  and per-op profiling reported it at 68 ms against 48 ms before at nearly
  identical `skv`, which I could not explain and still cannot -- it does not
  appear in the uninstrumented wall-clock numbers above. What profiling it did
  settle is what that 70% consists of, which was worth knowing: at 16k the KV
  cache copy is 79.5 ms/token of it, measured by ablating the copy (143.9 ->
  64.5 ms/token), because Gemma-4 exports `present` as
  `past_sequence_len + sequence_len`, so past and present are distinct buffers
  and every layer rewrites the whole cache every token. #780 (merged) cuts that
  copy directly. The sliding-window read, which looked like the obvious suspect
  because the local layers were reading the entire cache to mask 15/16ths of it
  away, is worth only ~18 ms/token by comparison (#795, draft). Neither changes
  anything in this PR; recording it so the next person does not re-derive it.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the
      result.

AI assistance: the diagnosis (IR dumps, the fenced RGP dispatch capture, the
prefill-vs-decode per-op comparison that isolated the square mask), the patch,
the tests and the benchmark runs were produced with Cursor. All measurements are
from real runs on the machine named, and I reviewed the change.
