### PR TITLE
test(ci): build OGA from the AMDGPU fork branch to exercise #795's sliding window (do not merge)

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -49,11 +49,14 @@ jobs:
       # editing this list auto-invalidates the cached ORT install prefix.
       # Remove a PR number once its fix is in the pinned ONNXRUNTIME_VERSION.
       ONNXRUNTIME_PR_PATCHES: ""
-      OGA_VERSION: "0.14.0"
-      # Space-separated microsoft/onnxruntime-genai PR numbers fetched from
-      # pull/<n>.patch and `git apply` on top of v<OGA_VERSION>. Part of the OGA
-      # cache key. Remove a PR once it lands in the pinned OGA release.
-      OGA_PR_PATCHES: "2194"
+      # Fork branch carrying AMDGPU MorphiZen integration (former PR 2194) plus
+      # sliding_window support.
+      OGA_REPO: "amd-genmingz/onnxruntime-genai"
+      OGA_REF: "test_0_3"
+      # Optional space-separated microsoft/onnxruntime-genai PR numbers applied
+      # on top of the fork checkout via pull/<n>.patch + git am. Empty when the
+      # fork branch already carries the needed integration.
+      OGA_PR_PATCHES: ""
       # ilammy/msvc-dev-cmd and mozilla-actions/sccache-action have no
       # Node.js 24 releases yet; allow Node.js 20 until they are updated.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
@@ -368,22 +371,19 @@ jobs:
         with:
           path: ${{ runner.workspace }}/oga-artifacts
           # OGA is built against the patched ort-install, so the key folds in
-          # both OGA's own PR list and ONNXRUNTIME_PR_PATCHES; editing either
-          # forces a rebuild. The mm<N> token bumps when the OGA artifact set
-          # changes shape, or when a PR's branch content changes under the same
-          # number (mm2: PR 2194 now carries the AMDGPU OGA integration).
-          key: oga-dml-mm2-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
+          # the fork ref, optional OGA_PR_PATCHES, and ONNXRUNTIME_PR_PATCHES.
+          # The mm<N> token bumps when the OGA artifact set changes shape.
+          key: oga-dml-mm3-${{ env.OGA_REPO }}-${{ env.OGA_REF }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}-2
 
-      # OGA is built from upstream microsoft/onnxruntime-genai + PR patches
-      # (OGA_PR_PATCHES). PR 2194 (the dynamic-shape-morphizen branch) now also
-      # carries the AMDGPU umbrella integration, so the patched upstream build
-      # is the AMDGPU-targeted OGA -- no fork checkout needed.
+      # OGA is built from the AMDGPU fork branch (AMDGPU MorphiZen integration +
+      # sliding_window). Optional OGA_PR_PATCHES apply extra upstream PRs on top
+      # of the fork checkout.
       - name: Checkout OGA
         if: steps.cache-oga.outputs.cache-hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: microsoft/onnxruntime-genai
-          ref: v${{ env.OGA_VERSION }}
+          repository: ${{ env.OGA_REPO }}
+          ref: ${{ env.OGA_REF }}
           path: source-oga
           submodules: true
           fetch-depth: 1

