### PR TITLE
Add asparkhi as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,45 +17,45 @@
 # compiler tree here because it shares the same owners today; split into
 # its own runtime entry if a runtime-only owner joins.
 # ---------------------------------------------------------------------------
-/lib/Compiler/                  @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/lib/Conversion/                @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/lib/Dialect/                   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/lib/Target/                    @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/lib/CInterface/                @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/include/hip/Compiler/          @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/include/hip/Conversion/        @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/include/hip/Dialect/           @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/include/hip/Target/            @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/include/hip/Support/           @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/include/hip/InitAllPasses.h    @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/include/hip/compiler_api.h     @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/include/hip/compiler_types.h   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/backend-mlir-compiler/         @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/morphizen_mlir_init/           @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/schemas/                       @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/test/lit/                      @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/tools/hip-compiler/            @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/tools/hip-mlir-opt/            @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/tools/hip-inspect/             @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/lib/Compiler/                  @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/lib/Conversion/                @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/lib/Dialect/                   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/lib/Target/                    @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/lib/CInterface/                @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/include/hip/Compiler/          @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/include/hip/Conversion/        @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/include/hip/Dialect/           @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/include/hip/Target/            @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/include/hip/Support/           @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/include/hip/InitAllPasses.h    @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/include/hip/compiler_api.h     @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/include/hip/compiler_types.h   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/backend-mlir-compiler/         @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/morphizen_mlir_init/           @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/schemas/                       @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/test/lit/                      @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/tools/hip-compiler/            @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/tools/hip-mlir-opt/            @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/tools/hip-inspect/             @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
 
 # ---------------------------------------------------------------------------
 # Runtime: EP runtime state, real/mock GPU backends, graph runtime, runtime
 # test tools that exercise the EP ABI.
 # ---------------------------------------------------------------------------
-/lib/Runtime/                   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/lib/HipDNNGraphRuntime/        @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/tools/hip-onnx-runner/         @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/tools/hip-test/                @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/lib/Runtime/                   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/lib/HipDNNGraphRuntime/        @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/tools/hip-onnx-runner/         @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/tools/hip-test/                @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
 
 # ---------------------------------------------------------------------------
 # Shared: utilities and graph machinery used by both compiler and runtime.
 # ---------------------------------------------------------------------------
-/lib/Support/                   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/lib/HipDNNGraph/               @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/lib/Support/                   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/lib/HipDNNGraph/               @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
 
 # ---------------------------------------------------------------------------
 # Tests + design docs: integration / accuracy / TPS coverage and
 # architecture decisions.
 # ---------------------------------------------------------------------------
-/test/python/                   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
-/docs/design/                   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao
+/test/python/                   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi
+/docs/design/                   @fhanuman @amd-mingw @edelaye @wcy123 @qianglin-amd @amd-bqiao @asparkhi


### PR DESCRIPTION
Adds @asparkhi as a code owner for all currently owned compiler, runtime, test, and design paths.