### PR TITLE
feat(onnx): add GridSample end-to-end

### DIFF
--- a/docs/onnx_to_hip_frontend.md
+++ b/docs/onnx_to_hip_frontend.md
@@ -65,6 +65,7 @@ existing `--convert-hip-to-llvm` pipeline.
 |---|---|---|
 | `LayerNormalization` | `hip.miopen.layer_norm` | `miopenLayerNormForward` |
 | `SimplifiedLayerNormalization` | `hip.miopen.t5_layer_norm` | `miopenT5LayerNormForward` |
+| `GridSample` | `hip.grid_sample` | custom HIP kernel |
 | `SkipLayerNormalization` | `hip.miopen.skip_layer_norm` | `miopenAddLayerNormForward` |
 | `SkipSimplifiedLayerNormalization` | `hip.miopen.skip_rms_norm` | `miopenAddLayerNormForward` (T5 mode) |
 | LpNorm+Mul pattern (fused) | `hip.miopen.rms_norm` | `miopenT5LayerNormForward` |

--- a/docs/supported-operations.md
+++ b/docs/supported-operations.md
@@ -97,6 +97,7 @@ The conversion registrations in `lib/Conversion/OnnxToHip/OnnxToHip.cpp` and the
 | AveragePool | Custom HIP kernel |
 | LpPool | Custom HIP kernel |
 | Resize | Custom HIP kernel |
+| GridSample | Custom HIP kernel |
 | GlobalAveragePool | Custom HIP kernel |
 | GlobalMaxPool | Custom HIP kernel |
 | GlobalLpPool | Custom HIP kernel |

--- a/include/hip/Dialect/IR/HipBufferize.h
+++ b/include/hip/Dialect/IR/HipBufferize.h
@@ -143,6 +143,7 @@ registerHipBufferizableOpInterfaceModels(DialectRegistry &registry) {
     FastGeluOp::attachInterface<HipDstBufferizableModel<FastGeluOp>>(*ctx);
     LeakyReluOp::attachInterface<HipDstBufferizableModel<LeakyReluOp>>(*ctx);
     ResizeOp::attachInterface<HipDstBufferizableModel<ResizeOp>>(*ctx);
+    GridSampleOp::attachInterface<HipDstBufferizableModel<GridSampleOp>>(*ctx);
     GlobalPoolOp::attachInterface<HipDstBufferizableModel<GlobalPoolOp>>(*ctx);
     ReciprocalOp::attachInterface<HipDstBufferizableModel<ReciprocalOp>>(*ctx);
     SqrtOp::attachInterface<HipDstBufferizableModel<SqrtOp>>(*ctx);

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -4354,6 +4354,54 @@ def Hip_ResizeOp : Hip_DpsOp<"resize"> {
   }];
 }
 
+def Hip_GridSampleOp : Hip_DpsOp<"grid_sample", /*traits=*/[],
+                                 /*outsAccessor=*/"Output",
+                                 /*autoReify=*/1,
+                                 /*autoInfer=*/1,
+                                 /*declareInfer=*/1> {
+  let summary = "ONNX GridSample (4D NCHW bilinear / nearest)";
+  let description = [{
+    Samples a 4-D input `X` of shape (N, C, H_in, W_in) at normalized
+    locations from `grid` of shape (N, H_out, W_out, 2).  The last grid
+    axis is (x, y) in [-1, 1].  Output Y has shape (N, C, H_out, W_out).
+
+    Attribute encoding (decoded at ONNX->HIP conversion):
+      * mode: 0 = nearest, 1 = bilinear (ONNX "bilinear" / "linear")
+      * padding_mode: 0 = zeros, 1 = border, 2 = reflection
+      * align_corners: 0 or 1 (ONNX default 0)
+
+    Cubic / bicubic interpolation and 5-D (volumetric) sampling are
+    rejected at conversion.
+
+    Example:
+    ```mlir
+    hip.grid_sample(%ctx)
+        ins(%x, %grid : memref<1x3x8x8xf32, 1>, memref<1x4x4x2xf32, 1>)
+        outs(%y : memref<1x3x4x4xf32, 1>)
+        {mode = 1, padding_mode = 0, align_corners = 0}
+    ```
+  }];
+
+  let arguments = (ins
+    Hip_ContextType:$ctx,
+    Hip_TensorOrMemRef:$input,
+    Hip_TensorOrMemRef:$grid,
+    Hip_TensorOrMemRef:$output,
+    I64Attr:$mode,
+    I64Attr:$padding_mode,
+    I64Attr:$align_corners
+  );
+
+  let assemblyFormat = [{
+    `(` $ctx `)` `ins` `(`
+        $input `,` $grid `:` type($input) `,` type($grid)
+    `)`
+    `outs` `(` $output `:` type($output) `)`
+    attr-dict (`:` type($result_tensors)^)?
+  }];
+  let hasVerifier = 1;
+}
+
 // hip.readback_dim : materialize a kernel-computed runtime extent as a host
 // `index`. It synchronizes the stream so the producing kernel has finished,
 // then reads back a single device-resident integer `scalar`.

--- a/lib/Conversion/HipToLLVM/CMakeLists.txt
+++ b/lib/Conversion/HipToLLVM/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(HipToLLVM STATIC
   IfLowering.cpp
   PoolLowering.cpp
   ResizeLowering.cpp
+  GridSampleLowering.cpp
   GlobalPoolLowering.cpp
 )
 

