### PR TITLE
feat(wmma): support gfx1170's gfx12-style WMMA encoding alongside gfx11

### DIFF
--- a/lib/Runtime/Kernels/hip/gemm_wmma_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gemm_wmma_kernel.hip
@@ -7,25 +7,32 @@
 #include <hip/hip_fp16.h>
 
 #include "hip_custom_kernels.h"
+#include "hip_arch_compat.h"
 
-typedef _Float16 half16 __attribute__((ext_vector_type(16)));
+// half16 holds one WMMA A/B fragment; its vector width matches
+// HIPDNN_WMMA_FRAG_ELEMS (16 on gfx11, 8 on the gfx12-style encoding
+// gfx1170/gfx12xx use -- see hip_arch_compat.h) so it binds directly to
+// whichever HIPDNN_WMMA_F32_16X16X16_F16 builtin is selected. The name is
+// kept for continuity with the existing RDNA3 comments/callers even though
+// the width is arch-dependent.
+typedef _Float16 half16 __attribute__((ext_vector_type(HIPDNN_WMMA_FRAG_ELEMS)));
 typedef float float8 __attribute__((ext_vector_type(8)));
 
-// The WMMA builtin below is RDNA3-family (wave32) only. Where __has_builtin
-// reports it absent, trap instead so this file still compiles and a WMMA
-// launch on an unsupported arch aborts loudly rather than returning garbage.
-#if !defined(__has_builtin) ||                                                  \
-    !__has_builtin(__builtin_amdgcn_wmma_f32_16x16x16_f16_w32)
+// Where neither WMMA builtin is available (non-RDNA3/3.5/4 arch), trap
+// instead so this file still compiles and a WMMA launch on an unsupported
+// arch aborts loudly rather than returning garbage.
+#if !HIPDNN_HAS_WMMA
 static __device__ __forceinline__ float8
