### PR TITLE
ci(cache): run sccache against a local directory instead of the GHA backend

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -581,12 +581,15 @@ jobs:
           retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 14 || 3 }}
 
       - name: Flush sccache
+        if: always()
+        continue-on-error: true
         run: |
           sccache --show-stats
           sccache --stop-server || true
 
       - name: Save sccache directory
-        if: github.ref_name == 'main'
+        if: always() && github.ref_name == 'main'
+        continue-on-error: true
         uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: ${{ runner.workspace }}/sccache-dir

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -580,13 +580,6 @@ jobs:
           path: staging/
           retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 14 || 3 }}
 
-      - name: Flush sccache
-        if: always()
-        continue-on-error: true
-        run: |
-          sccache --show-stats
-          sccache --stop-server || true
-
       - name: Save sccache directory
         if: always() && github.ref_name == 'main'
         continue-on-error: true

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -20,9 +20,6 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  # Route sccache through the GitHub Actions cache.
-  SCCACHE_GHA_ENABLED: "true"
-  SCCACHE_GHA_RW_MODE: ${{ github.ref_name == 'main' && 'READ_WRITE' || 'READ_ONLY' }}
   # Pins (kept in lockstep with cmake/deps.txt).
   # LLVM/MLIR/LLD are built from source at this upstream release tag; bumping it
   # only invalidates the llvm-install cache.
@@ -116,8 +113,19 @@ jobs:
           cmake --version
           ninja --version
 
-      # sccache (GitHub Actions cache backend) accelerates the from-source
-      # compiles (LLVM, the project, OGA) on cache miss.
+      - name: Prepare sccache local cache
+        run: |
+          echo "SCCACHE_DIR=${{ runner.workspace }}/sccache-dir" >> $GITHUB_ENV
+          echo "SCCACHE_KEY_DATE=$(date -u +'%Y%m%d')" >> $GITHUB_ENV
+
+      - name: Restore sccache directory
+        uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: ${{ runner.workspace }}/sccache-dir
+          key: sccache-linux-${{ env.SCCACHE_KEY_DATE }}
+          restore-keys: |
+            sccache-linux-
+
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
@@ -571,3 +579,15 @@ jobs:
           name: linux-gpu-test-package
           path: staging/
           retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 14 || 3 }}
+
+      - name: Flush sccache
+        run: |
+          sccache --show-stats
+          sccache --stop-server || true
+
+      - name: Save sccache directory
+        if: github.ref_name == 'main'
+        uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: ${{ runner.workspace }}/sccache-dir
+          key: sccache-linux-${{ env.SCCACHE_KEY_DATE }}

--- a/.github/workflows/windows-build-mock.yml
+++ b/.github/workflows/windows-build-mock.yml
@@ -37,8 +37,6 @@ jobs:
       # Must match windows-build.yml verbatim: it is part of the shared
       # ort-install cache key and drives the same patch set.
       ONNXRUNTIME_PR_PATCHES: ""
-      SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_GHA_RW_MODE: ${{ github.ref_name == 'main' && 'READ_WRITE' || 'READ_ONLY' }}
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
 
     steps:
@@ -88,6 +86,20 @@ jobs:
 
       - name: Setup MSVC environment
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
+      - name: Prepare sccache local cache
+        shell: bash
+        run: |
+          echo "SCCACHE_DIR=${{ runner.workspace }}/sccache-dir" >> $GITHUB_ENV
+          echo "SCCACHE_KEY_DATE=$(date -u +'%Y%m%d')" >> $GITHUB_ENV
+
+      - name: Restore sccache directory
+        uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: ${{ runner.workspace }}/sccache-dir
+          key: sccache-windows-mock-${{ env.SCCACHE_KEY_DATE }}
+          restore-keys: |
+            sccache-windows-mock-
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -256,3 +268,16 @@ jobs:
           cmake -B "$BUILD" -DHIPDNN_EP_COMPILER_PLUGINS=sample
           cmake --build "$BUILD" --config Release --target test_static_plugins
           ctest --test-dir "$BUILD" -C Release -R StaticPlugins --output-on-failure
+
+      - name: Flush sccache
+        shell: bash
+        run: |
+          sccache --show-stats
+          sccache --stop-server || true
+
+      - name: Save sccache directory
+        if: github.ref_name == 'main'
+        uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: ${{ runner.workspace }}/sccache-dir
+          key: sccache-windows-mock-${{ env.SCCACHE_KEY_DATE }}

