### PR TITLE
fix(gqa): tile the decomposed prefill over query rows (16K prefill allocatable, -89% workspace)

### DIFF
--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -1064,11 +1064,16 @@ extern "C" int hip_gqa_causal_mask_f32(
   GQA_RETURN_LAUNCH_STATUS();
 }
 
+// `sq` counts the query rows present in `scores`, which is a chunk of the full
+// query range when the caller is tiling the prefill. `bias_sq` is the full query
+// extent of the bias tensor and `bias_row_offset` locates the chunk inside it --
+// the two cannot be folded together because the bias plane stride is set by the
+// full extent while the score plane stride is set by the chunk.
 template <typename TBias>
 __global__ void add_attention_bias_kernel(
     float* __restrict__ scores, const TBias* __restrict__ bias,
     int total_heads, int num_heads, int bias_batch, int bias_heads, int sq,
-    int total_seq, int score_batch_stride) {
+    int total_seq, int score_batch_stride, int bias_sq, int bias_row_offset) {
   int head = blockIdx.y;
   int tid = blockIdx.x * blockDim.x + threadIdx.x;
   int n = sq * total_seq;
@@ -1080,9 +1085,10 @@ __global__ void add_attention_bias_kernel(
   int h = head % num_heads;
   int bias_b = (bias_batch == 1) ? 0 : b;
   int bias_h = (bias_heads == 1) ? 0 : h;
-  size_t bias_idx = static_cast<size_t>(bias_b) * bias_heads * sq * total_seq +
-                    static_cast<size_t>(bias_h) * sq * total_seq +
-                    static_cast<size_t>(row) * total_seq + col;
+  size_t bias_plane = static_cast<size_t>(bias_sq) * total_seq;
+  size_t bias_idx = static_cast<size_t>(bias_b) * bias_heads * bias_plane +
+                    static_cast<size_t>(bias_h) * bias_plane +
+                    static_cast<size_t>(bias_row_offset + row) * total_seq + col;
   scores[static_cast<size_t>(head) * score_batch_stride + tid] +=
       static_cast<float>(bias[bias_idx]);
 }
@@ -1090,10 +1096,13 @@ __global__ void add_attention_bias_kernel(
 extern "C" int hip_gqa_add_attention_bias_f32(
     void* stream_ptr, void* scores, const void* bias, int total_heads,
     int num_heads, int bias_batch, int bias_heads, int sq, int total_seq,
-    int score_batch_stride, int bias_element_size_bytes) {
+    int score_batch_stride, int bias_element_size_bytes, int bias_sq,
+    int bias_row_offset) {
   if (!scores || !bias)
     return -1;
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
+  if (bias_sq <= 0)
+    bias_sq = sq;
   int n = sq * total_seq;
   int blocksX = (n + GQA_THREADS - 1) / GQA_THREADS;
   (void)hipGetLastError();
@@ -1102,13 +1111,13 @@ extern "C" int hip_gqa_add_attention_bias_f32(
         <<<dim3(blocksX, total_heads), GQA_THREADS, 0, stream>>>(
             static_cast<float*>(scores), static_cast<const __half*>(bias),
             total_heads, num_heads, bias_batch, bias_heads, sq, total_seq,
-            score_batch_stride);
+            score_batch_stride, bias_sq, bias_row_offset);
   } else if (bias_element_size_bytes == 4) {
     add_attention_bias_kernel<float>
         <<<dim3(blocksX, total_heads), GQA_THREADS, 0, stream>>>(
             static_cast<float*>(scores), static_cast<const float*>(bias),
             total_heads, num_heads, bias_batch, bias_heads, sq, total_seq,
-            score_batch_stride);
+            score_batch_stride, bias_sq, bias_row_offset);
   } else {
     fprintf(stderr,
             "hip_gqa_add_attention_bias_f32: unsupported bias elem size %d\n",

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -653,12 +653,17 @@ HIP_KERNEL_API int hip_gqa_causal_mask_f32(
 /* Add an attention bias onto the fp32 score matrix before softmax.
  * scores layout: [total_heads, sq, total_seq] row-major with batch_stride
  * = sq * total_seq per head.
- * bias layout: [bias_batch, bias_heads, sq, total_seq], row-major.
- * bias_batch / bias_heads may be 1 for ONNX-style broadcast. */
+ * bias layout: [bias_batch, bias_heads, bias_sq, total_seq], row-major.
+ * bias_batch / bias_heads may be 1 for ONNX-style broadcast.
+ * sq is the number of query rows in `scores`, which is a chunk of the full
+ * query range when the caller tiles the prefill; bias_sq is the bias tensor's
+ * full query extent and bias_row_offset locates the chunk within it. Pass
+ * bias_sq = sq (or 0) and bias_row_offset = 0 for the untiled case. */
 HIP_KERNEL_API int hip_gqa_add_attention_bias_f32(
     void* stream, void* scores, const void* bias,
     int total_heads, int num_heads, int bias_batch, int bias_heads,
-    int sq, int total_seq, int score_batch_stride, int bias_element_size_bytes);
+    int sq, int total_seq, int score_batch_stride, int bias_element_size_bytes,
+    int bias_sq, int bias_row_offset);
 
 /* Column-wise softmax in-place. One threadblock per (head, query).
  * Smooth softmax is activated when head_sink is non-null OR use_smooth_softmax

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -733,6 +733,38 @@ static bool gqa_no_expand_prefill_enabled() {
   return enabled;
 }
 
+// Byte budget for the pair of score matrices the decomposed prefill holds. Once
+// the pair would exceed this, the prefill is tiled over query rows instead (see
+// the chunking comment in gqa_forward_hipblaslt). Set
+// HIPDNN_EP_GQA_SCORE_BUDGET_MB=0 to restore the untiled single-shot behaviour
+// for A/B testing.
+//
+// The default is deliberately far above any shape that already runs well: at
+// 1 GiB nothing tiles below roughly 3.5K tokens on a 16-head model, so short
+// and medium sequences keep their existing kernel launch counts and descriptor
+// cache entries exactly, and only the lengths whose score matrices are already
+// tens of gigabytes change behaviour.
+static size_t gqa_score_budget_bytes() {
+  static const size_t budget = [] {
+    const char *v = std::getenv("HIPDNN_EP_GQA_SCORE_BUDGET_MB");
+    long long mb = 1024;
+    if (v && *v) {
+      char *end = nullptr;
+      long long parsed = std::strtoll(v, &end, 10);
+      if (end != v && parsed >= 0)
+        mb = parsed;
+    }
+    return static_cast<size_t>(mb) * 1024u * 1024u;
+  }();
+  return budget;
+}
+
+// Query rows per chunk are rounded down to a multiple of this so the Score and
+// Value GEMMs see a tile-friendly n. Only applied when it does not cost an
+// extra chunk, since a ragged n on one chunk is cheaper than a whole extra
+// pass.
+static constexpr int64_t kScoreChunkAlign = 128;
+
 // Env-var gate to force decode through the decomposed hipBLASLt pipeline
 // instead of the fused custom kernel hip_gqa_fused_decode. Default off
 // (fused path is preferred). Set HIPDNN_EP_GQA_DISABLE_FUSED_DECODE=1 to
@@ -1399,9 +1431,89 @@ static int gqa_forward_hipblaslt(
                        (sq == 1 || gqa_no_expand_prefill_enabled());
   bool need_transpose = (sq > 1);
 
+  //===--------------------------------------------------------------------===//
+  // Query-row chunking of the score matrix
+  //
+  // This path materialises the whole [B*H, sq, total_seq] score matrix twice --
+  // once in fp32 for the bias add, the causal mask and the softmax reduction,
+  // and once in the GEMM input dtype as the probabilities the Value GEMM
+  // consumes. Both are quadratic in sequence length, and together they dominate
+  // every other allocation the runtime makes: at 16K on a 16-head model they
+  // are 96 bytes per S^2, or 23.6 GiB, which is 97.9% of the workspace.
+  //
+  // The softmax here reduces along total_seq, so each query row is independent
+  // of every other. A block of rows can therefore be scored, biased, masked,
+  // softmaxed and multiplied by V to completion before the next block starts,
+  // and the result is identical -- this is a tiling of the same arithmetic, not
+  // an approximation, and it needs no running maximum or rescaling because
+  // every row sees its full key range within one chunk.
+  //
+  // Only the two score buffers shrink. Q, K, V and O are linear in sq and stay
+  // whole, so Q is read and O is written through a per-chunk offset while their
+  // batch strides continue to describe the full sq.
+  //
+  // Chunking is skipped entirely unless the score pair exceeds the budget, in
+  // which case sq_chunk == sq, the loop below runs once, the GEMM keys keep
+  // their dense default strides and the behaviour is exactly what it was.
+  //
+  // The no-expand flavour is excluded: its Q and O operands are laid out
+  // [B, G, HPG, sq, d] with n = HPG*sq, so a range of query rows is not a
+  // contiguous range of n and the same offset trick does not apply. That path
+  // is off by default for prefill.
+  //===--------------------------------------------------------------------===//
+  int64_t sq_chunk = sq;
+  if (sq > 1 && !use_no_expand) {
+    const size_t score_row_bytes =
+        static_cast<size_t>(B) * H * total_seq * (sizeof(float) + elem_sz);
+    const size_t budget = gqa_score_budget_bytes();
+    if (budget > 0 && score_row_bytes > 0 &&
+        static_cast<size_t>(sq) * score_row_bytes > budget) {
+      int64_t rows = static_cast<int64_t>(budget / score_row_bytes);
+      // A single row can already exceed the budget on a long enough context.
+      // Correctness wins: one row per chunk is the floor.
+      if (rows < 1)
+        rows = 1;
+      if (rows >= 2 * kScoreChunkAlign)
+        rows -= rows % kScoreChunkAlign;
+      if (rows > sq)
+        rows = sq;
+      sq_chunk = rows;
+    }
+  }
+  const bool chunked = (sq_chunk < sq);
+  const int64_t sq_tail = chunked ? (sq % sq_chunk) : 0;
+
   // GEMM descriptor keys. The no-expand flavour uses explicit per-operand
   // strides (non-zero stride fields); the expand flavour leaves them zero so
   // queryOrCreateGemmState falls back to the dense packed-batch defaults.
+  //
+  // When chunking, the expand flavour must state Q's and O's strides
+  // explicitly: n is the chunk length but those two operands still advance by
+  // the full sq between heads. The score matrices are freshly packed per chunk,
+  // so their strides stay at the dense default.
+  auto makeKeys = [&](int64_t n_rows, GqaGemmKey *score, GqaGemmKey *value) {
+    *score = {total_seq,
+              n_rows,
+              d,
+              B * H,
+              true,
+              /*outputFp32=*/true,
+              gemm_fp32,
+              /*strideA=*/0,
+              /*strideB=*/chunked ? sq * d : 0,
+              /*strideC=*/0};
+    *value = {d,
+              n_rows,
+              total_seq,
+              B * H,
+              false,
+              /*outputFp32=*/gemm_fp32,
+              gemm_fp32,
+              /*strideA=*/0,
+              /*strideB=*/0,
+              /*strideC=*/chunked ? sq * d : 0};
+  };
+
   GqaGemmKey scoreKey, valueKey;
   if (use_no_expand) {
     // Score: C[total_seq, HPG*sq] = K^T[d,total_seq] * Q[d, HPG*sq] per (b, g)
@@ -1432,21 +1544,7 @@ static int gqa_forward_hipblaslt(
                 /*strideB=*/HPG * sq * total_seq,
                 /*strideC=*/HPG * sq * d};
   } else {
-    scoreKey = {total_seq,           sq,        d, B * H, true,
-                /*outputFp32=*/true, gemm_fp32,
-                /*strideA=*/0,
-                /*strideB=*/0,
-                /*strideC=*/0};
-    valueKey = {d,
-                sq,
-                total_seq,
-                B * H,
-                false,
-                /*outputFp32=*/gemm_fp32,
-                gemm_fp32,
-                /*strideA=*/0,
-                /*strideB=*/0,
-                /*strideC=*/0};
+    makeKeys(sq_chunk, &scoreKey, &valueKey);
   }
 
   const GqaGemmCacheEntry *scoreState =
@@ -1457,6 +1555,24 @@ static int gqa_forward_hipblaslt(
       queryOrCreateGemmState(state, ltHandle, valueKey, op_state_slot);
   if (!valueState)
     return -1;
+
+  // A ragged final chunk is a different n and so a different descriptor. Both
+  // shapes are resolved before sizing the workspace because the GEMM workspace
+  // region has to cover whichever algorithm asks for more.
+  const GqaGemmCacheEntry *scoreTailState = nullptr;
+  const GqaGemmCacheEntry *valueTailState = nullptr;
+  if (sq_tail > 0) {
+    GqaGemmKey scoreTailKey, valueTailKey;
+    makeKeys(sq_tail, &scoreTailKey, &valueTailKey);
+    scoreTailState =
+        queryOrCreateGemmState(state, ltHandle, scoreTailKey, op_state_slot);
+    if (!scoreTailState)
+      return -1;
+    valueTailState =
+        queryOrCreateGemmState(state, ltHandle, valueTailKey, op_state_slot);
+    if (!valueTailState)
+      return -1;
+  }
 
   // ---- Workspace layout ----
   // All temp buffers are packed contiguously into the shared workspace,
@@ -1470,15 +1586,18 @@ static int gqa_forward_hipblaslt(
   //
   // Qtrans / O are only allocated when need_transpose is true.
   // Kexp / Vexp are only allocated when use_no_expand is false.
-  // S_f32 and S_fp16 are always allocated (softmax is on every path).
+  // S_f32 and S_fp16 are always allocated (softmax is on every path), and are
+  // sized to one query chunk rather than the whole query range -- sq_chunk ==
+  // sq whenever chunking is inactive, so this is the full matrix in that case.
   size_t Qtrans_bytes =
       need_transpose ? static_cast<size_t>(B) * H * sq * d * elem_sz : 0;
   size_t Kexp_bytes =
       use_no_expand ? 0 : static_cast<size_t>(B) * H * total_seq * d * elem_sz;
   size_t Vexp_bytes = Kexp_bytes;
   size_t S_f32_bytes =
-      static_cast<size_t>(B) * H * sq * total_seq * sizeof(float);
-  size_t S_fp16_bytes = static_cast<size_t>(B) * H * sq * total_seq * elem_sz;
+      static_cast<size_t>(B) * H * sq_chunk * total_seq * sizeof(float);
+  size_t S_fp16_bytes =
+      static_cast<size_t>(B) * H * sq_chunk * total_seq * elem_sz;
   size_t O_bytes =
       need_transpose ? static_cast<size_t>(B) * H * sq * d * elem_sz : 0;
 
@@ -1520,6 +1639,10 @@ static int gqa_forward_hipblaslt(
   {
     size_t gemm_ws =
         std::max(scoreState->workspace_size, valueState->workspace_size);
+    if (scoreTailState)
+      gemm_ws = std::max(gemm_ws, scoreTailState->workspace_size);
+    if (valueTailState)
+      gemm_ws = std::max(gemm_ws, valueTailState->workspace_size);
     size_t total_needed = temp_end + gemm_ws;
     HIP_CHECK(hipdnn_ep_state_ensure_workspace(state, total_needed));
   }
@@ -1631,87 +1754,114 @@ static int gqa_forward_hipblaslt(
                             expandCopy, static_cast<int>(elem_sz)));
     }
 
-    // ---- Step 8: Score GEMM (fp16/fp32 in, fp32 out) ----
-    // A = K: no-expand reads present_key directly, expand reads d_Kexp.
-    // B = Q: need_transpose reads d_Qtrans (BNSD), else qSrc (BSHD==BNSD@sq=1).
+    // ---- Steps 8-10, per query chunk ----
+    // One iteration when chunking is inactive, in which case q0 is 0, c is sq
+    // and every pointer and stride below reduces to what it was.
     const void *scoreA = use_no_expand ? present_key : d_Kexp;
-    const void *scoreB = need_transpose ? d_Qtrans : qSrc;
+    const void *scoreBBase = need_transpose ? d_Qtrans : qSrc;
+    const void *valueA = use_no_expand ? present_value : d_Vexp;
+    void *valueCBase = need_transpose ? d_O : output;
     float scoreAlpha = scale;
     float beta = 0.0f;
-    hipblasLtMatmulAlgo_t sAlgo = scoreState->algo;
-
-    HIPBLAS_CHECK(hipblasLtMatmul(
-        ltHandle, scoreState->desc, &scoreAlpha, scoreA, scoreState->layA,
-        scoreB, scoreState->layB, &beta, d_S_f32, scoreState->layC, d_S_f32,
-        scoreState->layD, &sAlgo, gemm_ws_ptr, gemm_ws_bytes, stream));
-
-    // ---- Step 8b: Add external attention bias (onnx.Attention attn_mask) ----
-    int scoreF32BatchStride = static_cast<int>(sq * total_seq);
-    if (attention_bias) {
-      HIP_CHECK(hip_gqa_add_attention_bias_f32(
-          stream, d_S_f32, const_cast<void *>(attention_bias),
-          static_cast<int>(B * H), static_cast<int>(H),
-          static_cast<int>(attn_bias_batch),
-          static_cast<int>(attn_bias_num_heads), static_cast<int>(sq),
-          static_cast<int>(total_seq), scoreF32BatchStride,
-          static_cast<int>(elem_sz)));
-    }
-
-    // ---- Step 9: Causal Mask (fp32) + Softmax (fp32 -> fp16/fp32) ----
-    // S is treated as [B*H, sq, total_seq] (head stride sq*total_seq) by both
-    // GEMM flavours. softmax dtype follows gemm_fp32.
-    //
-    // The built-in causal triangle is applied whenever !no_causal,
-    // INDEPENDENTLY of attention_bias. This mirrors the ONNX Attention
-    // reference and the ORT GQA op: the additive mask (Step 8b, e.g.
-    // onnx.Attention attn_mask or a GQA/ALiBi bias) is ADDED first, then, if
-    // the op is causal, the upper triangle is masked out. For a mask that
-    // already encodes causal (the common HF export) this is idempotent (-inf
-    // stays -inf); for a padding-only mask + is_causal it supplies the missing
-    // triangle. The bidirectional paths (no_causal, e.g. Whisper
-    // encoder/cross-attn or onnx.Attention is_causal=0) set no_causal=true and
-    // thus skip this, letting the mask carry all masking. Note this Step is a
-    // no-op at sq==1 (single-query decode has no future tokens), gated by (sq >
-    // 1 || local_window_size > 0).
-    int scoreFp16BatchStride = static_cast<int>(sq * total_seq);
-    if ((sq > 1 || local_window_size > 0) && !no_causal) {
-      HIP_CHECK(hip_gqa_causal_mask_f32(
-          stream, d_S_f32, static_cast<int>(B * H), static_cast<int>(total_seq),
-          static_cast<int>(sq), scoreF32BatchStride, static_cast<int>(past_len),
-          static_cast<int>(local_window_size)));
-    }
-    // fp16 GQA: softmax writes fp16 probabilities for the fp16 Value GEMM.
-    // fp32 GQA (Whisper no_causal): softmax writes fp32 probabilities for the
-    // fp32 Value GEMM. d_S_fp16 is the probabilities buffer either way (sized
-    // by elem_sz above), so the name is fp16-specific but holds fp32 when
-    // gemm_fp32.
-    if (gemm_fp32) {
-      HIP_CHECK(hip_gqa_softmax_f32_to_f32(
-          stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * sq),
-          static_cast<int>(total_seq), static_cast<int>(sq),
-          scoreF32BatchStride, scoreFp16BatchStride, head_sink,
-          static_cast<int>(H), static_cast<int>(use_smooth_softmax)));
-    } else {
-      HIP_CHECK(hip_gqa_softmax_f32_to_f16(
-          stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * sq),
-          static_cast<int>(total_seq), static_cast<int>(sq),
-          scoreF32BatchStride, scoreFp16BatchStride, head_sink,
-          static_cast<int>(H), static_cast<int>(use_smooth_softmax)));
-    }
-
-    // ---- Step 10: Value GEMM (fp16/fp32 in, fp16/fp32 out) ----
-    // A = V: no-expand reads present_value directly, expand reads d_Vexp.
-    // C = O: need_transpose writes d_O (BNSD, transposed below); at sq==1 the
-    //        GEMM writes straight to output (BSHD==BNSD).
-    const void *valueA = use_no_expand ? present_value : d_Vexp;
-    void *valueC = need_transpose ? d_O : output;
     float valAlpha = 1.0f;
