### PR TITLE
feat(onnx): add InstanceNormalization end-to-end

### DIFF
--- a/docs/onnx_to_hip_frontend.md
+++ b/docs/onnx_to_hip_frontend.md
@@ -64,6 +64,7 @@ existing `--convert-hip-to-llvm` pipeline.
 | ONNX / ORT Contrib | HIP | MIOpen C API |
 |---|---|---|
 | `LayerNormalization` | `hip.miopen.layer_norm` | `miopenLayerNormForward` |
+| `InstanceNormalization` | `hip.instance_norm` | custom HIP kernel |
 | `SimplifiedLayerNormalization` | `hip.miopen.t5_layer_norm` | `miopenT5LayerNormForward` |
 | `SkipLayerNormalization` | `hip.miopen.skip_layer_norm` | `miopenAddLayerNormForward` |
 | `SkipSimplifiedLayerNormalization` | `hip.miopen.skip_rms_norm` | `miopenAddLayerNormForward` (T5 mode) |

--- a/docs/supported-operations.md
+++ b/docs/supported-operations.md
@@ -74,6 +74,7 @@ The conversion registrations in `lib/Conversion/OnnxToHip/OnnxToHip.cpp` and the
 | Compress | Custom HIP kernel; a dynamic selected extent is scanned and read back before allocation |
 | OneHot | Custom HIP kernel |
 | LayerNormalization | Custom HIP kernel |
+| InstanceNormalization | Custom HIP kernel |
 | SkipLayerNormalization (`com.microsoft`) | Decomposed to Add + LayerNormalization |
 | RMSNormalization | MIOpen |
 | SimplifiedLayerNormalization | MIOpen |

--- a/include/hip/Dialect/IR/HipBufferize.h
+++ b/include/hip/Dialect/IR/HipBufferize.h
@@ -167,6 +167,8 @@ registerHipBufferizableOpInterfaceModels(DialectRegistry &registry) {
     LinearAttentionOp::attachInterface<
         HipDstBufferizableModel<LinearAttentionOp>>(*ctx);
     LayerNormOp::attachInterface<HipDstBufferizableModel<LayerNormOp>>(*ctx);
+    InstanceNormOp::attachInterface<HipDstBufferizableModel<InstanceNormOp>>(
+        *ctx);
     MinOp::attachInterface<HipDstBufferizableModel<MinOp>>(*ctx);
     MaxOp::attachInterface<HipDstBufferizableModel<MaxOp>>(*ctx);
     AbsOp::attachInterface<HipDstBufferizableModel<AbsOp>>(*ctx);

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -1248,6 +1248,52 @@ def Hip_LayerNormOp : Hip_DpsOp<"layer_norm",
   let hasVerifier = 1;
 }
 
