### PR TITLE
testing PR780 on latest main with the AMDGPU OGA fork build

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -51,11 +51,14 @@ jobs:
       ONNXRUNTIME_PR_PATCHES: ""
       SCCACHE_GHA_ENABLED: "true"
       SCCACHE_GHA_RW_MODE: ${{ github.ref_name == 'main' && 'READ_WRITE' || 'READ_ONLY' }}
-      OGA_VERSION: "0.14.0"
-      # Space-separated microsoft/onnxruntime-genai PR numbers fetched from
-      # pull/<n>.patch and `git apply` on top of v<OGA_VERSION>. Part of the OGA
-      # cache key. Remove a PR once it lands in the pinned OGA release.
-      OGA_PR_PATCHES: "2194"
+      # Fork branch carrying AMDGPU MorphiZen integration (former PR 2194) plus
+      # sliding_window support.
+      OGA_REPO: "amd-genmingz/onnxruntime-genai"
+      OGA_REF: "test_0_3"
+      # Optional space-separated microsoft/onnxruntime-genai PR numbers applied
+      # on top of the fork checkout via pull/<n>.patch + git am. Empty when the
+      # fork branch already carries the needed integration.
+      OGA_PR_PATCHES: ""
       # ilammy/msvc-dev-cmd and mozilla-actions/sccache-action have no
       # Node.js 24 releases yet; allow Node.js 20 until they are updated.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
@@ -357,22 +360,19 @@ jobs:
         with:
           path: ${{ runner.workspace }}/oga-artifacts
           # OGA is built against the patched ort-install, so the key folds in
-          # both OGA's own PR list and ONNXRUNTIME_PR_PATCHES; editing either
-          # forces a rebuild. The mm<N> token bumps when the OGA artifact set
-          # changes shape, or when a PR's branch content changes under the same
-          # number (mm2: PR 2194 now carries the AMDGPU OGA integration).
-          key: oga-dml-mm2-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
+          # the fork ref, optional OGA_PR_PATCHES, and ONNXRUNTIME_PR_PATCHES.
+          # The mm<N> token bumps when the OGA artifact set changes shape.
+          key: oga-dml-mm3-${{ env.OGA_REPO }}-${{ env.OGA_REF }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}-2
 
-      # OGA is built from upstream microsoft/onnxruntime-genai + PR patches
-      # (OGA_PR_PATCHES). PR 2194 (the dynamic-shape-morphizen branch) now also
-      # carries the AMDGPU umbrella integration, so the patched upstream build
-      # is the AMDGPU-targeted OGA -- no fork checkout needed.
+      # OGA is built from the OGA_REPO fork branch (AMDGPU MorphiZen integration
+      # + sliding_window). Optional OGA_PR_PATCHES apply extra upstream PRs on
+      # top of the fork checkout.
       - name: Checkout OGA
         if: steps.cache-oga.outputs.cache-hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: microsoft/onnxruntime-genai
-          ref: v${{ env.OGA_VERSION }}
+          repository: ${{ env.OGA_REPO }}
+          ref: ${{ env.OGA_REF }}
           path: source-oga
           submodules: true
           fetch-depth: 1