--- a/lib/Conversion/HipToLLVM/GridSampleLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GridSampleLowering.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "HipToLLVMUtils.h"
+
+namespace mlir {
+namespace hip {
+namespace {
+
+//===----------------------------------------------------------------------===//
+// hip.grid_sample -> wrap_grid_sample runtime call
+//===----------------------------------------------------------------------===//
+//
+// Runtime ABI:
+//   wrap_grid_sample(state, input, grid, output,
+//                    data_type, N, C, inH, inW, outH, outW,
+//                    mode, padding_mode, align_corners)
+//   -> i32
+
+struct GridSampleOpLowering : public ConvertOpToLLVMPattern<GridSampleOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(GridSampleOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+    Type ptrType = LLVM::LLVMPointerType::get(rewriter.getContext(), 0);
+    Type i32Type = rewriter.getI32Type();
+    Type i64Type = rewriter.getI64Type();
+
+    auto inputType = dyn_cast<MemRefType>(op.getInput().getType());
+    auto gridType = dyn_cast<MemRefType>(op.getGrid().getType());
+    auto outputType = dyn_cast<MemRefType>(op.getOutput().getType());
+    if (!inputType || !gridType || !outputType)
+      return rewriter.notifyMatchFailure(op, "expected memref operands");
+    if (inputType.getRank() != 4 || gridType.getRank() != 4 ||
+        outputType.getRank() != 4)
+      return rewriter.notifyMatchFailure(op, "expected 4-D memrefs");
+
+    int64_t dataType = getHipdnnDataType(inputType.getElementType());
+    if (dataType < 0 || (dataType > 2 && dataType != 6))
+      return rewriter.notifyMatchFailure(
+          op, "GridSample: only f16 / f32 / bf16 / f64 supported");
+
+    Value statePtr = adaptor.getCtx();
+    Value inputPtr =
+        extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value gridPtr =
+        extractContiguousMemRefPtr(adaptor.getGrid(), rewriter, loc);
+    Value outputPtr =
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
+
+    Value inputDesc = adaptor.getInput();
+    Value gridDesc = adaptor.getGrid();
+
+    auto createI64 = [&](int64_t v) -> Value {
+      return LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                      rewriter.getI64IntegerAttr(v));
+    };
+
+    Value N = getMemRefDimSize(inputType, 0, inputDesc, rewriter, loc);
+    Value C = getMemRefDimSize(inputType, 1, inputDesc, rewriter, loc);
+    Value inH = getMemRefDimSize(inputType, 2, inputDesc, rewriter, loc);
+    Value inW = getMemRefDimSize(inputType, 3, inputDesc, rewriter, loc);
+    Value outH = getMemRefDimSize(gridType, 1, gridDesc, rewriter, loc);
+    Value outW = getMemRefDimSize(gridType, 2, gridDesc, rewriter, loc);
+
+    SmallVector<Type, 16> paramTypes;
+    SmallVector<Value, 16> args;
+    auto addPtr = [&](Value v) {
+      paramTypes.push_back(ptrType);
+      args.push_back(v);
+    };
+    auto addI64 = [&](Value v) {
+      paramTypes.push_back(i64Type);
+      args.push_back(v);
+    };
+
+    addPtr(statePtr);
+    addPtr(inputPtr);
+    addPtr(gridPtr);
+    addPtr(outputPtr);
+    addI64(createI64(dataType));
+    addI64(N);
+    addI64(C);
+    addI64(inH);
+    addI64(inW);
+    addI64(outH);
+    addI64(outW);
+    addI64(createI64(op.getMode()));
+    addI64(createI64(op.getPaddingMode()));
+    addI64(createI64(op.getAlignCorners()));
+
+    FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
+        rewriter, module, kWrapGridSample, paramTypes, i32Type);
+    if (failed(funcOp))
+      return failure();
+    LLVM::CallOp::create(rewriter, loc, *funcOp, args);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+} // namespace
+
+void populateGridSampleLoweringPatterns(const LLVMTypeConverter &converter,
+                                        RewritePatternSet &patterns) {
+  patterns.add<GridSampleOpLowering>(converter);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -284,6 +284,7 @@ void ConvertHipToLLVMPass::runOnOperation() {
   populateSizeLoweringPatterns(typeConverter, patterns);
   populatePoolLoweringPatterns(typeConverter, patterns);
   populateResizeLoweringPatterns(typeConverter, patterns);
+  populateGridSampleLoweringPatterns(typeConverter, patterns);
   populateGlobalPoolLoweringPatterns(typeConverter, patterns);
 
   // Standard dialect lowerings

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -121,6 +121,7 @@ inline constexpr const char *kWrapExpand = "wrap_expand";
 inline constexpr const char *kWrapReduceProd = "wrap_reduce_prod";
 inline constexpr const char *kWrapPool = "wrap_pool";
 inline constexpr const char *kWrapResize = "wrap_resize";
+inline constexpr const char *kWrapGridSample = "wrap_grid_sample";
 inline constexpr const char *kWrapGlobalPool = "wrap_global_pool";
 inline constexpr const char *kWrapLess = "wrap_less";
 inline constexpr const char *kWrapGatherND = "wrap_gather_nd";
@@ -498,6 +499,8 @@ void populatePoolLoweringPatterns(const LLVMTypeConverter &converter,
                                   RewritePatternSet &patterns);
 void populateResizeLoweringPatterns(const LLVMTypeConverter &converter,
                                     RewritePatternSet &patterns);
+void populateGridSampleLoweringPatterns(const LLVMTypeConverter &converter,
+                                        RewritePatternSet &patterns);
 void populateGlobalPoolLoweringPatterns(const LLVMTypeConverter &converter,
                                         RewritePatternSet &patterns);
 

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -87,6 +87,7 @@ add_library(OnnxToHip STATIC
   ConcatConversion.cpp
   PoolConversion.cpp
   ResizeConversion.cpp
+  GridSampleConversion.cpp
   GlobalPoolConversion.cpp
   FlattenConversion.cpp
   LoopOutline.cpp

--- a/lib/Conversion/OnnxToHip/GridSampleConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GridSampleConversion.cpp
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "OnnxToHipUtils.h"
+
+namespace mlir {
+namespace hip {
+namespace {
+
+//===----------------------------------------------------------------------===//
+// onnx.GridSample -> hip.grid_sample (4-D NCHW)
+//===----------------------------------------------------------------------===//
+//
+// Covers the ONNX GridSample subset used by BEV / STN exporters:
+//   * 4-D input (N, C, H_in, W_in)
+//   * 4-D grid  (N, H_out, W_out, 2) with last dim (x, y) in [-1, 1]
+//   * mode in {"bilinear", "linear", "nearest"}   (no cubic)
+//   * padding_mode in {"zeros", "border", "reflection"}
+//   * align_corners in {0, 1}
+//
+// Output shape is (N, C, H_out, W_out). Dynamic N/C come from the input;
+// dynamic H_out/W_out come from the grid.
+//
+// Before:
+//   %y = "onnx.GridSample"(%x, %grid)
+//          {mode = "bilinear", padding_mode = "zeros", align_corners = 0 : si64}
+//          : (tensor<1x3x8x8xf32>, tensor<1x4x4x2xf32>) -> tensor<1x3x4x4xf32>
+//
+// After:
+//   %init = tensor.empty() : tensor<1x3x4x4xf32>
+//   %y = hip.grid_sample(%ctx)
+//          ins(%x, %grid : tensor<1x3x8x8xf32>, tensor<1x4x4x2xf32>)
+//          outs(%init : tensor<1x3x4x4xf32>)
+//          {mode = 1, padding_mode = 0, align_corners = 0}
+
+struct GridSampleToHip : public mlir::RewritePattern {
+  GridSampleToHip(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.GridSample", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (op->getNumOperands() != 2 || op->getNumResults() != 1)
+      return rewriter.notifyMatchFailure(
+          op, "GridSample expects 2 operands (X, grid) and 1 result");
+
+    auto ctxOrFailure = getContextArg(op, rewriter);
+    if (mlir::failed(ctxOrFailure))
+      return rewriter.notifyMatchFailure(op, "missing context argument");
+    mlir::Value context = *ctxOrFailure;
+
+    mlir::Location loc = op->getLoc();
+    mlir::Value input = op->getOperand(0);
+    mlir::Value grid = op->getOperand(1);
+
+    auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(input.getType());
+    auto gridType = mlir::dyn_cast<mlir::RankedTensorType>(grid.getType());
+    auto outputType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    if (!inputType || !gridType || !outputType)
+      return rewriter.notifyMatchFailure(op, "expected ranked tensor types");
+    if (inputType.getRank() != 4)
+      return rewriter.notifyMatchFailure(
+          op, "only 4-D GridSample (N, C, H, W) is supported");
+    if (gridType.getRank() != 4)
+      return rewriter.notifyMatchFailure(
+          op, "grid must be 4-D (N, H_out, W_out, 2)");
+    if (outputType.getRank() != 4)
+      return rewriter.notifyMatchFailure(
+          op, "output must be 4-D (N, C, H_out, W_out)");
+    if (!gridType.isDynamicDim(3) && gridType.getDimSize(3) != 2)
+      return rewriter.notifyMatchFailure(op, "grid last dim must be 2");
+    if (!mlir::isa<mlir::FloatType>(inputType.getElementType()) ||
+        inputType.getElementType() != outputType.getElementType() ||
+        inputType.getElementType() != gridType.getElementType())
+      return rewriter.notifyMatchFailure(
+          op, "GridSample requires matching float types on X, grid, and Y");
+
+    auto getStrAttr = [&](mlir::StringRef name,
+                          mlir::StringRef defaultVal) -> std::string {
+      if (auto attr = op->getAttrOfType<mlir::StringAttr>(name))
+        return attr.getValue().str();
+      return defaultVal.str();
+    };
+
+    std::string mode = getStrAttr("mode", "linear");
+    int64_t modeId;
+    if (mode == "nearest")
+      modeId = 0;
+    else if (mode == "bilinear" || mode == "linear")
+      modeId = 1;
+    else
+      return rewriter.notifyMatchFailure(
+          op, "GridSample mode must be 'nearest', 'bilinear', or 'linear'");
+
+    std::string padding = getStrAttr("padding_mode", "zeros");
+    int64_t paddingId;
+    if (padding == "zeros")
+      paddingId = 0;
+    else if (padding == "border")
+      paddingId = 1;
+    else if (padding == "reflection")
+      paddingId = 2;
+    else
+      return rewriter.notifyMatchFailure(
+          op, "GridSample padding_mode must be 'zeros', 'border', or "
+              "'reflection'");
+
+    int64_t alignCorners = 0;
+    if (auto a = op->getAttrOfType<mlir::IntegerAttr>("align_corners"))
+      alignCorners = a.getValue().getSExtValue();
+    if (alignCorners != 0 && alignCorners != 1)
+      return rewriter.notifyMatchFailure(op, "align_corners must be 0 or 1");
+
+    // Output (N, C, H_out, W_out): N/C from input, spatial from grid.
+    llvm::SmallVector<mlir::Value> dynSizes;
+    for (int64_t i : llvm::seq<int64_t>(outputType.getRank())) {
+      if (!outputType.isDynamicDim(i))
+        continue;
+      if (i == 0 || i == 1)
+        dynSizes.push_back(
+            mlir::tensor::DimOp::create(rewriter, loc, input, i));
+      else
+        dynSizes.push_back(
+            mlir::tensor::DimOp::create(rewriter, loc, grid, i - 1));
+    }
+    mlir::Value init =
+        mlir::tensor::EmptyOp::create(rewriter, loc, outputType.getShape(),
+                                      outputType.getElementType(), dynSizes);
+
+    auto hipOp = mlir::hip::GridSampleOp::create(
+        rewriter, loc, context, input, grid, init,
+        rewriter.getI64IntegerAttr(modeId),
+        rewriter.getI64IntegerAttr(paddingId),
+        rewriter.getI64IntegerAttr(alignCorners));
+    rewriter.replaceOp(op, hipOp.getResult(0));
+    return mlir::success();
+  }
+};
+
+} // namespace
+
+void populateGridSampleConversionPatterns(RewritePatternSet &patterns,
+                                          MLIRContext *ctx) {
+  patterns.add<GridSampleToHip>(ctx);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/OnnxToHip/GridSampleConversion.cpp
+++ b/lib/Conversion/OnnxToHip/GridSampleConversion.cpp
@@ -25,8 +25,9 @@ namespace {
 //
 // Before:
 //   %y = "onnx.GridSample"(%x, %grid)
-//          {mode = "bilinear", padding_mode = "zeros", align_corners = 0 : si64}
-//          : (tensor<1x3x8x8xf32>, tensor<1x4x4x2xf32>) -> tensor<1x3x4x4xf32>
+//          {mode = "bilinear", padding_mode = "zeros", align_corners = 0 :
+//          si64} : (tensor<1x3x8x8xf32>, tensor<1x4x4x2xf32>) ->
+//          tensor<1x3x4x4xf32>
 //
 // After:
 //   %init = tensor.empty() : tensor<1x3x4x4xf32>

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -209,6 +209,7 @@ static mlir::LogicalResult convertComputeOps(mlir::func::FuncOp funcOp,
   populateClipConversionPatterns(patterns, ctx);
   populatePoolConversionPatterns(patterns, ctx);
   populateResizeConversionPatterns(patterns, ctx);
+  populateGridSampleConversionPatterns(patterns, ctx);
   populateGlobalPoolConversionPatterns(patterns, ctx);
   populateFlattenConversionPatterns(patterns, ctx);
 

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -428,6 +428,8 @@ void populatePoolConversionPatterns(RewritePatternSet &patterns,
                                     MLIRContext *ctx);
 void populateResizeConversionPatterns(RewritePatternSet &patterns,
                                       MLIRContext *ctx);
+void populateGridSampleConversionPatterns(RewritePatternSet &patterns,
+                                          MLIRContext *ctx);
 void populateGlobalPoolConversionPatterns(RewritePatternSet &patterns,
                                           MLIRContext *ctx);
 void populateFlattenConversionPatterns(RewritePatternSet &patterns,

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -1213,9 +1213,8 @@ LogicalResult GridSampleOp::verify() {
            << mode;
   int64_t padding = getPaddingMode();
   if (padding < 0 || padding > 2)
-    return emitOpError(
-               "padding_mode must be 0 (zeros), 1 (border), or 2 "
-               "(reflection), got ")
+    return emitOpError("padding_mode must be 0 (zeros), 1 (border), or 2 "
+                       "(reflection), got ")
            << padding;
   int64_t align = getAlignCorners();
   if (align != 0 && align != 1)

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -1171,6 +1171,59 @@ void ResizeOp::getEffects(
 }
 
 //===----------------------------------------------------------------------===//
+// GridSampleOp: ins(input, grid), outs(output)
+//===----------------------------------------------------------------------===//
+
+MutableOperandRange GridSampleOp::getDpsInitsMutable() {
+  return getOutputMutable();
+}
+
+void GridSampleOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
+}
+
+LogicalResult GridSampleOp::verify() {
+  SmallVector<Value> dataOperands{getInput(), getGrid(), getOutput()};
+  if (failed(verifyDpsComputeOp(*this, dataOperands, /*numInits=*/1)))
+    return failure();
+
+  auto rankedShape = [](Type t) -> std::optional<int64_t> {
+    if (auto tensor = dyn_cast<RankedTensorType>(t))
+      return tensor.getRank();
+    if (auto memref = dyn_cast<MemRefType>(t))
+      return memref.getRank();
+    return std::nullopt;
+  };
+
+  auto inputRank = rankedShape(getInput().getType());
+  auto gridRank = rankedShape(getGrid().getType());
+  auto outputRank = rankedShape(getOutput().getType());
+  if (!inputRank || *inputRank != 4)
+    return emitOpError("expected 4-D input (N, C, H, W)");
+  if (!gridRank || *gridRank != 4)
+    return emitOpError("expected 4-D grid (N, H_out, W_out, 2)");
+  if (!outputRank || *outputRank != 4)
+    return emitOpError("expected 4-D output (N, C, H_out, W_out)");
+
+  int64_t mode = getMode();
+  if (mode != 0 && mode != 1)
+    return emitOpError("mode must be 0 (nearest) or 1 (bilinear), got ")
+           << mode;
+  int64_t padding = getPaddingMode();
+  if (padding < 0 || padding > 2)
+    return emitOpError(
+               "padding_mode must be 0 (zeros), 1 (border), or 2 "
+               "(reflection), got ")
+           << padding;
+  int64_t align = getAlignCorners();
+  if (align != 0 && align != 1)
+    return emitOpError("align_corners must be 0 or 1, got ") << align;
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // GlobalPoolOp: ins(input), outs(output)
 //===----------------------------------------------------------------------===//
 

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -357,6 +357,7 @@ if(NOT BUILD_MOCK_RUNTIME)
     compile_to_bitcode(real/size.cpp runtime_size.bc)
     compile_to_bitcode(real/pool.cpp runtime_pool.bc)
     compile_to_bitcode(real/resize.cpp runtime_resize.bc)
+    compile_to_bitcode(real/grid_sample.cpp runtime_grid_sample.bc)
     compile_to_bitcode(real/global_pool.cpp runtime_global_pool.bc)
 
     set(RUNTIME_BC_MODULES
@@ -432,6 +433,7 @@ if(NOT BUILD_MOCK_RUNTIME)
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_size.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_pool.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_resize.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_grid_sample.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_global_pool.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_gather_block_quantized.bc
     )

--- a/lib/Runtime/Kernels/CMakeLists.txt
+++ b/lib/Runtime/Kernels/CMakeLists.txt
@@ -67,6 +67,7 @@ set(_kernel_sources
     hip/reduce_sum_kernel.hip
     hip/pool_kernel.hip
     hip/resize_kernel.hip
+    hip/grid_sample_kernel.hip
     hip/global_pool_kernel.hip
     hip/matmul_nbits_kernel.hip
     hip/qmoe_kernel.hip

--- a/lib/Runtime/Kernels/hip/grid_sample_kernel.hip
+++ b/lib/Runtime/Kernels/hip/grid_sample_kernel.hip
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ *
+ * ONNX GridSample (4-D NCHW). One thread per output element.
+ *
+ * Grid last dim is (x, y) in [-1, 1]. Coordinate unnormalization:
+ *   align_corners=1: ((g + 1) * (size - 1)) / 2
+ *   align_corners=0: ((g + 1) * size - 1) / 2
+ *
+ * mode: 0 nearest, 1 bilinear
+ * padding_mode: 0 zeros, 1 border, 2 reflection over [0, size-1]
+ */
+
+#include "hip_custom_kernels.h"
+#include "debug_log.h"
+
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+#include <cstdint>
+#include <cstdio>
+#include <cmath>
+
+namespace {
+
+template <typename T> __device__ inline float to_float(T v);
+template <> __device__ inline float to_float<float>(float v) { return v; }
+template <> __device__ inline float to_float<__half>(__half v) {
+  return __half2float(v);
+}
+template <> __device__ inline float to_float<__hip_bfloat16>(__hip_bfloat16 v) {
+  return __bfloat162float(v);
+}
+template <> __device__ inline float to_float<double>(double v) {
+  return static_cast<float>(v);
+}
+
+template <typename T> __device__ inline T from_float(float v);
+template <> __device__ inline float from_float<float>(float v) { return v; }
+template <> __device__ inline __half from_float<__half>(float v) {
+  return __float2half(v);
+}
+template <> __device__ inline __hip_bfloat16 from_float<__hip_bfloat16>(float v) {
+  return __float2bfloat16(v);
+}
+template <> __device__ inline double from_float<double>(float v) {
+  return static_cast<double>(v);
+}
+
+__device__ inline float unnormalize(float coord, int size, int align_corners) {
+  if (size <= 1)
+    return 0.0f;
+  if (align_corners)
+    return ((coord + 1.0f) * static_cast<float>(size - 1)) * 0.5f;
+  return ((coord + 1.0f) * static_cast<float>(size) - 1.0f) * 0.5f;
+}
+
+__device__ inline int reflect_idx(int x, int size) {
+  if (size <= 1)
+    return 0;
+  int period = 2 * size - 2;
+  int m = x % period;
+  if (m < 0)
+    m += period;
+  if (m >= size)
+    m = period - m;
+  return m;
+}
+
+template <typename T>
+__device__ inline float sample_at(const T *__restrict__ img, int h, int w,
+                                  int H, int W, int padding_mode) {
+  if (padding_mode == 0) {
+    if (h < 0 || h >= H || w < 0 || w >= W)
+      return 0.0f;
+    return to_float<T>(img[static_cast<int64_t>(h) * W + w]);
+  }
+  if (padding_mode == 1) {
+    if (h < 0)
+      h = 0;
+    if (h >= H)
+      h = H - 1;
+    if (w < 0)
+      w = 0;
+    if (w >= W)
+      w = W - 1;
+    return to_float<T>(img[static_cast<int64_t>(h) * W + w]);
+  }
+  h = reflect_idx(h, H);
+  w = reflect_idx(w, W);
+  return to_float<T>(img[static_cast<int64_t>(h) * W + w]);
+}
+
+template <typename T>
+__global__ void grid_sample_kernel(const T *__restrict__ input,
+                                   const T *__restrict__ grid,
+                                   T *__restrict__ output, int64_t N, int64_t C,
+                                   int64_t inH, int64_t inW, int64_t outH,
+                                   int64_t outW, int mode, int padding_mode,
+                                   int align_corners, int64_t total) {
+  int64_t tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (tid >= total)
+    return;
+
+  int64_t plane = outH * outW;
+  int64_t batch_stride = C * plane;
+  int64_t n = tid / batch_stride;
+  int64_t rem = tid - n * batch_stride;
+  int64_t c = rem / plane;
+  rem -= c * plane;
+  int64_t oh = rem / outW;
+  int64_t ow = rem - oh * outW;
+
+  const T *g = grid + ((n * outH + oh) * outW + ow) * 2;
+  float gx = to_float<T>(g[0]);
+  float gy = to_float<T>(g[1]);
+  float x = unnormalize(gx, static_cast<int>(inW), align_corners);
+  float y = unnormalize(gy, static_cast<int>(inH), align_corners);
+
+  const T *img =
+      input + (n * C + c) * (inH * inW);
+  int H = static_cast<int>(inH);
+  int W = static_cast<int>(inW);
+  float val;
+  if (mode == 0) {
+    int iy = static_cast<int>(floorf(y + 0.5f));
+    int ix = static_cast<int>(floorf(x + 0.5f));
+    val = sample_at(img, iy, ix, H, W, padding_mode);
+  } else {
+    int y0 = static_cast<int>(floorf(y));
+    int x0 = static_cast<int>(floorf(x));
+    int y1 = y0 + 1;
+    int x1 = x0 + 1;
+    float dy = y - static_cast<float>(y0);
+    float dx = x - static_cast<float>(x0);
+    float v00 = sample_at(img, y0, x0, H, W, padding_mode);
+    float v01 = sample_at(img, y0, x1, H, W, padding_mode);
+    float v10 = sample_at(img, y1, x0, H, W, padding_mode);
+    float v11 = sample_at(img, y1, x1, H, W, padding_mode);
+    val = v00 * (1.0f - dx) * (1.0f - dy) + v01 * dx * (1.0f - dy) +
+          v10 * (1.0f - dx) * dy + v11 * dx * dy;
+  }
+  output[tid] = from_float<T>(val);
+}
+
+} // namespace
+
+extern "C" int hip_grid_sample(void *stream, const void *input, const void *grid,
+                               void *output, int64_t n, int64_t c, int64_t in_h,
+                               int64_t in_w, int64_t out_h, int64_t out_w,
+                               int mode, int padding_mode, int align_corners,
+                               int hip_dtype) {
+  if (n <= 0 || c <= 0 || in_h <= 0 || in_w <= 0 || out_h <= 0 || out_w <= 0)
+    return 0;
+  if (mode != 0 && mode != 1) {
+    fprintf(stderr, "[custom_kernels] hip_grid_sample: bad mode=%d\n", mode);
+    return -1;
+  }
+
+  hipStream_t hip_stream = static_cast<hipStream_t>(stream);
+  int64_t total = n * c * out_h * out_w;
+  dim3 block(256);
+  dim3 grid_dim(static_cast<unsigned int>((total + 255) / 256));
+
+  (void)hipGetLastError();
+  CUSTOM_KERNELS_DEBUG_LOG(
+      "[custom_kernels] hip_grid_sample: dtype=%d N=%lld C=%lld in=%lldx%lld "
+      "out=%lldx%lld mode=%d pad=%d align=%d\n",
+      hip_dtype, (long long)n, (long long)c, (long long)in_h, (long long)in_w,
+      (long long)out_h, (long long)out_w, mode, padding_mode, align_corners);
+
+  if (hip_dtype == HIP_DTYPE_FLOAT16) {
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(grid_sample_kernel<__half>), grid_dim,
+                       block, 0, hip_stream,
+                       static_cast<const __half *>(input),
+                       static_cast<const __half *>(grid),
+                       static_cast<__half *>(output), n, c, in_h, in_w, out_h,
+                       out_w, mode, padding_mode, align_corners, total);
+  } else if (hip_dtype == HIP_DTYPE_BFLOAT16) {
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(grid_sample_kernel<__hip_bfloat16>),
+                       grid_dim, block, 0, hip_stream,
+                       static_cast<const __hip_bfloat16 *>(input),
+                       static_cast<const __hip_bfloat16 *>(grid),
+                       static_cast<__hip_bfloat16 *>(output), n, c, in_h, in_w,
+                       out_h, out_w, mode, padding_mode, align_corners, total);
+  } else if (hip_dtype == HIP_DTYPE_FLOAT32) {
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(grid_sample_kernel<float>), grid_dim,
+                       block, 0, hip_stream, static_cast<const float *>(input),
+                       static_cast<const float *>(grid),
+                       static_cast<float *>(output), n, c, in_h, in_w, out_h,
+                       out_w, mode, padding_mode, align_corners, total);
+  } else if (hip_dtype == HIP_DTYPE_FLOAT64) {
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(grid_sample_kernel<double>), grid_dim,
+                       block, 0, hip_stream,
+                       static_cast<const double *>(input),
+                       static_cast<const double *>(grid),
+                       static_cast<double *>(output), n, c, in_h, in_w, out_h,
+                       out_w, mode, padding_mode, align_corners, total);
+  } else {
+    fprintf(stderr, "[custom_kernels] hip_grid_sample: unsupported dtype=%d\n",
+            hip_dtype);
+    return -1;
+  }
+
+  hipError_t err = hipGetLastError();
+  if (err != hipSuccess) {
+    fprintf(stderr, "[custom_kernels] hip_grid_sample launch failed: %s\n",
+            hipGetErrorString(err));
+  }
+  return static_cast<int>(err);
+}

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -1160,6 +1160,34 @@ HIP_KERNEL_API int hip_resize(
     int nearest_mode);
 
 /* =========================================================================
+ * GridSample (ONNX 4-D NCHW)
+ * =========================================================================
+ *
+ * Samples input (N, C, H_in, W_in) at normalized (x, y) locations from
+ * grid (N, H_out, W_out, 2). Output is (N, C, H_out, W_out).
+ *
+ *  mode:           0 = nearest, 1 = bilinear
+ *  padding_mode:   0 = zeros, 1 = border, 2 = reflection
+ *  align_corners:  0 or 1
+ *
+ * Supported hip_dtypes: HIP_DTYPE_FLOAT32, HIP_DTYPE_FLOAT16,
+ * HIP_DTYPE_BFLOAT16, HIP_DTYPE_FLOAT64.
+ * Returns: 0 on success, non-zero on failure.
+ */
+HIP_KERNEL_API int hip_grid_sample(
+    void* stream,
+    const void* input,
+    const void* grid,
+    void* output,
+    int64_t n, int64_t c,
+    int64_t in_h, int64_t in_w,
+    int64_t out_h, int64_t out_w,
+    int mode,
+    int padding_mode,
+    int align_corners,
+    int hip_dtype);
+
+/* =========================================================================
  * Global pool (avg / max / lp)
  * =========================================================================
  *

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -1156,6 +1156,14 @@ int wrap_resize(RuntimeState *state, void *input, void *output,
                 int64_t out1, int64_t out2, int64_t mode,
                 int64_t coord_transform, int64_t nearest_mode);
 
+// GridSample (4-D NCHW). grid is (N, H_out, W_out, 2) with last dim (x, y).
+// mode: 0=nearest, 1=bilinear; padding_mode: 0=zeros, 1=border, 2=reflection;
+// align_corners: 0 or 1. data_type: HIPDNN_EP_DATATYPE_* (FLOAT/HALF/BFLOAT16/DOUBLE).
+int wrap_grid_sample(RuntimeState *state, void *input, void *grid, void *output,
+                     int64_t data_type, int64_t n, int64_t c, int64_t in_h,
+                     int64_t in_w, int64_t out_h, int64_t out_w, int64_t mode,
+                     int64_t padding_mode, int64_t align_corners);
+
 // Global pool wrapper (uses custom HIP kernel).
 // Treats the data as a flat [outer, reduce_size] matrix and writes one
 // reduced value per row into output. Covers ONNX GlobalAveragePool /

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -1158,7 +1158,8 @@ int wrap_resize(RuntimeState *state, void *input, void *output,
 
 // GridSample (4-D NCHW). grid is (N, H_out, W_out, 2) with last dim (x, y).
 // mode: 0=nearest, 1=bilinear; padding_mode: 0=zeros, 1=border, 2=reflection;
-// align_corners: 0 or 1. data_type: HIPDNN_EP_DATATYPE_* (FLOAT/HALF/BFLOAT16/DOUBLE).
+// align_corners: 0 or 1. data_type: HIPDNN_EP_DATATYPE_*
+// (FLOAT/HALF/BFLOAT16/DOUBLE).
 int wrap_grid_sample(RuntimeState *state, void *input, void *grid, void *output,
                      int64_t data_type, int64_t n, int64_t c, int64_t in_h,
                      int64_t in_w, int64_t out_h, int64_t out_w, int64_t mode,

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -1178,6 +1178,26 @@ int wrap_resize(RuntimeState *state, void *input, void *output,
   return 0;
 }
 
+int wrap_grid_sample(RuntimeState *state, void *input, void *grid, void *output,
+                     int64_t data_type, int64_t n, int64_t c, int64_t in_h,
+                     int64_t in_w, int64_t out_h, int64_t out_w, int64_t mode,
+                     int64_t padding_mode, int64_t align_corners) {
+  if (!state) {
+    fprintf(stderr, "Invalid state in wrap_grid_sample\n");
+    return -1;
+  }
+  MOCK_PRINT("[MOCK] wrap_grid_sample(dtype=%s(%lld), N=%lld, C=%lld, "
+             "in=%lldx%lld, out=%lldx%lld, mode=%lld, pad=%lld, align=%lld)\n",
+             hipdnn_ep_datatype_name(data_type), (long long)data_type,
+             (long long)n, (long long)c, (long long)in_h, (long long)in_w,
+             (long long)out_h, (long long)out_w, (long long)mode,
+             (long long)padding_mode, (long long)align_corners);
+  (void)input;
+  (void)grid;
+  (void)output;
+  return 0;
+}
+
 int wrap_global_pool(RuntimeState *state, void *input, void *output,
                      int64_t outer, int64_t reduce_size, int64_t data_type,
                      int64_t mode, int64_t p) {

--- a/lib/Runtime/real/grid_sample.cpp
+++ b/lib/Runtime/real/grid_sample.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "../debug_log.h"
+#include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
+#include "hip_custom_kernels.h"
+#include "runtime_types.h"
+
+#include <cstdio>
+#include <string>
+
+// wrap_grid_sample(state, input, grid, output,
+//                  data_type, N, C, inH, inW, outH, outW,
+//                  mode, padding_mode, align_corners)
+//
+// mode:          0 = nearest, 1 = bilinear
+// padding_mode:  0 = zeros, 1 = border, 2 = reflection
+// align_corners: 0 or 1
+
+static int hipdnn_ep_to_hip_dtype_grid_sample(int64_t data_type) {
+  switch (data_type) {
+  case HIPDNN_EP_DATATYPE_FLOAT:
+    return HIP_DTYPE_FLOAT32;
+  case HIPDNN_EP_DATATYPE_HALF:
+    return HIP_DTYPE_FLOAT16;
+  case HIPDNN_EP_DATATYPE_BFLOAT16:
+    return HIP_DTYPE_BFLOAT16;
+  case HIPDNN_EP_DATATYPE_DOUBLE:
+    return HIP_DTYPE_FLOAT64;
+  default:
+    return -1;
+  }
+}
+
+HIPDNN_EP_RT_EXPORT int wrap_grid_sample(
+    RuntimeState *state, void *input, void *grid, void *output,
+    int64_t data_type, int64_t n, int64_t c, int64_t in_h, int64_t in_w,
+    int64_t out_h, int64_t out_w, int64_t mode, int64_t padding_mode,
+    int64_t align_corners) {
+  OP_PROFILE(
+      "gridsample",
+      [&] {
+        char b[160];
+        snprintf(b, sizeof(b),
+                 "N=%lld C=%lld in=%lldx%lld out=%lldx%lld mode=%lld pad=%lld",
+                 (long long)n, (long long)c, (long long)in_h, (long long)in_w,
+                 (long long)out_h, (long long)out_w, (long long)mode,
+                 (long long)padding_mode);
+        return std::string(b);
+      },
+      state);
+
+  if (!state || !input || !grid || !output) {
+    fprintf(stderr, "[REAL] wrap_grid_sample: null argument\n");
+    return -1;
+  }
+  int hip_dtype = hipdnn_ep_to_hip_dtype_grid_sample(data_type);
+  if (hip_dtype < 0) {
+    fprintf(stderr, "[REAL] wrap_grid_sample: unsupported data_type %lld\n",
+            (long long)data_type);
+    return -1;
+  }
+  if (n <= 0 || c <= 0 || in_h <= 0 || in_w <= 0 || out_h <= 0 || out_w <= 0)
+    return 0;
+
+  void *stream = hipdnn_ep_state_get_stream(state);
+  RUNTIME_DEBUG_LOG(
+      "[REAL] wrap_grid_sample: dtype=%lld N=%lld C=%lld in=%lldx%lld "
+      "out=%lldx%lld mode=%lld pad=%lld align=%lld\n",
+      (long long)data_type, (long long)n, (long long)c, (long long)in_h,
+      (long long)in_w, (long long)out_h, (long long)out_w, (long long)mode,
+      (long long)padding_mode, (long long)align_corners);
+
+  int rc = hip_grid_sample(stream, input, grid, output, n, c, in_h, in_w, out_h,
+                           out_w, static_cast<int>(mode),
+                           static_cast<int>(padding_mode),
+                           static_cast<int>(align_corners), hip_dtype);
+  if (rc != 0) {
+    fprintf(stderr, "[REAL] wrap_grid_sample: kernel launch failed (%d)\n", rc);
+    return -1;
+  }
+  return 0;
+}

--- a/lib/Runtime/real/grid_sample.cpp
+++ b/lib/Runtime/real/grid_sample.cpp
@@ -35,11 +35,11 @@ static int hipdnn_ep_to_hip_dtype_grid_sample(int64_t data_type) {
   }
 }
 
-HIPDNN_EP_RT_EXPORT int wrap_grid_sample(
-    RuntimeState *state, void *input, void *grid, void *output,
-    int64_t data_type, int64_t n, int64_t c, int64_t in_h, int64_t in_w,
-    int64_t out_h, int64_t out_w, int64_t mode, int64_t padding_mode,
-    int64_t align_corners) {
+HIPDNN_EP_RT_EXPORT int
+wrap_grid_sample(RuntimeState *state, void *input, void *grid, void *output,
+                 int64_t data_type, int64_t n, int64_t c, int64_t in_h,
+                 int64_t in_w, int64_t out_h, int64_t out_w, int64_t mode,
+                 int64_t padding_mode, int64_t align_corners) {
   OP_PROFILE(
       "gridsample",
       [&] {

--- a/test/lit/Conversion/hip-to-llvm/test_grid_sample.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_grid_sample.mlir
@@ -1,0 +1,39 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify hip.grid_sample lowers to llvm.call @wrap_grid_sample.
+// ============================================================================
+
+// RUN: hip-mlir-opt %s --convert-hip-to-llvm | FileCheck %s
+
+module {
+  func.func @grid_sample_static(
+      %ctx: !hip.context,
+      %input: memref<1x3x8x8xf32, 1>,
+      %grid: memref<1x4x4x2xf32, 1>,
+      %output: memref<1x3x4x4xf32, 1>) {
+    // CHECK-LABEL: llvm.func @grid_sample_static
+    hip.grid_sample(%ctx)
+        ins(%input, %grid : memref<1x3x8x8xf32, 1>, memref<1x4x4x2xf32, 1>)
+        outs(%output : memref<1x3x4x4xf32, 1>)
+        {mode = 1, padding_mode = 0, align_corners = 0}
+    // CHECK: llvm.call @wrap_grid_sample
+    return
+  }
+
+  func.func @grid_sample_dynamic(
+      %ctx: !hip.context,
+      %input: memref<1x3x?x?xf32, 1>,
+      %grid: memref<1x?x?x2xf32, 1>,
+      %output: memref<1x3x?x?xf32, 1>) {
+    // CHECK-LABEL: llvm.func @grid_sample_dynamic
+    hip.grid_sample(%ctx)
+        ins(%input, %grid : memref<1x3x?x?xf32, 1>, memref<1x?x?x2xf32, 1>)
+        outs(%output : memref<1x3x?x?xf32, 1>)
+        {mode = 1, padding_mode = 0, align_corners = 0}
+    // CHECK: llvm.call @wrap_grid_sample
+    return
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_grid_sample.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_grid_sample.mlir
@@ -1,0 +1,61 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify ONNX GridSample is lowered to hip.grid_sample.
+//
+// Test cases:
+// 1. Static NCHW bilinear (SimpleBEV-style attrs)
+// 2. Nearest + zeros padding
+// 3. Dynamic output spatial dims taken from the grid
+// ============================================================================
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+    return %arg0 : tensor<4xf32>
+  }
+
+  // --- Case 1: static bilinear zeros ---
+  func.func @grid_sample_bilinear(%X: tensor<1x3x8x8xf32>, %Grid: tensor<1x4x4x2xf32>) -> tensor<1x3x4x4xf32> {
+    %Y = "onnx.GridSample"(%X, %Grid) {align_corners = 0 : si64, mode = "bilinear", padding_mode = "zeros"} : (tensor<1x3x8x8xf32>, tensor<1x4x4x2xf32>) -> tensor<1x3x4x4xf32>
+    return %Y : tensor<1x3x4x4xf32>
+  }
+
+  // CHECK-LABEL: func.func @grid_sample_bilinear
+  // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[X:.*]]: tensor<1x3x8x8xf32>, %[[GRID:.*]]: tensor<1x4x4x2xf32>)
+  // CHECK-NOT: onnx.GridSample
+  // CHECK: tensor.empty() : tensor<1x3x4x4xf32>
+  // CHECK: hip.grid_sample(%[[CTX]])
+  // CHECK-SAME: ins(%[[X]], %[[GRID]] :
+  // CHECK-SAME: {align_corners = 0 : i64, mode = 1 : i64, padding_mode = 0 : i64}
+
+  // --- Case 2: nearest ---
+  func.func @grid_sample_nearest(%X: tensor<2x1x4x4xf16>, %Grid: tensor<2x2x2x2xf16>) -> tensor<2x1x2x2xf16> {
+    %Y = "onnx.GridSample"(%X, %Grid) {align_corners = 1 : si64, mode = "nearest", padding_mode = "border"} : (tensor<2x1x4x4xf16>, tensor<2x2x2x2xf16>) -> tensor<2x1x2x2xf16>
+    return %Y : tensor<2x1x2x2xf16>
+  }
+
+  // CHECK-LABEL: func.func @grid_sample_nearest
+  // CHECK-NOT: onnx.GridSample
+  // CHECK: hip.grid_sample(%{{[^)]*}})
+  // CHECK-SAME: {align_corners = 1 : i64, mode = 0 : i64, padding_mode = 1 : i64}
+
+  // --- Case 3: dynamic output spatial from grid ---
+  func.func @grid_sample_dynamic(%X: tensor<1x3x8x8xf32>, %Grid: tensor<1x?x?x2xf32>) -> tensor<1x3x?x?xf32> {
+    %Y = "onnx.GridSample"(%X, %Grid) {align_corners = 0 : si64, mode = "linear", padding_mode = "zeros"} : (tensor<1x3x8x8xf32>, tensor<1x?x?x2xf32>) -> tensor<1x3x?x?xf32>
+    return %Y : tensor<1x3x?x?xf32>
+  }
+
+  // CHECK-LABEL: func.func @grid_sample_dynamic
+  // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[X:.*]]: tensor<1x3x8x8xf32>, %[[GRID:.*]]: tensor<1x?x?x2xf32>
+  // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+  // CHECK-DAG: %[[C2:.*]] = arith.constant 2 : index
+  // CHECK: %[[DIM1:.*]] = tensor.dim %[[GRID]], %[[C1]]
+  // CHECK: %[[DIM2:.*]] = tensor.dim %[[GRID]], %[[C2]]
+  // CHECK: %[[INIT:.*]] = tensor.empty(%[[DIM1]], %[[DIM2]]) : tensor<1x3x?x?xf32>
+  // CHECK: hip.grid_sample(%[[CTX]])
+  // CHECK-SAME: outs(%[[INIT]] :
+}

--- a/test/lit/e2e/test_grid_sample_model.mlir
+++ b/test/lit/e2e/test_grid_sample_model.mlir
@@ -1,0 +1,23 @@
+// RUN: hip-mlir-opt %s --hipdnn-pipeline | FileCheck %s
+
+// Test GridSample E2E full pipeline.
+//
+// 1. convert-onnx-to-hip: onnx.GridSample → hip.grid_sample
+// 2. convert-hip-to-llvm: hip.grid_sample → llvm.call @wrap_grid_sample
+//
+// CHECK: module attributes {
+// CHECK-SAME: hipdnn.input_count = 2
+// CHECK-SAME: hipdnn.output_count = 1
+// CHECK: llvm.func @wrap_grid_sample
+// CHECK: llvm.func @inference_init
+// CHECK: llvm.func @inference_compute
+// CHECK: llvm.func @inference_cleanup
+// CHECK: llvm.func @inference_get_metadata_json
+// CHECK-NOT: onnx.GridSample
+module {
+  func.func @main_graph(%arg0: tensor<1x3x8x8xf32> {onnx.name = "X"}, %arg1: tensor<1x4x4x2xf32> {onnx.name = "grid"}) -> (tensor<1x3x4x4xf32> {onnx.name = "Y"}) {
+    %0 = "onnx.GridSample"(%arg0, %arg1) {align_corners = 0 : si64, mode = "bilinear", padding_mode = "zeros", onnx_node_name = "gridsample_node"} : (tensor<1x3x8x8xf32>, tensor<1x4x4x2xf32>) -> tensor<1x3x4x4xf32>
+    "onnx.Return"(%0) : (tensor<1x3x4x4xf32>) -> ()
+  }
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}

--- a/test/numeric/tests/test_grid_sample.py
+++ b/test/numeric/tests/test_grid_sample.py
@@ -57,9 +57,7 @@ class TestGridSample:
             ("bilinear", "zeros", 1),
         ],
     )
-    def test_grid_sample_f32(
-        self, model_runner, mode, padding_mode, align_corners
-    ):
+    def test_grid_sample_f32(self, model_runner, mode, padding_mode, align_corners):
         input_shape = [1, 3, 8, 8]
         grid_shape = [1, 4, 4, 2]
         model = _make_grid_sample_model(

--- a/test/numeric/tests/test_grid_sample.py
+++ b/test/numeric/tests/test_grid_sample.py
@@ -1,0 +1,89 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+"""Numeric tests for ONNX GridSample (4-D NCHW)."""
+
+import numpy as np
+import pytest
+from onnx import TensorProto, helper
+
+from framework.comparator import compare_outputs
+from framework.onnx_utils import make_model_from_nodes
+
+
+def _make_grid_sample_model(
+    input_shape,
+    grid_shape,
+    dtype=np.float32,
+    mode="bilinear",
+    padding_mode="zeros",
+    align_corners=0,
+):
+    tp = {np.float16: TensorProto.FLOAT16, np.float32: TensorProto.FLOAT}[dtype]
+    n, c, _, _ = input_shape
+    _, oh, ow, _ = grid_shape
+    X = helper.make_tensor_value_info("X", tp, input_shape)
+    Grid = helper.make_tensor_value_info("grid", tp, grid_shape)
+    Y = helper.make_tensor_value_info("Y", tp, [n, c, oh, ow])
+    node = helper.make_node(
+        "GridSample",
+        ["X", "grid"],
+        ["Y"],
+        mode=mode,
+        padding_mode=padding_mode,
+        align_corners=align_corners,
+    )
+    return make_model_from_nodes([node], [X, Grid], [Y], opset=17)
+
+
+def _identity_grid(n, oh, ow, dtype):
+    """Normalized grid covering the interior of [-1, 1]."""
+    ys = np.linspace(-0.9, 0.9, oh, dtype=np.float32)
+    xs = np.linspace(-0.9, 0.9, ow, dtype=np.float32)
+    grid_y, grid_x = np.meshgrid(ys, xs, indexing="ij")
+    grid = np.stack([grid_x, grid_y], axis=-1)
+    return np.broadcast_to(grid, (n, oh, ow, 2)).astype(dtype, copy=True)
+
+
+class TestGridSample:
+    @pytest.mark.parametrize(
+        "mode,padding_mode,align_corners",
+        [
+            ("bilinear", "zeros", 0),
+            ("bilinear", "border", 0),
+            ("nearest", "zeros", 0),
+            ("bilinear", "zeros", 1),
+        ],
+    )
+    def test_grid_sample_f32(
+        self, model_runner, mode, padding_mode, align_corners
+    ):
+        input_shape = [1, 3, 8, 8]
+        grid_shape = [1, 4, 4, 2]
+        model = _make_grid_sample_model(
+            input_shape,
+            grid_shape,
+            np.float32,
+            mode=mode,
+            padding_mode=padding_mode,
+            align_corners=align_corners,
+        )
+        rng = np.random.default_rng(11)
+        x = rng.uniform(-2, 2, input_shape).astype(np.float32)
+        grid = _identity_grid(1, 4, 4, np.float32)
+        actual, expected = model_runner.run_sample(model, [x, grid])
+        compare_outputs(actual, expected, atol=1e-5, rtol=1e-5)
+
+    def test_grid_sample_f16(self, model_runner):
+        input_shape = [1, 2, 8, 8]
+        grid_shape = [1, 3, 3, 2]
+        model = _make_grid_sample_model(
+            input_shape, grid_shape, np.float16, mode="bilinear"
+        )
+        rng = np.random.default_rng(12)
+        x = rng.uniform(-2, 2, input_shape).astype(np.float16)
+        grid = _identity_grid(1, 3, 3, np.float16)
+        actual, expected = model_runner.run_sample(model, [x, grid])
+        compare_outputs(actual, expected, atol=2e-3, rtol=1e-3)


### PR DESCRIPTION
## Summary
- Wire `onnx.GridSample` through `hip.grid_sample`, HIP-to-LLVM lowering, mock/real runtime, and a custom 4-D NCHW kernel.
- Support nearest/bilinear sampling used by BEV exporters.

## Test plan
- [ ] LIT: `test_grid_sample.mlir` (onnx-to-hip, hip-to-llvm, e2e)
- [ ] Numeric: `test/numeric/tests/test_grid_sample.py`

Made with [Cursor](https://cursor.com)