--- a/lib/Conversion/OnnxToHip/AttentionWindowFold.cpp
+++ b/lib/Conversion/OnnxToHip/AttentionWindowFold.cpp
@@ -1,0 +1,531 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- AttentionWindowFold.cpp - Recover a sliding window from the mask ---===//
+//
+// `onnx.Attention` had no way to declare a sliding window until opset 25, which
+// added `left_window_size` / `right_window_size`. At opset 23 and 24 the op's
+// attributes are only `is_causal`, `kv_num_heads`, `q_num_heads`,
+// `qk_matmul_output_mode`, `scale`, `softcap` and `softmax_precision`, so a
+// model whose attention is windowed has nowhere to say so and bakes the window
+// into the additive float mask instead: the mask is 0 for the key positions a
+// query may attend to and a large negative value everywhere else. The op then
+// reaches the runtime with `local_window_size == -1`, so the decomposed path
+// scores and copies the whole key range even though everything older than the
+// window is already -inf in the scores.
+//
+// So this rewrite resolves the window in two ways, and the order matters: an
+// explicit `left_window_size` is read directly, and only when there is none
+// does it recover the window from the mask's producing subgraph. The declared
+// attribute is the model telling us; the mask walk is inference about what the
+// model happens to have built, which is strictly weaker evidence and is here to
+// serve the opset-24 exports that have no alternative. Either way the result is
+// stamped as `hipdnn.local_window_size`, which OnnxAttentionConversion reads
+// onto `hip.gqa`.
+//
+// The two spellings do not share a convention, which is the easiest thing to
+// get wrong here. Opset 25 defines `left_window_size = L` as L keys *preceding*
+// the current one, so the attended count is L + 1 -- the spec's own example has
+// `left_window_size=2` admitting "the current key and two preceding keys".
+// `hipdnn.local_window_size = N` means N attended keys *including* the current
+// one, matching `com.microsoft.GroupQueryAttention` (whose own definition moved
+// to include the current token in onnxruntime PR 25927) and the runtime's
+// `kv_lo = abs_q - local_window_size + 1`. Hence the `+ 1` on the attribute
+// path. A HuggingFace `sliding_window: 1024` is `left_window_size = 1023` is
+// `hipdnn.local_window_size = 1024`.
+//
+// What is matched
+// ---------------
+// Gemma-4's 25 windowed layers and its 5 global layers share one mask shape and
+// differ by exactly one node, which is what makes this recognizable:
+//
+//   windowed:  keep = And(pad, Or(win, seg))
+//   global:    keep = And(pad, Or(GreaterOrEqual(P,Q), seg))
+//   both:      mask = Where(keep, 0.0, -65504.0)
+//
+//   with  win = And(GreaterOrEqual(P,Q), Less(Sub(P,Q), 1024))
+//         seg = the same-image-block term described below
+//
+// The window leg is `And(P >= Q, P - Q < W)` where the compare and the
+// subtraction reference the SAME two values in the SAME order. That identity is
+// the whole proof, and it needs no knowledge of what P and Q are: the causal
+// conjunct `P >= Q` fixes P as the query index and Q as the key index (the
+// reverse reading would keep only future keys, which no decoder mask does), so
+// `P - Q < W` reads `q - k < W`, i.e. `k >= q - W + 1`. That is exactly the
+// runtime's `kv_lo = abs_q - local_window_size + 1`, so W transfers with no
+// off-by-one. Where both index tensors are recognizable unsqueezes their axes
+// are checked as corroboration.
+//
+// How the legs combine
+// --------------------
+// The keep-condition is a monotone And/Or tree, and the bound propagates
+// through it the only way it can:
+//
+//   * AND: a conjunct can only remove keeps, so an unrecognized conjunct is
+//     harmless and any bounded conjunct bounds the whole node (min of the
+//     bounds). This is what absorbs the padding leg for free.
+//   * OR: a disjunct can add keeps, so EVERY disjunct must be bounded or the
+//     node is unbounded (max of the bounds).
+//
+// The segment exception
+// ---------------------
+// Gemma-4's mask ORs in a same-image-block bidirectional term,
+// `And(Equal(a,b), a >= 0)`, built from `Equal(input_ids, <image token>)`
+// through a CumSum block index. It is identically false for a text-only prompt,
+// so narrowing is then exact. With images it keeps keys in the query's own
+// image block, and can therefore reach past the window only if a single image
+// block is longer than the window -- 256 soft tokens per image against a
+// 1024 window here, a 4x margin. That bound is a property of the input rather
+// than of the graph, so it cannot be proven here; this rewrite recognizes the
+// term explicitly and accepts it, rather than accepting anything it does not
+// understand. A leg that is neither windowed nor this exact shape makes the
+// whole match fail and the op keep its full range.
+//
+// Implementation notes
+// --------------------
+//   * Roots on `onnx.Attention`. Idempotent: bails if the attribute is already
+//     set, so the greedy `ExistingOps` pre-lowering loop quiesces.
+//   * Must run BEFORE `convertComputeOps`, whose greedy pattern set would have
+//     rewritten the mask's producers into `hip.*` ops in an order this cannot
+//     rely on. Pre-lowering still sees generic `onnx.*` with inline constants.
+//   * Recognition is conservative throughout: every unhandled shape declines
+//     with a breadcrumb and leaves the op scoring its full key range, which is
+//     what it does today.
+//
+//===----------------------------------------------------------------------===//
+
+#include "OnnxToHipUtils.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/Debug.h"
+
+#include <algorithm>
+#include <optional>
+
+#define DEBUG_TYPE "attention-window-fold"
+
+STATISTIC(NumAttentionWindowStamps,
+          "Number of onnx.Attention ops whose sliding window was recovered "
+          "from the additive mask subgraph");
+
+namespace mlir {
+namespace hip {
+
+namespace {
+
+/// Recursion and work caps. The real subgraphs sit at depth 7 with a few dozen
+/// nodes; these are loose enough not to bind and tight enough that a
+/// pathological graph cannot make the pre-lowering loop quadratic.
+constexpr int kMaxDepth = 16;
+constexpr int kMaxVisited = 128;
+
+/// The mask value must be negative enough to be a "drop" marker rather than a
+/// bias. fp16's most negative finite value (-65504) is the usual choice; -inf
+/// and float's -3.4e38 also appear.
+constexpr double kDropThreshold = -1.0e4;
+
+static llvm::StringRef opName(mlir::Value v) {
+  mlir::Operation *def = v ? v.getDefiningOp() : nullptr;
+  return def ? def->getName().getStringRef() : llvm::StringRef();
+}
+
+/// Return `v`'s value when it is an inline integer scalar: `onnx.Constant` with
+/// either a rank-0/single-element `value` tensor or the `value_int` attribute
+/// (both forms appear in the same graph -- initializers import as the former,
+/// exporter-synthesized literals as the latter), or an `arith.constant`.
+static std::optional<int64_t> getInlineScalarInt(mlir::Value v) {
+  if (!v)
+    return std::nullopt;
+  mlir::Operation *defOp = v.getDefiningOp();
+  if (!defOp)
+    return std::nullopt;
+
+  if (defOp->getName().getStringRef() == "onnx.Constant") {
+    if (auto asInt = defOp->getAttrOfType<mlir::IntegerAttr>("value_int"))
+      return asInt.getValue().getSExtValue();
+  }
+
+  mlir::DenseElementsAttr dense;
+  if (auto cst = mlir::dyn_cast<mlir::arith::ConstantOp>(defOp))
+    dense = mlir::dyn_cast<mlir::DenseElementsAttr>(cst.getValue());
+  else if (defOp->getName().getStringRef() == "onnx.Constant")
+    dense = defOp->getAttrOfType<mlir::DenseElementsAttr>("value");
+  if (!dense)
+    return std::nullopt;
+
+  auto tensorTy = mlir::dyn_cast<mlir::RankedTensorType>(dense.getType());
+  if (!tensorTy || tensorTy.getRank() > 1 || tensorTy.getNumElements() != 1)
+    return std::nullopt;
+  if (!tensorTy.getElementType().isIntOrIndex())
+    return std::nullopt;
+  return (*dense.getValues<mlir::APInt>().begin()).getSExtValue();
+}
+
+/// Return `v`'s value when it is an inline floating-point scalar. Used only to
+/// identify the Where's keep/drop literals.
+static std::optional<double> getInlineScalarFloat(mlir::Value v) {
+  if (!v)
+    return std::nullopt;
+  mlir::Operation *defOp = v.getDefiningOp();
+  if (!defOp)
+    return std::nullopt;
+
+  if (defOp->getName().getStringRef() == "onnx.Constant") {
+    if (auto asFloat = defOp->getAttrOfType<mlir::FloatAttr>("value_float"))
+      return asFloat.getValueAsDouble();
+  }
+
+  mlir::DenseElementsAttr dense;
+  if (auto cst = mlir::dyn_cast<mlir::arith::ConstantOp>(defOp))
+    dense = mlir::dyn_cast<mlir::DenseElementsAttr>(cst.getValue());
+  else if (defOp->getName().getStringRef() == "onnx.Constant")
+    dense = defOp->getAttrOfType<mlir::DenseElementsAttr>("value");
+  if (!dense)
+    return std::nullopt;
+
+  auto tensorTy = mlir::dyn_cast<mlir::RankedTensorType>(dense.getType());
+  if (!tensorTy || tensorTy.getRank() > 1 || tensorTy.getNumElements() != 1)
+    return std::nullopt;
+  if (!mlir::isa<mlir::FloatType>(tensorTy.getElementType()))
+    return std::nullopt;
+  return (*dense.getValues<mlir::APFloat>().begin()).convertToDouble();
+}
+
+/// Axis of an `onnx.Unsqueeze`, from the opset-13 `axes` operand or the older
+/// `axes` attribute, when it is a single inline value. Used only to corroborate
+/// which of the two index tensors varies along the query axis.
+static std::optional<int64_t> getUnsqueezeAxis(mlir::Value v) {
+  mlir::Operation *def = v ? v.getDefiningOp() : nullptr;
+  if (!def || def->getName().getStringRef() != "onnx.Unsqueeze")
+    return std::nullopt;
+  if (def->getNumOperands() > 1)
+    return getInlineScalarInt(def->getOperand(1));
+  if (auto arr = def->getAttrOfType<mlir::ArrayAttr>("axes")) {
+    if (arr.size() != 1)
+      return std::nullopt;
+    if (auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(arr[0]))
+      return intAttr.getValue().getSExtValue();
+  }
+  return std::nullopt;
+}
+
+/// Match a causal keep-compare, `p >= q`, in either spelling.
+static bool matchCausalCompare(mlir::Value v, mlir::Value &p, mlir::Value &q) {
+  mlir::Operation *def = v ? v.getDefiningOp() : nullptr;
+  if (!def || def->getNumOperands() != 2)
+    return false;
+  llvm::StringRef name = def->getName().getStringRef();
+  if (name == "onnx.GreaterOrEqual") {
+    p = def->getOperand(0);
+    q = def->getOperand(1);
+    return true;
+  }
+  if (name == "onnx.LessOrEqual") { // q <= p
+    p = def->getOperand(1);
+    q = def->getOperand(0);
+    return true;
+  }
+  return false;
+}
+
+/// Match an upper bound on `p - q`, returning the window it implies: the number
+/// of key positions the bound admits, counting the query's own position.
+/// `p - q < W` admits W of them; `p - q <= W` admits W + 1.
+static bool matchDistanceBound(mlir::Value v, mlir::Value &p, mlir::Value &q,
+                               int64_t &window) {
+  mlir::Operation *def = v ? v.getDefiningOp() : nullptr;
+  if (!def || def->getNumOperands() != 2)
+    return false;
+  llvm::StringRef name = def->getName().getStringRef();
+
+  // Which operand holds the difference and which the limit, and whether the
+  // comparison is strict.
+  mlir::Value diffSide, limitSide;
+  bool strict;
+  if (name == "onnx.Less") { // diff < W
+    diffSide = def->getOperand(0);
+    limitSide = def->getOperand(1);
+    strict = true;
+  } else if (name == "onnx.LessOrEqual") { // diff <= W
+    diffSide = def->getOperand(0);
+    limitSide = def->getOperand(1);
+    strict = false;
+  } else if (name == "onnx.Greater") { // W > diff
+    diffSide = def->getOperand(1);
+    limitSide = def->getOperand(0);
+    strict = true;
+  } else if (name == "onnx.GreaterOrEqual") { // W >= diff
+    diffSide = def->getOperand(1);
+    limitSide = def->getOperand(0);
+    strict = false;
+  } else {
+    return false;
+  }
+
+  if (opName(diffSide) != "onnx.Sub")
+    return false;
+  mlir::Operation *sub = diffSide.getDefiningOp();
+  if (sub->getNumOperands() != 2)
+    return false;
+
+  auto limit = getInlineScalarInt(limitSide);
+  if (!limit)
+    return false;
+
+  p = sub->getOperand(0);
+  q = sub->getOperand(1);
+  window = strict ? *limit : *limit + 1;
+  return true;
+}
+
+/// Match the same-segment bidirectional term, `And(Equal(a,b), a >= c)` with a
+/// constant `c`. See "The segment exception" above for why this is accepted
+/// rather than proven.
+static bool matchSegmentTerm(mlir::Operation *andOp) {
+  if (andOp->getNumOperands() != 2)
+    return false;
+  for (int i = 0; i < 2; ++i) {
+    mlir::Value eq = andOp->getOperand(i);
+    mlir::Value ge = andOp->getOperand(1 - i);
+    if (opName(eq) != "onnx.Equal")
+      continue;
+    mlir::Operation *eqOp = eq.getDefiningOp();
+    mlir::Operation *geOp = ge.getDefiningOp();
+    if (!geOp || eqOp->getNumOperands() != 2 || geOp->getNumOperands() != 2)
+      continue;
+    llvm::StringRef geName = geOp->getName().getStringRef();
+    if (geName != "onnx.GreaterOrEqual" && geName != "onnx.Greater")
+      continue;
+    if (!getInlineScalarInt(geOp->getOperand(1)))
+      continue;
+    // The "is in a segment at all" test must be on one of the two values the
+    // equality compares, or these are unrelated conditions.
+    mlir::Value probe = geOp->getOperand(0);
+    if (probe == eqOp->getOperand(0) || probe == eqOp->getOperand(1))
+      return true;
+  }
+  return false;
+}
+
+/// What a boolean leg of the keep-condition tells us about how far back a kept
+/// key can be.
+enum class LegKind {
+  /// No information. Safe as an AND conjunct (it can only remove keeps), fatal
+  /// as an OR disjunct.
+  Unbounded,
+  /// Keeping implies the key is within `window` positions of the query.
+  Windowed,
+  /// The recognized same-segment term, accepted under the documented
+  /// image-block bound.
+  Segment,
+};
+
+struct LegInfo {
+  LegKind kind = LegKind::Unbounded;
+  int64_t window = 0;
+
+  static LegInfo unbounded() { return {}; }
+  static LegInfo windowed(int64_t w) { return {LegKind::Windowed, w}; }
+  static LegInfo segment() { return {LegKind::Segment, 0}; }
+};
+
+/// Classify the keep-condition rooted at `v`. `visited` bounds total work.
+static LegInfo classifyKeep(mlir::Value v, int depth, int &visited) {
+  if (depth > kMaxDepth || ++visited > kMaxVisited)
+    return LegInfo::unbounded();
+  mlir::Operation *def = v ? v.getDefiningOp() : nullptr;
+  if (!def)
+    return LegInfo::unbounded();
+  llvm::StringRef name = def->getName().getStringRef();
+
+  // Value-preserving wrappers: a bool-to-bool cast keeps the predicate, and an
+  // int-to-bool cast is a nonzero test that we would classify as unbounded
+  // either way, so descending is always safe.
+  if (name == "onnx.Cast" || name == "onnx.CastLike" || name == "onnx.Identity")
+    return classifyKeep(def->getOperand(0), depth + 1, visited);
+
+  if (name == "onnx.And") {
+    if (def->getNumOperands() != 2)
+      return LegInfo::unbounded();
+    // Try the two leaf shapes first: both are And-rooted, and recursing into
+    // their halves would only find unbounded compares.
+    if (matchSegmentTerm(def))
+      return LegInfo::segment();
+
+    for (int i = 0; i < 2; ++i) {
+      mlir::Value causal = def->getOperand(i);
+      mlir::Value bound = def->getOperand(1 - i);
+      mlir::Value cp, cq, bp, bq;
+      int64_t window = 0;
+      if (!matchCausalCompare(causal, cp, cq))
+        continue;
+      if (!matchDistanceBound(bound, bp, bq, window))
+        continue;
+      // The proof: the causal compare and the subtraction must reference the
+      // same two values in the same order, which is what makes `p` the query
+      // index and `q` the key index without having to identify either.
+      if (cp != bp || cq != bq || window <= 0)
+        continue;
+      // Corroboration where the shapes allow it. Broadcast into [.., q, k]
+      // puts the query-varying tensor's data on the lower axis, so it is the
+      // one unsqueezed at the HIGHER axis. Only a clear inversion is rejected;
+      // an unreadable axis leaves the causal argument standing on its own.
+      auto pAxis = getUnsqueezeAxis(cp);
+      auto qAxis = getUnsqueezeAxis(cq);
+      if (pAxis && qAxis && *pAxis < *qAxis)
+        continue;
+      return LegInfo::windowed(window);
+    }
+
+    // A general conjunction: any bounded conjunct bounds the whole node, and
+    // the tightest one wins.
+    LegInfo a = classifyKeep(def->getOperand(0), depth + 1, visited);
+    LegInfo b = classifyKeep(def->getOperand(1), depth + 1, visited);
+    if (a.kind == LegKind::Windowed && b.kind == LegKind::Windowed)
+      return LegInfo::windowed(std::min(a.window, b.window));
+    if (a.kind == LegKind::Windowed)
+      return a;
+    if (b.kind == LegKind::Windowed)
+      return b;
+    if (a.kind == LegKind::Segment || b.kind == LegKind::Segment)
+      return LegInfo::segment();
+    return LegInfo::unbounded();
+  }
+
+  if (name == "onnx.Or") {
+    if (def->getNumOperands() != 2)
+      return LegInfo::unbounded();
+    LegInfo a = classifyKeep(def->getOperand(0), depth + 1, visited);
+    LegInfo b = classifyKeep(def->getOperand(1), depth + 1, visited);
+    // A disjunct adds keeps, so an unrecognized one leaves the whole node
+    // unbounded no matter how tight the other side is.
+    if (a.kind == LegKind::Unbounded || b.kind == LegKind::Unbounded)
+      return LegInfo::unbounded();
+    if (a.kind == LegKind::Windowed && b.kind == LegKind::Windowed)
+      return LegInfo::windowed(std::max(a.window, b.window));
+    if (a.kind == LegKind::Windowed)
+      return a;
+    if (b.kind == LegKind::Windowed)
+      return b;
+    return LegInfo::segment();
+  }
+
+  return LegInfo::unbounded();
+}
+
+/// Walk from the mask value down to the `onnx.Where` that turns the boolean
+/// keep-condition into the additive 0 / large-negative bias, through the layout
+/// ops that do not change values.
+static mlir::Operation *findSelect(mlir::Value mask) {
+  mlir::Value cur = mask;
+  for (int depth = 0; depth < kMaxDepth; ++depth) {
+    mlir::Operation *def = cur ? cur.getDefiningOp() : nullptr;
+    if (!def)
+      return nullptr;
+    llvm::StringRef name = def->getName().getStringRef();
+    if (name == "onnx.Where")
+      return def;
+    if (name == "onnx.Cast" || name == "onnx.CastLike" ||
+        name == "onnx.Identity" || name == "onnx.Unsqueeze" ||
+        name == "onnx.Squeeze" || name == "onnx.Reshape" ||
+        name == "onnx.Expand") {
+      cur = def->getOperand(0);
+      continue;
+    }
+    return nullptr;
+  }
+  return nullptr;
+}
+
+struct AttentionStampMaskWindow : public mlir::RewritePattern {
+  AttentionStampMaskWindow(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Attention", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (op->hasAttr("hipdnn.local_window_size"))
+      return rewriter.notifyMatchFailure(op, "window.already_stamped");
+
+    // Opset 25's declared window wins over anything inferred from the mask.
+    // Only a non-negative left bound is a window: the -1 default means "left
+    // side unbounded", which says nothing about the mask and so must fall
+    // through to the walk rather than suppress it.
+    if (auto left = op->getAttrOfType<mlir::IntegerAttr>("left_window_size")) {
+      int64_t l = left.getValue().getSExtValue();
+      if (l >= 0) {
+        // A right bound that admits keys past the current position is a
+        // bidirectional window, which `hipdnn.local_window_size` cannot express
+        // -- it is a causal left extent only. Decline rather than narrow by
+        // half a specification. Absent, -1 and 0 are all fine: 0 is "current
+        // key only" on the right, and with no bound at all there is nothing to
+        // the right of a decode step's query anyway.
+        if (auto right =
+                op->getAttrOfType<mlir::IntegerAttr>("right_window_size")) {
+          int64_t r = right.getValue().getSExtValue();
+          if (r > 0)
+            return rewriter.notifyMatchFailure(op, "window.bidirectional");
+        }
+        // +1: opset 25 counts preceding keys, hipdnn counts attended keys.
+        rewriter.modifyOpInPlace(op, [&] {
+          op->setAttr("hipdnn.local_window_size",
+                      rewriter.getI64IntegerAttr(l + 1));
+        });
+        return mlir::success();
+      }
+    }
+
+    // Operand 3 is attn_mask. Absent or None means there is no mask to read a
+    // window out of.
+    if (op->getNumOperands() < 4)
+      return rewriter.notifyMatchFailure(op, "window.no_mask_operand");
+    mlir::Value mask = op->getOperand(3);
+    if (!mask || mlir::isa<mlir::NoneType>(mask.getType()))
+      return rewriter.notifyMatchFailure(op, "window.mask_is_none");
+
+    mlir::Operation *select = findSelect(mask);
+    if (!select || select->getNumOperands() != 3)
+      return rewriter.notifyMatchFailure(op, "window.no_select_producer");
+
+    // Polarity: the true arm must be the neutral bias and the false arm the
+    // drop marker. The inverted spelling would need the boolean function
+    // negated, which turns every And into an Or and is not handled.
+    auto keepVal = getInlineScalarFloat(select->getOperand(1));
+    auto dropVal = getInlineScalarFloat(select->getOperand(2));
+    if (!keepVal || !dropVal)
+      return rewriter.notifyMatchFailure(op, "window.select_arms_not_const");
+    if (*keepVal != 0.0 || *dropVal > kDropThreshold)
+      return rewriter.notifyMatchFailure(op, "window.select_arms_not_0_neg");
+
+    int visited = 0;
+    LegInfo info = classifyKeep(select->getOperand(0), /*depth=*/0, visited);
+    if (info.kind != LegKind::Windowed)
+      return rewriter.notifyMatchFailure(op, "window.keep_cond_unbounded");
+
+    rewriter.modifyOpInPlace(op, [&] {
+      op->setAttr("hipdnn.local_window_size",
+                  rewriter.getI64IntegerAttr(info.window));
+    });
+
+    LLVM_DEBUG(llvm::dbgs() << "[" DEBUG_TYPE "] recovered local_window_size="
+                            << info.window << " from the mask subgraph ("
+                            << visited << " nodes visited)\n");
+    ++NumAttentionWindowStamps;
+    return mlir::success();
+  }
+};
+
+} // namespace
+
+void populateAttentionWindowFoldPatterns(mlir::RewritePatternSet &patterns,
+                                         mlir::MLIRContext *ctx) {
+  patterns.add<AttentionStampMaskWindow>(ctx);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(OnnxToHip STATIC
   ReshapeShapeFold.cpp
   PadShapeFold.cpp
   SliceShapeFold.cpp
+  AttentionWindowFold.cpp
   ShapeConversion.cpp
   ReshapeConversion.cpp
   CausalConvWithStateConversion.cpp

--- a/lib/Conversion/OnnxToHip/OnnxAttentionConversion.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxAttentionConversion.cpp
@@ -535,6 +535,20 @@ OnnxAttentionToHip::matchAndRewrite(mlir::Operation *op,
       rewriter.getNamedAttr("softcap", rewriter.getF32FloatAttr(softcap)));
   attrs.push_back(
       rewriter.getNamedAttr("no_causal", rewriter.getBoolAttr(noCausal)));
+  // AttentionWindowFold resolves the window during pre-lowering -- from a
+  // declared `left_window_size` when the op has one, otherwise from the
+  // additive mask, which is the only place a pre-opset-25 export can put it --
+  // and stamps the result here. Absent the stamp the op keeps hip.gqa's -1
+  // default and the runtime scores the full key range, as it did before. Only a
+  // positive window is forwarded, so a resolved 0 or a hand-written 0 cannot be
+  // mistaken for "windowed".
+  if (auto stampedWindow =
+          op->getAttrOfType<mlir::IntegerAttr>("hipdnn.local_window_size")) {
+    int64_t window = stampedWindow.getValue().getSExtValue();
+    if (window > 0)
+      attrs.push_back(rewriter.getNamedAttr(
+          "local_window_size", rewriter.getI64IntegerAttr(window)));
+  }
 
   mlir::OperationState gqaState(loc, "hip.gqa");
   gqaState.addOperands(operands);

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -421,6 +421,7 @@ void ConvertOnnxToHipPass::runOnOperation() {
         populateReshapeShapeFoldPatterns(preLoweringPatterns, ctx);
         populatePadShapeFoldPatterns(preLoweringPatterns, ctx);
         populateSliceShapeFoldPatterns(preLoweringPatterns, ctx);
+        populateAttentionWindowFoldPatterns(preLoweringPatterns, ctx);
         populateFastGeluFusionPatterns(preLoweringPatterns, ctx);
         populateErfGeluFusionPatterns(preLoweringPatterns, ctx);
         populateProjectorOpsRewritePatterns(preLoweringPatterns, ctx);

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -471,6 +471,17 @@ void populatePadShapeFoldPatterns(RewritePatternSet &patterns,
 void populateSliceShapeFoldPatterns(RewritePatternSet &patterns,
                                     MLIRContext *ctx);
 
+/// Pre-lowering pattern set: recover a sliding window from `onnx.Attention`'s
+/// additive mask subgraph and stamp it as `hipdnn.local_window_size`, which
+/// OnnxAttentionConversion then puts on `hip.gqa`. `onnx.Attention` has no
+/// window attribute, so a windowed model expresses the window only in the mask
+/// data and the runtime would otherwise score its whole key range. Must run
+/// BEFORE `convertComputeOps`, which rewrites the mask's producers into
+/// `hip.*` in an order this matcher cannot rely on. See
+/// AttentionWindowFold.cpp.
+void populateAttentionWindowFoldPatterns(RewritePatternSet &patterns,
+                                         MLIRContext *ctx);
+
 /// Pre-lowering pattern set: collapse ORT's inlined `FastGelu` primitive
 /// chain (Pow / Mul / Sum / Tanh) back into a single
 /// `onnx.Gelu(approximate="tanh")`. ORT inlines the Gelu function body

--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -1064,60 +1064,79 @@ extern "C" int hip_gqa_causal_mask_f32(
   GQA_RETURN_LAUNCH_STATUS();
 }
 
-// `sq` counts the query rows present in `scores`, which is a chunk of the full
-// query range when the caller is tiling the prefill. `bias_sq` is the full query
-// extent of the bias tensor and `bias_row_offset` locates the chunk inside it --
-// the two cannot be folded together because the bias plane stride is set by the
-// full extent while the score plane stride is set by the chunk.
+// The score matrix and the bias tensor are indexed independently on both axes,
+// because `scores` can be a sub-block of the full [sq, total_seq] logical
+// matrix while the bias always describes the whole thing.
+//
+// Query axis: `sq` counts the query rows present in `scores`, which is a chunk
+// of the full query range when the caller is tiling the prefill. `bias_sq` is
+// the full query extent of the bias tensor and `bias_row_offset` locates the
+// chunk inside it.
+//
+// Key axis: `score_cols` counts the key columns present in `scores`, which is
+// just the sliding window when the caller narrowed the decode key range.
+// `bias_total_seq` is the bias tensor's true last dim and `bias_col_offset`
+// locates the narrowed range inside it.
+//
+// Neither offset can be folded into the `bias` pointer: `bias_plane` must stay
+// on the bias tensor's own full extents or every batch/head plane after the
+// first mis-strides, so with bias_batch > 1 or bias_heads > 1 a pointer bump
+// would be wrong.
 template <typename TBias>
 __global__ void add_attention_bias_kernel(
     float* __restrict__ scores, const TBias* __restrict__ bias,
     int total_heads, int num_heads, int bias_batch, int bias_heads, int sq,
-    int total_seq, int score_batch_stride, int bias_sq, int bias_row_offset) {
+    int score_cols, int score_batch_stride, int bias_sq, int bias_row_offset,
+    int bias_total_seq, int bias_col_offset) {
   int head = blockIdx.y;
   int tid = blockIdx.x * blockDim.x + threadIdx.x;
-  int n = sq * total_seq;
+  int n = sq * score_cols;
   if (tid >= n)
     return;
-  int row = tid / total_seq;
-  int col = tid % total_seq;
+  int row = tid / score_cols;
+  int col = tid % score_cols;
   int b = head / num_heads;
   int h = head % num_heads;
   int bias_b = (bias_batch == 1) ? 0 : b;
   int bias_h = (bias_heads == 1) ? 0 : h;
-  size_t bias_plane = static_cast<size_t>(bias_sq) * total_seq;
+  size_t bias_plane = static_cast<size_t>(bias_sq) * bias_total_seq;
   size_t bias_idx = static_cast<size_t>(bias_b) * bias_heads * bias_plane +
                     static_cast<size_t>(bias_h) * bias_plane +
-                    static_cast<size_t>(bias_row_offset + row) * total_seq + col;
+                    static_cast<size_t>(bias_row_offset + row) * bias_total_seq +
+                    (bias_col_offset + col);
   scores[static_cast<size_t>(head) * score_batch_stride + tid] +=
       static_cast<float>(bias[bias_idx]);
 }
 
 extern "C" int hip_gqa_add_attention_bias_f32(
     void* stream_ptr, void* scores, const void* bias, int total_heads,
-    int num_heads, int bias_batch, int bias_heads, int sq, int total_seq,
+    int num_heads, int bias_batch, int bias_heads, int sq, int score_cols,
     int score_batch_stride, int bias_element_size_bytes, int bias_sq,
-    int bias_row_offset) {
+    int bias_row_offset, int bias_total_seq, int bias_col_offset) {
   if (!scores || !bias)
     return -1;
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
   if (bias_sq <= 0)
     bias_sq = sq;
-  int n = sq * total_seq;
+  if (bias_total_seq <= 0)
+    bias_total_seq = score_cols;
+  int n = sq * score_cols;
   int blocksX = (n + GQA_THREADS - 1) / GQA_THREADS;
   (void)hipGetLastError();
   if (bias_element_size_bytes == 2) {
     add_attention_bias_kernel<__half>
         <<<dim3(blocksX, total_heads), GQA_THREADS, 0, stream>>>(
             static_cast<float*>(scores), static_cast<const __half*>(bias),
-            total_heads, num_heads, bias_batch, bias_heads, sq, total_seq,
-            score_batch_stride, bias_sq, bias_row_offset);
+            total_heads, num_heads, bias_batch, bias_heads, sq, score_cols,
+            score_batch_stride, bias_sq, bias_row_offset, bias_total_seq,
+            bias_col_offset);
   } else if (bias_element_size_bytes == 4) {
     add_attention_bias_kernel<float>
         <<<dim3(blocksX, total_heads), GQA_THREADS, 0, stream>>>(
             static_cast<float*>(scores), static_cast<const float*>(bias),
-            total_heads, num_heads, bias_batch, bias_heads, sq, total_seq,
-            score_batch_stride, bias_sq, bias_row_offset);
+            total_heads, num_heads, bias_batch, bias_heads, sq, score_cols,
+            score_batch_stride, bias_sq, bias_row_offset, bias_total_seq,
+            bias_col_offset);
   } else {
     fprintf(stderr,
             "hip_gqa_add_attention_bias_f32: unsupported bias elem size %d\n",

--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -427,6 +427,11 @@ __global__ void kv_cache_append_vec_kernel(
 // Performs both the strided past copy and the BSHD->BNSD new-token transpose
 // in a single kernel launch, avoiding host-side loop overhead.
 // Thread: one per (b, s_present, g, d_i) element. blockIdx.y = batch.
+//
+// s_lo is the first present position written; [0, s_lo) is left untouched, for
+// a caller that will not read it back (a sliding-window layer at decode). The
+// grid is sized to (total_seq - s_lo) so the skipped positions cost no threads,
+// which is the entire point -- the indices below stay absolute in s.
 // -------------------------------------------------------------------------
 
 template <typename T>
@@ -435,17 +440,17 @@ __global__ void kv_cache_concat_kernel(
     const T* __restrict__ current,
     T* __restrict__ present,
     int past_len, int sq, int G, int d,
-    int past_seq, int present_seq) {
+    int past_seq, int present_seq, int s_lo) {
   const int batch_idx = __builtin_amdgcn_readfirstlane(blockIdx.y);
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   int total_seq = past_len + sq;
-  int total_per_batch = total_seq * G * d;
+  int total_per_batch = (total_seq - s_lo) * G * d;
   if (idx >= total_per_batch) return;
 
   int di = idx % d;
   int remaining = idx / d;
   int g = remaining % G;
-  int s = remaining / G;
+  int s = s_lo + remaining / G;
 
   int dst_idx = ((batch_idx * G + g) * present_seq + s) * d + di;
 
@@ -468,18 +473,18 @@ __global__ void kv_cache_concat_vec_kernel(
     const T* __restrict__ current,
     T* __restrict__ present,
     int past_len, int sq, int G, int d,
-    int past_seq, int present_seq) {
+    int past_seq, int present_seq, int s_lo) {
   const int batch_idx = __builtin_amdgcn_readfirstlane(blockIdx.y);
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   const int dv = d / VEC;
   int total_seq = past_len + sq;
-  int total_per_batch = total_seq * G * dv;
+  int total_per_batch = (total_seq - s_lo) * G * dv;
   if (idx >= total_per_batch) return;
 
   int dvi = idx % dv;
   int remaining = idx / dv;
   int g = remaining % G;
-  int s = remaining / G;
+  int s = s_lo + remaining / G;
 
   int dst_idx = ((batch_idx * G + g) * present_seq + s) * d + dvi * VEC;
 
@@ -538,15 +543,16 @@ __global__ void kv_cache_concat_quant_i8_kernel(
     const _Float16* __restrict__ current, // BSHD fp16 [B, sq, G, d]
     int8_t* __restrict__ present,         // BNSD int8 [B, G, present_seq, d]
     const float* __restrict__ scale,      // [G, d]
-    int past_len, int sq, int G, int d, int past_seq, int present_seq) {
+    int past_len, int sq, int G, int d, int past_seq, int present_seq,
+    int s_lo) {
   const int batch_idx = __builtin_amdgcn_readfirstlane(blockIdx.y);
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   int total_seq = past_len + sq;
-  if (idx >= total_seq * G * d) return;
+  if (idx >= (total_seq - s_lo) * G * d) return;
   int di = idx % d;
   int r = idx / d;
   int g = r % G;
-  int s = r / G;
+  int s = s_lo + r / G;
   int dst_idx = ((batch_idx * G + g) * present_seq + s) * d + di;
   if (s < past_len) {
     present[dst_idx] = past[((batch_idx * G + g) * past_seq + s) * d + di];
@@ -852,25 +858,27 @@ template <typename T>
 static void launch_kv_cache_concat(
     hipStream_t stream, const void* past, const void* current, void* present,
     int batch_size, int past_len, int sq, int G, int d,
-    int past_seq, int present_seq) {
+    int past_seq, int present_seq, int s_lo) {
   int total_seq = past_len + sq;
   constexpr int VEC = 16 / sizeof(T);
   if ((d % VEC) == 0 && kv_is_16b_aligned(past) && kv_is_16b_aligned(current) &&
       kv_is_16b_aligned(present)) {
-    int total = total_seq * G * (d / VEC);
+    int total = (total_seq - s_lo) * G * (d / VEC);
     int blocks = (total + GQA_THREADS - 1) / GQA_THREADS;
     kv_cache_concat_vec_kernel<T, VEC><<<dim3(blocks, batch_size), GQA_THREADS,
                                          0, stream>>>(
         static_cast<const T*>(past), static_cast<const T*>(current),
-        static_cast<T*>(present), past_len, sq, G, d, past_seq, present_seq);
+        static_cast<T*>(present), past_len, sq, G, d, past_seq, present_seq,
+        s_lo);
     return;
   }
-  int total = total_seq * G * d;
+  int total = (total_seq - s_lo) * G * d;
   int blocks = (total + GQA_THREADS - 1) / GQA_THREADS;
   kv_cache_concat_kernel<T><<<dim3(blocks, batch_size), GQA_THREADS, 0,
                               stream>>>(
       static_cast<const T*>(past), static_cast<const T*>(current),
-      static_cast<T*>(present), past_len, sq, G, d, past_seq, present_seq);
+      static_cast<T*>(present), past_len, sq, G, d, past_seq, present_seq,
+      s_lo);
 }
 
 template <typename T>
@@ -958,19 +966,27 @@ extern "C" int hip_gqa_kv_cache_append(
 
 // Step 4-5: KV cache concat (separate-buffer). `kv_dtype` selects the format, as
 // in hip_gqa_kv_cache_append (FP16 -> plain copy, INT8 -> INT8 quant).
+//
+// s_lo skips the past prefix below it. It is clamped to [0, past_len] here, once
+// for all three kernels: past_len is the hard ceiling because [past_len,
+// total_seq) is the new tokens, which are the one thing this call must never
+// drop. A caller asking for more than that is asking for silent data loss, so
+// the boundary refuses rather than obeys.
 extern "C" int hip_gqa_kv_cache_concat(
     void* stream_ptr, const void* past, const void* current, void* present,
     int batch_size, int past_len, int sq, int G, int d,
     int past_seq, int present_seq, int element_size_bytes,
-    int kv_dtype, const void* scale) {
+    int kv_dtype, const void* scale, int s_lo) {
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
+  if (s_lo < 0) s_lo = 0;
+  if (s_lo > past_len) s_lo = past_len;
   if (kv_dtype == HIP_KV_DTYPE_INT8) {
     if (scale == nullptr) {
       fprintf(stderr, "hip_gqa_kv_cache_concat: INT8 requires scale\n");
       return -1;
     }
     int total_seq = past_len + sq;
-    int total = total_seq * G * d;
+    int total = (total_seq - s_lo) * G * d;
     int blocks = (total + GQA_THREADS - 1) / GQA_THREADS;
     (void)hipGetLastError();
     kv_cache_concat_quant_i8_kernel<<<dim3(blocks, batch_size), GQA_THREADS, 0,
@@ -978,7 +994,7 @@ extern "C" int hip_gqa_kv_cache_concat(
         static_cast<const int8_t*>(past),
         static_cast<const _Float16*>(current), static_cast<int8_t*>(present),
         static_cast<const float*>(scale), past_len, sq, G, d, past_seq,
-        present_seq);
+        present_seq, s_lo);
     GQA_RETURN_LAUNCH_STATUS();
   }
   if (kv_dtype != HIP_KV_DTYPE_FP16) {
@@ -988,7 +1004,7 @@ extern "C" int hip_gqa_kv_cache_concat(
   }
   GQA_DISPATCH_BY_ELEM_SIZE(element_size_bytes, launch_kv_cache_concat, stream,
                             past, current, present, batch_size, past_len, sq, G,
-                            d, past_seq, present_seq);
+                            d, past_seq, present_seq, s_lo);
   GQA_RETURN_LAUNCH_STATUS();
 }
 

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -583,12 +583,19 @@ HIP_KERNEL_API int hip_gqa_kv_cache_append(
  * element_size_bytes: 2 = fp16, 4 = fp32 (used only by the FP16 copy path).
  * kv_dtype / scale select the storage format exactly as in
  * hip_gqa_kv_cache_append (HIP_KV_DTYPE_FP16 -> plain copy; HIP_KV_DTYPE_INT8 ->
- * INT8 quant of the new fp16 tokens, past then read as INT8, scale = [G,d]). */
+ * INT8 quant of the new fp16 tokens, past then read as INT8, scale = [G,d]).
+ * s_lo: first present position to write. Positions [0, s_lo) are LEFT UNWRITTEN
+ * -- not zeroed, not copied -- so present is only valid from s_lo onwards, and
+ * the caller must not read below it. Pass 0 for a full concat. The grid shrinks
+ * with s_lo, which is the point: a sliding-window layer at decode passes the
+ * same lower bound it reads from, so the bytes it skips writing are exactly the
+ * bytes it will not read. Clamped internally to [0, past_len] so the new tokens
+ * at [past_len, past_len+sq) are always written. */
 HIP_KERNEL_API int hip_gqa_kv_cache_concat(
     void* stream, const void* past, const void* current, void* present,
     int batch_size, int past_len, int sq, int G, int d,
     int past_seq, int present_seq, int element_size_bytes,
-    int kv_dtype, const void* scale);
+    int kv_dtype, const void* scale, int s_lo);
 
 /* INT8 KV cache (symmetric per-channel, kv_cache_bit_width=8) dequant.
  * dequant_kv_i8_to_fp16: rebuilds an fp16 BNSD view [B,G,dst_seq,d] of the first

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -651,19 +651,24 @@ HIP_KERNEL_API int hip_gqa_causal_mask_f32(
     int batch_stride, int past_len, int local_window_size);
 
 /* Add an attention bias onto the fp32 score matrix before softmax.
- * scores layout: [total_heads, sq, total_seq] row-major with batch_stride
- * = sq * total_seq per head.
- * bias layout: [bias_batch, bias_heads, bias_sq, total_seq], row-major.
+ * scores layout: [total_heads, sq, score_cols] row-major with batch_stride
+ * = sq * score_cols per head.
+ * bias layout: [bias_batch, bias_heads, bias_sq, bias_total_seq], row-major.
  * bias_batch / bias_heads may be 1 for ONNX-style broadcast.
- * sq is the number of query rows in `scores`, which is a chunk of the full
- * query range when the caller tiles the prefill; bias_sq is the bias tensor's
- * full query extent and bias_row_offset locates the chunk within it. Pass
- * bias_sq = sq (or 0) and bias_row_offset = 0 for the untiled case. */
+ * `scores` may be a sub-block of the full logical score matrix on either axis,
+ * so both axes carry a bias extent and an offset:
+ *   sq / bias_sq / bias_row_offset -- sq is the number of query rows present,
+ *     a chunk of the full range when the caller tiles the prefill.
+ *   score_cols / bias_total_seq / bias_col_offset -- score_cols is the number
+ *     of key columns present, just the sliding window when the caller narrowed
+ *     the decode key range.
+ * Pass bias_sq = sq (or 0) and bias_row_offset = 0, and bias_total_seq =
+ * score_cols (or 0) and bias_col_offset = 0, for the untiled/unnarrowed case. */
 HIP_KERNEL_API int hip_gqa_add_attention_bias_f32(
     void* stream, void* scores, const void* bias,
     int total_heads, int num_heads, int bias_batch, int bias_heads,
-    int sq, int total_seq, int score_batch_stride, int bias_element_size_bytes,
-    int bias_sq, int bias_row_offset);
+    int sq, int score_cols, int score_batch_stride, int bias_element_size_bytes,
+    int bias_sq, int bias_row_offset, int bias_total_seq, int bias_col_offset);
 
 /* Column-wise softmax in-place. One threadblock per (head, query).
  * Smooth softmax is activated when head_sink is non-null OR use_smooth_softmax

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -225,12 +225,21 @@ static inline int kv_dtype_abi(KvCacheFormat f) {
 // plain copy. Only the causal concat/append tail honours it (the no_causal
 // Whisper branches are fp16/fp32-only), so the format decision lives here
 // rather than in a separate helper or at each call site.
+//
+// copy_lo bounds the separate-buffer concat from below: past positions
+// [0, copy_lo) are not copied into present and are left whatever the allocator
+// held. It exists for the one caller that can prove it will not read them back
+// -- a sliding-window layer at decode passes the same lower bound it scores
+// from -- and must be 0 for everyone else. It is required rather than defaulted
+// so that a new call site has to say which it is. The append branches ignore
+// it: they only ever write the new tokens, and an in-place cache has no prefix
+// to copy in the first place.
 static int update_kv_cache(hipStream_t stream, const void *past_key,
                            const void *past_value, const void *new_key,
                            const void *new_value, void *present_key,
                            void *present_value, int B, int past_len, int sq,
                            int G, int d, int past_buf_seq, int present_seq,
-                           const void *seqlens_k_ptr, int elem_sz,
+                           const void *seqlens_k_ptr, int elem_sz, int copy_lo,
                            bool no_causal = false, int skv = -1,
                            KvCacheFormat kv_format = KvCacheFormat::Fp16,
                            const void *k_scale = nullptr,
@@ -285,11 +294,11 @@ static int update_kv_cache(hipStream_t stream, const void *past_key,
     // Separate-buffer concat: needs host-side past_len for stride computation.
     if (hip_gqa_kv_cache_concat(stream, past_key, new_key, present_key, B,
                                 past_len, sq, G, d, past_buf_seq, present_seq,
-                                elem_sz, kv_dtype, k_sc) != 0)
+                                elem_sz, kv_dtype, k_sc, copy_lo) != 0)
       return -1;
     if (hip_gqa_kv_cache_concat(stream, past_value, new_value, present_value, B,
                                 past_len, sq, G, d, past_buf_seq, present_seq,
-                                elem_sz, kv_dtype, v_sc) != 0)
+                                elem_sz, kv_dtype, v_sc, copy_lo) != 0)
       return -1;
   } else {
     // In-place append: kernel can read past_len from device via seqlens_k_ptr.
@@ -455,13 +464,22 @@ static int gqa_forward_fused(
     // Append the new token to the KV cache. Quantized cache:
     // quantize-and-append with the static per-channel scale; fp16 cache: plain
     // append. update_kv_cache dispatches on kv_format internally.
+    //
+    // copy_lo stays 0 here even though this path knows its window. Narrowing
+    // the concat needs a separate growing present buffer, and this path never
+    // gets one: seq_len_kv reaches the runtime as the present_key memref's
+    // sequence dim, which for a GroupQueryAttention export with a growing cache
+    // arrives one short of the declared present, and the seqlens_k check above
+    // then rejects the call before it can reach the concat. When the cache is
+    // instead in-place there is no prefix to copy and update_kv_cache appends.
+    // So a bound here would be unreachable, and therefore untestable, code.
     if (update_kv_cache(
             stream, past_key, past_value, kSrc, vSrc, present_key,
             present_value, static_cast<int>(B), static_cast<int>(past_len),
             static_cast<int>(sq), static_cast<int>(G), static_cast<int>(d),
             static_cast<int>(past_buf_seq), static_cast<int>(present_seq),
-            seqlens_k_ptr, static_cast<int>(elem_sz), /*no_causal=*/false,
-            /*skv=*/-1, kv_format, k_scale, v_scale) != 0)
+            seqlens_k_ptr, static_cast<int>(elem_sz), /*copy_lo=*/0,
+            /*no_causal=*/false, /*skv=*/-1, kv_format, k_scale, v_scale) != 0)
       return -1;
 
     {
@@ -619,8 +637,8 @@ static int gqa_forward_fused(
             present_value, static_cast<int>(B), static_cast<int>(past_len),
             static_cast<int>(sq), static_cast<int>(G), static_cast<int>(d),
             static_cast<int>(past_buf_seq), static_cast<int>(present_seq),
-            seqlens_k_ptr, static_cast<int>(elem_sz), /*no_causal=*/false,
-            /*skv=*/-1, kv_format, k_scale, v_scale) != 0)
+            seqlens_k_ptr, static_cast<int>(elem_sz), /*copy_lo=*/0,
+            /*no_causal=*/false, /*skv=*/-1, kv_format, k_scale, v_scale) != 0)
       return -1;
   }
 
@@ -1273,7 +1291,7 @@ static int gqa_forward_hipblaslt(
             present_value, static_cast<int>(B), static_cast<int>(past_len),
             static_cast<int>(sq), static_cast<int>(G), static_cast<int>(d),
             static_cast<int>(past_buf_seq), static_cast<int>(present_seq),
-            seqlens_k_ptr, static_cast<int>(elem_sz)) != 0)
+            seqlens_k_ptr, static_cast<int>(elem_sz), /*copy_lo=*/0) != 0)
       return -1;
 
     // hip_gqa_flash_decode owns every geometry it templates; this fallback