-hipdnn_wmma_f32_16x16x16_f16_w32_unavailable(half16, half16, float8 c) {
+hipdnn_wmma_f32_16x16x16_f16_unavailable(half16, half16, float8 c) {
   __builtin_trap();
   return c;
 }
-#define __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a, b, c)                     \
-  hipdnn_wmma_f32_16x16x16_f16_w32_unavailable((a), (b), (c))
+#undef HIPDNN_WMMA_F32_16X16X16_F16
+#define HIPDNN_WMMA_F32_16X16X16_F16(a, b, c)                                 \
+  hipdnn_wmma_f32_16x16x16_f16_unavailable((a), (b), (c))
 #endif
 
-static constexpr int kWmmaTile = 16;  // RDNA 3 WMMA tile dimension (16x16x16)
+static constexpr int kWmmaTile = 16;  // WMMA tile dimension (16x16x16)
 
 //===----------------------------------------------------------------------===//
 // WMMA GEMM kernel for small-M fp16 MatMuls (M <= 512)
@@ -33,23 +40,25 @@ static constexpr int kWmmaTile = 16;  // RDNA 3 WMMA tile dimension (16x16x16)
 //
 // Computes C[M,N] = A[M,K] * B[K,N]  (all row-major, fp16, fp32 accumulation)
 //
-// Uses __builtin_amdgcn_wmma_f32_16x16x16_f16_w32 for hardware-accelerated
-// 16x16x16 tile multiply-accumulate on RDNA 3+.
+// Uses HIPDNN_WMMA_F32_16X16X16_F16 (hip_arch_compat.h) for hardware-
+// accelerated 16x16x16 tile multiply-accumulate on RDNA 3/3.5/4.
 //
 // Register-tiled: each wavefront computes a (KX*16) x (KY*16) output tile.
 // KX A fragments are each reused KY times; KY B fragments each reused KX times.
 // Grid: (ceil(N/(KY*16)), ceil(M/(KX*16)))
 //
-// WMMA fragment layout (wave32, per AMD GPUOpen / tinygrad / GQA kernel):
-//   a_frag (half16): a_frag[k] at lane m = A_tile[m, k]
-//                     lane = M-row, element = K-col
-//   b_frag (half16): b_frag[k] at lane n = B_tile[k, n]
-//                     element = K-row, lane = N-col
-//   c_frag (float8):  c_frag[ele] -> row (ele*2 + pair), col (lane)
-//                     where lane = threadIdx.x % 16, pair = threadIdx.x / 16
-//
-// Lanes 0-15 and 16-31 load identical data (required by RDNA 3 WMMA),
-// automatically satisfied by indexing with threadIdx.x % 16.
+// WMMA fragment layout (wave32; two encodings, selected at compile time by
+// HIPDNN_WMMA_GFX12 -- see hip_arch_compat.h for how each was verified):
+//   gfx11 (HIPDNN_WMMA_FRAG_ELEMS==16): a_frag[k] at lane m = A_tile[m, k];
+//     b_frag[k] at lane n = B_tile[k, n]. Lanes 0-15 and 16-31 hold identical
+//     data (required by this encoding), satisfied by indexing with
+//     threadIdx.x % 16 == m (or n).
+//   gfx12-style (HIPDNN_WMMA_FRAG_ELEMS==8, e.g. gfx1170/gfx12xx): no
+//     replication; a_frag[j] at lane L = A_tile[L%16, hipdnn_wmma_k_off(pair)+j],
+//     b_frag[j] at lane L = B_tile[hipdnn_wmma_k_off(pair)+j, L%16], where
+//     pair = L/16 selects which half of K this lane contributes.
+//   c_frag (float8, both encodings): c_frag[ele] -> row hipdnn_wmma_acc_row(pair, ele),
+//     col (lane%16). lane = threadIdx.x % 16, pair = threadIdx.x / 16.
 
 template<int KX, int KY>
 __global__ void __launch_bounds__(32)
@@ -71,30 +80,35 @@ gemm_wmma_fp16_kernel(
     half16 b_frag[KY];
     float8 c_frag[KY][KX] = {};
 
+    // K-axis base this lane's pair-half contributes: 0 on gfx11 (each lane
+    // loads the full 16-wide K range), pair*8 on the gfx12-style encoding
+    // (each lane loads only its half, no replication).
+    const int k_off = hipdnn_wmma_k_off(pair);
+
     for (int k = 0; k < K; k += kWmmaTile) {
-        for (int ele = 0; ele < kWmmaTile; ++ele) {
+        for (int ele = 0; ele < HIPDNN_WMMA_FRAG_ELEMS; ++ele) {
             for (int x = 0; x < KX; ++x) {
                 int row = m_base + x * kWmmaTile + lane;
-                a_frag[x][ele] = (row < M) ? A[row * K + k + ele]
+                a_frag[x][ele] = (row < M) ? A[row * K + k + k_off + ele]
                                             : (_Float16)0;
             }
             for (int y = 0; y < KY; ++y) {
                 int col = n_base + y * kWmmaTile + lane;
-                b_frag[y][ele] = (col < N) ? B[(k + ele) * N + col]
+                b_frag[y][ele] = (col < N) ? B[(k + k_off + ele) * N + col]
                                             : (_Float16)0;
             }
         }
 
         for (int y = 0; y < KY; ++y)
             for (int x = 0; x < KX; ++x)
-                c_frag[y][x] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(
+                c_frag[y][x] = HIPDNN_WMMA_F32_16X16X16_F16(
                                     a_frag[x], b_frag[y], c_frag[y][x]);
     }
 
     for (int y = 0; y < KY; ++y) {
         for (int x = 0; x < KX; ++x) {
             for (int ele = 0; ele < 8; ++ele) {
-                int r = m_base + x * kWmmaTile + ele * 2 + pair;
+                int r = m_base + x * kWmmaTile + hipdnn_wmma_acc_row(pair, ele);
                 int c = n_base + y * kWmmaTile + lane;
                 if (r < M && c < N)
                     C[r * N + c] = (_Float16)c_frag[y][x][ele];
@@ -106,6 +120,10 @@ gemm_wmma_fp16_kernel(
 extern "C"
 int hip_gemm_wmma_fp16(void* stream, const void* A, const void* B,
                        void* C, int M, int K, int N) {
+    // WMMA is RDNA-only (wave32); CDNA (wave64, e.g. MI300/MI350) has no WMMA
+    // and would otherwise hit the __builtin_trap() fallback above at launch.
+    if (hipdnn_device_is_wave64())
+        return -1;
     constexpr int KX = 2;
     constexpr int KY = 4;
     dim3 block(32);

--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -1271,32 +1271,51 @@ extern "C" int hip_gqa_softmax_inplace(
 }
 
 //===----------------------------------------------------------------------===//
-// WMMA types for fused kernels (RDNA 3 / 3.5, wave32)
+// WMMA types for fused kernels (RDNA 3 / 3.5 / 4, wave32)
 //===----------------------------------------------------------------------===//
+// Two WMMA f16 16x16x16 encodings exist across these architectures (see
+// hip_arch_compat.h for how each was empirically verified): the original
+// gfx11 encoding (half16 fragments, K replicated across the wave's two
+// lane-halves) and the newer gfx12-style encoding gfx1170/gfx12xx use (half8
+// fragments, K split by pair = lane/16, no replication). HIPDNN_WMMA_FRAG_ELEMS
+// / HIPDNN_WMMA_F32_16X16X16_F16 / hipdnn_wmma_k_off / hipdnn_wmma_acc_row
+// abstract the three points of difference so the kernels below are written
+// once and compile correctly for either encoding.
 
-static constexpr int kWmmaTile = 16;  // RDNA 3 WMMA tile dimension (16x16x16)
+static constexpr int kWmmaTile = 16;  // WMMA tile dimension (16x16x16)
 
-typedef _Float16 half16 __attribute__((ext_vector_type(16)));
+// half16 holds one WMMA A/B fragment; its vector width matches
+// HIPDNN_WMMA_FRAG_ELEMS (16 on gfx11, 8 on the gfx12-style encoding). The
+// name is kept for continuity with the existing RDNA3-era call sites even
+// though the width is arch-dependent.
+typedef _Float16 half16 __attribute__((ext_vector_type(HIPDNN_WMMA_FRAG_ELEMS)));
 typedef float    float8 __attribute__((ext_vector_type(8)));
-#define HALF16(pointer) (reinterpret_cast<half16*>((void *)&(pointer))[0])
+// Loads one A/B fragment of HIPDNN_WMMA_FRAG_ELEMS contiguous K-major
+// elements starting at `pointer`, offset by this lane's pair-half
+// (hipdnn_wmma_k_off(pair): 0 on gfx11, pair*8 on the gfx12-style encoding).
+// Only valid when the source is contiguous along K, as it is at every call
+// site below (Q rows, K/P cache rows are all D- or BKV-contiguous).
+#define HALF16(pointer, pair)                                                  \
+  (reinterpret_cast<half16*>(                                                  \
+       (void *)(&(pointer) + hipdnn_wmma_k_off(pair)))[0])
 
 // 16-byte opaque vector, used only to widen KV cache global loads to a single
 // dwordx4 per lane. The element type is irrelevant; the bytes are memcpy'd
 // into the typed prefetch registers.
 typedef unsigned int bytes16 __attribute__((ext_vector_type(4)));
 
-// The WMMA builtin below is RDNA3-family (wave32) only. Where __has_builtin
-// reports it absent, trap instead so this file still compiles and a WMMA
-// launch on an unsupported arch aborts loudly rather than returning garbage.
-#if !defined(__has_builtin) ||                                                  \
-    !__has_builtin(__builtin_amdgcn_wmma_f32_16x16x16_f16_w32)
+// Where neither WMMA builtin is available (non-RDNA3/3.5/4 arch), trap
+// instead so this file still compiles and a WMMA launch on an unsupported
+// arch aborts loudly rather than returning garbage.
+#if !HIPDNN_HAS_WMMA
 static __device__ __forceinline__ float8
-hipdnn_wmma_f32_16x16x16_f16_w32_unavailable(half16, half16, float8 c) {
+hipdnn_wmma_f32_16x16x16_f16_unavailable(half16, half16, float8 c) {
   __builtin_trap();
   return c;
 }
-#define __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a, b, c)                     \
-  hipdnn_wmma_f32_16x16x16_f16_w32_unavailable((a), (b), (c))
+#undef HIPDNN_WMMA_F32_16X16X16_F16
+#define HIPDNN_WMMA_F32_16X16X16_F16(a, b, c)                                  \
+  hipdnn_wmma_f32_16x16x16_f16_unavailable((a), (b), (c))
 #endif
 
 // [removed] fused_gqa_decode_kernel / hip_gqa_fused_decode: the legacy
@@ -1777,20 +1796,22 @@ gqa_flash_decode_wmma_kernel(
     const size_t q_row = (static_cast<size_t>(batch) * H + head) * D;
     if constexpr (KV_I8) {
       const float* ks = k_scale + (size_t)head_kv * D;
+      const int k_off = hipdnn_wmma_k_off(pair);
       #pragma unroll
       for (int tk = 0; tk < Q_TILES; ++tk) {
         half16 q{};
         if (valid) {
           #pragma unroll
-          for (int e = 0; e < 16; ++e)
-            q[e] = (_Float16)((float)Q[q_row + tk * 16 + e] * ks[tk * 16 + e]);
+          for (int e = 0; e < HIPDNN_WMMA_FRAG_ELEMS; ++e)
+            q[e] = (_Float16)((float)Q[q_row + tk * 16 + k_off + e] *
+                               ks[tk * 16 + k_off + e]);
         }
         Q_reg[tk] = q;
       }
     } else {
       #pragma unroll
       for (int tk = 0; tk < Q_TILES; ++tk)
-        Q_reg[tk] = valid ? HALF16(Q[q_row + tk * 16]) : half16{};
+        Q_reg[tk] = valid ? HALF16(Q[q_row + tk * 16], pair) : half16{};
     }
   }
 
@@ -1917,12 +1938,12 @@ gqa_flash_decode_wmma_kernel(
       float8 s_frag = {};
       #pragma unroll
       for (int tk = 0; tk < Q_TILES; ++tk) {
-        half16 kf = HALF16(K_lds[(sj * 16 + wmma_lane) * DSTR + tk * 16]);
-        s_frag = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(Q_reg[tk], kf, s_frag);
+        half16 kf = HALF16(K_lds[(sj * 16 + wmma_lane) * DSTR + tk * 16], pair);
+        s_frag = HIPDNN_WMMA_F32_16X16X16_F16(Q_reg[tk], kf, s_frag);
       }
       #pragma unroll
       for (int ele = 0; ele < 8; ++ele) {
-        const int r = ele * 2 + pair;
+        const int r = hipdnn_wmma_acc_row(pair, ele);
         const int c = sj * 16 + wmma_lane;
         S_lds[r * S_STR + c] = s_frag[ele] * scale_log2e;
       }
@@ -1973,18 +1994,19 @@ gqa_flash_decode_wmma_kernel(
     for (int tj = 0; tj < O_TILES; ++tj)
       #pragma unroll
       for (int ele = 0; ele < 8; ++ele)
-        O_frag[tj][ele] *= ml[(ele * 2 + pair) * 3 + 2];
+        O_frag[tj][ele] *= ml[hipdnn_wmma_acc_row(pair, ele) * 3 + 2];
 
     #pragma unroll
     for (int tj = 0; tj < O_TILES; ++tj) {
       #pragma unroll
       for (int tk = 0; tk < N_TILES; ++tk) {
-        half16 p = HALF16(P_lds[wmma_lane * P_STR + tk * 16]);
+        half16 p = HALF16(P_lds[wmma_lane * P_STR + tk * 16], pair);
         half16 v;
+        const int v_k_off = hipdnn_wmma_k_off(pair);
         #pragma unroll
-        for (int e = 0; e < 16; ++e)
-          v[e] = V_lds[(tk * 16 + e) * DSTR + tj * 16 + wmma_lane];
-        O_frag[tj] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(p, v, O_frag[tj]);
+        for (int e = 0; e < HIPDNN_WMMA_FRAG_ELEMS; ++e)
+          v[e] = V_lds[(tk * 16 + v_k_off + e) * DSTR + tj * 16 + wmma_lane];
+        O_frag[tj] = HIPDNN_WMMA_F32_16X16X16_F16(p, v, O_frag[tj]);
       }
     }
     __syncthreads();
@@ -1999,7 +2021,7 @@ gqa_flash_decode_wmma_kernel(
   for (int tj = 0; tj < O_TILES; ++tj)
     #pragma unroll
     for (int ele = 0; ele < 8; ++ele) {
-      const int r = ele * 2 + pair;
+      const int r = hipdnn_wmma_acc_row(pair, ele);
       const int c = tj * 16 + wmma_lane;
       if (r < HPG) {
         const int head_q = head_kv * HPG + r;
@@ -2699,12 +2721,24 @@ extern "C" int hip_gqa_flash_decode(
 //                 reduction; halves per-wave Q_reg/O_h to lift occupancy)
 //===----------------------------------------------------------------------===//
 namespace {
-typedef _Float16 half16_t __attribute__((ext_vector_type(16)));
+// half16_t is a WMMA A/B fragment; width matches HIPDNN_WMMA_FRAG_ELEMS (see
+// the shared WMMA block above). half8_t is unrelated: a genuinely fixed
+// 8-wide fp16 vector used for O storage further below, not a WMMA operand.
+typedef _Float16 half16_t __attribute__((ext_vector_type(HIPDNN_WMMA_FRAG_ELEMS)));
 typedef _Float16 half8_t __attribute__((ext_vector_type(8)));
 typedef float float8_t __attribute__((ext_vector_type(8)));
 #ifndef HALF16_LOAD
-#define HALF16_LOAD(ptr) (*reinterpret_cast<const half16_t*>(ptr))
+// Loads one fragment of HIPDNN_WMMA_FRAG_ELEMS contiguous K-major elements
+// starting at `ptr`, offset by this lane's pair-half (see HALF16 above).
+#define HALF16_LOAD(ptr, pair)                                                 \
+  (*reinterpret_cast<const half16_t*>((ptr) + hipdnn_wmma_k_off(pair)))
 #endif
+// Always-16-wide vector, for coalesced bulk copies of a 16-element D-chunk
+// from global into LDS staging (e.g. the V tile below). This is plain memory
+// movement, not a WMMA operand, so unlike half16_t its width must NOT track
+// HIPDNN_WMMA_FRAG_ELEMS.
+typedef _Float16 half16_raw_t __attribute__((ext_vector_type(16)));
+#define HALF16_RAW_LOAD(ptr) (*reinterpret_cast<const half16_raw_t*>(ptr))
 
 
 
@@ -2776,7 +2810,7 @@ gqa_flash_prefill_v5_kernel(
             (static_cast<size_t>(batch * sq + (valid ? q_pos : 0)) * Hq + head_q) * D;
         #pragma unroll
         for (int tk = 0; tk < D_TILES; ++tk)
-            Q_reg[mi][tk] = valid ? HALF16_LOAD(&Q[q_row_base + tk * 16]) : half16_t{};
+            Q_reg[mi][tk] = valid ? HALF16_LOAD(&Q[q_row_base + tk * 16], pair) : half16_t{};
     }
 
     // ---- running state in registers (per owned row) ----
@@ -2804,11 +2838,11 @@ gqa_flash_prefill_v5_kernel(
             #pragma unroll
             for (int tk = 0; tk < D_TILES; ++tk) {
                 half16_t k_frag = (kvalid && !(abl & 8))
-                                         ? HALF16_LOAD(&Kcache[k_row + tk * 16])
+                                         ? HALF16_LOAD(&Kcache[k_row + tk * 16], pair)
                                          : half16_t{};
                 #pragma unroll
                 for (int mi = 0; mi < M_TILES; ++mi)
-                    S_reg[mi][sj] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(
+                    S_reg[mi][sj] = HIPDNN_WMMA_F32_16X16X16_F16(
                         Q_reg[mi][tk], k_frag, S_reg[mi][sj]);
             }
         }
@@ -2846,10 +2880,10 @@ gqa_flash_prefill_v5_kernel(
                 const int kv_local = i / D_TILES;
                 const int dt       = i % D_TILES;
                 const int kv_pos   = kv0 + kv_local;
-                half16_t vv = (kv_pos < skv)
-                    ? HALF16_LOAD(&Vcache[kv_base + (size_t)kv_pos * D + dt * 16])
-                    : half16_t{};
-                *reinterpret_cast<half16_t*>(&V_lds[kv_local * V_STR + dt * 16]) = vv;
+                half16_raw_t vv = (kv_pos < skv)
+                    ? HALF16_RAW_LOAD(&Vcache[kv_base + (size_t)kv_pos * D + dt * 16])
+                    : half16_raw_t{};
+                *reinterpret_cast<half16_raw_t*>(&V_lds[kv_local * V_STR + dt * 16]) = vv;
             }
         }
 
@@ -2867,7 +2901,7 @@ gqa_flash_prefill_v5_kernel(
         for (int mi = 0; mi < M_TILES; ++mi) {
             #pragma unroll
             for (int e = 0; e < 8; ++e) {
-                const int row    = mi * 16 + e * 2 + pair;        // local q row
+                const int row    = mi * 16 + hipdnn_wmma_acc_row(pair, e);  // local q row
                 const int q_pos  = q_start + row;
                 // causal mask, sliding-window lower bound, and per-row partial
                 // max over this lane's columns
@@ -2936,14 +2970,15 @@ gqa_flash_prefill_v5_kernel(
             for (int tk = 0; tk < S_TILES_J; ++tk) {
                 // V as B-fragment from LDS: v[e=kv] for column d = tj*16+wmma_lane
                 half16_t v_frag;
+                const int v_k_off = hipdnn_wmma_k_off(pair);
                 #pragma unroll
-                for (int e = 0; e < 16; ++e)
-                    v_frag[e] = V_lds[(tk * 16 + e) * V_STR + tj * 16 + wmma_lane];
+                for (int e = 0; e < HIPDNN_WMMA_FRAG_ELEMS; ++e)
+                    v_frag[e] = V_lds[(tk * 16 + v_k_off + e) * V_STR + tj * 16 + wmma_lane];
                 #pragma unroll
                 for (int mi = 0; mi < M_TILES; ++mi) {
                     half16_t p_frag = HALF16_LOAD(
-                        &P_lds[(mi * 16 + wmma_lane) * P_STR + tk * 16]);
-                    O_frag[mi][tj] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(
+                        &P_lds[(mi * 16 + wmma_lane) * P_STR + tk * 16], pair);
+                    O_frag[mi][tj] = HIPDNN_WMMA_F32_16X16X16_F16(
                         p_frag, v_frag, O_frag[mi][tj]);
                 }
             }
@@ -2988,7 +3023,7 @@ gqa_flash_prefill_v5_kernel(
         for (int tj = 0; tj < D_TILES; ++tj) {
             #pragma unroll
             for (int e = 0; e < 8; ++e) {
-                const int row   = mi * 16 + e * 2 + pair;
+                const int row   = mi * 16 + hipdnn_wmma_acc_row(pair, e);
                 const int c     = tj * 16 + wmma_lane;
                 const int q_pos = q_start + row;
                 if (q_pos < sq && c < D) {
@@ -3201,7 +3236,7 @@ gqa_flash_prefill_v7_kernel(
             (static_cast<size_t>(batch * sq + (valid ? q_pos : 0)) * Hq + head_q) * D;
         #pragma unroll
         for (int tk = 0; tk < D_TILES; ++tk)
-            Q_reg[mt][tk] = valid ? HALF16_LOAD(&Q[q_row_base + tk * 16]) : half16_t{};
+            Q_reg[mt][tk] = valid ? HALF16_LOAD(&Q[q_row_base + tk * 16], pair) : half16_t{};
     }
 
     // ---- running state: O stored compactly as half8 (fp16 carry) ----
@@ -3229,8 +3264,8 @@ gqa_flash_prefill_v7_kernel(
                 const int kv_pos   = kv0 + kv_local;
                 const bool kvalid  = kv_pos < skv;
                 const size_t off   = kv_base + (size_t)(kvalid ? kv_pos : 0) * D + dt * 16;
-                half16_t vv = kvalid ? HALF16_LOAD(&Vcache[off]) : half16_t{};
-                *reinterpret_cast<half16_t*>(&V_lds[kv_local * KV_STR + dt * 16]) = vv;
+                half16_raw_t vv = kvalid ? HALF16_RAW_LOAD(&Vcache[off]) : half16_raw_t{};
+                *reinterpret_cast<half16_raw_t*>(&V_lds[kv_local * KV_STR + dt * 16]) = vv;
             }
         }
         // NB: no barrier here. v7 streams K from global and softmax only touches
@@ -3252,10 +3287,10 @@ gqa_flash_prefill_v7_kernel(
                 const size_t k_row = kv_base + (size_t)(kvalid ? key : 0) * D;
                 for (int tk = 0; tk < D_TILES; ++tk) {
                     half16_t k_frag = (kvalid && !(abl & 16))
-                        ? HALF16_LOAD(&Kcache[k_row + tk * 16]) : half16_t{};
+                        ? HALF16_LOAD(&Kcache[k_row + tk * 16], pair) : half16_t{};
                     #pragma unroll
                     for (int mt = 0; mt < MT; ++mt)
-                        S_reg[mt][sj] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(
+                        S_reg[mt][sj] = HIPDNN_WMMA_F32_16X16X16_F16(
                             Q_reg[mt][tk], k_frag, S_reg[mt][sj]);
                 }
             }
@@ -3274,7 +3309,7 @@ gqa_flash_prefill_v7_kernel(
                 float corr_e[8];
                 #pragma unroll
                 for (int e = 0; e < 8; ++e) {
-                    const int row    = e * 2 + pair;
+                    const int row    = hipdnn_wmma_acc_row(pair, e);
                     const int q_pos  = row_base + mt * kWmmaTile + row;
                     float rmax = -INFINITY;
                     #pragma unroll
@@ -3332,14 +3367,15 @@ gqa_flash_prefill_v7_kernel(
             #pragma unroll
             for (int tk = 0; tk < S_TILES_J; ++tk) {
                 half16_t v_frag;
+                const int v_k_off = hipdnn_wmma_k_off(pair);
                 #pragma unroll
-                for (int e = 0; e < 16; ++e)
-                    v_frag[e] = V_lds[(tk * 16 + e) * KV_STR + tj * 16 + wmma_lane];
+                for (int e = 0; e < HIPDNN_WMMA_FRAG_ELEMS; ++e)
+                    v_frag[e] = V_lds[(tk * 16 + v_k_off + e) * KV_STR + tj * 16 + wmma_lane];
                 #pragma unroll
                 for (int mt = 0; mt < MT; ++mt) {
                     half16_t p_frag = HALF16_LOAD(
-                        &P_lds[(pbase + mt * kWmmaTile + wmma_lane) * P_STR + tk * 16]);
-                    Of[mt] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(
+                        &P_lds[(pbase + mt * kWmmaTile + wmma_lane) * P_STR + tk * 16], pair);
+                    Of[mt] = HIPDNN_WMMA_F32_16X16X16_F16(
                         p_frag, v_frag, Of[mt]);
                 }
             }
@@ -3359,7 +3395,7 @@ gqa_flash_prefill_v7_kernel(
         for (int tj = 0; tj < D_TILES; ++tj) {
             #pragma unroll
             for (int e = 0; e < 8; ++e) {
-                const int row   = e * 2 + pair;
+                const int row   = hipdnn_wmma_acc_row(pair, e);
                 const int c     = tj * 16 + wmma_lane;
                 const int q_pos = row_base + mt * kWmmaTile + row;
                 if (q_pos < sq && c < D) {
@@ -3529,9 +3565,9 @@ gqa_flash_prefill_v8_kernel(
     constexpr int S_TILES_J = BKV / kWmmaTile;
     constexpr int D_TILES   = D / kWmmaTile;
     constexpr int DPG       = D_TILES / ND;    // D-tiles owned per wave
-    // A WMMA accumulator holds 8 rows per lane (row = e*2 + pair), and the
-    // softmax over those rows is row-independent, so it splits ND ways instead of
-    // being repeated ND times or dumped on one wave while the rest wait.
+    // A WMMA accumulator holds 8 rows per lane (row = hipdnn_wmma_acc_row(pair, e)),
+    // and the softmax over those rows is row-independent, so it splits ND ways
+    // instead of being repeated ND times or dumped on one wave while the rest wait.
     constexpr int EPW       = 8 / ND;          // accumulator rows per wave
     static_assert(EPW * ND == 8, "ND must divide 8 for the softmax row split");
     constexpr int P_STR     = BKV + 2;
@@ -3579,7 +3615,7 @@ gqa_flash_prefill_v8_kernel(
         #pragma unroll
         for (int tk = 0; tk < DPG; ++tk)
             Q_reg[mt][tk] = valid
-                ? HALF16_LOAD(&Q[q_row_base + (dt_base + tk) * 16]) : half16_t{};
+                ? HALF16_LOAD(&Q[q_row_base + (dt_base + tk) * 16], pair) : half16_t{};
     }
 
     // Accumulate O in fp32 registers. The WMMA accumulator is already fp32, so
@@ -3612,8 +3648,8 @@ gqa_flash_prefill_v8_kernel(
                 const int kv_pos   = kv0 + kv_local;
                 const bool kvalid  = kv_pos < skv;
                 const size_t off   = kv_base + (size_t)(kvalid ? kv_pos : 0) * D + dt * 16;
-                half16_t vv = kvalid ? HALF16_LOAD(&Vcache[off]) : half16_t{};
-                *reinterpret_cast<half16_t*>(&V_lds[kv_local * KV_STR + dt * 16]) = vv;
+                half16_raw_t vv = kvalid ? HALF16_RAW_LOAD(&Vcache[off]) : half16_raw_t{};
+                *reinterpret_cast<half16_raw_t*>(&V_lds[kv_local * KV_STR + dt * 16]) = vv;
             }
         }
 
@@ -3632,10 +3668,10 @@ gqa_flash_prefill_v8_kernel(
                 #pragma unroll
                 for (int tk = 0; tk < DPG; ++tk) {
                     half16_t k_frag = (kvalid && !(abl & 16))
-                        ? HALF16_LOAD(&Kcache[k_row + (dt_base + tk) * 16]) : half16_t{};
+                        ? HALF16_LOAD(&Kcache[k_row + (dt_base + tk) * 16], pair) : half16_t{};
                     #pragma unroll
                     for (int mt = 0; mt < MT; ++mt)
-                        S_reg[mt][sj] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(
+                        S_reg[mt][sj] = HIPDNN_WMMA_F32_16X16X16_F16(
                             Q_reg[mt][tk], k_frag, S_reg[mt][sj]);
                 }
             }
@@ -3648,7 +3684,7 @@ gqa_flash_prefill_v8_kernel(
             for (int sj = 0; sj < S_TILES_J; ++sj)
                 #pragma unroll
                 for (int e = 0; e < 8; ++e) {
-                    const int rl  = e * 2 + pair;
+                    const int rl  = hipdnn_wmma_acc_row(pair, e);
                     const int col = sj * 16 + wmma_lane;
                     Sp_lds[((size_t)group * ROWS + mt * 16 + rl) * SP_STR + col] =
                         S_reg[mt][sj][e];
@@ -3686,7 +3722,7 @@ gqa_flash_prefill_v8_kernel(
                 #pragma unroll
                 for (int ei = 0; ei < EPW; ++ei) {
                     const int e     = group * EPW + ei;
-                    const int rl    = e * 2 + pair;
+                    const int rl    = hipdnn_wmma_acc_row(pair, e);
                     const int q_pos = q_start + mt * 16 + rl;
 
                     // Sum the ND partial scores for this row only.
@@ -3750,7 +3786,7 @@ gqa_flash_prefill_v8_kernel(
                 float corr_e[8];
                 #pragma unroll
                 for (int e = 0; e < 8; ++e)
-                    corr_e[e] = Cr_lds[mt * 16 + e * 2 + pair];
+                    corr_e[e] = Cr_lds[mt * 16 + hipdnn_wmma_acc_row(pair, e)];
                 #pragma unroll
                 for (int tj = 0; tj < DPG; ++tj)
                     #pragma unroll
@@ -3766,14 +3802,15 @@ gqa_flash_prefill_v8_kernel(
             #pragma unroll
             for (int tk = 0; tk < S_TILES_J; ++tk) {
                 half16_t v_frag;
+                const int v_k_off = hipdnn_wmma_k_off(pair);
                 #pragma unroll
-                for (int e = 0; e < 16; ++e)
-                    v_frag[e] = V_lds[(tk * 16 + e) * KV_STR + d_tile * 16 + wmma_lane];
+                for (int e = 0; e < HIPDNN_WMMA_FRAG_ELEMS; ++e)
+                    v_frag[e] = V_lds[(tk * 16 + v_k_off + e) * KV_STR + d_tile * 16 + wmma_lane];
                 #pragma unroll
                 for (int mt = 0; mt < MT; ++mt) {
                     half16_t p_frag = HALF16_LOAD(
-                        &P_lds[(mt * 16 + wmma_lane) * P_STR + tk * 16]);
-                    O_acc[mt][tj] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(
+                        &P_lds[(mt * 16 + wmma_lane) * P_STR + tk * 16], pair);
+                    O_acc[mt][tj] = HIPDNN_WMMA_F32_16X16X16_F16(
                         p_frag, v_frag, O_acc[mt][tj]);
                 }
             }
@@ -3789,14 +3826,14 @@ gqa_flash_prefill_v8_kernel(
     for (int mt = 0; mt < MT; ++mt)
         #pragma unroll
         for (int ei = 0; ei < EPW; ++ei)
-            Cr_lds[mt * 16 + (group * EPW + ei) * 2 + pair] = l_reg[mt][ei];
+            Cr_lds[mt * 16 + hipdnn_wmma_acc_row(pair, group * EPW + ei)] = l_reg[mt][ei];
     __syncthreads();
     float l_fin[MT][8];
     #pragma unroll
     for (int mt = 0; mt < MT; ++mt)
         #pragma unroll
         for (int e = 0; e < 8; ++e)
-            l_fin[mt][e] = Cr_lds[mt * 16 + e * 2 + pair];
+            l_fin[mt][e] = Cr_lds[mt * 16 + hipdnn_wmma_acc_row(pair, e)];
 
     // ---- Epilogue: this wave writes its owned D tiles ----
     #pragma unroll
@@ -3806,7 +3843,7 @@ gqa_flash_prefill_v8_kernel(
             const int c = (dt_base + tj) * 16 + wmma_lane;
             #pragma unroll
             for (int e = 0; e < 8; ++e) {
-                const int rl    = e * 2 + pair;
+                const int rl    = hipdnn_wmma_acc_row(pair, e);
                 const int q_pos = q_start + mt * 16 + rl;
                 if (q_pos < sq && c < D) {
                     const float l_val   = fmaxf(l_fin[mt][e], 1e-6f);

--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -2553,21 +2553,25 @@ __global__ void dequant_u4_to_fp16(
  * Section 2b: WMMA kernel (supports both fused dequant and fp16 B)
  * ======================================================================= */
 
-typedef _Float16 half16 __attribute__((ext_vector_type(16)));
+// half16 holds one WMMA A/B fragment; its vector width matches
+// HIPDNN_WMMA_FRAG_ELEMS (16 on gfx11, 8 on the gfx12-style encoding
+// gfx1170/gfx12xx use -- see hip_arch_compat.h). The name is kept for
+// continuity even though the width is arch-dependent.
+typedef _Float16 half16 __attribute__((ext_vector_type(HIPDNN_WMMA_FRAG_ELEMS)));
 typedef float    float8 __attribute__((ext_vector_type(8)));
 
-// The WMMA builtin below is RDNA3-family (wave32) only. Where __has_builtin
-// reports it absent, trap instead so this file still compiles and a WMMA
-// launch on an unsupported arch aborts loudly rather than returning garbage.
-#if !defined(__has_builtin) ||                                                  \
-    !__has_builtin(__builtin_amdgcn_wmma_f32_16x16x16_f16_w32)
+// Where neither WMMA builtin is available (non-RDNA3/3.5/4 arch), trap
+// instead so this file still compiles and a WMMA launch on an unsupported
+// arch aborts loudly rather than returning garbage.
+#if !HIPDNN_HAS_WMMA
 static __device__ __forceinline__ float8
-hipdnn_wmma_f32_16x16x16_f16_w32_unavailable(half16, half16, float8 c) {
+hipdnn_wmma_f32_16x16x16_f16_unavailable(half16, half16, float8 c) {
   __builtin_trap();
   return c;
 }
-#define __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a, b, c)                     \
-  hipdnn_wmma_f32_16x16x16_f16_w32_unavailable((a), (b), (c))
+#undef HIPDNN_WMMA_F32_16X16X16_F16
+#define HIPDNN_WMMA_F32_16X16X16_F16(a, b, c)                                  \
+  hipdnn_wmma_f32_16x16x16_f16_unavailable((a), (b), (c))
 #endif
 
 #define WMMA_TILE 16
@@ -2801,15 +2805,16 @@ void GemmFp16U4Impl(
         for(int ks = 0; ks < K_STEPS; ks++)
         {
             half16 b_frag[WT_N];
+            const int k_off = hipdnn_wmma_k_off(sub);
 #pragma unroll
             for(int wn = 0; wn < WT_N; wn++)
             {
                 int noff              = (wcol * WT_N + wn) * WMMA_TILE;
                 uint32_t* dst         = reinterpret_cast<uint32_t*>(&b_frag[wn]);
                 const uint32_t* src   = reinterpret_cast<const uint32_t*>(
-                    &smB[buf][noff + lane][ks * WMMA_TILE]);
+                    &smB[buf][noff + lane][ks * WMMA_TILE + k_off]);
 #pragma unroll
-                for(int i = 0; i < 8; i++)
+                for(int i = 0; i < HIPDNN_WMMA_FRAG_ELEMS / 2; i++)
                     dst[i] = src[i];
             }
 #pragma unroll
@@ -2819,14 +2824,14 @@ void GemmFp16U4Impl(
                 half16 a_frag;
                 uint32_t* dst         = reinterpret_cast<uint32_t*>(&a_frag);
                 const uint32_t* src   = reinterpret_cast<const uint32_t*>(
-                    &smA[buf][moff + lane][ks * WMMA_TILE]);
+                    &smA[buf][moff + lane][ks * WMMA_TILE + k_off]);
 #pragma unroll
-                for(int i = 0; i < 8; i++)
+                for(int i = 0; i < HIPDNN_WMMA_FRAG_ELEMS / 2; i++)
                     dst[i] = src[i];
 
 #pragma unroll
                 for(int wn = 0; wn < WT_N; wn++)
-                    acc[wm][wn] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(
+                    acc[wm][wn] = HIPDNN_WMMA_F32_16X16X16_F16(
                         a_frag, b_frag[wn], acc[wm][wn]);
             }
         }
@@ -2859,7 +2864,7 @@ void GemmFp16U4Impl(
 #pragma unroll
             for(int e = 0; e < 8; e++)
             {
-                int r = e * 2 + sub;
+                int r = hipdnn_wmma_acc_row(sub, e);
                 if constexpr (BOUNDS_CHECK) {
                     if (mbase + r < M && nbase + lane < N)
                         C[(mbase + r) * ldc + nbase + lane] =
@@ -3703,14 +3708,15 @@ void GemmFp16I8Impl(
 #pragma unroll
         for (int ks = 0; ks < K_STEPS; ks++) {
             half16 b_frag[WT_N];
+            const int k_off = hipdnn_wmma_k_off(sub);
 #pragma unroll
             for (int wn = 0; wn < WT_N; wn++) {
                 int noff              = (wcol * WT_N + wn) * WMMA_TILE;
                 uint32_t* dst         = reinterpret_cast<uint32_t*>(&b_frag[wn]);
                 const uint32_t* src   = reinterpret_cast<const uint32_t*>(
-                    &smB[buf][noff + lane][ks * WMMA_TILE]);
+                    &smB[buf][noff + lane][ks * WMMA_TILE + k_off]);
 #pragma unroll
-                for (int i = 0; i < 8; i++)
+                for (int i = 0; i < HIPDNN_WMMA_FRAG_ELEMS / 2; i++)
                     dst[i] = src[i];
             }
 #pragma unroll
@@ -3719,14 +3725,14 @@ void GemmFp16I8Impl(
                 half16 a_frag;
                 uint32_t* dst         = reinterpret_cast<uint32_t*>(&a_frag);
                 const uint32_t* src   = reinterpret_cast<const uint32_t*>(
-                    &smA[buf][moff + lane][ks * WMMA_TILE]);
+                    &smA[buf][moff + lane][ks * WMMA_TILE + k_off]);
 #pragma unroll
-                for (int i = 0; i < 8; i++)
+                for (int i = 0; i < HIPDNN_WMMA_FRAG_ELEMS / 2; i++)
                     dst[i] = src[i];
 
 #pragma unroll
                 for (int wn = 0; wn < WT_N; wn++)
-                    acc[wm][wn] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(
+                    acc[wm][wn] = HIPDNN_WMMA_F32_16X16X16_F16(
                         a_frag, b_frag[wn], acc[wm][wn]);
             }
         }
@@ -3755,7 +3761,7 @@ void GemmFp16I8Impl(
             int nbase = col0 + (wcol * WT_N + wn) * WMMA_TILE;
 #pragma unroll
             for (int e = 0; e < 8; e++) {
-                int r = e * 2 + sub;
+                int r = hipdnn_wmma_acc_row(sub, e);
                 if constexpr (BOUNDS_CHECK) {
                     if (mbase + r < M && nbase + lane < N)
                         C[(mbase + r) * ldc + nbase + lane] =
@@ -4229,14 +4235,15 @@ void GemmFp16U3Impl(
 #pragma unroll
         for (int ks = 0; ks < K_STEPS; ks++) {
             half16 b_frag[WT_N];
+            const int k_off = hipdnn_wmma_k_off(sub);
 #pragma unroll
             for (int wn = 0; wn < WT_N; wn++) {
                 int noff              = (wcol * WT_N + wn) * WMMA_TILE;
                 uint32_t* dst         = reinterpret_cast<uint32_t*>(&b_frag[wn]);
                 const uint32_t* src   = reinterpret_cast<const uint32_t*>(
-                    &smB[buf][noff + lane][ks * WMMA_TILE]);
+                    &smB[buf][noff + lane][ks * WMMA_TILE + k_off]);
 #pragma unroll
-                for (int i = 0; i < 8; i++)
+                for (int i = 0; i < HIPDNN_WMMA_FRAG_ELEMS / 2; i++)
                     dst[i] = src[i];
             }
 #pragma unroll
@@ -4245,14 +4252,14 @@ void GemmFp16U3Impl(
                 half16 a_frag;
                 uint32_t* dst         = reinterpret_cast<uint32_t*>(&a_frag);
                 const uint32_t* src   = reinterpret_cast<const uint32_t*>(
-                    &smA[buf][moff + lane][ks * WMMA_TILE]);
+                    &smA[buf][moff + lane][ks * WMMA_TILE + k_off]);
 #pragma unroll
-                for (int i = 0; i < 8; i++)
+                for (int i = 0; i < HIPDNN_WMMA_FRAG_ELEMS / 2; i++)
                     dst[i] = src[i];
 
 #pragma unroll
                 for (int wn = 0; wn < WT_N; wn++)
-                    acc[wm][wn] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(
+                    acc[wm][wn] = HIPDNN_WMMA_F32_16X16X16_F16(
                         a_frag, b_frag[wn], acc[wm][wn]);
             }
         }
@@ -4281,7 +4288,7 @@ void GemmFp16U3Impl(
             int nbase = col0 + (wcol * WT_N + wn) * WMMA_TILE;
 #pragma unroll
             for (int e = 0; e < 8; e++) {
-                int r = e * 2 + sub;
+                int r = hipdnn_wmma_acc_row(sub, e);
                 if constexpr (BOUNDS_CHECK) {
                     if (mbase + r < M && nbase + lane < N)
                         C[(mbase + r) * ldc + nbase + lane] =
@@ -4901,14 +4908,15 @@ void GemmFp16U2Impl(
 #pragma unroll
         for (int ks = 0; ks < K_STEPS; ks++) {
             half16 b_frag[WT_N];
+            const int k_off = hipdnn_wmma_k_off(sub);
 #pragma unroll
             for (int wn = 0; wn < WT_N; wn++) {
                 int noff              = (wcol * WT_N + wn) * WMMA_TILE;
                 uint32_t* dst         = reinterpret_cast<uint32_t*>(&b_frag[wn]);
                 const uint32_t* src   = reinterpret_cast<const uint32_t*>(
-                    &smB[buf][noff + lane][ks * WMMA_TILE]);
+                    &smB[buf][noff + lane][ks * WMMA_TILE + k_off]);
 #pragma unroll
-                for (int i = 0; i < 8; i++)
+                for (int i = 0; i < HIPDNN_WMMA_FRAG_ELEMS / 2; i++)
                     dst[i] = src[i];
             }
 #pragma unroll
@@ -4917,14 +4925,14 @@ void GemmFp16U2Impl(
                 half16 a_frag;
                 uint32_t* dst         = reinterpret_cast<uint32_t*>(&a_frag);
                 const uint32_t* src   = reinterpret_cast<const uint32_t*>(
-                    &smA[buf][moff + lane][ks * WMMA_TILE]);
+                    &smA[buf][moff + lane][ks * WMMA_TILE + k_off]);
 #pragma unroll
-                for (int i = 0; i < 8; i++)
+                for (int i = 0; i < HIPDNN_WMMA_FRAG_ELEMS / 2; i++)
                     dst[i] = src[i];
 
 #pragma unroll
                 for (int wn = 0; wn < WT_N; wn++)
-                    acc[wm][wn] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(
+                    acc[wm][wn] = HIPDNN_WMMA_F32_16X16X16_F16(
                         a_frag, b_frag[wn], acc[wm][wn]);
             }
         }
@@ -4953,7 +4961,7 @@ void GemmFp16U2Impl(
             int nbase = col0 + (wcol * WT_N + wn) * WMMA_TILE;
 #pragma unroll
             for (int e = 0; e < 8; e++) {
-                int r = e * 2 + sub;
+                int r = hipdnn_wmma_acc_row(sub, e);
                 if constexpr (BOUNDS_CHECK) {
                     if (mbase + r < M && nbase + lane < N)
                         C[(mbase + r) * ldc + nbase + lane] =

--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -2531,8 +2531,12 @@ __global__ void dequant_u4_to_fp16(
     _Float16 scale = scales[n * num_groups_k + grp];
     _Float16 zp    = zeros ? zeros[n * num_groups_k + grp] : (_Float16)8;
 
+    // Row stride is num_groups_k * (group_size/2) bytes (ONNX MatMulNBits
+    // padding: the last group is padded to a full group_size even when
+    // K % group_size != 0), not a plain K/2 -- see GemmFp16U4Impl's
+    // b_byte_base comment. The intra-row offset (k8/2) is unaffected.
     uint32_t four = *reinterpret_cast<const uint32_t*>(
-        &B_packed[n * (K / 2) + k8 / 2]);
+        &B_packed[n * (num_groups_k * (group_size / 2)) + k8 / 2]);
 
     _Float16 bv[8];
     bv[0] = (static_cast<_Float16>(static_cast<int>((four      ) & 0xF)) - zp) * scale;
@@ -2650,9 +2654,16 @@ void GemmFp16U4Impl(
     const bool b_valid    = BOUNDS_CHECK ? (b_n_g_raw < N) : true;
     const int b_n_g       = (BOUNDS_CHECK && !b_valid) ? 0 : b_n_g_raw;
 
-    // Fused dequant state (compile-time eliminated when FUSED_DQ=false)
+    // Fused dequant state (compile-time eliminated when FUSED_DQ=false).
+    // B_packed rows are padded to num_groups_k * (group_size/2) bytes (ONNX
+    // MatMulNBits blob layout -- the last group is padded to a full
+    // group_size even when K % group_size != 0), NOT a plain K/2 bytes/row;
+    // see the row-stride comment on matmul_nbits_gemv_kernel's b_base_arr.
+    // Within a row the nibbles are still packed compactly from k=0 (only the
+    // tail beyond K is padding), so the intra-row byte offset (b_k8 >> 1)
+    // below is unaffected -- only the per-row stride changes.
     [[maybe_unused]] const int b_byte_base =
-        FUSED_DQ ? (b_n_g * (K >> 1) + (b_k8 >> 1)) : 0;
+        FUSED_DQ ? (b_n_g * (num_groups_k * (group_size >> 1)) + (b_k8 >> 1)) : 0;
     [[maybe_unused]] const int b_gid_base =
         FUSED_DQ ? (b_n_g * num_groups_k) : 0;
     // cached_k_grp is the quant-group index currently loaded into cached_s/

--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -6017,9 +6017,16 @@ extern "C" int hip_matmul_nbits(
   }
 
   // Packed nibble ZPs [N, ceil(k_blocks/2)] must be unpacked before use:
-  //   - FP16 for WMMA and col-major GEMV paths (only when M > 1)
+  //   - FP16 for WMMA and col-major GEMV paths
   //   - Individual uint8 for row-major GEMV and naive fallback paths
-  // When zp_elem_size == 2 (FP16) or ZPs are NULL, no conversion needed.
+  // When zp_elem_size == 2, zero_points is already FP16 [N, num_groups_k]
+  // (not nibble-packed) and is used as zp_for_fp16_paths directly, with no
+  // conversion. zp_for_u8_paths is deliberately left unset in that case: the
+  // dispatch below never reads it when zp_elem_size==2, because M==1 is
+  // routed to the FP16-capable col-major GEMV kernel instead of the
+  // uint8-only row-major one (see fp16_zp_ready below) -- reinterpreting the
+  // FP16 buffer as raw uint8 bytes there previously produced garbage
+  // zero-points.
   // The runtime wrapper (lib/Runtime/real/matmul_nbits.cpp) caches the
   // unpacked buffers per zero_points pointer and passes them via
   // pre_unpacked_zp_{u8,fp16} so we skip the kernel launches here.
@@ -6039,6 +6046,15 @@ extern "C" int hip_matmul_nbits(
     if (pre_unpacked_zp_fp16)
       zp_for_fp16_paths = pre_unpacked_zp_fp16;
   }
+  // True once zp_for_fp16_paths is a genuinely-ready FP16 buffer (or there
+  // are no zero points at all): zp_elem_size==2 supplies it directly above;
+  // zp_elem_size==1 only pre-builds pre_unpacked_zp_fp16 for M>1 (see the
+  // wrapper), so M==1 with zp_elem_size==1 is deliberately excluded here and
+  // keeps using the row-major kernel's pre_unpacked_zp_u8 below instead of
+  // paying for an extra fp16 conversion on the M==1 decode hot path.
+  const bool fp16_zp_ready =
+      !zero_points || zp_elem_size == 2 ||
+      (zp_elem_size == 1 && pre_unpacked_zp_fp16 != nullptr);
 
   /* -------------------------------------------------------------------
    * WMMA data format: batch==1 && K%32==0
@@ -6135,16 +6151,19 @@ extern "C" int hip_matmul_nbits(
   }
 
   /* -------------------------------------------------------------------
-   * GEMV path with col-major data — small M (>1), WMMA data format
+   * GEMV path with col-major data — small M, WMMA data format
    *
-   * When batch==1, K%32==0, but 1 < M < kWmmaMinM: internally transpose
-   * A row->col and output col->row so the caller sees row-major I/O.
-   * GEMV kernel runs with COL_MAJOR=true for K-parallel reduction.
-   *
-   * M=1 skips this path entirely — row/col layouts are identical for a
-   * single row, and the row-major GEMV avoids the ZP conversion kernel.
+   * When batch==1, K%32==0, M < kWmmaMinM: internally transpose A row->col
+   * and output col->row so the caller sees row-major I/O (skipped for M==1,
+   * where row-major and col-major are the identical single row/column).
+   * GEMV kernel runs with COL_MAJOR=true, reading zero_points as FP16
+   * directly -- the only kernel variant that can, so M==1 must also take
+   * this path whenever an FP16 zp buffer is actually available
+   * (fp16_zp_ready above); M==1 with zp_elem_size==1 and no pre-built
+   * pre_unpacked_zp_fp16 instead falls through to the row-major path below,
+   * which already has the uint8 zp it needs at no extra cost.
    * ------------------------------------------------------------------- */
-  if (wmma_data_format && M > 1 && M < kWmmaMinM) {
+  if (wmma_data_format && M < kWmmaMinM && (M > 1 || fp16_zp_ready)) {
     CUSTOM_KERNELS_DEBUG_LOG(
         "[custom_kernels] hip_matmul_nbits: GEMV col-major path M=%lld "
         "N=%lld K=%lld bs=%lld zp=%s bias=%s\n",

--- a/lib/Runtime/Kernels/include/hip_arch_compat.h
+++ b/lib/Runtime/Kernels/include/hip_arch_compat.h
@@ -13,13 +13,42 @@
  *   HIPDNN_WAVE_SIZE  compile-time wavefront size in the *device* pass
  *                     (64 on CDNA/gfx9xx, 32 on RDNA/gfx10xx+). Used to make
  *                     warp-shuffle reductions span the whole wave correctly.
- *   HIPDNN_HAS_WMMA   1 only in a device pass for an arch that has the WMMA
- *                     intrinsics (RDNA3/RDNA4). 0 on CDNA and in the host pass,
- *                     so WMMA code paths compile away (and are never launched --
- *                     the host dispatch checks the device warpSize at runtime).
+ *   HIPDNN_HAS_WMMA   1 only in a device pass for an arch that has one of the
+ *                     WMMA f16 16x16x16 builtins below (RDNA3/RDNA3.5/RDNA4).
+ *                     0 on CDNA and in the host pass, so WMMA code paths
+ *                     compile away (and are never launched -- the host
+ *                     dispatch checks the device warpSize at runtime).
+ *   HIPDNN_WMMA_GFX12 1 when only the newer, gfx12-style WMMA encoding is
+ *                     available (see below). Selects the fragment layout the
+ *                     kernels must use.
  *
  * ROCm 7.x no longer defines __AMDGCN_WAVEFRONT_SIZE[_], so we key off the
- * clang-provided GPU-family macros (__GFX8__, __GFX9__, __GFX11__, __GFX12__).
+ * clang-provided GPU-family macros (__GFX8__, __GFX9__, __GFX11__, __GFX12__)
+ * for the wave size. WMMA support/layout, however, is NOT reliably keyed off
+ * those family macros: gfx1170 ("RDNA 4m") is numbered under the gfx11 family
+ * (__GFX11__ is defined, __GFX12__ is not) but its hardware does not implement
+ * the original gfx11 WMMA encoding (WMMA256bInsts) at all -- only the newer,
+ * unified encoding introduced for gfx12 (WMMA128bInsts). Concretely, on this
+ * target __has_builtin(__builtin_amdgcn_wmma_f32_16x16x16_f16_w32) is false
+ * and __has_builtin(..._w32_gfx12) is true, even though __GFX11__ is set.
+ * Verified by compiling a probe for each target with AMD clang 23.0.0git:
+ *   gfx1100/1102/1150/1151/gfx11-generic -> old builtin only, __GFX11__
+ *   gfx1170                              -> new (_gfx12) builtin only, __GFX11__
+ *   gfx1200/1201/gfx12-generic           -> new (_gfx12) builtin only, __GFX12__
+ * So WMMA capability/layout must be probed via __has_builtin against the
+ * *builtin names*, not the family macros -- that automatically resolves per
+ * the actual -offload-arch of each object in a multi-arch build, which is
+ * exactly the "pick the right code per machine" behavior HIP's fat-binary
+ * loader then dispatches at load time.
+ *
+ * The two encodings differ in exactly three ways (see gemm_wmma_kernel.hip /
+ * gqa_kernel.hip for the empirically-verified per-lane formulas):
+ *   - fragment width: 16 elements/lane (gfx11, K replicated across lane/16)
+ *     vs 8 elements/lane (gfx12-style, K split by lane/16, no replication)
+ *   - the builtin itself (plain vs "_gfx12" suffix)
+ *   - accumulator row mapping: e*2+pair (gfx11, interleaved) vs pair*8+e
+ *     (gfx12-style, blocked). The M/N<->lane mapping (row=lane%16 for A,
+ *     col=lane%16 for B/output) is identical between the two encodings.
  */
 #ifndef HIP_ARCH_COMPAT_H
 #define HIP_ARCH_COMPAT_H
@@ -36,11 +65,62 @@
 #  define HIPDNN_WAVE_SIZE 32
 #endif
 
-#if defined(__HIP_DEVICE_COMPILE__) && (defined(__GFX11__) || defined(__GFX12__))
+#if defined(__HIP_DEVICE_COMPILE__) &&                                        \
+    __has_builtin(__builtin_amdgcn_wmma_f32_16x16x16_f16_w32)
 #  define HIPDNN_HAS_WMMA 1
+#  define HIPDNN_WMMA_GFX12 0
+#elif defined(__HIP_DEVICE_COMPILE__) &&                                      \
+    __has_builtin(__builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12)
+#  define HIPDNN_HAS_WMMA 1
+#  define HIPDNN_WMMA_GFX12 1
 #else
 #  define HIPDNN_HAS_WMMA 0
+#  define HIPDNN_WMMA_GFX12 0
 #endif
+
+/* Fragment element count for one A/B operand of the f16 16x16x16 WMMA op:
+ * the whole K=16 (replicated across the wave's two lane-halves) on gfx11, or
+ * half of K=16 (no replication, split by lane/16) on the gfx12-style
+ * encoding. The accumulator is always 8 elements/lane in both encodings. */
+#define HIPDNN_WMMA_FRAG_ELEMS (HIPDNN_WMMA_GFX12 ? 8 : 16)
+
+#if HIPDNN_WMMA_GFX12
+#  define HIPDNN_WMMA_F32_16X16X16_F16(a, b, c)                               \
+     __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12((a), (b), (c))
+#else
+#  define HIPDNN_WMMA_F32_16X16X16_F16(a, b, c)                               \
+     __builtin_amdgcn_wmma_f32_16x16x16_f16_w32((a), (b), (c))
+#endif
+
+#if defined(__HIPCC__)
+/* __device__/__forceinline__ come from hip_runtime.h; some callers (e.g.
+ * matmul_nbits_kernel.hip) include this header before it, so pull it in here
+ * too rather than depending on include order. */
+#include <hip/hip_runtime.h>
+/* K-axis base offset (within a 16-wide K tile) that a fragment load must add
+ * for this lane's pair-half (pair = lane/16). Zero on gfx11 (each lane loads
+ * the whole 16-wide K range); pair*8 on the gfx12-style encoding (each lane
+ * loads only its half). */
+__device__ __forceinline__ int hipdnn_wmma_k_off(int pair) {
+#if HIPDNN_WMMA_GFX12
+  return pair * 8;
+#else
+  (void)pair;
+  return 0;
+#endif
+}
+
+/* Row contributed by accumulator element `e` (0..7) for this lane's pair-half
+ * (pair = lane/16): interleaved (e*2+pair) on gfx11, blocked (pair*8+e) on
+ * the gfx12-style encoding. col is lane%16 in both encodings (unchanged). */
+__device__ __forceinline__ int hipdnn_wmma_acc_row(int pair, int e) {
+#if HIPDNN_WMMA_GFX12
+  return pair * 8 + e;
+#else
+  return e * 2 + pair;
+#endif
+}
+#endif  /* __HIPCC__ */
 
 /* Portable 4x8-bit integer dot-product with i32 accumulate (a signed, b treated
  * as small non-negative bytes -- e.g. unpacked 4-bit weight nibbles 0..15, or

--- a/lib/Runtime/Kernels/test/example/gemm_fp16u2/gen_matmul_nbits_u2_data.py
+++ b/lib/Runtime/Kernels/test/example/gemm_fp16u2/gen_matmul_nbits_u2_data.py
@@ -155,7 +155,14 @@ def main():
     B_u4 = np.random.randint(0, 16, (N, K), dtype=np.uint8)
     B_u4_even = B_u4[:, 0::2]
     B_u4_odd = B_u4[:, 1::2]
-    B_u4_packed = (B_u4_even | (B_u4_odd << 4)).astype(np.uint8)
+    B_u4_packed_real = (B_u4_even | (B_u4_odd << 4)).astype(np.uint8)
+
+    # ONNX MatMulNBits pads each row's blob to num_groups_k * (group_size/2)
+    # bytes -- the last group is padded to a full group_size even when K is
+    # not a multiple of group_size (mirrors ../gemm_fp16u4/gen_matmul_nbits_data.py).
+    u4_row_bytes = num_groups_k * (group_size // 2)
+    B_u4_packed = np.zeros((N, u4_row_bytes), dtype=np.uint8)
+    B_u4_packed[:, :B_u4_packed_real.shape[1]] = B_u4_packed_real
 
     scales_u4 = np.random.uniform(0.01, 0.05, (N, num_groups_k)).astype(np.float16)
     zeros_u4_u8 = None

--- a/lib/Runtime/Kernels/test/example/gemm_fp16u2/test_matmul_nbits_u2.cpp
+++ b/lib/Runtime/Kernels/test/example/gemm_fp16u2/test_matmul_nbits_u2.cpp
@@ -410,7 +410,9 @@ bool testCompareShape(int M, int N, int K, int group_size,
     size_t countC          = static_cast<size_t>(M) * N;
     size_t rowBytesU2      = static_cast<size_t>(K) / 4;
     size_t countB_u2       = static_cast<size_t>(N) * rowBytesU2;
-    size_t countB_u4       = static_cast<size_t>(N) * K / 2;
+    // B_packed rows are padded to num_groups_k * (group_size/2) bytes (ONNX
+    // MatMulNBits blob layout), NOT a plain K/2 -- see ../gemm_fp16u4/test_matmul_nbits.cpp.
+    size_t countB_u4       = static_cast<size_t>(N) * num_groups_k * (group_size / 2);
     size_t countS          = static_cast<size_t>(N) * num_groups_k;
     size_t packedZpCols    = (static_cast<size_t>(num_groups_k) + 3) / 4;
     size_t countZ_packed   = static_cast<size_t>(N) * packedZpCols;

--- a/lib/Runtime/Kernels/test/example/gemm_fp16u3/gen_matmul_nbits_u3_data.py
+++ b/lib/Runtime/Kernels/test/example/gemm_fp16u3/gen_matmul_nbits_u3_data.py
@@ -168,7 +168,14 @@ def main():
     B_u4 = np.random.randint(0, 16, (N, K), dtype=np.uint8)
     B_u4_even = B_u4[:, 0::2]
     B_u4_odd = B_u4[:, 1::2]
-    B_u4_packed = (B_u4_even | (B_u4_odd << 4)).astype(np.uint8)
+    B_u4_packed_real = (B_u4_even | (B_u4_odd << 4)).astype(np.uint8)
+
+    # ONNX MatMulNBits pads each row's blob to num_groups_k * (group_size/2)
+    # bytes -- the last group is padded to a full group_size even when K is
+    # not a multiple of group_size (mirrors ../gemm_fp16u4/gen_matmul_nbits_data.py).
+    u4_row_bytes = num_groups_k * (group_size // 2)
+    B_u4_packed = np.zeros((N, u4_row_bytes), dtype=np.uint8)
+    B_u4_packed[:, :B_u4_packed_real.shape[1]] = B_u4_packed_real
 
     scales_u4 = np.random.uniform(0.01, 0.05, (N, num_groups_k)).astype(np.float16)
     zeros_u4_u8 = None

--- a/lib/Runtime/Kernels/test/example/gemm_fp16u3/test_matmul_nbits_u3.cpp
+++ b/lib/Runtime/Kernels/test/example/gemm_fp16u3/test_matmul_nbits_u3.cpp
@@ -393,7 +393,9 @@ bool testCompareShape(int M, int N, int K, int group_size,
     size_t countC         = static_cast<size_t>(M) * N;
     size_t rowBytesU3     = (static_cast<size_t>(K) * 3 + 7) / 8;
     size_t countB_u3      = static_cast<size_t>(N) * rowBytesU3;
-    size_t countB_u4      = static_cast<size_t>(N) * K / 2;
+    // B_packed rows are padded to num_groups_k * (group_size/2) bytes (ONNX
+    // MatMulNBits blob layout), NOT a plain K/2 -- see ../gemm_fp16u4/test_matmul_nbits.cpp.
+    size_t countB_u4      = static_cast<size_t>(N) * num_groups_k * (group_size / 2);
     size_t countS         = static_cast<size_t>(N) * num_groups_k;
 
     // ---- Load shared A ----

--- a/lib/Runtime/Kernels/test/example/gemm_fp16u4/gen_matmul_nbits_data.py
+++ b/lib/Runtime/Kernels/test/example/gemm_fp16u4/gen_matmul_nbits_data.py
@@ -81,7 +81,15 @@ def main():
 
     zeros = None
     if not args.no_zeros:
-        zeros = np.random.uniform(7.0, 9.0, (N, num_groups_k)).astype(np.float16)
+        # ONNX MatMulNBits zero_points are packed at `bits` bits (4 bits here),
+        # so they are always small integers (0..15), never fractional -- the
+        # FP16 buffer this test passes to hip_matmul_nbits (zp_elem_size==2)
+        # is a pre-converted cast of those integers, not an independently
+        # continuous value. Matches the integer convention already used by
+        # ../gemm_fp16u3/gen_matmul_nbits_u3_data.py and
+        # ../gemm_fp16u2/gen_matmul_nbits_u2_data.py's zero_points.
+        zeros = np.random.randint(7, 10, (N, num_groups_k)).astype(np.uint8) \
+                    .astype(np.float16)
 
     # A stored row-major (C order)
     file_A = os.path.join(out_dir, "matmul_nbits_A.bin")

--- a/lib/Runtime/Kernels/test/example/gemm_fp16u4/gen_matmul_nbits_data.py
+++ b/lib/Runtime/Kernels/test/example/gemm_fp16u4/gen_matmul_nbits_data.py
@@ -66,7 +66,16 @@ def main():
     B_uint4 = np.random.randint(0, 16, (N, K), dtype=np.uint8)
     B_even = B_uint4[:, 0::2]
     B_odd  = B_uint4[:, 1::2]
-    B_packed = (B_even | (B_odd << 4)).astype(np.uint8)
+    B_packed_real = (B_even | (B_odd << 4)).astype(np.uint8)
+
+    # ONNX MatMulNBits pads each row's blob to num_groups_k * (group_size/2)
+    # bytes -- the last group is padded to a full group_size even when K is not
+    # a multiple of group_size. hip_matmul_nbits' row stride assumes this
+    # padded layout (see matmul_nbits_kernel.hip row-stride comments), so an
+    # unpadded K/2-byte row misaligns every row n>0 whenever K % group_size != 0.
+    row_bytes = num_groups_k * (group_size // 2)
+    B_packed = np.zeros((N, row_bytes), dtype=np.uint8)
+    B_packed[:, :B_packed_real.shape[1]] = B_packed_real
 
     scales = np.random.uniform(0.01, 0.05, (N, num_groups_k)).astype(np.float16)
 

--- a/lib/Runtime/Kernels/test/example/gemm_fp16u4/test_matmul_nbits.cpp
+++ b/lib/Runtime/Kernels/test/example/gemm_fp16u4/test_matmul_nbits.cpp
@@ -347,7 +347,10 @@ bool test_matmul_nbits(int M, int N, int K, int group_size,
     std::vector<__half>  h_zeros;
 
     size_t countA = static_cast<size_t>(M) * K;
-    size_t countB = static_cast<size_t>(N) * K / 2;
+    // B_packed rows are padded to num_groups_k * (group_size/2) bytes (ONNX
+    // MatMulNBits blob layout -- the last group is padded to a full
+    // group_size even when K % group_size != 0), NOT a plain K/2 bytes/row.
+    size_t countB = static_cast<size_t>(N) * num_groups_k * (group_size / 2);
     size_t countS = static_cast<size_t>(N) * num_groups_k;
     size_t countZ = static_cast<size_t>(N) * num_groups_k;
     size_t countC = static_cast<size_t>(M) * N;
@@ -421,7 +424,10 @@ bool test_matmul_nbits(int M, int N, int K, int group_size,
             1,         // batch_count
             4,         // bits
             group_size,// block_size
-            2);        // element_size_bytes (fp16)
+            2,         // element_size_bytes (fp16)
+            2,         // zp_elem_size (fp16 zero_points, used as-is)
+            nullptr,   // pre_unpacked_zp_u8 (unused, zp_elem_size==2)
+            nullptr);  // pre_unpacked_zp_fp16 (unused, zero_points is already fp16)
     };
 
     constexpr int PRE_WARMUP = 2000;
@@ -449,7 +455,7 @@ bool test_matmul_nbits(int M, int N, int K, int group_size,
             nullptr,
             d_C,
             M, N, K,
-            1, 4, group_size, 2);
+            1, 4, group_size, 2, 2, nullptr, nullptr);
         if(status != 0) break;
     }
     HIP_CHECK(hipStreamSynchronize(stream));
@@ -609,7 +615,9 @@ static int runModelSweep(const std::string& json_path, int group_size,
 
             int num_groups_k = (K + group_size - 1) / group_size;
             size_t countA = (size_t)M * K;
-            size_t countB = (size_t)N * K / 2;
+            // See test_matmul_nbits() above: B_packed rows are padded to
+            // num_groups_k * (group_size/2) bytes, not a plain K/2.
+            size_t countB = (size_t)N * num_groups_k * (group_size / 2);
             size_t countS = (size_t)N * num_groups_k;
             size_t countZ = (size_t)N * num_groups_k;
             size_t countC = (size_t)M * N;
@@ -664,7 +672,7 @@ static int runModelSweep(const std::string& json_path, int group_size,
             auto launch = [&]() {
                 hip_matmul_nbits(stream, dA, dB, dS,
                                  use_zeros ? dZ : nullptr, nullptr, dC,
-                                 M, N, K, 1, 4, group_size, 2);
+                                 M, N, K, 1, 4, group_size, 2, 2, nullptr, nullptr);
             };
 
             // Pre-warmup (once, on first successfully loaded shape)
@@ -693,7 +701,7 @@ static int runModelSweep(const std::string& json_path, int group_size,
             {
                 status = hip_matmul_nbits(stream, dA, dB, dS,
                                           use_zeros ? dZ : nullptr, nullptr, dC,
-                                          M, N, K, 1, 4, group_size, 2);
+                                          M, N, K, 1, 4, group_size, 2, 2, nullptr, nullptr);
                 if(status != 0) break;
             }
             HIP_CHECK(hipStreamSynchronize(stream));


### PR DESCRIPTION
## Summary

Builds targeting gfx1170 ("RDNA 4m") previously compiled but hit a
`__builtin_trap()` at kernel launch (or, on older toolchains without gfx1170
support, silently produced wrong results when a nearby generic target was
substituted). All three WMMA kernels -- `gemm_wmma_kernel.hip`,
`gqa_kernel.hip` (flash decode + the v5/v7/v8 fused prefill kernels), and
`matmul_nbits_kernel.hip` (the fp16xU4 fused GEMM+dequant kernel) -- now
compile and run correctly on gfx1170, with no change to the generated code
for gfx11 (gfx1100-1103, gfx1150-1153).

Also includes an unrelated, pre-existing test-infra fix bundled into this
branch: `gemm_fp16u4`'s data generator and test harness now size/pad
`B_packed` rows to match ONNX MatMulNBits' blob layout (see that commit for
detail).

## Related issue or design

None.

## Why

gfx1170 is numbered under the gfx11 family (`__GFX11__` is defined,
`__GFX12__` is not), but its hardware only implements the newer
`WMMA128bInsts` encoding introduced for gfx12 -- not the original
`WMMA256bInsts` encoding every WMMA kernel in this repo called
unconditionally. `hip_arch_compat.h`'s `HIPDNN_HAS_WMMA` gate
(`__GFX11__ || __GFX12__`) therefore reported WMMA support on gfx1170, but
the only builtin referenced, `__builtin_amdgcn_wmma_f32_16x16x16_f16_w32`,
doesn't exist for that target, so it fell back to a `__builtin_trap()` stub.

## What

- `hip_arch_compat.h`: replaced the family-macro gate with an
  `__has_builtin` probe against the actual builtin names, which Clang
  resolves per the `-offload-arch` being compiled -- this makes the
  selection automatic and correct per architecture in a single build,
  including future targets that gain the same feature. Added
  `HIPDNN_WMMA_GFX12`, `HIPDNN_WMMA_FRAG_ELEMS`,
  `HIPDNN_WMMA_F32_16X16X16_F16(a,b,c)`, `hipdnn_wmma_k_off(pair)`, and
  `hipdnn_wmma_acc_row(pair,e)` to abstract the three points where the two
  WMMA encodings differ:
  - fragment width: 16 elements/lane (gfx11, K duplicated across the wave's
    two lane-halves) vs 8 elements/lane (gfx12-style, K split by
    `pair = lane/16`, no duplication);
  - the builtin itself (plain vs `_gfx12`-suffixed);
  - accumulator row mapping: `e*2+pair` (gfx11, interleaved) vs `pair*8+e`
    (gfx12-style, blocked). The M/N<->lane mapping is identical between the
    two encodings and required no change.
- Applied the same three-point substitution at every WMMA call site in
  `gemm_wmma_kernel.hip`, `gqa_kernel.hip`, and `matmul_nbits_kernel.hip`.
- The gfx12-style fragment layout was determined empirically (not from
  secondhand documentation): a standalone probe kernel was compiled and run
  on real gfx1170 hardware against a CPU reference with asymmetric
  matrices, giving an exact (`maxdiff == 0`) match before being applied to
  the production kernels.

## Test plan

All commands run against real gfx1170 hardware (`hipInfo`: major=11,
minor=7, wave32) using a toolchain that supports the target
(`therock-dist-*-gfx117X-all`, AMD clang 23.0.0git):

- `lib/Runtime/Kernels/test/example/gqa/decode/test_gqa_decode.cpp` built
  with `--offload-arch=gfx1170`: `ALL PASS (0 failing case(s))` across the
  full MHA/GQA/model shape matrix, `relL2` ~3e-04.
- `lib/Runtime/Kernels/test/example/gqa/prefill/test_gqa_prefill.cpp` built
  with `--offload-arch=gfx1170`: `ALL PASS (0 failing case(s))`, covering
  v5 (D=64), v7 (D=128), and v8 (D=256).
- `lib/Runtime/Kernels/test/example/gemm_fp16u4/test_matmul_nbits.cpp` built
  with `--offload-arch=gfx1170`: `ALL PASSED`, 0 errors vs the Python
  reference.
- Compiled (device-object, `--cuda-device-only`) all three kernel files for
  gfx1100/1101/1102/1103/gfx1150/1151/1152/1153/gfx1170/gfx1200/1201 --
  clean, no errors, on every target.
- Regression check for the untouched gfx11 path: compared the generated
  assembly (`-S -O3`) for gfx1150 and gfx1151 between this branch and
  `main`. `gemm_wmma_kernel.hip` and `matmul_nbits_kernel.hip` are
  byte-identical except the per-compilation-unit `__hip_cuid_*` content
  hash. `gqa_kernel.hip`: 133 of 146 kernel instantiations (decode, v5, v7,
  and every non-WMMA kernel) are byte-identical the same way; the 12 v8
  (D=256) instantiations show a small, equivalent-cost instruction
  reselection with identical-or-lower VGPR/SGPR usage and instruction
  count in every case checked -- no regression.

## Notes for reviewers

- The `gemm_fp16u4` test-infra commit (`fix(gemm_fp16u4): ...`) is bundled
  into this branch but is unrelated to the WMMA work; called out separately
  in its own commit so it can be reviewed/reverted independently.
- Substantial AI assistance (Claude Code) was used for the investigation,
  implementation, and the hardware-based verification described above; I
  reviewed the diff and the verification methodology and can walk through
  any part of it.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
