### PR TITLE
test: #787 on latest main with the AMDGPU OGA fork (CI only, do not merge)

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -49,11 +49,14 @@ jobs:
       # editing this list auto-invalidates the cached ORT install prefix.
       # Remove a PR number once its fix is in the pinned ONNXRUNTIME_VERSION.
       ONNXRUNTIME_PR_PATCHES: ""
-      OGA_VERSION: "0.14.0"
-      # Space-separated microsoft/onnxruntime-genai PR numbers fetched from
-      # pull/<n>.patch and `git apply` on top of v<OGA_VERSION>. Part of the OGA
-      # cache key. Remove a PR once it lands in the pinned OGA release.
-      OGA_PR_PATCHES: "2194"
+      # Fork branch carrying AMDGPU MorphiZen integration (former PR 2194) plus
+      # sliding_window support.
+      OGA_REPO: "amd-genmingz/onnxruntime-genai"
+      OGA_REF: "test_0_3"
+      # Optional space-separated microsoft/onnxruntime-genai PR numbers applied
+      # on top of the fork checkout via pull/<n>.patch + git am. Empty when the
+      # fork branch already carries the needed integration.
+      OGA_PR_PATCHES: ""
       # ilammy/msvc-dev-cmd and mozilla-actions/sccache-action have no
       # Node.js 24 releases yet; allow Node.js 20 until they are updated.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
@@ -368,22 +371,19 @@ jobs:
         with:
           path: ${{ runner.workspace }}/oga-artifacts
           # OGA is built against the patched ort-install, so the key folds in
-          # both OGA's own PR list and ONNXRUNTIME_PR_PATCHES; editing either
-          # forces a rebuild. The mm<N> token bumps when the OGA artifact set
-          # changes shape, or when a PR's branch content changes under the same
-          # number (mm2: PR 2194 now carries the AMDGPU OGA integration).
-          key: oga-dml-mm2-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
+          # the fork ref, optional OGA_PR_PATCHES, and ONNXRUNTIME_PR_PATCHES.
+          # The mm<N> token bumps when the OGA artifact set changes shape.
+          key: oga-dml-mm3-${{ env.OGA_REPO }}-${{ env.OGA_REF }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}-2
 
-      # OGA is built from upstream microsoft/onnxruntime-genai + PR patches
-      # (OGA_PR_PATCHES). PR 2194 (the dynamic-shape-morphizen branch) now also
-      # carries the AMDGPU umbrella integration, so the patched upstream build
-      # is the AMDGPU-targeted OGA -- no fork checkout needed.
+      # OGA is built from the AMDGPU fork branch (OGA_REPO/OGA_REF): AMDGPU
+      # MorphiZen integration + sliding_window. Optional OGA_PR_PATCHES apply
+      # extra upstream PRs on top of the fork checkout.
       - name: Checkout OGA
         if: steps.cache-oga.outputs.cache-hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: microsoft/onnxruntime-genai
-          ref: v${{ env.OGA_VERSION }}
+          repository: ${{ env.OGA_REPO }}
+          ref: ${{ env.OGA_REF }}
           path: source-oga
           submodules: true
           fetch-depth: 1

--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -1064,11 +1064,16 @@ extern "C" int hip_gqa_causal_mask_f32(
   GQA_RETURN_LAUNCH_STATUS();
 }
 