@@ -1814,14 +1832,30 @@ static int gqa_forward_hipblaslt(
       // seqlens_k to the append kernel (it would apply the +1 convention).
       // ONNX Attention with is_causal=0 + external mask keeps the standard
       // decode KV path (bidirectional_no_past=false).
+      //
+      // copy_lo is kv_lo, deliberately the identical value and not a separately
+      // derived one: the bytes this skips writing are then exactly the bytes
+      // the Score and Value GEMMs below skip reading, so the narrowing cannot
+      // be half-applied. That equality is the whole safety argument, and it is
+      // why this needs no gate of its own -- kv_lo is already 0 for prefill,
+      // for the expand flavour and whenever no window applies.
+      //
+      // It holds across steps as well as within one: this step writes
+      // [kv_lo, total_seq) and the next step reads from kv_lo + 1 (the window
+      // slides by exactly the one token it appends), so every step's read range
+      // is a subset of the previous step's written range.
+      //
+      // Only the separate-buffer concat can skip anything. When the cache is
+      // in-place (past_key == present_key) the prefix is already there and
+      // update_kv_cache appends, ignoring this.
       HIP_CHECK(update_kv_cache(
           stream, past_key, past_value, kSrc, vSrc, present_key, present_value,
           static_cast<int>(B), static_cast<int>(past_len), static_cast<int>(sq),
           static_cast<int>(G), static_cast<int>(d),
           static_cast<int>(past_buf_seq), static_cast<int>(present_seq),
           (use_no_expand && !bidirectional_no_past) ? seqlens_k_ptr : nullptr,
-          static_cast<int>(elem_sz), bidirectional_no_past,
-          static_cast<int>(skv)));
+          static_cast<int>(elem_sz), static_cast<int>(kv_lo),
+          bidirectional_no_past, static_cast<int>(skv)));
     }
 
     // ---- Steps 6-7: KV Expand [B*G,present_seq,d] -> [B*H,total_seq,d] ----