-    hipblasLtMatmulAlgo_t vAlgo = valueState->algo;
 
-    HIPBLAS_CHECK(hipblasLtMatmul(
-        ltHandle, valueState->desc, &valAlpha, valueA, valueState->layA,
-        d_S_fp16, valueState->layB, &beta, valueC, valueState->layC, valueC,
-        valueState->layD, &vAlgo, gemm_ws_ptr, gemm_ws_bytes, stream));
+    for (int64_t q0 = 0; q0 < sq; q0 += sq_chunk) {
+      const int64_t c = std::min<int64_t>(sq_chunk, sq - q0);
+      const bool is_tail = (c != sq_chunk);
+      const GqaGemmCacheEntry *sSt = is_tail ? scoreTailState : scoreState;
+      const GqaGemmCacheEntry *vSt = is_tail ? valueTailState : valueState;
+
+      // Q and O keep their full-sq batch strides (stated in the GEMM key), so
+      // selecting a chunk is a plain offset into the query axis of each.
+      const void *scoreB = static_cast<const char *>(scoreBBase) +
+                           static_cast<size_t>(q0) * d * elem_sz;
+      void *valueC = static_cast<char *>(valueCBase) +
+                     static_cast<size_t>(q0) * d * elem_sz;
+      // The score buffers are re-packed per chunk, so their per-head stride is
+      // the chunk's own row count.
+      const int scoreBatchStride = static_cast<int>(c * total_seq);
+
+      // ---- Step 8: Score GEMM (fp16/fp32 in, fp32 out) ----
+      // A = K: no-expand reads present_key directly, expand reads d_Kexp.
+      // B = Q: need_transpose reads d_Qtrans (BNSD), else qSrc
+      // (BSHD==BNSD@sq=1).
+      hipblasLtMatmulAlgo_t sAlgo = sSt->algo;
+      HIPBLAS_CHECK(hipblasLtMatmul(
+          ltHandle, sSt->desc, &scoreAlpha, scoreA, sSt->layA, scoreB,
+          sSt->layB, &beta, d_S_f32, sSt->layC, d_S_f32, sSt->layD, &sAlgo,
+          gemm_ws_ptr, gemm_ws_bytes, stream));
+
+      // ---- Step 8b: Add external attention bias (onnx.Attention attn_mask) --
+      // The bias is indexed over the full query range, so the chunk's row
+      // offset is passed through rather than folded into the pointer: with
+      // bias_batch or bias_heads > 1 the plane stride still spans all sq rows.
+      if (attention_bias) {
+        HIP_CHECK(hip_gqa_add_attention_bias_f32(
+            stream, d_S_f32, const_cast<void *>(attention_bias),
+            static_cast<int>(B * H), static_cast<int>(H),
+            static_cast<int>(attn_bias_batch),
+            static_cast<int>(attn_bias_num_heads), static_cast<int>(c),
+            static_cast<int>(total_seq), scoreBatchStride,
+            static_cast<int>(elem_sz), static_cast<int>(sq),
+            static_cast<int>(q0)));
+      }
+
+      // ---- Step 9: Causal Mask (fp32) + Softmax (fp32 -> fp16/fp32) ----
+      // S is treated as [B*H, c, total_seq] (head stride c*total_seq) by both
+      // GEMM flavours. softmax dtype follows gemm_fp32.
+      //
+      // The built-in causal triangle is applied whenever !no_causal,
+      // INDEPENDENTLY of attention_bias. This mirrors the ONNX Attention
+      // reference and the ORT GQA op: the additive mask (Step 8b, e.g.
+      // onnx.Attention attn_mask or a GQA/ALiBi bias) is ADDED first, then, if
+      // the op is causal, the upper triangle is masked out. For a mask that
+      // already encodes causal (the common HF export) this is idempotent (-inf
+      // stays -inf); for a padding-only mask + is_causal it supplies the
+      // missing triangle. The bidirectional paths (no_causal, e.g. Whisper
+      // encoder/cross-attn or onnx.Attention is_causal=0) set no_causal=true
+      // and thus skip this, letting the mask carry all masking. Note this Step
+      // is a no-op at sq==1 (single-query decode has no future tokens), gated
+      // by (sq > 1 || local_window_size > 0).
+      //
+      // The mask kernel derives each row's absolute query position as
+      // past_len + row, so advancing past_len by the chunk's start puts the
+      // triangle and the sliding window in the right place for the chunk.
+      if ((sq > 1 || local_window_size > 0) && !no_causal) {
+        HIP_CHECK(hip_gqa_causal_mask_f32(
+            stream, d_S_f32, static_cast<int>(B * H),
+            static_cast<int>(total_seq), static_cast<int>(c), scoreBatchStride,
+            static_cast<int>(past_len + q0),
+            static_cast<int>(local_window_size)));
+      }
+      // fp16 GQA: softmax writes fp16 probabilities for the fp16 Value GEMM.
+      // fp32 GQA (Whisper no_causal): softmax writes fp32 probabilities for the
+      // fp32 Value GEMM. d_S_fp16 is the probabilities buffer either way (sized
+      // by elem_sz above), so the name is fp16-specific but holds fp32 when
+      // gemm_fp32.
+      if (gemm_fp32) {
+        HIP_CHECK(hip_gqa_softmax_f32_to_f32(
+            stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * c),
+            static_cast<int>(total_seq), static_cast<int>(c), scoreBatchStride,
+            scoreBatchStride, head_sink, static_cast<int>(H),
+            static_cast<int>(use_smooth_softmax)));
+      } else {
+        HIP_CHECK(hip_gqa_softmax_f32_to_f16(
+            stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * c),
+            static_cast<int>(total_seq), static_cast<int>(c), scoreBatchStride,
+            scoreBatchStride, head_sink, static_cast<int>(H),
+            static_cast<int>(use_smooth_softmax)));
+      }
+
+      // ---- Step 10: Value GEMM (fp16/fp32 in, fp16/fp32 out) ----
+      // A = V: no-expand reads present_value directly, expand reads d_Vexp.
+      // C = O: need_transpose writes d_O (BNSD, transposed below); at sq==1 the
+      //        GEMM writes straight to output (BSHD==BNSD).
+      hipblasLtMatmulAlgo_t vAlgo = vSt->algo;
+      HIPBLAS_CHECK(hipblasLtMatmul(
+          ltHandle, vSt->desc, &valAlpha, valueA, vSt->layA, d_S_fp16,
+          vSt->layB, &beta, valueC, vSt->layC, valueC, vSt->layD, &vAlgo,
+          gemm_ws_ptr, gemm_ws_bytes, stream));
+    }
 
     // ---- Step 11: O Transpose BNSD [B,H,sq,d] -> BSHD [B,sq,H,d] ----
     // Skipped at sq == 1: the Value GEMM already wrote into output.