+// `sq` counts the query rows present in `scores`, which is a chunk of the full
+// query range when the caller is tiling the prefill. `bias_sq` is the full query
+// extent of the bias tensor and `bias_row_offset` locates the chunk inside it --
+// the two cannot be folded together because the bias plane stride is set by the
+// full extent while the score plane stride is set by the chunk.
 template <typename TBias>
 __global__ void add_attention_bias_kernel(
     float* __restrict__ scores, const TBias* __restrict__ bias,
     int total_heads, int num_heads, int bias_batch, int bias_heads, int sq,
-    int total_seq, int score_batch_stride) {
+    int total_seq, int score_batch_stride, int bias_sq, int bias_row_offset) {
   int head = blockIdx.y;
   int tid = blockIdx.x * blockDim.x + threadIdx.x;
   int n = sq * total_seq;
@@ -1080,9 +1085,10 @@ __global__ void add_attention_bias_kernel(
   int h = head % num_heads;
   int bias_b = (bias_batch == 1) ? 0 : b;
   int bias_h = (bias_heads == 1) ? 0 : h;
-  size_t bias_idx = static_cast<size_t>(bias_b) * bias_heads * sq * total_seq +
-                    static_cast<size_t>(bias_h) * sq * total_seq +
-                    static_cast<size_t>(row) * total_seq + col;
+  size_t bias_plane = static_cast<size_t>(bias_sq) * total_seq;
+  size_t bias_idx = static_cast<size_t>(bias_b) * bias_heads * bias_plane +
+                    static_cast<size_t>(bias_h) * bias_plane +
+                    static_cast<size_t>(bias_row_offset + row) * total_seq + col;
   scores[static_cast<size_t>(head) * score_batch_stride + tid] +=
       static_cast<float>(bias[bias_idx]);
 }
@@ -1090,10 +1096,13 @@ __global__ void add_attention_bias_kernel(
 extern "C" int hip_gqa_add_attention_bias_f32(
     void* stream_ptr, void* scores, const void* bias, int total_heads,
     int num_heads, int bias_batch, int bias_heads, int sq, int total_seq,
-    int score_batch_stride, int bias_element_size_bytes) {
+    int score_batch_stride, int bias_element_size_bytes, int bias_sq,
+    int bias_row_offset) {
   if (!scores || !bias)
     return -1;
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
+  if (bias_sq <= 0)
+    bias_sq = sq;
   int n = sq * total_seq;
   int blocksX = (n + GQA_THREADS - 1) / GQA_THREADS;
   (void)hipGetLastError();
@@ -1102,13 +1111,13 @@ extern "C" int hip_gqa_add_attention_bias_f32(
         <<<dim3(blocksX, total_heads), GQA_THREADS, 0, stream>>>(
             static_cast<float*>(scores), static_cast<const __half*>(bias),
             total_heads, num_heads, bias_batch, bias_heads, sq, total_seq,
-            score_batch_stride);
+            score_batch_stride, bias_sq, bias_row_offset);
   } else if (bias_element_size_bytes == 4) {
     add_attention_bias_kernel<float>
         <<<dim3(blocksX, total_heads), GQA_THREADS, 0, stream>>>(
             static_cast<float*>(scores), static_cast<const float*>(bias),
             total_heads, num_heads, bias_batch, bias_heads, sq, total_seq,
-            score_batch_stride);
+            score_batch_stride, bias_sq, bias_row_offset);
   } else {
     fprintf(stderr,
             "hip_gqa_add_attention_bias_f32: unsupported bias elem size %d\n",

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -653,12 +653,17 @@ HIP_KERNEL_API int hip_gqa_causal_mask_f32(
 /* Add an attention bias onto the fp32 score matrix before softmax.
  * scores layout: [total_heads, sq, total_seq] row-major with batch_stride
  * = sq * total_seq per head.
- * bias layout: [bias_batch, bias_heads, sq, total_seq], row-major.
- * bias_batch / bias_heads may be 1 for ONNX-style broadcast. */
+ * bias layout: [bias_batch, bias_heads, bias_sq, total_seq], row-major.
+ * bias_batch / bias_heads may be 1 for ONNX-style broadcast.
+ * sq is the number of query rows in `scores`, which is a chunk of the full
+ * query range when the caller tiles the prefill; bias_sq is the bias tensor's
+ * full query extent and bias_row_offset locates the chunk within it. Pass
+ * bias_sq = sq (or 0) and bias_row_offset = 0 for the untiled case. */
 HIP_KERNEL_API int hip_gqa_add_attention_bias_f32(
     void* stream, void* scores, const void* bias,
     int total_heads, int num_heads, int bias_batch, int bias_heads,
-    int sq, int total_seq, int score_batch_stride, int bias_element_size_bytes);
+    int sq, int total_seq, int score_batch_stride, int bias_element_size_bytes,
+    int bias_sq, int bias_row_offset);
 
 /* Column-wise softmax in-place. One threadblock per (head, query).
  * Smooth softmax is activated when head_sink is non-null OR use_smooth_softmax

--- a/lib/Runtime/Kernels/test/example/gqa/prefill/test_gqa_attention_bias.cpp
+++ b/lib/Runtime/Kernels/test/example/gqa/prefill/test_gqa_attention_bias.cpp
@@ -1,0 +1,248 @@
+// ============================================================
+// custom_kernels GQA attention-bias addressing test.
+//
+// Verifies hip_gqa_add_attention_bias_f32, the Step 8b kernel that adds an
+// external additive mask onto the fp32 score matrix in the decomposed prefill
+// pipeline (gqa.cpp).
+//
+// The score matrix is [total_heads, sq, total_seq] with a per-head stride of
+// score_batch_stride, while the bias is [bias_batch, bias_heads, bias_sq,
+// total_seq] and bias_batch / bias_heads may be 1 for ONNX-style broadcast.
+// When the prefill is tiled over query rows, `sq` is the chunk's row count and
+// the bias is still indexed over the full query range: bias_sq stays at the
+// full extent and bias_row_offset locates the chunk inside it. Those two cannot
+// be folded into the bias pointer, because the bias plane stride is set by the
+// full extent while the score plane stride is set by the chunk -- so with
+// bias_batch or bias_heads > 1 a folded pointer would land in the wrong plane.
+//
+// Each case is run twice: once untiled, and once as a sequence of chunks whose
+// results must reproduce the untiled answer row for row. The chunk sizes are
+// chosen so the final chunk is ragged, which is what a real prompt length
+// produces.
+//
+// Build (from this directory):
+//   hipcc --offload-arch=gfx1151 -O3 -std=c++17 -Wno-deprecated-declarations \
+//     test_gqa_attention_bias.cpp ../../../../hip/gqa_kernel.hip \
+//     -I../../../../include -o test_gqa_attention_bias.exe
+//   ./test_gqa_attention_bias.exe
+// ============================================================
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <random>
+#include <vector>
+
+extern "C" int hip_gqa_add_attention_bias_f32(
+    void* stream, void* scores, const void* bias, int total_heads,
+    int num_heads, int bias_batch, int bias_heads, int sq, int total_seq,
+    int score_batch_stride, int bias_element_size_bytes, int bias_sq,
+    int bias_row_offset);
+
+#define HIP_CHECK(expr)                                                        \
+  do {                                                                         \
+    hipError_t _e = (expr);                                                    \
+    if (_e != hipSuccess) {                                                    \
+      fprintf(stderr, "HIP error %s at %s:%d\n", hipGetErrorString(_e),        \
+              __FILE__, __LINE__);                                             \
+      std::exit(1);                                                            \
+    }                                                                          \
+  } while (0)
+
+struct Case {
+  const char* name;
+  int B, num_heads, sq, total_seq;
+  int bias_batch;  // 1 to broadcast, else B
+  int bias_heads;  // 1 to broadcast, else num_heads
+  int elem;        // bias element size: 2 (fp16) or 4 (fp32)
+  int chunk;       // query rows per chunk in the tiled arm
+  // Pass bias_sq = 0 instead of the real extent in the untiled arm, exercising
+  // the kernel's "bias_sq <= 0 means sq" defaulting.
+  bool bias_sq_zero;
+};
+
+// scores[head][row][col] += bias[bias_b][bias_h][row][col], with the same
+// broadcast rules the kernel implements.
+static void cpu_reference(std::vector<float>& scores,
+                          const std::vector<float>& bias, int total_heads,
+                          int num_heads, int bias_batch, int bias_heads, int sq,
+                          int total_seq) {
+  const size_t bias_plane = (size_t)sq * total_seq;
+  for (int head = 0; head < total_heads; ++head) {
+    const int b = head / num_heads;
+    const int h = head % num_heads;
+    const int bb = (bias_batch == 1) ? 0 : b;
+    const int bh = (bias_heads == 1) ? 0 : h;
+    const size_t bias_base =
+        (size_t)bb * bias_heads * bias_plane + (size_t)bh * bias_plane;
+    for (int r = 0; r < sq; ++r)
+      for (int c = 0; c < total_seq; ++c)
+        scores[(size_t)head * sq * total_seq + (size_t)r * total_seq + c] +=
+            bias[bias_base + (size_t)r * total_seq + c];
+  }
+}
+
+static double max_abs_diff(const std::vector<float>& a,
+                           const std::vector<float>& b) {
+  double m = 0.0;
+  for (size_t i = 0; i < a.size(); ++i)
+    m = std::fmax(m, std::fabs((double)a[i] - (double)b[i]));
+  return m;
+}
+
+static bool run_case(const Case& c) {
+  const int total_heads = c.B * c.num_heads;
+  const size_t score_n = (size_t)total_heads * c.sq * c.total_seq;
+  const size_t bias_n =
+      (size_t)c.bias_batch * c.bias_heads * c.sq * c.total_seq;
+
+  std::mt19937 rng(99 + c.sq + c.total_seq + c.elem + c.chunk);
+  std::uniform_real_distribution<float> dist(-4.0f, 4.0f);
+
+  std::vector<float> scores0(score_n), bias_f(bias_n);
+  for (auto& x : scores0) x = dist(rng);
+  for (auto& x : bias_f) x = dist(rng);
+
+  // Round the bias through its storage type so the reference reads exactly what
+  // the kernel reads; otherwise the comparison would charge the kernel for the
+  // host's fp16 rounding.
+  std::vector<__half> bias_h(bias_n);
+  if (c.elem == 2) {
+    for (size_t i = 0; i < bias_n; ++i) {
+      bias_h[i] = __float2half(bias_f[i]);
+      bias_f[i] = __half2float(bias_h[i]);
+    }
+  }
+
+  std::vector<float> expect = scores0;
+  cpu_reference(expect, bias_f, total_heads, c.num_heads, c.bias_batch,
+                c.bias_heads, c.sq, c.total_seq);
+
+  void* dBias = nullptr;
+  const size_t bias_bytes = bias_n * (c.elem == 2 ? sizeof(__half) : sizeof(float));
+  HIP_CHECK(hipMalloc(&dBias, bias_bytes));
+  HIP_CHECK(hipMemcpy(dBias,
+                      c.elem == 2 ? (const void*)bias_h.data()
+                                  : (const void*)bias_f.data(),
+                      bias_bytes, hipMemcpyHostToDevice));
+
+  // ---- Arm A: untiled, one call over the whole query range ----
+  float* dScores = nullptr;
+  HIP_CHECK(hipMalloc(&dScores, score_n * sizeof(float)));
+  HIP_CHECK(hipMemcpy(dScores, scores0.data(), score_n * sizeof(float),
+                      hipMemcpyHostToDevice));
+  int rc = hip_gqa_add_attention_bias_f32(
+      nullptr, dScores, dBias, total_heads, c.num_heads, c.bias_batch,
+      c.bias_heads, c.sq, c.total_seq, c.sq * c.total_seq, c.elem,
+      c.bias_sq_zero ? 0 : c.sq, 0);
+  HIP_CHECK(hipDeviceSynchronize());
+  if (rc != 0) {
+    fprintf(stderr, "%s: untiled call returned %d\n", c.name, rc);
+    HIP_CHECK(hipFree(dScores));
+    HIP_CHECK(hipFree(dBias));
+    return false;
+  }
+  std::vector<float> got_untiled(score_n);
+  HIP_CHECK(hipMemcpy(got_untiled.data(), dScores, score_n * sizeof(float),
+                      hipMemcpyDeviceToHost));
+  HIP_CHECK(hipFree(dScores));
+
+  // ---- Arm B: chunked, mirroring the tiled prefill's call sequence ----
+  // Each chunk gets its own [total_heads, rows, total_seq] score buffer with a
+  // per-head stride of rows*total_seq, while the bias keeps its full extent and
+  // is located by bias_row_offset.
+  std::vector<float> got_chunked(score_n);
+  bool chunk_ok = true;
+  for (int q0 = 0; q0 < c.sq && chunk_ok; q0 += c.chunk) {
+    const int rows = std::min(c.chunk, c.sq - q0);
+    const size_t chunk_n = (size_t)total_heads * rows * c.total_seq;
+    std::vector<float> chunk_in(chunk_n);
+    for (int head = 0; head < total_heads; ++head)
+      for (int r = 0; r < rows; ++r)
+        std::memcpy(&chunk_in[((size_t)head * rows + r) * c.total_seq],
+                    &scores0[((size_t)head * c.sq + q0 + r) * c.total_seq],
+                    (size_t)c.total_seq * sizeof(float));
+
+    float* dChunk = nullptr;
+    HIP_CHECK(hipMalloc(&dChunk, chunk_n * sizeof(float)));
+    HIP_CHECK(hipMemcpy(dChunk, chunk_in.data(), chunk_n * sizeof(float),
+                        hipMemcpyHostToDevice));
+    rc = hip_gqa_add_attention_bias_f32(
+        nullptr, dChunk, dBias, total_heads, c.num_heads, c.bias_batch,
+        c.bias_heads, rows, c.total_seq, rows * c.total_seq, c.elem, c.sq, q0);
+    HIP_CHECK(hipDeviceSynchronize());
+    if (rc != 0) {
+      fprintf(stderr, "%s: chunk at q0=%d returned %d\n", c.name, q0, rc);
+      chunk_ok = false;
+    } else {
+      std::vector<float> chunk_out(chunk_n);
+      HIP_CHECK(hipMemcpy(chunk_out.data(), dChunk, chunk_n * sizeof(float),
+                          hipMemcpyDeviceToHost));
+      for (int head = 0; head < total_heads; ++head)
+        for (int r = 0; r < rows; ++r)
+          std::memcpy(&got_chunked[((size_t)head * c.sq + q0 + r) * c.total_seq],
+                      &chunk_out[((size_t)head * rows + r) * c.total_seq],
+                      (size_t)c.total_seq * sizeof(float));
+    }
+    HIP_CHECK(hipFree(dChunk));
+  }
+  HIP_CHECK(hipFree(dBias));
+  if (!chunk_ok) return false;
+
+  // Both arms add the same fp32 operands in the same order, so anything other
+  // than an exact match is a real addressing error rather than rounding.
+  const double d_untiled = max_abs_diff(got_untiled, expect);
+  const double d_chunked = max_abs_diff(got_chunked, expect);
+  const bool pass = (d_untiled == 0.0) && (d_chunked == 0.0);
+
+  printf("%-18s B%d H%-3d sq=%-5d tseq=%-5d bias[%d,%d] %s chunk=%-5d | "
+         "untiled=%.1e chunked=%.1e  %s\n",
+         c.name, c.B, c.num_heads, c.sq, c.total_seq, c.bias_batch,
+         c.bias_heads, c.elem == 2 ? "fp16" : "fp32", c.chunk, d_untiled,
+         d_chunked, pass ? "PASS" : "FAIL");
+  return pass;
+}
+
+int main() {
+  const Case cases[] = {
+      // Gemma-4 26B-A4B prefill geometry, which is what the tiled path runs.
+      // A fully broadcast bias is the common HF export and cannot catch a plane
+      // -stride error, so it is only the baseline.
+      {"gemma4-bcast",   1, 16, 1024, 1024, 1, 1, 2, 384, false},
+      // bias_heads > 1 is what makes bias_row_offset load-bearing: the plane
+      // stride spans the full query extent, so folding the offset into the
+      // pointer would read the next head's rows.
+      {"gemma4-perhead", 1, 16, 1024, 1024, 1, 16, 2, 384, false},
+      // Both batch and head planes real, so an error in either stride shows.
+      {"multi-batch",    2,  4,  512,  512, 2,  4, 2, 200, false},
+      {"batch-bcast-h",  2,  4,  512,  512, 1,  4, 2, 200, false},
+      // fp32 bias takes the other kernel instantiation.
+      {"perhead-fp32",   1,  8,  512,  512, 1,  8, 4, 192, false},
+      {"multi-batch-f32",2,  4,  256,  256, 2,  4, 4, 100, false},
+      // total_seq != sq is the chunked-prefill shape (past_len > 0), where the
+      // row and column extents must not be conflated.
+      {"past-nonsquare", 1,  8,  512, 1536, 1,  8, 2, 192, false},
+      {"past-square-tail",1, 8,  500, 1500, 1,  8, 2, 128, false},
+      // Chunk that divides sq exactly: no ragged tail.
+      {"exact-chunks",   1,  8,  512,  512, 1,  8, 2, 128, false},
+      // One row per chunk is the floor the runtime falls back to when a single
+      // row already exceeds the budget.
+      {"single-row",     1,  4,   16,   64, 1,  4, 2,   1, false},
+      // Chunk wider than sq must behave as a single untiled pass.
+      {"chunk-gt-sq",    1,  4,   64,   64, 1,  4, 2, 256, false},
+      // bias_sq = 0 must default to sq on the untiled call.
+      {"bias-sq-zero",   1,  8,  256,  256, 1,  8, 2, 100, true},
+  };
+
+  int fails = 0;
+  for (const auto& c : cases)
+    if (!run_case(c)) ++fails;
+  printf("\n%s (%d failing case(s))\n", fails == 0 ? "ALL PASS" : "SOME FAILED",
+         fails);
+  return fails == 0 ? 0 : 1;
+}

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -733,6 +733,25 @@ static bool gqa_no_expand_prefill_enabled() {
   return enabled;
 }
 
+// Byte budget for the pair of score matrices the decomposed prefill holds. Once
+// the pair would exceed this, the prefill is tiled over query rows instead (see
+// the chunking comment in gqa_forward_hipblaslt).
+//
+// Deliberately far above any shape that already runs well: at 1 GiB nothing
+// tiles below roughly 3.5K tokens on a 16-head model, so short and medium
+// sequences keep their existing kernel launch counts and descriptor cache
+// entries exactly, and only the lengths whose score matrices are already tens
+// of gigabytes change behaviour. A fixed budget rather than a fraction of free
+// memory keeps the chunk count -- and so the set of GEMM descriptors a session
+// compiles -- reproducible across runs.
+static constexpr size_t kScoreBudgetBytes = size_t{1024} * 1024 * 1024;
+
+// Query rows per chunk are rounded down to a multiple of this so the Score and
+// Value GEMMs see a tile-friendly n. Only applied when it does not cost an
+// extra chunk, since a ragged n on one chunk is cheaper than a whole extra
+// pass.
+static constexpr int64_t kScoreChunkAlign = 128;
+
 // Env-var gate to force decode through the decomposed hipBLASLt pipeline
 // instead of the fused custom kernel hip_gqa_fused_decode. Default off
 // (fused path is preferred). Set HIPDNN_EP_GQA_DISABLE_FUSED_DECODE=1 to
@@ -1399,9 +1418,94 @@ static int gqa_forward_hipblaslt(
                        (sq == 1 || gqa_no_expand_prefill_enabled());
   bool need_transpose = (sq > 1);
 
+  //===--------------------------------------------------------------------===//
+  // Query-row chunking of the score matrix
+  //
+  // This path materialises the whole [B*H, sq, total_seq] score matrix twice --
+  // once in fp32 for the bias add, the causal mask and the softmax reduction,
+  // and once in the GEMM input dtype as the probabilities the Value GEMM
+  // consumes. Both are quadratic in sequence length, and together they dominate
+  // every other allocation the runtime makes: at 16K on a 16-head model they
+  // are 96 bytes per S^2, or 23.6 GiB, which is 97.9% of the workspace.
+  //
+  // The softmax here reduces along total_seq, so each query row is independent
+  // of every other. A block of rows can therefore be scored, biased, masked,
+  // softmaxed and multiplied by V to completion before the next block starts,
+  // and the result is identical -- this is a tiling of the same arithmetic, not
+  // an approximation, and it needs no running maximum or rescaling because
+  // every row sees its full key range within one chunk.
+  //
+  // Only the two score buffers shrink. Q, K, V and O are linear in sq and stay
+  // whole, so Q is read and O is written through a per-chunk offset while their
+  // batch strides continue to describe the full sq.
+  //
+  // Chunking is skipped entirely unless the score pair exceeds the budget, in
+  // which case sq_chunk == sq, the loop below runs once, the GEMM keys keep
+  // their dense default strides and the behaviour is exactly what it was.
+  //
+  // The no-expand flavour is excluded: its Q and O operands are laid out
+  // [B, G, HPG, sq, d] with n = HPG*sq, so a range of query rows is not a
+  // contiguous range of n and the same offset trick does not apply. That path
+  // is off by default for prefill.
+  //===--------------------------------------------------------------------===//
+  int64_t sq_chunk = sq;
+  if (sq > 1 && !use_no_expand) {
+    const size_t score_row_bytes =
+        static_cast<size_t>(B) * H * total_seq * (sizeof(float) + elem_sz);
+    if (score_row_bytes > 0 &&
+        static_cast<size_t>(sq) * score_row_bytes > kScoreBudgetBytes) {
+      int64_t rows = static_cast<int64_t>(kScoreBudgetBytes / score_row_bytes);
+      // A single row can already exceed the budget on a long enough context.
+      // Correctness wins: one row per chunk is the floor.
+      if (rows < 1)
+        rows = 1;
+      // Round down to a tile-friendly multiple only when that does not add a
+      // chunk. Comparing the two chunk counts is what enforces this: rounding
+      // 600 down to 512 at sq == 1200 would turn two passes into three, so it
+      // is skipped and the ragged n is kept instead.
+      const int64_t aligned = rows - rows % kScoreChunkAlign;
+      if (aligned > 0 &&
+          (sq + aligned - 1) / aligned == (sq + rows - 1) / rows)
+        rows = aligned;
+      if (rows > sq)
+        rows = sq;
+      sq_chunk = rows;
+    }
+  }
+  const bool chunked = (sq_chunk < sq);
+  const int64_t sq_tail = chunked ? (sq % sq_chunk) : 0;
+
   // GEMM descriptor keys. The no-expand flavour uses explicit per-operand
   // strides (non-zero stride fields); the expand flavour leaves them zero so
   // queryOrCreateGemmState falls back to the dense packed-batch defaults.
+  //
+  // When chunking, the expand flavour must state Q's and O's strides
+  // explicitly: n is the chunk length but those two operands still advance by
+  // the full sq between heads. The score matrices are freshly packed per chunk,
+  // so their strides stay at the dense default.
+  auto makeKeys = [&](int64_t n_rows, GqaGemmKey *score, GqaGemmKey *value) {
+    *score = {total_seq,
+              n_rows,
+              d,
+              B * H,
+              true,
+              /*outputFp32=*/true,
+              gemm_fp32,
+              /*strideA=*/0,
+              /*strideB=*/chunked ? sq * d : 0,
+              /*strideC=*/0};
+    *value = {d,
+              n_rows,
+              total_seq,
+              B * H,
+              false,
+              /*outputFp32=*/gemm_fp32,
+              gemm_fp32,
+              /*strideA=*/0,
+              /*strideB=*/0,
+              /*strideC=*/chunked ? sq * d : 0};
+  };
+
   GqaGemmKey scoreKey, valueKey;
   if (use_no_expand) {
     // Score: C[total_seq, HPG*sq] = K^T[d,total_seq] * Q[d, HPG*sq] per (b, g)
@@ -1432,21 +1536,7 @@ static int gqa_forward_hipblaslt(
                 /*strideB=*/HPG * sq * total_seq,
                 /*strideC=*/HPG * sq * d};
   } else {
-    scoreKey = {total_seq,           sq,        d, B * H, true,
-                /*outputFp32=*/true, gemm_fp32,
-                /*strideA=*/0,
-                /*strideB=*/0,
-                /*strideC=*/0};
-    valueKey = {d,
-                sq,
-                total_seq,
-                B * H,
-                false,
-                /*outputFp32=*/gemm_fp32,
-                gemm_fp32,
-                /*strideA=*/0,
-                /*strideB=*/0,
-                /*strideC=*/0};
+    makeKeys(sq_chunk, &scoreKey, &valueKey);
   }
 
   const GqaGemmCacheEntry *scoreState =
@@ -1457,6 +1547,24 @@ static int gqa_forward_hipblaslt(
       queryOrCreateGemmState(state, ltHandle, valueKey, op_state_slot);
   if (!valueState)
     return -1;
+
+  // A ragged final chunk is a different n and so a different descriptor. Both
+  // shapes are resolved before sizing the workspace because the GEMM workspace
+  // region has to cover whichever algorithm asks for more.
+  const GqaGemmCacheEntry *scoreTailState = nullptr;
+  const GqaGemmCacheEntry *valueTailState = nullptr;
+  if (sq_tail > 0) {
+    GqaGemmKey scoreTailKey, valueTailKey;
+    makeKeys(sq_tail, &scoreTailKey, &valueTailKey);
+    scoreTailState =
+        queryOrCreateGemmState(state, ltHandle, scoreTailKey, op_state_slot);
+    if (!scoreTailState)
+      return -1;
+    valueTailState =
+        queryOrCreateGemmState(state, ltHandle, valueTailKey, op_state_slot);
+    if (!valueTailState)
+      return -1;
+  }
 
   // ---- Workspace layout ----
   // All temp buffers are packed contiguously into the shared workspace,
@@ -1470,15 +1578,18 @@ static int gqa_forward_hipblaslt(
   //
   // Qtrans / O are only allocated when need_transpose is true.
   // Kexp / Vexp are only allocated when use_no_expand is false.
-  // S_f32 and S_fp16 are always allocated (softmax is on every path).
+  // S_f32 and S_fp16 are always allocated (softmax is on every path), and are
+  // sized to one query chunk rather than the whole query range -- sq_chunk ==
+  // sq whenever chunking is inactive, so this is the full matrix in that case.
   size_t Qtrans_bytes =
       need_transpose ? static_cast<size_t>(B) * H * sq * d * elem_sz : 0;
   size_t Kexp_bytes =
       use_no_expand ? 0 : static_cast<size_t>(B) * H * total_seq * d * elem_sz;
   size_t Vexp_bytes = Kexp_bytes;
   size_t S_f32_bytes =
-      static_cast<size_t>(B) * H * sq * total_seq * sizeof(float);
-  size_t S_fp16_bytes = static_cast<size_t>(B) * H * sq * total_seq * elem_sz;
+      static_cast<size_t>(B) * H * sq_chunk * total_seq * sizeof(float);
+  size_t S_fp16_bytes =
+      static_cast<size_t>(B) * H * sq_chunk * total_seq * elem_sz;
   size_t O_bytes =
       need_transpose ? static_cast<size_t>(B) * H * sq * d * elem_sz : 0;
 
@@ -1520,6 +1631,10 @@ static int gqa_forward_hipblaslt(
   {
     size_t gemm_ws =
         std::max(scoreState->workspace_size, valueState->workspace_size);
+    if (scoreTailState)
+      gemm_ws = std::max(gemm_ws, scoreTailState->workspace_size);
+    if (valueTailState)
+      gemm_ws = std::max(gemm_ws, valueTailState->workspace_size);
     size_t total_needed = temp_end + gemm_ws;
     HIP_CHECK(hipdnn_ep_state_ensure_workspace(state, total_needed));
   }
@@ -1631,87 +1746,114 @@ static int gqa_forward_hipblaslt(
                             expandCopy, static_cast<int>(elem_sz)));
     }
 
-    // ---- Step 8: Score GEMM (fp16/fp32 in, fp32 out) ----
-    // A = K: no-expand reads present_key directly, expand reads d_Kexp.
-    // B = Q: need_transpose reads d_Qtrans (BNSD), else qSrc (BSHD==BNSD@sq=1).
+    // ---- Steps 8-10, per query chunk ----
+    // One iteration when chunking is inactive, in which case q0 is 0, c is sq
+    // and every pointer and stride below reduces to what it was.
     const void *scoreA = use_no_expand ? present_key : d_Kexp;
-    const void *scoreB = need_transpose ? d_Qtrans : qSrc;
+    const void *scoreBBase = need_transpose ? d_Qtrans : qSrc;
+    const void *valueA = use_no_expand ? present_value : d_Vexp;
+    void *valueCBase = need_transpose ? d_O : output;
     float scoreAlpha = scale;
     float beta = 0.0f;
-    hipblasLtMatmulAlgo_t sAlgo = scoreState->algo;
-
-    HIPBLAS_CHECK(hipblasLtMatmul(
-        ltHandle, scoreState->desc, &scoreAlpha, scoreA, scoreState->layA,
-        scoreB, scoreState->layB, &beta, d_S_f32, scoreState->layC, d_S_f32,
-        scoreState->layD, &sAlgo, gemm_ws_ptr, gemm_ws_bytes, stream));
-
-    // ---- Step 8b: Add external attention bias (onnx.Attention attn_mask) ----
-    int scoreF32BatchStride = static_cast<int>(sq * total_seq);
-    if (attention_bias) {
-      HIP_CHECK(hip_gqa_add_attention_bias_f32(
-          stream, d_S_f32, const_cast<void *>(attention_bias),
-          static_cast<int>(B * H), static_cast<int>(H),
-          static_cast<int>(attn_bias_batch),
-          static_cast<int>(attn_bias_num_heads), static_cast<int>(sq),
-          static_cast<int>(total_seq), scoreF32BatchStride,
-          static_cast<int>(elem_sz)));
-    }
-
-    // ---- Step 9: Causal Mask (fp32) + Softmax (fp32 -> fp16/fp32) ----
-    // S is treated as [B*H, sq, total_seq] (head stride sq*total_seq) by both
-    // GEMM flavours. softmax dtype follows gemm_fp32.
-    //
-    // The built-in causal triangle is applied whenever !no_causal,
-    // INDEPENDENTLY of attention_bias. This mirrors the ONNX Attention
-    // reference and the ORT GQA op: the additive mask (Step 8b, e.g.
-    // onnx.Attention attn_mask or a GQA/ALiBi bias) is ADDED first, then, if
-    // the op is causal, the upper triangle is masked out. For a mask that
-    // already encodes causal (the common HF export) this is idempotent (-inf
-    // stays -inf); for a padding-only mask + is_causal it supplies the missing
-    // triangle. The bidirectional paths (no_causal, e.g. Whisper
-    // encoder/cross-attn or onnx.Attention is_causal=0) set no_causal=true and
-    // thus skip this, letting the mask carry all masking. Note this Step is a
-    // no-op at sq==1 (single-query decode has no future tokens), gated by (sq >
-    // 1 || local_window_size > 0).
-    int scoreFp16BatchStride = static_cast<int>(sq * total_seq);
-    if ((sq > 1 || local_window_size > 0) && !no_causal) {
-      HIP_CHECK(hip_gqa_causal_mask_f32(
-          stream, d_S_f32, static_cast<int>(B * H), static_cast<int>(total_seq),
-          static_cast<int>(sq), scoreF32BatchStride, static_cast<int>(past_len),
-          static_cast<int>(local_window_size)));
-    }
-    // fp16 GQA: softmax writes fp16 probabilities for the fp16 Value GEMM.
-    // fp32 GQA (Whisper no_causal): softmax writes fp32 probabilities for the
-    // fp32 Value GEMM. d_S_fp16 is the probabilities buffer either way (sized
-    // by elem_sz above), so the name is fp16-specific but holds fp32 when
-    // gemm_fp32.
-    if (gemm_fp32) {
-      HIP_CHECK(hip_gqa_softmax_f32_to_f32(
-          stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * sq),
-          static_cast<int>(total_seq), static_cast<int>(sq),
-          scoreF32BatchStride, scoreFp16BatchStride, head_sink,
-          static_cast<int>(H), static_cast<int>(use_smooth_softmax)));
-    } else {
-      HIP_CHECK(hip_gqa_softmax_f32_to_f16(
-          stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * sq),
-          static_cast<int>(total_seq), static_cast<int>(sq),
-          scoreF32BatchStride, scoreFp16BatchStride, head_sink,
-          static_cast<int>(H), static_cast<int>(use_smooth_softmax)));
-    }
-
-    // ---- Step 10: Value GEMM (fp16/fp32 in, fp16/fp32 out) ----
-    // A = V: no-expand reads present_value directly, expand reads d_Vexp.
-    // C = O: need_transpose writes d_O (BNSD, transposed below); at sq==1 the
-    //        GEMM writes straight to output (BSHD==BNSD).
-    const void *valueA = use_no_expand ? present_value : d_Vexp;
-    void *valueC = need_transpose ? d_O : output;
     float valAlpha = 1.0f;