@@ -1980,14 +2014,24 @@ static int gqa_forward_hipblaslt(
           static_cast<int>(elem_sz)));
     }
 
+    // kv_inplace and the three sequence lengths are here because they decide
+    // whether any of this narrowing does anything: the copy can only be skipped
+    // on the separate-buffer branch, which is exactly kv_inplace=0, and that in
+    // turn is visible only as present_seq differing from past_buf_seq. A model
+    // exporting its cache in place takes the append branch and the copy_lo
+    // below is inert, which is otherwise indistinguishable from the narrowing
+    // failing to engage.
     RUNTIME_DEBUG_LOG(
         "[REAL] GQA hipBLASLt: B=%lld sq=%lld sq_chunk=%lld total_seq=%lld "
         "kv_lo=%lld kv_span=%lld H=%lld G=%lld d=%lld no_expand=%d "
-        "transpose=%d\n",
+        "transpose=%d kv_inplace=%d past_len=%lld past_buf_seq=%lld "
+        "present_seq=%lld\n",
         (long long)B, (long long)sq, (long long)sq_chunk, (long long)total_seq,
         (long long)kv_lo, (long long)kv_span, (long long)H, (long long)G,
         (long long)d, static_cast<int>(use_no_expand),
-        static_cast<int>(need_transpose));
+        static_cast<int>(need_transpose),
+        static_cast<int>(past_key != nullptr && past_key == present_key),
+        (long long)past_len, (long long)past_buf_seq, (long long)present_seq);
   }
 
 cleanup:

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -1363,11 +1363,27 @@ static int gqa_forward_hipblaslt(
       // Defensive fallback for B == 1 when the pre-dispatch helper bailed out
       // (D2H or sync failure). Rare path; not cached because the same failure
       // mode would have prevented the helper from caching too.
-      if (hipMemcpyAsync(&seqlens_k_val, seqlens_k_ptr, sizeof(int32_t),
-                         hipMemcpyDeviceToHost, stream) != hipSuccess)
+      //
+      // Both failures are reported rather than returned bare: this is the one
+      // place the decomposed path can fail before it has done any work, and a
+      // silent -1 here surfaces only as a zero-filled attention output, which
+      // looks like a kernel bug rather than a seqlens_k that could not be read.
+      hipError_t cp =
+          hipMemcpyAsync(&seqlens_k_val, seqlens_k_ptr, sizeof(int32_t),
+                         hipMemcpyDeviceToHost, stream);
+      if (cp != hipSuccess) {
+        fprintf(stderr,
+                "gqa_forward_hipblaslt: could not read seqlens_k from %p: %s\n",
+                seqlens_k_ptr, hipGetErrorString(cp));
         return -1;
-      if (hipStreamSynchronize(stream) != hipSuccess)
+      }
+      hipError_t sy = hipStreamSynchronize(stream);
+      if (sy != hipSuccess) {
+        fprintf(stderr,
+                "gqa_forward_hipblaslt: sync after seqlens_k read failed: %s\n",
+                hipGetErrorString(sy));
         return -1;
+      }
     }
 
     // ORT prefill sentinel: when there is no past KV yet, the producer
