### PR TITLE
feat(onnx): add Erf end-to-end

### DIFF
--- a/docs/supported-operations.md
+++ b/docs/supported-operations.md
@@ -42,6 +42,7 @@ The conversion registrations in `lib/Conversion/OnnxToHip/OnnxToHip.cpp` and the
 | Or | Custom HIP kernel |
 | Abs | Custom HIP kernel |
 | Cos | Custom HIP kernel |
+| Erf | Custom HIP kernel |
 | Sin | Custom HIP kernel |
 | Div | Custom HIP kernel |
 | Mod | Custom HIP kernel |

--- a/include/hip/Dialect/IR/HipBufferize.h
+++ b/include/hip/Dialect/IR/HipBufferize.h
@@ -177,6 +177,7 @@ registerHipBufferizableOpInterfaceModels(DialectRegistry &registry) {
     OrOp::attachInterface<HipDstBufferizableModel<OrOp>>(*ctx);
     AndOp::attachInterface<HipDstBufferizableModel<AndOp>>(*ctx);
     CosOp::attachInterface<HipDstBufferizableModel<CosOp>>(*ctx);
+    ErfOp::attachInterface<HipDstBufferizableModel<ErfOp>>(*ctx);
     SinOp::attachInterface<HipDstBufferizableModel<SinOp>>(*ctx);
     CeilOp::attachInterface<HipDstBufferizableModel<CeilOp>>(*ctx);
     ExpOp::attachInterface<HipDstBufferizableModel<ExpOp>>(*ctx);

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -2454,6 +2454,40 @@ def Hip_CosOp : Hip_DpsOp<"cos", /*traits=*/[],
   }];
 }
 
+def Hip_ErfOp : Hip_DpsOp<"erf", /*traits=*/[],
+                          /*outsAccessor=*/"Y",
+                          /*autoReify=*/1,
+                          /*autoInfer=*/1,
+                          /*declareInfer=*/1> {
+  let summary = "Element-wise error function: y = erf(x)";
+  let description = [{
+    Computes the Gauss error function of each element.
+    Implements the standard ONNX Erf operator.
+
+    Formula: Y = erf(X)
+
+    Uses destination-passing style: output buffer is provided as argument.
+
+    Example:
+    ```mlir
+    hip.erf(%ctx) ins(%x : memref<1x128x200x200xf32, 1>)
+                  outs(%y : memref<1x128x200x200xf32, 1>)
+    ```
+  }];
+
+  let arguments = (ins
+    Hip_ContextType:$ctx,
+    Hip_TensorOrMemRef:$x,
+    Hip_TensorOrMemRef:$y
+  );
+
+  let assemblyFormat = [{
+    `(` $ctx `)` `ins` `(` $x `:` type($x) `)`
+    `outs` `(` $y `:` type($y) `)`
+    attr-dict (`:` type($result_tensors)^)?
+  }];
+}
+
 def Hip_SinOp : Hip_DpsOp<"sin", /*traits=*/[],
                           /*outsAccessor=*/"Y",
                           /*autoReify=*/1,

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -109,6 +109,7 @@ inline constexpr const char *kWrapAbs = "wrap_abs";
 inline constexpr const char *kWrapNeg = "wrap_neg";
 inline constexpr const char *kWrapNot = "wrap_not";
 inline constexpr const char *kWrapCos = "wrap_cos";
+inline constexpr const char *kWrapErf = "wrap_erf";
 inline constexpr const char *kWrapSin = "wrap_sin";
 inline constexpr const char *kWrapCeil = "wrap_ceil";
 inline constexpr const char *kWrapExp = "wrap_exp";