-    hipblasLtMatmulAlgo_t vAlgo = valueState->algo;
 
-    HIPBLAS_CHECK(hipblasLtMatmul(
-        ltHandle, valueState->desc, &valAlpha, valueA, valueState->layA,
-        d_S_fp16, valueState->layB, &beta, valueC, valueState->layC, valueC,
-        valueState->layD, &vAlgo, gemm_ws_ptr, gemm_ws_bytes, stream));
+    for (int64_t q0 = 0; q0 < sq; q0 += sq_chunk) {
+      const int64_t c = std::min<int64_t>(sq_chunk, sq - q0);
+      const bool is_tail = (c != sq_chunk);
+      const GqaGemmCacheEntry *sSt = is_tail ? scoreTailState : scoreState;
+      const GqaGemmCacheEntry *vSt = is_tail ? valueTailState : valueState;
+
+      // Q and O keep their full-sq batch strides (stated in the GEMM key), so
+      // selecting a chunk is a plain offset into the query axis of each.
+      const void *scoreB = static_cast<const char *>(scoreBBase) +
+                           static_cast<size_t>(q0) * d * elem_sz;
+      void *valueC = static_cast<char *>(valueCBase) +
+                     static_cast<size_t>(q0) * d * elem_sz;
+      // The score buffers are re-packed per chunk, so their per-head stride is
+      // the chunk's own row count.
+      const int scoreBatchStride = static_cast<int>(c * total_seq);
+
+      // ---- Step 8: Score GEMM (fp16/fp32 in, fp32 out) ----
+      // A = K: no-expand reads present_key directly, expand reads d_Kexp.
+      // B = Q: need_transpose reads d_Qtrans (BNSD), else qSrc
+      // (BSHD==BNSD@sq=1).
+      hipblasLtMatmulAlgo_t sAlgo = sSt->algo;
+      HIPBLAS_CHECK(hipblasLtMatmul(
+          ltHandle, sSt->desc, &scoreAlpha, scoreA, sSt->layA, scoreB,
+          sSt->layB, &beta, d_S_f32, sSt->layC, d_S_f32, sSt->layD, &sAlgo,
+          gemm_ws_ptr, gemm_ws_bytes, stream));
+
+      // ---- Step 8b: Add external attention bias (onnx.Attention attn_mask) --
+      // The bias is indexed over the full query range, so the chunk's row
+      // offset is passed through rather than folded into the pointer: with
+      // bias_batch or bias_heads > 1 the plane stride still spans all sq rows.
+      if (attention_bias) {
+        HIP_CHECK(hip_gqa_add_attention_bias_f32(
+            stream, d_S_f32, const_cast<void *>(attention_bias),
+            static_cast<int>(B * H), static_cast<int>(H),
+            static_cast<int>(attn_bias_batch),
+            static_cast<int>(attn_bias_num_heads), static_cast<int>(c),
+            static_cast<int>(total_seq), scoreBatchStride,
+            static_cast<int>(elem_sz), static_cast<int>(sq),
+            static_cast<int>(q0)));
+      }
+
+      // ---- Step 9: Causal Mask (fp32) + Softmax (fp32 -> fp16/fp32) ----
+      // S is treated as [B*H, c, total_seq] (head stride c*total_seq) by both
+      // GEMM flavours. softmax dtype follows gemm_fp32.
+      //
+      // The built-in causal triangle is applied whenever !no_causal,
+      // INDEPENDENTLY of attention_bias. This mirrors the ONNX Attention
+      // reference and the ORT GQA op: the additive mask (Step 8b, e.g.
+      // onnx.Attention attn_mask or a GQA/ALiBi bias) is ADDED first, then, if
+      // the op is causal, the upper triangle is masked out. For a mask that
+      // already encodes causal (the common HF export) this is idempotent (-inf
+      // stays -inf); for a padding-only mask + is_causal it supplies the
+      // missing triangle. The bidirectional paths (no_causal, e.g. Whisper
+      // encoder/cross-attn or onnx.Attention is_causal=0) set no_causal=true
+      // and thus skip this, letting the mask carry all masking. Note this Step
+      // is a no-op at sq==1 (single-query decode has no future tokens), gated
+      // by (sq > 1 || local_window_size > 0).
+      //
+      // The mask kernel derives each row's absolute query position as
+      // past_len + row, so advancing past_len by the chunk's start puts the
+      // triangle and the sliding window in the right place for the chunk.
+      if ((sq > 1 || local_window_size > 0) && !no_causal) {
+        HIP_CHECK(hip_gqa_causal_mask_f32(
+            stream, d_S_f32, static_cast<int>(B * H),
+            static_cast<int>(total_seq), static_cast<int>(c), scoreBatchStride,
+            static_cast<int>(past_len + q0),
+            static_cast<int>(local_window_size)));
+      }
+      // fp16 GQA: softmax writes fp16 probabilities for the fp16 Value GEMM.
+      // fp32 GQA (Whisper no_causal): softmax writes fp32 probabilities for the
+      // fp32 Value GEMM. d_S_fp16 is the probabilities buffer either way (sized
+      // by elem_sz above), so the name is fp16-specific but holds fp32 when
+      // gemm_fp32.
+      if (gemm_fp32) {
+        HIP_CHECK(hip_gqa_softmax_f32_to_f32(
+            stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * c),
+            static_cast<int>(total_seq), static_cast<int>(c), scoreBatchStride,
+            scoreBatchStride, head_sink, static_cast<int>(H),
+            static_cast<int>(use_smooth_softmax)));
+      } else {
+        HIP_CHECK(hip_gqa_softmax_f32_to_f16(
+            stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * c),
+            static_cast<int>(total_seq), static_cast<int>(c), scoreBatchStride,
+            scoreBatchStride, head_sink, static_cast<int>(H),
+            static_cast<int>(use_smooth_softmax)));
+      }
+
+      // ---- Step 10: Value GEMM (fp16/fp32 in, fp16/fp32 out) ----
+      // A = V: no-expand reads present_value directly, expand reads d_Vexp.
+      // C = O: need_transpose writes d_O (BNSD, transposed below); at sq==1 the
+      //        GEMM writes straight to output (BSHD==BNSD).
+      hipblasLtMatmulAlgo_t vAlgo = vSt->algo;
+      HIPBLAS_CHECK(hipblasLtMatmul(
+          ltHandle, vSt->desc, &valAlpha, valueA, vSt->layA, d_S_fp16,
+          vSt->layB, &beta, valueC, vSt->layC, valueC, vSt->layD, &vAlgo,
+          gemm_ws_ptr, gemm_ws_bytes, stream));
+    }
 
     // ---- Step 11: O Transpose BNSD [B,H,sq,d] -> BSHD [B,sq,H,d] ----
     // Skipped at sq == 1: the Value GEMM already wrote into output.
