### PR TITLE
feat: fuse conv + ReLU/ReLU6 via parametric MIOpen activation

### DIFF
--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -639,8 +639,13 @@ def Hip_ConvOp : Hip_DpsOp<"conv", /*traits=*/[OpStateOpInterface], /*outsAccess
     - pads: Array of padding values [top, left, bottom, right]
     - dilations: Array of dilation values [H, W]
     - group: Number of groups for grouped convolution
-    - activation: Optional fused post-conv activation. 0 = none (default),
-      1 = ReLU6 (Clip to [0, 6] via MIOpen FusionPlan CLIPPEDRELU).
+    - fused_activation: When true, apply a fused post-conv activation via MIOpen
+      after conv (+ bias). When false (default), no activation is applied.
+    - activation_clip_lo: Lower clip bound (default 0.0). Used when
+      fused_activation is true.
+    - activation_clip_hi: Upper clip bound (default 0.0). 0.0 means no upper
+      clip (plain ReLU when clip_lo is 0). ReLU6 uses clip_hi = 6.0.
+    - activation_alpha: Reserved for future leaky/slope activations (default 0.0).
 
     Example:
     ```mlir
@@ -665,7 +670,10 @@ def Hip_ConvOp : Hip_DpsOp<"conv", /*traits=*/[OpStateOpInterface], /*outsAccess
     I64ArrayAttr:$pads,
     I64ArrayAttr:$dilations,
     I64Attr:$group,
-    DefaultValuedAttr<I64Attr, "0">:$activation
+    DefaultValuedAttr<BoolAttr, "false">:$fused_activation,
+    DefaultValuedAttr<F32Attr, "0.0">:$activation_clip_lo,
+    DefaultValuedAttr<F32Attr, "0.0">:$activation_clip_hi,
+    DefaultValuedAttr<F32Attr, "0.0">:$activation_alpha
   );
 
   let assemblyFormat = [{

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -639,6 +639,8 @@ def Hip_ConvOp : Hip_DpsOp<"conv", /*traits=*/[OpStateOpInterface], /*outsAccess
     - pads: Array of padding values [top, left, bottom, right]
     - dilations: Array of dilation values [H, W]
     - group: Number of groups for grouped convolution
+    - activation: Optional fused post-conv activation. 0 = none (default),
+      1 = ReLU6 (Clip to [0, 6] via MIOpen FusionPlan CLIPPEDRELU).
 
     Example:
     ```mlir
@@ -662,7 +664,8 @@ def Hip_ConvOp : Hip_DpsOp<"conv", /*traits=*/[OpStateOpInterface], /*outsAccess
     I64ArrayAttr:$strides,
     I64ArrayAttr:$pads,
     I64ArrayAttr:$dilations,
-    I64Attr:$group
+    I64Attr:$group,
+    DefaultValuedAttr<I64Attr, "0">:$activation
   );
 
   let assemblyFormat = [{

--- a/include/hip/Dialect/Transforms/Passes.td
+++ b/include/hip/Dialect/Transforms/Passes.td
@@ -611,11 +611,15 @@ def UseOutputAllocatorPass
 }
 
 def FuseConvRelu6Pass : Pass<"hip-fuse-conv-relu6", "mlir::func::FuncOp"> {
-  let summary = "Fuse hip.conv + hip.max(0) + hip.min(6) into conv with ReLU6";
+  let summary = "Fuse hip.conv + ReLU/ReLU6 elementwise chains into conv";
   let description = [{
-    Matches MobileNet-style ReLU6 (Clip 0..6) when it is the sole consumer of
-    a convolution and sets `activation = 1` on the conv so the runtime can use
-    MIOpen FusionPlan (Conv+Bias+ClippedReLU).
+    Folds post-conv activation elementwise chains into `hip.conv`:
+      - ReLU6: hip.conv + hip.max(0) + hip.min(6)
+          -> fused_activation, activation_clip_lo=0, activation_clip_hi=6
+      - ReLU:  hip.conv + hip.max(0)
+          -> fused_activation, activation_clip_lo=0, activation_clip_hi=0
+    The runtime applies MIOpen ReLU / ClippedReLU after conv+bias (FusionPlan
+    when supported).
   }];
   let dependentDialects = [
     "mlir::hip::HipDialect",

--- a/include/hip/Dialect/Transforms/Passes.td
+++ b/include/hip/Dialect/Transforms/Passes.td
@@ -610,6 +610,19 @@ def UseOutputAllocatorPass
   ];
 }
 
+def FuseConvRelu6Pass : Pass<"hip-fuse-conv-relu6", "mlir::func::FuncOp"> {
+  let summary = "Fuse hip.conv + hip.max(0) + hip.min(6) into conv with ReLU6";
+  let description = [{
+    Matches MobileNet-style ReLU6 (Clip 0..6) when it is the sole consumer of
+    a convolution and sets `activation = 1` on the conv so the runtime can use
+    MIOpen FusionPlan (Conv+Bias+ClippedReLU).
+  }];
+  let dependentDialects = [
+    "mlir::hip::HipDialect",
+    "mlir::func::FuncDialect"
+  ];
+}
+
 def InferShapesPass : Pass<"hip-infer-shapes", "mlir::ModuleOp"> {
   let summary = "Refine dynamic dims in HIP DPS op result types via "
                 "`ReifyRankedShapedTypeOpInterface`";

--- a/lib/Conversion/HipToLLVM/ConvLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ConvLowering.cpp
@@ -180,9 +180,10 @@ struct ConvOpLowering : public ConvertOpToLLVMPattern<ConvOp> {
       return op.emitError("hip.conv: unsupported output element type ")
              << outputType.getElementType();
     Value dataType = createI64Const(dataTypeEnum);
+    Value activationVal = createI64Const(op.getActivation());
 
     // Build function signature
-    SmallVector<Type, 25> paramTypes = {
+    SmallVector<Type, 26> paramTypes = {
         ptrType, // state
         i32Type, // op_state_slot
         ptrType, // input
@@ -207,7 +208,8 @@ struct ConvOpLowering : public ConvertOpToLLVMPattern<ConvOp> {
         i64Type, // dilation_h
         i64Type, // dilation_w
         i64Type, // group
-        i64Type  // data_type
+        i64Type, // data_type
+        i64Type  // activation
     };
 
     // Lookup or create the runtime function
@@ -218,12 +220,12 @@ struct ConvOpLowering : public ConvertOpToLLVMPattern<ConvOp> {
 
     // Build argument list matching the signature
     auto opStateSlot = getOpStateSlotValue(op, rewriter, loc);
-    SmallVector<Value, 25> args = {
-        statePtr,  opStateSlot, inputPtr,   inputN,   inputC,
-        inputH,    inputW,      weightsPtr, weightsK, biasPtr,
-        outputPtr, outputH,     outputW,    kernelH,  kernelW,
-        strideH,   strideW,     padTop,     padLeft,  padBottom,
-        padRight,  dilationH,   dilationW,  groupVal, dataType,
+    SmallVector<Value, 26> args = {
+        statePtr, opStateSlot,   inputPtr, inputN,    inputC,    inputH,
+        inputW,   weightsPtr,    weightsK, biasPtr,   outputPtr, outputH,
+        outputW,  kernelH,       kernelW,  strideH,   strideW,   padTop,
+        padLeft,  padBottom,     padRight, dilationH, dilationW, groupVal,
+        dataType, activationVal,
     };
 
     // Call the runtime function

--- a/lib/Conversion/HipToLLVM/ConvLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ConvLowering.cpp
@@ -180,36 +180,47 @@ struct ConvOpLowering : public ConvertOpToLLVMPattern<ConvOp> {
       return op.emitError("hip.conv: unsupported output element type ")
              << outputType.getElementType();
     Value dataType = createI64Const(dataTypeEnum);
-    Value activationVal = createI64Const(op.getActivation());
+    Value fusedActivationVal = createI64Const(op.getFusedActivation() ? 1 : 0);
+
+    auto createF32Const = [&](float value) -> Value {
+      return LLVM::ConstantOp::create(rewriter, loc, rewriter.getF32Type(),
+                                      rewriter.getF32FloatAttr(value));
+    };
+    Value clipLoVal = createF32Const(op.getActivationClipLo().convertToFloat());
+    Value clipHiVal = createF32Const(op.getActivationClipHi().convertToFloat());
+    Value alphaVal = createF32Const(op.getActivationAlpha().convertToFloat());
 
     // Build function signature
-    SmallVector<Type, 26> paramTypes = {
-        ptrType, // state
-        i32Type, // op_state_slot
-        ptrType, // input
-        i64Type, // input_n
-        i64Type, // input_c
-        i64Type, // input_h
-        i64Type, // input_w
-        ptrType, // weights
-        i64Type, // weights_k
-        ptrType, // bias
-        ptrType, // output
-        i64Type, // output_h
-        i64Type, // output_w
-        i64Type, // kernel_h
-        i64Type, // kernel_w
-        i64Type, // stride_h
-        i64Type, // stride_w
-        i64Type, // pad_top
-        i64Type, // pad_left
-        i64Type, // pad_bottom
-        i64Type, // pad_right
-        i64Type, // dilation_h
-        i64Type, // dilation_w
-        i64Type, // group
-        i64Type, // data_type
-        i64Type  // activation
+    SmallVector<Type, 29> paramTypes = {
+        ptrType,               // state
+        i32Type,               // op_state_slot
+        ptrType,               // input
+        i64Type,               // input_n
+        i64Type,               // input_c
+        i64Type,               // input_h
+        i64Type,               // input_w
+        ptrType,               // weights
+        i64Type,               // weights_k
+        ptrType,               // bias
+        ptrType,               // output
+        i64Type,               // output_h
+        i64Type,               // output_w
+        i64Type,               // kernel_h
+        i64Type,               // kernel_w
+        i64Type,               // stride_h
+        i64Type,               // stride_w
+        i64Type,               // pad_top
+        i64Type,               // pad_left
+        i64Type,               // pad_bottom
+        i64Type,               // pad_right
+        i64Type,               // dilation_h
+        i64Type,               // dilation_w
+        i64Type,               // group
+        i64Type,               // data_type
+        i64Type,               // fused_activation
+        rewriter.getF32Type(), // activation_clip_lo
+        rewriter.getF32Type(), // activation_clip_hi
+        rewriter.getF32Type()  // activation_alpha
     };
 
     // Lookup or create the runtime function
@@ -220,12 +231,22 @@ struct ConvOpLowering : public ConvertOpToLLVMPattern<ConvOp> {
 
     // Build argument list matching the signature
     auto opStateSlot = getOpStateSlotValue(op, rewriter, loc);
-    SmallVector<Value, 26> args = {
-        statePtr, opStateSlot,   inputPtr, inputN,    inputC,    inputH,
-        inputW,   weightsPtr,    weightsK, biasPtr,   outputPtr, outputH,
-        outputW,  kernelH,       kernelW,  strideH,   strideW,   padTop,
-        padLeft,  padBottom,     padRight, dilationH, dilationW, groupVal,
-        dataType, activationVal,
+    SmallVector<Value, 29> args = {
+        statePtr,  opStateSlot,
+        inputPtr,  inputN,
+        inputC,    inputH,
+        inputW,    weightsPtr,
+        weightsK,  biasPtr,
+        outputPtr, outputH,
+        outputW,   kernelH,
+        kernelW,   strideH,
+        strideW,   padTop,
+        padLeft,   padBottom,
+        padRight,  dilationH,
+        dilationW, groupVal,
+        dataType,  fusedActivationVal,
+        clipLoVal, clipHiVal,
+        alphaVal,
     };
 
     // Call the runtime function

--- a/lib/Dialect/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Transforms/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(HipDialectTransforms STATIC
   BufferUtils.cpp
   ExternalizeConstants.cpp
   FixLoopAccumulatorOffset.cpp
+  FuseConvRelu6.cpp
   GenerateInterface.cpp
   GenerateOpStateInit.cpp
   HoistAllocSizeArith.cpp

--- a/lib/Dialect/Transforms/FuseConvRelu6.cpp
+++ b/lib/Dialect/Transforms/FuseConvRelu6.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- FuseConvRelu6.cpp - hip.conv + hip.max/min -> fused conv -----------===//
+//
+// MobileNet ReLU6 lowers as Clip(0, 6) -> hip.max(x, 0) + hip.min(x, 6).
+// When this chain is the sole consumer of a conv, fold it into hip.conv with
+// activation=1 so the runtime can execute MIOpen FusionPlan (Conv+Bias+Act).
+//
+//===----------------------------------------------------------------------===//
+
+#include "hip/Dialect/IR/HipDialect.h"
+#include "hip/Dialect/Transforms/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "llvm/ADT/Statistic.h"
+
+#define DEBUG_TYPE "fuse-conv-relu6"
+
+STATISTIC(NumConvRelu6Fused, "Number of conv+ReLU6 chains fused");
+
+namespace mlir {
+namespace hip {
+
+#define GEN_PASS_DEF_FUSECONVRELU6PASS
+#include "hip/Dialect/Transforms/Passes.h.inc"
+
+namespace {
+
+static constexpr int64_t kConvActivationRelu6 = 1;
+
+static std::optional<double> getScalarConstant(mlir::Value v) {
+  while (v) {
+    if (auto castOp = v.getDefiningOp<mlir::UnrealizedConversionCastOp>())
+      v = castOp.getOperand(0);
+    else
+      break;
+  }
+
+  mlir::Operation *def = v.getDefiningOp();
+  if (!def)
+    return std::nullopt;
+
+  mlir::DenseElementsAttr dense;
+  if (def->getName().getStringRef() == "onnx.Constant") {
+    dense =
+        mlir::dyn_cast_or_null<mlir::DenseElementsAttr>(def->getAttr("value"));
+  } else if (auto cst = mlir::dyn_cast<mlir::arith::ConstantOp>(def)) {
+    dense = mlir::dyn_cast<mlir::DenseElementsAttr>(cst.getValue());
+  } else if (auto hc = mlir::dyn_cast<mlir::hip::ConstantOp>(def)) {
+    if (auto val = hc.getValue())
+      dense = mlir::dyn_cast<mlir::DenseElementsAttr>(*val);
+  }
+  if (!dense)
+    return std::nullopt;
+  if (!dense.isSplat() && dense.getNumElements() != 1)
+    return std::nullopt;
+
+  mlir::Type et = dense.getElementType();
+  if (et.isF32())
+    return static_cast<double>(*dense.getValues<float>().begin());
+  if (et.isF64())
+    return *dense.getValues<double>().begin();
+  if (et.isF16() || et.isBF16())
+    return (*dense.getValues<llvm::APFloat>().begin()).convertToDouble();
+  if (et.isIntOrIndex())
+    return static_cast<double>(
+        (*dense.getValues<llvm::APInt>().begin()).getSExtValue());
+  return std::nullopt;
+}
+
+struct FuseConvRelu6Pattern : public OpRewritePattern<MinOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(MinOp minOp,
+                                PatternRewriter &rewriter) const override {
+    auto maxOp = minOp.getLhs().getDefiningOp<MaxOp>();
+    if (!maxOp || !maxOp->hasOneUse())
+      return failure();
+
+    auto convOp = maxOp.getLhs().getDefiningOp<ConvOp>();
+    if (!convOp || convOp.getActivation() != 0)
+      return failure();
+    if (!convOp.getResults().front().hasOneUse())
+      return failure();
+
+    std::optional<double> lo = getScalarConstant(maxOp.getRhs());
+    std::optional<double> hi = getScalarConstant(minOp.getRhs());
+    if (!lo || !hi)
+      return failure();
+    if (std::abs(*lo) > 1e-3 || std::abs(*hi - 6.0) > 1e-3)
+      return failure();
+
+    Value finalOutput = minOp.getOutput();
+    if (finalOutput == convOp.getOutput()) {
+      rewriter.modifyOpInPlace(
+          convOp, [&]() { convOp.setActivation(kConvActivationRelu6); });
+      rewriter.replaceOp(minOp, convOp.getResult(0));
+      rewriter.eraseOp(maxOp);
+      ++NumConvRelu6Fused;
+      return success();
+    }
+
+    // The final output buffer is allocated after the conv in the typical
+    // conv -> max -> min chain. Reassigning conv's outs in-place would make
+    // conv reference a value that does not dominate it.
+    Operation *outputDef = finalOutput.getDefiningOp();
+    if (!outputDef)
+      return failure();
+
+    SmallVector<Value> operands = {convOp.getCtx(), convOp.getInput(),
+                                   convOp.getWeights()};
+    if (Value bias = convOp.getBias())
+      operands.push_back(bias);
+    operands.push_back(finalOutput);
+
+    SmallVector<NamedAttribute> attrs;
+    for (NamedAttribute attr : convOp->getAttrs()) {
+      if (attr.getName() == "activation")
+        continue;
+      attrs.push_back(attr);
+    }
+    attrs.push_back(rewriter.getNamedAttr(
+        "activation", rewriter.getI64IntegerAttr(kConvActivationRelu6)));
+
+    rewriter.setInsertionPointAfter(outputDef);
+    auto fusedConv = ConvOp::create(rewriter, convOp.getLoc(), operands, attrs);
+
+    rewriter.replaceOp(minOp, fusedConv.getResult(0));
+    rewriter.eraseOp(maxOp);
+    rewriter.eraseOp(convOp);
+    ++NumConvRelu6Fused;
+    return success();
+  }
+};
+
+struct FuseConvRelu6Pass
+    : public impl::FuseConvRelu6PassBase<FuseConvRelu6Pass> {
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    RewritePatternSet patterns(&getContext());
+    patterns.add<FuseConvRelu6Pattern>(&getContext());
+    if (failed(applyPatternsGreedily(func, std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
+} // namespace
+} // namespace hip
+} // namespace mlir

--- a/lib/Dialect/Transforms/FuseConvRelu6.cpp
+++ b/lib/Dialect/Transforms/FuseConvRelu6.cpp
@@ -5,8 +5,9 @@
 //===- FuseConvRelu6.cpp - hip.conv + hip.max/min -> fused conv -----------===//
 //
 // MobileNet ReLU6 lowers as Clip(0, 6) -> hip.max(x, 0) + hip.min(x, 6).
-// When this chain is the sole consumer of a conv, fold it into hip.conv with
-// activation=1 so the runtime can execute MIOpen FusionPlan (Conv+Bias+Act).
+// ResNet ReLU lowers as hip.max(x, 0). When either chain is the sole consumer
+// of a convolution, fold it into hip.conv with fused_activation and clip bounds
+// so the runtime can apply MIOpen ReLU / ClippedReLU after conv+bias.
 //
 //===----------------------------------------------------------------------===//
 
@@ -14,16 +15,24 @@
 #include "hip/Dialect/Transforms/Passes.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
+#include "llvm/ADT/APFloat.h"
+#include "llvm/ADT/APInt.h"
 #include "llvm/ADT/Statistic.h"
+
+#include <cstring>
 
 #define DEBUG_TYPE "fuse-conv-relu6"
 
 STATISTIC(NumConvRelu6Fused, "Number of conv+ReLU6 chains fused");
+STATISTIC(NumConvReluFused, "Number of conv+ReLU chains fused");
 
 namespace mlir {
 namespace hip {
@@ -33,7 +42,105 @@ namespace hip {
 
 namespace {
 
-static constexpr int64_t kConvActivationRelu6 = 1;
+static constexpr float kClipLoZero = 0.0f;
+static constexpr float kClipHiNone = 0.0f;
+static constexpr float kClipHiRelu6 = 6.0f;
+
+static FloatAttr f32Attr(PatternRewriter &rewriter, float value) {
+  return rewriter.getF32FloatAttr(value);
+}
+
+static std::optional<double> decodeSplatBytes(Type elemType,
+                                              ArrayRef<uint8_t> bytes) {
+  if (elemType.isF32()) {
+    if (bytes.size() < sizeof(float))
+      return std::nullopt;
+    float value;
+    std::memcpy(&value, bytes.data(), sizeof(float));
+    return static_cast<double>(value);
+  }
+  if (elemType.isF64()) {
+    if (bytes.size() < sizeof(double))
+      return std::nullopt;
+    double value;
+    std::memcpy(&value, bytes.data(), sizeof(double));
+    return value;
+  }
+  if (elemType.isF16()) {
+    if (bytes.size() < sizeof(uint16_t))
+      return std::nullopt;
+    uint16_t bits;
+    std::memcpy(&bits, bytes.data(), sizeof(uint16_t));
+    llvm::APFloat value(llvm::APFloat::IEEEhalf(), llvm::APInt(16, bits));
+    return value.convertToDouble();
+  }
+  if (elemType.isBF16()) {
+    if (bytes.size() < sizeof(uint16_t))
+      return std::nullopt;
+    uint16_t bits;
+    std::memcpy(&bits, bytes.data(), sizeof(uint16_t));
+    llvm::APFloat value(llvm::APFloat::BFloat(), llvm::APInt(16, bits));
+    return value.convertToDouble();
+  }
+  if (elemType.isIntOrIndex()) {
+    if (bytes.empty() || bytes.size() > 8)
+      return std::nullopt;
+    int64_t raw = 0;
+    std::memcpy(&raw, bytes.data(), bytes.size());
+    const unsigned bitWidth = static_cast<unsigned>(bytes.size() * 8);
+    return static_cast<double>(llvm::APInt(bitWidth, raw, true).getSExtValue());
+  }
+  return std::nullopt;
+}
+
+static std::optional<double>
+getExternalizedSplatScalar(bufferization::ToTensorOp toTensor) {
+  auto getGlobal = toTensor.getBuffer().getDefiningOp<memref::GetGlobalOp>();
+  if (!getGlobal)
+    return std::nullopt;
+
+  auto module = getGlobal->getParentOfType<ModuleOp>();
+  if (!module)
+    return std::nullopt;
+
+  auto global = module.lookupSymbol<memref::GlobalOp>(getGlobal.getName());
+  if (!global)
+    return std::nullopt;
+
+  auto externalData =
+      dyn_cast_or_null<DictionaryAttr>(global->getAttr("hip.external_data"));
+  if (!externalData)
+    return std::nullopt;
+
+  auto indexAttr = dyn_cast_or_null<IntegerAttr>(externalData.get("index"));
+  if (!indexAttr)
+    return std::nullopt;
+  int64_t index = indexAttr.getInt();
+
+  auto sourceKinds =
+      module->getAttrOfType<DenseI32ArrayAttr>("hipdnn.constant_source_kinds");
+  auto splatValues = module->getAttrOfType<DenseI64ArrayAttr>(
+      "hipdnn.constant_splat_elem_values");
+  auto splatElemSizes = module->getAttrOfType<DenseI64ArrayAttr>(
+      "hipdnn.constant_splat_elem_sizes");
+  if (!sourceKinds || !splatValues || !splatElemSizes || index < 0 ||
+      index >= static_cast<int64_t>(sourceKinds.size()))
+    return std::nullopt;
+
+  if (static_cast<ConstantMetadataSourceKind>(sourceKinds[index]) !=
+      ConstantMetadataSourceKind::Splat)
+    return std::nullopt;
+
+  int64_t elemSize = splatElemSizes[index];
+  if (elemSize <= 0 || elemSize > 8)
+    return std::nullopt;
+
+  int64_t rawValue = splatValues[index];
+  const auto *bytes = reinterpret_cast<const uint8_t *>(&rawValue);
+  return decodeSplatBytes(
+      global.getType().getElementType(),
+      ArrayRef<uint8_t>(bytes, static_cast<size_t>(elemSize)));
+}
 
 static std::optional<double> getScalarConstant(mlir::Value v) {
   while (v) {
@@ -46,6 +153,11 @@ static std::optional<double> getScalarConstant(mlir::Value v) {
   mlir::Operation *def = v.getDefiningOp();
   if (!def)
     return std::nullopt;
+
+  if (auto toTensor = dyn_cast<bufferization::ToTensorOp>(def)) {
+    if (auto splat = getExternalizedSplatScalar(toTensor))
+      return splat;
+  }
 
   mlir::DenseElementsAttr dense;
   if (def->getName().getStringRef() == "onnx.Constant") {
@@ -75,6 +187,65 @@ static std::optional<double> getScalarConstant(mlir::Value v) {
   return std::nullopt;
 }
 
+static bool convHasFusedActivation(ConvOp convOp) {
+  return convOp.getFusedActivation();
+}
+
+static bool isRelu6MinChain(MaxOp maxOp) {
+  if (!maxOp->hasOneUse())
+    return false;
+  auto minOp = dyn_cast<MinOp>(*maxOp->getUsers().begin());
+  if (!minOp)
+    return false;
+  std::optional<double> lo = getScalarConstant(maxOp.getRhs());
+  std::optional<double> hi = getScalarConstant(minOp.getRhs());
+  return lo && hi && std::abs(*lo) <= 1e-3 && std::abs(*hi - 6.0) <= 1e-3;
+}
+
+static void setFusedClipActivation(ConvOp convOp, float clipLo, float clipHi) {
+  convOp.setFusedActivation(true);
+  convOp.setActivationClipLo(llvm::APFloat(clipLo));
+  convOp.setActivationClipHi(llvm::APFloat(clipHi));
+}
+
+static LogicalResult fuseConvWithActivation(ConvOp convOp, Value finalOutput,
+                                            float clipLo, float clipHi,
+                                            PatternRewriter &rewriter,
+                                            Operation *tailOp, MaxOp maxOp,
+                                            MinOp minOp) {
+  if (finalOutput == convOp.getOutput()) {
+    rewriter.modifyOpInPlace(
+        convOp, [&]() { setFusedClipActivation(convOp, clipLo, clipHi); });
+    rewriter.replaceOp(tailOp, convOp.getResult(0));
+    if (maxOp && maxOp.getOperation() != tailOp)
+      rewriter.eraseOp(maxOp);
+    if (minOp && minOp.getOperation() != tailOp)
+      rewriter.eraseOp(minOp);
+    return success();
+  }
+
+  Operation *outputDef = finalOutput.getDefiningOp();
+  if (!outputDef)
+    return failure();
+
+  rewriter.setInsertionPointAfter(outputDef);
+  auto fusedConv = ConvOp::create(
+      rewriter, convOp.getLoc(), convOp.getCtx(), convOp.getInput(),
+      convOp.getWeights(), convOp.getBias(), finalOutput,
+      convOp.getKernelShapeAttr(), convOp.getStridesAttr(),
+      convOp.getPadsAttr(), convOp.getDilationsAttr(), convOp.getGroupAttr(),
+      rewriter.getBoolAttr(true), f32Attr(rewriter, clipLo),
+      f32Attr(rewriter, clipHi), convOp.getActivationAlphaAttr());
+
+  rewriter.replaceOp(tailOp, fusedConv.getResult(0));
+  if (maxOp && maxOp.getOperation() != tailOp)
+    rewriter.eraseOp(maxOp);
+  if (minOp && minOp.getOperation() != tailOp)
+    rewriter.eraseOp(minOp);
+  rewriter.eraseOp(convOp);
+  return success();
+}
+
 struct FuseConvRelu6Pattern : public OpRewritePattern<MinOp> {
   using OpRewritePattern::OpRewritePattern;
 
@@ -85,7 +256,7 @@ struct FuseConvRelu6Pattern : public OpRewritePattern<MinOp> {
       return failure();
 
     auto convOp = maxOp.getLhs().getDefiningOp<ConvOp>();
-    if (!convOp || convOp.getActivation() != 0)
+    if (!convOp || convHasFusedActivation(convOp))
       return failure();
     if (!convOp.getResults().front().hasOneUse())
       return failure();
@@ -97,45 +268,38 @@ struct FuseConvRelu6Pattern : public OpRewritePattern<MinOp> {
     if (std::abs(*lo) > 1e-3 || std::abs(*hi - 6.0) > 1e-3)
       return failure();
 
-    Value finalOutput = minOp.getOutput();
-    if (finalOutput == convOp.getOutput()) {
-      rewriter.modifyOpInPlace(
-          convOp, [&]() { convOp.setActivation(kConvActivationRelu6); });
-      rewriter.replaceOp(minOp, convOp.getResult(0));
-      rewriter.eraseOp(maxOp);
-      ++NumConvRelu6Fused;
-      return success();
-    }
+    if (failed(fuseConvWithActivation(convOp, minOp.getOutput(), kClipLoZero,
+                                      kClipHiRelu6, rewriter, minOp, maxOp,
+                                      minOp)))
+      return failure();
+    ++NumConvRelu6Fused;
+    return success();
+  }
+};
 
-    // The final output buffer is allocated after the conv in the typical
-    // conv -> max -> min chain. Reassigning conv's outs in-place would make
-    // conv reference a value that does not dominate it.
-    Operation *outputDef = finalOutput.getDefiningOp();
-    if (!outputDef)
+struct FuseConvReluPattern : public OpRewritePattern<MaxOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(MaxOp maxOp,
+                                PatternRewriter &rewriter) const override {
+    if (isRelu6MinChain(maxOp))
       return failure();
 
-    SmallVector<Value> operands = {convOp.getCtx(), convOp.getInput(),
-                                   convOp.getWeights()};
-    if (Value bias = convOp.getBias())
-      operands.push_back(bias);
-    operands.push_back(finalOutput);
+    auto convOp = maxOp.getLhs().getDefiningOp<ConvOp>();
+    if (!convOp || convHasFusedActivation(convOp))
+      return failure();
+    if (!convOp.getResults().front().hasOneUse())
+      return failure();
 
-    SmallVector<NamedAttribute> attrs;
-    for (NamedAttribute attr : convOp->getAttrs()) {
-      if (attr.getName() == "activation")
-        continue;
-      attrs.push_back(attr);
-    }
-    attrs.push_back(rewriter.getNamedAttr(
-        "activation", rewriter.getI64IntegerAttr(kConvActivationRelu6)));
+    std::optional<double> lo = getScalarConstant(maxOp.getRhs());
+    if (!lo || std::abs(*lo) > 1e-3)
+      return failure();
 
-    rewriter.setInsertionPointAfter(outputDef);
-    auto fusedConv = ConvOp::create(rewriter, convOp.getLoc(), operands, attrs);
-
-    rewriter.replaceOp(minOp, fusedConv.getResult(0));
-    rewriter.eraseOp(maxOp);
-    rewriter.eraseOp(convOp);
-    ++NumConvRelu6Fused;
+    if (failed(fuseConvWithActivation(convOp, maxOp.getOutput(), kClipLoZero,
+                                      kClipHiNone, rewriter, maxOp, maxOp,
+                                      nullptr)))
+      return failure();
+    ++NumConvReluFused;
     return success();
   }
 };
@@ -145,7 +309,7 @@ struct FuseConvRelu6Pass
   void runOnOperation() override {
     func::FuncOp func = getOperation();
     RewritePatternSet patterns(&getContext());
-    patterns.add<FuseConvRelu6Pattern>(&getContext());
+    patterns.add<FuseConvRelu6Pattern, FuseConvReluPattern>(&getContext());
     if (failed(applyPatternsGreedily(func, std::move(patterns))))
       signalPassFailure();
   }

--- a/lib/Dialect/Transforms/Pipelines.cpp
+++ b/lib/Dialect/Transforms/Pipelines.cpp
@@ -127,6 +127,7 @@ buildOnnxToHipPipelineTail(OpPassManager &pm,
   //     implement the interface. See `docs/design/hip-shape-inference.md`
   //     for the design and `test/lit/Dialect/hip-infer-shapes.mlir` for
   //     the reference cases.
+  pm.addNestedPass<func::FuncOp>(mlir::hip::createFuseConvRelu6Pass());
   pm.addPass(mlir::hip::createInferShapesPass());
 
   // Apply constant storage policy only after HIP shape inference has consumed

--- a/lib/Dialect/Transforms/Pipelines.cpp
+++ b/lib/Dialect/Transforms/Pipelines.cpp
@@ -127,7 +127,6 @@ buildOnnxToHipPipelineTail(OpPassManager &pm,
   //     implement the interface. See `docs/design/hip-shape-inference.md`
   //     for the design and `test/lit/Dialect/hip-infer-shapes.mlir` for
   //     the reference cases.
-  pm.addNestedPass<func::FuncOp>(mlir::hip::createFuseConvRelu6Pass());
   pm.addPass(mlir::hip::createInferShapesPass());
 
   // Apply constant storage policy only after HIP shape inference has consumed
@@ -146,6 +145,10 @@ buildOnnxToHipPipelineTail(OpPassManager &pm,
     pm.addPass(mlir::hip::createExternalizeConstantsPass(
         std::move(externalizeOptions)));
   }
+
+  // Fold conv+ReLU6 after constant externalization: greedy rewrite can DCE
+  // unused hip.constant carriers if this runs earlier (StaticPlugins test).
+  pm.addNestedPass<func::FuncOp>(mlir::hip::createFuseConvRelu6Pass());
 
   // 1b'. Canonicalize + CSE immediately after shape inference and constant
   //      externalization. The dynamic-shape op conversions (e.g. pool /

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -137,9 +137,23 @@ static inline const char *hipdnn_ep_datatype_name(int64_t data_type) {
 #define HIPDNN_EP_ACTIVATION_TANH 2
 #define HIPDNN_EP_ACTIVATION_SOFTPLUS 3
 
-// Fused post-conv activation modes for wrap_miopenConvolutionForward.
-#define HIPDNN_EP_CONV_ACTIVATION_NONE 0
-#define HIPDNN_EP_CONV_ACTIVATION_RELU6 1
+// Fused post-conv activation parameters for wrap_miopenConvolutionForward.
+// When fused_activation is 0, clip/alpha params are ignored.
+// activation_clip_hi == 0 means no upper clip (plain ReLU when clip_lo == 0).
+#define HIPDNN_EP_CONV_CLIP_HI_NONE 0.0f
+
+static inline const char *
+hipdnn_ep_conv_fused_activation_name(int64_t fused_activation,
+                                     float activation_clip_lo,
+                                     float activation_clip_hi) {
+  if (!fused_activation)
+    return "none";
+  if (activation_clip_hi > 0.0f)
+    return "clipped_relu";
+  if (activation_clip_lo == 0.0f)
+    return "relu";
+  return "clip";
+}
 
 static inline const char *hipdnn_ep_activation_name(int64_t activation_mode) {
   switch (activation_mode) {
@@ -746,31 +760,34 @@ int wrap_strided_copy(RuntimeState *state, void *dst_ptr, const void *src_ptr,
 int wrap_miopenConvolutionForward(
     RuntimeState
         *state, // RuntimeState (opaque - extracts handle/stream internally)
-    int32_t op_state_slot, // Op state slot
-    const void *input,     // Input tensor GPU pointer
-    int64_t input_n,       // Input batch size
-    int64_t input_c,       // Input channels
-    int64_t input_h,       // Input height
-    int64_t input_w,       // Input width
-    const void *weights,   // Weights tensor GPU pointer
-    int64_t weights_k,     // Output channels (number of filters)
-    const void *bias,      // Bias tensor GPU pointer (nullable)
-    void *output,          // Output tensor GPU pointer (in-place)
-    int64_t output_h,      // Output height
-    int64_t output_w,      // Output width
-    int64_t kernel_h,      // Kernel height
-    int64_t kernel_w,      // Kernel width
-    int64_t stride_h,      // Stride height
-    int64_t stride_w,      // Stride width
-    int64_t pad_top,       // Padding top
-    int64_t pad_left,      // Padding left
-    int64_t pad_bottom,    // Padding bottom
-    int64_t pad_right,     // Padding right
-    int64_t dilation_h,    // Dilation height
-    int64_t dilation_w,    // Dilation width
-    int64_t group,         // Number of groups
-    int64_t data_type,     // HIPDNN_EP_DATATYPE_* for I/O and weights
-    int64_t activation);   // HIPDNN_EP_CONV_ACTIVATION_* (0=none, 1=ReLU6)
+    int32_t op_state_slot,    // Op state slot
+    const void *input,        // Input tensor GPU pointer
+    int64_t input_n,          // Input batch size
+    int64_t input_c,          // Input channels
+    int64_t input_h,          // Input height
+    int64_t input_w,          // Input width
+    const void *weights,      // Weights tensor GPU pointer
+    int64_t weights_k,        // Output channels (number of filters)
+    const void *bias,         // Bias tensor GPU pointer (nullable)
+    void *output,             // Output tensor GPU pointer (in-place)
+    int64_t output_h,         // Output height
+    int64_t output_w,         // Output width
+    int64_t kernel_h,         // Kernel height
+    int64_t kernel_w,         // Kernel width
+    int64_t stride_h,         // Stride height
+    int64_t stride_w,         // Stride width
+    int64_t pad_top,          // Padding top
+    int64_t pad_left,         // Padding left
+    int64_t pad_bottom,       // Padding bottom
+    int64_t pad_right,        // Padding right
+    int64_t dilation_h,       // Dilation height
+    int64_t dilation_w,       // Dilation width
+    int64_t group,            // Number of groups
+    int64_t data_type,        // HIPDNN_EP_DATATYPE_* for I/O and weights
+    int64_t fused_activation, // 0 = none, 1 = apply fused activation
+    float activation_clip_lo, // lower clip (typically 0)
+    float activation_clip_hi, // upper clip; 0 = no upper clip
+    float activation_alpha);  // reserved for leaky/slope activations
 
 // MIOpen transposed convolution (deconvolution) wrapper
 // Uses MIOpen's miopenTranspose convolution mode. Follows the opaque

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -137,6 +137,10 @@ static inline const char *hipdnn_ep_datatype_name(int64_t data_type) {
 #define HIPDNN_EP_ACTIVATION_TANH 2
 #define HIPDNN_EP_ACTIVATION_SOFTPLUS 3
 
+// Fused post-conv activation modes for wrap_miopenConvolutionForward.
+#define HIPDNN_EP_CONV_ACTIVATION_NONE 0
+#define HIPDNN_EP_CONV_ACTIVATION_RELU6 1
+
 static inline const char *hipdnn_ep_activation_name(int64_t activation_mode) {
   switch (activation_mode) {
   case HIPDNN_EP_ACTIVATION_SIGMOID:
@@ -765,7 +769,8 @@ int wrap_miopenConvolutionForward(
     int64_t dilation_h,    // Dilation height
     int64_t dilation_w,    // Dilation width
     int64_t group,         // Number of groups
-    int64_t data_type);    // HIPDNN_EP_DATATYPE_* for I/O and weights
+    int64_t data_type,     // HIPDNN_EP_DATATYPE_* for I/O and weights
+    int64_t activation);   // HIPDNN_EP_CONV_ACTIVATION_* (0=none, 1=ReLU6)
 
 // MIOpen transposed convolution (deconvolution) wrapper
 // Uses MIOpen's miopenTranspose convolution mode. Follows the opaque

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -449,7 +449,7 @@ int wrap_miopenConvolutionForward(
     int64_t output_h, int64_t output_w, int64_t kernel_h, int64_t kernel_w,
     int64_t stride_h, int64_t stride_w, int64_t pad_top, int64_t pad_left,
     int64_t pad_bottom, int64_t pad_right, int64_t dilation_h,
-    int64_t dilation_w, int64_t group, int64_t data_type) {
+    int64_t dilation_w, int64_t group, int64_t data_type, int64_t activation) {
   if (!state || !input || !weights || !output) {
     fprintf(stderr, "Invalid arguments to wrap_miopenConvolutionForward\n");
     return -1;
@@ -464,10 +464,11 @@ int wrap_miopenConvolutionForward(
   MOCK_PRINT("[MOCK]   output=[%lld,%lld,%lld,%lld],\n", (long long)input_n,
              (long long)weights_k, (long long)output_h, (long long)output_w);
   MOCK_PRINT("[MOCK]   stride=[%lld,%lld], pad=[%lld,%lld,%lld,%lld], "
-             "dilation=[%lld,%lld], group=%lld)\n",
+             "dilation=[%lld,%lld], group=%lld, dtype=%lld, activation=%lld)\n",
              (long long)stride_h, (long long)stride_w, (long long)pad_top,
              (long long)pad_left, (long long)pad_bottom, (long long)pad_right,
-             (long long)dilation_h, (long long)dilation_w, (long long)group);
+             (long long)dilation_h, (long long)dilation_w, (long long)group,
+             (long long)data_type, (long long)activation);
 
   // Mock: Fill output with dummy data (zeros in this case)
   // In a real implementation, this would call MIOpen. Use the actual element

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -449,7 +449,10 @@ int wrap_miopenConvolutionForward(
     int64_t output_h, int64_t output_w, int64_t kernel_h, int64_t kernel_w,
     int64_t stride_h, int64_t stride_w, int64_t pad_top, int64_t pad_left,
     int64_t pad_bottom, int64_t pad_right, int64_t dilation_h,
-    int64_t dilation_w, int64_t group, int64_t data_type, int64_t activation) {
+    int64_t dilation_w, int64_t group, int64_t data_type,
+    int64_t fused_activation, float activation_clip_lo,
+    float activation_clip_hi, float activation_alpha) {
+  (void)activation_alpha;
   if (!state || !input || !weights || !output) {
     fprintf(stderr, "Invalid arguments to wrap_miopenConvolutionForward\n");
     return -1;
@@ -464,11 +467,13 @@ int wrap_miopenConvolutionForward(
   MOCK_PRINT("[MOCK]   output=[%lld,%lld,%lld,%lld],\n", (long long)input_n,
              (long long)weights_k, (long long)output_h, (long long)output_w);
   MOCK_PRINT("[MOCK]   stride=[%lld,%lld], pad=[%lld,%lld,%lld,%lld], "
-             "dilation=[%lld,%lld], group=%lld, dtype=%lld, activation=%lld)\n",
+             "dilation=[%lld,%lld], group=%lld, dtype=%lld, "
+             "fused=%lld clip=[%.3f,%.3f] alpha=%.3f)\n",
              (long long)stride_h, (long long)stride_w, (long long)pad_top,
              (long long)pad_left, (long long)pad_bottom, (long long)pad_right,
              (long long)dilation_h, (long long)dilation_w, (long long)group,
-             (long long)data_type, (long long)activation);
+             (long long)data_type, (long long)fused_activation,
+             activation_clip_lo, activation_clip_hi, activation_alpha);
 
   // Mock: Fill output with dummy data (zeros in this case)
   // In a real implementation, this would call MIOpen. Use the actual element

--- a/lib/Runtime/real/miopen.cpp
+++ b/lib/Runtime/real/miopen.cpp
@@ -408,11 +408,12 @@ static void disableConvFusion(ConvFusionTable &table,
   table.disabled_keys.insert(key);
 }
 
-// MIOpen Conv+Bias+Act FusionPlan is unreliable (workspace null on some solvers,
-// slower than Find API + activation on ResNet-class models). Default off: the
-// compiler still fuses conv+ReLU/ReLU6 into hip.conv, but runtime executes via
-// miopenRunSolution + applyFusedActivationFallback (~3 ms on ResNet50).
-// Opt in with HIPDNN_EP_CONV_FUSION=1 when validating FusionPlan kernels.
+// MIOpen Conv+Bias+Act FusionPlan is unreliable (workspace null on some
+// solvers, slower than Find API + activation on ResNet-class models). Default
+// off: the compiler still fuses conv+ReLU/ReLU6 into hip.conv, but runtime
+// executes via miopenRunSolution + applyFusedActivationFallback (~3 ms on
+// ResNet50). Opt in with HIPDNN_EP_CONV_FUSION=1 when validating FusionPlan
+// kernels.
 static bool convFusionPlanEnabled() {
   char buf[8];
   unsigned long n =

--- a/lib/Runtime/real/miopen.cpp
+++ b/lib/Runtime/real/miopen.cpp
@@ -408,34 +408,18 @@ static void disableConvFusion(ConvFusionTable &table,
   table.disabled_keys.insert(key);
 }
 
-// MIOpen Conv+Bias+Act FusionPlan is unreliable on gfx115x (Strix Halo).
-// Default: skip FusionPlan there and use Find API conv + ClippedReLU instead.
-// Override: HIPDNN_EP_CONV_FUSION=1 force enable, =0 force disable.
+// MIOpen Conv+Bias+Act FusionPlan is unreliable (workspace null on some solvers,
+// slower than Find API + activation on ResNet-class models). Default off: the
+// compiler still fuses conv+ReLU/ReLU6 into hip.conv, but runtime executes via
+// miopenRunSolution + applyFusedActivationFallback (~3 ms on ResNet50).
+// Opt in with HIPDNN_EP_CONV_FUSION=1 when validating FusionPlan kernels.
 static bool convFusionPlanEnabled() {
   char buf[8];
   unsigned long n =
       hipdnn_ep::read_env("HIPDNN_EP_CONV_FUSION", buf, sizeof(buf));
-  if (n > 0) {
-    if (buf[0] == '0')
-      return false;
-    if (buf[0] >= '1')
-      return true;
-  }
-
-  static int cached = -1; // 0 = disabled, 1 = enabled
-  if (cached >= 0)
-    return cached != 0;
-
-  hipDeviceProp_t prop{};
-  int dev = 0;
-  hipGetDevice(&dev);
-  if (hipGetDeviceProperties(&prop, dev) != hipSuccess ||
-      prop.gcnArchName[0] == '\0') {
-    cached = 1;
-    return true;
-  }
-  cached = (strncmp(prop.gcnArchName, "gfx115", 6) == 0) ? 0 : 1;
-  return cached != 0;
+  if (n > 0)
+    return buf[0] >= '1';
+  return false;
 }
 
 static void logConvFusionPlanSkipOnce() {
@@ -444,8 +428,7 @@ static void logConvFusionPlanSkipOnce() {
     return;
   logged = true;
   RUNTIME_DEBUG_LOG(
-      "[CONV] FusionPlan skipped (gfx115x or HIPDNN_EP_CONV_FUSION=0), "
-      "using Find+activ fallback\n");
+      "[CONV] FusionPlan disabled (default), using Find+activ fallback\n");
 }
 
 static const ConvFusionTableEntry *

--- a/lib/Runtime/real/miopen.cpp
+++ b/lib/Runtime/real/miopen.cpp
@@ -11,8 +11,11 @@
 #include "runtime_types.h"
 
 #include <cstdio>
+#include <cstring>
+#include <memory>
 #include <mutex>
 #include <unordered_map>
+#include <unordered_set>
 
 // Convenience wrappers for goto cleanup pattern (all functions use 'cleanup'
 // label)
@@ -202,13 +205,104 @@ struct ConvTable {
   std::unordered_map<ConvTableKey, ConvTableEntry, ConvKeyHash> map;
 };
 
+struct ConvFusionTableEntry {
+  miopenFusionPlanDescriptor_t fuse_plan = nullptr;
+  miopenFusionOpDescriptor_t conv_op = nullptr;
+  miopenFusionOpDescriptor_t bias_op = nullptr;
+  miopenFusionOpDescriptor_t activ_op = nullptr;
+  bool has_bias = false;
+  miopenTensorDescriptor_t input_desc = nullptr;
+  miopenTensorDescriptor_t weights_desc = nullptr;
+  miopenTensorDescriptor_t output_desc = nullptr;
+  miopenTensorDescriptor_t bias_desc = nullptr;
+  miopenConvolutionDescriptor_t conv_desc = nullptr;
+  miopenConvFwdAlgorithm_t conv_algo = miopenConvolutionFwdAlgoDirect;
+  void *fusion_workspace = nullptr;
+  size_t fusion_workspace_size = 0;
+
+  ConvFusionTableEntry() = default;
+  ConvFusionTableEntry(const ConvFusionTableEntry &) = delete;
+  ConvFusionTableEntry &operator=(const ConvFusionTableEntry &) = delete;
+
+  ConvFusionTableEntry(ConvFusionTableEntry &&other)
+      : fuse_plan(other.fuse_plan), conv_op(other.conv_op),
+        bias_op(other.bias_op), activ_op(other.activ_op),
+        has_bias(other.has_bias), input_desc(other.input_desc),
+        weights_desc(other.weights_desc), output_desc(other.output_desc),
+        bias_desc(other.bias_desc), conv_desc(other.conv_desc),
+        conv_algo(other.conv_algo), fusion_workspace(other.fusion_workspace),
+        fusion_workspace_size(other.fusion_workspace_size) {
+    other.fuse_plan = nullptr;
+    other.conv_op = nullptr;
+    other.bias_op = nullptr;
+    other.activ_op = nullptr;
+    other.input_desc = nullptr;
+    other.weights_desc = nullptr;
+    other.output_desc = nullptr;
+    other.bias_desc = nullptr;
+    other.conv_desc = nullptr;
+    other.fusion_workspace = nullptr;
+    other.fusion_workspace_size = 0;
+  }
+
+  ~ConvFusionTableEntry() {
+    if (fuse_plan)
+      miopenDestroyFusionPlan(fuse_plan);
+    if (input_desc)
+      miopenDestroyTensorDescriptor(input_desc);
+    if (weights_desc)
+      miopenDestroyTensorDescriptor(weights_desc);
+    if (output_desc)
+      miopenDestroyTensorDescriptor(output_desc);
+    if (bias_desc)
+      miopenDestroyTensorDescriptor(bias_desc);
+    if (conv_desc)
+      miopenDestroyConvolutionDescriptor(conv_desc);
+    if (fusion_workspace)
+      hipFree(fusion_workspace);
+  }
+};
+
+struct ConvFusionTable {
+  std::mutex mutex;
+  std::unordered_map<ConvTableKey, ConvFusionTableEntry, ConvKeyHash> map;
+  // Keys whose FusionPlan compile/execute failed; skip on later inferences.
+  std::unordered_set<ConvTableKey, ConvKeyHash> disabled_keys;
+};
+
+struct ClippedRelu6ActivCache {
+  miopenActivationDescriptor_t desc = nullptr;
+
+  ClippedRelu6ActivCache() {
+    if (miopenCreateActivationDescriptor(&desc) != miopenStatusSuccess)
+      desc = nullptr;
+    else if (miopenSetActivationDescriptor(desc, miopenActivationCLIPPEDRELU,
+                                           6.0, 0.0,
+                                           0.0) != miopenStatusSuccess) {
+      miopenDestroyActivationDescriptor(desc);
+      desc = nullptr;
+    }
+  }
+
+  ~ClippedRelu6ActivCache() {
+    if (desc)
+      miopenDestroyActivationDescriptor(desc);
+  }
+};
+
 struct ConvState : public OpStateT<ConvState> {
   std::shared_ptr<ConvTable> table;
+  std::shared_ptr<ConvFusionTable> fusion_table;
+  std::shared_ptr<ClippedRelu6ActivCache> relu6_activ;
   ConvState() {
     int dev = 0;
     hipGetDevice(&dev);
     table = WeakStore<int, ConvTable>::get_or_create(
         dev, [] { return std::make_shared<ConvTable>(); });
+    fusion_table = WeakStore<int, ConvFusionTable>::get_or_create(
+        dev, [] { return std::make_shared<ConvFusionTable>(); });
+    relu6_activ = WeakStore<int, ClippedRelu6ActivCache>::get_or_create(
+        0, [] { return std::make_shared<ClippedRelu6ActivCache>(); });
   }
 };
 
@@ -216,6 +310,191 @@ extern "C" int8_t hipdnn_ep_op_state_construct_conv(RuntimeState *state,
                                                     int32_t slot) {
   hipdnn_ep_op_state_set(state, slot, ConvState::create().release());
   return 0;
+}
+
+//===----------------------------------------------------------------------===//
+// MIOpen FusionPlan cache (Conv + Bias + ClippedReLU for ReLU6)
+//===----------------------------------------------------------------------===//
+
+static int applyClippedRelu6Fallback(ConvState *os, miopenHandle_t handle,
+                                     miopenTensorDescriptor_t desc,
+                                     void *data) {
+  if (!os || !os->relu6_activ || !os->relu6_activ->desc)
+    return -1;
+  const float alpha = 1.f, beta = 0.f;
+  if (miopenActivationForward(handle, os->relu6_activ->desc, &alpha, desc, data,
+                              &beta, desc, data) != miopenStatusSuccess)
+    return -1;
+  return 0;
+}
+
+static void disableConvFusion(ConvFusionTable &table, const ConvTableKey &key) {
+  table.disabled_keys.insert(key);
+}
+
+// MIOpen Conv+Bias+Act FusionPlan is unreliable on gfx115x (Strix Halo).
+// Default: skip FusionPlan there and use Find API conv + ClippedReLU instead.
+// Override: HIPDNN_EP_CONV_FUSION=1 force enable, =0 force disable.
+static bool convFusionPlanEnabled() {
+  char buf[8];
+  unsigned long n =
+      hipdnn_ep::read_env("HIPDNN_EP_CONV_FUSION", buf, sizeof(buf));
+  if (n > 0) {
+    if (buf[0] == '0')
+      return false;
+    if (buf[0] >= '1')
+      return true;
+  }
+
+  static int cached = -1; // 0 = disabled, 1 = enabled
+  if (cached >= 0)
+    return cached != 0;
+
+  hipDeviceProp_t prop{};
+  int dev = 0;
+  hipGetDevice(&dev);
+  if (hipGetDeviceProperties(&prop, dev) != hipSuccess ||
+      prop.gcnArchName[0] == '\0') {
+    cached = 1;
+    return true;
+  }
+  cached = (strncmp(prop.gcnArchName, "gfx115", 6) == 0) ? 0 : 1;
+  return cached != 0;
+}
+
+static void logConvFusionPlanSkipOnce() {
+  static bool logged = false;
+  if (logged)
+    return;
+  logged = true;
+  RUNTIME_DEBUG_LOG(
+      "[CONV] FusionPlan skipped (gfx115x or HIPDNN_EP_CONV_FUSION=0), "
+      "using Find+activ for ReLU6\n");
+}
+
+static const ConvFusionTableEntry *
+queryOrCreateConvFusion(ConvFusionTable &table, const ConvTableKey &key,
+                        miopenHandle_t miopen_handle, bool has_bias,
+                        int64_t weights_k) {
+  std::lock_guard<std::mutex> guard(table.mutex);
+  auto it = table.map.find(key);
+  if (it != table.map.end())
+    return &it->second;
+
+  int result = 0;
+  ConvFusionTableEntry entry;
+
+  MIOPEN_CHECK(miopenCreateTensorDescriptor(&entry.input_desc));
+  MIOPEN_CHECK(miopenCreateTensorDescriptor(&entry.weights_desc));
+  MIOPEN_CHECK(miopenCreateTensorDescriptor(&entry.output_desc));
+
+  {
+    int in_dims[] = {
+        static_cast<int>(key.input_n), static_cast<int>(key.input_c),
+        static_cast<int>(key.input_h), static_cast<int>(key.input_w)};
+    MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        entry.input_desc, key.data_type, miopenTensorNCHW, in_dims, 4));
+
+    int w_dims[] = {
+        static_cast<int>(key.weights_k),
+        static_cast<int>(key.input_c / key.group),
+        static_cast<int>(key.kernel_h),
+        static_cast<int>(key.kernel_w),
+    };
+    MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        entry.weights_desc, key.data_type, miopenTensorNCHW, w_dims, 4));
+
+    int out_dims[] = {
+        static_cast<int>(key.input_n), static_cast<int>(key.weights_k),
+        static_cast<int>(key.output_h), static_cast<int>(key.output_w)};
+    MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        entry.output_desc, key.data_type, miopenTensorNCHW, out_dims, 4));
+  }
+
+  if (has_bias) {
+    MIOPEN_CHECK(miopenCreateTensorDescriptor(&entry.bias_desc));
+    int b_dims[] = {1, static_cast<int>(weights_k), 1, 1};
+    MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
+        entry.bias_desc, key.data_type, miopenTensorNCHW, b_dims, 4));
+    entry.has_bias = true;
+  }
+
+  MIOPEN_CHECK(miopenCreateConvolutionDescriptor(&entry.conv_desc));
+  MIOPEN_CHECK(miopenInitConvolutionDescriptor(
+      entry.conv_desc, miopenConvolution, key.pad_top, key.pad_left,
+      key.stride_h, key.stride_w, key.dilation_h, key.dilation_w));
+  if (key.group > 1)
+    MIOPEN_CHECK(miopenSetConvolutionGroupCount(entry.conv_desc, key.group));
+
+  MIOPEN_CHECK(miopenCreateFusionPlan(&entry.fuse_plan, miopenVerticalFusion,
+                                      entry.input_desc));
+  MIOPEN_CHECK(miopenCreateOpConvForward(entry.fuse_plan, &entry.conv_op,
+                                         entry.conv_desc, entry.weights_desc));
+  if (has_bias) {
+    MIOPEN_CHECK(miopenCreateOpBiasForward(entry.fuse_plan, &entry.bias_op,
+                                           entry.bias_desc));
+  }
+  MIOPEN_CHECK(miopenCreateOpActivationForward(entry.fuse_plan, &entry.activ_op,
+                                               miopenActivationCLIPPEDRELU));
+
+  {
+    int returned = 0;
+    miopenConvFwdAlgorithm_t algos[8] = {};
+    if (miopenFusionPlanConvolutionGetAlgo(entry.fuse_plan, 8, &returned,
+                                           algos) == miopenStatusSuccess &&
+        returned > 0) {
+      entry.conv_algo = algos[0];
+    }
+  }
+
+  if (miopenCompileFusionPlan(miopen_handle, entry.fuse_plan) !=
+      miopenStatusSuccess) {
+    goto cleanup;
+  }
+
+  MIOPEN_CHECK(miopenFusionPlanGetWorkSpaceSize(miopen_handle, entry.fuse_plan,
+                                                &entry.fusion_workspace_size,
+                                                entry.conv_algo));
+  if (entry.fusion_workspace_size > 0)
+    HIP_CHECK(hipMalloc(&entry.fusion_workspace, entry.fusion_workspace_size));
+
+  {
+    auto [ins, _] = table.map.emplace(key, std::move(entry));
+    return &ins->second;
+  }
+
+cleanup:
+  return nullptr;
+}
+
+static int runConvFusionPlan(const ConvFusionTableEntry *entry,
+                             miopenHandle_t miopen_handle, const void *input,
+                             const void *weights, const void *bias,
+                             void *output) {
+  miopenOperatorArgs_t args = nullptr;
+  const float alpha = 1.f, beta = 0.f;
+  int result = 0;
+
+  MIOPEN_CHECK(miopenCreateOperatorArgs(&args));
+  MIOPEN_CHECK(
+      miopenSetOpArgsConvForward(args, entry->conv_op, &alpha, &beta, weights));
+  if (entry->has_bias && bias) {
+    MIOPEN_CHECK(
+        miopenSetOpArgsBiasForward(args, entry->bias_op, &alpha, &beta, bias));
+  }
+  MIOPEN_CHECK(miopenSetOpArgsActivForward(args, entry->activ_op, &alpha, &beta,
+                                           6.0, 0.0, 0.0));
+  MIOPEN_CHECK(miopenExecuteFusionPlan_v2(
+      miopen_handle, entry->fuse_plan, entry->input_desc, input,
+      entry->output_desc, output, args, entry->fusion_workspace,
+      entry->fusion_workspace_size));
+  MIOPEN_CHECK(miopenDestroyOperatorArgs(args));
+  return 0;
+
+cleanup:
+  if (args)
+    miopenDestroyOperatorArgs(args);
+  return result;
 }
 
 static const ConvTableEntry *
@@ -349,7 +628,7 @@ int wrap_miopenConvolutionForward(
     int64_t output_h, int64_t output_w, int64_t kernel_h, int64_t kernel_w,
     int64_t stride_h, int64_t stride_w, int64_t pad_top, int64_t pad_left,
     int64_t pad_bottom, int64_t pad_right, int64_t dilation_h,
-    int64_t dilation_w, int64_t group, int64_t data_type) {
+    int64_t dilation_w, int64_t group, int64_t data_type, int64_t activation) {
   OP_PROFILE(
       "conv",
       [&] {
@@ -380,14 +659,13 @@ int wrap_miopenConvolutionForward(
 
   RUNTIME_DEBUG_LOG(
       "[REAL] wrap_miopenConvolutionForward N=%lld Cin=%lld H=%lld W=%lld "
-      "Cout=%lld kHxkW=%lldx%lld s=%lldx%lld bias=%s dtype=%lld\n",
+      "Cout=%lld kHxkW=%lldx%lld s=%lldx%lld bias=%s dtype=%lld "
+      "activation=%lld\n",
       (long long)input_n, (long long)input_c, (long long)input_h,
       (long long)input_w, (long long)weights_k, (long long)kernel_h,
       (long long)kernel_w, (long long)stride_h, (long long)stride_w,
-      bias ? "yes" : "null", (long long)data_type);
+      bias ? "yes" : "null", (long long)data_type, (long long)activation);
 
-  // Extract handle and stream from opaque RuntimeState via accessor functions
-  // (Maintains abstraction barrier - no direct field access)
   miopenHandle_t miopen_handle =
       static_cast<miopenHandle_t>(hipdnn_ep_state_get_miopen_handle(state));
 
@@ -405,6 +683,42 @@ int wrap_miopenConvolutionForward(
       pad_left,  pad_bottom,        pad_right, dilation_h, dilation_w, group,
       miopen_dt, miopenConvolution, 0,         0,
   };
+
+  if (activation == HIPDNN_EP_CONV_ACTIVATION_RELU6) {
+    if (!convFusionPlanEnabled()) {
+      logConvFusionPlanSkipOnce();
+    } else if (os->fusion_table) {
+      bool fusion_disabled = false;
+      {
+        std::lock_guard<std::mutex> guard(os->fusion_table->mutex);
+        fusion_disabled = os->fusion_table->disabled_keys.count(key) != 0;
+      }
+      if (!fusion_disabled) {
+        const ConvFusionTableEntry *fusion_entry = queryOrCreateConvFusion(
+            *os->fusion_table, key, miopen_handle, bias != nullptr, weights_k);
+        if (fusion_entry && fusion_entry->fuse_plan) {
+          int fusion_rc = runConvFusionPlan(fusion_entry, miopen_handle, input,
+                                            weights, bias, output);
+          if (fusion_rc == 0) {
+            RUNTIME_DEBUG_LOG("[CONV] FusionPlan ReLU6 ok N=%lld Cout=%lld\n",
+                              (long long)input_n, (long long)weights_k);
+            return 0;
+          }
+          RUNTIME_DEBUG_LOG("[CONV] FusionPlan ReLU6 failed (rc=%d), falling "
+                            "back to Find+activ\n",
+                            fusion_rc);
+          std::lock_guard<std::mutex> guard(os->fusion_table->mutex);
+          disableConvFusion(*os->fusion_table, key);
+        } else {
+          RUNTIME_DEBUG_LOG(
+              "[CONV] FusionPlan compile unsupported, fallback\n");
+          std::lock_guard<std::mutex> guard(os->fusion_table->mutex);
+          disableConvFusion(*os->fusion_table, key);
+        }
+      }
+    }
+  }
+
   miopenTensorDescriptor_t bias_desc = nullptr;
   int result = 0;
 
@@ -429,14 +743,6 @@ int wrap_miopenConvolutionForward(
   MIOPEN_CHECK(miopenRunSolution(miopen_handle, entry->solution, 3, tensorArgs,
                                  entry->workspace, entry->workspaceSize));
 
-  // Add per-channel bias via miopenOpTensor (TensorOpAdd):
-  //   C = alpha1*A + alpha2*B + beta*C  with A=C=output, B=bias, beta=0
-  //   -> output = output + bias  (broadcast from [1, weights_k, 1, 1])
-  //
-  // We do NOT use miopenConvolutionForwardBias: the MIOpen header states its
-  // alpha/beta are "only supported for alpha = 1 and beta = 0", so it cannot
-  // fuse y = conv + bias (it would compute y = bias). miopenOpTensor with
-  // alpha1=alpha2=1, beta=0 computes y = conv + bias as ONNX Conv requires.
   if (bias) {
     const float alpha_bias = 1.0f, beta_zero = 0.0f;
     MIOPEN_CHECK(miopenCreateTensorDescriptor(&bias_desc));
@@ -447,6 +753,14 @@ int wrap_miopenConvolutionForward(
                                 entry->output_desc, output, &alpha_bias,
                                 bias_desc, bias, &beta_zero, entry->output_desc,
                                 output));
+  }
+
+  if (activation == HIPDNN_EP_CONV_ACTIVATION_RELU6) {
+    if (applyClippedRelu6Fallback(os, miopen_handle, entry->output_desc,
+                                  output) != 0) {
+      result = -1;
+      goto cleanup;
+    }
   }
 
 cleanup:

--- a/lib/Runtime/real/miopen.cpp
+++ b/lib/Runtime/real/miopen.cpp
@@ -205,11 +205,34 @@ struct ConvTable {
   std::unordered_map<ConvTableKey, ConvTableEntry, ConvKeyHash> map;
 };
 
+struct ConvFusionKey {
+  ConvTableKey conv;
+  float clip_lo;
+  float clip_hi;
+
+  bool operator==(const ConvFusionKey &other) const {
+    return conv == other.conv && clip_lo == other.clip_lo &&
+           clip_hi == other.clip_hi;
+  }
+};
+
+struct ConvFusionKeyHash {
+  size_t operator()(const ConvFusionKey &key) const {
+    ConvKeyHash conv_hash;
+    size_t h = conv_hash(key.conv);
+    hash_combine_val(h, key.clip_lo);
+    hash_combine_val(h, key.clip_hi);
+    return h;
+  }
+};
+
 struct ConvFusionTableEntry {
   miopenFusionPlanDescriptor_t fuse_plan = nullptr;
   miopenFusionOpDescriptor_t conv_op = nullptr;
   miopenFusionOpDescriptor_t bias_op = nullptr;
   miopenFusionOpDescriptor_t activ_op = nullptr;
+  float clip_lo = 0.f;
+  float clip_hi = 0.f;
   bool has_bias = false;
   miopenTensorDescriptor_t input_desc = nullptr;
   miopenTensorDescriptor_t weights_desc = nullptr;
@@ -227,6 +250,7 @@ struct ConvFusionTableEntry {
   ConvFusionTableEntry(ConvFusionTableEntry &&other)
       : fuse_plan(other.fuse_plan), conv_op(other.conv_op),
         bias_op(other.bias_op), activ_op(other.activ_op),
+        clip_lo(other.clip_lo), clip_hi(other.clip_hi),
         has_bias(other.has_bias), input_desc(other.input_desc),
         weights_desc(other.weights_desc), output_desc(other.output_desc),
         bias_desc(other.bias_desc), conv_desc(other.conv_desc),
@@ -265,35 +289,70 @@ struct ConvFusionTableEntry {
 
 struct ConvFusionTable {
   std::mutex mutex;
-  std::unordered_map<ConvTableKey, ConvFusionTableEntry, ConvKeyHash> map;
-  // Keys whose FusionPlan compile/execute failed; skip on later inferences.
-  std::unordered_set<ConvTableKey, ConvKeyHash> disabled_keys;
+  std::unordered_map<ConvFusionKey, ConvFusionTableEntry, ConvFusionKeyHash>
+      map;
+  std::unordered_set<ConvFusionKey, ConvFusionKeyHash> disabled_keys;
 };
 
-struct ClippedRelu6ActivCache {
+struct ReluActivCache {
   miopenActivationDescriptor_t desc = nullptr;
 
-  ClippedRelu6ActivCache() {
+  ReluActivCache() {
     if (miopenCreateActivationDescriptor(&desc) != miopenStatusSuccess)
       desc = nullptr;
-    else if (miopenSetActivationDescriptor(desc, miopenActivationCLIPPEDRELU,
-                                           6.0, 0.0,
+    else if (miopenSetActivationDescriptor(desc, miopenActivationRELU, 0.0, 0.0,
                                            0.0) != miopenStatusSuccess) {
       miopenDestroyActivationDescriptor(desc);
       desc = nullptr;
     }
   }
 
-  ~ClippedRelu6ActivCache() {
+  ~ReluActivCache() {
     if (desc)
       miopenDestroyActivationDescriptor(desc);
+  }
+};
+
+struct ClippedReluActivCache {
+  std::mutex mutex;
+  std::unordered_map<uint32_t, miopenActivationDescriptor_t> desc_by_ceiling;
+
+  miopenActivationDescriptor_t get(float ceiling) {
+    uint32_t key = 0;
+    static_assert(sizeof(float) == sizeof(uint32_t));
+    std::memcpy(&key, &ceiling, sizeof(float));
+
+    std::lock_guard<std::mutex> guard(mutex);
+    auto it = desc_by_ceiling.find(key);
+    if (it != desc_by_ceiling.end())
+      return it->second;
+
+    miopenActivationDescriptor_t desc = nullptr;
+    if (miopenCreateActivationDescriptor(&desc) != miopenStatusSuccess)
+      return nullptr;
+    if (miopenSetActivationDescriptor(desc, miopenActivationCLIPPEDRELU,
+                                      ceiling, 0.0,
+                                      0.0) != miopenStatusSuccess) {
+      miopenDestroyActivationDescriptor(desc);
+      return nullptr;
+    }
+    desc_by_ceiling[key] = desc;
+    return desc;
+  }
+
+  ~ClippedReluActivCache() {
+    for (auto &kv : desc_by_ceiling) {
+      if (kv.second)
+        miopenDestroyActivationDescriptor(kv.second);
+    }
   }
 };
 
 struct ConvState : public OpStateT<ConvState> {
   std::shared_ptr<ConvTable> table;
   std::shared_ptr<ConvFusionTable> fusion_table;
-  std::shared_ptr<ClippedRelu6ActivCache> relu6_activ;
+  std::shared_ptr<ReluActivCache> relu_activ;
+  std::shared_ptr<ClippedReluActivCache> clipped_relu_activ;
   ConvState() {
     int dev = 0;
     hipGetDevice(&dev);
@@ -301,8 +360,10 @@ struct ConvState : public OpStateT<ConvState> {
         dev, [] { return std::make_shared<ConvTable>(); });
     fusion_table = WeakStore<int, ConvFusionTable>::get_or_create(
         dev, [] { return std::make_shared<ConvFusionTable>(); });
-    relu6_activ = WeakStore<int, ClippedRelu6ActivCache>::get_or_create(
-        0, [] { return std::make_shared<ClippedRelu6ActivCache>(); });
+    relu_activ = WeakStore<int, ReluActivCache>::get_or_create(
+        0, [] { return std::make_shared<ReluActivCache>(); });
+    clipped_relu_activ = WeakStore<int, ClippedReluActivCache>::get_or_create(
+        0, [] { return std::make_shared<ClippedReluActivCache>(); });
   }
 };
 
@@ -313,22 +374,37 @@ extern "C" int8_t hipdnn_ep_op_state_construct_conv(RuntimeState *state,
 }
 
 //===----------------------------------------------------------------------===//
-// MIOpen FusionPlan cache (Conv + Bias + ClippedReLU for ReLU6)
+// MIOpen FusionPlan cache (Conv + Bias + parametric ReLU / ClippedReLU)
 //===----------------------------------------------------------------------===//
 
-static int applyClippedRelu6Fallback(ConvState *os, miopenHandle_t handle,
-                                     miopenTensorDescriptor_t desc,
-                                     void *data) {
-  if (!os || !os->relu6_activ || !os->relu6_activ->desc)
-    return -1;
+static bool convHasUpperClip(float clip_hi) { return clip_hi > 0.f; }
+
+static int applyFusedActivationFallback(ConvState *os, miopenHandle_t handle,
+                                        miopenTensorDescriptor_t desc,
+                                        void *data, float clip_lo,
+                                        float clip_hi) {
+  (void)clip_lo;
   const float alpha = 1.f, beta = 0.f;
-  if (miopenActivationForward(handle, os->relu6_activ->desc, &alpha, desc, data,
-                              &beta, desc, data) != miopenStatusSuccess)
+  miopenActivationDescriptor_t act_desc = nullptr;
+  if (convHasUpperClip(clip_hi)) {
+    if (!os || !os->clipped_relu_activ)
+      return -1;
+    act_desc = os->clipped_relu_activ->get(clip_hi);
+  } else {
+    if (!os || !os->relu_activ || !os->relu_activ->desc)
+      return -1;
+    act_desc = os->relu_activ->desc;
+  }
+  if (!act_desc)
+    return -1;
+  if (miopenActivationForward(handle, act_desc, &alpha, desc, data, &beta, desc,
+                              data) != miopenStatusSuccess)
     return -1;
   return 0;
 }
 
-static void disableConvFusion(ConvFusionTable &table, const ConvTableKey &key) {
+static void disableConvFusion(ConvFusionTable &table,
+                              const ConvFusionKey &key) {
   table.disabled_keys.insert(key);
 }
 
@@ -369,11 +445,11 @@ static void logConvFusionPlanSkipOnce() {
   logged = true;
   RUNTIME_DEBUG_LOG(
       "[CONV] FusionPlan skipped (gfx115x or HIPDNN_EP_CONV_FUSION=0), "
-      "using Find+activ for ReLU6\n");
+      "using Find+activ fallback\n");
 }
 
 static const ConvFusionTableEntry *
-queryOrCreateConvFusion(ConvFusionTable &table, const ConvTableKey &key,
+queryOrCreateConvFusion(ConvFusionTable &table, const ConvFusionKey &key,
                         miopenHandle_t miopen_handle, bool has_bias,
                         int64_t weights_k) {
   std::lock_guard<std::mutex> guard(table.mutex);
@@ -383,6 +459,9 @@ queryOrCreateConvFusion(ConvFusionTable &table, const ConvTableKey &key,
 
   int result = 0;
   ConvFusionTableEntry entry;
+  entry.clip_lo = key.clip_lo;
+  entry.clip_hi = key.clip_hi;
+  const ConvTableKey &conv = key.conv;
 
   MIOPEN_CHECK(miopenCreateTensorDescriptor(&entry.input_desc));
   MIOPEN_CHECK(miopenCreateTensorDescriptor(&entry.weights_desc));
@@ -390,41 +469,41 @@ queryOrCreateConvFusion(ConvFusionTable &table, const ConvTableKey &key,
 
   {
     int in_dims[] = {
-        static_cast<int>(key.input_n), static_cast<int>(key.input_c),
-        static_cast<int>(key.input_h), static_cast<int>(key.input_w)};
+        static_cast<int>(conv.input_n), static_cast<int>(conv.input_c),
+        static_cast<int>(conv.input_h), static_cast<int>(conv.input_w)};
     MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
-        entry.input_desc, key.data_type, miopenTensorNCHW, in_dims, 4));
+        entry.input_desc, conv.data_type, miopenTensorNCHW, in_dims, 4));
 
     int w_dims[] = {
-        static_cast<int>(key.weights_k),
-        static_cast<int>(key.input_c / key.group),
-        static_cast<int>(key.kernel_h),
-        static_cast<int>(key.kernel_w),
+        static_cast<int>(conv.weights_k),
+        static_cast<int>(conv.input_c / conv.group),
+        static_cast<int>(conv.kernel_h),
+        static_cast<int>(conv.kernel_w),
     };
     MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
-        entry.weights_desc, key.data_type, miopenTensorNCHW, w_dims, 4));
+        entry.weights_desc, conv.data_type, miopenTensorNCHW, w_dims, 4));
 
     int out_dims[] = {
-        static_cast<int>(key.input_n), static_cast<int>(key.weights_k),
-        static_cast<int>(key.output_h), static_cast<int>(key.output_w)};
+        static_cast<int>(conv.input_n), static_cast<int>(conv.weights_k),
+        static_cast<int>(conv.output_h), static_cast<int>(conv.output_w)};
     MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
-        entry.output_desc, key.data_type, miopenTensorNCHW, out_dims, 4));
+        entry.output_desc, conv.data_type, miopenTensorNCHW, out_dims, 4));
   }
 
   if (has_bias) {
     MIOPEN_CHECK(miopenCreateTensorDescriptor(&entry.bias_desc));
     int b_dims[] = {1, static_cast<int>(weights_k), 1, 1};
     MIOPEN_CHECK(miopenSetNdTensorDescriptorWithLayout(
-        entry.bias_desc, key.data_type, miopenTensorNCHW, b_dims, 4));
+        entry.bias_desc, conv.data_type, miopenTensorNCHW, b_dims, 4));
     entry.has_bias = true;
   }
 
   MIOPEN_CHECK(miopenCreateConvolutionDescriptor(&entry.conv_desc));
   MIOPEN_CHECK(miopenInitConvolutionDescriptor(
-      entry.conv_desc, miopenConvolution, key.pad_top, key.pad_left,
-      key.stride_h, key.stride_w, key.dilation_h, key.dilation_w));
-  if (key.group > 1)
-    MIOPEN_CHECK(miopenSetConvolutionGroupCount(entry.conv_desc, key.group));
+      entry.conv_desc, miopenConvolution, conv.pad_top, conv.pad_left,
+      conv.stride_h, conv.stride_w, conv.dilation_h, conv.dilation_w));
+  if (conv.group > 1)
+    MIOPEN_CHECK(miopenSetConvolutionGroupCount(entry.conv_desc, conv.group));
 
   MIOPEN_CHECK(miopenCreateFusionPlan(&entry.fuse_plan, miopenVerticalFusion,
                                       entry.input_desc));
@@ -434,8 +513,11 @@ queryOrCreateConvFusion(ConvFusionTable &table, const ConvTableKey &key,
     MIOPEN_CHECK(miopenCreateOpBiasForward(entry.fuse_plan, &entry.bias_op,
                                            entry.bias_desc));
   }
+  const miopenActivationMode_t activ_mode = convHasUpperClip(key.clip_hi)
+                                                ? miopenActivationCLIPPEDRELU
+                                                : miopenActivationRELU;
   MIOPEN_CHECK(miopenCreateOpActivationForward(entry.fuse_plan, &entry.activ_op,
-                                               miopenActivationCLIPPEDRELU));
+                                               activ_mode));
 
   {
     int returned = 0;
@@ -482,8 +564,9 @@ static int runConvFusionPlan(const ConvFusionTableEntry *entry,
     MIOPEN_CHECK(
         miopenSetOpArgsBiasForward(args, entry->bias_op, &alpha, &beta, bias));
   }
-  MIOPEN_CHECK(miopenSetOpArgsActivForward(args, entry->activ_op, &alpha, &beta,
-                                           6.0, 0.0, 0.0));
+  MIOPEN_CHECK(miopenSetOpArgsActivForward(
+      args, entry->activ_op, &alpha, &beta,
+      convHasUpperClip(entry->clip_hi) ? entry->clip_hi : 0.0, 0.0, 0.0));
   MIOPEN_CHECK(miopenExecuteFusionPlan_v2(
       miopen_handle, entry->fuse_plan, entry->input_desc, input,
       entry->output_desc, output, args, entry->fusion_workspace,
@@ -628,7 +711,10 @@ int wrap_miopenConvolutionForward(
     int64_t output_h, int64_t output_w, int64_t kernel_h, int64_t kernel_w,
     int64_t stride_h, int64_t stride_w, int64_t pad_top, int64_t pad_left,
     int64_t pad_bottom, int64_t pad_right, int64_t dilation_h,
-    int64_t dilation_w, int64_t group, int64_t data_type, int64_t activation) {
+    int64_t dilation_w, int64_t group, int64_t data_type,
+    int64_t fused_activation, float activation_clip_lo,
+    float activation_clip_hi, float activation_alpha) {
+  (void)activation_alpha;
   OP_PROFILE(
       "conv",
       [&] {
@@ -660,11 +746,12 @@ int wrap_miopenConvolutionForward(
   RUNTIME_DEBUG_LOG(
       "[REAL] wrap_miopenConvolutionForward N=%lld Cin=%lld H=%lld W=%lld "
       "Cout=%lld kHxkW=%lldx%lld s=%lldx%lld bias=%s dtype=%lld "
-      "activation=%lld\n",
+      "fused=%lld clip=[%.3f,%.3f]\n",
       (long long)input_n, (long long)input_c, (long long)input_h,
       (long long)input_w, (long long)weights_k, (long long)kernel_h,
       (long long)kernel_w, (long long)stride_h, (long long)stride_w,
-      bias ? "yes" : "null", (long long)data_type, (long long)activation);
+      bias ? "yes" : "null", (long long)data_type, (long long)fused_activation,
+      activation_clip_lo, activation_clip_hi);
 
   miopenHandle_t miopen_handle =
       static_cast<miopenHandle_t>(hipdnn_ep_state_get_miopen_handle(state));
@@ -684,36 +771,42 @@ int wrap_miopenConvolutionForward(
       miopen_dt, miopenConvolution, 0,         0,
   };
 
-  if (activation == HIPDNN_EP_CONV_ACTIVATION_RELU6) {
+  if (fused_activation) {
+    ConvFusionKey fusion_key{key, activation_clip_lo, activation_clip_hi};
     if (!convFusionPlanEnabled()) {
       logConvFusionPlanSkipOnce();
     } else if (os->fusion_table) {
       bool fusion_disabled = false;
       {
         std::lock_guard<std::mutex> guard(os->fusion_table->mutex);
-        fusion_disabled = os->fusion_table->disabled_keys.count(key) != 0;
+        fusion_disabled =
+            os->fusion_table->disabled_keys.count(fusion_key) != 0;
       }
       if (!fusion_disabled) {
-        const ConvFusionTableEntry *fusion_entry = queryOrCreateConvFusion(
-            *os->fusion_table, key, miopen_handle, bias != nullptr, weights_k);
+        const ConvFusionTableEntry *fusion_entry =
+            queryOrCreateConvFusion(*os->fusion_table, fusion_key,
+                                    miopen_handle, bias != nullptr, weights_k);
         if (fusion_entry && fusion_entry->fuse_plan) {
           int fusion_rc = runConvFusionPlan(fusion_entry, miopen_handle, input,
                                             weights, bias, output);
           if (fusion_rc == 0) {
-            RUNTIME_DEBUG_LOG("[CONV] FusionPlan ReLU6 ok N=%lld Cout=%lld\n",
-                              (long long)input_n, (long long)weights_k);
+            RUNTIME_DEBUG_LOG(
+                "[CONV] FusionPlan %s ok N=%lld Cout=%lld\n",
+                hipdnn_ep_conv_fused_activation_name(
+                    fused_activation, activation_clip_lo, activation_clip_hi),
+                (long long)input_n, (long long)weights_k);
             return 0;
           }
-          RUNTIME_DEBUG_LOG("[CONV] FusionPlan ReLU6 failed (rc=%d), falling "
-                            "back to Find+activ\n",
-                            fusion_rc);
+          RUNTIME_DEBUG_LOG(
+              "[CONV] FusionPlan failed (rc=%d), falling back to Find+activ\n",
+              fusion_rc);
           std::lock_guard<std::mutex> guard(os->fusion_table->mutex);
-          disableConvFusion(*os->fusion_table, key);
+          disableConvFusion(*os->fusion_table, fusion_key);
         } else {
           RUNTIME_DEBUG_LOG(
               "[CONV] FusionPlan compile unsupported, fallback\n");
           std::lock_guard<std::mutex> guard(os->fusion_table->mutex);
-          disableConvFusion(*os->fusion_table, key);
+          disableConvFusion(*os->fusion_table, fusion_key);
         }
       }
     }
@@ -755,9 +848,10 @@ int wrap_miopenConvolutionForward(
                                 output));
   }
 
-  if (activation == HIPDNN_EP_CONV_ACTIVATION_RELU6) {
-    if (applyClippedRelu6Fallback(os, miopen_handle, entry->output_desc,
-                                  output) != 0) {
+  if (fused_activation) {
+    if (applyFusedActivationFallback(os, miopen_handle, entry->output_desc,
+                                     output, activation_clip_lo,
+                                     activation_clip_hi) != 0) {
       result = -1;
       goto cleanup;
     }

--- a/lib/Runtime/real/miopen.cpp
+++ b/lib/Runtime/real/miopen.cpp
@@ -462,6 +462,9 @@ queryOrCreateConvFusion(ConvFusionTable &table, const ConvFusionKey &key,
   entry.clip_lo = key.clip_lo;
   entry.clip_hi = key.clip_hi;
   const ConvTableKey &conv = key.conv;
+  const miopenActivationMode_t activ_mode = convHasUpperClip(key.clip_hi)
+                                                ? miopenActivationCLIPPEDRELU
+                                                : miopenActivationRELU;
 
   MIOPEN_CHECK(miopenCreateTensorDescriptor(&entry.input_desc));
   MIOPEN_CHECK(miopenCreateTensorDescriptor(&entry.weights_desc));
@@ -513,9 +516,6 @@ queryOrCreateConvFusion(ConvFusionTable &table, const ConvFusionKey &key,
     MIOPEN_CHECK(miopenCreateOpBiasForward(entry.fuse_plan, &entry.bias_op,
                                            entry.bias_desc));
   }
-  const miopenActivationMode_t activ_mode = convHasUpperClip(key.clip_hi)
-                                                ? miopenActivationCLIPPEDRELU
-                                                : miopenActivationRELU;
   MIOPEN_CHECK(miopenCreateOpActivationForward(entry.fuse_plan, &entry.activ_op,
                                                activ_mode));
 

--- a/test/lit/Dialect/fuse-conv-relu-externalized.mlir
+++ b/test/lit/Dialect/fuse-conv-relu-externalized.mlir
@@ -1,0 +1,48 @@
+// RUN: hip-mlir-opt --hip-fuse-conv-relu6 %s | FileCheck %s
+
+// ReLU clip constants are externalized before fuse-conv-relu6 runs in the EP
+// pipeline. The pass must read splat metadata, not just inline hip.constant.
+
+module attributes {
+  hipdnn.constant_source_kinds = array<i32: 1, 1>,
+  hipdnn.constant_splat_elem_values = array<i64: 0, 17920>,
+  hipdnn.constant_splat_elem_sizes = array<i64: 2, 2>
+} {
+  memref.global "private" @hip_ext_constant_0 : memref<f16> {hip.external_data = {index = 0 : i64, offset = 0 : i64, size = 2 : i64}}
+  memref.global "private" @hip_ext_constant_1 : memref<f16> {hip.external_data = {index = 1 : i64, offset = 64 : i64, size = 2 : i64}}
+
+  func.func @relu(%ctx: !hip.context, %arg0: tensor<1x3x4x4xf16>, %arg1: tensor<8x3x3x3xf16>, %arg2: tensor<8xf16>) -> tensor<1x8x4x4xf16> {
+    %c0_mem = memref.get_global @hip_ext_constant_0 : memref<f16>
+    %c0 = bufferization.to_tensor %c0_mem restrict : memref<f16> to tensor<f16>
+    %empty_conv = tensor.empty() : tensor<1x8x4x4xf16>
+    %conv = hip.conv(%ctx) ins(%arg0, %arg1, %arg2 : tensor<1x3x4x4xf16>, tensor<8x3x3x3xf16>, tensor<8xf16>) outs(%empty_conv : tensor<1x8x4x4xf16>) {dilations = [1, 1], group = 1 : i64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : tensor<1x8x4x4xf16>
+    %empty_out = tensor.empty() : tensor<1x8x4x4xf16>
+    %max = hip.max(%ctx) ins(%conv, %c0 : tensor<1x8x4x4xf16>, tensor<f16>) outs(%empty_out : tensor<1x8x4x4xf16>) : tensor<1x8x4x4xf16>
+    return %max : tensor<1x8x4x4xf16>
+  }
+
+  func.func @relu6(%ctx: !hip.context, %arg0: tensor<1x3x4x4xf16>, %arg1: tensor<8x3x3x3xf16>, %arg2: tensor<8xf16>) -> tensor<1x8x4x4xf16> {
+    %c0_mem = memref.get_global @hip_ext_constant_0 : memref<f16>
+    %c0 = bufferization.to_tensor %c0_mem restrict : memref<f16> to tensor<f16>
+    %c6_mem = memref.get_global @hip_ext_constant_1 : memref<f16>
+    %c6 = bufferization.to_tensor %c6_mem restrict : memref<f16> to tensor<f16>
+    %empty_conv = tensor.empty() : tensor<1x8x4x4xf16>
+    %conv = hip.conv(%ctx) ins(%arg0, %arg1, %arg2 : tensor<1x3x4x4xf16>, tensor<8x3x3x3xf16>, tensor<8xf16>) outs(%empty_conv : tensor<1x8x4x4xf16>) {dilations = [1, 1], group = 1 : i64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : tensor<1x8x4x4xf16>
+    %empty_max = tensor.empty() : tensor<1x8x4x4xf16>
+    %max = hip.max(%ctx) ins(%conv, %c0 : tensor<1x8x4x4xf16>, tensor<f16>) outs(%empty_max : tensor<1x8x4x4xf16>) : tensor<1x8x4x4xf16>
+    %empty_out = tensor.empty() : tensor<1x8x4x4xf16>
+    %min = hip.min(%ctx) ins(%max, %c6 : tensor<1x8x4x4xf16>, tensor<f16>) outs(%empty_out : tensor<1x8x4x4xf16>) : tensor<1x8x4x4xf16>
+    return %min : tensor<1x8x4x4xf16>
+  }
+}
+
+// CHECK-LABEL: func.func @relu
+// CHECK-NOT: hip.max
+// CHECK: hip.conv{{.*}}fused_activation = true
+// CHECK-SAME: activation_clip_hi = 0.000000e+00
+
+// CHECK-LABEL: func.func @relu6
+// CHECK-NOT: hip.max
+// CHECK-NOT: hip.min
+// CHECK: hip.conv{{.*}}fused_activation = true
+// CHECK-SAME: activation_clip_hi = 6.000000e+00

--- a/test/lit/Dialect/fuse-conv-relu-externalized.mlir
+++ b/test/lit/Dialect/fuse-conv-relu-externalized.mlir
@@ -39,10 +39,8 @@ module attributes {
 // CHECK-LABEL: func.func @relu
 // CHECK-NOT: hip.max
 // CHECK: hip.conv{{.*}}fused_activation = true
-// CHECK-SAME: activation_clip_hi = 0.000000e+00
 
 // CHECK-LABEL: func.func @relu6
 // CHECK-NOT: hip.max
 // CHECK-NOT: hip.min
-// CHECK: hip.conv{{.*}}fused_activation = true
-// CHECK-SAME: activation_clip_hi = 6.000000e+00
+// CHECK: hip.conv{{.*}}activation_clip_hi = 6.000000e+00{{.*}}fused_activation = true

--- a/test/lit/Dialect/fuse-conv-relu.mlir
+++ b/test/lit/Dialect/fuse-conv-relu.mlir
@@ -14,5 +14,4 @@ module {
 // CHECK-LABEL: func.func @main_graph
 // CHECK-NOT: hip.max
 // CHECK: hip.conv{{.*}}fused_activation = true
-// CHECK-SAME: activation_clip_hi = 0.000000e+00
 // CHECK: return

--- a/test/lit/Dialect/fuse-conv-relu.mlir
+++ b/test/lit/Dialect/fuse-conv-relu.mlir
@@ -3,20 +3,16 @@
 module {
   func.func @main_graph(%ctx: !hip.context, %arg0: tensor<1x3x4x4xf16>, %arg1: tensor<8x3x3x3xf16>, %arg2: tensor<8xf16>) -> tensor<1x8x4x4xf16> {
     %c0 = arith.constant dense<0.0> : tensor<f16>
-    %c6 = arith.constant dense<6.0> : tensor<f16>
     %empty_conv = tensor.empty() : tensor<1x8x4x4xf16>
     %conv = hip.conv(%ctx) ins(%arg0, %arg1, %arg2 : tensor<1x3x4x4xf16>, tensor<8x3x3x3xf16>, tensor<8xf16>) outs(%empty_conv : tensor<1x8x4x4xf16>) {dilations = [1, 1], group = 1 : i64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : tensor<1x8x4x4xf16>
-    %empty_max = tensor.empty() : tensor<1x8x4x4xf16>
-    %max = hip.max(%ctx) ins(%conv, %c0 : tensor<1x8x4x4xf16>, tensor<f16>) outs(%empty_max : tensor<1x8x4x4xf16>) : tensor<1x8x4x4xf16>
     %empty_out = tensor.empty() : tensor<1x8x4x4xf16>
-    %min = hip.min(%ctx) ins(%max, %c6 : tensor<1x8x4x4xf16>, tensor<f16>) outs(%empty_out : tensor<1x8x4x4xf16>) : tensor<1x8x4x4xf16>
-    return %min : tensor<1x8x4x4xf16>
+    %max = hip.max(%ctx) ins(%conv, %c0 : tensor<1x8x4x4xf16>, tensor<f16>) outs(%empty_out : tensor<1x8x4x4xf16>) : tensor<1x8x4x4xf16>
+    return %max : tensor<1x8x4x4xf16>
   }
 }
 
 // CHECK-LABEL: func.func @main_graph
 // CHECK-NOT: hip.max
-// CHECK-NOT: hip.min
 // CHECK: hip.conv{{.*}}fused_activation = true
-// CHECK-SAME: activation_clip_hi = 6.000000e+00
+// CHECK-SAME: activation_clip_hi = 0.000000e+00
 // CHECK: return

--- a/test/lit/Dialect/fuse-conv-relu6.mlir
+++ b/test/lit/Dialect/fuse-conv-relu6.mlir
@@ -17,6 +17,5 @@ module {
 // CHECK-LABEL: func.func @main_graph
 // CHECK-NOT: hip.max
 // CHECK-NOT: hip.min
-// CHECK: hip.conv{{.*}}fused_activation = true
-// CHECK-SAME: activation_clip_hi = 6.000000e+00
+// CHECK: hip.conv{{.*}}activation_clip_hi = 6.000000e+00{{.*}}fused_activation = true
 // CHECK: return

--- a/test/lit/Dialect/fuse-conv-relu6.mlir
+++ b/test/lit/Dialect/fuse-conv-relu6.mlir
@@ -1,0 +1,21 @@
+// RUN: hip-mlir-opt --hip-fuse-conv-relu6 %s | FileCheck %s
+
+module {
+  func.func @main_graph(%ctx: !hip.context, %arg0: tensor<1x3x4x4xf16>, %arg1: tensor<8x3x3x3xf16>, %arg2: tensor<8xf16>) -> tensor<1x8x4x4xf16> {
+    %c0 = arith.constant dense<0.0> : tensor<f16>
+    %c6 = arith.constant dense<6.0> : tensor<f16>
+    %empty_conv = tensor.empty() : tensor<1x8x4x4xf16>
+    %conv = hip.conv(%ctx) ins(%arg0, %arg1, %arg2 : tensor<1x3x4x4xf16>, tensor<8x3x3x3xf16>, tensor<8xf16>) outs(%empty_conv : tensor<1x8x4x4xf16>) {dilations = [1, 1], group = 1 : i64, kernel_shape = [3, 3], pads = [1, 1, 1, 1], strides = [1, 1]} : tensor<1x8x4x4xf16>
+    %empty_max = tensor.empty() : tensor<1x8x4x4xf16>
+    %max = hip.max(%ctx) ins(%conv, %c0 : tensor<1x8x4x4xf16>, tensor<f16>) outs(%empty_max : tensor<1x8x4x4xf16>) : tensor<1x8x4x4xf16>
+    %empty_out = tensor.empty() : tensor<1x8x4x4xf16>
+    %min = hip.min(%ctx) ins(%max, %c6 : tensor<1x8x4x4xf16>, tensor<f16>) outs(%empty_out : tensor<1x8x4x4xf16>) : tensor<1x8x4x4xf16>
+    return %min : tensor<1x8x4x4xf16>
+  }
+}
+
+// CHECK-LABEL: func.func @main_graph
+// CHECK-NOT: hip.max
+// CHECK-NOT: hip.min
+// CHECK: hip.conv{{.*}}activation = 1
+// CHECK: return


### PR DESCRIPTION
## Summary
- Add `hip-fuse-conv-relu6` pass to fold direct `hip.conv` + `hip.max` (+ optional `hip.min`) into `hip.conv { fused_activation = true, activation_clip_lo, activation_clip_hi }`.
- Support **plain ReLU** (ResNet50: clip_lo=0, clip_hi=0) and **ReLU6** (MobileNet: clip_hi=6) through one parametric runtime path instead of a fixed activation enum.
- Extend `wrap_miopenConvolutionForward` with `fused_activation` + clip bounds; apply MIOpen ReLU / ClippedReLU after conv+bias, with optional FusionPlan (Conv+Bias+Activation) when supported.
- Run the pass **after** `hip-externalize-constants` and resolve externalized splat clip constants (`memref.get_global` + `bufferization.to_tensor`) so ResNet50 ReLU zeros fuse correctly.
- FusionPlan is auto-disabled on gfx115x (MIOpen limitation on gfx1151); set `HIPDNN_EP_CONV_FUSION=1` to force attempt or `=0` to force off.

## ResNet50 v1.5 fp16 results (gfx1151, batch=1, 224×224)
| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Average inference time | 3.15 ms | 3.04 ms | ~3.3% faster |
| Elementwise kernel calls | 65 | 32 | −33 (−51%) |
| Direct Conv→ReLU fused | 0 | ~33 | ReLU folded into conv |

Remaining 32 elementwise ops are residual **Add** + **ReLU after Add** (not covered by this pass).

## Test plan
- [x] Pre-commit hooks pass on all changed files
- [x] LIT: `test/lit/Dialect/fuse-conv-relu.mlir`
- [x] LIT: `test/lit/Dialect/fuse-conv-relu6.mlir`
- [x] LIT: `test/lit/Dialect/fuse-conv-relu-externalized.mlir`
- [x] ResNet50 v1.5 fp16 ONNX compiles and runs on gfx1151
- [x] MobileNet v2 fp16 ONNX compiles and runs on gfx1151

## Known limitations
- FusionPlan not used on gfx115x by default (compile/execute failures on gfx1151 with MIOpen 3.5.1)
- Bias remains a separate `miopenOpTensor(ADD)` on gfx1151 fallback path
- Residual Add + ReLU after Add are not fused (future work: custom add+relu kernel)