--- a/.github/workflows/windows-build-mock.yml
+++ b/.github/workflows/windows-build-mock.yml
@@ -269,14 +269,6 @@ jobs:
           cmake --build "$BUILD" --config Release --target test_static_plugins
           ctest --test-dir "$BUILD" -C Release -R StaticPlugins --output-on-failure
 
-      - name: Flush sccache
-        if: always()
-        continue-on-error: true
-        shell: bash
-        run: |
-          sccache --show-stats
-          sccache --stop-server || true
-
       - name: Save sccache directory
         if: always() && github.ref_name == 'main'
         continue-on-error: true

--- a/.github/workflows/windows-build-mock.yml
+++ b/.github/workflows/windows-build-mock.yml
@@ -270,13 +270,16 @@ jobs:
           ctest --test-dir "$BUILD" -C Release -R StaticPlugins --output-on-failure
 
       - name: Flush sccache
+        if: always()
+        continue-on-error: true
         shell: bash
         run: |
           sccache --show-stats
           sccache --stop-server || true
 
       - name: Save sccache directory
-        if: github.ref_name == 'main'
+        if: always() && github.ref_name == 'main'
+        continue-on-error: true
         uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: ${{ runner.workspace }}/sccache-dir

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -675,13 +675,16 @@ jobs:
           retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 14 || 3 }}
 
       - name: Flush sccache
+        if: always()
+        continue-on-error: true
         shell: bash
         run: |
           sccache --show-stats
           sccache --stop-server || true
 
       - name: Save sccache directory
-        if: github.ref_name == 'main'
+        if: always() && github.ref_name == 'main'
+        continue-on-error: true
         uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: ${{ runner.workspace }}/sccache-dir

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -674,14 +674,6 @@ jobs:
           path: wheelpkg/
           retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 14 || 3 }}
 
-      - name: Flush sccache
-        if: always()
-        continue-on-error: true
-        shell: bash
-        run: |
-          sccache --show-stats
-          sccache --stop-server || true
-
       - name: Save sccache directory
         if: always() && github.ref_name == 'main'
         continue-on-error: true

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -49,8 +49,6 @@ jobs:
       # editing this list auto-invalidates the cached ORT install prefix.
       # Remove a PR number once its fix is in the pinned ONNXRUNTIME_VERSION.
       ONNXRUNTIME_PR_PATCHES: ""
-      SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_GHA_RW_MODE: ${{ github.ref_name == 'main' && 'READ_WRITE' || 'READ_ONLY' }}
       OGA_VERSION: "0.14.0"
       # Space-separated microsoft/onnxruntime-genai PR numbers fetched from
       # pull/<n>.patch and `git apply` on top of v<OGA_VERSION>. Part of the OGA
@@ -113,7 +111,20 @@ jobs:
       - name: Setup MSVC environment
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
-      # Cache compilation results across runs via GitHub Actions Cache backend
+      - name: Prepare sccache local cache
+        shell: bash
+        run: |
+          echo "SCCACHE_DIR=${{ runner.workspace }}/sccache-dir" >> $GITHUB_ENV
+          echo "SCCACHE_KEY_DATE=$(date -u +'%Y%m%d')" >> $GITHUB_ENV
+
+      - name: Restore sccache directory
+        uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: ${{ runner.workspace }}/sccache-dir
+          key: sccache-windows-real-${{ env.SCCACHE_KEY_DATE }}
+          restore-keys: |
+            sccache-windows-real-
+
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
@@ -662,6 +673,19 @@ jobs:
           name: hip-python-package
           path: wheelpkg/
           retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 14 || 3 }}
+
+      - name: Flush sccache
+        shell: bash
+        run: |
+          sccache --show-stats
+          sccache --stop-server || true
+
+      - name: Save sccache directory
+        if: github.ref_name == 'main'
+        uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        with:
+          path: ${{ runner.workspace }}/sccache-dir
+          key: sccache-windows-real-${{ env.SCCACHE_KEY_DATE }}
 
   # ---------------------------------------------------------------------------
   # GPU test job: runs on the self-hosted machine with a real AMD GPU.


### PR DESCRIPTION
## Summary