@@ -1723,11 +1865,11 @@ static int gqa_forward_hipblaslt(
     }
 
     RUNTIME_DEBUG_LOG(
-        "[REAL] GQA hipBLASLt: B=%lld sq=%lld total_seq=%lld H=%lld G=%lld "
-        "d=%lld no_expand=%d transpose=%d\n",
-        (long long)B, (long long)sq, (long long)total_seq, (long long)H,
-        (long long)G, (long long)d, static_cast<int>(use_no_expand),
-        static_cast<int>(need_transpose));
+        "[REAL] GQA hipBLASLt: B=%lld sq=%lld sq_chunk=%lld total_seq=%lld "
+        "H=%lld G=%lld d=%lld no_expand=%d transpose=%d\n",
+        (long long)B, (long long)sq, (long long)sq_chunk, (long long)total_seq,
+        (long long)H, (long long)G, (long long)d,
+        static_cast<int>(use_no_expand), static_cast<int>(need_transpose));
   }
 
 cleanup:


### PR DESCRIPTION
## Purpose

**CI only — not for merge.** This branch exists to exercise #787 against current `main` using the OGA build that Gemma-4 requires. #787 itself should merge on its own, without the workflow commit below.

## Contents

| commit | what |
|---|---|
| `65bf1b94` | #787 (`fix/gqa-chunked-scores`) rebased onto `main` @ `5f4a20bc` |
| `e7be8c4a` | #599's OGA fork workflow change |