+def Hip_InstanceNormOp : Hip_DpsOp<"instance_norm", /*traits=*/[],
+                                   /*outsAccessor=*/"Output",
+                                   /*autoReify=*/1,
+                                   /*autoInfer=*/1,
+                                   /*declareInfer=*/1> {
+  let summary = "ONNX InstanceNormalization (per-instance per-channel mean/var)";
+  let description = [{
+    Carries out instance normalization as described in
+    https://arxiv.org/abs/1607.08022 / ONNX InstanceNormalization:
+
+      y = scale * (x - mean) / sqrt(variance + epsilon) + B
+
+    Mean and variance are computed over the spatial axes of each (N, C)
+    slice. Input rank is at least 3: (N, C, D1, ..., Dn). Scale and B are
+    1-D tensors of length C.
+
+    Example:
+    ```mlir
+    hip.instance_norm(%ctx)
+        ins(%input, %scale, %bias :
+            memref<2x3x8x8xf32, 1>, memref<3xf32, 1>, memref<3xf32, 1>)
+        outs(%output : memref<2x3x8x8xf32, 1>)
+        {epsilon = 1.000000e-05 : f32}
+    ```
+  }];
+
+  let arguments = (ins
+    Hip_ContextType:$ctx,
+    Hip_TensorOrMemRef:$input,
+    Hip_TensorOrMemRef:$scale,
+    Hip_TensorOrMemRef:$bias,
+    Hip_TensorOrMemRef:$output,
+    DefaultValuedAttr<F32Attr, "1.000000e-05">:$epsilon
+  );
+
+  let assemblyFormat = [{
+    `(` $ctx `)` `ins` `(`
+        $input `,` $scale `,` $bias `:`
+        type($input) `,` type($scale) `,` type($bias)
+    `)`
+    `outs` `(` $output `:` type($output) `)`
+    attr-dict (`:` type($result_tensors)^)?
+  }];
+  let hasVerifier = 1;
+}
+
 def Hip_SkipRmsNormOp : Hip_DpsOp<"skip_rms_norm",
     [AttrSizedOperandSegments, OpStateOpInterface]> {
   let summary = "Fused skip + RMS normalization (com.microsoft.SkipSimplifiedLayerNormalization)";

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -58,6 +58,8 @@ inline constexpr const char *kWrapSkipSimplifiedLayerNorm =
     "wrap_skip_simplified_layer_norm";
 inline constexpr const char *kWrapLayerNormalization =
     "wrap_layer_normalization";
+inline constexpr const char *kWrapInstanceNormalization =
+    "wrap_instance_normalization";
 inline constexpr const char *kMiopenAdd = "hip_miopen_add";
 inline constexpr const char *kMiopenMul = "hip_miopen_mul";
 inline constexpr const char *kMiopenSoftmax = "hip_miopen_softmax";

--- a/lib/Conversion/HipToLLVM/NormLowering.cpp
+++ b/lib/Conversion/HipToLLVM/NormLowering.cpp
@@ -333,10 +333,8 @@ struct InstanceNormOpLowering : public ConvertOpToLLVMPattern<InstanceNormOp> {
       return rewriter.notifyMatchFailure(
           op, "hip.instance_norm requires input rank >= 3");
 
-    Value n =
-        getMemRefDimSize(inputType, 0, adaptor.getInput(), rewriter, loc);
-    Value c =
-        getMemRefDimSize(inputType, 1, adaptor.getInput(), rewriter, loc);
+    Value n = getMemRefDimSize(inputType, 0, adaptor.getInput(), rewriter, loc);
+    Value c = getMemRefDimSize(inputType, 1, adaptor.getInput(), rewriter, loc);
     Value spatial = LLVM::ConstantOp::create(rewriter, loc, i64Type,
                                              rewriter.getI64IntegerAttr(1));
     for (int64_t dimIdx = 2, rank = inputType.getRank(); dimIdx < rank;
@@ -370,8 +368,8 @@ struct InstanceNormOpLowering : public ConvertOpToLLVMPattern<InstanceNormOp> {
     if (failed(funcOp))
       return failure();
 
-    SmallVector<Value> args = {statePtr,  inputPtr,     scalePtr,    biasPtr,
-                               outputPtr, n,            c,           spatial,
+    SmallVector<Value> args = {statePtr,    inputPtr,  scalePtr, biasPtr,
+                               outputPtr,   n,         c,        spatial,
                                dataTypeVal, epsilonVal};
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);

--- a/lib/Conversion/HipToLLVM/NormLowering.cpp
+++ b/lib/Conversion/HipToLLVM/NormLowering.cpp
@@ -303,12 +303,88 @@ struct LayerNormOpLowering : public ConvertOpToLLVMPattern<LayerNormOp> {
   }
 };
 
+// hip.instance_norm(%ctx) ins(%input, %scale, %bias) outs(%output)
+//   -> wrap_instance_normalization(state, input, scale, bias, output,
+//        n, c, spatial, data_type, epsilon)
+struct InstanceNormOpLowering : public ConvertOpToLLVMPattern<InstanceNormOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(InstanceNormOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+    Type ptrType = getPtrType();
+    Type i64Type = rewriter.getI64Type();
+    Type f32Type = rewriter.getF32Type();
+
+    Value statePtr = adaptor.getCtx();
+    Value inputPtr =
+        extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value scalePtr =
+        extractContiguousMemRefPtr(adaptor.getScale(), rewriter, loc);
+    Value biasPtr =
+        extractContiguousMemRefPtr(adaptor.getBias(), rewriter, loc);
+    Value outputPtr =
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
+
+    auto inputType = cast<MemRefType>(op.getInput().getType());
+    if (inputType.getRank() < 3)
+      return rewriter.notifyMatchFailure(
+          op, "hip.instance_norm requires input rank >= 3");
+
+    Value n =
+        getMemRefDimSize(inputType, 0, adaptor.getInput(), rewriter, loc);
+    Value c =
+        getMemRefDimSize(inputType, 1, adaptor.getInput(), rewriter, loc);
+    Value spatial = LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                             rewriter.getI64IntegerAttr(1));
+    for (int64_t dimIdx = 2, rank = inputType.getRank(); dimIdx < rank;
+         ++dimIdx) {
+      spatial = LLVM::MulOp::create(
+          rewriter, loc,
+          getMemRefDimSize(inputType, static_cast<unsigned>(dimIdx),
+                           adaptor.getInput(), rewriter, loc),
+          spatial);
+    }
+
+    int64_t dataType = getHipdnnDataType(inputType.getElementType());
+    if (dataType < 0)
+      return rewriter.notifyMatchFailure(op, "unsupported element type");
+    Value dataTypeVal = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(dataType));
+    Value epsilonVal =
+        LLVM::ConstantOp::create(rewriter, loc, f32Type, op.getEpsilonAttr());
+
+    SmallVector<Type> paramTypes = {
+        ptrType,                   // state
+        ptrType, ptrType, ptrType, // input, scale, bias
+        ptrType,                   // output
+        i64Type, i64Type, i64Type, // n, c, spatial
+        i64Type, f32Type           // data_type, epsilon
+    };
+
+    FailureOr<LLVM::LLVMFuncOp> funcOp =
+        LLVM::lookupOrCreateFn(rewriter, module, kWrapInstanceNormalization,
+                               paramTypes, rewriter.getI32Type());
+    if (failed(funcOp))
+      return failure();
+
+    SmallVector<Value> args = {statePtr,  inputPtr,     scalePtr,    biasPtr,
+                               outputPtr, n,            c,           spatial,
+                               dataTypeVal, epsilonVal};
+    LLVM::CallOp::create(rewriter, loc, *funcOp, args);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 } // namespace
 
 void populateNormLoweringPatterns(const LLVMTypeConverter &converter,
                                   RewritePatternSet &patterns) {
-  patterns.add<RmsNormOpLowering, SkipRmsNormOpLowering, LayerNormOpLowering>(
-      converter);
+  patterns.add<RmsNormOpLowering, SkipRmsNormOpLowering, LayerNormOpLowering,
+               InstanceNormOpLowering>(converter);
 }
 
 } // namespace hip

--- a/lib/Conversion/OnnxToHip/NormConversion.cpp
+++ b/lib/Conversion/OnnxToHip/NormConversion.cpp
@@ -16,6 +16,7 @@
 //   - onnx.Custom(SkipSimplifiedLayerNormalization)     -> hip.skip_rms_norm
 //   - onnx.Custom(SkipLayerNormalization)               -> add + layer_norm
 //   - onnx.LayerNormalization (standard, opset 17+)     -> hip.layer_norm
+//   - onnx.InstanceNormalization                        -> hip.instance_norm
 //===----------------------------------------------------------------------===//
 
 #include "OnnxToHipUtils.h"
@@ -632,14 +633,79 @@ LayerNormToHip::matchAndRewrite(mlir::Operation *op,
   return mlir::success();
 }
 
