### PR TITLE
perf(gqa): recover onnx.Attention's sliding window from its mask and narrow the KV cache to it

### DIFF
--- a/lib/Conversion/OnnxToHip/AttentionWindowFold.cpp
+++ b/lib/Conversion/OnnxToHip/AttentionWindowFold.cpp
@@ -1,0 +1,632 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- AttentionWindowFold.cpp - Recover a sliding window from the mask ---===//
+//
+// `onnx.Attention` had no way to declare a sliding window until opset 25, which
+// added `left_window_size` / `right_window_size`. At opset 23 and 24 the op's
+// attributes are only `is_causal`, `kv_num_heads`, `q_num_heads`,
+// `qk_matmul_output_mode`, `scale`, `softcap` and `softmax_precision`, so a
+// model whose attention is windowed has nowhere to say so and bakes the window
+// into the additive float mask instead: the mask is 0 for the key positions a
+// query may attend to and a large negative value everywhere else. The op then
+// reaches the runtime with `local_window_size == -1`, so the decomposed path
+// scores and copies the whole key range even though everything older than the
+// window is already -inf in the scores.
+//
+// So this rewrite recovers the window from the mask's producing subgraph and
+// stamps it as `hipdnn.local_window_size`, which OnnxAttentionConversion reads
+// onto `hip.gqa`. This is inference about what the model happens to have built,
+// not the model telling us, and it is here to serve the opset-24 exports that
+// have no way to tell us. Reading a declared `left_window_size` where one
+// exists is a separate and strictly easier change, deliberately not made here:
+// no export on hand has the attribute, so it could not be tested against
+// anything real.
+//
+// `hipdnn.local_window_size = N` means N attended keys *including* the current
+// one, matching `com.microsoft.GroupQueryAttention` (whose own definition moved
+// to include the current token in onnxruntime PR 25927) and the runtime's
+// `kv_lo = abs_q - local_window_size + 1`. A HuggingFace `sliding_window: 1024`
+// is `hipdnn.local_window_size = 1024`, and the mask's `P - Q < 1024` below
+// carries that same count, so W transfers with no adjustment.
+//
+// What is matched
+// ---------------
+// Gemma-4's 25 windowed layers and its 5 global layers share one mask shape and
+// differ by exactly one node, which is what makes this recognizable:
+//
+//   windowed:  keep = And(pad, Or(win, seg))
+//   global:    keep = And(pad, Or(GreaterOrEqual(P,Q), seg))
+//   both:      mask = Where(keep, 0.0, -65504.0)
+//
+//   with  win = And(GreaterOrEqual(P,Q), Less(Sub(P,Q), 1024))
+//         seg = the same-image-block term described below
+//
+// The window leg is `And(P >= Q, P - Q < W)` where the compare and the
+// subtraction reference the SAME two values in the SAME order. That identity
+// fixes the two roles relative to each other: the causal conjunct `P >= Q`
+// makes P the query side and Q the key side, since the reverse reading would
+// keep only future keys, which no decoder mask does. So `P - Q < W` reads
+// `q - k < W`, i.e. `k >= q - W + 1`, which is exactly the runtime's
+// `kv_lo = abs_q - local_window_size + 1`.
+//
+// Identity alone is not enough, though, and this is the part worth being
+// careful about. It says `P - Q < W` bounds the difference of two tensors; the
+// runtime then narrows KV cache reads by ABSOLUTE POSITION. For the second to
+// follow from the first, P and Q have to be positions on one common scale --
+// same origin, unit stride. Structurally identical arithmetic over tensors that
+// were scaled or re-based would match just as well and yield a W in the wrong
+// units, and the narrowing would then drop keys the model wanted.
+//
+// So P and Q must additionally be drawn from the SAME position sequence: both
+// must reach a common `onnx.CumSum` or `onnx.Range` within
+// `kPositionProvenanceDepth`. That is the standard way a decoder builds
+// positions -- a cumulative count over the attention mask, or a plain range --
+// and sharing the node is what makes the subtraction a genuine distance rather
+// than a difference of two unrelated quantities. On the Gemma-4 export the key
+// side is `Unsqueeze(CumSum(attention_mask))` and the query side is
+// `Unsqueeze(Slice(CumSum(attention_mask)))`, the same CumSum reached at depths
+// 1 and 2, so the bound is small. Where both index tensors are recognizable
+// unsqueezes their axes are checked as further corroboration.
+//
+// How the legs combine
+// --------------------
+// The keep-condition is a monotone And/Or tree, and the bound propagates
+// through it the only way it can:
+//
+//   * AND: a conjunct can only remove keeps, so an unrecognized conjunct is
+//     harmless and any bounded conjunct bounds the whole node (min of the
+//     bounds). This is what absorbs the padding leg for free.
+//   * OR: a disjunct can add keeps, so EVERY disjunct must be bounded or the
+//     node is unbounded (max of the bounds).
+//
+// The segment exception
+// ---------------------
+// Gemma-4's mask ORs in a same-image-block bidirectional term,
+// `And(Equal(a,b), a >= 0)`. It is identically false for a text-only prompt, so
+// narrowing is then exact. With images it keeps keys in the query's own image
+// block, and can therefore reach past the window only if a single image block
+// is longer than the window -- 256 soft tokens per image against a 1024 window
+// here, a 4x margin. That bound is a property of the input rather than of the
+// graph, so it cannot be proven here; this rewrite recognizes the term
+// explicitly and accepts it, rather than accepting anything it does not
+// understand. A leg that is neither windowed nor this exact shape makes the
+// whole match fail and the op keep its full range.
+//
+// `And(Equal(a,b), Cmp(a, const))` on its own is too weak to accept, because it
+// is also how a same-document mask or a prefix-LM mask is spelled, and those
+// reach arbitrarily far back. What separates the block-index reading is where
+// the compared values come from: a block index is a running count, so an
+// `onnx.CumSum` is an ancestor of the equality's operands. Requiring that
+// ancestor is what makes the leg identifiable rather than merely plausible --
+// a document id read straight out of an input tensor has no CumSum behind it
+// and is declined. On the Gemma-4 export the CumSum sits 3 and 4 nodes above
+// the two `Equal` operands respectively, so `kSegmentProvenanceDepth` only has
+// to be a small constant.
+//
+// Both legs therefore ask for a CumSum, for different reasons and -- worth
+// knowing when reading a dump -- not the same one. The export has exactly two:
+// a block-index CumSum over the image-block starts, which is the one the
+// segment leg reaches, and a position CumSum over `attention_mask`, which is
+// the one the window leg's P and Q share. Finding the position CumSum behind a
+// segment leg would say nothing about block extent, which is why the segment
+// check looks above the `Equal` operands specifically rather than anywhere in
+// the mask region.
+//
+// Implementation notes
+// --------------------
+//   * Roots on `onnx.Attention`. Idempotent: bails if the attribute is already
+//     set, so the greedy `ExistingOps` pre-lowering loop quiesces.
+//   * Must run BEFORE `convertComputeOps`, whose greedy pattern set would have
+//     rewritten the mask's producers into `hip.*` ops in an order this cannot
+//     rely on. Pre-lowering still sees generic `onnx.*` with inline constants.
+//   * Recognition is conservative throughout: every unhandled shape declines
+//     with a breadcrumb and leaves the op scoring its full key range, which is
+//     what it does today.
+//
+//===----------------------------------------------------------------------===//
+
+#include "OnnxToHipUtils.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/Debug.h"
+
+#include <algorithm>
+#include <optional>
+
+// DEBUG_TYPE comes from OnnxToHipUtils.h ("convert-onnx-to-hip"), shared with
+// the rest of this directory rather than defined per file here, so that this
+// change does not also have to move the header's definition.
+
+STATISTIC(NumAttentionWindowStamps,
+          "Number of onnx.Attention ops stamped with a sliding window "
+          "recovered from the additive mask subgraph");
+
+namespace mlir {
+namespace hip {
+
+namespace {
+
+/// Recursion and work caps. The real subgraphs sit at depth 7 with a few dozen
+/// nodes; these are loose enough not to bind and tight enough that a
+/// pathological graph cannot make the pre-lowering loop quadratic.
+constexpr int kMaxDepth = 16;
+constexpr int kMaxVisited = 128;
+
+/// The mask value must be negative enough to be a "drop" marker rather than a
+/// bias. fp16's most negative finite value (-65504) is the usual choice; -inf
+/// and float's -3.4e38 also appear.
+constexpr double kDropThreshold = -1.0e4;
+
+static llvm::StringRef opName(mlir::Value v) {
+  mlir::Operation *def = v ? v.getDefiningOp() : nullptr;
+  return def ? def->getName().getStringRef() : llvm::StringRef();
+}
+
+/// Return `v`'s value when it is an inline integer scalar: `onnx.Constant` with
+/// either a rank-0/single-element `value` tensor or the `value_int` attribute
+/// (both forms appear in the same graph -- initializers import as the former,
+/// exporter-synthesized literals as the latter), or an `arith.constant`.
+static std::optional<int64_t> getInlineScalarInt(mlir::Value v) {
+  if (!v)
+    return std::nullopt;
+  mlir::Operation *defOp = v.getDefiningOp();
+  if (!defOp)
+    return std::nullopt;
+
+  if (defOp->getName().getStringRef() == "onnx.Constant") {
+    if (auto asInt = defOp->getAttrOfType<mlir::IntegerAttr>("value_int"))
+      return asInt.getValue().getSExtValue();
+  }
+
+  mlir::DenseElementsAttr dense;
+  if (auto cst = mlir::dyn_cast<mlir::arith::ConstantOp>(defOp))
+    dense = mlir::dyn_cast<mlir::DenseElementsAttr>(cst.getValue());
+  else if (defOp->getName().getStringRef() == "onnx.Constant")
+    dense = defOp->getAttrOfType<mlir::DenseElementsAttr>("value");
+  if (!dense)
+    return std::nullopt;
+
+  auto tensorTy = mlir::dyn_cast<mlir::RankedTensorType>(dense.getType());
+  if (!tensorTy || tensorTy.getRank() > 1 || tensorTy.getNumElements() != 1)
+    return std::nullopt;
+  if (!tensorTy.getElementType().isIntOrIndex())
+    return std::nullopt;
+  return (*dense.getValues<mlir::APInt>().begin()).getSExtValue();
+}
+
+/// Return `v`'s value when it is an inline floating-point scalar. Used only to
+/// identify the Where's keep/drop literals.
+static std::optional<double> getInlineScalarFloat(mlir::Value v) {
+  if (!v)
+    return std::nullopt;
+  mlir::Operation *defOp = v.getDefiningOp();
+  if (!defOp)
+    return std::nullopt;
+
+  if (defOp->getName().getStringRef() == "onnx.Constant") {
+    if (auto asFloat = defOp->getAttrOfType<mlir::FloatAttr>("value_float"))
+      return asFloat.getValueAsDouble();
+  }
+
+  mlir::DenseElementsAttr dense;
+  if (auto cst = mlir::dyn_cast<mlir::arith::ConstantOp>(defOp))
+    dense = mlir::dyn_cast<mlir::DenseElementsAttr>(cst.getValue());
+  else if (defOp->getName().getStringRef() == "onnx.Constant")
+    dense = defOp->getAttrOfType<mlir::DenseElementsAttr>("value");
+  if (!dense)
+    return std::nullopt;
+
+  auto tensorTy = mlir::dyn_cast<mlir::RankedTensorType>(dense.getType());
+  if (!tensorTy || tensorTy.getRank() > 1 || tensorTy.getNumElements() != 1)
+    return std::nullopt;
+  if (!mlir::isa<mlir::FloatType>(tensorTy.getElementType()))
+    return std::nullopt;
+  return (*dense.getValues<mlir::APFloat>().begin()).convertToDouble();
+}
+
+/// Axis of an `onnx.Unsqueeze`, from the opset-13 `axes` operand or the older
+/// `axes` attribute, when it is a single inline value. Used only to corroborate
+/// which of the two index tensors varies along the query axis.
+static std::optional<int64_t> getUnsqueezeAxis(mlir::Value v) {
+  mlir::Operation *def = v ? v.getDefiningOp() : nullptr;
+  if (!def || def->getName().getStringRef() != "onnx.Unsqueeze")
+    return std::nullopt;
+  if (def->getNumOperands() > 1)
+    return getInlineScalarInt(def->getOperand(1));
+  if (auto arr = def->getAttrOfType<mlir::ArrayAttr>("axes")) {
+    if (arr.size() != 1)
+      return std::nullopt;
+    if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(arr[0]))
+      return intAttr.getValue().getSExtValue();
+  }
+  return std::nullopt;
+}
+
+/// Match a causal keep-compare, `p >= q`, in either spelling.
+static bool matchCausalCompare(mlir::Value v, mlir::Value &p, mlir::Value &q) {
+  mlir::Operation *def = v ? v.getDefiningOp() : nullptr;
+  if (!def || def->getNumOperands() != 2)
+    return false;
+  llvm::StringRef name = def->getName().getStringRef();
+  if (name == "onnx.GreaterOrEqual") {
+    p = def->getOperand(0);
+    q = def->getOperand(1);
+    return true;
+  }
+  if (name == "onnx.LessOrEqual") { // q <= p
+    p = def->getOperand(1);
+    q = def->getOperand(0);
+    return true;
+  }
+  return false;
+}
+
+/// Match an upper bound on `p - q`, returning the window it implies: the number
+/// of key positions the bound admits, counting the query's own position.
+/// `p - q < W` admits W of them; `p - q <= W` admits W + 1.
+static bool matchDistanceBound(mlir::Value v, mlir::Value &p, mlir::Value &q,
+                               int64_t &window) {
+  mlir::Operation *def = v ? v.getDefiningOp() : nullptr;
+  if (!def || def->getNumOperands() != 2)
+    return false;
+  llvm::StringRef name = def->getName().getStringRef();
+
+  // Which operand holds the difference and which the limit, and whether the
+  // comparison is strict.
+  mlir::Value diffSide, limitSide;
+  bool strict;
+  if (name == "onnx.Less") { // diff < W
+    diffSide = def->getOperand(0);
+    limitSide = def->getOperand(1);
+    strict = true;
+  } else if (name == "onnx.LessOrEqual") { // diff <= W
+    diffSide = def->getOperand(0);
+    limitSide = def->getOperand(1);
+    strict = false;
+  } else if (name == "onnx.Greater") { // W > diff
+    diffSide = def->getOperand(1);
+    limitSide = def->getOperand(0);
+    strict = true;
+  } else if (name == "onnx.GreaterOrEqual") { // W >= diff
+    diffSide = def->getOperand(1);
+    limitSide = def->getOperand(0);
+    strict = false;
+  } else {
+    return false;
+  }
+
+  if (opName(diffSide) != "onnx.Sub")
+    return false;
+  mlir::Operation *sub = diffSide.getDefiningOp();
+  if (sub->getNumOperands() != 2)
+    return false;
+
+  auto limit = getInlineScalarInt(limitSide);
+  if (!limit)
+    return false;
+
+  p = sub->getOperand(0);
+  q = sub->getOperand(1);
+  window = strict ? *limit : *limit + 1;
+  return true;
+}
+
+/// How far above an `onnx.Equal` operand an `onnx.CumSum` may sit and still
+/// count as its provenance. The Gemma-4 export needs 4; the slack absorbs the
+/// layout ops an exporter may add without admitting an unrelated CumSum from
+/// elsewhere in the graph.
+constexpr int kSegmentProvenanceDepth = 6;
+
+/// How far above the window leg's `P` / `Q` a shared position source may sit.
+/// The Gemma-4 export needs 2 on the query side (through an `onnx.Slice` that
+/// takes the trailing `sq` entries) and 1 on the key side.
+constexpr int kPositionProvenanceDepth = 6;
+
+/// Collect the position sources reachable above `v`.
+///
+/// A position source is an `onnx.CumSum` (the cumulative count over an
+/// attention mask that a decoder builds `position_ids` from) or an
+/// `onnx.Range`. Both are treated as leaves: the walk stops there rather than
+/// descending into what fed them, because it is the identity of the node that
+/// matters, not its inputs.
+static void
+collectPositionSources(mlir::Value v, int depth, int &visited,
+                       llvm::SmallPtrSetImpl<mlir::Operation *> &out) {
+  if (!v || depth > kPositionProvenanceDepth || ++visited > kMaxVisited)
+    return;
+  mlir::Operation *def = v.getDefiningOp();
+  if (!def)
+    return;
+  llvm::StringRef name = def->getName().getStringRef();
+  if (name == "onnx.CumSum" || name == "onnx.Range") {
+    out.insert(def);
+    return;
+  }
+  for (mlir::Value operand : def->getOperands())
+    collectPositionSources(operand, depth + 1, visited, out);
+}
+
+/// Are `p` and `q` drawn from the same position sequence?
+///
+/// See "The window leg" in the file header. The same-value identity between the
+/// causal compare and the subtraction fixes which side is the query and which
+/// the key, but it says nothing about the units of `p - q`, and the runtime
+/// narrows the KV cache by absolute position. Requiring both to reach one
+/// common position source is what makes the difference a position distance: two
+/// tensors sliced from a single monotone position sequence share an origin and
+/// a stride, so subtracting them measures positions.
+///
+/// A common ancestor of any op type would be far too weak -- two unrelated
+/// index tensors routinely share a `Shape` -- so the shared node must itself be
+/// a recognized position source.
+static bool hasSharedPositionSource(mlir::Value p, mlir::Value q,
+                                    int &visited) {
+  llvm::SmallPtrSet<mlir::Operation *, 4> pSources;
+  collectPositionSources(p, /*depth=*/0, visited, pSources);
+  if (pSources.empty())
+    return false;
+  llvm::SmallPtrSet<mlir::Operation *, 4> qSources;
+  collectPositionSources(q, /*depth=*/0, visited, qSources);
+  for (mlir::Operation *src : pSources)
+    if (qSources.contains(src))
+      return true;
+  return false;
+}
+
+/// Is an `onnx.CumSum` an ancestor of `v` within `kSegmentProvenanceDepth`?
+///
+/// This is the provenance check described under "The segment exception": it is
+/// what distinguishes a block index (a running count, hence a CumSum) from a
+/// document id or prefix-LM boundary read straight out of an input, which wear
+/// the same `Equal` spelling but bound nothing. `visited` is the caller's
+/// budget, so a wide graph cannot turn this into a quadratic walk.
+static bool hasCumSumAncestor(mlir::Value v, int depth, int &visited) {
+  if (depth > kSegmentProvenanceDepth || ++visited > kMaxVisited)
+    return false;
+  mlir::Operation *def = v ? v.getDefiningOp() : nullptr;
+  if (!def)
+    return false;
+  if (def->getName().getStringRef() == "onnx.CumSum")
+    return true;
+  for (mlir::Value operand : def->getOperands())
+    if (hasCumSumAncestor(operand, depth + 1, visited))
+      return true;
+  return false;
+}
+
+/// Match the same-segment bidirectional term, `And(Equal(a,b), a >= c)` with a
+/// constant `c` and a CumSum behind the equality. See "The segment exception"
+/// above for why the shape is accepted rather than proven, and why the CumSum
+/// is required rather than merely documented.
+static bool matchSegmentTerm(mlir::Operation *andOp, int &visited) {
+  if (andOp->getNumOperands() != 2)
+    return false;
+  for (int i = 0; i < 2; ++i) {
+    mlir::Value eq = andOp->getOperand(i);
+    mlir::Value ge = andOp->getOperand(1 - i);
+    if (opName(eq) != "onnx.Equal")
+      continue;
+    mlir::Operation *eqOp = eq.getDefiningOp();
+    mlir::Operation *geOp = ge.getDefiningOp();
+    if (!geOp || eqOp->getNumOperands() != 2 || geOp->getNumOperands() != 2)
+      continue;
+    llvm::StringRef geName = geOp->getName().getStringRef();
+    if (geName != "onnx.GreaterOrEqual" && geName != "onnx.Greater")
+      continue;
+    if (!getInlineScalarInt(geOp->getOperand(1)))
+      continue;
+    // The "is in a segment at all" test must be on one of the two values the
+    // equality compares, or these are unrelated conditions.
+    mlir::Value probe = geOp->getOperand(0);
+    if (probe != eqOp->getOperand(0) && probe != eqOp->getOperand(1))
+      continue;
+    // Provenance: one side of the equality must be a running count. Either
+    // side satisfies it -- the export derives both from the same CumSum, at
+    // different depths, and which one is shallower is an exporter detail.
+    if (hasCumSumAncestor(eqOp->getOperand(0), /*depth=*/0, visited) ||
+        hasCumSumAncestor(eqOp->getOperand(1), /*depth=*/0, visited))
+      return true;
+  }
+  return false;
+}
+
+/// What a boolean leg of the keep-condition tells us about how far back a kept
+/// key can be.
+enum class LegKind {
+  /// No information. Safe as an AND conjunct (it can only remove keeps), fatal
+  /// as an OR disjunct.
+  Unbounded,
+  /// Keeping implies the key is within `window` positions of the query.
+  Windowed,
+  /// The recognized same-segment term, accepted under the documented
+  /// image-block bound.
+  Segment,
+};
+
+struct LegInfo {
+  LegKind kind = LegKind::Unbounded;
+  int64_t window = 0;
+
+  static LegInfo unbounded() { return {}; }
+  static LegInfo windowed(int64_t w) { return {LegKind::Windowed, w}; }
+  static LegInfo segment() { return {LegKind::Segment, 0}; }
+};
+
+/// Classify the keep-condition rooted at `v`. `visited` bounds total work.
+static LegInfo classifyKeep(mlir::Value v, int depth, int &visited) {
+  if (depth > kMaxDepth || ++visited > kMaxVisited)
+    return LegInfo::unbounded();
+  mlir::Operation *def = v ? v.getDefiningOp() : nullptr;
+  if (!def)
+    return LegInfo::unbounded();
+  llvm::StringRef name = def->getName().getStringRef();
+
+  // Value-preserving wrappers: a bool-to-bool cast keeps the predicate, and an
+  // int-to-bool cast is a nonzero test that we would classify as unbounded
+  // either way, so descending is always safe.
+  if (name == "onnx.Cast" || name == "onnx.CastLike" || name == "onnx.Identity")
+    return classifyKeep(def->getOperand(0), depth + 1, visited);
+
+  if (name == "onnx.And") {
+    if (def->getNumOperands() != 2)
+      return LegInfo::unbounded();
+    // Try the two leaf shapes first: both are And-rooted, and recursing into
+    // their halves would only find unbounded compares.
+    if (matchSegmentTerm(def, visited))
+      return LegInfo::segment();
+
+    for (int i = 0; i < 2; ++i) {
+      mlir::Value causal = def->getOperand(i);
+      mlir::Value bound = def->getOperand(1 - i);
+      mlir::Value cp, cq, bp, bq;
+      int64_t window = 0;
+      if (!matchCausalCompare(causal, cp, cq))
+        continue;
+      if (!matchDistanceBound(bound, bp, bq, window))
+        continue;
+      // Half the proof: the causal compare and the subtraction must reference
+      // the same two values in the same order, which is what makes `p` the
+      // query index and `q` the key index without having to identify either.
+      if (cp != bp || cq != bq || window <= 0)
+        continue;
+      // The other half: they must be positions on a common scale, or `p - q`
+      // is not a position distance and W is not in units of key positions.
+      if (!hasSharedPositionSource(cp, cq, visited))
+        continue;
+      // Corroboration where the shapes allow it. Broadcast into [.., q, k]
+      // puts the query-varying tensor's data on the lower axis, so it is the
+      // one unsqueezed at the HIGHER axis. Only a clear inversion is rejected;
+      // an unreadable axis leaves the causal argument standing on its own.
+      auto pAxis = getUnsqueezeAxis(cp);
+      auto qAxis = getUnsqueezeAxis(cq);
+      if (pAxis && qAxis && *pAxis < *qAxis)
+        continue;
+      return LegInfo::windowed(window);
+    }
+
+    // A general conjunction: any bounded conjunct bounds the whole node, and
+    // the tightest one wins.
+    LegInfo a = classifyKeep(def->getOperand(0), depth + 1, visited);
+    LegInfo b = classifyKeep(def->getOperand(1), depth + 1, visited);
+    if (a.kind == LegKind::Windowed && b.kind == LegKind::Windowed)
+      return LegInfo::windowed(std::min(a.window, b.window));
+    if (a.kind == LegKind::Windowed)
+      return a;
+    if (b.kind == LegKind::Windowed)
+      return b;
+    if (a.kind == LegKind::Segment || b.kind == LegKind::Segment)
+      return LegInfo::segment();
+    return LegInfo::unbounded();
+  }
+
+  if (name == "onnx.Or") {
+    if (def->getNumOperands() != 2)
+      return LegInfo::unbounded();
+    LegInfo a = classifyKeep(def->getOperand(0), depth + 1, visited);
+    LegInfo b = classifyKeep(def->getOperand(1), depth + 1, visited);
+    // A disjunct adds keeps, so an unrecognized one leaves the whole node
+    // unbounded no matter how tight the other side is.
+    if (a.kind == LegKind::Unbounded || b.kind == LegKind::Unbounded)
+      return LegInfo::unbounded();
+    if (a.kind == LegKind::Windowed && b.kind == LegKind::Windowed)
+      return LegInfo::windowed(std::max(a.window, b.window));
+    if (a.kind == LegKind::Windowed)
+      return a;
+    if (b.kind == LegKind::Windowed)
+      return b;
+    return LegInfo::segment();
+  }
+
+  return LegInfo::unbounded();
+}
+
+/// Walk from the mask value down to the `onnx.Where` that turns the boolean
+/// keep-condition into the additive 0 / large-negative bias, through the layout
+/// ops that do not change values.
+static mlir::Operation *findSelect(mlir::Value mask) {
+  mlir::Value cur = mask;
+  for (int depth = 0; depth < kMaxDepth; ++depth) {
+    mlir::Operation *def = cur ? cur.getDefiningOp() : nullptr;
+    if (!def)
+      return nullptr;
+    llvm::StringRef name = def->getName().getStringRef();
+    if (name == "onnx.Where")
+      return def;
+    if (name == "onnx.Cast" || name == "onnx.CastLike" ||
+        name == "onnx.Identity" || name == "onnx.Unsqueeze" ||
+        name == "onnx.Squeeze" || name == "onnx.Reshape" ||
+        name == "onnx.Expand") {
+      cur = def->getOperand(0);
+      continue;
+    }
+    return nullptr;
+  }
+  return nullptr;
+}
+
+struct AttentionStampMaskWindow : public mlir::RewritePattern {
+  AttentionStampMaskWindow(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Attention", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (op->hasAttr("hipdnn.local_window_size"))
+      return rewriter.notifyMatchFailure(op, "window.already_stamped");
+
+    // Operand 3 is attn_mask. Absent or None means there is no mask to read a
+    // window out of.
+    if (op->getNumOperands() < 4)
+      return rewriter.notifyMatchFailure(op, "window.no_mask_operand");
+    mlir::Value mask = op->getOperand(3);
+    if (!mask || mlir::isa<mlir::NoneType>(mask.getType()))
+      return rewriter.notifyMatchFailure(op, "window.mask_is_none");
+
+    mlir::Operation *select = findSelect(mask);
+    if (!select || select->getNumOperands() != 3)
+      return rewriter.notifyMatchFailure(op, "window.no_select_producer");
+
+    // Polarity: the true arm must be the neutral bias and the false arm the
+    // drop marker. The inverted spelling would need the boolean function
+    // negated, which turns every And into an Or and is not handled.
+    auto keepVal = getInlineScalarFloat(select->getOperand(1));
+    auto dropVal = getInlineScalarFloat(select->getOperand(2));
+    if (!keepVal || !dropVal)
+      return rewriter.notifyMatchFailure(op, "window.select_arms_not_const");
+    if (*keepVal != 0.0 || *dropVal > kDropThreshold)
+      return rewriter.notifyMatchFailure(op, "window.select_arms_not_0_neg");
+
+    int visited = 0;
+    LegInfo info = classifyKeep(select->getOperand(0), /*depth=*/0, visited);
+    if (info.kind != LegKind::Windowed)
+      return rewriter.notifyMatchFailure(op, "window.keep_cond_unbounded");
+
+    rewriter.modifyOpInPlace(op, [&] {
+      op->setAttr("hipdnn.local_window_size",
+                  rewriter.getI64IntegerAttr(info.window));
+    });
+
+    LLVM_DEBUG(llvm::dbgs() << "[" DEBUG_TYPE "] recovered local_window_size="
+                            << info.window << " from the mask subgraph ("
+                            << visited << " nodes visited)\n");
+    ++NumAttentionWindowStamps;
+    return mlir::success();
+  }
+};
+
+} // namespace
+
+void populateAttentionWindowFoldPatterns(mlir::RewritePatternSet &patterns,
+                                         mlir::MLIRContext *ctx) {
+  patterns.add<AttentionStampMaskWindow>(ctx);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(OnnxToHip STATIC
   PadShapeFold.cpp
   SliceShapeFold.cpp
   PackBroadcastTo4D.cpp
+  AttentionWindowFold.cpp
   ShapeConversion.cpp
   ReshapeConversion.cpp
   CausalConvWithStateConversion.cpp

--- a/lib/Conversion/OnnxToHip/OnnxAttentionConversion.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxAttentionConversion.cpp
@@ -535,6 +535,19 @@ OnnxAttentionToHip::matchAndRewrite(mlir::Operation *op,
       rewriter.getNamedAttr("softcap", rewriter.getF32FloatAttr(softcap)));
   attrs.push_back(
       rewriter.getNamedAttr("no_causal", rewriter.getBoolAttr(noCausal)));
+  // AttentionWindowFold recovers the window during pre-lowering from the
+  // additive mask, which is the only place a pre-opset-25 export can put it,
+  // and stamps the result here. Absent the stamp the op keeps hip.gqa's -1
+  // default and the runtime scores the full key range, as it did before. Only a
+  // positive window is forwarded, so a recovered 0 or a hand-written 0 cannot
+  // be mistaken for "windowed".
+  if (auto stampedWindow =
+          op->getAttrOfType<mlir::IntegerAttr>("hipdnn.local_window_size")) {
+    int64_t window = stampedWindow.getValue().getSExtValue();
+    if (window > 0)
+      attrs.push_back(rewriter.getNamedAttr(
+          "local_window_size", rewriter.getI64IntegerAttr(window)));
+  }
 
   mlir::OperationState gqaState(loc, "hip.gqa");
   gqaState.addOperands(operands);

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -428,6 +428,7 @@ void ConvertOnnxToHipPass::runOnOperation() {
         populatePadShapeFoldPatterns(preLoweringPatterns, ctx);
         populateSliceShapeFoldPatterns(preLoweringPatterns, ctx);
         populatePackBroadcastTo4DPatterns(preLoweringPatterns, ctx);
+        populateAttentionWindowFoldPatterns(preLoweringPatterns, ctx);
         populateFastGeluFusionPatterns(preLoweringPatterns, ctx);
         populateErfGeluFusionPatterns(preLoweringPatterns, ctx);
         populateProjectorOpsRewritePatterns(preLoweringPatterns, ctx);

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -496,6 +496,17 @@ void populateSliceShapeFoldPatterns(RewritePatternSet &patterns,
 void populatePackBroadcastTo4DPatterns(RewritePatternSet &patterns,
                                        MLIRContext *ctx);
 
+/// Pre-lowering pattern set: recover a sliding window from `onnx.Attention`'s
+/// additive mask subgraph and stamp it as `hipdnn.local_window_size`, which
+/// OnnxAttentionConversion then puts on `hip.gqa`. `onnx.Attention` has no
+/// window attribute, so a windowed model expresses the window only in the mask
+/// data and the runtime would otherwise score its whole key range. Must run
+/// BEFORE `convertComputeOps`, which rewrites the mask's producers into
+/// `hip.*` in an order this matcher cannot rely on. See
+/// AttentionWindowFold.cpp.
+void populateAttentionWindowFoldPatterns(RewritePatternSet &patterns,
+                                         MLIRContext *ctx);
+
 /// Pre-lowering pattern set: collapse ORT's inlined `FastGelu` primitive
 /// chain (Pow / Mul / Sum / Tanh) back into a single
 /// `onnx.Gelu(approximate="tanh")`. ORT inlines the Gelu function body

--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -1064,60 +1064,79 @@ extern "C" int hip_gqa_causal_mask_f32(
   GQA_RETURN_LAUNCH_STATUS();
 }
 
-// `sq` counts the query rows present in `scores`, which is a chunk of the full
-// query range when the caller is tiling the prefill. `bias_sq` is the full query
-// extent of the bias tensor and `bias_row_offset` locates the chunk inside it --
-// the two cannot be folded together because the bias plane stride is set by the
-// full extent while the score plane stride is set by the chunk.
+// The score matrix and the bias tensor are indexed independently on both axes,
+// because `scores` can be a sub-block of the full [sq, total_seq] logical
+// matrix while the bias always describes the whole thing.
+//
+// Query axis: `sq` counts the query rows present in `scores`, which is a chunk
+// of the full query range when the caller is tiling the prefill. `bias_sq` is
+// the full query extent of the bias tensor and `bias_row_offset` locates the
+// chunk inside it.
+//
+// Key axis: `score_cols` counts the key columns present in `scores`, which is
+// just the sliding window when the caller narrowed the decode key range.
+// `bias_total_seq` is the bias tensor's true last dim and `bias_col_offset`
+// locates the narrowed range inside it.
+//
+// Neither offset can be folded into the `bias` pointer: `bias_plane` must stay
+// on the bias tensor's own full extents or every batch/head plane after the
+// first mis-strides, so with bias_batch > 1 or bias_heads > 1 a pointer bump
+// would be wrong.
 template <typename TBias>
 __global__ void add_attention_bias_kernel(
     float* __restrict__ scores, const TBias* __restrict__ bias,
     int total_heads, int num_heads, int bias_batch, int bias_heads, int sq,
-    int total_seq, int score_batch_stride, int bias_sq, int bias_row_offset) {
+    int score_cols, int score_batch_stride, int bias_sq, int bias_row_offset,
+    int bias_total_seq, int bias_col_offset) {
   int head = blockIdx.y;
   int tid = blockIdx.x * blockDim.x + threadIdx.x;
-  int n = sq * total_seq;
+  int n = sq * score_cols;
   if (tid >= n)
     return;
-  int row = tid / total_seq;
-  int col = tid % total_seq;
+  int row = tid / score_cols;
+  int col = tid % score_cols;
   int b = head / num_heads;
   int h = head % num_heads;
   int bias_b = (bias_batch == 1) ? 0 : b;
   int bias_h = (bias_heads == 1) ? 0 : h;
-  size_t bias_plane = static_cast<size_t>(bias_sq) * total_seq;
+  size_t bias_plane = static_cast<size_t>(bias_sq) * bias_total_seq;
   size_t bias_idx = static_cast<size_t>(bias_b) * bias_heads * bias_plane +
                     static_cast<size_t>(bias_h) * bias_plane +
-                    static_cast<size_t>(bias_row_offset + row) * total_seq + col;
+                    static_cast<size_t>(bias_row_offset + row) * bias_total_seq +
+                    (bias_col_offset + col);
   scores[static_cast<size_t>(head) * score_batch_stride + tid] +=
       static_cast<float>(bias[bias_idx]);
 }
 
 extern "C" int hip_gqa_add_attention_bias_f32(
     void* stream_ptr, void* scores, const void* bias, int total_heads,
-    int num_heads, int bias_batch, int bias_heads, int sq, int total_seq,
+    int num_heads, int bias_batch, int bias_heads, int sq, int score_cols,
     int score_batch_stride, int bias_element_size_bytes, int bias_sq,
-    int bias_row_offset) {
+    int bias_row_offset, int bias_total_seq, int bias_col_offset) {
   if (!scores || !bias)
     return -1;
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
   if (bias_sq <= 0)
     bias_sq = sq;
-  int n = sq * total_seq;
+  if (bias_total_seq <= 0)
+    bias_total_seq = score_cols;
+  int n = sq * score_cols;
   int blocksX = (n + GQA_THREADS - 1) / GQA_THREADS;
   (void)hipGetLastError();
   if (bias_element_size_bytes == 2) {
     add_attention_bias_kernel<__half>
         <<<dim3(blocksX, total_heads), GQA_THREADS, 0, stream>>>(
             static_cast<float*>(scores), static_cast<const __half*>(bias),
-            total_heads, num_heads, bias_batch, bias_heads, sq, total_seq,
-            score_batch_stride, bias_sq, bias_row_offset);
+            total_heads, num_heads, bias_batch, bias_heads, sq, score_cols,
+            score_batch_stride, bias_sq, bias_row_offset, bias_total_seq,
+            bias_col_offset);
   } else if (bias_element_size_bytes == 4) {
     add_attention_bias_kernel<float>
         <<<dim3(blocksX, total_heads), GQA_THREADS, 0, stream>>>(
             static_cast<float*>(scores), static_cast<const float*>(bias),
-            total_heads, num_heads, bias_batch, bias_heads, sq, total_seq,
-            score_batch_stride, bias_sq, bias_row_offset);
+            total_heads, num_heads, bias_batch, bias_heads, sq, score_cols,
+            score_batch_stride, bias_sq, bias_row_offset, bias_total_seq,
+            bias_col_offset);
   } else {
     fprintf(stderr,
             "hip_gqa_add_attention_bias_f32: unsupported bias elem size %d\n",

--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -427,6 +427,11 @@ __global__ void kv_cache_append_vec_kernel(
 // Performs both the strided past copy and the BSHD->BNSD new-token transpose
 // in a single kernel launch, avoiding host-side loop overhead.
 // Thread: one per (b, s_present, g, d_i) element. blockIdx.y = batch.
+//
+// s_lo is the first present position written; [0, s_lo) is left untouched, for
+// a caller that will not read it back (a sliding-window layer at decode). The
+// grid is sized to (total_seq - s_lo) so the skipped positions cost no threads,
+// which is the entire point -- the indices below stay absolute in s.
 // -------------------------------------------------------------------------
 
 template <typename T>
@@ -435,17 +440,17 @@ __global__ void kv_cache_concat_kernel(
     const T* __restrict__ current,
     T* __restrict__ present,
     int past_len, int sq, int G, int d,
-    int past_seq, int present_seq) {
+    int past_seq, int present_seq, int s_lo) {
   const int batch_idx = __builtin_amdgcn_readfirstlane(blockIdx.y);
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   int total_seq = past_len + sq;
-  int total_per_batch = total_seq * G * d;
+  int total_per_batch = (total_seq - s_lo) * G * d;
   if (idx >= total_per_batch) return;
 
   int di = idx % d;
   int remaining = idx / d;
   int g = remaining % G;
-  int s = remaining / G;
+  int s = s_lo + remaining / G;
 
   int dst_idx = ((batch_idx * G + g) * present_seq + s) * d + di;
 
@@ -468,18 +473,18 @@ __global__ void kv_cache_concat_vec_kernel(
     const T* __restrict__ current,
     T* __restrict__ present,
     int past_len, int sq, int G, int d,
-    int past_seq, int present_seq) {
+    int past_seq, int present_seq, int s_lo) {
   const int batch_idx = __builtin_amdgcn_readfirstlane(blockIdx.y);
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   const int dv = d / VEC;
   int total_seq = past_len + sq;
-  int total_per_batch = total_seq * G * dv;
+  int total_per_batch = (total_seq - s_lo) * G * dv;
   if (idx >= total_per_batch) return;
 
   int dvi = idx % dv;
   int remaining = idx / dv;
   int g = remaining % G;
-  int s = remaining / G;
+  int s = s_lo + remaining / G;
 
   int dst_idx = ((batch_idx * G + g) * present_seq + s) * d + dvi * VEC;
 
@@ -538,15 +543,16 @@ __global__ void kv_cache_concat_quant_i8_kernel(
     const _Float16* __restrict__ current, // BSHD fp16 [B, sq, G, d]
     int8_t* __restrict__ present,         // BNSD int8 [B, G, present_seq, d]
     const float* __restrict__ scale,      // [G, d]
-    int past_len, int sq, int G, int d, int past_seq, int present_seq) {
+    int past_len, int sq, int G, int d, int past_seq, int present_seq,
+    int s_lo) {
   const int batch_idx = __builtin_amdgcn_readfirstlane(blockIdx.y);
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   int total_seq = past_len + sq;
-  if (idx >= total_seq * G * d) return;
+  if (idx >= (total_seq - s_lo) * G * d) return;
   int di = idx % d;
   int r = idx / d;
   int g = r % G;
-  int s = r / G;
+  int s = s_lo + r / G;
   int dst_idx = ((batch_idx * G + g) * present_seq + s) * d + di;
   if (s < past_len) {
     present[dst_idx] = past[((batch_idx * G + g) * past_seq + s) * d + di];
@@ -852,25 +858,27 @@ template <typename T>
 static void launch_kv_cache_concat(
     hipStream_t stream, const void* past, const void* current, void* present,
     int batch_size, int past_len, int sq, int G, int d,
-    int past_seq, int present_seq) {
+    int past_seq, int present_seq, int s_lo) {
   int total_seq = past_len + sq;
   constexpr int VEC = 16 / sizeof(T);
   if ((d % VEC) == 0 && kv_is_16b_aligned(past) && kv_is_16b_aligned(current) &&
       kv_is_16b_aligned(present)) {
-    int total = total_seq * G * (d / VEC);
+    int total = (total_seq - s_lo) * G * (d / VEC);
     int blocks = (total + GQA_THREADS - 1) / GQA_THREADS;
     kv_cache_concat_vec_kernel<T, VEC><<<dim3(blocks, batch_size), GQA_THREADS,
                                          0, stream>>>(
         static_cast<const T*>(past), static_cast<const T*>(current),
-        static_cast<T*>(present), past_len, sq, G, d, past_seq, present_seq);
+        static_cast<T*>(present), past_len, sq, G, d, past_seq, present_seq,
+        s_lo);
     return;
   }
-  int total = total_seq * G * d;
+  int total = (total_seq - s_lo) * G * d;
   int blocks = (total + GQA_THREADS - 1) / GQA_THREADS;
   kv_cache_concat_kernel<T><<<dim3(blocks, batch_size), GQA_THREADS, 0,
                               stream>>>(
       static_cast<const T*>(past), static_cast<const T*>(current),
-      static_cast<T*>(present), past_len, sq, G, d, past_seq, present_seq);
+      static_cast<T*>(present), past_len, sq, G, d, past_seq, present_seq,
+      s_lo);
 }
 
 template <typename T>
@@ -958,19 +966,27 @@ extern "C" int hip_gqa_kv_cache_append(
 
 // Step 4-5: KV cache concat (separate-buffer). `kv_dtype` selects the format, as
 // in hip_gqa_kv_cache_append (FP16 -> plain copy, INT8 -> INT8 quant).
+//
+// s_lo skips the past prefix below it. It is clamped to [0, past_len] here, once
+// for all three kernels: past_len is the hard ceiling because [past_len,
+// total_seq) is the new tokens, which are the one thing this call must never
+// drop. A caller asking for more than that is asking for silent data loss, so
+// the boundary refuses rather than obeys.
 extern "C" int hip_gqa_kv_cache_concat(
     void* stream_ptr, const void* past, const void* current, void* present,
     int batch_size, int past_len, int sq, int G, int d,
     int past_seq, int present_seq, int element_size_bytes,
-    int kv_dtype, const void* scale) {
+    int kv_dtype, const void* scale, int s_lo) {
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
+  if (s_lo < 0) s_lo = 0;
+  if (s_lo > past_len) s_lo = past_len;
   if (kv_dtype == HIP_KV_DTYPE_INT8) {
     if (scale == nullptr) {
       fprintf(stderr, "hip_gqa_kv_cache_concat: INT8 requires scale\n");
       return -1;
     }
     int total_seq = past_len + sq;
-    int total = total_seq * G * d;
+    int total = (total_seq - s_lo) * G * d;
     int blocks = (total + GQA_THREADS - 1) / GQA_THREADS;
     (void)hipGetLastError();
     kv_cache_concat_quant_i8_kernel<<<dim3(blocks, batch_size), GQA_THREADS, 0,
@@ -978,7 +994,7 @@ extern "C" int hip_gqa_kv_cache_concat(
         static_cast<const int8_t*>(past),
         static_cast<const _Float16*>(current), static_cast<int8_t*>(present),
         static_cast<const float*>(scale), past_len, sq, G, d, past_seq,
-        present_seq);
+        present_seq, s_lo);
     GQA_RETURN_LAUNCH_STATUS();
   }
   if (kv_dtype != HIP_KV_DTYPE_FP16) {
@@ -988,7 +1004,7 @@ extern "C" int hip_gqa_kv_cache_concat(
   }
   GQA_DISPATCH_BY_ELEM_SIZE(element_size_bytes, launch_kv_cache_concat, stream,
                             past, current, present, batch_size, past_len, sq, G,
-                            d, past_seq, present_seq);
+                            d, past_seq, present_seq, s_lo);
   GQA_RETURN_LAUNCH_STATUS();
 }
 

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -704,19 +704,24 @@ HIP_KERNEL_API int hip_gqa_causal_mask_f32(
     int batch_stride, int past_len, int local_window_size);
 
 /* Add an attention bias onto the fp32 score matrix before softmax.
- * scores layout: [total_heads, sq, total_seq] row-major with batch_stride
- * = sq * total_seq per head.
- * bias layout: [bias_batch, bias_heads, bias_sq, total_seq], row-major.
+ * scores layout: [total_heads, sq, score_cols] row-major with batch_stride
+ * = sq * score_cols per head.
+ * bias layout: [bias_batch, bias_heads, bias_sq, bias_total_seq], row-major.
  * bias_batch / bias_heads may be 1 for ONNX-style broadcast.
- * sq is the number of query rows in `scores`, which is a chunk of the full
- * query range when the caller tiles the prefill; bias_sq is the bias tensor's
- * full query extent and bias_row_offset locates the chunk within it. Pass
- * bias_sq = sq (or 0) and bias_row_offset = 0 for the untiled case. */
+ * `scores` may be a sub-block of the full logical score matrix on either axis,
+ * so both axes carry a bias extent and an offset:
+ *   sq / bias_sq / bias_row_offset -- sq is the number of query rows present,
+ *     a chunk of the full range when the caller tiles the prefill.
+ *   score_cols / bias_total_seq / bias_col_offset -- score_cols is the number
+ *     of key columns present, just the sliding window when the caller narrowed
+ *     the decode key range.
+ * Pass bias_sq = sq (or 0) and bias_row_offset = 0, and bias_total_seq =
+ * score_cols (or 0) and bias_col_offset = 0, for the untiled/unnarrowed case. */
 HIP_KERNEL_API int hip_gqa_add_attention_bias_f32(
     void* stream, void* scores, const void* bias,
     int total_heads, int num_heads, int bias_batch, int bias_heads,
-    int sq, int total_seq, int score_batch_stride, int bias_element_size_bytes,
-    int bias_sq, int bias_row_offset);
+    int sq, int score_cols, int score_batch_stride, int bias_element_size_bytes,
+    int bias_sq, int bias_row_offset, int bias_total_seq, int bias_col_offset);
 
 /* Column-wise softmax in-place. One threadblock per (head, query).
  * Smooth softmax is activated when head_sink is non-null OR use_smooth_softmax

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -636,12 +636,19 @@ HIP_KERNEL_API int hip_gqa_kv_cache_append(
  * element_size_bytes: 2 = fp16, 4 = fp32 (used only by the FP16 copy path).
  * kv_dtype / scale select the storage format exactly as in
  * hip_gqa_kv_cache_append (HIP_KV_DTYPE_FP16 -> plain copy; HIP_KV_DTYPE_INT8 ->
- * INT8 quant of the new fp16 tokens, past then read as INT8, scale = [G,d]). */
+ * INT8 quant of the new fp16 tokens, past then read as INT8, scale = [G,d]).
+ * s_lo: first present position to write. Positions [0, s_lo) are LEFT UNWRITTEN
+ * -- not zeroed, not copied -- so present is only valid from s_lo onwards, and
+ * the caller must not read below it. Pass 0 for a full concat. The grid shrinks
+ * with s_lo, which is the point: a sliding-window layer at decode passes the
+ * same lower bound it reads from, so the bytes it skips writing are exactly the
+ * bytes it will not read. Clamped internally to [0, past_len] so the new tokens
+ * at [past_len, past_len+sq) are always written. */
 HIP_KERNEL_API int hip_gqa_kv_cache_concat(
     void* stream, const void* past, const void* current, void* present,
     int batch_size, int past_len, int sq, int G, int d,
     int past_seq, int present_seq, int element_size_bytes,
-    int kv_dtype, const void* scale);
+    int kv_dtype, const void* scale, int s_lo);
 
 /* INT8 KV cache (symmetric per-channel, kv_cache_bit_width=8) dequant.
  * dequant_kv_i8_to_fp16: rebuilds an fp16 BNSD view [B,G,dst_seq,d] of the first

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -1448,11 +1448,27 @@ static int gqa_forward_hipblaslt(
       // Defensive fallback for B == 1 when the pre-dispatch helper bailed out
       // (D2H or sync failure). Rare path; not cached because the same failure
       // mode would have prevented the helper from caching too.
-      if (hipMemcpyAsync(&seqlens_k_val, seqlens_k_ptr, sizeof(int32_t),
-                         hipMemcpyDeviceToHost, stream) != hipSuccess)
+      //
+      // Both failures are reported rather than returned bare: this is the one
+      // place the decomposed path can fail before it has done any work, and a
+      // silent -1 here surfaces only as a zero-filled attention output, which
+      // looks like a kernel bug rather than a seqlens_k that could not be read.
+      hipError_t cp =
+          hipMemcpyAsync(&seqlens_k_val, seqlens_k_ptr, sizeof(int32_t),
+                         hipMemcpyDeviceToHost, stream);
+      if (cp != hipSuccess) {
+        fprintf(stderr,
+                "gqa_forward_hipblaslt: could not read seqlens_k from %p: %s\n",
+                seqlens_k_ptr, hipGetErrorString(cp));
         return -1;
-      if (hipStreamSynchronize(stream) != hipSuccess)
+      }
+      hipError_t sy = hipStreamSynchronize(stream);
+      if (sy != hipSuccess) {
+        fprintf(stderr,
+                "gqa_forward_hipblaslt: sync after seqlens_k read failed: %s\n",
+                hipGetErrorString(sy));
         return -1;
+      }
     }
 
     // ORT prefill sentinel: when there is no past KV yet, the producer
@@ -1515,6 +1531,72 @@ static int gqa_forward_hipblaslt(
                        present_value &&
                        (sq == 1 || gqa_no_expand_prefill_enabled());
   bool need_transpose = (sq > 1);
+
+  //===--------------------------------------------------------------------===//
+  // Sliding-window narrowing of the decode key range
+  //
+  // A windowed layer can only attend to the last `window` key positions, but
+  // this path scored all of them and then had hip_gqa_causal_mask_f32 write
+  // -inf over everything older. On Gemma-4 at 16K that is 16x the KV traffic
+  // the layer needs: 25 of its 30 layers have a 1024-token window, and their
+  // measured gqa time scaled 7.3x from 2K to 16K as if the window did not
+  // exist.
+  //
+  // Dropping the out-of-window keys is exact rather than an approximation. The
+  // entries being dropped are -INFINITY: the softmax takes a max then
+  // exp2f(x - max), so they never win the max and add exactly 0 to the
+  // denominator, and the Value GEMM runs alpha=1/beta=0 so they contribute
+  // exactly 0 to the output. What is left is a difference in GEMM tile
+  // reassociation, the same standard as use_no_expand.
+  //
+  // The KV cache is BNSD [B, G, present_seq, d] with d fastest, so a run of key
+  // positions is contiguous at + kv_lo * d and the batch stride stays
+  // present_seq * d whatever the offset. The A pointer is a hipblasLtMatmul
+  // call argument rather than part of the descriptor, so the offset costs
+  // nothing.
+  //
+  // Restrictions:
+  //  - Decode only (sq == 1). Windowed prefill wants a banded score matrix, not
+  //    a single narrowed range, and that is a separate effort.
+  //  - use_no_expand only. The expand flavour materialises Kexp/Vexp over the
+  //    full range, so narrowing would have to narrow the expand copies too;
+  //    that path is not the default at decode.
+  //
+  // A positive local_window_size is a promise that the window is ENFORCED
+  // somewhere, and narrowing is exact only because of that. Both of the ways it
+  // can reach us keep that promise, by different mechanisms:
+  //
+  //  - !no_causal: the ONNX attribute, forwarded from
+  //    com.microsoft.GroupQueryAttention. hip_gqa_causal_mask_f32 below applies
+  //    the window itself, so narrowing is provably the same arithmetic.
+  //
+  //  - no_causal: recovered from the additive mask by the converter's
+  //    AttentionWindowFold, which matched `And(q >= k, q - k < W)` in the
+  //    mask's own keep-condition. The mask is then the enforcer -- the entries
+  //    being dropped are exactly the ones it already set to its large-negative
+  //    value. This is the shape that needs it: onnx.Attention gained a window
+  //    attribute only in opset 25, so a windowed export below that arrives with
+  //    is_causal=0 and the window in the mask (Gemma-4's 25 local layers are
+  //    exactly this).
+  //
+  // So no_causal is deliberately NOT a gate here. It was one while the window
+  // could only arrive as an attribute, because a bidirectional op's window was
+  // being ignored rather than applied; now that a window can also come from the
+  // mask, gating on no_causal would reject the only case that needs narrowing.
+  // Nothing else changes as a result: no producer emits a window together with
+  // no_causal except the recovery above (GqaConversion sets no_causal=false
+  // explicitly, and the Whisper bidirectional builders set no window).
+
+  // Number of key positions actually scored, and the first one. kv_span ==
+  // total_seq and kv_lo == 0 whenever narrowing is inactive, which keeps every
+  // downstream expression below identical to what it was.
+  int64_t kv_span = total_seq;
+  int64_t kv_lo = 0;
+  if (sq == 1 && use_no_expand && local_window_size > 0 &&
+      local_window_size < total_seq) {
+    kv_span = local_window_size;
+    kv_lo = total_seq - kv_span;
+  }
 
   //===--------------------------------------------------------------------===//
   // Query-row chunking of the score matrix
@@ -1601,11 +1683,14 @@ static int gqa_forward_hipblaslt(
 
   GqaGemmKey scoreKey, valueKey;
   if (use_no_expand) {
-    // Score: C[total_seq, HPG*sq] = K^T[d,total_seq] * Q[d, HPG*sq] per (b, g)
+    // Score: C[kv_span, HPG*sq] = K^T[d,kv_span] * Q[d, HPG*sq] per (b, g)
     // pair. strideA steps over the buffer page (present_seq*d) even though only
-    // the first total_seq tokens are read, keeping the descriptor stable across
-    // token steps.
-    scoreKey = {/*m=*/total_seq,
+    // kv_span tokens are read, keeping the descriptor stable across token
+    // steps. Under window narrowing kv_span also stops changing per token once
+    // the context passes the window, so the descriptor cache stops missing on
+    // every token and the per-token hipblasLtMatmulAlgoGetHeuristic calls
+    // collapse to one entry per shape.
+    scoreKey = {/*m=*/kv_span,
                 /*n=*/HPG * sq,
                 /*k=*/d,
                 /*batch=*/B * G,
@@ -1614,19 +1699,19 @@ static int gqa_forward_hipblaslt(
                 /*inputFp32=*/gemm_fp32,
                 /*strideA=*/present_seq * d,
                 /*strideB=*/HPG * sq * d,
-                /*strideC=*/HPG * sq * total_seq};
-    // Value: C[d, HPG*sq] = V[d, total_seq] * S[total_seq, HPG*sq] per (b, g)
+                /*strideC=*/HPG * sq * kv_span};
+    // Value: C[d, HPG*sq] = V[d, kv_span] * S[kv_span, HPG*sq] per (b, g)
     // pair, writing into BNSD [B, G, HPG, sq, d] which at sq==1 coincides with
     // BSHD [B, 1, H, d].
     valueKey = {/*m=*/d,
                 /*n=*/HPG * sq,
-                /*k=*/total_seq,
+                /*k=*/kv_span,
                 /*batch=*/B * G,
                 /*transA=*/false,
                 /*outputFp32=*/gemm_fp32,
                 /*inputFp32=*/gemm_fp32,
                 /*strideA=*/present_seq * d,
-                /*strideB=*/HPG * sq * total_seq,
+                /*strideB=*/HPG * sq * kv_span,
                 /*strideC=*/HPG * sq * d};
   } else {
     makeKeys(sq_chunk, &scoreKey, &valueKey);
@@ -1679,10 +1764,15 @@ static int gqa_forward_hipblaslt(
   size_t Kexp_bytes =
       use_no_expand ? 0 : static_cast<size_t>(B) * H * total_seq * d * elem_sz;
   size_t Vexp_bytes = Kexp_bytes;
+  // Both score buffers span kv_span keys, not total_seq: they hold exactly what
+  // the Score GEMM writes. These offsets chain into off_S_fp16, off_O, temp_end
+  // and the GEMM workspace, so kv_span has to appear in both or the region
+  // boundaries disagree with the GEMM extents and it is a silent heap
+  // overwrite rather than a crash.
   size_t S_f32_bytes =
-      static_cast<size_t>(B) * H * sq_chunk * total_seq * sizeof(float);
+      static_cast<size_t>(B) * H * sq_chunk * kv_span * sizeof(float);
   size_t S_fp16_bytes =
-      static_cast<size_t>(B) * H * sq_chunk * total_seq * elem_sz;
+      static_cast<size_t>(B) * H * sq_chunk * kv_span * elem_sz;
   size_t O_bytes =
       need_transpose ? static_cast<size_t>(B) * H * sq * d * elem_sz : 0;
 
@@ -1842,9 +1932,19 @@ static int gqa_forward_hipblaslt(
     // ---- Steps 8-10, per query chunk ----
     // One iteration when chunking is inactive, in which case q0 is 0, c is sq
     // and every pointer and stride below reduces to what it was.
-    const void *scoreA = use_no_expand ? present_key : d_Kexp;
+    //
+    // K and V are advanced to the first key position in range. The cache is
+    // BNSD with d fastest, so this selects a contiguous span and leaves the
+    // per-(b,g) batch stride at present_seq*d. kv_lo is 0 unless the sliding
+    // window narrowed the range.
+    const size_t kv_byte_off = static_cast<size_t>(kv_lo) * d * elem_sz;
+    const void *scoreA =
+        (use_no_expand ? static_cast<const char *>(present_key) + kv_byte_off
+                       : static_cast<const char *>(d_Kexp));
     const void *scoreBBase = need_transpose ? d_Qtrans : qSrc;
-    const void *valueA = use_no_expand ? present_value : d_Vexp;
+    const void *valueA =
+        (use_no_expand ? static_cast<const char *>(present_value) + kv_byte_off
+                       : static_cast<const char *>(d_Vexp));
     void *valueCBase = need_transpose ? d_O : output;
     float scoreAlpha = scale;
     float beta = 0.0f;
@@ -1863,8 +1963,8 @@ static int gqa_forward_hipblaslt(
       void *valueC = static_cast<char *>(valueCBase) +
                      static_cast<size_t>(q0) * d * elem_sz;
       // The score buffers are re-packed per chunk, so their per-head stride is
-      // the chunk's own row count.
-      const int scoreBatchStride = static_cast<int>(c * total_seq);
+      // the chunk's own row count over the key range actually scored.
+      const int scoreBatchStride = static_cast<int>(c * kv_span);
 
       // ---- Step 8: Score GEMM (fp16/fp32 in, fp32 out) ----
       // A = K: no-expand reads present_key directly, expand reads d_Kexp.
@@ -1877,22 +1977,24 @@ static int gqa_forward_hipblaslt(
           gemm_ws_ptr, gemm_ws_bytes, stream));
 
       // ---- Step 8b: Add external attention bias (onnx.Attention attn_mask) --
-      // The bias is indexed over the full query range, so the chunk's row
-      // offset is passed through rather than folded into the pointer: with
-      // bias_batch or bias_heads > 1 the plane stride still spans all sq rows.
+      // The bias is indexed over the full query and key ranges, so the chunk's
+      // row offset and the window's key offset are passed through rather than
+      // folded into the pointer: with bias_batch or bias_heads > 1 the plane
+      // stride still spans all sq rows and all total_seq columns.
       if (attention_bias) {
         HIP_CHECK(hip_gqa_add_attention_bias_f32(
             stream, d_S_f32, const_cast<void *>(attention_bias),
             static_cast<int>(B * H), static_cast<int>(H),
             static_cast<int>(attn_bias_batch),
             static_cast<int>(attn_bias_num_heads), static_cast<int>(c),
-            static_cast<int>(total_seq), scoreBatchStride,
+            static_cast<int>(kv_span), scoreBatchStride,
             static_cast<int>(elem_sz), static_cast<int>(sq),
-            static_cast<int>(q0)));
+            static_cast<int>(q0), static_cast<int>(total_seq),
+            static_cast<int>(kv_lo)));
       }
 
       // ---- Step 9: Causal Mask (fp32) + Softmax (fp32 -> fp16/fp32) ----
-      // S is treated as [B*H, c, total_seq] (head stride c*total_seq) by both
+      // S is treated as [B*H, c, kv_span] (head stride c*kv_span) by both
       // GEMM flavours. softmax dtype follows gemm_fp32.
       //
       // The built-in causal triangle is applied whenever !no_causal,
@@ -1911,11 +2013,17 @@ static int gqa_forward_hipblaslt(
       // The mask kernel derives each row's absolute query position as
       // past_len + row, so advancing past_len by the chunk's start puts the
       // triangle and the sliding window in the right place for the chunk.
+      // Under window narrowing the score columns start at kv_lo rather than 0,
+      // and since both of the kernel's predicates reference the query position
+      // only as (past_len_arg + row), shifting past_len down by kv_lo is
+      // exactly equivalent to shifting the column index up by it. No kernel
+      // change needed. (At sq == 1 the narrowed range is precisely the window,
+      // so the kernel then writes nothing -- correct, just redundant.)
       if ((sq > 1 || local_window_size > 0) && !no_causal) {
         HIP_CHECK(hip_gqa_causal_mask_f32(
-            stream, d_S_f32, static_cast<int>(B * H),
-            static_cast<int>(total_seq), static_cast<int>(c), scoreBatchStride,
-            static_cast<int>(past_len + q0),
+            stream, d_S_f32, static_cast<int>(B * H), static_cast<int>(kv_span),
+            static_cast<int>(c), scoreBatchStride,
+            static_cast<int>(past_len + q0 - kv_lo),
             static_cast<int>(local_window_size)));
       }
       // fp16 GQA: softmax writes fp16 probabilities for the fp16 Value GEMM.
@@ -1926,13 +2034,13 @@ static int gqa_forward_hipblaslt(
       if (gemm_fp32) {
         HIP_CHECK(hip_gqa_softmax_f32_to_f32(
             stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * c),
-            static_cast<int>(total_seq), static_cast<int>(c), scoreBatchStride,
+            static_cast<int>(kv_span), static_cast<int>(c), scoreBatchStride,
             scoreBatchStride, head_sink, static_cast<int>(H),
             static_cast<int>(use_smooth_softmax)));
       } else {
         HIP_CHECK(hip_gqa_softmax_f32_to_f16(
             stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * c),
-            static_cast<int>(total_seq), static_cast<int>(c), scoreBatchStride,
+            static_cast<int>(kv_span), static_cast<int>(c), scoreBatchStride,
             scoreBatchStride, head_sink, static_cast<int>(H),
             static_cast<int>(use_smooth_softmax)));
       }
@@ -1959,10 +2067,12 @@ static int gqa_forward_hipblaslt(
 
     RUNTIME_DEBUG_LOG(
         "[REAL] GQA hipBLASLt: B=%lld sq=%lld sq_chunk=%lld total_seq=%lld "
-        "H=%lld G=%lld d=%lld no_expand=%d transpose=%d\n",
+        "kv_lo=%lld kv_span=%lld H=%lld G=%lld d=%lld no_expand=%d "
+        "transpose=%d\n",
         (long long)B, (long long)sq, (long long)sq_chunk, (long long)total_seq,
-        (long long)H, (long long)G, (long long)d,
-        static_cast<int>(use_no_expand), static_cast<int>(need_transpose));
+        (long long)kv_lo, (long long)kv_span, (long long)H, (long long)G,
+        (long long)d, static_cast<int>(use_no_expand),
+        static_cast<int>(need_transpose));
   }
 
 cleanup:

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -226,12 +226,21 @@ static inline int kv_dtype_abi(KvCacheFormat f) {
 // plain copy. Only the causal concat/append tail honours it (the no_causal
 // Whisper branches are fp16/fp32-only), so the format decision lives here
 // rather than in a separate helper or at each call site.
+//
+// copy_lo bounds the separate-buffer concat from below: past positions
+// [0, copy_lo) are not copied into present and are left whatever the allocator
+// held. It exists for the one caller that can prove it will not read them back
+// -- a sliding-window layer at decode passes the same lower bound it scores
+// from -- and must be 0 for everyone else. It is required rather than defaulted
+// so that a new call site has to say which it is. The append branches ignore
+// it: they only ever write the new tokens, and an in-place cache has no prefix
+// to copy in the first place.
 static int update_kv_cache(hipStream_t stream, const void *past_key,
                            const void *past_value, const void *new_key,
                            const void *new_value, void *present_key,
                            void *present_value, int B, int past_len, int sq,
                            int G, int d, int past_buf_seq, int present_seq,
-                           const void *seqlens_k_ptr, int elem_sz,
+                           const void *seqlens_k_ptr, int elem_sz, int copy_lo,
                            bool no_causal = false, int skv = -1,
                            KvCacheFormat kv_format = KvCacheFormat::Fp16,
                            const void *k_scale = nullptr,
@@ -286,11 +295,11 @@ static int update_kv_cache(hipStream_t stream, const void *past_key,
     // Separate-buffer concat: needs host-side past_len for stride computation.
     if (hip_gqa_kv_cache_concat(stream, past_key, new_key, present_key, B,
                                 past_len, sq, G, d, past_buf_seq, present_seq,
-                                elem_sz, kv_dtype, k_sc) != 0)
+                                elem_sz, kv_dtype, k_sc, copy_lo) != 0)
       return -1;
     if (hip_gqa_kv_cache_concat(stream, past_value, new_value, present_value, B,
                                 past_len, sq, G, d, past_buf_seq, present_seq,
-                                elem_sz, kv_dtype, v_sc) != 0)
+                                elem_sz, kv_dtype, v_sc, copy_lo) != 0)
       return -1;
   } else {
     // In-place append: kernel can read past_len from device via seqlens_k_ptr.
@@ -456,13 +465,22 @@ static int gqa_forward_fused(
     // Append the new token to the KV cache. Quantized cache:
     // quantize-and-append with the static per-channel scale; fp16 cache: plain
     // append. update_kv_cache dispatches on kv_format internally.
+    //
+    // copy_lo stays 0 here even though this path knows its window. Narrowing
+    // the concat needs a separate growing present buffer, and this path never
+    // gets one: seq_len_kv reaches the runtime as the present_key memref's
+    // sequence dim, which for a GroupQueryAttention export with a growing cache
+    // arrives one short of the declared present, and the seqlens_k check above
+    // then rejects the call before it can reach the concat. When the cache is
+    // instead in-place there is no prefix to copy and update_kv_cache appends.
+    // So a bound here would be unreachable, and therefore untestable, code.
     if (update_kv_cache(
             stream, past_key, past_value, kSrc, vSrc, present_key,
             present_value, static_cast<int>(B), static_cast<int>(past_len),
             static_cast<int>(sq), static_cast<int>(G), static_cast<int>(d),
             static_cast<int>(past_buf_seq), static_cast<int>(present_seq),
-            seqlens_k_ptr, static_cast<int>(elem_sz), /*no_causal=*/false,
-            /*skv=*/-1, kv_format, k_scale, v_scale) != 0)
+            seqlens_k_ptr, static_cast<int>(elem_sz), /*copy_lo=*/0,
+            /*no_causal=*/false, /*skv=*/-1, kv_format, k_scale, v_scale) != 0)
       return -1;
 
     {
@@ -661,8 +679,8 @@ static int gqa_forward_fused(
             present_value, static_cast<int>(B), static_cast<int>(past_len),
             static_cast<int>(sq), static_cast<int>(G), static_cast<int>(d),
             static_cast<int>(past_buf_seq), static_cast<int>(present_seq),
-            seqlens_k_ptr, static_cast<int>(elem_sz), /*no_causal=*/false,
-            /*skv=*/-1, kv_format, k_scale, v_scale) != 0)
+            seqlens_k_ptr, static_cast<int>(elem_sz), /*copy_lo=*/0,
+            /*no_causal=*/false, /*skv=*/-1, kv_format, k_scale, v_scale) != 0)
       return -1;
   }
 