The #787 rebase was textually clean, despite both it and `main`'s #780 touching `gqa_kernel.hip`. Its diff is unchanged from the PR: 3 files, +272 −108.

## Why the OGA fork is needed

Gemma-4 requires `onnxruntime-genai >= 0.15.0`. 0.14.x loads the model but mis-allocates the KV cache for Gemma-4's per-layer attention geometry (local heads x head_dim differs from global). The fork branch carries the AMDGPU MorphiZen integration (former upstream PR 2194) plus `sliding_window`, and reports `0.15.0.dev0`.

## Deviations from #599's diff

#599 is stale against current `main`, so two of its three hunks were dropped rather than applied verbatim:

- **sccache hunk dropped.** #599 edits `SCCACHE_GHA_ENABLED` / `SCCACHE_GHA_RW_MODE`, but #785 deleted both when it moved sccache to a local cache directory. Applying #599's version would reintroduce the GHA backend config. This is the hunk that makes a straight cherry-pick of #599 conflict.
- **`sidecar` -> `constants-file` comment rename dropped.** That hunk only exists because #599's branch predates `main`'s rename; applying it reverts `main`'s wording. Unrelated to OGA.
- **One comment reworded.** #599 says the fork is `cliu1003/onnxruntime-genai` @ `sliding_window_support_amdgpu`, which contradicts the variables it sets three lines earlier (`amd-genmingz/onnxruntime-genai` @ `test_0_3`). The comment here references `OGA_REPO` / `OGA_REF` instead. Worth fixing in #599.