+//===----------------------------------------------------------------------===//
+// onnx.InstanceNormalization -> hip.instance_norm
+//===----------------------------------------------------------------------===//
+
+/// ONNX InstanceNormalization (schema 6+ / 22):
+///   inputs:  input (N,C,D1,...,Dn), scale (C), B (C)
+///   attrs:   epsilon (default 1e-5)
+///   output:  same shape as input
+///
+///   y = scale * (x - mean) / sqrt(variance + epsilon) + B
+///   mean/var are per (N, C) over the spatial axes D1..Dn.
+struct InstanceNormToHip : public mlir::RewritePattern {
+  InstanceNormToHip(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.InstanceNormalization", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override;
+};
+
+mlir::LogicalResult
+InstanceNormToHip::matchAndRewrite(mlir::Operation *op,
+                                   mlir::PatternRewriter &rewriter) const {
+  if (op->getNumOperands() != 3 || op->getNumResults() != 1)
+    return rewriter.notifyMatchFailure(
+        op, "InstanceNormalization expects 3 operands (X, scale, B) and 1 "
+            "result");
+
+  auto ctxOrFailure = getContextArg(op, rewriter);
+  if (mlir::failed(ctxOrFailure))
+    return rewriter.notifyMatchFailure(op, "missing context argument");
+  mlir::Value context = *ctxOrFailure;
+
+  mlir::Location loc = op->getLoc();
+  mlir::Value input = op->getOperand(0);
+  mlir::Value scale = op->getOperand(1);
+  mlir::Value bias = op->getOperand(2);
+
+  auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(input.getType());
+  if (!inputType || inputType.getRank() < 3)
+    return rewriter.notifyMatchFailure(
+        op, "InstanceNormalization requires ranked input of rank >= 3");
+
+  auto scaleType = mlir::dyn_cast<mlir::RankedTensorType>(scale.getType());
+  auto biasType = mlir::dyn_cast<mlir::RankedTensorType>(bias.getType());
+  if (!scaleType || scaleType.getRank() != 1 || !biasType ||
+      biasType.getRank() != 1)
+    return rewriter.notifyMatchFailure(
+        op, "InstanceNormalization scale and B must be 1-D of length C");
+
+  llvm::APFloat epsValue(1.0e-05f);
+  if (auto a = op->getAttrOfType<mlir::FloatAttr>("epsilon"))
+    epsValue = a.getValue();
+
+  auto outputType =
+      mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
+  mlir::Value outputInit = createEmptyTensor(rewriter, loc, outputType, input);
+
+  auto hipOp = mlir::hip::InstanceNormOp::create(
+      rewriter, loc, context, input, scale, bias, outputInit,
+      rewriter.getF32FloatAttr(epsValue.convertToFloat()));
+  rewriter.replaceOp(op, hipOp->getResult(0));
+  return mlir::success();
+}
+
 } // namespace
 
 void populateNormConversionPatterns(RewritePatternSet &patterns,
                                     MLIRContext *ctx) {
   patterns
       .add<SimplifiedLayerNormToHip, RMSNormalizationToHip,
-           SkipSimplifiedLayerNormToHip, SkipLayerNormToHip, LayerNormToHip>(
-          ctx);
+           SkipSimplifiedLayerNormToHip, SkipLayerNormToHip, LayerNormToHip,
+           InstanceNormToHip>(ctx);
 }
 
 } // namespace hip