@@ -1358,7 +1376,7 @@ static int gqa_forward_hipblaslt(
             present_value, static_cast<int>(B), static_cast<int>(past_len),
             static_cast<int>(sq), static_cast<int>(G), static_cast<int>(d),
             static_cast<int>(past_buf_seq), static_cast<int>(present_seq),
-            seqlens_k_ptr, static_cast<int>(elem_sz)) != 0)
+            seqlens_k_ptr, static_cast<int>(elem_sz), /*copy_lo=*/0) != 0)
       return -1;
 
     // hip_gqa_flash_decode owns every geometry it templates; this fallback
@@ -1555,12 +1573,52 @@ static int gqa_forward_hipblaslt(
   // call argument rather than part of the descriptor, so the offset costs
   // nothing.
   //
+  // The bound is one global lower bound per call rather than a band per query
+  // row. A call's query rows occupy absolute positions
+  // [past_len, past_len + sq), so the oldest key any row of it may attend to is
+  // past_len - local_window_size + 1, and that single value serves the whole
+  // call: rows above the first simply have keys they do not use left in range,
+  // where the mask below drops them exactly as it did before. A true band would
+  // save more on a long windowed prefill, but it needs a per-row score offset
+  // and is a separate effort; this bound needs no per-row state at all.
+  //
+  // At sq == 1 this reduces to total_seq - local_window_size, since past_len is
+  // then total_seq - 1. At a first prefill past_len is 0, the bound is
+  // non-positive, and nothing narrows -- so initial prefill and TTFT are
+  // bit-identical by construction and only continuation prefill changes.
+  //
+  // Applying it to prefill as well as decode is what closes the invariant
+  // rather than just widening the optimisation. The KV copy below skips writing
+  // [0, kv_lo), so some prefix of `present` is never written on a narrowed
+  // step. Every subsequent call reads from its own kv_lo, and because
+  // past_len' == total_seq > past_len, its kv_lo is strictly greater than this
+  // call's: each read range is a strict subset of the previous write range, for
+  // decode and prefill alike. Leaving prefill unnarrowed would break exactly
+  // that -- a continuation prefill would read from 0 into memory a narrowed
+  // decode never wrote, and unwritten memory can hold a non-finite bit pattern
+  // that no finite mask suppresses (the softmax's first pass reduces with
+  // fmaxf, which ignores NaN, but the second pass accumulates it, so one such
+  // key poisons its whole output row).
+  //
   // Restrictions:
-  //  - Decode only (sq == 1). Windowed prefill wants a banded score matrix, not
-  //    a single narrowed range, and that is a separate effort.
-  //  - use_no_expand only. The expand flavour materialises Kexp/Vexp over the
-  //    full range, so narrowing would have to narrow the expand copies too;
-  //    that path is not the default at decode.
+  //  - Not under bidirectional_no_past, which is the one branch where
+  //    total_seq != past_len + sq (there total_seq == skv and past_len == 0, a
+  //    Whisper encoder / cross-attention shape with no past at all). The bound
+  //    above is derived from that identity, so without it kv_lo would be
+  //    computed against the wrong absolute query position.
+  //
+  //    With today's only producer of a window this pairing cannot actually
+  //    occur: the converter recovers a window from the additive mask, so a
+  //    window implies a mask, a mask means attention_bias is non-null, and
+  //    bidirectional_no_past is no_causal && !attention_bias. The guard is kept
+  //    anyway because that is a property of the converter rather than of this
+  //    function's contract -- a producer that stamps a window from a declared
+  //    attribute (opset 25's left_window_size) would not need a mask at all,
+  //    and would reach here with both set.
+  //  - Only with a present cache. kv_lo indexes key positions by their absolute
+  //    position in a BNSD cache page; without present_key / present_value the
+  //    GEMMs read the raw key / value operands, where a past_len derived from
+  //    skv - sq does not describe an offset into anything.
   //
   // A positive local_window_size is a promise that the window is ENFORCED
   // somewhere, and narrowing is exact only because of that. Both of the ways it
@@ -1583,19 +1641,21 @@ static int gqa_forward_hipblaslt(
   // could only arrive as an attribute, because a bidirectional op's window was
   // being ignored rather than applied; now that a window can also come from the
   // mask, gating on no_causal would reject the only case that needs narrowing.
-  // Nothing else changes as a result: no producer emits a window together with
-  // no_causal except the recovery above (GqaConversion sets no_causal=false
-  // explicitly, and the Whisper bidirectional builders set no window).
+  // What no_causal does still gate is bidirectional_no_past below, which is the
+  // shape whose sequence lengths the bound cannot be derived from.
 
   // Number of key positions actually scored, and the first one. kv_span ==
   // total_seq and kv_lo == 0 whenever narrowing is inactive, which keeps every
   // downstream expression below identical to what it was.
   int64_t kv_span = total_seq;
   int64_t kv_lo = 0;
-  if (sq == 1 && use_no_expand && local_window_size > 0 &&
-      local_window_size < total_seq) {
-    kv_span = local_window_size;
-    kv_lo = total_seq - kv_span;
+  if (local_window_size > 0 && !bidirectional_no_past && present_key &&
+      present_value) {
+    const int64_t lo = past_len - local_window_size + 1;
+    if (lo > 0) {
+      kv_lo = lo;
+      kv_span = total_seq - kv_lo;
+    }
   }
 
   //===--------------------------------------------------------------------===//
@@ -1630,8 +1690,11 @@ static int gqa_forward_hipblaslt(
   //===--------------------------------------------------------------------===//
   int64_t sq_chunk = sq;
   if (sq > 1 && !use_no_expand) {
+    // kv_span, matching what the score buffers are actually sized to below: on
+    // a narrowed windowed prefill a row is cheaper, so more rows fit per chunk
+    // and the loop runs fewer times.
     const size_t score_row_bytes =
-        static_cast<size_t>(B) * H * total_seq * (sizeof(float) + elem_sz);
+        static_cast<size_t>(B) * H * kv_span * (sizeof(float) + elem_sz);
     const size_t budget = gqa_score_budget_bytes();
     if (budget > 0 && score_row_bytes > 0 &&
         static_cast<size_t>(sq) * score_row_bytes > budget) {
@@ -1658,8 +1721,13 @@ static int gqa_forward_hipblaslt(
   // explicitly: n is the chunk length but those two operands still advance by
   // the full sq between heads. The score matrices are freshly packed per chunk,
   // so their strides stay at the dense default.
+  //
+  // The key extent is kv_span, not total_seq: Kexp / Vexp are materialised over
+  // the narrowed range and the score matrices are sized to match, so stating
+  // total_seq here would have the GEMMs read and write past the regions
+  // allocated for them.
   auto makeKeys = [&](int64_t n_rows, GqaGemmKey *score, GqaGemmKey *value) {
-    *score = {total_seq,
+    *score = {kv_span,
               n_rows,
               d,
               B * H,
@@ -1671,7 +1739,7 @@ static int gqa_forward_hipblaslt(
               /*strideC=*/0};
     *value = {d,
               n_rows,
-              total_seq,
+              kv_span,
               B * H,
               false,
               /*outputFp32=*/gemm_fp32,
@@ -1761,8 +1829,11 @@ static int gqa_forward_hipblaslt(
   // sq whenever chunking is inactive, so this is the full matrix in that case.
   size_t Qtrans_bytes =
       need_transpose ? static_cast<size_t>(B) * H * sq * d * elem_sz : 0;
+  // Kexp / Vexp span kv_span key positions, not total_seq: the expand copies
+  // below start at kv_lo, so the out-of-window prefix is neither copied nor
+  // allocated for.
   size_t Kexp_bytes =
-      use_no_expand ? 0 : static_cast<size_t>(B) * H * total_seq * d * elem_sz;
+      use_no_expand ? 0 : static_cast<size_t>(B) * H * kv_span * d * elem_sz;
   size_t Vexp_bytes = Kexp_bytes;
   // Both score buffers span kv_span keys, not total_seq: they hold exactly what
   // the Score GEMM writes. These offsets chain into off_S_fp16, off_O, temp_end
@@ -1899,25 +1970,61 @@ static int gqa_forward_hipblaslt(
       // seqlens_k to the append kernel (it would apply the +1 convention).
       // ONNX Attention with is_causal=0 + external mask keeps the standard
       // decode KV path (bidirectional_no_past=false).
+      //
+      // copy_lo is kv_lo, deliberately the identical value and not a separately
+      // derived one: the bytes this skips writing are then exactly the bytes
+      // the Score and Value GEMMs below skip reading, so the narrowing cannot
+      // be half-applied, and a wrong window is wrong identically for both. That
+      // equality is why this needs no gate of its own -- kv_lo is already 0
+      // whenever no window applies.
+      //
+      // It holds across calls as well as within one. This call writes
+      // [kv_lo, total_seq); the next call has past_len' == total_seq >
+      // past_len, so its own kv_lo == past_len' - W + 1 is strictly greater
+      // than this call's, and its read range is a strict subset of what this
+      // call wrote. That is an induction over calls, not a claim about one
+      // step's stride, so it covers a prefill following a decode as well as
+      // decode following decode -- which is the reason the bound above is
+      // applied at every sq rather than only at sq == 1.
+      //
+      // Only the separate-buffer concat can skip anything. When the cache is
+      // in-place (past_key == present_key) the prefix is already there and
+      // update_kv_cache appends, ignoring this.
       HIP_CHECK(update_kv_cache(
           stream, past_key, past_value, kSrc, vSrc, present_key, present_value,
           static_cast<int>(B), static_cast<int>(past_len), static_cast<int>(sq),
           static_cast<int>(G), static_cast<int>(d),
           static_cast<int>(past_buf_seq), static_cast<int>(present_seq),
           (use_no_expand && !bidirectional_no_past) ? seqlens_k_ptr : nullptr,
-          static_cast<int>(elem_sz), bidirectional_no_past,
-          static_cast<int>(skv)));
+          static_cast<int>(elem_sz), static_cast<int>(kv_lo),
+          bidirectional_no_past, static_cast<int>(skv)));
     }
 
     // ---- Steps 6-7: KV Expand [B*G,present_seq,d] -> [B*H,total_seq,d] ----
     // Skipped in no-expand mode: the Score/Value GEMMs read K/V directly from
     // the BNSD cache via per-operand batch strides instead.
     if (!use_no_expand) {
-      const void *kCache = present_key ? present_key : key;
-      const void *vCache = present_value ? present_value : value;
+      // The window is selected by advancing the source base pointer rather than
+      // by a new kernel argument. expand_kv_kernel reads
+      // src[g * src_stride + idx], so one offset shifts every group by the same
+      // amount and src_stride keeps describing the untouched cache page -- the
+      // same trick scoreA / valueA use below. The destination is packed over
+      // kv_span, so its stride and the copy length both shrink with it, which
+      // is what makes the skipped positions cost no threads instead of one
+      // predicated-off thread each.
+      // kv_lo is non-zero only when both present pointers exist (see the
+      // narrowing gate above), so this offset never applies to the raw key /
+      // value fallback.
+      const size_t kvExpandOff = static_cast<size_t>(kv_lo) * d * elem_sz;
+      const void *kCache =
+          static_cast<const char *>(present_key ? present_key : key) +
+          kvExpandOff;
+      const void *vCache =
+          static_cast<const char *>(present_value ? present_value : value) +
+          kvExpandOff;
       int kvSrcStride = static_cast<int>(present_seq * d);
-      int kvDstStride = static_cast<int>(total_seq * d);
-      int expandCopy = static_cast<int>(total_seq * d);
+      int kvDstStride = static_cast<int>(kv_span * d);
+      int expandCopy = static_cast<int>(kv_span * d);
 
       HIP_CHECK(
           hip_gqa_expand_kv(stream, kCache, d_Kexp, static_cast<int>(B * H),
@@ -1937,6 +2044,11 @@ static int gqa_forward_hipblaslt(
     // BNSD with d fastest, so this selects a contiguous span and leaves the
     // per-(b,g) batch stride at present_seq*d. kv_lo is 0 unless the sliding
     // window narrowed the range.
+    //
+    // elem_sz is the cache's element size as well as the GEMM's: unlike
+    // update_kv_cache, gqa_forward_hipblaslt takes no separate kv_format, so
+    // the two cannot differ here. A quantized KV cache would have to pass its
+    // own element size for this offset to stay correct.
     const size_t kv_byte_off = static_cast<size_t>(kv_lo) * d * elem_sz;
     const void *scoreA =
         (use_no_expand ? static_cast<const char *>(present_key) + kv_byte_off
@@ -2065,14 +2177,24 @@ static int gqa_forward_hipblaslt(
           static_cast<int>(elem_sz)));
     }
 
+    // kv_inplace and the three sequence lengths are here because they decide
+    // whether any of this narrowing does anything: the copy can only be skipped
+    // on the separate-buffer branch, which is exactly kv_inplace=0, and that in
+    // turn is visible only as present_seq differing from past_buf_seq. A model
+    // exporting its cache in place takes the append branch and the copy_lo
+    // below is inert, which is otherwise indistinguishable from the narrowing
+    // failing to engage.
     RUNTIME_DEBUG_LOG(
         "[REAL] GQA hipBLASLt: B=%lld sq=%lld sq_chunk=%lld total_seq=%lld "
         "kv_lo=%lld kv_span=%lld H=%lld G=%lld d=%lld no_expand=%d "
-        "transpose=%d\n",
+        "transpose=%d kv_inplace=%d past_len=%lld past_buf_seq=%lld "
+        "present_seq=%lld\n",
         (long long)B, (long long)sq, (long long)sq_chunk, (long long)total_seq,
         (long long)kv_lo, (long long)kv_span, (long long)H, (long long)G,
         (long long)d, static_cast<int>(use_no_expand),
-        static_cast<int>(need_transpose));
+        static_cast<int>(need_transpose),
+        static_cast<int>(past_key != nullptr && past_key == present_key),
+        (long long)past_len, (long long)past_buf_seq, (long long)present_seq);
   }
 
 cleanup:

--- a/test/lit/Conversion/onnx-to-hip/test_onnx_attention.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_onnx_attention.mlir
@@ -13,12 +13,20 @@
 //     and seqlens_k = total_seq - 1 (ORT convention total_seq = seqlens_k + 1)
 //   - present_key/value DPS inits sized to the past+current total
 //
+//   - a sliding window baked into the additive mask recovered from the mask's
+//     producing subgraph and stamped as local_window_size, since
+//     onnx.Attention has no attribute to carry one
+//
 // Cases: a static-shape decode (16 query heads, 8 KV heads), a dynamic-shape
 // prefill with an EMPTY past (the case that previously sized present from
 // dim(past_key, 2) alone -> zero-length present buffer -> null present_key ->
 // zeroed attention output), the Gemma-4-E2B decoder self-attn (is_causal=1 +
 // fp16 mask + past KV + 3 outputs -- previously rejected), a single-output
-// causal case, a bidirectional no-mask case, and a rank-4 BNSH case.
+// causal case, a bidirectional no-mask case, a rank-4 BNSH case, and the
+// window-recovery cases: windowed layer, global layer, unrecognized OR leg,
+// the segment leg stripped of its CumSum provenance, the window leg's indices
+// stripped of their shared position source, and the window leg's indices drawn
+// from two DIFFERENT position sources.
 // ============================================================================
 
 // The pass runs `--convert-onnx-to-hip`, whose module-metadata step requires
@@ -291,5 +299,625 @@ module {
     // CHECK-NOT: onnx.Attention
 
     return %y : tensor<1x16x8x64xf16>
+  }
+}
+
+// -----
+
+// ===== Sliding window recovered from the mask subgraph (windowed layer) =====
+//
+// Before opset 25 there was no window attribute on `onnx.Attention`, so a
+// windowed model could only express its window in the additive mask.
+// AttentionWindowFold reads it back out and stamps it, which is what lets the
+// runtime narrow its key range instead of scoring everything.
+//
+// This is Gemma-4's local-layer mask, reproduced node for node: the keep
+// condition ANDs the padding mask with an OR of the windowed-causal leg and the
+// same-image-block bidirectional leg. The window leg is
+// `And(qpos >= kpos, qpos - kpos < 1024)`, and the compare and the subtraction
+// reference the SAME two values in the same order -- that identity is what
+// makes `qpos` the query side and `kpos` the key side.
+//
+// Both index tensors are then built from ONE onnx.CumSum, which is the other
+// half of what the matcher requires: identity alone bounds the difference of
+// two tensors, and only a shared position source makes that difference a
+// position distance in units of key positions. Two later cases strip this,
+// once entirely and once by giving each side its own source.
+//
+// The segment leg's block index is built through a SEPARATE onnx.CumSum, as it
+// is in the real export -- which has exactly two, a block-index one behind the
+// equality and a position one behind the indices. The matcher requires that
+// ancestor too, so removing it alone is enough to make the whole match decline.
+module {
+  func.func @main_graph(
+      %query: tensor<?x?x4096xf16>,
+      %key: tensor<?x?x2048xf16>,
+      %value: tensor<?x?x2048xf16>,
+      %attnmask: tensor<?x?xi64>,
+      %imgstart: tensor<?x?xi64>,
+      %pad: tensor<?x?xi64>,
+      %past_key: tensor<?x8x?x256xf16>,
+      %past_value: tensor<?x8x?x256xf16>)
+      -> (tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>,
+          tensor<?x8x?x256xf16>) {
+
+    // CHECK-LABEL: func.func @main_graph
+    // CHECK-SAME: (%[[CTXW:.*]]: !hip.context,
+
+    %c1 = "onnx.Constant"() {value = dense<1> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %c2 = "onnx.Constant"() {value = dense<2> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %w = "onnx.Constant"() {value = dense<1024> : tensor<i64>}
+        : () -> tensor<i64>
+    %zi = "onnx.Constant"() {value = dense<0> : tensor<i64>} : () -> tensor<i64>
+    %keepv = "onnx.Constant"() {value = dense<0.000000e+00> : tensor<f32>}
+        : () -> tensor<f32>
+    %dropv = "onnx.Constant"() {value = dense<-6.550400e+04> : tensor<f32>}
+        : () -> tensor<f32>
+
+    // Positions, built as the real export builds them: a cumulative count over
+    // the attention mask numbers the keys, and the query positions are the
+    // trailing entries of that SAME sequence. On the export the key side
+    // reaches this CumSum in one hop and the query side in two, through the
+    // Slice; kPositionProvenanceDepth is 6, so both are well inside it.
+    %ax1 = "onnx.Constant"() {value = dense<1> : tensor<i64>} : () -> tensor<i64>
+    %kidx = "onnx.CumSum"(%attnmask, %ax1)
+        : (tensor<?x?xi64>, tensor<i64>) -> tensor<?x?xi64>
+    %sbeg = "onnx.Constant"() {value = dense<-8> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %send = "onnx.Constant"() {value = dense<9223372036854775807> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %qidx = "onnx.Slice"(%kidx, %sbeg, %send, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>)
+        -> tensor<?x?xi64>
+
+    // Broadcast the two index vectors into [B, q, k]: the query index goes on
+    // the lower axis (unsqueezed at 2), the key index on the higher (at 1).
+    %qpos = "onnx.Unsqueeze"(%qidx, %c2)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x?x1xi64>
+    %kpos = "onnx.Unsqueeze"(%kidx, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x1x?xi64>
+
+    %causal = "onnx.GreaterOrEqual"(%qpos, %kpos)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi1>
+    %dist = "onnx.Sub"(%qpos, %kpos)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi64>
+    %inwin = "onnx.Less"(%dist, %w)
+        : (tensor<?x?x?xi64>, tensor<i64>) -> tensor<?x?x?xi1>
+    %wleg = "onnx.And"(%causal, %inwin)
+        : (tensor<?x?x?xi1>, tensor<?x?x?xi1>) -> tensor<?x?x?xi1>
+
+    // Same-image-block bidirectional leg: identically false for a text-only
+    // prompt, and bounded by the image block length otherwise.
+    //
+    // The block index is a running count of image-block starts, so an
+    // onnx.CumSum sits behind the equality -- a different one from the position
+    // CumSum above. That is the provenance the matcher requires: it is what
+    // distinguishes a block index from a document id or a prefix-LM boundary,
+    // which wear the same Equal shape but bound nothing.
+    %blk = "onnx.CumSum"(%imgstart, %ax1)
+        : (tensor<?x?xi64>, tensor<i64>) -> tensor<?x?xi64>
+    %qblk = "onnx.Unsqueeze"(%blk, %c2)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x?x1xi64>
+    %kblk = "onnx.Unsqueeze"(%blk, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x1x?xi64>
+    %sameblk = "onnx.Equal"(%qblk, %kblk)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi1>
+    %isimg = "onnx.GreaterOrEqual"(%qblk, %zi)
+        : (tensor<?x?x1xi64>, tensor<i64>) -> tensor<?x?x1xi1>
+    %segleg = "onnx.And"(%sameblk, %isimg)
+        : (tensor<?x?x?xi1>, tensor<?x?x1xi1>) -> tensor<?x?x?xi1>
+
+    %or = "onnx.Or"(%wleg, %segleg)
+        : (tensor<?x?x?xi1>, tensor<?x?x?xi1>) -> tensor<?x?x?xi1>
+    %padu = "onnx.Unsqueeze"(%pad, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x1x?xi64>
+    %padb = "onnx.Cast"(%padu) {to = 9 : si64}
+        : (tensor<?x1x?xi64>) -> tensor<?x1x?xi1>
+    %keep = "onnx.And"(%padb, %or)
+        : (tensor<?x1x?xi1>, tensor<?x?x?xi1>) -> tensor<?x?x?xi1>
+    %bias32 = "onnx.Where"(%keep, %keepv, %dropv)
+        : (tensor<?x?x?xi1>, tensor<f32>, tensor<f32>) -> tensor<?x?x?xf32>
+    %bias16 = "onnx.Cast"(%bias32) {to = 10 : si64}
+        : (tensor<?x?x?xf32>) -> tensor<?x?x?xf16>
+    %bias = "onnx.Unsqueeze"(%bias16, %c1)
+        : (tensor<?x?x?xf16>, tensor<1xi64>) -> tensor<?x1x?x?xf16>
+
+    %out:3 = "onnx.Attention"(%query, %key, %value, %bias, %past_key,
+                              %past_value)
+        {q_num_heads = 16 : si64,
+         kv_num_heads = 8 : si64,
+         is_causal = 0 : si64,
+         scale = 6.250000e-02 : f32,
+         softcap = 0.000000e+00 : f32}
+        : (tensor<?x?x4096xf16>, tensor<?x?x2048xf16>, tensor<?x?x2048xf16>,
+           tensor<?x1x?x?xf16>, tensor<?x8x?x256xf16>, tensor<?x8x?x256xf16>)
+        -> (tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>,
+            tensor<?x8x?x256xf16>)
+
+    // CHECK: hip.gqa(%[[CTXW]])
+    // Attributes print alphabetically, so the recovered window lands between
+    // kv_num_heads and no_causal.
+    // CHECK-SAME: {kv_num_heads = 8 : i64, local_window_size = 1024 : i64, no_causal = true, num_heads = 16 : i64
+    // CHECK-NOT: onnx.Attention
+
+    return %out#0, %out#1, %out#2
+        : tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>, tensor<?x8x?x256xf16>
+  }
+}
+
+// -----
+
+// ===== Global layer: the same mask WITHOUT the window leg =====
+//
+// Gemma-4's 5 full-attention layers differ from its 25 windowed ones by exactly
+// one node: the OR's causal leg is the bare compare rather than
+// `And(causal, within-window)`. A bare causal term bounds nothing from below, so
+// no window is recovered and the op keeps hip.gqa's -1 default. This is the
+// case that must NOT be stamped -- forcing a window here would change results
+// rather than just make them cheaper.
+module {
+  func.func @main_graph(
+      %query: tensor<?x?x8192xf16>,
+      %key: tensor<?x?x1024xf16>,
+      %value: tensor<?x?x1024xf16>,
+      %qidx: tensor<?x?xi64>,
+      %kidx: tensor<?x?xi64>,
+      %pad: tensor<?x?xi64>,
+      %past_key: tensor<?x2x?x512xf16>,
+      %past_value: tensor<?x2x?x512xf16>)
+      -> (tensor<?x?x8192xf16>, tensor<?x2x?x512xf16>,
+          tensor<?x2x?x512xf16>) {
+
+    // CHECK-LABEL: func.func @main_graph
+    // CHECK-SAME: (%[[CTXG2:.*]]: !hip.context,
+
+    %c1 = "onnx.Constant"() {value = dense<1> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %c2 = "onnx.Constant"() {value = dense<2> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %keepv = "onnx.Constant"() {value = dense<0.000000e+00> : tensor<f32>}
+        : () -> tensor<f32>
+    %dropv = "onnx.Constant"() {value = dense<-6.550400e+04> : tensor<f32>}
+        : () -> tensor<f32>
+
+    %qpos = "onnx.Unsqueeze"(%qidx, %c2)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x?x1xi64>
+    %kpos = "onnx.Unsqueeze"(%kidx, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x1x?xi64>
+    %causal = "onnx.GreaterOrEqual"(%qpos, %kpos)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi1>
+
+    %padu = "onnx.Unsqueeze"(%pad, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x1x?xi64>
+    %padb = "onnx.Cast"(%padu) {to = 9 : si64}
+        : (tensor<?x1x?xi64>) -> tensor<?x1x?xi1>
+    %keep = "onnx.And"(%padb, %causal)
+        : (tensor<?x1x?xi1>, tensor<?x?x?xi1>) -> tensor<?x?x?xi1>
+    %bias32 = "onnx.Where"(%keep, %keepv, %dropv)
+        : (tensor<?x?x?xi1>, tensor<f32>, tensor<f32>) -> tensor<?x?x?xf32>
+    %bias16 = "onnx.Cast"(%bias32) {to = 10 : si64}
+        : (tensor<?x?x?xf32>) -> tensor<?x?x?xf16>
+    %bias = "onnx.Unsqueeze"(%bias16, %c1)
+        : (tensor<?x?x?xf16>, tensor<1xi64>) -> tensor<?x1x?x?xf16>
+
+    %out:3 = "onnx.Attention"(%query, %key, %value, %bias, %past_key,
+                              %past_value)
+        {q_num_heads = 16 : si64,
+         kv_num_heads = 2 : si64,
+         is_causal = 0 : si64,
+         scale = 4.419420e-02 : f32,
+         softcap = 0.000000e+00 : f32}
+        : (tensor<?x?x8192xf16>, tensor<?x?x1024xf16>, tensor<?x?x1024xf16>,
+           tensor<?x1x?x?xf16>, tensor<?x2x?x512xf16>, tensor<?x2x?x512xf16>)
+        -> (tensor<?x?x8192xf16>, tensor<?x2x?x512xf16>,
+            tensor<?x2x?x512xf16>)
+
+    // No local_window_size: the dict goes straight from kv_num_heads to
+    // no_causal, so the attribute is absent and the -1 default stands.
+    // CHECK: hip.gqa(%[[CTXG2]])
+    // CHECK-SAME: {kv_num_heads = 2 : i64, no_causal = true, num_heads = 16 : i64
+    // CHECK-NOT: onnx.Attention
+
+    return %out#0, %out#1, %out#2
+        : tensor<?x?x8192xf16>, tensor<?x2x?x512xf16>, tensor<?x2x?x512xf16>
+  }
+}
+
+// -----
+
+// ===== An unrecognized OR leg must abandon the window =====
+//
+// A disjunct ADDS keeps, so one that cannot be bounded leaves the whole
+// condition unbounded no matter how tight the window leg is: the model may be
+// keeping a key the narrowing would drop. Here the second leg is a bare
+// equality on the position indices, which is neither a window nor the
+// recognized same-segment shape, so nothing is stamped even though the window
+// leg itself is a perfect match -- indices share a position source and all.
+// Recognizing only what it understands is the whole safety property of this
+// rewrite.
+module {
+  func.func @main_graph(
+      %query: tensor<?x?x4096xf16>,
+      %key: tensor<?x?x2048xf16>,
+      %value: tensor<?x?x2048xf16>,
+      %attnmask: tensor<?x?xi64>,
+      %past_key: tensor<?x8x?x256xf16>,
+      %past_value: tensor<?x8x?x256xf16>)
+      -> (tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>,
+          tensor<?x8x?x256xf16>) {
+
+    // CHECK-LABEL: func.func @main_graph
+    // CHECK-SAME: (%[[CTXU:.*]]: !hip.context,
+
+    %c1 = "onnx.Constant"() {value = dense<1> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %c2 = "onnx.Constant"() {value = dense<2> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %w = "onnx.Constant"() {value = dense<1024> : tensor<i64>}
+        : () -> tensor<i64>
+    %keepv = "onnx.Constant"() {value = dense<0.000000e+00> : tensor<f32>}
+        : () -> tensor<f32>
+    %dropv = "onnx.Constant"() {value = dense<-6.550400e+04> : tensor<f32>}
+        : () -> tensor<f32>
+
+    %ax1 = "onnx.Constant"() {value = dense<1> : tensor<i64>} : () -> tensor<i64>
+    %kidx = "onnx.CumSum"(%attnmask, %ax1)
+        : (tensor<?x?xi64>, tensor<i64>) -> tensor<?x?xi64>
+    %sbeg = "onnx.Constant"() {value = dense<-8> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %send = "onnx.Constant"() {value = dense<9223372036854775807> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %qidx = "onnx.Slice"(%kidx, %sbeg, %send, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>)
+        -> tensor<?x?xi64>
+
+    %qpos = "onnx.Unsqueeze"(%qidx, %c2)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x?x1xi64>
+    %kpos = "onnx.Unsqueeze"(%kidx, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x1x?xi64>
+    %causal = "onnx.GreaterOrEqual"(%qpos, %kpos)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi1>
+    %dist = "onnx.Sub"(%qpos, %kpos)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi64>
+    %inwin = "onnx.Less"(%dist, %w)
+        : (tensor<?x?x?xi64>, tensor<i64>) -> tensor<?x?x?xi1>
+    %wleg = "onnx.And"(%causal, %inwin)
+        : (tensor<?x?x?xi1>, tensor<?x?x?xi1>) -> tensor<?x?x?xi1>
+
+    %other = "onnx.Equal"(%qpos, %kpos)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi1>
+    %keep = "onnx.Or"(%wleg, %other)
+        : (tensor<?x?x?xi1>, tensor<?x?x?xi1>) -> tensor<?x?x?xi1>
+    %bias32 = "onnx.Where"(%keep, %keepv, %dropv)
+        : (tensor<?x?x?xi1>, tensor<f32>, tensor<f32>) -> tensor<?x?x?xf32>
+    %bias16 = "onnx.Cast"(%bias32) {to = 10 : si64}
+        : (tensor<?x?x?xf32>) -> tensor<?x?x?xf16>
+    %bias = "onnx.Unsqueeze"(%bias16, %c1)
+        : (tensor<?x?x?xf16>, tensor<1xi64>) -> tensor<?x1x?x?xf16>
+
+    %out:3 = "onnx.Attention"(%query, %key, %value, %bias, %past_key,
+                              %past_value)
+        {q_num_heads = 16 : si64,
+         kv_num_heads = 8 : si64,
+         is_causal = 0 : si64,
+         scale = 6.250000e-02 : f32,
+         softcap = 0.000000e+00 : f32}
+        : (tensor<?x?x4096xf16>, tensor<?x?x2048xf16>, tensor<?x?x2048xf16>,
+           tensor<?x1x?x?xf16>, tensor<?x8x?x256xf16>, tensor<?x8x?x256xf16>)
+        -> (tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>,
+            tensor<?x8x?x256xf16>)
+
+    // CHECK: hip.gqa(%[[CTXU]])
+    // CHECK-SAME: {kv_num_heads = 8 : i64, no_causal = true, num_heads = 16 : i64
+    // CHECK-NOT: onnx.Attention
+
+    return %out#0, %out#1, %out#2
+        : tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>, tensor<?x8x?x256xf16>
+  }
+}
+
+// -----
+
+// ===== The segment shape WITHOUT its CumSum provenance is declined =====
+//
+// Node for node the windowed case above, except the block index comes straight
+// out of a graph input instead of through an onnx.CumSum. `And(Equal(a,b),
+// a >= 0)` is also how a same-document mask and a prefix-LM mask are spelled,
+// and those reach arbitrarily far back, so the shape alone is not enough to
+// accept: without a running count behind the equality the leg is unrecognized,
+// the OR it sits under becomes unbounded, and no window is stamped even though
+// the window leg is a perfect match, position source included. This is the
+// negative half of the segment provenance check -- the positive half is the
+// windowed case above, which is identical but for that CumSum.
+module {
+  func.func @main_graph(
+      %query: tensor<?x?x4096xf16>,
+      %key: tensor<?x?x2048xf16>,
+      %value: tensor<?x?x2048xf16>,
+      %attnmask: tensor<?x?xi64>,
+      %docid: tensor<?x?xi64>,
+      %pad: tensor<?x?xi64>,
+      %past_key: tensor<?x8x?x256xf16>,
+      %past_value: tensor<?x8x?x256xf16>)
+      -> (tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>,
+          tensor<?x8x?x256xf16>) {
+
+    // CHECK-LABEL: func.func @main_graph
+    // CHECK-SAME: (%[[CTXNP:.*]]: !hip.context,
+
+    %c1 = "onnx.Constant"() {value = dense<1> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %c2 = "onnx.Constant"() {value = dense<2> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %w = "onnx.Constant"() {value = dense<1024> : tensor<i64>}
+        : () -> tensor<i64>
+    %zi = "onnx.Constant"() {value = dense<0> : tensor<i64>} : () -> tensor<i64>
+    %keepv = "onnx.Constant"() {value = dense<0.000000e+00> : tensor<f32>}
+        : () -> tensor<f32>
+    %dropv = "onnx.Constant"() {value = dense<-6.550400e+04> : tensor<f32>}
+        : () -> tensor<f32>
+
+    %ax1 = "onnx.Constant"() {value = dense<1> : tensor<i64>} : () -> tensor<i64>
+    %kidx = "onnx.CumSum"(%attnmask, %ax1)
+        : (tensor<?x?xi64>, tensor<i64>) -> tensor<?x?xi64>
+    %sbeg = "onnx.Constant"() {value = dense<-8> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %send = "onnx.Constant"() {value = dense<9223372036854775807> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %qidx = "onnx.Slice"(%kidx, %sbeg, %send, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>, tensor<1xi64>, tensor<1xi64>)
+        -> tensor<?x?xi64>
+
+    %qpos = "onnx.Unsqueeze"(%qidx, %c2)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x?x1xi64>
+    %kpos = "onnx.Unsqueeze"(%kidx, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x1x?xi64>
+    %causal = "onnx.GreaterOrEqual"(%qpos, %kpos)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi1>
+    %dist = "onnx.Sub"(%qpos, %kpos)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi64>
+    %inwin = "onnx.Less"(%dist, %w)
+        : (tensor<?x?x?xi64>, tensor<i64>) -> tensor<?x?x?xi1>
+    %wleg = "onnx.And"(%causal, %inwin)
+        : (tensor<?x?x?xi1>, tensor<?x?x?xi1>) -> tensor<?x?x?xi1>
+
+    // Same shape as the recognized segment leg, but %docid is an input rather
+    // than a running count.
+    %qdoc = "onnx.Unsqueeze"(%docid, %c2)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x?x1xi64>
+    %kdoc = "onnx.Unsqueeze"(%docid, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x1x?xi64>
+    %samedoc = "onnx.Equal"(%qdoc, %kdoc)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi1>
+    %isdoc = "onnx.GreaterOrEqual"(%qdoc, %zi)
+        : (tensor<?x?x1xi64>, tensor<i64>) -> tensor<?x?x1xi1>
+    %docleg = "onnx.And"(%samedoc, %isdoc)
+        : (tensor<?x?x?xi1>, tensor<?x?x1xi1>) -> tensor<?x?x?xi1>
+
+    %or = "onnx.Or"(%wleg, %docleg)
+        : (tensor<?x?x?xi1>, tensor<?x?x?xi1>) -> tensor<?x?x?xi1>
+    %padu = "onnx.Unsqueeze"(%pad, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x1x?xi64>
+    %padb = "onnx.Cast"(%padu) {to = 9 : si64}
+        : (tensor<?x1x?xi64>) -> tensor<?x1x?xi1>
+    %keep = "onnx.And"(%padb, %or)
+        : (tensor<?x1x?xi1>, tensor<?x?x?xi1>) -> tensor<?x?x?xi1>
+    %bias32 = "onnx.Where"(%keep, %keepv, %dropv)
+        : (tensor<?x?x?xi1>, tensor<f32>, tensor<f32>) -> tensor<?x?x?xf32>
+    %bias16 = "onnx.Cast"(%bias32) {to = 10 : si64}
+        : (tensor<?x?x?xf32>) -> tensor<?x?x?xf16>
+    %bias = "onnx.Unsqueeze"(%bias16, %c1)
+        : (tensor<?x?x?xf16>, tensor<1xi64>) -> tensor<?x1x?x?xf16>
+
+    %out:3 = "onnx.Attention"(%query, %key, %value, %bias, %past_key,
+                              %past_value)
+        {q_num_heads = 16 : si64,
+         kv_num_heads = 8 : si64,
+         is_causal = 0 : si64,
+         scale = 6.250000e-02 : f32,
+         softcap = 0.000000e+00 : f32}
+        : (tensor<?x?x4096xf16>, tensor<?x?x2048xf16>, tensor<?x?x2048xf16>,
+           tensor<?x1x?x?xf16>, tensor<?x8x?x256xf16>, tensor<?x8x?x256xf16>)
+        -> (tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>,
+            tensor<?x8x?x256xf16>)
+
+    // No local_window_size: the dict goes straight from kv_num_heads to
+    // no_causal.
+    // CHECK: hip.gqa(%[[CTXNP]])
+    // CHECK-SAME: {kv_num_heads = 8 : i64, no_causal = true, num_heads = 16 : i64
+    // CHECK-NOT: onnx.Attention
+
+    return %out#0, %out#1, %out#2
+        : tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>, tensor<?x8x?x256xf16>
+  }
+}
+
+// -----
+
+// ===== A window leg with no position source is declined =====
+//
+// `And(p >= q, p - q < 1024)` on two tensors that arrive straight out of graph
+// inputs. The shape is a flawless window leg and the same-value identity holds
+// on both halves, so this is what the matcher accepted before it asked where
+// the indices came from.
+//
+// It is not enough. The identity proves `p - q` is bounded by 1024; the runtime
+// turns that into `kv_lo = abs_q - 1024 + 1`, an ABSOLUTE KEY POSITION. That
+// step needs p and q to be positions on one common scale, and nothing here says
+// they are -- indices scaled by a block size, or re-based per segment, wear
+// exactly this shape and would hand over a W in the wrong units, dropping keys
+// the model wanted. So the leg is unrecognized, the And above it has no bounded
+// conjunct, and no window is stamped.
+//
+// There is no OR leg and no segment leg in this mask, so the decline is
+// attributable to the missing provenance and nothing else.
+module {
+  func.func @main_graph(
+      %query: tensor<?x?x4096xf16>,
+      %key: tensor<?x?x2048xf16>,
+      %value: tensor<?x?x2048xf16>,
+      %qidx: tensor<?x?xi64>,
+      %kidx: tensor<?x?xi64>,
+      %pad: tensor<?x?xi64>,
+      %past_key: tensor<?x8x?x256xf16>,
+      %past_value: tensor<?x8x?x256xf16>)
+      -> (tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>,
+          tensor<?x8x?x256xf16>) {
+
+    // CHECK-LABEL: func.func @main_graph
+    // CHECK-SAME: (%[[CTXNS:.*]]: !hip.context,
+
+    %c1 = "onnx.Constant"() {value = dense<1> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %c2 = "onnx.Constant"() {value = dense<2> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %w = "onnx.Constant"() {value = dense<1024> : tensor<i64>}
+        : () -> tensor<i64>
+    %keepv = "onnx.Constant"() {value = dense<0.000000e+00> : tensor<f32>}
+        : () -> tensor<f32>
+    %dropv = "onnx.Constant"() {value = dense<-6.550400e+04> : tensor<f32>}
+        : () -> tensor<f32>
+
+    %qpos = "onnx.Unsqueeze"(%qidx, %c2)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x?x1xi64>
+    %kpos = "onnx.Unsqueeze"(%kidx, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x1x?xi64>
+    %causal = "onnx.GreaterOrEqual"(%qpos, %kpos)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi1>
+    %dist = "onnx.Sub"(%qpos, %kpos)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi64>
+    %inwin = "onnx.Less"(%dist, %w)
+        : (tensor<?x?x?xi64>, tensor<i64>) -> tensor<?x?x?xi1>
+    %wleg = "onnx.And"(%causal, %inwin)
+        : (tensor<?x?x?xi1>, tensor<?x?x?xi1>) -> tensor<?x?x?xi1>
+
+    %padu = "onnx.Unsqueeze"(%pad, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x1x?xi64>
+    %padb = "onnx.Cast"(%padu) {to = 9 : si64}
+        : (tensor<?x1x?xi64>) -> tensor<?x1x?xi1>
+    %keep = "onnx.And"(%padb, %wleg)
+        : (tensor<?x1x?xi1>, tensor<?x?x?xi1>) -> tensor<?x?x?xi1>
+    %bias32 = "onnx.Where"(%keep, %keepv, %dropv)
+        : (tensor<?x?x?xi1>, tensor<f32>, tensor<f32>) -> tensor<?x?x?xf32>
+    %bias16 = "onnx.Cast"(%bias32) {to = 10 : si64}
+        : (tensor<?x?x?xf32>) -> tensor<?x?x?xf16>
+    %bias = "onnx.Unsqueeze"(%bias16, %c1)
+        : (tensor<?x?x?xf16>, tensor<1xi64>) -> tensor<?x1x?x?xf16>
+
+    %out:3 = "onnx.Attention"(%query, %key, %value, %bias, %past_key,
+                              %past_value)
+        {q_num_heads = 16 : si64,
+         kv_num_heads = 8 : si64,
+         is_causal = 0 : si64,
+         scale = 6.250000e-02 : f32,
+         softcap = 0.000000e+00 : f32}
+        : (tensor<?x?x4096xf16>, tensor<?x?x2048xf16>, tensor<?x?x2048xf16>,
+           tensor<?x1x?x?xf16>, tensor<?x8x?x256xf16>, tensor<?x8x?x256xf16>)
+        -> (tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>,
+            tensor<?x8x?x256xf16>)
+
+    // CHECK: hip.gqa(%[[CTXNS]])
+    // CHECK-SAME: {kv_num_heads = 8 : i64, no_causal = true, num_heads = 16 : i64
+    // CHECK-NOT: onnx.Attention
+
+    return %out#0, %out#1, %out#2
+        : tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>, tensor<?x8x?x256xf16>
+  }
+}
+
+// -----
+
+// ===== Two DIFFERENT position sources are declined =====
+//
+// The sharp case, and the reason the check intersects sources rather than just
+// requiring each side to have one. Both indices are cumulative counts here, so
+// "is there a CumSum above this value" is true of each in isolation -- but they
+// are counts over two different tensors, so they are two unrelated numberings.
+//
+// Subtracting across them measures nothing: `p - q < 1024` says the two counts
+// are within 1024 of each other, which does not bound how far back in the KEY
+// sequence a query reaches. Narrowing on it would be unsound, so the leg is
+// unrecognized and no window is stamped.
+module {
+  func.func @main_graph(
+      %query: tensor<?x?x4096xf16>,
+      %key: tensor<?x?x2048xf16>,
+      %value: tensor<?x?x2048xf16>,
+      %maska: tensor<?x?xi64>,
+      %maskb: tensor<?x?xi64>,
+      %pad: tensor<?x?xi64>,
+      %past_key: tensor<?x8x?x256xf16>,
+      %past_value: tensor<?x8x?x256xf16>)
+      -> (tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>,
+          tensor<?x8x?x256xf16>) {
+
+    // CHECK-LABEL: func.func @main_graph
+    // CHECK-SAME: (%[[CTXTS:.*]]: !hip.context,
+
+    %c1 = "onnx.Constant"() {value = dense<1> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %c2 = "onnx.Constant"() {value = dense<2> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %w = "onnx.Constant"() {value = dense<1024> : tensor<i64>}
+        : () -> tensor<i64>
+    %keepv = "onnx.Constant"() {value = dense<0.000000e+00> : tensor<f32>}
+        : () -> tensor<f32>
+    %dropv = "onnx.Constant"() {value = dense<-6.550400e+04> : tensor<f32>}
+        : () -> tensor<f32>
+
+    // Two CumSums, two numberings. Each side would pass a per-side provenance
+    // test; the pair does not share a source, which is what actually matters.
+    %ax1 = "onnx.Constant"() {value = dense<1> : tensor<i64>} : () -> tensor<i64>
+    %qidx = "onnx.CumSum"(%maska, %ax1)
+        : (tensor<?x?xi64>, tensor<i64>) -> tensor<?x?xi64>
+    %kidx = "onnx.CumSum"(%maskb, %ax1)
+        : (tensor<?x?xi64>, tensor<i64>) -> tensor<?x?xi64>
+
+    %qpos = "onnx.Unsqueeze"(%qidx, %c2)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x?x1xi64>
+    %kpos = "onnx.Unsqueeze"(%kidx, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x1x?xi64>
+    %causal = "onnx.GreaterOrEqual"(%qpos, %kpos)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi1>
+    %dist = "onnx.Sub"(%qpos, %kpos)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi64>
+    %inwin = "onnx.Less"(%dist, %w)
+        : (tensor<?x?x?xi64>, tensor<i64>) -> tensor<?x?x?xi1>
+    %wleg = "onnx.And"(%causal, %inwin)
+        : (tensor<?x?x?xi1>, tensor<?x?x?xi1>) -> tensor<?x?x?xi1>
+
+    %padu = "onnx.Unsqueeze"(%pad, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x1x?xi64>
+    %padb = "onnx.Cast"(%padu) {to = 9 : si64}
+        : (tensor<?x1x?xi64>) -> tensor<?x1x?xi1>
+    %keep = "onnx.And"(%padb, %wleg)
+        : (tensor<?x1x?xi1>, tensor<?x?x?xi1>) -> tensor<?x?x?xi1>
+    %bias32 = "onnx.Where"(%keep, %keepv, %dropv)
+        : (tensor<?x?x?xi1>, tensor<f32>, tensor<f32>) -> tensor<?x?x?xf32>
+    %bias16 = "onnx.Cast"(%bias32) {to = 10 : si64}
+        : (tensor<?x?x?xf32>) -> tensor<?x?x?xf16>
+    %bias = "onnx.Unsqueeze"(%bias16, %c1)
+        : (tensor<?x?x?xf16>, tensor<1xi64>) -> tensor<?x1x?x?xf16>
+
+    %out:3 = "onnx.Attention"(%query, %key, %value, %bias, %past_key,
+                              %past_value)
+        {q_num_heads = 16 : si64,
+         kv_num_heads = 8 : si64,
+         is_causal = 0 : si64,
+         scale = 6.250000e-02 : f32,
+         softcap = 0.000000e+00 : f32}
+        : (tensor<?x?x4096xf16>, tensor<?x?x2048xf16>, tensor<?x?x2048xf16>,
+           tensor<?x1x?x?xf16>, tensor<?x8x?x256xf16>, tensor<?x8x?x256xf16>)
+        -> (tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>,
+            tensor<?x8x?x256xf16>)
+
+    // CHECK: hip.gqa(%[[CTXTS]])
+    // CHECK-SAME: {kv_num_heads = 8 : i64, no_causal = true, num_heads = 16 : i64
+    // CHECK-NOT: onnx.Attention
+
+    return %out#0, %out#1, %out#2
+        : tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>, tensor<?x8x?x256xf16>
   }
 }


### PR DESCRIPTION
## Summary

A windowed attention layer only ever attends to the last `W` key positions, but
the decomposed GQA path read, expanded and copied the entire KV cache on every
step regardless. This recovers the sliding window from `onnx.Attention`'s
additive mask subgraph — the only place a pre-opset-25 export can put one — and
then narrows the KV read, the expand and the separate-buffer copy to that window
on every call, prefill and decode alike.

On Gemma-4 26B-A4B-it (25 of 30 decoder layers windowed at `W = 1024`) this is
**1.60x steady-state decode at a 12K prompt** and **1.47x at 8K**. Initial
prefill and TTFT are unchanged by construction.

## Related issue or design

None. There was no design discussion before implementation, which CONTRIBUTING
asks for at this size — see the scope note under *Notes for reviewers*.

## Why

`onnx.Attention` gained window attributes only in opset 25. A model exported
below that with sliding-window layers — Gemma-4 among them — arrives with
`is_causal = 0` and the window expressed entirely inside its additive mask, so
nothing downstream knows the layer is windowed. The mask is applied faithfully
and the result is correct, but every step still pays for the full cache: at a
12K prompt a windowed layer scores 12K keys to keep 1024, and the other ~92% are
multiplied, exponentiated and then annihilated by the mask's large-negative
entries.

Attention is where that shows up on this model. The window is a hard promise
about which keys can matter, and the whole change is about pushing that promise
one level down, from "masked to zero after the fact" to "never read".

## What

Three commits, in dependency order.

**1. `feat(onnx-to-hip)`: recover the window from the mask.** A new
`AttentionWindowFold.cpp` pre-lowering pass matches the mask's boolean
keep-condition, `And(pad, Or(win, seg))`, recovers `W` from
`win = And(GreaterOrEqual(P, Q), Less(Sub(P, Q), W))`, and stamps
`hipdnn.local_window_size`, which `OnnxAttentionConversion` puts on `hip.gqa`.

The window leg has to satisfy two separate requirements, and the second is the
one worth reviewing closely.

*Identity.* The compare and the subtraction must reference the same two tensors
in the same order, so a mask that merely resembles the shape does not match.
That fixes which side is the query and which the key.

*Provenance.* Identity alone only says `P - Q < W` bounds the difference of two
tensors. The runtime then converts `W` into `kv_lo = abs_q - W + 1`, an
**absolute key position**. For that step to follow, `P` and `Q` have to be
positions on one common scale — same origin, unit stride. Structurally identical
arithmetic over tensors scaled by a block size or re-based per segment would
match just as well and yield a `W` in the wrong units, and the narrowing would
then drop keys the model wanted. So both sides must reach a **common**
`onnx.CumSum` or `onnx.Range` within a bounded walk. Requiring a shared node
rather than one per side is deliberate: two unrelated numberings each have a
position source, and subtracting across them measures nothing.

That requirement was written against the export, not guessed at. Walking the
Gemma-4 decoder shows the key side is `Unsqueeze(CumSum(attention_mask))` and
the query side is `Unsqueeze(Slice(CumSum(attention_mask)))` — the same CumSum
node, at depths 1 and 2.

The `seg` leg is Gemma-4's same-image exception, `And(Equal(bq, bk), bidx >= 0)`,
which lets tokens of one image attend to each other past the window. Recovering
a window in its presence is only sound because that leg is bounded, and what
bounds it is that the block index is a `CumSum` — a running count of block
starts, so equal values are necessarily within one block. The identical
expression tree over a document ID or a prefix-LM boundary has *unbounded*
reach. So `matchSegmentTerm` requires a `CumSum` ancestor of one of the `Equal`
operands within `kSegmentProvenanceDepth = 6`, rather than trusting the shape.

Both legs therefore ask for a `CumSum`, and — worth knowing when reading a dump
— not the same one. The export has exactly two: a block-index CumSum over the
image-block starts, which the segment leg reaches at depths 3 and 4, and a
position CumSum over `attention_mask`, which the window leg's `P` and `Q` share.
Finding the position CumSum behind a segment leg would say nothing about block
extent, which is why the segment check looks above the `Equal` operands
specifically rather than anywhere in the mask region.

Reading a declared `left_window_size` where an export has one is a separate and
strictly easier change, deliberately **not** made here — see the scope note.

**2. `perf(gqa)`: narrow the decode KV read.** `kv_lo` / `kv_span` replace `0` /
`total_seq` in the score and value GEMM descriptors, the expand source offsets,
the buffer sizing and the chunk budget.

**3. `perf(gqa)`: narrow the copy, and the read bound at every `sq`.** The
separate-buffer concat skips `[0, kv_lo)`, and the read bound generalizes from
decode to all `sq`:

```cpp
int64_t kv_span = total_seq;
int64_t kv_lo = 0;
if (local_window_size > 0 && !bidirectional_no_past && present_key &&
    present_value) {
  const int64_t lo = past_len - local_window_size + 1;
  if (lo > 0) { kv_lo = lo; kv_span = total_seq - kv_lo; }
}
```

### Why skipping the write is safe

A call's query rows occupy absolute positions `[past_len, past_len + sq)`, so
the oldest key any row may attend to is `past_len - W + 1`. One global lower
bound serves the whole call — rows above the first are left keys they do not
use, which the mask drops exactly as before, so no per-row state is needed.

`copy_lo` is `kv_lo`, deliberately the same value and not a second bound derived
in parallel. That equality is what closes the invariant:

- a call writes `[kv_lo, total_seq)` where `kv_lo = past_len - W + 1`;
- the next call has `past_len' = total_seq > past_len`, so its
  `kv_lo' = past_len' - W + 1 > kv_lo`;
- so **every read range is a strict subset of the previous write range**, for
  decode and prefill alike.

Applying the bound to prefill as well as decode is what makes that hold. Leaving
prefill unnarrowed — reading from 0 while decode writes from `kv_lo` — is
precisely the case that breaks it: a continuation prefill would read memory a
narrowed decode never wrote. Unwritten memory can hold a non-finite bit pattern,
and no finite mask suppresses it. The softmax's first pass reduces with `fmaxf`,
which ignores NaN, but the second pass accumulates it, so a single such key
poisons its whole output row.

At `sq == 1` the bound reduces to `total_seq - W`. At a first prefill
`past_len = 0` makes it non-positive and nothing narrows, so **initial prefill
and TTFT are bit-identical by construction**.

### Restrictions

- **`!bidirectional_no_past`.** The bound is derived from
  `total_seq = past_len + sq`, and `bidirectional_no_past` (Whisper encoder and
  cross-attention) is the one branch where that identity does not hold —
  `total_seq = skv`, `past_len = 0`. With mask recovery as the only producer of
  a window, that pairing cannot currently occur: a window implies a mask, a mask
  means `attention_bias` is non-null, and `bidirectional_no_past` is
  `no_causal && !attention_bias`. The gate is there anyway, because that is a
  property of the converter rather than of the runtime function's contract — a
  future producer reading opset 25's `left_window_size` would need no mask at
  all and would arrive with both set.
- **A present cache is required.** `kv_lo` indexes key positions by absolute
  position in a BNSD cache page; without `present_key` / `present_value` the
  GEMMs read the raw operands, where a `past_len` derived from `skv - sq` does
  not describe an offset into anything.
- **`no_causal` is deliberately not a gate.** It was one while a window could
  only arrive as an attribute, where it would have been ignored rather than
  applied. A window read out of the mask is enforced by that mask, so gating on
  `no_causal` would reject the only shape that needs narrowing.

## Test plan

Hardware: AMD Radeon 8050S (Strix Halo, gfx1151), Windows, HIP 7.2.53150.

**Lit** — `check-hip-mlir-lit`: 470 tests, 458 passed, 12 unsupported, 0 failed.

The six window-recovery cases are four negative controls and two positives, each
isolating one requirement:

| case | expected |
| --- | --- |
| windowed mask, indices from one CumSum, segment block index from another | `local_window_size = 1024` |
| global mask, identical but for the window leg | nothing |
| unrecognized OR leg above a valid window leg | nothing |
| segment leg with its CumSum removed, nothing else changed | nothing |
| window leg whose indices come straight from graph inputs | nothing |
| window leg whose indices come from two *different* CumSums | nothing |

The last three each pass if the corresponding requirement is dropped, which is
why they are there. The final one is what distinguishes "each side has a position
source" from "both sides share one".

**Numeric** (`test/numeric`, `--backend ort_ep --ep-name hipgpu`):

| suite | result |
| --- | --- |
| whisper cross / encoder / self + MHA (97) | **97 pass** |
| `test_gqa.py` (22) | 14 fail, the identical set as on main |

The 97 whisper/MHA cases are the regression cover for the
`!bidirectional_no_past` gate: they are exactly the `total_seq = skv`,
`past_len = 0` geometry it excludes. `test_gqa.py`'s 14 failures were diffed
against a main-only arm and are the same set, so they are pre-existing and
unrelated (a `seqlens_k` geometry problem in the converter).

**No numeric test for the narrowing itself is included**, and that is a real gap
rather than an oversight — see the scope note. No existing numeric test drives a
windowed layer through `gqa_forward_hipblaslt`: both windowed cases in
`test_gqa.py` use `d == 64` and route to the fused kernels instead.

**What the local validation found, for whoever closes that gap.** A harness at
Gemma-4's geometry (H=16, G=8, d=256) was used while developing this, not
included here. Two results from it are worth recording because they constrain
what a future test has to assert:

- Poisoning `[0, kv_lo)` with NaN after a narrowed decode at `past_seq = 2048`,
  then running a continuation prefill at `past_len = 2049`, gives an output that
  is **entirely NaN** without commit 3's generalized bound and NaN-free with it.
  That is the unwritten-prefix hazard, driven directly.
- Rebuilt with the copy bound one position above the read bound
  (`copy_lo = kv_lo + 1`), the attention-output comparison **passes** at cosine
  0.999884 (max diff 2.7e-3) while the in-window slice of `present` is wrong in
  2047 of 2,111,488 elements. One missing key out of 1024 does not move a
  softmax enough to trip a 2e-2 tolerance, so **an output-only test would not
  catch this**. Whatever covers this later has to assert `present` from the same
  `kv_lo` the runtime narrows to — and deliberately not the dead region, since
  asserting anything about memory nobody promised anything about, even that it
  is zero, would be asserting on the allocator.

**Recovery and narrowing on the real model** — `HIPDNN_EP_DEBUG=1`, 1800-token
prompt plus generation, 270 `[REAL] GQA hipBLASLt` lines:

| phase | calls | narrowed | `kv_span` |
| --- | ---: | ---: | --- |
| initial prefill `sq = 2068` | 30 | 0 | full range |
| decode `sq = 1` | 240 | **200** | **1024** |

The 200 / 40 split of the decode calls is exactly the export's 25 windowed
against 5 global layers over 8 steps; `kv_span` is pinned at 1024 on every
narrowed call and `kv_lo` tracks `past_len - 1023` (`kv_lo = 1045` at
`total_seq = 2069`). All 30 initial-prefill calls run their full range, which is
the measured form of "TTFT is untouched". The same run on an arm built before the
provenance check was added produces an identical narrowing profile, so the check
does not cost any recovery on this export.

## Performance

Interleaved three-arm A/B against `52886b28`, round-robin with the order
reversed on even rounds, one process per measurement so no arm inherits
another's warm caches, 48 tokens per iteration.

Steady-state decode, p20 of per-step times:

| prompt | main `52886b28` | this PR | speedup |
| --- | ---: | ---: | ---: |
| 8192 | 95.0 ms | 64.8 ms | **1.47x** |
| 12288 | 129.5 ms | 81.1 ms | **1.60x** |

TTFT, median over post-compile iterations — flat to within 3%, as designed:

| prompt | main | this PR |
| --- | ---: | ---: |
| 8192 | 19.2 s | 19.0 s |
| 12288 | 34.8 s | 34.2 s |

Two measurement notes, both of which forced the statistic:

- **Iteration 1 of every process is 4-6x slower than iteration 2** (main at 12K:
  554 ms then 131 ms) in every arm, because graph compilation lands on the first
  one. A pooled median is therefore bimodal by construction. The p20 above
  tracks the iteration-2 median to within 1 ms. The pooled median over all
  samples, including that regime, is the conservative floor: 223.0 → 196.8 ms
  at 8K (1.13x) and 321.8 → 269.9 ms at 12K (1.19x).
- **48 tokens, not 100.** A 100-token run at 12K measured ~66 ms for 10 steps,
  ~81 ms through step 54, then jumped to ~520 ms and stayed there. That cliff is
  a memory-pressure regime change, not attention scaling, and any statistic
  spanning it reports which side of it the run landed on.

Run-to-run spread within an arm is under 1%: main `[95.3, 95.0]` and
`[130.4, 129.5]`, this PR `[64.9, 64.8]` and `[80.8, 81.8]`.

Whether the correctness work costs anything was measured separately, four paired
rounds at 8192: 64.8 ms with the `sq == 1` restriction against 64.9 with the
generalized bound. Parity — the `bidirectional_no_past` gate is inert on this
model and the prefill bound is inert at `sq == 1`.

The branch has since been rebased onto `f219dd21`. The commits between that and
the measured base are hipsr dialect work, a move of the `HIPDNN_EP_DATATYPE_*`
defines into a shared header with values unchanged, and shape-fold patterns;
none touch `gqa.cpp`, the GQA kernels or the attention path, so the A/B was not
re-run against them. Lit and the numeric suites above were re-run on the rebased
tree.

## Notes for reviewers

**The 1.90x at 16K in an earlier version of this description is withdrawn.** It
was baselined against `6f334726` and cannot be reproduced against current main —
not because the optimization changed, but because 16K does not complete on
current main at all. `bench_seqlen.py 16384` dies with `STATUS_HEAP_CORRUPTION`
(`0xC0000374`) about 130 s in, around the end of prefill, on **plain
`52886b28`** with none of this PR's code present. `HIPDNN_EP_DEBUG=1` masks it,
which is the signature of a race rather than a deterministic overrun. 8192 and
12288 were stable across every run, so the numbers above are at those lengths.
The 16K crash is a separate pre-existing bug and is not addressed here.

**The unwritten-prefix hazard is real at the operator level but latent on this
model.** The multi-turn path that would produce `sq > 1` with `past_len > 0`,
`og.Generator.append_tokens`, fails before reaching the EP's attention — and
fails identically on an arm without this PR's provenance work, re-confirmed
today:

```
The output OrtValue provided for output 'present.0.key' has shape
{1,8,2154,256} but the computed output shape for this run is {1,8,2153,256}
```

genai pre-allocates `past + sq` while ORT computes one less. So the generalized
bound closes the hole *before* users can reach it, rather than repairing a
regression they can hit today. Claiming an observable model-level fix would be
false.

**Scope.** 1662 insertions and 97 deletions across 9 files, under CONTRIBUTING's
2000-line threshold, of which 630 lines are lit tests. Four things were removed
from an earlier revision of this PR to get there and to keep the diff to what
the measurement actually justifies:

- the opset-25 `left_window_size` / `right_window_size` attribute path and its
  three lit cases. Gemma-4 exports at opset 24, so that path never fired in any
  measurement here and could not be tested against a real export;
- a `DEBUG_TYPE` move (briefly its own PR, #880, now closed). It was warning
  hygiene only — MSVC C4005, non-fatal — and current main has three sibling
  files raising the same warning, so it belongs in a cleanup of its own rather
  than here. This PR's new file uses the header's `DEBUG_TYPE` and adds no
  warning;
- a `window=` field on the runtime debug line;
- `test/numeric/tests/test_attention_sliding_window.py`. This is the removal
  worth arguing about: it is the only thing that exercised the narrowing
  numerically, and dropping it leaves the gap documented under *Test plan*.
  Restoring it is a straightforward follow-up and I will do that if a reviewer
  would rather have the 690 lines than the threshold.

The three commits are individually reviewable and in dependency order — recover
the window, use it for the read, then extend it to the copy and to prefill — but
they are not independently *shippable*: commit 1 alone stamps an attribute
nothing consumes, and commit 2 alone narrows the read while the copy still
writes the full range, which is the inconsistent state commit 3 resolves.

**Where to look first.** The two provenance checks in
`AttentionWindowFold.cpp`, `hasSharedPositionSource` and `matchSegmentTerm`'s
`CumSum` requirement, are the places where a wrong answer is silent rather than
loud. Each decides whether a mask actually enforces the window being recovered,
and a false accept would narrow against a promise the model does not make. Both
were written after walking the real export rather than from the shape alone:
both `Equal` operands in the segment leg trace to the same block-index `CumSum`
at depths 3 and 4, in both the windowed and the global mask and in both copies
of the export, and the window leg's two indices trace to a single position
`CumSum` at depths 1 and 2.

## AI disclosure

Substantial AI assistance (Cursor), disclosed per CONTRIBUTING and trailered on
each commit. The mask-topology matcher, the narrowing arithmetic and this
description were AI-assisted. Validation was run locally and is reported above
rather than asserted: the mask shape, the segment `CumSum` provenance and the
position provenance of the window leg's indices were each confirmed by walking
the actual export before the predicate was written; the `present`-assertion
coverage was confirmed by deliberately breaking the copy bound and checking that
an output-only comparison would have missed it; and the performance claims come
from the interleaved A/B above, with the earlier 16K claim withdrawn because it
could not be reproduced. I reviewed the result and own every claim here.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