--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -341,6 +341,23 @@ __global__ void transpose_mid_dims_kernel(
 // Ref: onnxruntime/contrib_ops/cpu/bert/gqa_attention_base.h (ConcatStateChunkGQA)
 // -------------------------------------------------------------------------
 
+// Widest copy unit for the KV data-movement kernels. Both append and concat are
+// pure relocation, so the element type only matters for indexing -- the payload
+// can move as opaque 16 B chunks. One fp16 per lane leaves the copy issue-rate
+// limited well short of the memory roofline (measured ~99 GB/s of 256 GB/s at
+// 12K context); eight per lane is what closes that gap.
+struct __align__(16) KvVec16 {
+  uint32_t x, y, z, w;
+};
+
+// The vectorised path indexes in KvVec16 units, which is only valid when the
+// head dim divides evenly and every buffer is 16 B aligned. Element offsets are
+// then automatically aligned too: each is (multiple of d) + (multiple of VEC),
+// and d % VEC == 0. Callers fall back to the scalar kernel when this fails.
+static inline bool kv_is_16b_aligned(const void* p) {
+  return (reinterpret_cast<uintptr_t>(p) & 15u) == 0;
+}
+
 template <typename T>
 __global__ void kv_cache_append_kernel(
     const T* __restrict__ src,
@@ -363,6 +380,35 @@ __global__ void kv_cache_append_kernel(
   int src_idx = ((batch_idx * sq + s) * G + g) * d + di;
   int dst_idx = ((batch_idx * G + g) * present_seq + (eff_past_len + s)) * d + di;
   cache[dst_idx] = src[src_idx];
+}
+
+// 16 B-per-lane form of kv_cache_append_kernel. VEC elements of T are moved as
+// one KvVec16, so the thread count drops by VEC and each lane issues a single
+// dwordx4. Indexing is identical, just in vector units along d.
+template <typename T, int VEC>
+__global__ void kv_cache_append_vec_kernel(
+    const T* __restrict__ src,
+    T* __restrict__ cache,
+    int sq, int G, int d, int present_seq, int past_len,
+    const int* __restrict__ seqlens_k) {
+  const int batch_idx = __builtin_amdgcn_readfirstlane(blockIdx.y);
+  int eff_past_len = seqlens_k ? (seqlens_k[batch_idx] + 1 - sq) : past_len;
+  if (eff_past_len < 0 || eff_past_len + sq > present_seq) return;
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int dv = d / VEC;
+  int total_per_batch = sq * G * dv;
+  if (idx >= total_per_batch) return;
+
+  int dvi = idx % dv;
+  int remaining = idx / dv;
+  int g = remaining % G;
+  int s = remaining / G;
+
+  int src_idx = ((batch_idx * sq + s) * G + g) * d + dvi * VEC;
+  int dst_idx =
+      ((batch_idx * G + g) * present_seq + (eff_past_len + s)) * d + dvi * VEC;
+  *reinterpret_cast<KvVec16*>(cache + dst_idx) =
+      *reinterpret_cast<const KvVec16*>(src + src_idx);
 }
 
 // -------------------------------------------------------------------------
@@ -410,6 +456,42 @@ __global__ void kv_cache_concat_kernel(
     int cs = s - past_len;
     int src_idx = ((batch_idx * sq + cs) * G + g) * d + di;
     present[dst_idx] = current[src_idx];
+  }
+}
+
+// 16 B-per-lane form of kv_cache_concat_kernel. A VEC-wide chunk never straddles
+// the past/new boundary (the split is along s, the chunk runs along d), so the
+// source branch stays uniform per lane exactly as in the scalar kernel.
+template <typename T, int VEC>
+__global__ void kv_cache_concat_vec_kernel(
+    const T* __restrict__ past,
+    const T* __restrict__ current,
+    T* __restrict__ present,
+    int past_len, int sq, int G, int d,
+    int past_seq, int present_seq) {
+  const int batch_idx = __builtin_amdgcn_readfirstlane(blockIdx.y);
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  const int dv = d / VEC;
+  int total_seq = past_len + sq;
+  int total_per_batch = total_seq * G * dv;
+  if (idx >= total_per_batch) return;
+
+  int dvi = idx % dv;
+  int remaining = idx / dv;
+  int g = remaining % G;
+  int s = remaining / G;
+
+  int dst_idx = ((batch_idx * G + g) * present_seq + s) * d + dvi * VEC;
+
+  if (s < past_len) {
+    int src_idx = ((batch_idx * G + g) * past_seq + s) * d + dvi * VEC;
+    *reinterpret_cast<KvVec16*>(present + dst_idx) =
+        *reinterpret_cast<const KvVec16*>(past + src_idx);
+  } else {
+    int cs = s - past_len;
+    int src_idx = ((batch_idx * sq + cs) * G + g) * d + dvi * VEC;
+    *reinterpret_cast<KvVec16*>(present + dst_idx) =
+        *reinterpret_cast<const KvVec16*>(current + src_idx);
   }
 }
 
@@ -748,6 +830,16 @@ static void launch_kv_cache_append(
     hipStream_t stream, const void* src, void* cache,
     int batch_size, int sq, int G, int d, int present_seq, int past_len,
     const void* seqlens_k) {
+  constexpr int VEC = 16 / sizeof(T);
+  if ((d % VEC) == 0 && kv_is_16b_aligned(src) && kv_is_16b_aligned(cache)) {
+    int total = sq * G * (d / VEC);
+    int blocks = (total + GQA_THREADS - 1) / GQA_THREADS;
+    kv_cache_append_vec_kernel<T, VEC><<<dim3(blocks, batch_size), GQA_THREADS,
+                                         0, stream>>>(
+        static_cast<const T*>(src), static_cast<T*>(cache),
+        sq, G, d, present_seq, past_len, static_cast<const int*>(seqlens_k));
+    return;
+  }
   int total = sq * G * d;
   int blocks = (total + GQA_THREADS - 1) / GQA_THREADS;
   kv_cache_append_kernel<T><<<dim3(blocks, batch_size), GQA_THREADS, 0,
@@ -762,6 +854,17 @@ static void launch_kv_cache_concat(
     int batch_size, int past_len, int sq, int G, int d,
     int past_seq, int present_seq) {
   int total_seq = past_len + sq;
+  constexpr int VEC = 16 / sizeof(T);
+  if ((d % VEC) == 0 && kv_is_16b_aligned(past) && kv_is_16b_aligned(current) &&
+      kv_is_16b_aligned(present)) {
+    int total = total_seq * G * (d / VEC);
+    int blocks = (total + GQA_THREADS - 1) / GQA_THREADS;
+    kv_cache_concat_vec_kernel<T, VEC><<<dim3(blocks, batch_size), GQA_THREADS,
+                                         0, stream>>>(
+        static_cast<const T*>(past), static_cast<const T*>(current),
+        static_cast<T*>(present), past_len, sq, G, d, past_seq, present_seq);
+    return;
+  }
   int total = total_seq * G * d;
   int blocks = (total + GQA_THREADS - 1) / GQA_THREADS;
   kv_cache_concat_kernel<T><<<dim3(blocks, batch_size), GQA_THREADS, 0,


### PR DESCRIPTION
Testing branch: latest main + the AMDGPU OGA fork CI switch + PR #780. Do not merge.

PR #780 itself is now clean (main + the perf commit only) after `c0798598` was dropped from it as testing-only. This branch puts that CI commit back alongside the perf work so the kernel change can be exercised against the fork OGA build.

## Contents

| Commit | Source | What it does |
| --- | --- | --- |
| d47479fe | `c0798598` (testing only) | Points the OGA build at `amd-genmingz/onnxruntime-genai` ref `test_0_3` instead of upstream v0.14.0 + PR 2194. |
| 1bb801ef | PR #780 | Moves the GQA KV cache append/concat to 16 B per lane (-15.4% decode ms/token at 12K). |

Both commits are byte-identical to their sources, verified with `git range-diff`. Cherry-picked onto main (`26a6f1d2`) with no conflicts.

## Notes

The workflow is coherent after the pick: no `OGA_VERSION` references remain, main's `SCCACHE_GHA_RW_MODE` gating from PR #768 is preserved, and the OGA cache key is at `-2`.

Because this branch is not `main`, that sccache gating makes the cache `READ_ONLY` here, so the Windows build will be slower than on `main`.

`lib/Runtime/Kernels/hip/gqa_kernel.hip` is formatter-exempt in `.lintrunner.toml`, so the kernel change is not subject to clang-format.