### PR TITLE
fix(runtime): amortize workspace growth by quantizing the request (-31% peak, 14K prefill unblocked)

### DIFF
--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -1175,6 +1175,31 @@ size_t hipdnn_ep_state_get_workspace_size(RuntimeState *state) {
   return state ? state->workspace_size : 0;
 }
 
+// Round a workspace request up onto a coarse grid so that two requests
+// differing by less than the grid step resolve to the same allocation and the
+// second one reuses the buffer.
+//
+// The step is the largest power-of-two multiple of 64 KiB at or below a
+// sixteenth of the request, which bounds the slack at 6.25% of what was asked
+// for at every scale. A sixteenth rather than something smaller because slack
+// only has to cover the increment between one request and the next: measured
+// across a Gemma-4 prefill the two attention geometries ask for sizes 2% apart,
+// so a 6.25% step absorbs the second request into the first allocation. The
+// 64 KiB floor stops buffers that are a few kilobytes from reallocating over a
+// few bytes.
+static size_t quantize_workspace_request(size_t needed_size) {
+  constexpr size_t kMinStep = size_t{64} * 1024;
+  size_t step = kMinStep;
+  const size_t bound = needed_size / 16;
+  while (step <= bound / 2)
+    step <<= 1;
+  // Unsigned wraparound is the overflow signal: a rounded size below the
+  // request means the grid step pushed it past the address space, so ask for
+  // exactly what was requested.
+  const size_t rounded = ((needed_size + step - 1) / step) * step;
+  return rounded < needed_size ? needed_size : rounded;
+}
+
 int hipdnn_ep_state_ensure_workspace(RuntimeState *state, size_t needed_size) {
   if (!state)
     return -1;
@@ -1183,21 +1208,27 @@ int hipdnn_ep_state_ensure_workspace(RuntimeState *state, size_t needed_size) {
   if (state->workspace_size >= needed_size)
     return 0;
 
-  // Amortize growth: when enlarging an existing workspace, round the new
-  // size up to at least 1.5x the current buffer. Callers whose request
-  // size grows monotonically by a small increment per inference (e.g. the
-  // GQA decode path, which sizes S buffers to B*H*total_seq and adds B*H
-  // elements per token) would otherwise trigger a hipStreamSynchronize +
-  // hipFree + hipMalloc cycle on every decode step; with the 1.5x factor
-  // that drops to O(log N) reallocations over the whole generation.
-  // Cold-start (no existing workspace) keeps the exact requested size so
-  // warmup doesn't silently double large initial allocations.
-  size_t alloc_size = needed_size;
-  if (state->workspace_size > 0) {
-    size_t grown = state->workspace_size + state->workspace_size / 2; // 1.5x
-    if (grown > alloc_size)
-      alloc_size = grown;
-  }
+  // Amortize growth by quantizing the request rather than by scaling whatever
+  // is already allocated.
+  //
+  // This used to round up to 1.5x the current buffer, which reacts to the
+  // buffer instead of to the request: a caller asking for 2% more than the last
+  // time got an allocation 50% larger than the last one, and because the factor
+  // applies to a base that is itself unbounded, the overshoot grows with the
+  // model. Measured on a Gemma-4 26B-A4B 16K prefill, the decomposed attention
+  // path asked for 24.08 GiB and then 24.57 GiB as the layer geometry changed,
+  // and the second request turned into a 36.12 GiB hipMalloc -- 11.5 GiB beyond
+  // anything anyone asked for, on a 63.6 GiB shared-memory part that already
+  // held the weights, which failed while the 24.57 GiB it actually needed would
+  // have fit.
+  //
+  // Quantizing keeps the property the 1.5x factor existed for. A caller whose
+  // request creeps up by a few elements per decode step (the GQA decode path
+  // sizes its score buffers to B*H*total_seq and adds B*H elements per token)
+  // still reallocates a logarithmic number of times overall, because the step
+  // scales with the buffer -- but the slack is bounded at a sixteenth of the
+  // request instead of half of the buffer.
+  size_t alloc_size = quantize_workspace_request(needed_size);
 
   // Grow: free old, allocate new.
   // Sync the stream first to ensure no in-flight kernel is still using the
@@ -1212,10 +1243,25 @@ int hipdnn_ep_state_ensure_workspace(RuntimeState *state, size_t needed_size) {
   }
 
   if (hipMalloc(&state->workspace, alloc_size) != hipSuccess) {
+    // Slack is an optimization, so it must never be the reason a model stops
+    // running. Retry at the exact request before giving up, so an abort here
+    // means the workspace genuinely does not fit rather than that the rounding
+    // pushed it over.
+    if (alloc_size > needed_size) {
+      fprintf(stderr,
+              "hipdnn_ep_state_ensure_workspace: hipMalloc failed for %zu "
+              "bytes; retrying at the exact request of %zu bytes\n",
+              alloc_size, needed_size);
+      fflush(stderr);
+      if (hipMalloc(&state->workspace, needed_size) == hipSuccess) {
+        state->workspace_size = needed_size;
+        return 0;
+      }
+    }
     fprintf(
         stderr,
         "hipdnn_ep_state_ensure_workspace: hipMalloc failed for %zu bytes\n",
-        alloc_size);
+        needed_size);
     std::abort();
   }
 


### PR DESCRIPTION
## Summary

One commit on `main`. Changes how the shared workspace amortizes growth: round
the **request** onto a coarse grid, instead of rounding up to 1.5x the **buffer
that already exists**.

The old rule reacts to the buffer rather than to the request. A caller asking for
2% more than last time got an allocation 50% larger than last time, and because
the factor multiplies a base that is itself unbounded, the overshoot grows with
the model rather than with the increment it exists to absorb.

Measured on a Gemma-4 26B-A4B 16K prefill, the decomposed attention path asks for
24.08 GiB at the first layer and 24.57 GiB five layers later when the head
geometry changes from 25 local layers (`H=16 G=8 d=256`) to 5 global ones
(`H=16 G=2 d=512`). That second request became a **36.12 GiB** `hipMalloc` - 11.5
GiB beyond anything any caller asked for, on a 63.6 GiB shared-memory part that
already held the weights. It failed, and the 24.57 GiB actually requested would
have fit.

Quantizing keeps the property the 1.5x factor existed for while bounding what it
costs. Requests that differ by less than the grid step land on the same size, so
the second one reuses the buffer and no reallocation happens at all; a caller
whose request creeps up by a few elements per decode step (the GQA decode path
sizes its score buffers to `B*H*total_seq` and adds `B*H` elements per token)
still reallocates only a logarithmic number of times, because the step scales
with the buffer.

The step is the largest power-of-two multiple of 64 KiB at or below **a sixteenth
of the request**, so slack is under 6.25% at every scale instead of 50% of
whatever happened to be allocated. A sixteenth because slack only has to cover
the gap between consecutive requests, and the two geometries above are 2% apart.
The 64 KiB floor stops kilobyte-sized buffers reallocating over a few bytes.

Slack is an optimization, so it must never be why a model stops running: an
oversized `hipMalloc` failure now **retries at the exact request** before
aborting. An abort here therefore means the workspace genuinely does not fit.

## Measurements

Gemma-4 26B-A4B, `max_length=16512` fixed. "peak" is the largest single workspace
block requested; "allocs" counts workspace allocations in one prefill.

| prompt | base allocs / peak | this PR allocs / peak | outcome |
|---|---|---|---|
| 12K | 3 / 20.77 GiB | 3 / 14.50 GiB | passes both; peak -30%, TTFT 28.2 s -> 27.4 s |
| 14K | 3 / 27.06 GiB | **2 / 19.00 GiB** | **abort -> completes** |
| 15K | 3 / 30.93 GiB | 3 / 22.00 GiB | aborts either way |
| 16K | 3 / 36.12 GiB | **2 / 25.00 GiB** | aborts either way, but for a different reason |

The retry path fires and is visible in the trace at 15K:

```
workspace event=grow needed=22636090752 alloc=23622320128
hipMalloc failed for 23622320128 bytes; retrying at the exact request of 22636090752 bytes
hipMalloc failed for 22636090752 bytes
```

**Provenance.** The per-allocation request and granted sizes above are not
printed by any build in this PR; I read them from an env-gated `hipMalloc`
tracing patch applied locally over the same tree, deliberately not included here.
The `retrying at the exact request` line is emitted by this commit. Pass/fail
outcomes and TTFT are observable from a stock build of this branch. The numbers
were collected on a tree that also carried the unmerged slice fix from #782;
that fix is not on `main` and is not a prerequisite - I confirmed separately that
Gemma-4 26B-A4B prefills at 12K and 16K on the merge base (`6c4544c2`) without it.

Note that the harness's "Peak Memory Usage" line is host RSS sampled once at exit
(`psutil` `memory_info().rss`), not GPU memory, so it is not the metric above and
does not move with this change.

## What this does not fix

Being explicit, because the headline number is easy to over-read: **this bounds
the request, not the demand.**

- **16K's workspace now succeeds** - 25.00 GiB is granted where 36.12 GiB was
  refused, and that is larger than any allocation previously observed to succeed
  on this part. The run then dies in a later KV-cache allocation
  (`tensor[43].data is null but size_bytes=66543616`, and
  `wrap_group_query_attention: GQA requires present_key/present_value`), because
  25 GiB of workspace is still 25 GiB standing in the way. So 16K moves from
  "cannot allocate the workspace" to "cannot allocate what comes after it".
- **15K still aborts**, now at 22.00 GiB, and the exact-size retry at 21.08 GiB
  fails too - the memory genuinely is not there.
- **12K and 15K show the limit of a grid.** Their two requests happen to straddle
  a step boundary, so they still reallocate three times, just to smaller sizes.
  A grid reduces the expected number of reallocations; it cannot guarantee one.

For 15K and 16K to actually run on this part the quadratic score buffers have to
shrink, which is #787. That PR reduces attention's demand far enough that the
workspace stops growing at all, so it reaches the single-allocation outcome this
PR only approaches. The two are complementary, and neither is a prerequisite for
the other: they touch disjoint files (`hipdnn_ep_runtime_state.cpp` here,
`gqa.cpp` and the kernels there), both sit directly on `main`, and they can land
in either order.

## Test plan

- [x] Builds clean on `main` (`6c4544c2`); only pre-existing kernel warnings
- [x] 12K/14K/15K/16K on Gemma-4 26B-A4B with allocation tracing, request and
      granted sizes verified per allocation (table above)
- [x] Retry-at-exact-size path exercised (15K, quoted above)
- [x] 12K TTFT unchanged, confirming quantization does not alter compute
- [x] Small-buffer behaviour: the kilobyte-scale `matmul_dp4a_scratch` requests
      (3168 -> 4608 -> 9216 B) collapse onto one 64 KiB allocation instead of three
- [ ] Decode-path reallocation count over a long generation not measured
      directly; the logarithmic-growth argument is analytical

## Reviewer questions

1. **Is a sixteenth the right step?** An eighth would have absorbed the 12K and
   15K straddles too, at 12.5% slack - on a part this memory-constrained 12.5% of
   24 GiB is 3 GiB, which is why I did not. Easy to change; it is one constant.
2. **Should the same policy apply to the other grow-on-demand buffers?** The
   workspace is the only site that currently inflates a request, so this PR
   changes only it. `pool`, `host_scratch` and the qmoe scratches allocate exactly
   what was asked for and churn instead.