@@ -1723,11 +1873,11 @@ static int gqa_forward_hipblaslt(
     }
 
     RUNTIME_DEBUG_LOG(
-        "[REAL] GQA hipBLASLt: B=%lld sq=%lld total_seq=%lld H=%lld G=%lld "
-        "d=%lld no_expand=%d transpose=%d\n",
-        (long long)B, (long long)sq, (long long)total_seq, (long long)H,
-        (long long)G, (long long)d, static_cast<int>(use_no_expand),
-        static_cast<int>(need_transpose));
+        "[REAL] GQA hipBLASLt: B=%lld sq=%lld sq_chunk=%lld total_seq=%lld "
+        "H=%lld G=%lld d=%lld no_expand=%d transpose=%d\n",
+        (long long)B, (long long)sq, (long long)sq_chunk, (long long)total_seq,
+        (long long)H, (long long)G, (long long)d,
+        static_cast<int>(use_no_expand), static_cast<int>(need_transpose));
   }
 
 cleanup:


### PR DESCRIPTION
## Summary

One commit on `main`. Makes the decomposed attention prefill's memory linear in
sequence length instead of quadratic, which is what stops a Gemma-4 26B-A4B
prefill above 12K from allocating at all on a 64 GB shared-memory part.

The decomposed path materialises the whole `[B*H, sq, total_seq]` score matrix
**twice**: once in fp32, which the bias add, the causal mask and the softmax
reduction need, and once in the GEMM input dtype as the probabilities the Value
GEMM consumes. Measured, the pair is exactly `96 * S^2` bytes - 23.58 GiB at a
16K prompt, or 97.9% of the workspace. Every other buffer on this path (Q, K, V,
O) is linear in `sq` and they come to under half a gigabyte between them. A
single block that size is not something the driver will hand out while the
weights are already resident, so the op does not run slowly, it fails.