Point sccache at a local directory instead of the GitHub Actions cache backend, and ship that directory as a single cache entry keyed per platform and rolled daily. This removes ~950-1200 cache API calls per build job, which is what exhausts the repository download quota and makes the dependency-cache restores fail with 429.

## Related issue or design

Follow-up to #778.

## Why

The GHA cache backend stores one entry per translation unit. A warm build job issues 950 (Linux), 948 (Windows) or 1194 (Windows mock) requests over a compile window of 4 to 13 minutes, which is 70 to 229 requests per minute per job against a repository-wide budget of 1500 downloads/min. Three concurrent PR builds are enough to saturate it, and a dependency-cache restore that gets a 429 is what turns a warm 10 minute run into a 3 hour cold LLVM rebuild.

#778 pinned `actions/cache` back to v5.0.1 so a 429 retries instead of reporting a miss, but its retry window is 24 to 35 seconds against a one-minute rate-limit window, so a sustained burst still exhausts it. Reducing the request count is the part that actually removes the pressure.

Those per-object entries are also a poor fit for the storage they occupy: the repository currently holds 11904 sccache entries totalling 563 MB, an average of 46 KB each. They are 99.8% of the entry count and 8% of the bytes. One packed directory per platform per day carries the same content in 3 requests.

## What

All three build workflows (`linux-build.yml`, `windows-build.yml`, `windows-build-mock.yml`) get the same shape:

- `SCCACHE_GHA_ENABLED` / `SCCACHE_GHA_RW_MODE` removed, so sccache falls back to its local disk backend.
- `SCCACHE_DIR` is exported from a step rather than the env block, because the `runner` context is not available at job or workflow level.
- `actions/cache/restore` before `Setup sccache`, `actions/cache/save` at the end of the job, both v5.0.1.
- Key is `sccache-<platform>-<UTC date>` with a `sccache-<platform>-` prefix in `restore-keys`. A cache entry cannot be overwritten, so a fixed key would freeze the directory at its first contents; the daily roll lets each day publish a fresh snapshot and GitHub's 7-day unused-entry expiry retires the old ones.
- Save runs `if: always() && github.ref_name == 'main'`. `always()` because a job that times out mid-LLVM-build still holds objects worth publishing, and sccache entries are keyed by compilation input so a partial build contributes valid ones. `continue-on-error` keeps an early failure, before the directory exists, from adding a second red mark.

The three platforms keep separate keys rather than sharing a Windows one. `restore-keys` resolves to exactly one entry, and the real Windows build compiles for 13:27 against the mock's 6:03, so under a shared key the mock always writes first and the real job's objects would never be published.

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] All three workflows parse as YAML, with `Prepare` / `Restore` ordered before every compile step and `Save` after them
- [x] The backend switch is live on all three platforms: `Cache location  Local disk: ".../sccache-dir"`, with 951 (Linux), 866 (mock) and 1096 (Windows) compile requests. All were misses, as expected while main has published no snapshot yet
- [x] `Save sccache directory` is skipped on the PR run, and no dependency-cache restore reported 429
- [ ] `Post Setup sccache` reports the real numbers in the job summary
- [ ] Once main publishes a snapshot, the next PR restores it at a hit rate near the GHA-backend baseline (Linux 99.68%, mock 98.66%, Windows 98.42%)

## Notes for reviewers

PRs restore the most recent snapshot main published and do not write one back, so a PR's own compilation products are not cached. That is a deliberate cost: a PR-scoped entry is readable only by that PR.

The sccache server is left running while the directory is packed. Its disk backend writes each object as it is compiled, so there is nothing to flush, and stopping it would pre-empt sccache-action's post step, which reads `--show-stats` into the job summary.

Storage moves in the other direction. A global deduplicated set of 563 MB becomes up to 7 daily snapshots per platform. The first run here measured 19 MiB (Linux), 68 MiB (mock) and 88 MiB (Windows) after a full cold compile, so one day costs about 175 MiB and seven days about 1.2 GB. Treat that as a floor rather than a ceiling: each day restores the previous snapshot and adds to it, so a directory grows with churn instead of resetting.

That matters because the repository is at 7.10 GB of its 10 GB quota, and 6.61 GB of it is dependency caches written back into PR scopes — five copies of LLVM alone, 6.1 GB, each readable by one PR. The follow-up is to make `dep-llvm` / `dep-ort` / `dep-amdgpu` / `dep-oga` restore-only on PRs, same restore/save split as here. It should land soon after this one.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
