### PR TITLE
diag(runtime): env-gated allocation tracing for every growable buffer

### DIFF
--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -32,6 +32,82 @@ static int per_entry_load_constants(RuntimeState *state,
                                     morphizen::FileSystem *fs,
                                     const char *constants_filename);
 
+//===----------------------------------------------------------------------===//
+// Allocation tracing (diagnostic, HIPDNN_EP_ALLOC_TRACE=1)
+//===----------------------------------------------------------------------===//
+//
+// Every grow-on-demand buffer in this file reports both the size its caller
+// asked for and the size actually requested from the driver. The two differ
+// wherever a growth-amortisation rule applies, so an inflated request is
+// attributable to the policy rather than to a genuine rise in demand -- which
+// is not otherwise distinguishable from the failure message alone.
+//
+// Off unless the env var is set; when off this costs one relaxed load of a
+// function-local static per allocation, and allocations here are rare by
+// construction (every one of these buffers never shrinks).
+static bool alloc_trace_enabled() {
+  static const bool enabled = [] {
+    const char *v = std::getenv("HIPDNN_EP_ALLOC_TRACE");
+    return v && std::strcmp(v, "0") != 0;
+  }();
+  return enabled;
+}
+
+// Per-site high-water marks, so each trace line also carries the sum across
+// every site. None of these buffers shrink, so that sum is the actual standing
+// residency at the moment of the allocation -- which is what a failing
+// allocation has to fit alongside, and is not recoverable from the individual
+// failure messages.
+namespace {
+struct AllocTraceHwm {
+  static constexpr int kMaxSites = 24;
+  char names[kMaxSites][32] = {};
+  size_t peaks[kMaxSites] = {};
+  int count = 0;
+
+  // Returns this site's peak after folding in `alloc`, and the sum over all
+  // sites seen so far. Sites are few and the trace path is cold, so a linear
+  // scan is cheaper than the machinery to avoid it.
+  void update(const char *site, size_t alloc, size_t *site_peak,
+              size_t *total) {
+    int idx = -1;
+    for (int i = 0; i < count; ++i) {
+      if (std::strcmp(names[i], site) == 0) {
+        idx = i;
+        break;
+      }
+    }
+    if (idx < 0 && count < kMaxSites) {
+      idx = count++;
+      snprintf(names[idx], sizeof(names[idx]), "%s", site);
+    }
+    if (idx >= 0 && alloc > peaks[idx])
+      peaks[idx] = alloc;
+    *site_peak = idx >= 0 ? peaks[idx] : alloc;
+    *total = 0;
+    for (int i = 0; i < count; ++i)
+      *total += peaks[i];
+  }
+};
+} // namespace
+
+// `old` is 0 for a cold allocation, which is how the reader tells a first-touch
+// from a grow without needing the event field to be parsed positionally.
+static void alloc_trace(const char *site, size_t needed, size_t alloc,
+                        size_t old_size) {
+  if (!alloc_trace_enabled())
+    return;
+  static AllocTraceHwm hwm;
+  size_t site_peak = 0, total_peak = 0;
+  hwm.update(site, alloc, &site_peak, &total_peak);
+  fprintf(stderr,
+          "ALLOC_TRACE site=%s event=%s needed=%zu alloc=%zu old=%zu hwm=%zu "
+          "hwm_all=%zu\n",
+          site, old_size ? "grow" : "cold", needed, alloc, old_size, site_peak,
+          total_peak);
+  fflush(stderr);
+}
+
 int hipdnn_ep_state_init_with_fs(RuntimeState **out_state, void *fs,
                                  const void *metadata_blob, size_t blob_size) {
   auto t0 = timing_now();
@@ -316,6 +392,7 @@ static int hipmalloc_and_fixup(RuntimeState *state,
                                const mlir::hip::HipModelMetaInfo *meta,
                                size_t total_size) {
   auto t_prev = timing_now();
+  alloc_trace("gpu_constants_blob", total_size, total_size, 0);
   if (hipMalloc(&state->gpu_constants_blob, total_size) != hipSuccess) {
     fprintf(stderr, "hipMalloc failed for constants blob (%zu bytes)\n",
             total_size);
@@ -999,6 +1076,7 @@ int hipdnn_ep_pool_init(RuntimeState *state, size_t pool_size,
   // time. Multi-domain functions leave domains 1..N empty here; those are grown
   // on first hip.get_pool call (lazy init).
   if (pool_size > 0) {
+    alloc_trace("pool[0]", pool_size, pool_size, 0);
     if (hipMalloc(&state->pool_base[0], pool_size) != hipSuccess) {
       fprintf(stderr, "Failed to allocate memory pool of size %zu bytes\n",
               pool_size);
@@ -1088,6 +1166,11 @@ void *hipdnn_ep_get_pool_base(RuntimeState *state, int domain_id,
   // its pool. Pools never shrink, and other domains are untouched —
   // growing domain N is independent of domain M.
   if (needed_size > state->pool_size[domain_id]) {
+    if (alloc_trace_enabled()) {
+      char site[32];
+      snprintf(site, sizeof(site), "pool[%d]", domain_id);
+      alloc_trace(site, needed_size, needed_size, state->pool_size[domain_id]);
+    }
     // Sync the stream before freeing: the previous inference may have
     // dispatched async kernels that still hold pointers into THIS domain's
     // pool. hipFree on an in-flight buffer is undefined behavior. Other
@@ -1136,6 +1219,8 @@ void *hipdnn_ep_get_host_scratch_base(RuntimeState *state, size_t needed_size) {
   // same pointer can be stored into from host code and then read by
   // subsequent GPU kernels.
   if (needed_size > state->host_scratch_size) {
+    alloc_trace("host_scratch", needed_size, needed_size,
+                state->host_scratch_size);
     if (state->host_scratch_base) {
       if (state->stream)
         HIP_CLEANUP(hipStreamSynchronize(state->stream));
@@ -1198,6 +1283,7 @@ int hipdnn_ep_state_ensure_workspace(RuntimeState *state, size_t needed_size) {
     if (grown > alloc_size)
       alloc_size = grown;
   }
+  alloc_trace("workspace", needed_size, alloc_size, state->workspace_size);
 
   // Grow: free old, allocate new.
   // Sync the stream first to ensure no in-flight kernel is still using the
@@ -1262,6 +1348,8 @@ int hipdnn_ep_state_ensure_qmoe_scratch(RuntimeState *state,
     if (grown > alloc_size)
       alloc_size = grown;
   }
+  alloc_trace("qmoe_scratch", needed_size, alloc_size,
+              state->qmoe_scratch_size);
 
   if (state->qmoe_scratch) {
     if (state->stream) {
@@ -1307,6 +1395,8 @@ int hipdnn_ep_state_ensure_qmoe_host_scratch(RuntimeState *state,
     if (grown > alloc_size)
       alloc_size = grown;
   }
+  alloc_trace("qmoe_host_scratch", needed_size, alloc_size,
+              state->qmoe_host_scratch_size);
 
   if (state->qmoe_host_scratch) {
     // Sync first: any in-flight hipMemcpyAsync(D2H) targeting this pinned
@@ -1355,6 +1445,8 @@ int hipdnn_ep_state_ensure_conv_scratch(RuntimeState *state,
     if (grown > alloc_size)
       alloc_size = grown;
   }
+  alloc_trace("conv_scratch", needed_size, alloc_size,
+              state->conv_scratch_size);
 
   if (state->conv_scratch) {
     // Drain any in-flight conv that may still be reading the old workspace
@@ -1400,6 +1492,8 @@ int hipdnn_ep_state_ensure_matmul_dp4a_scratch(RuntimeState *state,
     if (grown > alloc_size)
       alloc_size = grown;
   }
+  alloc_trace("matmul_dp4a_scratch", needed_size, alloc_size,
+              state->matmul_dp4a_scratch_size);
 
   if (state->matmul_dp4a_scratch) {
     // Drain any in-flight dp4a gemv that may still be reading the old buffer
@@ -1449,6 +1543,7 @@ int hipdnn_ep_state_ensure_la_scratch(RuntimeState *state, size_t needed_size) {
     if (grown > alloc_size)
       alloc_size = grown;
   }
+  alloc_trace("la_scratch", needed_size, alloc_size, state->la_scratch_size);
 
   if (state->la_scratch) {
     // Drain any in-flight prefill still reading the old buffer before freeing.

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -108,6 +108,20 @@ static bool gqa_cache_seqlens_enabled() {
   return enabled;
 }
 
+// Shares HIPDNN_EP_ALLOC_TRACE with the runtime-state allocator tracing so one
+// switch produces both the per-allocator sizes and the per-call breakdown of
+// what the decomposed attention path asked the workspace for. The workspace
+// trace alone gives a total; only this breakdown says which term grew, and the
+// quadratic score terms are indistinguishable from the linear ones once
+// summed.
+static bool gqa_alloc_trace_enabled() {
+  static const bool enabled = [] {
+    const char *v = std::getenv("HIPDNN_EP_ALLOC_TRACE");
+    return v && std::strcmp(v, "0") != 0;
+  }();
+  return enabled;
+}
+
 // Sentinel returned by read_seqlens_k_for_dispatch when the pre-dispatch read
 // is not applicable (multi-batch or missing seqlens_k_ptr) or failed (D2H copy
 // / stream sync error). Outside the valid range of real seqlens_k values (-1 is
@@ -1521,6 +1535,18 @@ static int gqa_forward_hipblaslt(
     size_t gemm_ws =
         std::max(scoreState->workspace_size, valueState->workspace_size);
     size_t total_needed = temp_end + gemm_ws;
+    if (gqa_alloc_trace_enabled()) {
+      fprintf(stderr,
+              "GQA_WS layer=%d H=%zu G=%zu d=%zu sq=%zu total_seq=%zu "
+              "qtrans=%zu kexp=%zu vexp=%zu sf32=%zu sf16=%zu o=%zu "
+              "gemm_ws=%zu temp_end=%zu total=%zu\n",
+              op_state_slot, static_cast<size_t>(H), static_cast<size_t>(G),
+              static_cast<size_t>(d), static_cast<size_t>(sq),
+              static_cast<size_t>(total_seq), Qtrans_bytes, Kexp_bytes,
+              Vexp_bytes, S_f32_bytes, S_fp16_bytes, O_bytes, gemm_ws, temp_end,
+              total_needed);
+      fflush(stderr);
+    }
     HIP_CHECK(hipdnn_ep_state_ensure_workspace(state, total_needed));
   }
 


### PR DESCRIPTION
## Summary

One commit. Env-gated allocation tracing, added because a memory-growth
investigation on Gemma-4 26B-A4B could not be done with what the runtime reports
today.

Every grow-on-demand buffer in `hipdnn_ep_runtime_state.cpp` prints the size the
caller asked for next to the size actually requested from the driver, plus a
per-site and an all-site high-water mark. The gap between those two numbers is
the whole question when a `hipMalloc` fails: today a failure is indistinguishable
between "demand genuinely rose" and "a growth policy inflated the request", and
the existing error message prints only the inflated figure. None of these buffers
ever shrink, so the all-site sum is the standing residency a failing allocation
has to fit alongside — which no individual site can report.

The decomposed attention path additionally prints its per-call workspace
composition, because the workspace total cannot separate the quadratic score
terms from the linear ones, and cannot say which layer's geometry triggered a
grow.

Off unless `HIPDNN_EP_ALLOC_TRACE=1`. No behaviour change when unset: the gate is
a function-local static read once, and every call site is inside it.

## Why this is a separate PR

It is the measurement apparatus for #TBD_CHUNK and #TBD_QUANTUM, which are based
on it, and it is what makes the numbers in those two reproducible. It stands
alone and can be merged, held, or dropped independently — neither fix needs it at
runtime.

## Output format

```
ALLOC_TRACE site=<name> event=cold|grow needed=<bytes> alloc=<bytes> old=<bytes> hwm=<bytes> hwm_all=<bytes>
GQA_WS layer=<n> H=.. G=.. d=.. sq=.. total_seq=.. qtrans=.. kexp=.. vexp=.. sf32=.. sf16=.. o=.. gemm_ws=.. temp_end=.. total=..
```

An example of what it resolves, from a 16K Gemma-4 prefill — three workspace
allocations in one prefill, the third asking for 11.5 GiB more than any caller
requested:

```
workspace event=cold needed=4220321296  alloc=4220321296
workspace event=grow needed=25854112864 alloc=25854112864
workspace event=grow needed=26386297952 alloc=38781169296   <- 1.5x of the previous buffer
```

## Test plan

- [x] Swept 2K/4K/8K/12K/14K/15K/16K prompts on Gemma-4 26B-A4B; trace lines
      parse cleanly and the reported per-site sums reconcile with the totals
- [x] Score-buffer figures cross-checked against a closed form: `sf32 + sf16`
      is exactly `96 * S^2` bytes at every length measured
- [x] Unset-by-default confirmed: runs with the variable absent produce no
      output and no measurable TTFT change

## Notes for the reviewer

Redirect stderr at the process level when collecting these. PowerShell wraps a
native process's stderr into ErrorRecords, word-wraps them at the console width
and prefixes each with `python.exe :`, which splits trace lines mid-field.