Nothing here needs all query rows resident at once. **The softmax reduces along
`total_seq`, so every query row is independent of every other**: a block of rows
can be scored, biased, masked, softmaxed and multiplied by V to completion before
the next block starts. This is a tiling of the same arithmetic, not an
approximation - and unlike a fused flash kernel it needs no running maximum and
no rescaling, because each row still sees its whole key range inside one chunk.

Only the score buffers shrink. Q, K, V and O stay whole, so Q is read and O is
written through a per-chunk offset while their batch strides keep describing the
full `sq`.

Chunk size comes from a byte budget rather than a row count, because what has to
fit is bytes. `HIPDNN_EP_GQA_SCORE_BUDGET_MB` defaults to 1024, well above
anything that already runs: nothing tiles below roughly 3.5K tokens on a 16-head
model, so shorter sequences keep their existing launch counts and descriptor
cache entries and take a single-iteration loop whose pointers and strides all
reduce to what they were. `=0` restores the untiled path for A/B.

## Measurements

Gemma-4 26B-A4B, `max_length=16512` held constant so the KV cache is fixed and
prompt length is the only variable. "peak" is the largest single workspace block
requested from the driver; "allocs" counts workspace allocations in one prefill.

| prompt | base allocs | base peak | chunk | allocs | peak | peak drop |
|---|---|---|---|---|---|---|
| 12K | 3 | 20.77 GiB | 896 | **1** | 2.25 GiB | -89.2% |
| 14K | 3 | 27.06 GiB -> **abort** | 768 | **1** | 2.93 GiB | -89.2% |
| 15K | 3 | 30.93 GiB -> **abort** | 640 | **1** | 3.36 GiB | -89.1% |
| 16K | 3 | 36.12 GiB -> **abort** | 640 | **1** | 3.93 GiB | -89.1% |