--- a/lib/Conversion/HipToLLVM/UnaryElementwiseLowering.cpp
+++ b/lib/Conversion/HipToLLVM/UnaryElementwiseLowering.cpp
@@ -10,7 +10,7 @@ namespace hip {
 namespace {
 
 // Generic template for unary elementwise operations lowering.
-// Handles: hip.neg, hip.not, hip.cos, hip.sin, hip.sign (and future unary
+// Handles: hip.neg, hip.not, hip.cos, hip.erf, hip.sin, hip.sign (and future unary
 // elementwise ops).
 //
 // Ops lower to wrap_{op}(state, input, output, num_elements, data_type).
@@ -97,6 +97,8 @@ void populateUnaryElementwiseLoweringPatterns(
                                                      "not");
   patterns.insert<UnaryElementwiseOpLowering<CosOp>>(converter, kWrapCos,
                                                      "cos");
+  patterns.insert<UnaryElementwiseOpLowering<ErfOp>>(converter, kWrapErf,
+                                                     "erf");
   patterns.insert<UnaryElementwiseOpLowering<SinOp>>(converter, kWrapSin,
                                                      "sin");
   patterns.insert<UnaryElementwiseOpLowering<CeilOp>>(converter, kWrapCeil,

--- a/lib/Conversion/HipToLLVM/UnaryElementwiseLowering.cpp
+++ b/lib/Conversion/HipToLLVM/UnaryElementwiseLowering.cpp
@@ -10,8 +10,8 @@ namespace hip {
 namespace {
 
 // Generic template for unary elementwise operations lowering.
-// Handles: hip.neg, hip.not, hip.cos, hip.erf, hip.sin, hip.sign (and future unary
-// elementwise ops).
+// Handles: hip.neg, hip.not, hip.cos, hip.erf, hip.sin, hip.sign (and future
+// unary elementwise ops).
 //
 // Ops lower to wrap_{op}(state, input, output, num_elements, data_type).
 template <typename OpTy>

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -59,6 +59,7 @@ add_library(OnnxToHip STATIC
   MaxConversion.cpp
   NotConversion.cpp
   CosConversion.cpp
+  ErfConversion.cpp
   SinConversion.cpp
   CeilConversion.cpp
   ExpConversion.cpp

--- a/lib/Conversion/OnnxToHip/ErfConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ErfConversion.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "OnnxToHipUtils.h"
+
+namespace mlir {
+namespace hip {
+namespace {
+
+/// onnx.Erf -> hip.erf
+/// Unary element-wise Gauss error function: Y = erf(X). Float types.
+struct ErfToHip : public mlir::RewritePattern {
+  ErfToHip(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Erf", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto ctxOrFailure = getContextArg(op, rewriter);
+    if (mlir::failed(ctxOrFailure))
+      return mlir::failure();
+    mlir::Value context = *ctxOrFailure;
+
+    mlir::Location loc = op->getLoc();
+    mlir::Value input = op->getOperand(0);
+    if (!mlir::isa<mlir::RankedTensorType>(input.getType()))
+      return rewriter.notifyMatchFailure(
+          op, "onnx.Erf lowering expects a ranked tensor input");
+    auto resultType =
+        mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    mlir::Value init = createEmptyTensor(rewriter, loc, resultType, input);
+    auto hipOp = mlir::hip::ErfOp::create(rewriter, loc, context, input, init);
+    rewriter.replaceOp(op, hipOp->getResult(0));
+    return mlir::success();
+  }
+};
+
+} // namespace
+
+void populateErfConversionPatterns(RewritePatternSet &patterns,
+                                   MLIRContext *ctx) {
+  patterns.add<ErfToHip>(ctx);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -178,6 +178,7 @@ static mlir::LogicalResult convertComputeOps(mlir::func::FuncOp funcOp,
   populateMaxConversionPatterns(patterns, ctx);
   populateNotConversionPatterns(patterns, ctx);
   populateCosConversionPatterns(patterns, ctx);
+  populateErfConversionPatterns(patterns, ctx);
   populateSinConversionPatterns(patterns, ctx);
   populateCeilConversionPatterns(patterns, ctx);
   populateExpConversionPatterns(patterns, ctx);

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -366,6 +366,8 @@ void populateNotConversionPatterns(RewritePatternSet &patterns,
                                    MLIRContext *ctx);
 void populateCosConversionPatterns(RewritePatternSet &patterns,
                                    MLIRContext *ctx);
+void populateErfConversionPatterns(RewritePatternSet &patterns,
+                                   MLIRContext *ctx);
 void populateSinConversionPatterns(RewritePatternSet &patterns,
                                    MLIRContext *ctx);
 void populateCeilConversionPatterns(RewritePatternSet &patterns,

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -1742,6 +1742,18 @@ void CosOp::getEffects(
 }
 
 //===----------------------------------------------------------------------===//
+// ErfOp: ins(x), outs(y)
+//===----------------------------------------------------------------------===//
+
+MutableOperandRange ErfOp::getDpsInitsMutable() { return getYMutable(); }
+
+void ErfOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
+}
+
+//===----------------------------------------------------------------------===//
 // SinOp: ins(x), outs(y)
 //===----------------------------------------------------------------------===//
 

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -337,6 +337,7 @@ if(NOT BUILD_MOCK_RUNTIME)
     compile_to_bitcode(real/neg.cpp runtime_neg.bc)
     compile_to_bitcode(real/not.cpp runtime_not.bc)
     compile_to_bitcode(real/cos.cpp runtime_cos.bc)
+    compile_to_bitcode(real/erf.cpp runtime_erf.bc)
     compile_to_bitcode(real/sin.cpp runtime_sin.bc)
     compile_to_bitcode(real/ceil.cpp runtime_ceil.bc)
     compile_to_bitcode(real/exp.cpp runtime_exp.bc)
@@ -412,6 +413,7 @@ if(NOT BUILD_MOCK_RUNTIME)
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_neg.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_not.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_cos.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_erf.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_sin.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_ceil.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_exp.bc

--- a/lib/Runtime/Kernels/hip/elementwise_unary_kernel.hip
+++ b/lib/Runtime/Kernels/hip/elementwise_unary_kernel.hip
@@ -20,6 +20,7 @@
 #include "debug_log.h"
 
 #include <cmath>
+#include <hip/hip_bf16.h>
 #include <hip/hip_fp16.h>
 #include <hip/hip_runtime.h>
 #include <cstdint>
@@ -177,6 +178,51 @@ __global__ void elementwise_cos_f32_kernel(const float *__restrict__ input,
   if (idx < num_elements) {
     output[idx] = cosf(input[idx]);
   }
+}
+
+// =====================================================================
+// Erf: y = erf(x)
+// =====================================================================
+
+__global__ void elementwise_erf_f16_kernel(const __half *__restrict__ input,
+                                           __half *__restrict__ output,
+                                           int64_t num_elements) {
+  int64_t idx =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    float x = __half2float(input[idx]);
+    output[idx] = __float2half(erff(x));
+  }
+}
+
+__global__ void
+elementwise_erf_bf16_kernel(const __hip_bfloat16 *__restrict__ input,
+                            __hip_bfloat16 *__restrict__ output,
+                            int64_t num_elements) {
+  int64_t idx =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements) {
+    float x = __bfloat162float(input[idx]);
+    output[idx] = __float2bfloat16(erff(x));
+  }
+}
+
+__global__ void elementwise_erf_f32_kernel(const float *__restrict__ input,
+                                           float *__restrict__ output,
+                                           int64_t num_elements) {
+  int64_t idx =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements)
+    output[idx] = erff(input[idx]);
+}
+
+__global__ void elementwise_erf_f64_kernel(const double *__restrict__ input,
+                                           double *__restrict__ output,
+                                           int64_t num_elements) {
+  int64_t idx =
+      static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < num_elements)
+    output[idx] = erf(input[idx]);
 }
 
 // =====================================================================
@@ -531,6 +577,72 @@ extern "C" int hip_elementwise_cos(void *stream, const void *input,
   if (err != hipSuccess) {
     fprintf(stderr,
             "[custom_kernels] hip_elementwise_cos launch failed: %s\n",
+            hipGetErrorString(err));
+  }
+  return static_cast<int>(err);
+}
+
+extern "C" int hip_elementwise_erf(void *stream, const void *input,
+                                   void *output, int64_t num_elements,
+                                   int hip_dtype) {
+  if (num_elements <= 0)
+    return 0;
+
+  hipStream_t hip_stream = static_cast<hipStream_t>(stream);
+  constexpr int kBlockSize = 256;
+  int grid_size =
+      static_cast<int>((num_elements + kBlockSize - 1) / kBlockSize);
+
+  (void)hipGetLastError();
+
+  switch (hip_dtype) {
+  case HIP_DTYPE_FLOAT16:
+    CUSTOM_KERNELS_DEBUG_LOG(
+        "[custom_kernels] hip_elementwise_erf: f16, num=%lld\n",
+        (long long)num_elements);
+    hipLaunchKernelGGL(elementwise_erf_f16_kernel, dim3(grid_size),
+                       dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const __half *>(input),
+                       static_cast<__half *>(output), num_elements);
+    break;
+  case HIP_DTYPE_BFLOAT16:
+    CUSTOM_KERNELS_DEBUG_LOG(
+        "[custom_kernels] hip_elementwise_erf: bf16, num=%lld\n",
+        (long long)num_elements);
+    hipLaunchKernelGGL(elementwise_erf_bf16_kernel, dim3(grid_size),
+                       dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const __hip_bfloat16 *>(input),
+                       static_cast<__hip_bfloat16 *>(output), num_elements);
+    break;
+  case HIP_DTYPE_FLOAT32:
+    CUSTOM_KERNELS_DEBUG_LOG(
+        "[custom_kernels] hip_elementwise_erf: f32, num=%lld\n",
+        (long long)num_elements);
+    hipLaunchKernelGGL(elementwise_erf_f32_kernel, dim3(grid_size),
+                       dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const float *>(input),
+                       static_cast<float *>(output), num_elements);
+    break;
+  case HIP_DTYPE_FLOAT64:
+    CUSTOM_KERNELS_DEBUG_LOG(
+        "[custom_kernels] hip_elementwise_erf: f64, num=%lld\n",
+        (long long)num_elements);
+    hipLaunchKernelGGL(elementwise_erf_f64_kernel, dim3(grid_size),
+                       dim3(kBlockSize), 0, hip_stream,
+                       static_cast<const double *>(input),
+                       static_cast<double *>(output), num_elements);
+    break;
+  default:
+    fprintf(stderr,
+            "[custom_kernels] hip_elementwise_erf: unsupported dtype=%d\n",
+            hip_dtype);
+    return -1;
+  }
+
+  hipError_t err = hipGetLastError();
+  if (err != hipSuccess) {
+    fprintf(stderr,
+            "[custom_kernels] hip_elementwise_erf launch failed: %s\n",
             hipGetErrorString(err));
   }
   return static_cast<int>(err);

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -175,6 +175,13 @@ HIP_KERNEL_API int hip_elementwise_cos(
     int64_t num_elements,
     int hip_dtype);
 
+HIP_KERNEL_API int hip_elementwise_erf(
+    void* stream,
+    const void* input,
+    void* output,
+    int64_t num_elements,
+    int hip_dtype);
+
 HIP_KERNEL_API int hip_elementwise_sin(
     void* stream,
     const void* input,

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -1464,6 +1464,8 @@ void hipdnn_ep_readback_scalar(RuntimeState *state, void *host_dst,
 int wrap_size(RuntimeState *state, void *output, int64_t num_elements);
 int wrap_cos(RuntimeState *state, void *input, void *output,
              int64_t num_elements, int64_t data_type);
+int wrap_erf(RuntimeState *state, void *input, void *output,
+             int64_t num_elements, int64_t data_type);
 int wrap_sin(RuntimeState *state, void *input, void *output,
              int64_t num_elements, int64_t data_type);
 int wrap_ceil(RuntimeState *state, void *input, void *output,

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -1728,6 +1728,20 @@ int wrap_cos(RuntimeState *state, void *input, void *output,
   return 0;
 }
 
+int wrap_erf(RuntimeState *state, void *input, void *output,
+             int64_t num_elements, int64_t data_type) {
+  if (!state) {
+    fprintf(stderr, "Invalid state in wrap_erf\n");
+    return -1;
+  }
+  MOCK_PRINT("[MOCK] wrap_erf(num_elements=%lld, data_type=%s(%lld))\n",
+             (long long)num_elements, hipdnn_ep_datatype_name(data_type),
+             (long long)data_type);
+  (void)input;
+  (void)output;
+  return 0;
+}
+
 int wrap_sin(RuntimeState *state, void *input, void *output,
              int64_t num_elements, int64_t data_type) {
   if (!state) {

--- a/lib/Runtime/real/erf.cpp
+++ b/lib/Runtime/real/erf.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// Erf: y = erf(x) (element-wise Gauss error function).
+#include "../debug_log.h"
+#include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
+#include "hip_custom_kernels.h"
+
+#include <cstdio>
+
+static int erf_hipdnn_to_hip_dtype(int64_t hipdnn_type) {
+  switch (hipdnn_type) {
+  case HIPDNN_EP_DATATYPE_HALF:
+    return HIP_DTYPE_FLOAT16;
+  case HIPDNN_EP_DATATYPE_BFLOAT16:
+    return HIP_DTYPE_BFLOAT16;
+  case HIPDNN_EP_DATATYPE_FLOAT:
+    return HIP_DTYPE_FLOAT32;
+  case HIPDNN_EP_DATATYPE_DOUBLE:
+    return HIP_DTYPE_FLOAT64;
+  default:
+    return -1;
+  }
+}
+
+int wrap_erf(RuntimeState *state, void *input, void *output,
+             int64_t num_elements, int64_t data_type) {
+  OP_PROFILE(
+      "erf",
+      [&] {
+        char b[48];
+        snprintf(b, sizeof(b), "%lld:%s", (long long)num_elements,
+                 hipdnn_ep_datatype_name(data_type));
+        return std::string(b);
+      },
+      state);
+
+  if (!state || !input || !output) {
+    RUNTIME_DEBUG_LOG("[REAL] wrap_erf: null argument\n");
+    return -1;
+  }
+  if (num_elements <= 0) {
+    return 0;
+  }
+
+  int hip_dtype = erf_hipdnn_to_hip_dtype(data_type);
+  if (hip_dtype < 0) {
+    fprintf(stderr,
+            "[REAL] wrap_erf: unsupported data_type=%s(%lld) "
+            "(supported: f16, bf16, f32, f64)\n",
+            hipdnn_ep_datatype_name(data_type), (long long)data_type);
+    return -1;
+  }
+
+  void *stream = hipdnn_ep_state_get_stream(state);
+  RUNTIME_DEBUG_LOG(
+      "[REAL] wrap_erf: num=%lld, data_type=%s -> hip_elementwise_erf\n",
+      (long long)num_elements, hipdnn_ep_datatype_name(data_type));
+  return hip_elementwise_erf(stream, input, output, num_elements, hip_dtype);
+}

--- a/test/lit/Conversion/hip-to-llvm/test_erf.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_erf.mlir
@@ -1,0 +1,28 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s --convert-hip-to-llvm | FileCheck %s
+
+module {
+  func.func @erf_static_f32(
+      %ctx: !hip.context,
+      %x: memref<256xf32, 1>,
+      %y: memref<256xf32, 1>) {
+    // CHECK-LABEL: llvm.func @erf_static_f32
+    hip.erf(%ctx) ins(%x : memref<256xf32, 1>)
+                  outs(%y : memref<256xf32, 1>)
+    // CHECK: llvm.call @wrap_erf({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64) -> i32
+    return
+  }
+
+  func.func @erf_dynamic_f16(
+      %ctx: !hip.context,
+      %x: memref<?x?xf16, 1>,
+      %y: memref<?x?xf16, 1>) {
+    // CHECK-LABEL: llvm.func @erf_dynamic_f16
+    hip.erf(%ctx) ins(%x : memref<?x?xf16, 1>)
+                  outs(%y : memref<?x?xf16, 1>)
+    // CHECK: llvm.call @wrap_erf({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64) -> i32
+    return
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_erf.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_erf.mlir
@@ -1,0 +1,35 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+    return %arg0 : tensor<4xf32>
+  }
+
+  func.func @erf_f32(%input: tensor<1x128x200x200xf32>) -> tensor<1x128x200x200xf32> {
+    %result = "onnx.Erf"(%input) : (tensor<1x128x200x200xf32>) -> tensor<1x128x200x200xf32>
+    return %result : tensor<1x128x200x200xf32>
+  }
+
+  // CHECK-LABEL: func.func @erf_f32
+  // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[IN:.*]]: tensor<1x128x200x200xf32>)
+  // CHECK-NOT: onnx.Erf
+  // CHECK: tensor.empty() : tensor<1x128x200x200xf32>
+  // CHECK: hip.erf(%[[CTX]]) ins(%[[IN]] : tensor<1x128x200x200xf32>)
+
+  func.func @erf_dynamic(%input: tensor<?x?xf16>) -> tensor<?x?xf16> {
+    %result = "onnx.Erf"(%input) : (tensor<?x?xf16>) -> tensor<?x?xf16>
+    return %result : tensor<?x?xf16>
+  }
+
+  // CHECK-LABEL: func.func @erf_dynamic
+  // CHECK-SAME: (%[[CTX2:.*]]: !hip.context, %[[ARG:.*]]: tensor<?x?xf16>)
+  // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+  // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+  // CHECK: %[[DIM0:.*]] = tensor.dim %[[ARG]], %[[C0]]
+  // CHECK: %[[DIM1:.*]] = tensor.dim %[[ARG]], %[[C1]]
+  // CHECK: %[[INIT:.*]] = tensor.empty(%[[DIM0]], %[[DIM1]]) : tensor<?x?xf16>
+  // CHECK: hip.erf(%[[CTX2]]) ins(%[[ARG]] : tensor<?x?xf16>) outs(%[[INIT]] : tensor<?x?xf16>)
+}

--- a/test/lit/e2e/test_erf_model.mlir
+++ b/test/lit/e2e/test_erf_model.mlir
@@ -1,0 +1,21 @@
+// RUN: hip-mlir-opt %s --hipdnn-pipeline | FileCheck %s
+
+// Test Erf E2E full pipeline
+// Erf: Y = erf(X), lowered via wrap_erf
+
+// CHECK: module attributes {
+// CHECK-SAME: hipdnn.input_count = 1
+// CHECK-SAME: hipdnn.output_count = 1
+// CHECK: llvm.func @wrap_erf
+// CHECK: llvm.func @inference_init
+// CHECK: llvm.func @inference_compute
+// CHECK: llvm.func @inference_cleanup
+// CHECK: llvm.func @inference_get_metadata_json
+// CHECK-NOT: onnx.Erf
+module {
+  func.func @main_graph(%arg0: tensor<1x128x200x200xf32> {onnx.name = "input"}) -> (tensor<1x128x200x200xf32> {onnx.name = "output"}) {
+    %0 = "onnx.Erf"(%arg0) {onnx_node_name = "erf_node"} : (tensor<1x128x200x200xf32>) -> tensor<1x128x200x200xf32>
+    "onnx.Return"(%0) : (tensor<1x128x200x200xf32>) -> ()
+  }
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}

--- a/test/numeric/tests/test_unary_math.py
+++ b/test/numeric/tests/test_unary_math.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License.
 #
 
-"""Tests for the unary math ops Abs, Ceil, Log.
+"""Tests for the unary math ops Abs, Ceil, Log, Erf.
 
 All three route through the shared unary elementwise HIP kernel family
 (lib/Runtime/real/{abs,ceil,log}.cpp). Per those dtype tables:
@@ -111,3 +111,26 @@ class TestLog:
         x = rng.uniform(0.1, 10.0, shape).astype(np.float16)
         actual, expected = model_runner.run_sample(model, [x])
         compare_outputs(actual, expected, atol=1e-3, rtol=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Erf : y = erf(x)
+# ---------------------------------------------------------------------------
+class TestErf:
+    @pytest.mark.parametrize("dtype", [np.float16, np.float32])
+    def test_erf(self, model_runner, dtype):
+        shape = [4, 8]
+        model = _make_unary_model("Erf", dtype, shape)
+        rng = np.random.default_rng(907)
+        x = rng.uniform(-3.0, 3.0, shape).astype(dtype)
+        actual, expected = model_runner.run_sample(model, [x])
+        atol = 2e-3 if dtype == np.float16 else 1e-5
+        compare_outputs(actual, expected, atol=atol, rtol=1e-3)
+
+    def test_erf_bev_shape(self, model_runner):
+        shape = [1, 128, 200, 200]
+        model = _make_unary_model("Erf", np.float32, shape)
+        rng = np.random.default_rng(908)
+        x = rng.uniform(-2.0, 2.0, shape).astype(np.float32)
+        actual, expected = model_runner.run_sample(model, [x])
+        compare_outputs(actual, expected, atol=1e-5, rtol=1e-5)


### PR DESCRIPTION
## Summary
- Wire `onnx.Erf` through `hip.erf`, unary elementwise HIP-to-LLVM lowering, mock/real runtime, and the unary HIP kernel.
- Add LIT, e2e, and numeric coverage so Gauss error-function nodes can run on GPU.

## Test plan
- [ ] LIT: `test_erf.mlir` (onnx-to-hip, hip-to-llvm, e2e)
- [ ] Numeric: `test/numeric/tests/test_unary_math.py` Erf cases

Made with [Cursor](https://cursor.com)