--- a/lib/Conversion/OnnxToHip/NormConversion.cpp
+++ b/lib/Conversion/OnnxToHip/NormConversion.cpp
@@ -702,10 +702,9 @@ InstanceNormToHip::matchAndRewrite(mlir::Operation *op,
 
 void populateNormConversionPatterns(RewritePatternSet &patterns,
                                     MLIRContext *ctx) {
-  patterns
-      .add<SimplifiedLayerNormToHip, RMSNormalizationToHip,
-           SkipSimplifiedLayerNormToHip, SkipLayerNormToHip, LayerNormToHip,
-           InstanceNormToHip>(ctx);
+  patterns.add<SimplifiedLayerNormToHip, RMSNormalizationToHip,
+               SkipSimplifiedLayerNormToHip, SkipLayerNormToHip, LayerNormToHip,
+               InstanceNormToHip>(ctx);
 }
 
 } // namespace hip

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -803,8 +803,7 @@ LogicalResult InstanceNormOp::verify() {
     return emitOpError("expected 1-D scale of length C, got rank ")
            << *scaleRank;
   if (biasRank && *biasRank != 1)
-    return emitOpError("expected 1-D bias of length C, got rank ")
-           << *biasRank;
+    return emitOpError("expected 1-D bias of length C, got rank ") << *biasRank;
   return success();
 }
 

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -763,6 +763,52 @@ LogicalResult LayerNormOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// InstanceNormOp: ins(input, scale, bias), outs(output)
+//===----------------------------------------------------------------------===//
+
+MutableOperandRange InstanceNormOp::getDpsInitsMutable() {
+  return getOutputMutable();
+}
+
+void InstanceNormOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
+}
+
+LogicalResult InstanceNormOp::verify() {
+  SmallVector<Value> dataOperands{getInput(), getScale(), getBias(),
+                                  getOutput()};
+  if (failed(verifyDpsComputeOp(*this, dataOperands, /*numInits=*/1)))
+    return failure();
+
+  auto rankedShape = [](Type t) -> std::optional<int64_t> {
+    if (auto tensor = dyn_cast<RankedTensorType>(t))
+      return tensor.getRank();
+    if (auto memref = dyn_cast<MemRefType>(t))
+      return memref.getRank();
+    return std::nullopt;
+  };
+
+  auto inputRank = rankedShape(getInput().getType());
+  if (!inputRank)
+    return emitOpError("expected ranked input of rank >= 3 (N, C, D1, ...)");
+  if (*inputRank < 3)
+    return emitOpError("expected input rank >= 3 (N, C, D1, ...), got ")
+           << *inputRank;
+
+  auto scaleRank = rankedShape(getScale().getType());
+  auto biasRank = rankedShape(getBias().getType());
+  if (scaleRank && *scaleRank != 1)
+    return emitOpError("expected 1-D scale of length C, got rank ")
+           << *scaleRank;
+  if (biasRank && *biasRank != 1)
+    return emitOpError("expected 1-D bias of length C, got rank ")
+           << *biasRank;
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // RopeOp: ins(input, [position_ids], cos_cache, sin_cache), outs(output)
 //===----------------------------------------------------------------------===//
 

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -303,6 +303,7 @@ if(NOT BUILD_MOCK_RUNTIME)
     compile_to_bitcode(real/bias_gelu.cpp runtime_bias_gelu.bc)
     compile_to_bitcode(real/fast_gelu.cpp runtime_fast_gelu.bc)
     compile_to_bitcode(real/layer_normalization.cpp runtime_layer_normalization.bc)
+    compile_to_bitcode(real/instance_normalization.cpp runtime_instance_normalization.bc)
     compile_to_bitcode(real/simplified_layer_norm.cpp runtime_simplified_layer_norm.bc)
     compile_to_bitcode(real/skip_simplified_layer_norm.cpp runtime_skip_simplified_layer_norm.bc)
     compile_to_bitcode(real/rotary_embedding.cpp runtime_rotary_embedding.bc)
@@ -379,6 +380,7 @@ if(NOT BUILD_MOCK_RUNTIME)
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_bias_gelu.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_fast_gelu.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_layer_normalization.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_instance_normalization.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_simplified_layer_norm.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_skip_simplified_layer_norm.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_rotary_embedding.bc

--- a/lib/Runtime/Kernels/CMakeLists.txt
+++ b/lib/Runtime/Kernels/CMakeLists.txt
@@ -56,6 +56,7 @@ set(_kernel_sources
     hip/cumsum_kernel.hip
     hip/pad_kernel.hip
     hip/layer_norm_kernel.hip
+    hip/instance_norm_kernel.hip
     hip/cast_kernel.hip
     hip/range_kernel.hip
     hip/gather_kernel.hip

--- a/lib/Runtime/Kernels/hip/instance_norm_kernel.hip
+++ b/lib/Runtime/Kernels/hip/instance_norm_kernel.hip
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ *
+ * InstanceNormalization: per-(N,C) mean/variance over spatial axes, then
+ * channel-wise affine.
+ *
+ *   y = scale[c] * (x - mean) * rsqrt(var + epsilon) + bias[c]
+ *
+ * Layout: input/output are (N, C, spatial) row-major. One block per (n, c)
+ * row; two-pass FP32 (or FP64 for f64) reduction, matching the LayerNorm
+ * small-N kernel.
+ */
+
+#include "hip_custom_kernels.h"
+#include "debug_log.h"
+
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+#include <cstdint>
+#include <cstdio>
+
+static constexpr int kInstanceNormBlockSize = 256;
+
+template <typename T> struct InstanceNormTraits;
+
+template <> struct InstanceNormTraits<float> {
+  using Compute = float;
+  __device__ static inline Compute load(float v) { return v; }
+  __device__ static inline float store(Compute v) { return v; }
+  __device__ static inline Compute rsqrt_fn(Compute v) { return rsqrtf(v); }
+};
+
+template <> struct InstanceNormTraits<__half> {
+  using Compute = float;
+  __device__ static inline Compute load(__half v) { return __half2float(v); }
+  __device__ static inline __half store(Compute v) { return __float2half(v); }
+  __device__ static inline Compute rsqrt_fn(Compute v) { return rsqrtf(v); }
+};
+
+template <> struct InstanceNormTraits<__hip_bfloat16> {
+  using Compute = float;
+  __device__ static inline Compute load(__hip_bfloat16 v) {
+    return __bfloat162float(v);
+  }
+  __device__ static inline __hip_bfloat16 store(Compute v) {
+    return __float2bfloat16(v);
+  }
+  __device__ static inline Compute rsqrt_fn(Compute v) { return rsqrtf(v); }
+};
+
+template <> struct InstanceNormTraits<double> {
+  using Compute = double;
+  __device__ static inline Compute load(double v) { return v; }
+  __device__ static inline double store(Compute v) { return v; }
+  __device__ static inline Compute rsqrt_fn(Compute v) { return rsqrt(v); }
+};
+
+template <typename T>
+__global__ void hip_instance_norm_kernel(const T *__restrict__ input,
+                                         const T *__restrict__ scale,
+                                         const T *__restrict__ bias,
+                                         T *__restrict__ output, int64_t outer,
+                                         int64_t channels, int64_t spatial,
+                                         float epsilon) {
+  using Tr = InstanceNormTraits<T>;
+  using Compute = typename Tr::Compute;
+
+  int64_t row = blockIdx.x;
+  if (row >= outer)
+    return;
+
+  int64_t channel = row % channels;
+  const T *x_row = input + row * spatial;
+  T *y_row = output + row * spatial;
+
+  __shared__ Compute s_sum;
+  __shared__ Compute s_sumsq;
+  __shared__ Compute s_mean;
+  __shared__ Compute s_inv_std;
+  __shared__ Compute s_reduce[kInstanceNormBlockSize];
+
+  Compute local_sum = Compute(0);
+  Compute local_sumsq = Compute(0);
+  for (int64_t i = threadIdx.x; i < spatial; i += blockDim.x) {
+    Compute v = Tr::load(x_row[i]);
+    local_sum += v;
+    local_sumsq += v * v;
+  }
+
+  s_reduce[threadIdx.x] = local_sum;
+  __syncthreads();
+  for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+    if (threadIdx.x < stride)
+      s_reduce[threadIdx.x] += s_reduce[threadIdx.x + stride];
+    __syncthreads();
+  }
+  if (threadIdx.x == 0)
+    s_sum = s_reduce[0];
+  __syncthreads();
+
+  s_reduce[threadIdx.x] = local_sumsq;
+  __syncthreads();
+  for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+    if (threadIdx.x < stride)
+      s_reduce[threadIdx.x] += s_reduce[threadIdx.x + stride];
+    __syncthreads();
+  }
+  if (threadIdx.x == 0) {
+    s_sumsq = s_reduce[0];
+    Compute mean = s_sum / static_cast<Compute>(spatial);
+    Compute var =
+        s_sumsq / static_cast<Compute>(spatial) - mean * mean;
+    if (var < Compute(0))
+      var = Compute(0);
+    s_mean = mean;
+    s_inv_std = Tr::rsqrt_fn(var + static_cast<Compute>(epsilon));
+  }
+  __syncthreads();
+
+  Compute mean = s_mean;
+  Compute inv_std = s_inv_std;
+  Compute s = Tr::load(scale[channel]);
+  Compute b = Tr::load(bias[channel]);
+  for (int64_t i = threadIdx.x; i < spatial; i += blockDim.x) {
+    Compute v = Tr::load(x_row[i]);
+    y_row[i] = Tr::store((v - mean) * inv_std * s + b);
+  }
+}
+
+extern "C" int hip_instance_norm(void *stream, const void *input,
+                                 const void *scale, const void *bias,
+                                 void *output, int64_t n, int64_t c,
+                                 int64_t spatial, float epsilon,
+                                 int hip_dtype) {
+  if (n <= 0 || c <= 0 || spatial <= 0)
+    return 0;
+
+  hipStream_t hip_stream = static_cast<hipStream_t>(stream);
+  int64_t outer = n * c;
+  dim3 grid(static_cast<unsigned int>(outer));
+  dim3 block(kInstanceNormBlockSize);
+
+  (void)hipGetLastError();
+
+  CUSTOM_KERNELS_DEBUG_LOG(
+      "[custom_kernels] hip_instance_norm: dtype=%d n=%lld c=%lld spatial=%lld "
+      "eps=%f\n",
+      hip_dtype, (long long)n, (long long)c, (long long)spatial, epsilon);
+
+  if (hip_dtype == HIP_DTYPE_FLOAT16) {
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_instance_norm_kernel<__half>), grid,
+                       block, 0, hip_stream, static_cast<const __half *>(input),
+                       static_cast<const __half *>(scale),
+                       static_cast<const __half *>(bias),
+                       static_cast<__half *>(output), outer, c, spatial,
+                       epsilon);
+  } else if (hip_dtype == HIP_DTYPE_BFLOAT16) {
+    hipLaunchKernelGGL(
+        HIP_KERNEL_NAME(hip_instance_norm_kernel<__hip_bfloat16>), grid, block,
+        0, hip_stream, static_cast<const __hip_bfloat16 *>(input),
+        static_cast<const __hip_bfloat16 *>(scale),
+        static_cast<const __hip_bfloat16 *>(bias),
+        static_cast<__hip_bfloat16 *>(output), outer, c, spatial, epsilon);
+  } else if (hip_dtype == HIP_DTYPE_FLOAT32) {
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_instance_norm_kernel<float>), grid,
+                       block, 0, hip_stream, static_cast<const float *>(input),
+                       static_cast<const float *>(scale),
+                       static_cast<const float *>(bias),
+                       static_cast<float *>(output), outer, c, spatial,
+                       epsilon);
+  } else if (hip_dtype == HIP_DTYPE_FLOAT64) {
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_instance_norm_kernel<double>), grid,
+                       block, 0, hip_stream, static_cast<const double *>(input),
+                       static_cast<const double *>(scale),
+                       static_cast<const double *>(bias),
+                       static_cast<double *>(output), outer, c, spatial,
+                       epsilon);
+  } else {
+    fprintf(stderr, "[custom_kernels] hip_instance_norm: unsupported dtype=%d\n",
+            hip_dtype);
+    return -1;
+  }
+
+  hipError_t err = hipGetLastError();
+  if (err != hipSuccess) {
+    fprintf(stderr, "[custom_kernels] hip_instance_norm launch failed: %s\n",
+            hipGetErrorString(err));
+  }
+  return static_cast<int>(err);
+}

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -1501,6 +1501,29 @@ HIP_KERNEL_API int hip_layer_norm(
     int mean_dtype);
 
 /* =========================================================================
+ * InstanceNormalization
+ * =========================================================================
+ *
+ *   y = scale[c] * (x - mean) * rsqrt(var + epsilon) + bias[c]
+ *
+ * Mean/var over the spatial axes of each (N, C) slice. Input is
+ * (N, C, spatial) in row-major layout. Scale and bias are length C.
+ *
+ * `hip_dtype`: FLOAT16, BFLOAT16, FLOAT32, or FLOAT64.
+ */
+HIP_KERNEL_API int hip_instance_norm(
+    void* stream,
+    const void* input,
+    const void* scale,
+    const void* bias,
+    void* output,
+    int64_t n,
+    int64_t c,
+    int64_t spatial,
+    float epsilon,
+    int hip_dtype);
+
+/* =========================================================================
  * Range (1-D sequence generation)
  * =========================================================================
  *

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -1207,6 +1207,13 @@ int wrap_layer_normalization(RuntimeState *state, void *input, void *scale,
                              int64_t element_size_bytes, int64_t axis,
                              float epsilon, int64_t stash_type);
 
+// InstanceNormalization: y = scale * (x - mean) / sqrt(var + epsilon) + B
+// with mean/var over spatial axes of each (N, C) slice. Input is (N,C,D1..Dn).
+int wrap_instance_normalization(RuntimeState *state, void *input, void *scale,
+                                void *bias, void *output, int64_t n, int64_t c,
+                                int64_t spatial, int64_t data_type,
+                                float epsilon);
+
 // SkipSimplifiedLayerNormalization operation wrapper (Full MS spec)
 // Computes: input_skip_bias_sum = input + skip [+ bias]
 //           output = RMSNorm(input_skip_bias_sum) * gamma

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -2006,6 +2006,26 @@ int wrap_layer_normalization(RuntimeState *state, void *input, void *scale,
   return 0;
 }
 
+int wrap_instance_normalization(RuntimeState *state, void *input, void *scale,
+                                void *bias, void *output, int64_t n, int64_t c,
+                                int64_t spatial, int64_t data_type,
+                                float epsilon) {
+  if (!state) {
+    fprintf(stderr, "Invalid state in wrap_instance_normalization\n");
+    return -1;
+  }
+
+  MOCK_PRINT("[MOCK] wrap_instance_normalization(n=%lld, c=%lld, spatial=%lld, "
+             "data_type=%lld, epsilon=%f)\n",
+             (long long)n, (long long)c, (long long)spatial,
+             (long long)data_type, epsilon);
+  (void)input;
+  (void)scale;
+  (void)bias;
+  (void)output;
+  return 0;
+}
+
 int wrap_hipMemcpyD2H(void *dst, const void *src, int64_t size, void *stream) {
   HIP_CHECK(hipMemcpyAsync(dst, src, size, hipMemcpyDeviceToHost,
                            static_cast<hipStream_t>(stream)));

--- a/lib/Runtime/real/instance_normalization.cpp
+++ b/lib/Runtime/real/instance_normalization.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// InstanceNormalization: y = scale * (x - mean) / sqrt(var + epsilon) + B
+// Mean/var are computed per (N, C) over the spatial axes.
+
+#include "../debug_log.h"
+#include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
+#include "hip_custom_kernels.h"
+#include "runtime_types.h"
+
+#include <cstdio>
+#include <string>
+
+static int hipdnn_ep_to_hip_dtype_instance_norm(int64_t data_type) {
+  switch (data_type) {
+  case HIPDNN_EP_DATATYPE_FLOAT:
+    return HIP_DTYPE_FLOAT32;
+  case HIPDNN_EP_DATATYPE_HALF:
+    return HIP_DTYPE_FLOAT16;
+  case HIPDNN_EP_DATATYPE_BFLOAT16:
+    return HIP_DTYPE_BFLOAT16;
+  case HIPDNN_EP_DATATYPE_DOUBLE:
+    return HIP_DTYPE_FLOAT64;
+  default:
+    return -1;
+  }
+}
+
+HIPDNN_EP_RT_EXPORT int wrap_instance_normalization(
+    RuntimeState *state, void *input, void *scale, void *bias, void *output,
+    int64_t n, int64_t c, int64_t spatial, int64_t data_type, float epsilon) {
+  OP_PROFILE(
+      "instancenorm",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "%lldx%lldx%lld", (long long)n, (long long)c,
+                 (long long)spatial);
+        return std::string(b);
+      },
+      state);
+
+  if (!state || !input || !scale || !bias || !output) {
+    RUNTIME_DEBUG_LOG("[REAL] wrap_instance_normalization: null required arg\n");
+    return -1;
+  }
+  if (n <= 0 || c <= 0 || spatial <= 0) {
+    RUNTIME_DEBUG_LOG(
+        "[REAL] wrap_instance_normalization: empty shape n=%lld c=%lld "
+        "spatial=%lld\n",
+        (long long)n, (long long)c, (long long)spatial);
+    return 0;
+  }
+
+  int hip_dtype = hipdnn_ep_to_hip_dtype_instance_norm(data_type);
+  if (hip_dtype < 0) {
+    fprintf(stderr,
+            "[REAL] wrap_instance_normalization: unsupported data_type=%lld\n",
+            (long long)data_type);
+    return -1;
+  }
+
+  void *stream = hipdnn_ep_state_get_stream(state);
+  RUNTIME_DEBUG_LOG(
+      "[REAL] wrap_instance_normalization: n=%lld c=%lld spatial=%lld "
+      "dtype=%lld eps=%e\n",
+      (long long)n, (long long)c, (long long)spatial, (long long)data_type,
+      (double)epsilon);
+
+  return hip_instance_norm(stream, input, scale, bias, output, n, c, spatial,
+                           epsilon, hip_dtype);
+}

--- a/lib/Runtime/real/instance_normalization.cpp
+++ b/lib/Runtime/real/instance_normalization.cpp
@@ -30,9 +30,10 @@ static int hipdnn_ep_to_hip_dtype_instance_norm(int64_t data_type) {
   }
 }
 
-HIPDNN_EP_RT_EXPORT int wrap_instance_normalization(
-    RuntimeState *state, void *input, void *scale, void *bias, void *output,
-    int64_t n, int64_t c, int64_t spatial, int64_t data_type, float epsilon) {
+HIPDNN_EP_RT_EXPORT int
+wrap_instance_normalization(RuntimeState *state, void *input, void *scale,
+                            void *bias, void *output, int64_t n, int64_t c,
+                            int64_t spatial, int64_t data_type, float epsilon) {
   OP_PROFILE(
       "instancenorm",
       [&] {
@@ -44,7 +45,8 @@ HIPDNN_EP_RT_EXPORT int wrap_instance_normalization(
       state);
 
   if (!state || !input || !scale || !bias || !output) {
-    RUNTIME_DEBUG_LOG("[REAL] wrap_instance_normalization: null required arg\n");
+    RUNTIME_DEBUG_LOG(
+        "[REAL] wrap_instance_normalization: null required arg\n");
     return -1;
   }
   if (n <= 0 || c <= 0 || spatial <= 0) {

--- a/test/lit/Conversion/hip-to-llvm/test_instance_normalization.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_instance_normalization.mlir
@@ -1,0 +1,46 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify hip.instance_norm lowers to llvm.call @wrap_instance_normalization.
+// ============================================================================
+
+// RUN: hip-mlir-opt %s --convert-hip-to-llvm | FileCheck %s
+
+module {
+  func.func @instance_norm_static(
+      %ctx: !hip.context,
+      %input: memref<2x3x8x8xf32, 1>,
+      %scale: memref<3xf32, 1>,
+      %bias: memref<3xf32, 1>,
+      %output: memref<2x3x8x8xf32, 1>) {
+    // CHECK-LABEL: llvm.func @instance_norm_static
+    hip.instance_norm(%ctx)
+        ins(%input, %scale, %bias :
+            memref<2x3x8x8xf32, 1>, memref<3xf32, 1>, memref<3xf32, 1>)
+        outs(%output : memref<2x3x8x8xf32, 1>)
+        {epsilon = 1.000000e-05 : f32}
+    // CHECK: llvm.call @wrap_instance_normalization
+    return
+  }
+
+  func.func @instance_norm_dynamic(
+      %ctx: !hip.context,
+      %input: memref<1x3x?x?xf16, 1>,
+      %scale: memref<3xf16, 1>,
+      %bias: memref<3xf16, 1>,
+      %output: memref<1x3x?x?xf16, 1>) {
+    // CHECK-LABEL: llvm.func @instance_norm_dynamic
+    hip.instance_norm(%ctx)
+        ins(%input, %scale, %bias :
+            memref<1x3x?x?xf16, 1>, memref<3xf16, 1>, memref<3xf16, 1>)
+        outs(%output : memref<1x3x?x?xf16, 1>)
+        {epsilon = 1.000000e-05 : f32}
+    // CHECK: llvm.mlir.constant(1 : i64)
+    // CHECK: llvm.extractvalue {{.*}}[3, 2]
+    // CHECK: llvm.mul
+    // CHECK: llvm.call @wrap_instance_normalization
+    return
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_instance_normalization.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_instance_normalization.mlir
@@ -1,0 +1,59 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify ONNX InstanceNormalization is lowered to hip.instance_norm.
+//
+// Test cases:
+// 1. Static NCHW f32
+// 2. Rank-3 (N, C, D) f16
+// 3. Dynamic spatial dims
+// ============================================================================
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+    return %arg0 : tensor<4xf32>
+  }
+
+  // --- Case 1: NCHW f32 ---
+  func.func @instance_norm_nchw(%X: tensor<2x3x8x8xf32>, %Scale: tensor<3xf32>, %B: tensor<3xf32>) -> tensor<2x3x8x8xf32> {
+    %Y = "onnx.InstanceNormalization"(%X, %Scale, %B) {epsilon = 9.99999974E-6 : f32} : (tensor<2x3x8x8xf32>, tensor<3xf32>, tensor<3xf32>) -> tensor<2x3x8x8xf32>
+    return %Y : tensor<2x3x8x8xf32>
+  }
+
+  // CHECK-LABEL: func.func @instance_norm_nchw
+  // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[X:.*]]: tensor<2x3x8x8xf32>, %[[SCALE:.*]]: tensor<3xf32>, %[[B:.*]]: tensor<3xf32>)
+  // CHECK-NOT: onnx.InstanceNormalization
+  // CHECK: tensor.empty() : tensor<2x3x8x8xf32>
+  // CHECK: hip.instance_norm(%[[CTX]])
+  // CHECK-SAME: ins(%[[X]], %[[SCALE]], %[[B]] :
+
+  // --- Case 2: rank-3 f16 ---
+  func.func @instance_norm_rank3(%X: tensor<1x4x16xf16>, %Scale: tensor<4xf16>, %B: tensor<4xf16>) -> tensor<1x4x16xf16> {
+    %Y = "onnx.InstanceNormalization"(%X, %Scale, %B) {epsilon = 1.000000e-05 : f32} : (tensor<1x4x16xf16>, tensor<4xf16>, tensor<4xf16>) -> tensor<1x4x16xf16>
+    return %Y : tensor<1x4x16xf16>
+  }
+
+  // CHECK-LABEL: func.func @instance_norm_rank3
+  // CHECK-NOT: onnx.InstanceNormalization
+  // CHECK: hip.instance_norm(%{{[^)]*}})
+
+  // --- Case 3: dynamic spatial ---
+  func.func @instance_norm_dynamic(%X: tensor<1x3x?x?xf16>, %Scale: tensor<3xf16>, %B: tensor<3xf16>) -> tensor<1x3x?x?xf16> {
+    %Y = "onnx.InstanceNormalization"(%X, %Scale, %B) {epsilon = 1.000000e-05 : f32} : (tensor<1x3x?x?xf16>, tensor<3xf16>, tensor<3xf16>) -> tensor<1x3x?x?xf16>
+    return %Y : tensor<1x3x?x?xf16>
+  }
+
+  // CHECK-LABEL: func.func @instance_norm_dynamic
+  // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[X:.*]]: tensor<1x3x?x?xf16>
+  // CHECK-DAG: %[[C2:.*]] = arith.constant 2 : index
+  // CHECK-DAG: %[[C3:.*]] = arith.constant 3 : index
+  // CHECK: %[[DIM2:.*]] = tensor.dim %[[X]], %[[C2]]
+  // CHECK: %[[DIM3:.*]] = tensor.dim %[[X]], %[[C3]]
+  // CHECK: %[[INIT:.*]] = tensor.empty(%[[DIM2]], %[[DIM3]]) : tensor<1x3x?x?xf16>
+  // CHECK: hip.instance_norm(%[[CTX]])
+  // CHECK-SAME: outs(%[[INIT]] :
+}

--- a/test/lit/e2e/test_instance_normalization_model.mlir
+++ b/test/lit/e2e/test_instance_normalization_model.mlir
@@ -1,0 +1,23 @@
+// RUN: hip-mlir-opt %s --hipdnn-pipeline | FileCheck %s
+
+// Test InstanceNormalization E2E full pipeline.
+//
+// 1. convert-onnx-to-hip: onnx.InstanceNormalization → hip.instance_norm
+// 2. convert-hip-to-llvm: hip.instance_norm → llvm.call @wrap_instance_normalization
+//
+// CHECK: module attributes {
+// CHECK-SAME: hipdnn.input_count = 3
+// CHECK-SAME: hipdnn.output_count = 1
+// CHECK: llvm.func @wrap_instance_normalization
+// CHECK: llvm.func @inference_init
+// CHECK: llvm.func @inference_compute
+// CHECK: llvm.func @inference_cleanup
+// CHECK: llvm.func @inference_get_metadata_json
+// CHECK-NOT: onnx.InstanceNormalization
+module {
+  func.func @main_graph(%arg0: tensor<2x3x8x8xf32> {onnx.name = "X"}, %arg1: tensor<3xf32> {onnx.name = "scale"}, %arg2: tensor<3xf32> {onnx.name = "B"}) -> (tensor<2x3x8x8xf32> {onnx.name = "Y"}) {
+    %0 = "onnx.InstanceNormalization"(%arg0, %arg1, %arg2) {epsilon = 9.99999974E-6 : f32, onnx_node_name = "instancenorm_node"} : (tensor<2x3x8x8xf32>, tensor<3xf32>, tensor<3xf32>) -> tensor<2x3x8x8xf32>
+    "onnx.Return"(%0) : (tensor<2x3x8x8xf32>) -> ()
+  }
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}

--- a/test/numeric/tests/test_layer_norm.py
+++ b/test/numeric/tests/test_layer_norm.py
@@ -382,69 +382,7 @@ def _make_instance_norm_model(input_shape: list[int], dtype=np.float32):
         ["Y"],
         epsilon=1e-5,
     )
-    return make_model_from_nodes(
-        [node], [X], [Y], initializers=[scale_init, bias_init]
-    )
-
-
-class TestInstanceNormalization:
-    """Per-(N, C) mean/var over spatial axes, then channel affine."""
-
-    @pytest.mark.parametrize(
-        "input_shape",
-        [
-            [1, 4, 8],
-            [2, 3, 8, 8],
-            [1, 3, 4, 5, 6],
-        ],
-    )
-    def test_instance_norm_f32(self, model_runner, input_shape):
-        model = _make_instance_norm_model(input_shape, np.float32)
-        rng = np.random.default_rng(7)
-        x = rng.uniform(-2, 2, input_shape).astype(np.float32)
-        actual, expected = model_runner.run_sample(model, [x])
-        compare_outputs(actual, expected, atol=1e-5, rtol=1e-5)
-
-    @pytest.mark.parametrize(
-        "input_shape",
-        [
-            [1, 4, 16],
-            [2, 3, 8, 8],
-        ],
-    )
-    def test_instance_norm_f16(self, model_runner, input_shape):
-        model = _make_instance_norm_model(input_shape, np.float16)
-        rng = np.random.default_rng(8)
-        x = rng.uniform(-2, 2, input_shape).astype(np.float16)
-        actual, expected = model_runner.run_sample(model, [x])
-        compare_outputs(actual, expected, atol=2e-3, rtol=1e-3)
-
-
-def _make_instance_norm_model(input_shape: list[int], dtype=np.float32):
-    """Build an ONNX InstanceNormalization model (scale/B as initializers)."""
-    channels = input_shape[1]
-    tp = {
-        np.float16: TensorProto.FLOAT16,
-        np.float32: TensorProto.FLOAT,
-    }[dtype]
-    X = helper.make_tensor_value_info("X", tp, input_shape)
-    Y = helper.make_tensor_value_info("Y", tp, input_shape)
-    rng = np.random.default_rng(2026)
-    scale_init = numpy_helper.from_array(
-        rng.uniform(0.5, 1.5, [channels]).astype(dtype), name="scale"
-    )
-    bias_init = numpy_helper.from_array(
-        rng.uniform(-0.5, 0.5, [channels]).astype(dtype), name="B"
-    )
-    node = helper.make_node(
-        "InstanceNormalization",
-        ["X", "scale", "B"],
-        ["Y"],
-        epsilon=1e-5,
-    )
-    return make_model_from_nodes(
-        [node], [X], [Y], initializers=[scale_init, bias_init]
-    )
+    return make_model_from_nodes([node], [X], [Y], initializers=[scale_init, bias_init])
 
 
 class TestInstanceNormalization:

--- a/test/numeric/tests/test_layer_norm.py
+++ b/test/numeric/tests/test_layer_norm.py
@@ -358,3 +358,123 @@ class TestLayerNormalization:
         x = rng.uniform(-2, 2, input_shape).astype(np.float32)
         actual, expected = model_runner.run_sample(model, [x])
         compare_outputs(actual, expected, atol=1e-5, rtol=1e-5)
+
+
+def _make_instance_norm_model(input_shape: list[int], dtype=np.float32):
+    """Build an ONNX InstanceNormalization model (scale/B as initializers)."""
+    channels = input_shape[1]
+    tp = {
+        np.float16: TensorProto.FLOAT16,
+        np.float32: TensorProto.FLOAT,
+    }[dtype]
+    X = helper.make_tensor_value_info("X", tp, input_shape)
+    Y = helper.make_tensor_value_info("Y", tp, input_shape)
+    rng = np.random.default_rng(2026)
+    scale_init = numpy_helper.from_array(
+        rng.uniform(0.5, 1.5, [channels]).astype(dtype), name="scale"
+    )
+    bias_init = numpy_helper.from_array(
+        rng.uniform(-0.5, 0.5, [channels]).astype(dtype), name="B"
+    )
+    node = helper.make_node(
+        "InstanceNormalization",
+        ["X", "scale", "B"],
+        ["Y"],
+        epsilon=1e-5,
+    )
+    return make_model_from_nodes(
+        [node], [X], [Y], initializers=[scale_init, bias_init]
+    )
+
+
+class TestInstanceNormalization:
+    """Per-(N, C) mean/var over spatial axes, then channel affine."""
+
+    @pytest.mark.parametrize(
+        "input_shape",
+        [
+            [1, 4, 8],
+            [2, 3, 8, 8],
+            [1, 3, 4, 5, 6],
+        ],
+    )
+    def test_instance_norm_f32(self, model_runner, input_shape):
+        model = _make_instance_norm_model(input_shape, np.float32)
+        rng = np.random.default_rng(7)
+        x = rng.uniform(-2, 2, input_shape).astype(np.float32)
+        actual, expected = model_runner.run_sample(model, [x])
+        compare_outputs(actual, expected, atol=1e-5, rtol=1e-5)
+
+    @pytest.mark.parametrize(
+        "input_shape",
+        [
+            [1, 4, 16],
+            [2, 3, 8, 8],
+        ],
+    )
+    def test_instance_norm_f16(self, model_runner, input_shape):
+        model = _make_instance_norm_model(input_shape, np.float16)
+        rng = np.random.default_rng(8)
+        x = rng.uniform(-2, 2, input_shape).astype(np.float16)
+        actual, expected = model_runner.run_sample(model, [x])
+        compare_outputs(actual, expected, atol=2e-3, rtol=1e-3)
+
+
+def _make_instance_norm_model(input_shape: list[int], dtype=np.float32):
+    """Build an ONNX InstanceNormalization model (scale/B as initializers)."""
+    channels = input_shape[1]
+    tp = {
+        np.float16: TensorProto.FLOAT16,
+        np.float32: TensorProto.FLOAT,
+    }[dtype]
+    X = helper.make_tensor_value_info("X", tp, input_shape)
+    Y = helper.make_tensor_value_info("Y", tp, input_shape)
+    rng = np.random.default_rng(2026)
+    scale_init = numpy_helper.from_array(
+        rng.uniform(0.5, 1.5, [channels]).astype(dtype), name="scale"
+    )
+    bias_init = numpy_helper.from_array(
+        rng.uniform(-0.5, 0.5, [channels]).astype(dtype), name="B"
+    )
+    node = helper.make_node(
+        "InstanceNormalization",
+        ["X", "scale", "B"],
+        ["Y"],
+        epsilon=1e-5,
+    )
+    return make_model_from_nodes(
+        [node], [X], [Y], initializers=[scale_init, bias_init]
+    )
+
+
+class TestInstanceNormalization:
+    """Per-(N, C) mean/var over spatial axes, then channel affine."""
+
+    @pytest.mark.parametrize(
+        "input_shape",
+        [
+            [1, 4, 8],
+            [2, 3, 8, 8],
+            [1, 3, 4, 5, 6],
+        ],
+    )
+    def test_instance_norm_f32(self, model_runner, input_shape):
+        model = _make_instance_norm_model(input_shape, np.float32)
+        rng = np.random.default_rng(7)
+        x = rng.uniform(-2, 2, input_shape).astype(np.float32)
+        actual, expected = model_runner.run_sample(model, [x])
+        compare_outputs(actual, expected, atol=1e-5, rtol=1e-5)
+
+    @pytest.mark.parametrize(
+        "input_shape",
+        [
+            [1, 4, 16],
+            [2, 3, 8, 8],
+        ],
+    )
+    def test_instance_norm_f16(self, model_runner, input_shape):
+        model = _make_instance_norm_model(input_shape, np.float16)
+        rng = np.random.default_rng(8)
+        x = rng.uniform(-2, 2, input_shape).astype(np.float16)
+        actual, expected = model_runner.run_sample(model, [x])
+        compare_outputs(actual, expected, atol=2e-3, rtol=1e-3)


### PR DESCRIPTION
## Summary
- Wire `onnx.InstanceNormalization` through `hip.instance_norm`, HIP-to-LLVM lowering, mock/real runtime, and a custom HIP kernel.
- Add LIT, e2e, and numeric coverage for rank >= 3 per-channel instance norm.

## Test plan
- [ ] LIT: `test_instance_normalization.mlir` (onnx-to-hip, hip-to-llvm, e2e)
- [ ] Numeric: `test/numeric/tests/test_layer_norm.py` instance-norm cases

Made with [Cursor](https://cursor.com)