14K, 15K and 16K go from aborting to completing. The score pair at 12K drops from
14.47 GB to 1006 MiB.

The allocation count falling to 1 is a side effect worth calling out: once the
quadratic term is gone, attention's workspace demand lands below the size the
workspace already had from an earlier consumer, so it never grows. The
three-allocations-per-prefill churn disappears without touching the allocator.

**Provenance of the two allocation columns.** Per-allocation request and granted
sizes are not printed by any build in this PR; I read them from an env-gated
`hipMalloc`/`hipFree` tracing patch applied locally over the same tree. That
patch is deliberately not part of this PR. Everything else here (pass/fail, TTFT,
generated text) is observable from a stock build of this branch.

**Re-verified on this PR's actual merge base.** The table above was collected on a
tree that also carried that tracing patch and the unmerged slice fix from #782.
Since neither is on `main`, I rebuilt this branch on the merge base alone
(`6c4544c2`) and re-ran the outcome that matters:

| prompt | budget | exit | result |
|---|---|---|---|
| 12K | 0 (untiled) | 0 | completes |
| 12K | 1024 (tiled) | 0 | completes, TTFT 26.5 s, 16 tokens |
| 16K | 1024 (tiled) | 0 | **completes** |
| 16K | 0 (untiled) | `0xC0000409` | **abort** |