Functional content is identical to #599: `OGA_REPO`, `OGA_REF`, `OGA_PR_PATCHES: ""`, the `mm3` cache key, and the checkout `repository` / `ref`.

Verified after the edit: no dangling `OGA_VERSION` references in `windows-build.yml`, the YAML parses, and the empty-`OGA_PR_PATCHES` path is already handled. The remaining `OGA_VERSION` references live in `linux-build.yml`, which #599 does not touch and which keeps its own copy.

## Local verification

Built on Windows (gfx1151, Ninja, Release) at `e7be8c4a`:

- lit: **390 passed / 12 unsupported / 0 failed** (402 discovered)
- ctest `StaticPlugins|OutputAllocator`: 2/2 passed

## Expected CI cost

The OGA cache key changes from `oga-dml-mm2-0.14.0-pr2194-...` to `oga-dml-mm3-amd-genmingz/onnxruntime-genai-test_0_3-...`, so the OGA cache is cold and onnxruntime-genai will be built from the fork source rather than restored.

## Why #787 is the interesting one for Gemma-4

Gemma-4's 30 `ai.onnx.Attention` nodes all carry `is_causal=0` plus an explicit additive `attn_mask`, both of which disqualify them from `fused_supported` in `gqa.cpp`. Every attention dispatch therefore lands on the decomposed hipBLASLt pipeline (verified locally: 60 decomposed, 0 fused prefill, 0 fused decode). #787 tiles that decomposed prefill, so unlike the fused-path GQA work it should actually move this model.