@@ -1430,6 +1446,72 @@ static int gqa_forward_hipblaslt(
                        present_value &&
                        (sq == 1 || gqa_no_expand_prefill_enabled());
   bool need_transpose = (sq > 1);
+
+  //===--------------------------------------------------------------------===//
+  // Sliding-window narrowing of the decode key range
+  //
+  // A windowed layer can only attend to the last `window` key positions, but
+  // this path scored all of them and then had hip_gqa_causal_mask_f32 write
+  // -inf over everything older. On Gemma-4 at 16K that is 16x the KV traffic
+  // the layer needs: 25 of its 30 layers have a 1024-token window, and their
+  // measured gqa time scaled 7.3x from 2K to 16K as if the window did not
+  // exist.
+  //
+  // Dropping the out-of-window keys is exact rather than an approximation. The
+  // entries being dropped are -INFINITY: the softmax takes a max then
+  // exp2f(x - max), so they never win the max and add exactly 0 to the
+  // denominator, and the Value GEMM runs alpha=1/beta=0 so they contribute
+  // exactly 0 to the output. What is left is a difference in GEMM tile
+  // reassociation, the same standard as use_no_expand.
+  //
+  // The KV cache is BNSD [B, G, present_seq, d] with d fastest, so a run of key
+  // positions is contiguous at + kv_lo * d and the batch stride stays
+  // present_seq * d whatever the offset. The A pointer is a hipblasLtMatmul
+  // call argument rather than part of the descriptor, so the offset costs
+  // nothing.
+  //
+  // Restrictions:
+  //  - Decode only (sq == 1). Windowed prefill wants a banded score matrix, not
+  //    a single narrowed range, and that is a separate effort.
+  //  - use_no_expand only. The expand flavour materialises Kexp/Vexp over the
+  //    full range, so narrowing would have to narrow the expand copies too;
+  //    that path is not the default at decode.
+  //
+  // A positive local_window_size is a promise that the window is ENFORCED
+  // somewhere, and narrowing is exact only because of that. Both of the ways it
+  // can reach us keep that promise, by different mechanisms:
+  //
+  //  - !no_causal: the ONNX attribute, forwarded from
+  //    com.microsoft.GroupQueryAttention. hip_gqa_causal_mask_f32 below applies
+  //    the window itself, so narrowing is provably the same arithmetic.
+  //
+  //  - no_causal: recovered from the additive mask by the converter's
+  //    AttentionWindowFold, which matched `And(q >= k, q - k < W)` in the
+  //    mask's own keep-condition. The mask is then the enforcer -- the entries
+  //    being dropped are exactly the ones it already set to its large-negative
+  //    value. This is the shape that needs it: onnx.Attention gained a window
+  //    attribute only in opset 25, so a windowed export below that arrives with
+  //    is_causal=0 and the window in the mask (Gemma-4's 25 local layers are
+  //    exactly this).
+  //
+  // So no_causal is deliberately NOT a gate here. It was one while the window
+  // could only arrive as an attribute, because a bidirectional op's window was
+  // being ignored rather than applied; now that a window can also come from the
+  // mask, gating on no_causal would reject the only case that needs narrowing.
+  // Nothing else changes as a result: no producer emits a window together with
+  // no_causal except the recovery above (GqaConversion sets no_causal=false
+  // explicitly, and the Whisper bidirectional builders set no window).
+
+  // Number of key positions actually scored, and the first one. kv_span ==
+  // total_seq and kv_lo == 0 whenever narrowing is inactive, which keeps every
+  // downstream expression below identical to what it was.
+  int64_t kv_span = total_seq;
+  int64_t kv_lo = 0;
+  if (sq == 1 && use_no_expand && local_window_size > 0 &&
+      local_window_size < total_seq) {
+    kv_span = local_window_size;
+    kv_lo = total_seq - kv_span;
+  }
 
   //===--------------------------------------------------------------------===//
   // Query-row chunking of the score matrix
@@ -1516,11 +1598,14 @@ static int gqa_forward_hipblaslt(
 
   GqaGemmKey scoreKey, valueKey;
   if (use_no_expand) {
-    // Score: C[total_seq, HPG*sq] = K^T[d,total_seq] * Q[d, HPG*sq] per (b, g)
+    // Score: C[kv_span, HPG*sq] = K^T[d,kv_span] * Q[d, HPG*sq] per (b, g)
     // pair. strideA steps over the buffer page (present_seq*d) even though only
-    // the first total_seq tokens are read, keeping the descriptor stable across
-    // token steps.
-    scoreKey = {/*m=*/total_seq,
+    // kv_span tokens are read, keeping the descriptor stable across token
+    // steps. Under window narrowing kv_span also stops changing per token once
+    // the context passes the window, so the descriptor cache stops missing on
+    // every token and the per-token hipblasLtMatmulAlgoGetHeuristic calls
+    // collapse to one entry per shape.
+    scoreKey = {/*m=*/kv_span,
                 /*n=*/HPG * sq,
                 /*k=*/d,
                 /*batch=*/B * G,
@@ -1529,19 +1614,19 @@ static int gqa_forward_hipblaslt(
                 /*inputFp32=*/gemm_fp32,
                 /*strideA=*/present_seq * d,
                 /*strideB=*/HPG * sq * d,
-                /*strideC=*/HPG * sq * total_seq};
-    // Value: C[d, HPG*sq] = V[d, total_seq] * S[total_seq, HPG*sq] per (b, g)
+                /*strideC=*/HPG * sq * kv_span};
+    // Value: C[d, HPG*sq] = V[d, kv_span] * S[kv_span, HPG*sq] per (b, g)
     // pair, writing into BNSD [B, G, HPG, sq, d] which at sq==1 coincides with
     // BSHD [B, 1, H, d].
     valueKey = {/*m=*/d,
                 /*n=*/HPG * sq,
-                /*k=*/total_seq,
+                /*k=*/kv_span,
                 /*batch=*/B * G,
                 /*transA=*/false,
                 /*outputFp32=*/gemm_fp32,
                 /*inputFp32=*/gemm_fp32,
                 /*strideA=*/present_seq * d,
-                /*strideB=*/HPG * sq * total_seq,
+                /*strideB=*/HPG * sq * kv_span,
                 /*strideC=*/HPG * sq * d};
   } else {
     makeKeys(sq_chunk, &scoreKey, &valueKey);
@@ -1594,10 +1679,15 @@ static int gqa_forward_hipblaslt(
   size_t Kexp_bytes =
       use_no_expand ? 0 : static_cast<size_t>(B) * H * total_seq * d * elem_sz;
   size_t Vexp_bytes = Kexp_bytes;
+  // Both score buffers span kv_span keys, not total_seq: they hold exactly what
+  // the Score GEMM writes. These offsets chain into off_S_fp16, off_O, temp_end
+  // and the GEMM workspace, so kv_span has to appear in both or the region
+  // boundaries disagree with the GEMM extents and it is a silent heap
+  // overwrite rather than a crash.
   size_t S_f32_bytes =
-      static_cast<size_t>(B) * H * sq_chunk * total_seq * sizeof(float);
+      static_cast<size_t>(B) * H * sq_chunk * kv_span * sizeof(float);
   size_t S_fp16_bytes =
-      static_cast<size_t>(B) * H * sq_chunk * total_seq * elem_sz;
+      static_cast<size_t>(B) * H * sq_chunk * kv_span * elem_sz;
   size_t O_bytes =
       need_transpose ? static_cast<size_t>(B) * H * sq * d * elem_sz : 0;
 
@@ -1757,9 +1847,19 @@ static int gqa_forward_hipblaslt(
     // ---- Steps 8-10, per query chunk ----
     // One iteration when chunking is inactive, in which case q0 is 0, c is sq
     // and every pointer and stride below reduces to what it was.
-    const void *scoreA = use_no_expand ? present_key : d_Kexp;
+    //
+    // K and V are advanced to the first key position in range. The cache is
+    // BNSD with d fastest, so this selects a contiguous span and leaves the
+    // per-(b,g) batch stride at present_seq*d. kv_lo is 0 unless the sliding
+    // window narrowed the range.
+    const size_t kv_byte_off = static_cast<size_t>(kv_lo) * d * elem_sz;
+    const void *scoreA =
+        (use_no_expand ? static_cast<const char *>(present_key) + kv_byte_off
+                       : static_cast<const char *>(d_Kexp));
     const void *scoreBBase = need_transpose ? d_Qtrans : qSrc;
-    const void *valueA = use_no_expand ? present_value : d_Vexp;
+    const void *valueA =
+        (use_no_expand ? static_cast<const char *>(present_value) + kv_byte_off
+                       : static_cast<const char *>(d_Vexp));
     void *valueCBase = need_transpose ? d_O : output;
     float scoreAlpha = scale;
     float beta = 0.0f;
@@ -1778,8 +1878,8 @@ static int gqa_forward_hipblaslt(
       void *valueC = static_cast<char *>(valueCBase) +
                      static_cast<size_t>(q0) * d * elem_sz;
       // The score buffers are re-packed per chunk, so their per-head stride is
-      // the chunk's own row count.
-      const int scoreBatchStride = static_cast<int>(c * total_seq);
+      // the chunk's own row count over the key range actually scored.
+      const int scoreBatchStride = static_cast<int>(c * kv_span);
 
       // ---- Step 8: Score GEMM (fp16/fp32 in, fp32 out) ----
       // A = K: no-expand reads present_key directly, expand reads d_Kexp.
@@ -1792,22 +1892,24 @@ static int gqa_forward_hipblaslt(
           gemm_ws_ptr, gemm_ws_bytes, stream));
 
       // ---- Step 8b: Add external attention bias (onnx.Attention attn_mask) --
-      // The bias is indexed over the full query range, so the chunk's row
-      // offset is passed through rather than folded into the pointer: with
-      // bias_batch or bias_heads > 1 the plane stride still spans all sq rows.
+      // The bias is indexed over the full query and key ranges, so the chunk's
+      // row offset and the window's key offset are passed through rather than
+      // folded into the pointer: with bias_batch or bias_heads > 1 the plane
+      // stride still spans all sq rows and all total_seq columns.
       if (attention_bias) {
         HIP_CHECK(hip_gqa_add_attention_bias_f32(
             stream, d_S_f32, const_cast<void *>(attention_bias),
             static_cast<int>(B * H), static_cast<int>(H),
             static_cast<int>(attn_bias_batch),
             static_cast<int>(attn_bias_num_heads), static_cast<int>(c),
-            static_cast<int>(total_seq), scoreBatchStride,
+            static_cast<int>(kv_span), scoreBatchStride,
             static_cast<int>(elem_sz), static_cast<int>(sq),
-            static_cast<int>(q0)));
+            static_cast<int>(q0), static_cast<int>(total_seq),
+            static_cast<int>(kv_lo)));
       }
 
       // ---- Step 9: Causal Mask (fp32) + Softmax (fp32 -> fp16/fp32) ----
-      // S is treated as [B*H, c, total_seq] (head stride c*total_seq) by both
+      // S is treated as [B*H, c, kv_span] (head stride c*kv_span) by both
       // GEMM flavours. softmax dtype follows gemm_fp32.
       //
       // The built-in causal triangle is applied whenever !no_causal,
@@ -1826,11 +1928,17 @@ static int gqa_forward_hipblaslt(
       // The mask kernel derives each row's absolute query position as
       // past_len + row, so advancing past_len by the chunk's start puts the
       // triangle and the sliding window in the right place for the chunk.
+      // Under window narrowing the score columns start at kv_lo rather than 0,
+      // and since both of the kernel's predicates reference the query position
+      // only as (past_len_arg + row), shifting past_len down by kv_lo is
+      // exactly equivalent to shifting the column index up by it. No kernel
+      // change needed. (At sq == 1 the narrowed range is precisely the window,
+      // so the kernel then writes nothing -- correct, just redundant.)
       if ((sq > 1 || local_window_size > 0) && !no_causal) {
         HIP_CHECK(hip_gqa_causal_mask_f32(
-            stream, d_S_f32, static_cast<int>(B * H),
-            static_cast<int>(total_seq), static_cast<int>(c), scoreBatchStride,
-            static_cast<int>(past_len + q0),
+            stream, d_S_f32, static_cast<int>(B * H), static_cast<int>(kv_span),
+            static_cast<int>(c), scoreBatchStride,
+            static_cast<int>(past_len + q0 - kv_lo),
             static_cast<int>(local_window_size)));
       }
       // fp16 GQA: softmax writes fp16 probabilities for the fp16 Value GEMM.
@@ -1841,13 +1949,13 @@ static int gqa_forward_hipblaslt(
       if (gemm_fp32) {
         HIP_CHECK(hip_gqa_softmax_f32_to_f32(
             stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * c),
-            static_cast<int>(total_seq), static_cast<int>(c), scoreBatchStride,
+            static_cast<int>(kv_span), static_cast<int>(c), scoreBatchStride,
             scoreBatchStride, head_sink, static_cast<int>(H),
             static_cast<int>(use_smooth_softmax)));
       } else {
         HIP_CHECK(hip_gqa_softmax_f32_to_f16(
             stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * c),
-            static_cast<int>(total_seq), static_cast<int>(c), scoreBatchStride,
+            static_cast<int>(kv_span), static_cast<int>(c), scoreBatchStride,
             scoreBatchStride, head_sink, static_cast<int>(H),
             static_cast<int>(use_smooth_softmax)));
       }
@@ -1874,10 +1982,12 @@ static int gqa_forward_hipblaslt(
 
     RUNTIME_DEBUG_LOG(
         "[REAL] GQA hipBLASLt: B=%lld sq=%lld sq_chunk=%lld total_seq=%lld "
-        "H=%lld G=%lld d=%lld no_expand=%d transpose=%d\n",
+        "kv_lo=%lld kv_span=%lld H=%lld G=%lld d=%lld no_expand=%d "
+        "transpose=%d\n",
         (long long)B, (long long)sq, (long long)sq_chunk, (long long)total_seq,
-        (long long)H, (long long)G, (long long)d,
-        static_cast<int>(use_no_expand), static_cast<int>(need_transpose));
+        (long long)kv_lo, (long long)kv_span, (long long)H, (long long)G,
+        (long long)d, static_cast<int>(use_no_expand),
+        static_cast<int>(need_transpose));
   }
 
 cleanup:

--- a/test/lit/Conversion/onnx-to-hip/test_onnx_attention.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_onnx_attention.mlir
@@ -13,12 +13,17 @@
 //     and seqlens_k = total_seq - 1 (ORT convention total_seq = seqlens_k + 1)
 //   - present_key/value DPS inits sized to the past+current total
 //
+//   - a sliding window baked into the additive mask recovered from the mask's
+//     producing subgraph and stamped as local_window_size, since
+//     onnx.Attention has no attribute to carry one
+//
 // Cases: a static-shape decode (16 query heads, 8 KV heads), a dynamic-shape
 // prefill with an EMPTY past (the case that previously sized present from
 // dim(past_key, 2) alone -> zero-length present buffer -> null present_key ->
 // zeroed attention output), the Gemma-4-E2B decoder self-attn (is_causal=1 +
 // fp16 mask + past KV + 3 outputs -- previously rejected), a single-output
-// causal case, a bidirectional no-mask case, and a rank-4 BNSH case.
+// causal case, a bidirectional no-mask case, a rank-4 BNSH case, and three
+// window-recovery cases (windowed layer, global layer, unrecognized OR leg).
 // ============================================================================
 
 // The pass runs `--convert-onnx-to-hip`, whose module-metadata step requires
@@ -291,5 +296,437 @@ module {
     // CHECK-NOT: onnx.Attention
 
     return %y : tensor<1x16x8x64xf16>
+  }
+}
+
+// -----
+
+// ===== Sliding window recovered from the mask subgraph (windowed layer) =====
+//
+// Before opset 25 there was no window attribute on `onnx.Attention`, so a
+// windowed model could only express its window in the additive mask.
+// AttentionWindowFold reads it back out and stamps it, which is what lets the
+// runtime narrow its key range instead of scoring everything. This is the
+// fallback path -- see the left_window_size section below for the declared one.
+//
+// This is Gemma-4's local-layer mask, reproduced node for node: the keep
+// condition ANDs the padding mask with an OR of the windowed-causal leg and the
+// same-image-block bidirectional leg. The window leg is
+// `And(qpos >= kpos, qpos - kpos < 1024)`, and the compare and the subtraction
+// reference the SAME two values in the same order -- that identity is what
+// makes `qpos` the query index and `qpos - kpos < 1024` the window, so W
+// transfers to local_window_size unchanged.
+module {
+  func.func @main_graph(
+      %query: tensor<?x?x4096xf16>,
+      %key: tensor<?x?x2048xf16>,
+      %value: tensor<?x?x2048xf16>,
+      %qidx: tensor<?x?xi64>,
+      %kidx: tensor<?x?xi64>,
+      %blk: tensor<?x?xi64>,
+      %pad: tensor<?x?xi64>,
+      %past_key: tensor<?x8x?x256xf16>,
+      %past_value: tensor<?x8x?x256xf16>)
+      -> (tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>,
+          tensor<?x8x?x256xf16>) {
+
+    // CHECK-LABEL: func.func @main_graph
+    // CHECK-SAME: (%[[CTXW:.*]]: !hip.context,
+
+    %c1 = "onnx.Constant"() {value = dense<1> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %c2 = "onnx.Constant"() {value = dense<2> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %w = "onnx.Constant"() {value = dense<1024> : tensor<i64>}
+        : () -> tensor<i64>
+    %zi = "onnx.Constant"() {value = dense<0> : tensor<i64>} : () -> tensor<i64>
+    %keepv = "onnx.Constant"() {value = dense<0.000000e+00> : tensor<f32>}
+        : () -> tensor<f32>
+    %dropv = "onnx.Constant"() {value = dense<-6.550400e+04> : tensor<f32>}
+        : () -> tensor<f32>
+
+    // Broadcast the two index vectors into [B, q, k]: the query index goes on
+    // the lower axis (unsqueezed at 2), the key index on the higher (at 1).
+    %qpos = "onnx.Unsqueeze"(%qidx, %c2)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x?x1xi64>
+    %kpos = "onnx.Unsqueeze"(%kidx, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x1x?xi64>
+
+    %causal = "onnx.GreaterOrEqual"(%qpos, %kpos)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi1>
+    %dist = "onnx.Sub"(%qpos, %kpos)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi64>
+    %inwin = "onnx.Less"(%dist, %w)
+        : (tensor<?x?x?xi64>, tensor<i64>) -> tensor<?x?x?xi1>
+    %wleg = "onnx.And"(%causal, %inwin)
+        : (tensor<?x?x?xi1>, tensor<?x?x?xi1>) -> tensor<?x?x?xi1>
+
+    // Same-image-block bidirectional leg: identically false for a text-only
+    // prompt, and bounded by the image block length otherwise.
+    %qblk = "onnx.Unsqueeze"(%blk, %c2)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x?x1xi64>
+    %kblk = "onnx.Unsqueeze"(%blk, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x1x?xi64>
+    %sameblk = "onnx.Equal"(%qblk, %kblk)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi1>
+    %isimg = "onnx.GreaterOrEqual"(%qblk, %zi)
+        : (tensor<?x?x1xi64>, tensor<i64>) -> tensor<?x?x1xi1>
+    %segleg = "onnx.And"(%sameblk, %isimg)
+        : (tensor<?x?x?xi1>, tensor<?x?x1xi1>) -> tensor<?x?x?xi1>
+
+    %or = "onnx.Or"(%wleg, %segleg)
+        : (tensor<?x?x?xi1>, tensor<?x?x?xi1>) -> tensor<?x?x?xi1>
+    %padu = "onnx.Unsqueeze"(%pad, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x1x?xi64>
+    %padb = "onnx.Cast"(%padu) {to = 9 : si64}
+        : (tensor<?x1x?xi64>) -> tensor<?x1x?xi1>
+    %keep = "onnx.And"(%padb, %or)
+        : (tensor<?x1x?xi1>, tensor<?x?x?xi1>) -> tensor<?x?x?xi1>
+    %bias32 = "onnx.Where"(%keep, %keepv, %dropv)
+        : (tensor<?x?x?xi1>, tensor<f32>, tensor<f32>) -> tensor<?x?x?xf32>
+    %bias16 = "onnx.Cast"(%bias32) {to = 10 : si64}
+        : (tensor<?x?x?xf32>) -> tensor<?x?x?xf16>
+    %bias = "onnx.Unsqueeze"(%bias16, %c1)
+        : (tensor<?x?x?xf16>, tensor<1xi64>) -> tensor<?x1x?x?xf16>
+
+    %out:3 = "onnx.Attention"(%query, %key, %value, %bias, %past_key,
+                              %past_value)
+        {q_num_heads = 16 : si64,
+         kv_num_heads = 8 : si64,
+         is_causal = 0 : si64,
+         scale = 6.250000e-02 : f32,
+         softcap = 0.000000e+00 : f32}
+        : (tensor<?x?x4096xf16>, tensor<?x?x2048xf16>, tensor<?x?x2048xf16>,
+           tensor<?x1x?x?xf16>, tensor<?x8x?x256xf16>, tensor<?x8x?x256xf16>)
+        -> (tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>,
+            tensor<?x8x?x256xf16>)
+
+    // CHECK: hip.gqa(%[[CTXW]])
+    // Attributes print alphabetically, so the recovered window lands between
+    // kv_num_heads and no_causal.
+    // CHECK-SAME: {kv_num_heads = 8 : i64, local_window_size = 1024 : i64, no_causal = true, num_heads = 16 : i64
+    // CHECK-NOT: onnx.Attention
+
+    return %out#0, %out#1, %out#2
+        : tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>, tensor<?x8x?x256xf16>
+  }
+}
+
+// -----
+
+// ===== Global layer: the same mask WITHOUT the window leg =====
+//
+// Gemma-4's 5 full-attention layers differ from its 25 windowed ones by exactly
+// one node: the OR's causal leg is the bare compare rather than
+// `And(causal, within-window)`. A bare causal term bounds nothing from below, so
+// no window is recovered and the op keeps hip.gqa's -1 default. This is the
+// case that must NOT be stamped -- forcing a window here would change results
+// rather than just make them cheaper.
+module {
+  func.func @main_graph(
+      %query: tensor<?x?x8192xf16>,
+      %key: tensor<?x?x1024xf16>,
+      %value: tensor<?x?x1024xf16>,
+      %qidx: tensor<?x?xi64>,
+      %kidx: tensor<?x?xi64>,
+      %pad: tensor<?x?xi64>,
+      %past_key: tensor<?x2x?x512xf16>,
+      %past_value: tensor<?x2x?x512xf16>)
+      -> (tensor<?x?x8192xf16>, tensor<?x2x?x512xf16>,
+          tensor<?x2x?x512xf16>) {
+
+    // CHECK-LABEL: func.func @main_graph
+    // CHECK-SAME: (%[[CTXG2:.*]]: !hip.context,
+
+    %c1 = "onnx.Constant"() {value = dense<1> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %c2 = "onnx.Constant"() {value = dense<2> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %keepv = "onnx.Constant"() {value = dense<0.000000e+00> : tensor<f32>}
+        : () -> tensor<f32>
+    %dropv = "onnx.Constant"() {value = dense<-6.550400e+04> : tensor<f32>}
+        : () -> tensor<f32>
+
+    %qpos = "onnx.Unsqueeze"(%qidx, %c2)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x?x1xi64>
+    %kpos = "onnx.Unsqueeze"(%kidx, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x1x?xi64>
+    %causal = "onnx.GreaterOrEqual"(%qpos, %kpos)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi1>
+
+    %padu = "onnx.Unsqueeze"(%pad, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x1x?xi64>
+    %padb = "onnx.Cast"(%padu) {to = 9 : si64}
+        : (tensor<?x1x?xi64>) -> tensor<?x1x?xi1>
+    %keep = "onnx.And"(%padb, %causal)
+        : (tensor<?x1x?xi1>, tensor<?x?x?xi1>) -> tensor<?x?x?xi1>
+    %bias32 = "onnx.Where"(%keep, %keepv, %dropv)
+        : (tensor<?x?x?xi1>, tensor<f32>, tensor<f32>) -> tensor<?x?x?xf32>
+    %bias16 = "onnx.Cast"(%bias32) {to = 10 : si64}
+        : (tensor<?x?x?xf32>) -> tensor<?x?x?xf16>
+    %bias = "onnx.Unsqueeze"(%bias16, %c1)
+        : (tensor<?x?x?xf16>, tensor<1xi64>) -> tensor<?x1x?x?xf16>
+
+    %out:3 = "onnx.Attention"(%query, %key, %value, %bias, %past_key,
+                              %past_value)
+        {q_num_heads = 16 : si64,
+         kv_num_heads = 2 : si64,
+         is_causal = 0 : si64,
+         scale = 4.419420e-02 : f32,
+         softcap = 0.000000e+00 : f32}
+        : (tensor<?x?x8192xf16>, tensor<?x?x1024xf16>, tensor<?x?x1024xf16>,
+           tensor<?x1x?x?xf16>, tensor<?x2x?x512xf16>, tensor<?x2x?x512xf16>)
+        -> (tensor<?x?x8192xf16>, tensor<?x2x?x512xf16>,
+            tensor<?x2x?x512xf16>)
+
+    // No local_window_size: the dict goes straight from kv_num_heads to
+    // no_causal, so the attribute is absent and the -1 default stands.
+    // CHECK: hip.gqa(%[[CTXG2]])
+    // CHECK-SAME: {kv_num_heads = 2 : i64, no_causal = true, num_heads = 16 : i64
+    // CHECK-NOT: onnx.Attention
+
+    return %out#0, %out#1, %out#2
+        : tensor<?x?x8192xf16>, tensor<?x2x?x512xf16>, tensor<?x2x?x512xf16>
+  }
+}
+
+// -----
+
+// ===== An unrecognized OR leg must abandon the window =====
+//
+// A disjunct ADDS keeps, so one that cannot be bounded leaves the whole
+// condition unbounded no matter how tight the window leg is: the model may be
+// keeping a key the narrowing would drop. Here the second leg is a bare
+// equality on the position indices, which is neither a window nor the
+// recognized same-segment shape, so nothing is stamped even though the window
+// leg itself is a perfect match. Recognizing only what it understands is the
+// whole safety property of this rewrite.
+module {
+  func.func @main_graph(
+      %query: tensor<?x?x4096xf16>,
+      %key: tensor<?x?x2048xf16>,
+      %value: tensor<?x?x2048xf16>,
+      %qidx: tensor<?x?xi64>,
+      %kidx: tensor<?x?xi64>,
+      %past_key: tensor<?x8x?x256xf16>,
+      %past_value: tensor<?x8x?x256xf16>)
+      -> (tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>,
+          tensor<?x8x?x256xf16>) {
+
+    // CHECK-LABEL: func.func @main_graph
+    // CHECK-SAME: (%[[CTXU:.*]]: !hip.context,
+
+    %c1 = "onnx.Constant"() {value = dense<1> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %c2 = "onnx.Constant"() {value = dense<2> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %w = "onnx.Constant"() {value = dense<1024> : tensor<i64>}
+        : () -> tensor<i64>
+    %keepv = "onnx.Constant"() {value = dense<0.000000e+00> : tensor<f32>}
+        : () -> tensor<f32>
+    %dropv = "onnx.Constant"() {value = dense<-6.550400e+04> : tensor<f32>}
+        : () -> tensor<f32>
+
+    %qpos = "onnx.Unsqueeze"(%qidx, %c2)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x?x1xi64>
+    %kpos = "onnx.Unsqueeze"(%kidx, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x1x?xi64>
+    %causal = "onnx.GreaterOrEqual"(%qpos, %kpos)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi1>
+    %dist = "onnx.Sub"(%qpos, %kpos)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi64>
+    %inwin = "onnx.Less"(%dist, %w)
+        : (tensor<?x?x?xi64>, tensor<i64>) -> tensor<?x?x?xi1>
+    %wleg = "onnx.And"(%causal, %inwin)
+        : (tensor<?x?x?xi1>, tensor<?x?x?xi1>) -> tensor<?x?x?xi1>
+
+    %other = "onnx.Equal"(%qpos, %kpos)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi1>
+    %keep = "onnx.Or"(%wleg, %other)
+        : (tensor<?x?x?xi1>, tensor<?x?x?xi1>) -> tensor<?x?x?xi1>
+    %bias32 = "onnx.Where"(%keep, %keepv, %dropv)
+        : (tensor<?x?x?xi1>, tensor<f32>, tensor<f32>) -> tensor<?x?x?xf32>
+    %bias16 = "onnx.Cast"(%bias32) {to = 10 : si64}
+        : (tensor<?x?x?xf32>) -> tensor<?x?x?xf16>
+    %bias = "onnx.Unsqueeze"(%bias16, %c1)
+        : (tensor<?x?x?xf16>, tensor<1xi64>) -> tensor<?x1x?x?xf16>
+
+    %out:3 = "onnx.Attention"(%query, %key, %value, %bias, %past_key,
+                              %past_value)
+        {q_num_heads = 16 : si64,
+         kv_num_heads = 8 : si64,
+         is_causal = 0 : si64,
+         scale = 6.250000e-02 : f32,
+         softcap = 0.000000e+00 : f32}
+        : (tensor<?x?x4096xf16>, tensor<?x?x2048xf16>, tensor<?x?x2048xf16>,
+           tensor<?x1x?x?xf16>, tensor<?x8x?x256xf16>, tensor<?x8x?x256xf16>)
+        -> (tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>,
+            tensor<?x8x?x256xf16>)
+
+    // CHECK: hip.gqa(%[[CTXU]])
+    // CHECK-SAME: {kv_num_heads = 8 : i64, no_causal = true, num_heads = 16 : i64
+    // CHECK-NOT: onnx.Attention
+
+    return %out#0, %out#1, %out#2
+        : tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>, tensor<?x8x?x256xf16>
+  }
+}
+
+// -----
+
+// ===== A declared left_window_size (opset 25) wins over the mask =====
+//
+// Opset 25 added left_window_size / right_window_size to onnx.Attention, so a
+// window no longer has to be inferred. When the attribute is there it is the
+// model's own statement and takes precedence; the mask walk exists for the
+// opset-23/24 exports that have nothing to declare.
+//
+// The two conventions differ by one and this pins that down: left_window_size
+// counts keys PRECEDING the current one, local_window_size counts keys
+// ATTENDED including the current one, so 511 becomes 512. The mask here still
+// encodes 1024, so 512 in the output also proves which source was used.
+module {
+  func.func @main_graph(
+      %query: tensor<?x?x4096xf16>,
+      %key: tensor<?x?x2048xf16>,
+      %value: tensor<?x?x2048xf16>,
+      %qidx: tensor<?x?xi64>,
+      %kidx: tensor<?x?xi64>,
+      %past_key: tensor<?x8x?x256xf16>,
+      %past_value: tensor<?x8x?x256xf16>)
+      -> (tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>,
+          tensor<?x8x?x256xf16>) {
+
+    // CHECK-LABEL: func.func @main_graph
+    // CHECK-SAME: (%[[CTXA:.*]]: !hip.context,
+
+    %c1 = "onnx.Constant"() {value = dense<1> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %c2 = "onnx.Constant"() {value = dense<2> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %w = "onnx.Constant"() {value = dense<1024> : tensor<i64>}
+        : () -> tensor<i64>
+    %keepv = "onnx.Constant"() {value = dense<0.000000e+00> : tensor<f32>}
+        : () -> tensor<f32>
+    %dropv = "onnx.Constant"() {value = dense<-6.550400e+04> : tensor<f32>}
+        : () -> tensor<f32>
+
+    %qpos = "onnx.Unsqueeze"(%qidx, %c2)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x?x1xi64>
+    %kpos = "onnx.Unsqueeze"(%kidx, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x1x?xi64>
+    %causal = "onnx.GreaterOrEqual"(%qpos, %kpos)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi1>
+    %dist = "onnx.Sub"(%qpos, %kpos)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi64>
+    %inwin = "onnx.Less"(%dist, %w)
+        : (tensor<?x?x?xi64>, tensor<i64>) -> tensor<?x?x?xi1>
+    %keep = "onnx.And"(%causal, %inwin)
+        : (tensor<?x?x?xi1>, tensor<?x?x?xi1>) -> tensor<?x?x?xi1>
+    %bias32 = "onnx.Where"(%keep, %keepv, %dropv)
+        : (tensor<?x?x?xi1>, tensor<f32>, tensor<f32>) -> tensor<?x?x?xf32>
+    %bias16 = "onnx.Cast"(%bias32) {to = 10 : si64}
+        : (tensor<?x?x?xf32>) -> tensor<?x?x?xf16>
+    %bias = "onnx.Unsqueeze"(%bias16, %c1)
+        : (tensor<?x?x?xf16>, tensor<1xi64>) -> tensor<?x1x?x?xf16>
+
+    %out:3 = "onnx.Attention"(%query, %key, %value, %bias, %past_key,
+                              %past_value)
+        {q_num_heads = 16 : si64,
+         kv_num_heads = 8 : si64,
+         is_causal = 0 : si64,
+         left_window_size = 511 : si64,
+         right_window_size = 0 : si64,
+         scale = 6.250000e-02 : f32,
+         softcap = 0.000000e+00 : f32}
+        : (tensor<?x?x4096xf16>, tensor<?x?x2048xf16>, tensor<?x?x2048xf16>,
+           tensor<?x1x?x?xf16>, tensor<?x8x?x256xf16>, tensor<?x8x?x256xf16>)
+        -> (tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>,
+            tensor<?x8x?x256xf16>)
+
+    // 511 declared + 1 = 512 attended, and NOT the 1024 the mask encodes.
+    // CHECK: hip.gqa(%[[CTXA]])
+    // CHECK-SAME: {kv_num_heads = 8 : i64, local_window_size = 512 : i64, no_causal = true, num_heads = 16 : i64
+    // CHECK-NOT: onnx.Attention
+
+    return %out#0, %out#1, %out#2
+        : tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>, tensor<?x8x?x256xf16>
+  }
+}
+
+// -----
+
+// ===== A bidirectional window declines rather than narrowing by half =====
+//
+// right_window_size > 0 admits keys AFTER the query position. local_window_size
+// is a causal left extent and cannot say that, so taking the left bound alone
+// would silently keep a window the model did not ask for. Decline entirely: no
+// local_window_size is stamped, the runtime sees -1 and reads the full range.
+// The mask still encodes 1024 and must not be used as a consolation prize.
+module {
+  func.func @main_graph(
+      %query: tensor<?x?x4096xf16>,
+      %key: tensor<?x?x2048xf16>,
+      %value: tensor<?x?x2048xf16>,
+      %qidx: tensor<?x?xi64>,
+      %kidx: tensor<?x?xi64>,
+      %past_key: tensor<?x8x?x256xf16>,
+      %past_value: tensor<?x8x?x256xf16>)
+      -> (tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>,
+          tensor<?x8x?x256xf16>) {
+
+    // CHECK-LABEL: func.func @main_graph
+    // CHECK-SAME: (%[[CTXB:.*]]: !hip.context,
+
+    %c1 = "onnx.Constant"() {value = dense<1> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %c2 = "onnx.Constant"() {value = dense<2> : tensor<1xi64>}
+        : () -> tensor<1xi64>
+    %w = "onnx.Constant"() {value = dense<1024> : tensor<i64>}
+        : () -> tensor<i64>
+    %keepv = "onnx.Constant"() {value = dense<0.000000e+00> : tensor<f32>}
+        : () -> tensor<f32>
+    %dropv = "onnx.Constant"() {value = dense<-6.550400e+04> : tensor<f32>}
+        : () -> tensor<f32>
+
+    %qpos = "onnx.Unsqueeze"(%qidx, %c2)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x?x1xi64>
+    %kpos = "onnx.Unsqueeze"(%kidx, %c1)
+        : (tensor<?x?xi64>, tensor<1xi64>) -> tensor<?x1x?xi64>
+    %causal = "onnx.GreaterOrEqual"(%qpos, %kpos)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi1>
+    %dist = "onnx.Sub"(%qpos, %kpos)
+        : (tensor<?x?x1xi64>, tensor<?x1x?xi64>) -> tensor<?x?x?xi64>
+    %inwin = "onnx.Less"(%dist, %w)
+        : (tensor<?x?x?xi64>, tensor<i64>) -> tensor<?x?x?xi1>
+    %keep = "onnx.And"(%causal, %inwin)
+        : (tensor<?x?x?xi1>, tensor<?x?x?xi1>) -> tensor<?x?x?xi1>
+    %bias32 = "onnx.Where"(%keep, %keepv, %dropv)
+        : (tensor<?x?x?xi1>, tensor<f32>, tensor<f32>) -> tensor<?x?x?xf32>
+    %bias16 = "onnx.Cast"(%bias32) {to = 10 : si64}
+        : (tensor<?x?x?xf32>) -> tensor<?x?x?xf16>
+    %bias = "onnx.Unsqueeze"(%bias16, %c1)
+        : (tensor<?x?x?xf16>, tensor<1xi64>) -> tensor<?x1x?x?xf16>
+
+    %out:3 = "onnx.Attention"(%query, %key, %value, %bias, %past_key,
+                              %past_value)
+        {q_num_heads = 16 : si64,
+         kv_num_heads = 8 : si64,
+         is_causal = 0 : si64,
+         left_window_size = 511 : si64,
+         right_window_size = 2 : si64,
+         scale = 6.250000e-02 : f32,
+         softcap = 0.000000e+00 : f32}
+        : (tensor<?x?x4096xf16>, tensor<?x?x2048xf16>, tensor<?x?x2048xf16>,
+           tensor<?x1x?x?xf16>, tensor<?x8x?x256xf16>, tensor<?x8x?x256xf16>)
+        -> (tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>,
+            tensor<?x8x?x256xf16>)
+
+    // CHECK: hip.gqa(%[[CTXB]])
+    // CHECK-SAME: {kv_num_heads = 8 : i64, no_causal = true, num_heads = 16 : i64
+    // CHECK-NOT: onnx.Attention
+
+    return %out#0, %out#1, %out#2
+        : tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>, tensor<?x8x?x256xf16>
   }
 }

--- a/test/numeric/tests/test_attention_sliding_window.py
+++ b/test/numeric/tests/test_attention_sliding_window.py
@@ -1,0 +1,553 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+"""Numeric tests for a windowed ``onnx.Attention`` layer on the decomposed path.
+
+These cover the geometry that had no numeric coverage at all: a sliding-window
+attention layer running through ``gqa_forward_hipblaslt``. The two windowed
+cases in ``test_gqa.py`` both use ``head_dim == 64``, which
+``flash_decode_geometry_ok`` accepts, so they exercise the fused kernels and
+never reach the decomposed pipeline.
+
+The model here is Gemma-4 26B-A4B's local attention layer as exported:
+
+  ``onnx.Attention`` (standard domain, opset 24), 3D Q/K/V + additive mask +
+  past KV, ``q_num_heads=16``, ``kv_num_heads=8``, ``head_dim=256``,
+  ``is_causal=0``.
+
+Three properties of that export matter and are reproduced exactly:
+
+  * An additive mask operand is present, which makes ``fused_supported`` false
+    (the lean fused path would silently drop the bias), so every one of these
+    runs is on the decomposed path by construction.
+  * ``is_causal=0`` lowers to ``no_causal=true``, so the built-in causal/window
+    mask kernel does not run and the mask operand carries all masking.
+  * The window is not an attribute anywhere. It is baked into the mask, and the
+    mask is BUILT IN THE GRAPH from the same node shape the real export uses --
+    ``Where(And(qpos >= kpos, qpos - kpos < W), 0, -65504)``. That is what makes
+    these tests exercise the shipping mechanism: the converter's
+    AttentionWindowFold has to recognize that subgraph and recover ``W``, or the
+    runtime never narrows and the narrowed path goes untested. Handing the mask
+    in as a graph input would test the arithmetic while skipping the part that
+    decides whether it runs at all.
+
+Reference is fp64 numpy rather than ORT CPU on the same model: the comparison
+needs to be against the mask semantics we intend, and fp16 CPU attention
+accumulates enough softmax error on a 2K key range to make a mismatch
+ambiguous.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from onnx import TensorProto, helper, numpy_helper
+
+from framework.comparator import compare_outputs
+
+# Gemma-4 26B-A4B local-layer geometry.
+NUM_HEADS = 16
+KV_NUM_HEADS = 8
+HEAD_DIM = 256
+Q_HIDDEN = NUM_HEADS * HEAD_DIM  # 4096
+KV_HIDDEN = KV_NUM_HEADS * HEAD_DIM  # 2048
+
+# The value the real export's mask Where selects for a disallowed position.
+MASK_FILL = -65504.0
+
+
+def _mask_subgraph(prefix, qidx, kidx, window, out):
+    """Nodes + initializers building an additive mask the converter can read.
+
+    Reproduces the real export's node shape, which is what
+    AttentionWindowFold matches on:
+
+        qpos   = Unsqueeze(qidx, [2])          # varies along the query axis
+        kpos   = Unsqueeze(kidx, [1])          # varies along the key axis
+        keep   = And(qpos >= kpos, qpos - kpos < W)
+        bias   = Where(keep, 0.0, -65504.0)
+        <out>  = Unsqueeze(Cast(bias, fp16), [1])
+
+    The compare and the subtraction share the same two values in the same
+    order; that identity is what lets the converter conclude the bound is on
+    the query-key distance. ``window <= 0`` emits the bare causal compare
+    instead, which is the global-layer shape and must NOT yield a window.
+    """
+    p = f"{prefix}_"
+    inits = [
+        numpy_helper.from_array(np.array([1], dtype=np.int64), p + "ax1"),
+        numpy_helper.from_array(np.array([2], dtype=np.int64), p + "ax2"),
+        numpy_helper.from_array(np.array(0.0, dtype=np.float32), p + "keepv"),
+        numpy_helper.from_array(np.array(MASK_FILL, dtype=np.float32), p + "dropv"),
+    ]
+    nodes = [
+        helper.make_node("Unsqueeze", [qidx, p + "ax2"], [p + "qpos"]),
+        helper.make_node("Unsqueeze", [kidx, p + "ax1"], [p + "kpos"]),
+        helper.make_node("GreaterOrEqual", [p + "qpos", p + "kpos"], [p + "causal"]),
+    ]
+    if window > 0:
+        inits.append(numpy_helper.from_array(np.array(window, dtype=np.int64), p + "w"))
+        nodes += [
+            helper.make_node("Sub", [p + "qpos", p + "kpos"], [p + "dist"]),
+            helper.make_node("Less", [p + "dist", p + "w"], [p + "inwin"]),
+            helper.make_node("And", [p + "causal", p + "inwin"], [p + "keep"]),
+        ]
+        keep = p + "keep"
+    else:
+        keep = p + "causal"
+    nodes += [
+        helper.make_node("Where", [keep, p + "keepv", p + "dropv"], [p + "bias32"]),
+        helper.make_node(
+            "Cast", [p + "bias32"], [p + "bias16"], to=TensorProto.FLOAT16
+        ),
+        helper.make_node("Unsqueeze", [p + "bias16", p + "ax1"], [out]),
+    ]
+    return nodes, inits
+
+
+def _attention_attrs():
+    return dict(
+        q_num_heads=NUM_HEADS,
+        kv_num_heads=KV_NUM_HEADS,
+        scale=float(1.0 / np.sqrt(HEAD_DIM)),
+        softcap=0.0,
+        is_causal=0,
+    )
+
+
+def _make_attention_model(batch, seq_len, window):
+    """Build a single-op ``onnx.Attention`` model in the Gemma-4 export shape.
+
+    Q/K/V are rank-3 ``[B, S, heads*head_dim]``, past/present KV are BNSH, and
+    the additive mask is computed in-graph from the absolute query/key position
+    vectors so the window is recoverable. ``is_causal=0`` so the mask is the
+    only source of masking, matching the export.
+
+    The KV sequence dims are symbolic, matching the export's
+    ``past_sequence_len`` / ``past_sequence_len + sequence_len``. This is not
+    cosmetic: with every dim static, the converter's synthesised ``seqlens_k``
+    folds to a compile-time constant that lands in the host constants blob, and
+    the decomposed path's D2H readback of it fails with "invalid argument"
+    (rc=-1, zero-filled output). Symbolic KV dims keep ``seqlens_k`` a runtime
+    device value, which is what the real model produces.
+    """
+    past_dim = "past_seq"
+    total_dim = "past_seq + seq"
+
+    def vi(name, dtype, shape):
+        return helper.make_tensor_value_info(name, dtype, shape)
+
+    inputs = [
+        vi("query", TensorProto.FLOAT16, [batch, seq_len, Q_HIDDEN]),
+        vi("key", TensorProto.FLOAT16, [batch, seq_len, KV_HIDDEN]),
+        vi("value", TensorProto.FLOAT16, [batch, seq_len, KV_HIDDEN]),
+        vi("qidx", TensorProto.INT64, [batch, seq_len]),
+        vi("kidx", TensorProto.INT64, [batch, total_dim]),
+        vi(
+            "past_key",
+            TensorProto.FLOAT16,
+            [batch, KV_NUM_HEADS, past_dim, HEAD_DIM],
+        ),
+        vi(
+            "past_value",
+            TensorProto.FLOAT16,
+            [batch, KV_NUM_HEADS, past_dim, HEAD_DIM],
+        ),
+    ]
+    outputs = [
+        vi("output", TensorProto.FLOAT16, [batch, seq_len, Q_HIDDEN]),
+        vi(
+            "present_key",
+            TensorProto.FLOAT16,
+            [batch, KV_NUM_HEADS, total_dim, HEAD_DIM],
+        ),
+        vi(
+            "present_value",
+            TensorProto.FLOAT16,
+            [batch, KV_NUM_HEADS, total_dim, HEAD_DIM],
+        ),
+    ]
+
+    mask_nodes, mask_inits = _mask_subgraph("m", "qidx", "kidx", window, "attn_mask")
+    node = helper.make_node(
+        "Attention",
+        ["query", "key", "value", "attn_mask", "past_key", "past_value"],
+        ["output", "present_key", "present_value"],
+        **_attention_attrs(),
+    )
+
+    graph = helper.make_graph(
+        mask_nodes + [node],
+        "attention_sliding_window",
+        inputs,
+        outputs,
+        initializer=mask_inits,
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_opsetid("", 24)])
+
+
+def _make_chained_model(batch, second_seq, window):
+    """Two ``Attention`` nodes where the first's ``present`` is the second's past.
+
+    This is the shape of the one hazard the decode copy narrowing introduces. A
+    narrowed decode leaves ``present`` valid only from ``kv_lo`` up, on the
+    promise that whoever reads it next is another narrowed decode. A call with
+    ``sq > 1`` and ``past_len > 0`` breaks that promise: prefill is deliberately
+    not narrowed, so it reads the whole range, including the part the decode
+    never wrote.
+
+    Chaining the two nodes in one graph makes ORT hand node A's ``present``
+    buffer to node B as its ``past``, which is the same aliasing a multi-turn
+    generate loop produces across session runs -- and unlike that loop, it is
+    reproducible in one call.
+    """
+    dim_a_past = "past_seq"
+    dim_a_total = "past_seq_plus_1"
+    dim_b_total = "past_seq_plus_1_plus_s2"
+
+    def vi(name, shape, dtype=TensorProto.FLOAT16):
+        return helper.make_tensor_value_info(name, dtype, shape)
+
+    i64 = TensorProto.INT64
+    inputs = [
+        vi("query_a", [batch, 1, Q_HIDDEN]),
+        vi("key_a", [batch, 1, KV_HIDDEN]),
+        vi("value_a", [batch, 1, KV_HIDDEN]),
+        vi("qidx_a", [batch, 1], i64),
+        vi("kidx_a", [batch, dim_a_total], i64),
+        vi("past_key", [batch, KV_NUM_HEADS, dim_a_past, HEAD_DIM]),
+        vi("past_value", [batch, KV_NUM_HEADS, dim_a_past, HEAD_DIM]),
+        vi("query_b", [batch, second_seq, Q_HIDDEN]),
+        vi("key_b", [batch, second_seq, KV_HIDDEN]),
+        vi("value_b", [batch, second_seq, KV_HIDDEN]),
+        vi("qidx_b", [batch, second_seq], i64),
+        vi("kidx_b", [batch, dim_b_total], i64),
+    ]
+    # Every ``present`` is a graph output, node A's included even though node B
+    # also consumes it. The EP's meta-def requires a declared value info for
+    # each subgraph output (morphizen-ep.cpp asserts the counts match), and
+    # exposing node A's present is useful in its own right: it is the tensor
+    # whose lower region the narrowing deliberately leaves unwritten.
+    outputs = [
+        vi("output_b", [batch, second_seq, Q_HIDDEN]),
+        vi("output_a", [batch, 1, Q_HIDDEN]),
+        vi("present_a_key", [batch, KV_NUM_HEADS, dim_a_total, HEAD_DIM]),
+        vi("present_a_value", [batch, KV_NUM_HEADS, dim_a_total, HEAD_DIM]),
+        vi("present_b_key", [batch, KV_NUM_HEADS, dim_b_total, HEAD_DIM]),
+        vi("present_b_value", [batch, KV_NUM_HEADS, dim_b_total, HEAD_DIM]),
+    ]
+
+    attrs = _attention_attrs()
+    nodes_a, inits_a = _mask_subgraph("ma", "qidx_a", "kidx_a", window, "mask_a")
+    nodes_b, inits_b = _mask_subgraph("mb", "qidx_b", "kidx_b", window, "mask_b")
+    node_a = helper.make_node(
+        "Attention",
+        ["query_a", "key_a", "value_a", "mask_a", "past_key", "past_value"],
+        ["output_a", "present_a_key", "present_a_value"],
+        name="decode",
+        **attrs,
+    )
+    node_b = helper.make_node(
+        "Attention",
+        ["query_b", "key_b", "value_b", "mask_b", "present_a_key", "present_a_value"],
+        ["output_b", "present_b_key", "present_b_value"],
+        name="prefill_after_decode",
+        **attrs,
+    )
+
+    graph = helper.make_graph(
+        nodes_a + nodes_b + [node_a, node_b],
+        "decode_then_prefill",
+        inputs,
+        outputs,
+        initializer=inits_a + inits_b,
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_opsetid("", 24)])
+
+
+def _positions(batch, seq_len, past_seq):
+    """Absolute query and key positions, the mask subgraph's two inputs."""
+    total_kv = past_seq + seq_len
+    qidx = np.broadcast_to(
+        past_seq + np.arange(seq_len, dtype=np.int64), (batch, seq_len)
+    ).copy()
+    kidx = np.broadcast_to(
+        np.arange(total_kv, dtype=np.int64), (batch, total_kv)
+    ).copy()
+    return qidx, kidx
+
+
+def _make_window_mask(batch, seq_len, past_seq, window):
+    """The reference for what the in-graph mask subgraph computes.
+
+    Query row ``i`` has absolute position ``past_seq + i`` and may attend to
+    key ``j`` when ``j <= abs_q`` (causal) and ``j > abs_q - window`` (window,
+    i.e. ``abs_q - j < window``). ``window <= 0`` means causal only.
+    """
+    total_kv = past_seq + seq_len
+    abs_q = (past_seq + np.arange(seq_len))[:, None]
+    keys = np.arange(total_kv)[None, :]
+    allowed = keys <= abs_q
+    if window > 0:
+        allowed &= abs_q - keys < window
+    mask = np.where(allowed, 0.0, MASK_FILL).astype(np.float32)
+    return np.broadcast_to(mask, (batch, 1, seq_len, total_kv)).copy()
+
+
+def _gqa_reference(q, k, v, past_k, past_v, mask):
+    """fp64 numpy GQA reference: (output, present_key, present_value).
+
+    Q/K/V arrive rank-3 ``[B, S, heads*head_dim]``; past/present are BNSH. KV
+    heads are repeated to the query head count, the additive mask is applied to
+    the scaled scores, and softmax runs over the whole key range -- so a key
+    whose mask entry is MASK_FILL contributes ~0 without being dropped, which
+    is exactly what the narrowed path has to reproduce.
+    """
+    batch, seq_len, _ = q.shape
+
+    present_k = np.concatenate(
+        [past_k.astype(np.float64), _to_bnsh(k, batch, seq_len)], axis=2
+    )
+    present_v = np.concatenate(
+        [past_v.astype(np.float64), _to_bnsh(v, batch, seq_len)], axis=2
+    )
+    return _attend(q, present_k, present_v, mask), present_k, present_v
+
+
+def _attend(q, present_k, present_v, mask):
+    """fp64 attention of rank-3 ``q`` over BNSH ``present_k``/``present_v``."""
+    batch, seq_len, _ = q.shape
+    hpg = NUM_HEADS // KV_NUM_HEADS
+
+    qh = q.astype(np.float64).reshape(batch, seq_len, NUM_HEADS, HEAD_DIM)
+    qh = qh.transpose(0, 2, 1, 3)  # [B, H, S, d]
+    kh = np.repeat(present_k, hpg, axis=1)  # [B, H, T, d]
+    vh = np.repeat(present_v, hpg, axis=1)
+
+    scores = (qh @ kh.transpose(0, 1, 3, 2)) * (1.0 / np.sqrt(HEAD_DIM))
+    scores = scores + mask.astype(np.float64)  # broadcasts over the head axis
+    scores = scores - scores.max(axis=-1, keepdims=True)
+    probs = np.exp(scores)
+    probs /= probs.sum(axis=-1, keepdims=True)
+    out = probs @ vh
+    return out.transpose(0, 2, 1, 3).reshape(batch, seq_len, Q_HIDDEN)
+
+
+def _to_bnsh(t, batch, seq_len):
+    t = t.astype(np.float64).reshape(batch, seq_len, KV_NUM_HEADS, HEAD_DIM)
+    return t.transpose(0, 2, 1, 3)
+
+
+def _assert_live_present(got, ref, total_kv, window):
+    """Assert ``present`` matches the reference over the range decode will read.
+
+    The lower bound is the same ``kv_lo`` the EP narrows to, so this checks the
+    exact region the copy is still responsible for. Below it the copy is allowed
+    to write nothing at all, so that region is not compared -- and it must not
+    be, since asserting anything about it (even that it is zero) would be
+    asserting on memory nobody promised anything about.
+
+    Bit-exactness is the right bar here rather than a tolerance: the concat is a
+    copy, so any difference at all in the live region means the wrong bytes
+    moved.
+    """
+    kv_lo = max(0, total_kv - window) if window > 0 else 0
+    got = np.asarray(got)[:, :, kv_lo:, :].astype(np.float32)
+    ref = np.asarray(ref)[:, :, kv_lo:, :].astype(np.float32)
+    assert got.shape == ref.shape, f"{got.shape} vs {ref.shape}"
+    mismatched = int(np.count_nonzero(got != ref))
+    assert mismatched == 0, (
+        f"present[{kv_lo}:] differs from the reference in {mismatched} of "
+        f"{got.size} elements: the narrowed copy did not write everything the "
+        f"narrowed read consumes"
+    )
+
+
+def _persist(model_runner, model):
+    """Write *model* to a fresh per-test work subdir and return its path."""
+    sub = model_runner._next_subdir()
+    path = sub / "model.onnx"
+    path.write_bytes(model.SerializeToString())
+    return str(path)
+
+
+def _run_case(model_runner, seq_len, past_seq, window, seed):
+    batch = 1
+    model = _make_attention_model(batch, seq_len, window)
+
+    rng = np.random.default_rng(seed)
+
+    def rand(shape, spread=0.5):
+        return (rng.standard_normal(shape) * spread).astype(np.float16)
+
+    q = rand([batch, seq_len, Q_HIDDEN])
+    k = rand([batch, seq_len, KV_HIDDEN])
+    v = rand([batch, seq_len, KV_HIDDEN])
+    past_k = rand([batch, KV_NUM_HEADS, past_seq, HEAD_DIM])
+    past_v = rand([batch, KV_NUM_HEADS, past_seq, HEAD_DIM])
+    qidx, kidx = _positions(batch, seq_len, past_seq)
+    mask = _make_window_mask(batch, seq_len, past_seq, window)
+
+    actual = model_runner.backend.run(
+        _persist(model_runner, model),
+        [q, k, v, qidx, kidx, past_k, past_v],
+    )
+    expected = _gqa_reference(q, k, v, past_k, past_v, mask)
+    compare_outputs(
+        actual[:1], list(expected[:1]), atol=2e-2, rtol=2e-2, cos_threshold=0.999
+    )
+
+    # present KV is checked over the range this call's read consumes, and only
+    # that range: the copy is narrowed to the same bound as the read, so
+    # everything below it is legitimately unwritten. The bound is the case's
+    # own window, because that is now what the EP narrows by -- it recovered it
+    # from this model's mask subgraph. A window at or above the context does not
+    # narrow, and neither does a prefill.
+    total_kv = past_seq + seq_len
+    narrowed = seq_len == 1 and 0 < window < total_kv
+    _assert_live_present(actual[1], expected[1], total_kv, window if narrowed else 0)
+    _assert_live_present(actual[2], expected[2], total_kv, window if narrowed else 0)
+
+
+class TestAttentionSlidingWindow:
+    """Windowed ``onnx.Attention`` through ``gqa_forward_hipblaslt``."""
+
+    @pytest.mark.parametrize(
+        "past_seq,window",
+        [
+            # Window saturated well inside the context: the case the narrowing
+            # exists for, and the one where a wrong kv_lo shows up as a large
+            # error rather than a rounding difference.
+            (2048, 1024),
+            # Window one key short of the context: kv_lo == 1, which catches an
+            # off-by-one that a power-of-two offset would hide.
+            (1024, 1024),
+            # Window wider than the context: narrowing must not engage, and the
+            # result must match the same reference.
+            (512, 4096),
+        ],
+    )
+    def test_decode_windowed(self, model_runner, past_seq, window):
+        """Single-token decode (sq == 1) with the window carried by the mask."""
+        _run_case(model_runner, seq_len=1, past_seq=past_seq, window=window, seed=7)
+
+    def test_decode_full_attention(self, model_runner):
+        """Decode with a causal-only mask: the no-window control.
+
+        This is the global-layer shape. The mask subgraph has no distance bound,
+        so the converter must recover no window and the runtime must read the
+        whole key range. If it narrowed anyway the output would be wrong here,
+        which makes this the guard on over-eager recognition.
+        """
+        _run_case(model_runner, seq_len=1, past_seq=1024, window=0, seed=11)
+
+    def test_decode_then_prefill_reads_full_range(self, model_runner):
+        """A prefill reading the cache a narrowed decode just wrote.
+
+        The decode narrowing skips writing ``present`` below ``kv_lo`` because
+        the next decode will not read below it. This case is the exception: node
+        B has ``sq > 1``, so it is not narrowed and reads the whole range,
+        including what node A skipped. It is the one sequence that can turn the
+        copy narrowing into wrong numbers rather than fewer bytes.
+
+        Node B's mask is windowed, as a real export's is -- the window belongs to
+        the layer, so prefill carries it too. Each of node B's query rows sits at
+        absolute position >= ``past_seq + 1``, so its window admits nothing below
+        ``kv_lo``: the skipped region is masked for every row, and any finite
+        content there is suppressed by the ``-65504`` fill.
+
+        What is asserted, and what deliberately is not:
+
+        * Node A's output and the live ``[kv_lo, total)`` part of its ``present``
+          are asserted exactly. That is the narrowing's own contract.
+        * Node B's output is asserted only to be free of NaN, which is the
+          failure this case exists to detect: a stale non-finite value in the
+          skipped region survives any finite mask and would take the whole
+          softmax row with it.
+        * Node B's *values* are not asserted, because they are wrong for an
+          unrelated reason. In a chained graph the EP misderives node B's
+          geometry -- it reports ``total_seq = past_buf_seq`` and hence
+          ``past_len = total_seq - sq``, writing the new tokens over valid past
+          keys. The same geometry as a single node scores 1.000000, and the
+          error is identical with the narrowing off, so asserting on it here
+          would only encode a pre-existing bug.
+        """
+        batch, past_seq, second_seq, window = 1, 2048, 8, 1024
+        rng = np.random.default_rng(23)
+
+        def rand(shape):
+            return (rng.standard_normal(shape) * 0.5).astype(np.float16)
+
+        q_a = rand([batch, 1, Q_HIDDEN])
+        k_a = rand([batch, 1, KV_HIDDEN])
+        v_a = rand([batch, 1, KV_HIDDEN])
+        past_k = rand([batch, KV_NUM_HEADS, past_seq, HEAD_DIM])
+        past_v = rand([batch, KV_NUM_HEADS, past_seq, HEAD_DIM])
+        qidx_a, kidx_a = _positions(batch, 1, past_seq)
+        mask_a = _make_window_mask(batch, 1, past_seq, window)
+
+        q_b = rand([batch, second_seq, Q_HIDDEN])
+        k_b = rand([batch, second_seq, KV_HIDDEN])
+        v_b = rand([batch, second_seq, KV_HIDDEN])
+        qidx_b, kidx_b = _positions(batch, second_seq, past_seq + 1)
+
+        actual = model_runner.backend.run(
+            _persist(model_runner, _make_chained_model(batch, second_seq, window)),
+            [
+                q_a,
+                k_a,
+                v_a,
+                qidx_a,
+                kidx_a,
+                past_k,
+                past_v,
+                q_b,
+                k_b,
+                v_b,
+                qidx_b,
+                kidx_b,
+            ],
+        )
+        out_b, out_a, present_a_k, present_a_v = (
+            actual[0],
+            actual[1],
+            actual[2],
+            actual[3],
+        )
+
+        ref_pa_k = np.concatenate(
+            [past_k.astype(np.float64), _to_bnsh(k_a, batch, 1)], axis=2
+        )
+        ref_pa_v = np.concatenate(
+            [past_v.astype(np.float64), _to_bnsh(v_a, batch, 1)], axis=2
+        )
+
+        assert not np.isnan(np.asarray(out_b, dtype=np.float32)).any(), (
+            "prefill-after-decode output has NaN: it read cache positions the "
+            "narrowed decode left unwritten, and a finite mask cannot suppress "
+            "a non-finite value"
+        )
+        _assert_live_present(present_a_k, ref_pa_k, past_seq + 1, window)
+        _assert_live_present(present_a_v, ref_pa_v, past_seq + 1, window)
+        compare_outputs(
+            [out_a],
+            [_attend(q_a, ref_pa_k, ref_pa_v, mask_a)],
+            atol=2e-2,
+            rtol=2e-2,
+            cos_threshold=0.999,
+        )
+
+    @pytest.mark.parametrize("seq_len,past_seq,window", [(128, 0, 32), (64, 64, 32)])
+    def test_prefill_windowed(self, model_runner, seq_len, past_seq, window):
+        """Windowed prefill (sq > 1) must be unaffected by decode narrowing.
+
+        The decode narrowing is gated on ``sq == 1``; a banded prefill is a
+        separate problem. This is the guard that the gate holds: a recovered
+        window is present on these runs too, and they still have to match the
+        full reference.
+        """
+        _run_case(
+            model_runner, seq_len=seq_len, past_seq=past_seq, window=window, seed=13
+        )


### PR DESCRIPTION
## Summary

**Throwaway CI experiment. Not for merge — [#599](https://github.com/ROCm/hip-ep/pull/599) is the PR that should land this change.**

Carries #599's `windows-build.yml` change on top of #795 so that CI builds against an OGA with `sliding_window` support. #795 recovers Gemma-4's sliding window from its attention mask and narrows the decode KV read and copy to it; this is what lets CI exercise that end to end rather than only through the numeric suite.

Base is `fix/gqa-decode-window`, so the diff here is exactly the workflow change; the head carries #795's three commits underneath it.

## Related issue or design

Depends on #795. Duplicates #599 for testing purposes.

## What

`OGA_VERSION: "0.14.0"` plus `OGA_PR_PATCHES: "2194"` becomes a checkout of `amd-genmingz/onnxruntime-genai @ test_0_3`, the fork branch carrying the AMDGPU MorphiZen integration that was PR 2194, plus `sliding_window`. `OGA_PR_PATCHES` survives as the mechanism for applying extra upstream PRs on top of the fork checkout and is now empty. The OGA cache key folds in the repo and ref instead of the version, and bumps `mm2` -> `mm3`.

Two deviations from #599, both deliberate:

- **Reapplied by hand rather than cherry-picked.** #599's patch no longer applies to `main`: its context still contains the `SCCACHE_GHA_ENABLED` / `SCCACHE_GHA_RW_MODE` env that #785 removed when it moved sccache to a local directory.
- **#599's third hunk is left out.** It renames "constants-file-in-tar" to "sidecar-in-tar" in an EPContext comment, which is wording drift from an older `main` rather than part of the OGA change, and carrying it would revert `main`'s current wording.

## Test plan

The point of the PR is the CI run. Locally verified before pushing:

- `windows-build.yml` parses as YAML and the `build-windows` env block resolves to `OGA_REPO=amd-genmingz/onnxruntime-genai`, `OGA_REF=test_0_3`, `OGA_PR_PATCHES=''`, with no `OGA_VERSION` left.
- No remaining `OGA_VERSION` references in `windows-build.yml`. (`linux-build.yml` still pins `v0.14.0` + PR 2194; #599 does not touch it and neither does this.)
- `git ls-remote` resolves `amd-genmingz/onnxruntime-genai @ test_0_3` to `ee25a5da`, so the checkout step has something to fetch.

The `mm3` cache key is identical to #599's, so if #599's CI has already populated it, this run reuses those OGA artifacts instead of rebuilding.

## Notes for reviewers

- Close this once #599 lands or the experiment is done; it should never be merged.
- The interesting checks are `build-windows` and `gpu-test`. `build-linux` is unaffected and only confirms #795 still builds.

<sub>AI assistance: created with Cursor.</sub>