So the unblock is a property of this commit on `main`, not of anything it was
measured on top of. #782 is not a prerequisite.

### TTFT

Paired A/B on one build at a 12K prompt, toggling only the budget. Warmup
iteration discarded, arm order alternated between rounds so thermal drift does
not land on the same arm twice:

| round | untiled | tiled | delta |
|---|---|---|---|
| 1 | 25272.9 ms | 25436.4 ms | +0.65% |
| 2 | 25528.9 ms | 25543.8 ms | +0.06% |
| mean | 25400.9 ms | 25490.1 ms | **+0.35%** |

At 14K/15K/16K there is no comparison arm - the untiled path does not allocate.

:warning: Do not use per-length sweep TTFT for this. Each sweep arm is a fresh
process with one measured iteration, so it carries model compilation; the untiled
sweep is non-monotonic in prompt length (4K slower than 12K) for that reason. An
earlier reading of 245 s for tiled 12K was that artefact, not the change.

Note also that the harness's "Peak Memory Usage" line is host RSS sampled once at
exit (`psutil` `memory_info().rss`), so it does not move with this change and is
not the metric in the tables above.

## Implementation notes

- **Bias row offset is passed to the kernel, not folded into the pointer.** The
  bias plane stride is set by the full query extent while the score plane stride
  is set by the chunk; with `bias_batch` or `bias_heads` above 1 those differ, so
  folding would silently mis-address every plane after the first. This is the one
  kernel signature change (`hip_gqa_add_attention_bias_f32` gains `bias_sq` and
  `bias_row_offset`); it has a single caller.
- **The mask needs nothing new.** It already derives each row's absolute query
  position as `past_len + row`, so advancing `past_len` by the chunk start puts
  both the causal triangle and the sliding window where they belong.
- **A ragged final chunk is a second GEMM descriptor.** Both shapes are resolved
  before the workspace is sized, since the GEMM workspace region has to cover
  whichever algorithm asks for more.
- **The no-expand flavour is excluded.** Its Q and O operands are laid out
  `[B, G, HPG, sq, d]` with `n = HPG*sq`, so a range of query rows is not a
  contiguous range of `n` and the offset trick does not hold. That path is off by
  default for prefill.

## Test plan

- [x] Builds clean on `main` (`6c4544c2`); only pre-existing kernel warnings
- [x] 12K/14K/15K/16K on Gemma-4 26B-A4B, allocation trace verified per arm
- [x] 12K and 16K, tiled and untiled, re-run on the merge base with no other patches
- [x] Paired TTFT A/B at 12K (above)
- [x] Equivalence against the untiled path at 4K, three arms in one script
- [ ] **No unit-level numeric test** - see below

## Correctness evidence, and its limit

I could not run `test/numeric`: it needs `onnxruntime_morphizen_ep.dll`, which
has no target in this build tree. Equivalence is therefore model-level, greedy
decoding, 32 tokens, one 4K prompt, three arms differing only in budget:

| arm | chunks | result |
|---|---|---|
| `budget=0` | 1 (untiled) | reference |
| `budget=1024` | 2, offset 2688 in use | identical for 26 of 32 words; differs only on a trailing token |
| `budget=17` | 92, ragged tail | diverges at word 8, stays coherent, and still reads an exact fact out of the prompt ("repeats the same paragraph 28 times") |

Why I read the 92-chunk divergence as accumulation order rather than a
positional error: only prefill is tiled (decode runs at `sq==1`), and the last
query row is the one the first token is read from. Its mask row sits at the very
end of the bias, in chunk 91 at local row 1. If the row offset were being dropped
or misapplied, that row would attend to the first two positions instead of all
4096 and the first token would be garbage. It is not - the first token is
identical across all three arms, and the arm still extracts a precise count from
the prompt body. Divergence appears later, which is where fp differences
propagate through the KV cache that subsequent layers write.

That is an argument, not a unit test. If you want the stronger check before this
lands, the numeric suite needs its EP shim buildable here, or a standalone
`onnx.Attention` model with a bias at a length long enough to force tiling.

## Prior art you should know about

Commit `579ad66a` ("fix(gemma4): make the 16K VLM prefill correct and
allocatable", on `perf/qwen-ttft-stack`, never merged) already solved this by
**head grouping** - splitting steps 8-10 over groups of heads sized to a budget,
with benchmarked TTFT (39.8 s for 8 groups of 2 heads against 38.1 s for 2 groups
of 8 at 16K).

I chose query-row tiling over extracting that, for two reasons. It declines on
`B > 1`, a per-head bias, a head sink, or smooth softmax, because grouping
renumbers the head index the kernels see - so gpt-oss, which uses head sinks,
would never get the fix. And it can only divide by divisors of `B*H`, which
floors the score buffers at one head's worth (1.58 GiB at 16K), where a byte
budget goes as low as asked. Happy to be argued out of this if the benchmarked
implementation is preferred; the two are alternatives, not complements.
