### PR TITLE
feat(gqa): ring append for a right-sized sliding-window KV cache (3.0 GB off an 8.3 GB peak at 16K)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,6 @@ _local/
 # Whisper test audio (auto-downloaded at test setup, cached locally; README kept)
 test/python/data/whisper/*.wav
 test/python/data/whisper/librispeech/
+
+# Standalone kernel example test binaries (built by hand via hipcc)
+lib/Runtime/Kernels/test/example/**/*.exe

--- a/backend-mlir-compiler/level-1-pass/src/MlirCompiler.cpp
+++ b/backend-mlir-compiler/level-1-pass/src/MlirCompiler.cpp
@@ -48,6 +48,8 @@ std::string build_compiler_options_json(const CompilationConfig &config) {
   json << "\"opt_level\": " << config.optLevel;
   json << ", \"skip_constant_data\": "
        << (config.skipConstantData ? "true" : "false");
+  json << ", \"kv_share_buffer\": "
+       << (config.kvShareBuffer ? "true" : "false");
   // output_mode maps to the flatbuffers OutputMode enum
   // (schemas/compilation_options.fbs). The flatbuffers JSON parser accepts
   // the enum value name.

--- a/backend-mlir-compiler/level-1-pass/src/MlirCompiler.h
+++ b/backend-mlir-compiler/level-1-pass/src/MlirCompiler.h
@@ -40,6 +40,12 @@ struct CompilationConfig {
   ArtifactFormat artifactFormat;
   int optLevel;
   bool skipConstantData = true;
+  // present_key/value name the same allocation as past_key/value. The graph
+  // cannot infer this -- a right-sized shared buffer and a growing separate
+  // one both have past < total -- so it comes from the `kv_share_buffer`
+  // provider option, which must agree with past_present_share_buffer in the
+  // model's genai_config.json.
+  bool kvShareBuffer = false;
 };
 
 // Compiled artifact (bytes + metadata)

--- a/backend-mlir-compiler/level-1-pass/src/pass_main.cpp
+++ b/backend-mlir-compiler/level-1-pass/src/pass_main.cpp
@@ -6,6 +6,7 @@
 #include "MlirCompiler.h"
 
 // Morphizen headers
+#include "hip/env.h"
 #include "hip/timing.h"
 #include "morphizen/env_config.hpp"
 #include "morphizen/morphizen.hpp"
@@ -71,6 +72,18 @@ static CompilationConfig load_config(PassContext *ctx) {
         ctx->get_provider_option("optimization_level", "2");
     config.optLevel = std::stoi(opt_level_str);
 
+    // Whether present_key/value alias past_key/value. Seeded from the legacy
+    // env var so existing shells keep working, then overridden by the provider
+    // option when the session sets one. The option is the source of truth
+    // because it has to agree with past_present_share_buffer, and provider
+    // options are where that flag already lives; an env var can only disagree
+    // with it from somewhere the reader cannot see. The optional overload is
+    // deliberate -- the defaulted one cannot tell "unset" from "0" and would
+    // silently clear the env seed.
+    config.kvShareBuffer = hipdnn_ep::env_enabled("HIPDNN_EP_KV_SHARE_BUFFER");
+    if (auto kv_share = ctx->get_provider_option("kv_share_buffer"))
+      config.kvShareBuffer = !kv_share->empty() && (*kv_share)[0] >= '1';
+
   } catch (const std::exception &ex) {
     MY_LOG(1) << "Failed to parse provider options: " << ex.what()
               << ", using defaults";
@@ -82,7 +95,8 @@ static CompilationConfig load_config(PassContext *ctx) {
             << "; skipConstantData="
             << (config.skipConstantData ? "true" : "false")
             << (epctxExport ? " (EPContext export -> constants file)"
-                            : " (streaming default)");
+                            : " (streaming default)")
+            << "; kvShareBuffer=" << (config.kvShareBuffer ? "true" : "false");
 
   return config;
 }

--- a/include/hip/Dialect/Transforms/Passes.td
+++ b/include/hip/Dialect/Transforms/Passes.td
@@ -85,6 +85,15 @@ def ConvertOnnxToHipPass : Pass<"convert-onnx-to-hip", "mlir::ModuleOp"> {
     Requires hip-add-context-arg to have run first so that !hip.context is
     available as function argument 0.
   }];
+  let options = [
+    Option<"kvShareBuffer", "kv-share-buffer", "bool", /*default=*/"false",
+           "present_key/value name the same allocation as past_key/value "
+           "rather than a freshly grown past+current, so the present buffer's "
+           "capacity is the past extent alone. Must agree with "
+           "past_present_share_buffer in the model's genai_config.json: the "
+           "operand shapes cannot tell a right-sized shared buffer from a "
+           "growing separate one, since both have past < total.">
+  ];
   let dependentDialects = [
     "mlir::hip::HipDialect",
     "mlir::arith::ArithDialect",

--- a/include/hip/Dialect/Transforms/Pipelines.h
+++ b/include/hip/Dialect/Transforms/Pipelines.h
@@ -64,6 +64,13 @@ struct OnnxToHipPipelineOptions
       llvm::cl::desc("Skip writing constant data to constants.bin (metadata "
                      "only). Used for ORT EP live-compile path."),
       llvm::cl::init(false)};
+  Option<bool> kvShareBuffer{
+      *this, "kv-share-buffer",
+      llvm::cl::desc("present_key/value name the same allocation as "
+                     "past_key/value, so present capacity is the past extent "
+                     "rather than past+current. Must agree with "
+                     "past_present_share_buffer in genai_config.json."),
+      llvm::cl::init(false)};
 };
 
 /// Pipeline options for the HIP-to-LLVM lowering pipeline.

--- a/lib/Compiler/CompilerDriver.cpp
+++ b/lib/Compiler/CompilerDriver.cpp
@@ -308,6 +308,7 @@ bool CompilerDriver::runMLIRPasses(
     onnxToHipOpts.externalizeMinNumElements =
         mlir::hip::kDefaultExternalizeMinNumElements;
     onnxToHipOpts.skipConstantData = options.skip_constant_data;
+    onnxToHipOpts.kvShareBuffer = options.kv_share_buffer;
 
     if (hipdnnHandle_) {
       compiledGraphs_ =

--- a/lib/Conversion/OnnxToHip/OnnxAttentionConversion.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxAttentionConversion.cpp
@@ -5,6 +5,8 @@
 
 #include "OnnxToHipUtils.h"
 
+#include "hip/env.h"
+
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 
@@ -74,6 +76,8 @@ namespace {
 ///   %past      = tensor.dim %past_k, %c2   // past buffer EXTENT (see below)
 ///   %tot       = tensor.dim %mask, %c3     // valid total KV, else %past + %cur
 ///   %cap       = arith.maxsi %past, %tot   // present buffer capacity
+///                                          // (just %past under
+///                                          //  HIPDNN_EP_KV_SHARE_BUFFER)
 ///   %seqlens_k = tensor.from_elements (%tot - 1)  : tensor<1xi32>
 ///   %total_seq = tensor.from_elements %cap        : tensor<i32>
 ///   %pk_init   = tensor.empty(%B, %cap)    // present sized to capacity
@@ -376,15 +380,34 @@ OnnxAttentionToHip::matchAndRewrite(mlir::Operation *op,
                       .getResult();
 
   // present buffer capacity, which is NOT the same as the valid length above.
-  // Taking the max keeps both callers correct: with a separately allocated
-  // present it collapses to past + current (the past extent is the valid past
-  // length, which is smaller), while with a shared buffer it yields the
-  // max_length capacity so the requested output shape matches the buffer ORT
-  // already bound -- which is what makes past_key == present_key, and hence the
-  // in-place append path, reachable at all.
+  //
+  // The two deployments want different things, and only one of them can be
+  // inferred from the operands. A separately allocated present has to hold
+  // past + current, and there dim(past_key, 2) is the valid past length, so it
+  // is strictly smaller than the total. A shared present IS the past buffer, so
+  // its capacity is dim(past_key, 2) exactly -- never the total.
+  //
+  // max() computes the right answer for both only as long as a shared buffer is
+  // allocated to max_length, where the past extent dominates the total anyway.
+  // It stops working the moment a buffer is deliberately allocated shorter than
+  // the context, which is what right-sizing a sliding-window layer's cache to
+  // its window does: max(1024, 2240) asks ORT for a 2240-long present and ORT
+  // refuses, because the buffer it bound is 1024.
+  //
+  // The relation between the extents cannot tell those apart -- a right-sized
+  // shared buffer and a growing separate one both have past < total -- so the
+  // deployment has to say. HIPDNN_EP_KV_SHARE_BUFFER must agree with
+  // past_present_share_buffer in genai_config.json; they are two views of one
+  // fact and disagreeing gets a shape rejection at the first Run.
+  // With no past operand there is nothing to share, so the flag does not apply
+  // and a zero-length present would be nonsense.
+  const bool kvShareBuffer =
+      pastKey && hipdnn_ep::env_enabled("HIPDNN_EP_KV_SHARE_BUFFER");
   mlir::Value presentCapIdx =
-      mlir::arith::MaxSIOp::create(rewriter, loc, pastSeqIdx, totalKvIdx)
-          .getResult();
+      kvShareBuffer
+          ? pastSeqIdx
+          : mlir::arith::MaxSIOp::create(rewriter, loc, pastSeqIdx, totalKvIdx)
+                .getResult();
 
   // seqlens_k[b] = total_seq - 1 (ORT GQA convention total_seq = seqlens_k + 1;
   // the runtime derives past_len = total_seq - sq). Ignored by the runtime on

--- a/lib/Conversion/OnnxToHip/OnnxAttentionConversion.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxAttentionConversion.cpp
@@ -5,8 +5,6 @@
 
 #include "OnnxToHipUtils.h"
 
-#include "hip/env.h"
-
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 
@@ -77,7 +75,7 @@ namespace {
 ///   %tot       = tensor.dim %mask, %c3     // valid total KV, else %past +
 ///   %cur %cap       = arith.maxsi %past, %tot   // present buffer capacity
 ///                                          // (just %past under
-///                                          //  HIPDNN_EP_KV_SHARE_BUFFER)
+///                                          //  kv-share-buffer)
 ///   %seqlens_k = tensor.from_elements (%tot - 1)  : tensor<1xi32>
 ///   %total_seq = tensor.from_elements %cap        : tensor<i32>
 ///   %pk_init   = tensor.empty(%B, %cap)    // present sized to capacity
@@ -107,12 +105,17 @@ namespace {
 /// null present_key/present_value and wrap_group_query_attention rejects the
 /// call, leaving the attention output zero-filled.
 struct OnnxAttentionToHip : public mlir::RewritePattern {
-  OnnxAttentionToHip(mlir::MLIRContext *ctx)
-      : RewritePattern("onnx.Attention", /*benefit=*/1, ctx) {}
+  OnnxAttentionToHip(mlir::MLIRContext *ctx, bool kvShareBuffer)
+      : RewritePattern("onnx.Attention", /*benefit=*/1, ctx),
+        kvShareBuffer(kvShareBuffer) {}
 
   mlir::LogicalResult
   matchAndRewrite(mlir::Operation *op,
                   mlir::PatternRewriter &rewriter) const override;
+
+  /// present and past name one allocation. See the capacity comment in
+  /// matchAndRewrite for why the graph cannot supply this on its own.
+  bool kvShareBuffer;
 };
 
 mlir::LogicalResult
@@ -332,13 +335,13 @@ OnnxAttentionToHip::matchAndRewrite(mlir::Operation *op,
     return transOp->getResult(0);
   };
 
-  // Whether present and past are one allocation. Read here, ahead of any IR
-  // construction, because the check below has to reject before the pattern
-  // starts building: a pattern that creates ops and then returns failure leaves
-  // the greedy driver holding orphaned IR. See the capacity comment further
-  // down for what the flag means and why the graph alone cannot supply it.
-  const bool kvShareBuffer =
-      pastKey && hipdnn_ep::env_enabled("HIPDNN_EP_KV_SHARE_BUFFER");
+  // With no past operand there is nothing to share, so the option does not
+  // apply and a zero-length present would be nonsense. Resolved here, ahead of
+  // any IR construction, because the check below has to reject before the
+  // pattern starts building: a pattern that creates ops and then returns
+  // failure leaves the greedy driver holding orphaned IR. See the capacity
+  // comment further down for what it means and why the graph cannot supply it.
+  const bool sharedPresent = kvShareBuffer && pastKey;
 
   // A static present seq dim short-circuits the capacity computation entirely:
   // total_seq_len becomes a constant read off the result type and
@@ -352,7 +355,7 @@ OnnxAttentionToHip::matchAndRewrite(mlir::Operation *op,
   // whose signature still declares the old extent. A graph that pins present to
   // a length its shared past buffer does not have is inconsistent at the
   // source, so report it rather than quietly emitting the wrong capacity.
-  if (kvShareBuffer && numResults >= 2) {
+  if (sharedPresent && numResults >= 2) {
     auto presentTy =
         mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(1).getType());
     auto pastTy = mlir::dyn_cast<mlir::RankedTensorType>(pastKey.getType());
@@ -361,9 +364,9 @@ OnnxAttentionToHip::matchAndRewrite(mlir::Operation *op,
           (pastTy && pastTy.getRank() == 4) ? pastTy.getDimSize(2) : kDyn;
       if (pastExtent != presentTy.getDimSize(2))
         return rewriter.notifyMatchFailure(
-            op, "HIPDNN_EP_KV_SHARE_BUFFER: present pins a seq extent the "
-                "shared past buffer does not have; they are one allocation, so "
-                "the extents must match");
+            op, "kv-share-buffer: present pins a seq extent the shared past "
+                "buffer does not have; they are one allocation, so the extents "
+                "must match");
     }
   }
 
@@ -431,13 +434,14 @@ OnnxAttentionToHip::matchAndRewrite(mlir::Operation *op,
   //
   // The relation between the extents cannot tell those apart -- a right-sized
   // shared buffer and a growing separate one both have past < total -- so the
-  // deployment has to say. HIPDNN_EP_KV_SHARE_BUFFER must agree with
+  // deployment has to say. That is the kv-share-buffer pass option, set from
+  // the `kv_share_buffer` provider option, which must agree with
   // past_present_share_buffer in genai_config.json; they are two views of one
-  // fact and disagreeing gets a shape rejection at the first Run.
-  // With no past operand there is nothing to share, so the flag does not apply
-  // and a zero-length present would be nonsense.
+  // fact and disagreeing gets a shape rejection at the first Run. Keeping both
+  // in provider_options puts them in the same file, where a reader can see
+  // them together.
   mlir::Value presentCapIdx =
-      kvShareBuffer
+      sharedPresent
           ? pastSeqIdx
           : mlir::arith::MaxSIOp::create(rewriter, loc, pastSeqIdx, totalKvIdx)
                 .getResult();
@@ -676,8 +680,9 @@ OnnxAttentionToHip::matchAndRewrite(mlir::Operation *op,
 } // namespace
 
 void populateOnnxAttentionConversionPatterns(RewritePatternSet &patterns,
-                                             MLIRContext *ctx) {
-  patterns.add<OnnxAttentionToHip>(ctx);
+                                             MLIRContext *ctx,
+                                             bool kvShareBuffer) {
+  patterns.add<OnnxAttentionToHip>(ctx, kvShareBuffer);
 }
 
 } // namespace hip

--- a/lib/Conversion/OnnxToHip/OnnxAttentionConversion.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxAttentionConversion.cpp
@@ -74,8 +74,8 @@ namespace {
 /// After:
 ///   %cur       = tensor.dim %q, %c1        // current KV tokens (== query seq)
 ///   %past      = tensor.dim %past_k, %c2   // past buffer EXTENT (see below)
-///   %tot       = tensor.dim %mask, %c3     // valid total KV, else %past + %cur
-///   %cap       = arith.maxsi %past, %tot   // present buffer capacity
+///   %tot       = tensor.dim %mask, %c3     // valid total KV, else %past +
+///   %cur %cap       = arith.maxsi %past, %tot   // present buffer capacity
 ///                                          // (just %past under
 ///                                          //  HIPDNN_EP_KV_SHARE_BUFFER)
 ///   %seqlens_k = tensor.from_elements (%tot - 1)  : tensor<1xi32>
@@ -332,6 +332,41 @@ OnnxAttentionToHip::matchAndRewrite(mlir::Operation *op,
     return transOp->getResult(0);
   };
 
+  // Whether present and past are one allocation. Read here, ahead of any IR
+  // construction, because the check below has to reject before the pattern
+  // starts building: a pattern that creates ops and then returns failure leaves
+  // the greedy driver holding orphaned IR. See the capacity comment further
+  // down for what the flag means and why the graph alone cannot supply it.
+  const bool kvShareBuffer =
+      pastKey && hipdnn_ep::env_enabled("HIPDNN_EP_KV_SHARE_BUFFER");
+
+  // A static present seq dim short-circuits the capacity computation entirely:
+  // total_seq_len becomes a constant read off the result type and
+  // buildPresentInit skips the dim, so presentCapIdx -- and with it the
+  // shared-buffer rule -- is never consulted. Harmless when the graph and the
+  // buffer agree, silently wrong when they do not, which is precisely the case
+  // the flag exists for.
+  //
+  // Rewriting the type is not an option: replaceOp hands the result straight to
+  // the original op's users, and in a real graph present is a function result
+  // whose signature still declares the old extent. A graph that pins present to
+  // a length its shared past buffer does not have is inconsistent at the
+  // source, so report it rather than quietly emitting the wrong capacity.
+  if (kvShareBuffer && numResults >= 2) {
+    auto presentTy =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(1).getType());
+    auto pastTy = mlir::dyn_cast<mlir::RankedTensorType>(pastKey.getType());
+    if (presentTy && presentTy.getRank() == 4 && !presentTy.isDynamicDim(2)) {
+      const int64_t pastExtent =
+          (pastTy && pastTy.getRank() == 4) ? pastTy.getDimSize(2) : kDyn;
+      if (pastExtent != presentTy.getDimSize(2))
+        return rewriter.notifyMatchFailure(
+            op, "HIPDNN_EP_KV_SHARE_BUFFER: present pins a seq extent the "
+                "shared past buffer does not have; they are one allocation, so "
+                "the extents must match");
+    }
+  }
+
   // Flatten rank-4 Q/K/V to the rank-3 BSHD layout the runtime consumes.
   mlir::Value q3 = query, k3 = key, v3 = value;
   if (rank4) {
@@ -374,10 +409,10 @@ OnnxAttentionToHip::matchAndRewrite(mlir::Operation *op,
                       .getResult();
   }
   mlir::Value totalKvIdx =
-      maskKvIdx ? maskKvIdx
-                : mlir::arith::AddIOp::create(rewriter, loc, pastSeqIdx,
-                                              curSeqIdx)
-                      .getResult();
+      maskKvIdx
+          ? maskKvIdx
+          : mlir::arith::AddIOp::create(rewriter, loc, pastSeqIdx, curSeqIdx)
+                .getResult();
 
   // present buffer capacity, which is NOT the same as the valid length above.
   //
@@ -401,8 +436,6 @@ OnnxAttentionToHip::matchAndRewrite(mlir::Operation *op,
   // fact and disagreeing gets a shape rejection at the first Run.
   // With no past operand there is nothing to share, so the flag does not apply
   // and a zero-length present would be nonsense.
-  const bool kvShareBuffer =
-      pastKey && hipdnn_ep::env_enabled("HIPDNN_EP_KV_SHARE_BUFFER");
   mlir::Value presentCapIdx =
       kvShareBuffer
           ? pastSeqIdx

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -132,7 +132,8 @@ static void lowerOnnxReturns(mlir::func::FuncOp funcOp) {
 //===----------------------------------------------------------------------===//
 
 static mlir::LogicalResult convertComputeOps(mlir::func::FuncOp funcOp,
-                                             mlir::MLIRContext *ctx) {
+                                             mlir::MLIRContext *ctx,
+                                             bool kvShareBuffer) {
   mlir::RewritePatternSet patterns(ctx);
   populateMatMulConversionPatterns(patterns, ctx);
   populateTransposeConversionPatterns(patterns, ctx);
@@ -160,7 +161,7 @@ static mlir::LogicalResult convertComputeOps(mlir::func::FuncOp funcOp,
   populateGqaConversionPatterns(patterns, ctx);
   populateMultiHeadAttentionConversionPatterns(patterns, ctx);
   populateAttentionConversionPatterns(patterns, ctx);
-  populateOnnxAttentionConversionPatterns(patterns, ctx);
+  populateOnnxAttentionConversionPatterns(patterns, ctx, kvShareBuffer);
   populateMatMulNBitsConversionPatterns(patterns, ctx);
   populateQMoEConversionPatterns(patterns, ctx);
   populateGatherBlockQuantizedConversionPatterns(patterns, ctx);
@@ -465,7 +466,7 @@ void ConvertOnnxToHipPass::runOnOperation() {
     if (mlir::failed(lowerOnnxConstants(funcOp, constantOrder)))
       return signalPassFailure();
     lowerOnnxReturns(funcOp);
-    if (mlir::failed(convertComputeOps(funcOp, ctx)))
+    if (mlir::failed(convertComputeOps(funcOp, ctx, kvShareBuffer)))
       return signalPassFailure();
     // Phase 2: lower any `onnx.Constant` ops SYNTHESIZED during
     // convertComputeOps. Some ONNX->HIP patterns introduce a fresh literal as

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -322,8 +322,13 @@ void populateMultiHeadAttentionConversionPatterns(RewritePatternSet &patterns,
                                                   MLIRContext *ctx);
 void populateAttentionConversionPatterns(RewritePatternSet &patterns,
                                          MLIRContext *ctx);
+/// \p kvShareBuffer: present_key/value name the same allocation as
+/// past_key/value, so the present capacity is the past extent rather than
+/// past+current. Sourced from the convert-onnx-to-hip pass option of the same
+/// name; see OnnxAttentionConversion.cpp for why the graph cannot infer it.
 void populateOnnxAttentionConversionPatterns(RewritePatternSet &patterns,
-                                             MLIRContext *ctx);
+                                             MLIRContext *ctx,
+                                             bool kvShareBuffer);
 void populateGatherConversionPatterns(RewritePatternSet &patterns,
                                       MLIRContext *ctx);
 void populateCompressConversionPatterns(RewritePatternSet &patterns,

--- a/lib/Dialect/Transforms/Pipelines.cpp
+++ b/lib/Dialect/Transforms/Pipelines.cpp
@@ -400,7 +400,11 @@ void mlir::hip::buildOnnxToHipPipeline(OpPassManager &pm,
   addPluginPassesForSlot(pm,
                          ::hip::compiler::PipelineSlot::AfterOnnxLoopOutline);
 
-  pm.addPass(createConvertOnnxToHipPass());
+  {
+    ConvertOnnxToHipPassOptions convertOptions;
+    convertOptions.kvShareBuffer = options.kvShareBuffer;
+    pm.addPass(createConvertOnnxToHipPass(std::move(convertOptions)));
+  }
 
   // Plugin slot: AfterConvertOnnxToHip. The most common slot for
   // vendor lowerings of `onnx.Custom` ops or vendor-specific hip.*
@@ -433,7 +437,11 @@ void mlir::hip::buildOnnxToHipPipeline(OpPassManager &pm,
     pm.addPass(createCompileHipDNNGraphsPass(handle, std::move(output_graphs)));
   }
 
-  pm.addPass(createConvertOnnxToHipPass());
+  {
+    ConvertOnnxToHipPassOptions convertOptions;
+    convertOptions.kvShareBuffer = options.kvShareBuffer;
+    pm.addPass(createConvertOnnxToHipPass(std::move(convertOptions)));
+  }
 
   addPluginPassesForSlot(pm,
                          ::hip::compiler::PipelineSlot::AfterConvertOnnxToHip);

--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -358,16 +358,38 @@ static inline bool kv_is_16b_aligned(const void* p) {
   return (reinterpret_cast<uintptr_t>(p) & 15u) == 0;
 }
 
+// Destination sequence slot for absolute KV position `pos`, given that the
+// append covers positions [.., total) into a buffer of `capacity` cells.
+// Returns -1 for a position this append must not write.
+//
+// Linear (ring == 0): the slot IS the position, which is what a cache allocated
+// to max_length wants.
+//
+// Ring (ring != 0): the buffer holds only the most recent `capacity` positions,
+// so position pos lives at pos % capacity and anything older than
+// total - capacity is dropped. Dropping is load-bearing rather than an
+// optimisation: a sliding-window prefill hands this kernel far more positions
+// than the ring has cells, and writing them all would leave several source rows
+// racing for one slot with the last wave to retire deciding the winner. Writing
+// exactly the newest `capacity` positions touches each slot once.
+__device__ __forceinline__ int kv_ring_slot(int pos, int total, int capacity,
+                                            int ring) {
+  if (!ring) return pos;
+  if (pos < total - capacity) return -1;
+  return pos % capacity;
+}
+
 template <typename T>
 __global__ void kv_cache_append_kernel(
     const T* __restrict__ src,
     T* __restrict__ cache,
     int sq, int G, int d, int present_seq, int past_len,
-    const int* __restrict__ seqlens_k) {
+    const int* __restrict__ seqlens_k, int ring) {
   const int batch_idx = __builtin_amdgcn_readfirstlane(blockIdx.y);
   int eff_past_len = seqlens_k ? (seqlens_k[batch_idx] + 1 - sq) : past_len;
   // Skip malformed batches rather than write past this slice.
-  if (eff_past_len < 0 || eff_past_len + sq > present_seq) return;
+  if (eff_past_len < 0) return;
+  if (!ring && eff_past_len + sq > present_seq) return;
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   int total_per_batch = sq * G * d;
   if (idx >= total_per_batch) return;
@@ -377,8 +399,11 @@ __global__ void kv_cache_append_kernel(
   int g = remaining % G;
   int s = remaining / G;
 
+  int dst_s = kv_ring_slot(eff_past_len + s, eff_past_len + sq, present_seq, ring);
+  if (dst_s < 0) return;
+
   int src_idx = ((batch_idx * sq + s) * G + g) * d + di;
-  int dst_idx = ((batch_idx * G + g) * present_seq + (eff_past_len + s)) * d + di;
+  int dst_idx = ((batch_idx * G + g) * present_seq + dst_s) * d + di;
   cache[dst_idx] = src[src_idx];
 }
 
@@ -390,10 +415,11 @@ __global__ void kv_cache_append_vec_kernel(
     const T* __restrict__ src,
     T* __restrict__ cache,
     int sq, int G, int d, int present_seq, int past_len,
-    const int* __restrict__ seqlens_k) {
+    const int* __restrict__ seqlens_k, int ring) {
   const int batch_idx = __builtin_amdgcn_readfirstlane(blockIdx.y);
   int eff_past_len = seqlens_k ? (seqlens_k[batch_idx] + 1 - sq) : past_len;
-  if (eff_past_len < 0 || eff_past_len + sq > present_seq) return;
+  if (eff_past_len < 0) return;
+  if (!ring && eff_past_len + sq > present_seq) return;
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   const int dv = d / VEC;
   int total_per_batch = sq * G * dv;
@@ -404,9 +430,11 @@ __global__ void kv_cache_append_vec_kernel(
   int g = remaining % G;
   int s = remaining / G;
 
+  int dst_s = kv_ring_slot(eff_past_len + s, eff_past_len + sq, present_seq, ring);
+  if (dst_s < 0) return;
+
   int src_idx = ((batch_idx * sq + s) * G + g) * d + dvi * VEC;
-  int dst_idx =
-      ((batch_idx * G + g) * present_seq + (eff_past_len + s)) * d + dvi * VEC;
+  int dst_idx = ((batch_idx * G + g) * present_seq + dst_s) * d + dvi * VEC;
   *reinterpret_cast<KvVec16*>(cache + dst_idx) =
       *reinterpret_cast<const KvVec16*>(src + src_idx);
 }
@@ -517,10 +545,11 @@ __global__ void kv_cache_append_quant_i8_kernel(
     int8_t* __restrict__ cache,           // BNSD [B, G, present_seq, d]
     const float* __restrict__ scale,      // [G, d]
     int sq, int G, int d, int present_seq, int past_len,
-    const int* __restrict__ seqlens_k) {
+    const int* __restrict__ seqlens_k, int ring) {
   const int batch_idx = __builtin_amdgcn_readfirstlane(blockIdx.y);
   int eff_past_len = seqlens_k ? (seqlens_k[batch_idx] + 1 - sq) : past_len;
-  if (eff_past_len < 0 || eff_past_len + sq > present_seq) return;
+  if (eff_past_len < 0) return;
+  if (!ring && eff_past_len + sq > present_seq) return;
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   int total_per_batch = sq * G * d;
   if (idx >= total_per_batch) return;
@@ -528,8 +557,10 @@ __global__ void kv_cache_append_quant_i8_kernel(
   int remaining = idx / d;
   int g = remaining % G;
   int s = remaining / G;
+  int dst_s = kv_ring_slot(eff_past_len + s, eff_past_len + sq, present_seq, ring);
+  if (dst_s < 0) return;
   int src_idx = ((batch_idx * sq + s) * G + g) * d + di;
-  int dst_idx = ((batch_idx * G + g) * present_seq + (eff_past_len + s)) * d + di;
+  int dst_idx = ((batch_idx * G + g) * present_seq + dst_s) * d + di;
   float inv = 1.0f / scale[g * d + di];
   float q = rintf((float)src[src_idx] * inv);
   q = fminf(fmaxf(q, -128.0f), 127.0f);
@@ -835,7 +866,7 @@ template <typename T>
 static void launch_kv_cache_append(
     hipStream_t stream, const void* src, void* cache,
     int batch_size, int sq, int G, int d, int present_seq, int past_len,
-    const void* seqlens_k) {
+    const void* seqlens_k, int ring) {
   constexpr int VEC = 16 / sizeof(T);
   if ((d % VEC) == 0 && kv_is_16b_aligned(src) && kv_is_16b_aligned(cache)) {
     int total = sq * G * (d / VEC);
@@ -843,7 +874,8 @@ static void launch_kv_cache_append(
     kv_cache_append_vec_kernel<T, VEC><<<dim3(blocks, batch_size), GQA_THREADS,
                                          0, stream>>>(
         static_cast<const T*>(src), static_cast<T*>(cache),
-        sq, G, d, present_seq, past_len, static_cast<const int*>(seqlens_k));
+        sq, G, d, present_seq, past_len, static_cast<const int*>(seqlens_k),
+        ring);
     return;
   }
   int total = sq * G * d;
@@ -851,7 +883,7 @@ static void launch_kv_cache_append(
   kv_cache_append_kernel<T><<<dim3(blocks, batch_size), GQA_THREADS, 0,
                               stream>>>(
       static_cast<const T*>(src), static_cast<T*>(cache),
-      sq, G, d, present_seq, past_len, static_cast<const int*>(seqlens_k));
+      sq, G, d, present_seq, past_len, static_cast<const int*>(seqlens_k), ring);
 }
 
 template <typename T>
@@ -936,7 +968,7 @@ extern "C" int hip_gqa_kv_cache_append(
     void* stream_ptr, const void* src, void* cache,
     int batch_size, int sq, int G, int d, int present_seq, int past_len,
     const void* seqlens_k, int element_size_bytes,
-    int kv_dtype, const void* scale) {
+    int kv_dtype, const void* scale, int ring) {
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
   if (kv_dtype == HIP_KV_DTYPE_INT8) {
     if (scale == nullptr) {
@@ -950,7 +982,7 @@ extern "C" int hip_gqa_kv_cache_append(
                                       stream>>>(
         static_cast<const _Float16*>(src), static_cast<int8_t*>(cache),
         static_cast<const float*>(scale), sq, G, d, present_seq, past_len,
-        static_cast<const int*>(seqlens_k));
+        static_cast<const int*>(seqlens_k), ring);
     GQA_RETURN_LAUNCH_STATUS();
   }
   if (kv_dtype != HIP_KV_DTYPE_FP16) {
@@ -960,7 +992,7 @@ extern "C" int hip_gqa_kv_cache_append(
   }
   GQA_DISPATCH_BY_ELEM_SIZE(element_size_bytes, launch_kv_cache_append, stream,
                             src, cache, batch_size, sq, G, d, present_seq,
-                            past_len, seqlens_k);
+                            past_len, seqlens_k, ring);
   GQA_RETURN_LAUNCH_STATUS();
 }
 
@@ -1103,7 +1135,7 @@ __global__ void add_attention_bias_kernel(
     float* __restrict__ scores, const TBias* __restrict__ bias,
     int total_heads, int num_heads, int bias_batch, int bias_heads, int sq,
     int score_cols, int score_batch_stride, int bias_sq, int bias_row_offset,
-    int bias_total_seq, int bias_col_offset) {
+    int bias_total_seq, int bias_col_offset, int ring_base, int ring_cap) {
   int head = blockIdx.y;
   int tid = blockIdx.x * blockDim.x + threadIdx.x;
   int n = sq * score_cols;
@@ -1116,10 +1148,20 @@ __global__ void add_attention_bias_kernel(
   int bias_b = (bias_batch == 1) ? 0 : b;
   int bias_h = (bias_heads == 1) ? 0 : h;
   size_t bias_plane = static_cast<size_t>(bias_sq) * bias_total_seq;
+  // A ring cache presents its keys rotated: slot `col` holds the position
+  // congruent to col mod capacity that falls in [ring_base, ring_base+cap).
+  // The bias is indexed by absolute position, so undo the rotation here rather
+  // than assuming the window part of the bias makes it a no-op.
+  int bias_col = bias_col_offset + col;
+  if (ring_cap > 0) {
+    int off = (col - ring_base) % ring_cap;
+    if (off < 0) off += ring_cap;
+    bias_col = ring_base + off;
+  }
   size_t bias_idx = static_cast<size_t>(bias_b) * bias_heads * bias_plane +
                     static_cast<size_t>(bias_h) * bias_plane +
                     static_cast<size_t>(bias_row_offset + row) * bias_total_seq +
-                    (bias_col_offset + col);
+                    bias_col;
   scores[static_cast<size_t>(head) * score_batch_stride + tid] +=
       static_cast<float>(bias[bias_idx]);
 }
@@ -1128,7 +1170,8 @@ extern "C" int hip_gqa_add_attention_bias_f32(
     void* stream_ptr, void* scores, const void* bias, int total_heads,
     int num_heads, int bias_batch, int bias_heads, int sq, int score_cols,
     int score_batch_stride, int bias_element_size_bytes, int bias_sq,
-    int bias_row_offset, int bias_total_seq, int bias_col_offset) {
+    int bias_row_offset, int bias_total_seq, int bias_col_offset, int ring_base,
+    int ring_cap) {
   if (!scores || !bias)
     return -1;
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
@@ -1145,14 +1188,14 @@ extern "C" int hip_gqa_add_attention_bias_f32(
             static_cast<float*>(scores), static_cast<const __half*>(bias),
             total_heads, num_heads, bias_batch, bias_heads, sq, score_cols,
             score_batch_stride, bias_sq, bias_row_offset, bias_total_seq,
-            bias_col_offset);
+            bias_col_offset, ring_base, ring_cap);
   } else if (bias_element_size_bytes == 4) {
     add_attention_bias_kernel<float>
         <<<dim3(blocksX, total_heads), GQA_THREADS, 0, stream>>>(
             static_cast<float*>(scores), static_cast<const float*>(bias),
             total_heads, num_heads, bias_batch, bias_heads, sq, score_cols,
             score_batch_stride, bias_sq, bias_row_offset, bias_total_seq,
-            bias_col_offset);
+            bias_col_offset, ring_base, ring_cap);
   } else {
     fprintf(stderr,
             "hip_gqa_add_attention_bias_f32: unsupported bias elem size %d\n",

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -566,12 +566,19 @@ typedef enum {
  *                        scale is ignored (pass NULL).
  *   HIP_KV_DTYPE_INT8 -> symmetric per-channel INT8 quant (fp16 src, int8
  *                        cache); scale is the static fp32 per-channel table
- *                        [G,d] (no zero point), q = clamp(round(x/scale),-128,127). */
+ *                        [G,d] (no zero point), q = clamp(round(x/scale),-128,127).
+ * ring: 0 = linear, position p goes to slot p and the append refuses to run at
+ *       all if past_len+sq exceeds present_seq.
+ *       1 = ring, for a sliding-window layer whose cache is right-sized to the
+ *       window instead of max_length. Position p goes to slot p % present_seq,
+ *       and only the newest present_seq positions are written -- a prefill hands
+ *       this far more positions than the ring has cells, and writing them all
+ *       would race several source rows onto one slot. */
 HIP_KERNEL_API int hip_gqa_kv_cache_append(
     void* stream, const void* src, void* cache,
     int batch_size, int sq, int G, int d, int present_seq, int past_len,
     const void* seqlens_k, int element_size_bytes,
-    int kv_dtype, const void* scale);
+    int kv_dtype, const void* scale, int ring);
 
 /* KV cache concat: concatenate past data and new tokens into a fresh present
  * buffer.  Fills present [B,G,present_seq,d] by copying past data from
@@ -670,12 +677,17 @@ HIP_KERNEL_API int hip_gqa_causal_mask_f32(
  *     of key columns present, just the sliding window when the caller narrowed
  *     the decode key range.
  * Pass bias_sq = sq (or 0) and bias_row_offset = 0, and bias_total_seq =
- * score_cols (or 0) and bias_col_offset = 0, for the untiled/unnarrowed case. */
+ * score_cols (or 0) and bias_col_offset = 0, for the untiled/unnarrowed case.
+ * ring_base / ring_cap describe a right-sized sliding-window cache, whose keys
+ * arrive rotated: slot col holds the absolute position congruent to col modulo
+ * ring_cap that lies in [ring_base, ring_base+ring_cap). Pass ring_cap = 0 for
+ * a linear cache, where the column index is bias_col_offset + col. */
 HIP_KERNEL_API int hip_gqa_add_attention_bias_f32(
     void* stream, void* scores, const void* bias,
     int total_heads, int num_heads, int bias_batch, int bias_heads,
     int sq, int score_cols, int score_batch_stride, int bias_element_size_bytes,
-    int bias_sq, int bias_row_offset, int bias_total_seq, int bias_col_offset);
+    int bias_sq, int bias_row_offset, int bias_total_seq, int bias_col_offset,
+    int ring_base, int ring_cap);
 
 /* Column-wise softmax in-place. One threadblock per (head, query).
  * Smooth softmax is activated when head_sink is non-null OR use_smooth_softmax

--- a/lib/Runtime/Kernels/test/example/gqa/ring/README.md
+++ b/lib/Runtime/Kernels/test/example/gqa/ring/README.md
@@ -1,0 +1,50 @@
+# GQA ring-append test
+
+Pins the wrap arithmetic of `hip_gqa_kv_cache_append(..., ring=1)`, the append
+behind a sliding-window layer whose KV cache is right-sized to the window
+instead of `max_length`. The buffer holds only the newest `present_seq`
+positions, so position `p` lives at slot `p % present_seq`.
+
+This is the cheapest place to pin that arithmetic: no ORT, no session, no
+model. The numeric suite cannot reach it, because the ring requires `past` and
+`present` to be the same allocation (`lib/Runtime/real/gqa.cpp`, the
+`past_key != present_key` rejection) and that harness allocates every output
+itself.
+
+## Build and run
+
+From this directory:
+
+```bash
+hipcc -std=c++17 -O2 --offload-arch=gfx1151 \
+  test_gqa_ring.cpp ../../../../hip/gqa_kernel.hip \
+  -I../../../../include -o test_gqa_ring.exe
+./test_gqa_ring.exe
+```
+
+Substitute your own `--offload-arch`. Exit status is 0 when every check
+passes, 1 otherwise, and each failure prints the head, the slot, the position
+found and the position expected.
+
+## What it checks
+
+Each absolute position carries its own index as its payload, so a slot holding
+the wrong position is reported directly rather than inferred from a numeric
+mismatch. Comparison is bit-exact -- the append is pure relocation, so any
+difference means the wrong bytes moved.
+
+| Property | Why it can break |
+|---|---|
+| A decode lands at `(total-1) % capacity` | Off-by-one is invisible until the ring wraps, because before the first wrap slot and position coincide. |
+| A prefill writes each slot exactly once | A windowed prefill is handed far more positions than the ring has cells. Writing them all races several source rows onto one slot, and the last wave to retire wins. |
+| Positions older than `total - capacity` are dropped | That drop is what makes the mapping one-to-one, and hence what makes the prefill race-free. |
+| `capacity` need not be a power of two | An implementation reaching for a bitmask instead of `%` passes every power-of-two case and fails these. |
+
+The cases run at and around each boundary: one before the first wrap, exactly
+at it, well past it, a prefill onto an already-wrapped ring, and the same at a
+non-power-of-two capacity.
+
+Removing the drop rule from `kv_ring_slot` -- the one line that makes the
+prefill race-free -- fails the 2.5x-capacity prefill with `slot 0 holds
+position 16, expected 32`, which is the negative control this test was checked
+against.

--- a/lib/Runtime/Kernels/test/example/gqa/ring/test_gqa_ring.cpp
+++ b/lib/Runtime/Kernels/test/example/gqa/ring/test_gqa_ring.cpp
@@ -1,0 +1,220 @@
+// ============================================================
+// custom_kernels KV-cache *ring append* test.
+//
+// Pins the wrap arithmetic of hip_gqa_kv_cache_append(..., ring=1), which backs
+// a sliding-window layer whose cache is right-sized to the window instead of
+// max_length. The buffer then holds only the newest present_seq positions and
+// position p lives at slot p % present_seq.
+//
+// Two properties, and they fail in different ways:
+//
+//   * A prefill writes each slot EXACTLY ONCE, by writing only the newest
+//     `capacity` positions. This is a correctness condition, not a tidiness
+//     one: a windowed prefill hands the kernel far more positions than the
+//     ring has cells, and writing them all would leave several source rows
+//     racing for one slot with the last wave to retire deciding the winner.
+//     The check is that each slot ends up holding the position the drop rule
+//     assigns it -- under a race the surviving payload names some older
+//     position instead.
+//
+//   * A decode lands at (total-1) % capacity. Off-by-one here is invisible
+//     until the ring wraps, because before the first wrap slot and position
+//     coincide.
+//
+// Each position carries its own index as its payload, so a slot holding the
+// wrong position is caught directly rather than inferred from a numeric
+// mismatch. The check is bit-exact: the append is pure relocation, so any
+// difference at all means the wrong bytes moved.
+//
+// Build (from this directory):
+//   hipcc -std=c++17 -O2 --offload-arch=gfx1151 \
+//     test_gqa_ring.cpp ../../../../hip/gqa_kernel.hip \
+//     -I../../../../include -o test_gqa_ring.exe
+//   ./test_gqa_ring.exe
+// ============================================================
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+extern "C" int hip_gqa_kv_cache_append(
+    void* stream, const void* src, void* cache,
+    int batch_size, int sq, int G, int d, int present_seq, int past_len,
+    const void* seqlens_k, int element_size_bytes,
+    int kv_dtype, const void* scale, int ring);
+
+#define HIP_CHECK(expr)                                                        \
+  do {                                                                         \
+    hipError_t _e = (expr);                                                    \
+    if (_e != hipSuccess) {                                                    \
+      fprintf(stderr, "HIP error %s at %s:%d\n", hipGetErrorString(_e),        \
+              __FILE__, __LINE__);                                             \
+      std::exit(1);                                                            \
+    }                                                                          \
+  } while (0)
+
+namespace {
+
+constexpr int kFp16 = 0; // hip_kv_dtype_t HIP_KV_DTYPE_FP16
+
+int g_failures = 0;
+
+// Sentinel for a slot the append never touched. Distinct from every payload,
+// so "unwritten" and "wrong position" are different diagnoses.
+constexpr float kUntouched = -1.0f;
+
+// Payload for absolute position p. Every element of the row carries it, so a
+// partially written row is caught too, not just a misplaced one.
+float payload(int pos) { return static_cast<float>(pos + 1); }
+
+// Recover the position a row claims to hold, or -2 if the row is not uniform
+// (a torn write: two positions landed on one slot).
+int claimed_position(const std::vector<__half>& cache, size_t row_base, int d) {
+  const float first = __half2float(cache[row_base]);
+  for (int i = 1; i < d; ++i)
+    if (__half2float(cache[row_base + i]) != first)
+      return -2;
+  if (first == kUntouched)
+    return -1;
+  return static_cast<int>(first) - 1;
+}
+
+void report(const char* name, bool ok, const char* detail) {
+  if (ok) {
+    printf("  [ok]   %s\n", name);
+    return;
+  }
+  printf("  [FAIL] %s: %s\n", name, detail);
+  ++g_failures;
+}
+
+// Run one ring append and check every slot against the positions the ring is
+// supposed to hold afterwards.
+//
+// past_len   absolute positions already in the cache
+// sq         new tokens in this call
+// capacity   ring cells (== the window)
+//
+// After the call the ring must hold the newest `capacity` positions of
+// [0, past_len+sq), each at position % capacity. Positions older than that are
+// dropped, and whatever the earlier state left in their slots stays -- the
+// append promises nothing about a slot it is not the newest writer of, so the
+// expectation below is built from that same rule rather than from "everything
+// is fresh".
+void check_ring_append(const char* name, int past_len, int sq, int capacity) {
+  const int B = 1, G = 2, d = 8;
+  const int total = past_len + sq;
+
+  std::vector<__half> cache(static_cast<size_t>(B) * G * capacity * d,
+                            __float2half(kUntouched));
+  std::vector<__half> src(static_cast<size_t>(B) * sq * G * d);
+  for (int s = 0; s < sq; ++s)
+    for (int g = 0; g < G; ++g)
+      for (int i = 0; i < d; ++i)
+        src[(static_cast<size_t>(s) * G + g) * d + i] =
+            __float2half(payload(past_len + s));
+
+  void *d_cache = nullptr, *d_src = nullptr;
+  HIP_CHECK(hipMalloc(&d_cache, cache.size() * sizeof(__half)));
+  HIP_CHECK(hipMalloc(&d_src, src.size() * sizeof(__half)));
+  HIP_CHECK(hipMemcpy(d_cache, cache.data(), cache.size() * sizeof(__half),
+                      hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(d_src, src.data(), src.size() * sizeof(__half),
+                      hipMemcpyHostToDevice));
+
+  const int rc = hip_gqa_kv_cache_append(
+      /*stream=*/nullptr, d_src, d_cache, B, sq, G, d, /*present_seq=*/capacity,
+      past_len, /*seqlens_k=*/nullptr, /*element_size_bytes=*/2, kFp16,
+      /*scale=*/nullptr, /*ring=*/1);
+  HIP_CHECK(hipDeviceSynchronize());
+  HIP_CHECK(hipMemcpy(cache.data(), d_cache, cache.size() * sizeof(__half),
+                      hipMemcpyDeviceToHost));
+  HIP_CHECK(hipFree(d_cache));
+  HIP_CHECK(hipFree(d_src));
+
+  char detail[256];
+  if (rc != 0) {
+    snprintf(detail, sizeof(detail), "append returned %d", rc);
+    report(name, false, detail);
+    return;
+  }
+
+  // The positions this append was responsible for writing, and where each
+  // belongs. Anything older than total-capacity it must have skipped, so over
+  // the surviving range p -> p % capacity is one-to-one and every entry below
+  // is set by exactly one position.
+  const int oldest_written = (total > capacity) ? total - capacity : 0;
+  std::vector<int> expected(capacity, -1); // -1 = untouched by this append
+  for (int p = past_len; p < total; ++p) {
+    if (p < oldest_written)
+      continue; // dropped on purpose: a newer position owns this slot
+    expected[p % capacity] = p;
+  }
+
+  // Comparing against that expectation is also what detects the race the drop
+  // rule exists to prevent. A kernel that wrote every position it was handed
+  // would put several of them on one slot, and the surviving payload names
+  // whichever wave retired last -- a position other than the newest, which is
+  // a mismatch here. Dropping the rule from kv_ring_slot is caught on the
+  // 2.5x-capacity prefill below as "slot 0 holds position 16, expected 32".
+  for (int g = 0; g < G; ++g) {
+    for (int slot = 0; slot < capacity; ++slot) {
+      const size_t row = (static_cast<size_t>(g) * capacity + slot) * d;
+      const int got = claimed_position(cache, row, d);
+      if (got == -2) {
+        snprintf(detail, sizeof(detail),
+                 "head %d slot %d holds a torn row: two positions landed on "
+                 "one slot",
+                 g, slot);
+        report(name, false, detail);
+        return;
+      }
+      if (got != expected[slot]) {
+        snprintf(detail, sizeof(detail),
+                 "head %d slot %d holds position %d, expected %d "
+                 "(past_len=%d sq=%d capacity=%d)",
+                 g, slot, got, expected[slot], past_len, sq, capacity);
+        report(name, false, detail);
+        return;
+      }
+    }
+  }
+  report(name, true, "");
+}
+
+} // namespace
+
+int main() {
+  printf("ring append: slot = position %% capacity\n");
+
+  // Decode, the common case: one token at (total-1) % capacity.
+  // Before the first wrap slot and position coincide, so the interesting
+  // instances are the ones at and after it.
+  check_ring_append("decode below capacity  (past=5   sq=1 cap=16)", 5, 1, 16);
+  check_ring_append("decode at the wrap     (past=16  sq=1 cap=16)", 16, 1, 16);
+  check_ring_append("decode past the wrap   (past=37  sq=1 cap=16)", 37, 1, 16);
+  check_ring_append("decode one before wrap (past=15  sq=1 cap=16)", 15, 1, 16);
+
+  // Prefill, where the drop rule earns its keep: far more positions than cells.
+  // Each writes every slot exactly once, which is the race property.
+  check_ring_append("prefill 2.5x capacity  (past=0   sq=40 cap=16)", 0, 40, 16);
+  check_ring_append("prefill exact capacity (past=0   sq=16 cap=16)", 0, 16, 16);
+  check_ring_append("prefill under capacity (past=0   sq=9  cap=16)", 0, 9, 16);
+  check_ring_append("prefill onto a wrapped ring (past=37 sq=20 cap=16)", 37, 20,
+                    16);
+
+  // A capacity that is not a power of two: `%` is exact, but an implementation
+  // that reached for a mask instead would only pass above.
+  check_ring_append("decode, odd capacity   (past=100 sq=1 cap=13)", 100, 1, 13);
+  check_ring_append("prefill, odd capacity  (past=0  sq=31 cap=13)", 0, 31, 13);
+
+  if (g_failures == 0) {
+    printf("all ring append checks passed\n");
+    return 0;
+  }
+  printf("%d ring append check(s) FAILED\n", g_failures);
+  return 1;
+}

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -240,13 +240,18 @@ static inline int kv_dtype_abi(KvCacheFormat f) {
 // and appends, so nothing here runs. It stays because that configuration is a
 // property of the model directory, not of this repo, and a caller that ships
 // without it still gets a separate buffer and still wants a narrowed copy.
+//
+// ring says the present buffer is a right-sized sliding-window cache holding
+// only the newest present_seq positions, so the append wraps and drops anything
+// older. It is meaningless on the concat branch -- a separate present is always
+// allocated to the full length -- and so is required to be 0 there.
 static int update_kv_cache(hipStream_t stream, const void *past_key,
                            const void *past_value, const void *new_key,
                            const void *new_value, void *present_key,
                            void *present_value, int B, int past_len, int sq,
                            int G, int d, int past_buf_seq, int present_seq,
                            const void *seqlens_k_ptr, int elem_sz, int copy_lo,
-                           bool no_causal = false, int skv = -1,
+                           int ring, bool no_causal = false, int skv = -1,
                            KvCacheFormat kv_format = KvCacheFormat::Fp16,
                            const void *k_scale = nullptr,
                            const void *v_scale = nullptr) {
@@ -280,12 +285,14 @@ static int update_kv_cache(hipStream_t stream, const void *past_key,
     if (hip_gqa_kv_cache_append(stream, new_key, present_key, B, sq, G, d,
                                 present_seq, /*past_len=*/0,
                                 /*seqlens_k_ptr=*/nullptr, elem_sz,
-                                HIP_KV_DTYPE_FP16, /*scale=*/nullptr) != 0)
+                                HIP_KV_DTYPE_FP16, /*scale=*/nullptr,
+                                /*ring=*/0) != 0)
       return -1;
     if (hip_gqa_kv_cache_append(stream, new_value, present_value, B, sq, G, d,
                                 present_seq, /*past_len=*/0,
                                 /*seqlens_k_ptr=*/nullptr, elem_sz,
-                                HIP_KV_DTYPE_FP16, /*scale=*/nullptr) != 0)
+                                HIP_KV_DTYPE_FP16, /*scale=*/nullptr,
+                                /*ring=*/0) != 0)
       return -1;
     return 0;
   }
@@ -298,6 +305,13 @@ static int update_kv_cache(hipStream_t stream, const void *past_key,
   const void *v_sc = quantized ? v_scale : nullptr;
   if (past_key && past_len > 0 && past_key != present_key) {
     // Separate-buffer concat: needs host-side past_len for stride computation.
+    if (ring) {
+      fprintf(stderr,
+              "update_kv_cache: ring append requested with separate past and "
+              "present buffers (past_buf_seq=%d present_seq=%d)\n",
+              past_buf_seq, present_seq);
+      return -1;
+    }
     if (hip_gqa_kv_cache_concat(stream, past_key, new_key, present_key, B,
                                 past_len, sq, G, d, past_buf_seq, present_seq,
                                 elem_sz, kv_dtype, k_sc, copy_lo) != 0)
@@ -310,11 +324,11 @@ static int update_kv_cache(hipStream_t stream, const void *past_key,
     // In-place append: kernel can read past_len from device via seqlens_k_ptr.
     if (hip_gqa_kv_cache_append(stream, new_key, present_key, B, sq, G, d,
                                 present_seq, past_len, seqlens_k_ptr, elem_sz,
-                                kv_dtype, k_sc) != 0)
+                                kv_dtype, k_sc, ring) != 0)
       return -1;
     if (hip_gqa_kv_cache_append(stream, new_value, present_value, B, sq, G, d,
                                 present_seq, past_len, seqlens_k_ptr, elem_sz,
-                                kv_dtype, v_sc) != 0)
+                                kv_dtype, v_sc, ring) != 0)
       return -1;
   }
   return 0;
@@ -485,7 +499,8 @@ static int gqa_forward_fused(
             static_cast<int>(sq), static_cast<int>(G), static_cast<int>(d),
             static_cast<int>(past_buf_seq), static_cast<int>(present_seq),
             seqlens_k_ptr, static_cast<int>(elem_sz), /*copy_lo=*/0,
-            /*no_causal=*/false, /*skv=*/-1, kv_format, k_scale, v_scale) != 0)
+            /*ring=*/0, /*no_causal=*/false, /*skv=*/-1, kv_format, k_scale,
+            v_scale) != 0)
       return -1;
 
     {
@@ -644,7 +659,8 @@ static int gqa_forward_fused(
             static_cast<int>(sq), static_cast<int>(G), static_cast<int>(d),
             static_cast<int>(past_buf_seq), static_cast<int>(present_seq),
             seqlens_k_ptr, static_cast<int>(elem_sz), /*copy_lo=*/0,
-            /*no_causal=*/false, /*skv=*/-1, kv_format, k_scale, v_scale) != 0)
+            /*ring=*/0, /*no_causal=*/false, /*skv=*/-1, kv_format, k_scale,
+            v_scale) != 0)
       return -1;
   }
 
@@ -1297,7 +1313,8 @@ static int gqa_forward_hipblaslt(
             present_value, static_cast<int>(B), static_cast<int>(past_len),
             static_cast<int>(sq), static_cast<int>(G), static_cast<int>(d),
             static_cast<int>(past_buf_seq), static_cast<int>(present_seq),
-            seqlens_k_ptr, static_cast<int>(elem_sz), /*copy_lo=*/0) != 0)
+            seqlens_k_ptr, static_cast<int>(elem_sz), /*copy_lo=*/0,
+            /*ring=*/0) != 0)
       return -1;
 
     // hip_gqa_flash_decode owns every geometry it templates; this fallback
@@ -1419,8 +1436,15 @@ static int gqa_forward_hipblaslt(
     } else {
       total_seq = static_cast<int64_t>(seqlens_k_val) + 1;
       past_len = total_seq - sq;
-      if (total_seq < 1 || past_len < 0 || total_seq > present_seq ||
-          past_len > past_buf_seq) {
+      // A cache right-sized to a sliding window is legitimately shorter than
+      // the context, so present_seq stops being an upper bound on total_seq for
+      // those layers. It still bounds a layer without a window, where a short
+      // buffer means the graph and the runtime disagree about the cache. The
+      // ring block further down re-checks the capacity against the window
+      // before letting anything wrap.
+      const bool short_ok = (local_window_size > 0 && present_seq >= local_window_size);
+      if (total_seq < 1 || past_len < 0 ||
+          ((total_seq > present_seq || past_len > past_buf_seq) && !short_ok)) {
         fprintf(stderr,
                 "gqa_forward_hipblaslt: invalid seqlens_k[0]+1=%lld "
                 "(sq=%lld, past_len=%lld, present_seq=%lld, "
@@ -1533,13 +1557,65 @@ static int gqa_forward_hipblaslt(
   // no_causal except the recovery above (GqaConversion sets no_causal=false
   // explicitly, and the Whisper bidirectional builders set no window).
 
+  //===--------------------------------------------------------------------===//
+  // Right-sized sliding-window cache (ring)
+  //
+  // OGA can allocate a sliding-window layer's cache to the window rather than
+  // max_length, which on Gemma-4 is 25 of 30 layers and 3.0 GB. The buffer then
+  // holds only the newest present_seq positions and the append wraps, so
+  // present_seq < total_seq stops being a malformed call and becomes the steady
+  // state once the context passes the window.
+  //
+  // Capacity is required to equal the window exactly, and that is a correctness
+  // condition rather than a convenience. A ring of exactly `window` cells holds
+  // precisely the positions the current query may attend to, so the causal and
+  // window masks have nothing to reject and can be skipped -- which matters
+  // because the mask kernel derives a column's position from its index and a
+  // ring presents them rotated. Give it one cell more and the oldest slot is
+  // outside the window with no way to say so.
+  //===--------------------------------------------------------------------===//
+  const bool ring_cache = (present_key != nullptr && present_seq < total_seq);
+  if (ring_cache) {
+    if (local_window_size <= 0 || present_seq != local_window_size) {
+      fprintf(stderr,
+              "gqa_forward_hipblaslt: present KV buffer (%lld) is shorter than "
+              "the context (%lld), which is only supported for a sliding-window "
+              "layer whose cache is right-sized to exactly the window, but "
+              "local_window_size=%lld\n",
+              (long long)present_seq, (long long)total_seq,
+              (long long)local_window_size);
+      return -1;
+    }
+    if (past_key != present_key) {
+      fprintf(stderr,
+              "gqa_forward_hipblaslt: a right-sized sliding-window cache needs "
+              "past and present aliased (past_present_share_buffer), but they "
+              "differ\n");
+      return -1;
+    }
+  }
+
+  // The two halves of ring mode, which want opposite things. A prefill scores
+  // against the whole context, so it reads a full-length linear copy and only
+  // the cache write wraps. A decode reads the ring itself, whose keys arrive
+  // rotated.
+  const bool ring_prefill = ring_cache && sq > 1;
+  const bool ring_read = ring_cache && sq == 1;
+
   // Number of key positions actually scored, and the first one. kv_span ==
   // total_seq and kv_lo == 0 whenever narrowing is inactive, which keeps every
   // downstream expression below identical to what it was.
   int64_t kv_span = total_seq;
   int64_t kv_lo = 0;
-  if (sq == 1 && use_no_expand && local_window_size > 0 &&
-      local_window_size < total_seq) {
+  if (ring_cache && sq == 1) {
+    // The whole ring is in-window by construction, so #795's narrowing
+    // collapses: read every slot from 0 and let the ring rotation, not an
+    // offset, place them. kv_lo must stay 0 -- a ring has no contiguous "first
+    // scored position" to point at.
+    kv_span = present_seq;
+    kv_lo = 0;
+  } else if (sq == 1 && use_no_expand && local_window_size > 0 &&
+             local_window_size < total_seq) {
     kv_span = local_window_size;
     kv_lo = total_seq - kv_span;
   }
@@ -1627,6 +1703,11 @@ static int gqa_forward_hipblaslt(
               /*strideC=*/chunked ? sq * d : 0};
   };
 
+  // strideA is the buffer page the K/V operand steps over per (b, g). It is the
+  // present cache's own capacity, except on a ring prefill, which reads the
+  // full-length workspace copy instead.
+  const int64_t kv_page_seq = ring_prefill ? total_seq : present_seq;
+
   GqaGemmKey scoreKey, valueKey;
   if (use_no_expand) {
     // Score: C[kv_span, HPG*sq] = K^T[d,kv_span] * Q[d, HPG*sq] per (b, g)
@@ -1643,7 +1724,7 @@ static int gqa_forward_hipblaslt(
                 /*transA=*/true,
                 /*outputFp32=*/true,
                 /*inputFp32=*/gemm_fp32,
-                /*strideA=*/present_seq * d,
+                /*strideA=*/kv_page_seq * d,
                 /*strideB=*/HPG * sq * d,
                 /*strideC=*/HPG * sq * kv_span};
     // Value: C[d, HPG*sq] = V[d, kv_span] * S[kv_span, HPG*sq] per (b, g)
@@ -1656,7 +1737,7 @@ static int gqa_forward_hipblaslt(
                 /*transA=*/false,
                 /*outputFp32=*/gemm_fp32,
                 /*inputFp32=*/gemm_fp32,
-                /*strideA=*/present_seq * d,
+                /*strideA=*/kv_page_seq * d,
                 /*strideB=*/HPG * sq * kv_span,
                 /*strideC=*/HPG * sq * d};
   } else {
@@ -1752,6 +1833,23 @@ static int gqa_forward_hipblaslt(
     off_Ksplit = off_Qsplit + Q_bytes;
     off_Vsplit = off_Ksplit + K_bytes;
     temp_end = off_Vsplit + K_bytes;
+  }
+
+  // Full-length BNSD K/V for a ring prefill. A prefill scores every query
+  // against every earlier key, so it needs all total_seq keys laid out
+  // contiguously -- but the ring only has `window` cells, and the incoming
+  // kSrc/vSrc are BSHD, which is not the layout the expand step and the
+  // no-expand GEMM strides read. So the prefill gets a transient BNSD copy of
+  // the full range here, and the persistent cache separately receives just the
+  // tail the next decode will read. This is workspace, sized once and reused by
+  // every layer, not 25 more caches: it is the same order as Kexp/Vexp
+  // alongside it, and it disappears when prefill does.
+  size_t off_Kfull = 0, off_Vfull = 0;
+  if (ring_prefill) {
+    size_t KV_bytes = static_cast<size_t>(B) * G * total_seq * d * elem_sz;
+    off_Kfull = temp_end;
+    off_Vfull = off_Kfull + KV_bytes;
+    temp_end = off_Vfull + KV_bytes;
   }
 
   int result = 0;
@@ -1868,16 +1966,36 @@ static int gqa_forward_hipblaslt(
           static_cast<int>(past_buf_seq), static_cast<int>(present_seq),
           (use_no_expand && !bidirectional_no_past) ? seqlens_k_ptr : nullptr,
           static_cast<int>(elem_sz), static_cast<int>(kv_lo),
-          bidirectional_no_past, static_cast<int>(skv)));
+          ring_cache ? 1 : 0, bidirectional_no_past, static_cast<int>(skv)));
+
+      // Ring prefill: the append above stored the tail the next decode reads.
+      // The attention below still needs the whole range, so lay it out BNSD in
+      // workspace. past_len is 0 for a prefill, so this is a plain linear
+      // append into a buffer that is exactly total_seq long.
+      if (ring_prefill) {
+        HIP_CHECK(update_kv_cache(
+            stream, /*past_key=*/nullptr, /*past_value=*/nullptr, kSrc, vSrc,
+            ws + off_Kfull, ws + off_Vfull, static_cast<int>(B),
+            /*past_len=*/0, static_cast<int>(sq), static_cast<int>(G),
+            static_cast<int>(d), /*past_buf_seq=*/0,
+            static_cast<int>(total_seq), /*seqlens_k_ptr=*/nullptr,
+            static_cast<int>(elem_sz), /*copy_lo=*/0, /*ring=*/0,
+            /*no_causal=*/false, /*skv=*/-1));
+      }
     }
 
     // ---- Steps 6-7: KV Expand [B*G,present_seq,d] -> [B*H,total_seq,d] ----
     // Skipped in no-expand mode: the Score/Value GEMMs read K/V directly from
     // the BNSD cache via per-operand batch strides instead.
     if (!use_no_expand) {
-      const void *kCache = present_key ? present_key : key;
-      const void *vCache = present_value ? present_value : value;
-      int kvSrcStride = static_cast<int>(present_seq * d);
+      // A ring prefill expands out of the full-length workspace copy, whose
+      // batch stride is total_seq rather than the ring's capacity.
+      const void *kCache = ring_prefill ? (ws + off_Kfull)
+                                        : (present_key ? present_key : key);
+      const void *vCache = ring_prefill ? (ws + off_Vfull)
+                                        : (present_value ? present_value : value);
+      int kvSrcStride =
+          static_cast<int>((ring_prefill ? total_seq : present_seq) * d);
       int kvDstStride = static_cast<int>(total_seq * d);
       int expandCopy = static_cast<int>(total_seq * d);
 
@@ -1899,14 +2017,20 @@ static int gqa_forward_hipblaslt(
     // BNSD with d fastest, so this selects a contiguous span and leaves the
     // per-(b,g) batch stride at present_seq*d. kv_lo is 0 unless the sliding
     // window narrowed the range.
+    // A ring prefill reads the full-length workspace copy instead of the cache,
+    // for the same reason the expand step above does: the ring holds only the
+    // window, and a prefill scores against everything before it.
     const size_t kv_byte_off = static_cast<size_t>(kv_lo) * d * elem_sz;
-    const void *scoreA =
-        (use_no_expand ? static_cast<const char *>(present_key) + kv_byte_off
-                       : static_cast<const char *>(d_Kexp));
+    const char *noExpandK = ring_prefill ? (ws + off_Kfull)
+                                         : static_cast<const char *>(present_key);
+    const char *noExpandV = ring_prefill
+                                ? (ws + off_Vfull)
+                                : static_cast<const char *>(present_value);
+    const void *scoreA = (use_no_expand ? noExpandK + kv_byte_off
+                                        : static_cast<const char *>(d_Kexp));
     const void *scoreBBase = need_transpose ? d_Qtrans : qSrc;
-    const void *valueA =
-        (use_no_expand ? static_cast<const char *>(present_value) + kv_byte_off
-                       : static_cast<const char *>(d_Vexp));
+    const void *valueA = (use_no_expand ? noExpandV + kv_byte_off
+                                        : static_cast<const char *>(d_Vexp));
     void *valueCBase = need_transpose ? d_O : output;
     float scoreAlpha = scale;
     float beta = 0.0f;
@@ -1952,7 +2076,9 @@ static int gqa_forward_hipblaslt(
             static_cast<int>(kv_span), scoreBatchStride,
             static_cast<int>(elem_sz), static_cast<int>(sq),
             static_cast<int>(q0), static_cast<int>(total_seq),
-            static_cast<int>(kv_lo)));
+            static_cast<int>(kv_lo),
+            static_cast<int>(ring_read ? total_seq - present_seq : 0),
+            static_cast<int>(ring_read ? present_seq : 0)));
       }
 
       // ---- Step 9: Causal Mask (fp32) + Softmax (fp32 -> fp16/fp32) ----
@@ -1981,7 +2107,13 @@ static int gqa_forward_hipblaslt(
       // exactly equivalent to shifting the column index up by it. No kernel
       // change needed. (At sq == 1 the narrowed range is precisely the window,
       // so the kernel then writes nothing -- correct, just redundant.)
-      if ((sq > 1 || local_window_size > 0) && !no_causal) {
+      // A ring read is exempt, and has to be: the kernel derives a column's
+      // absolute position from its index, which a rotated ring breaks. It is
+      // also unnecessary, and for the same reason the capacity is pinned to the
+      // window -- a ring of exactly `window` cells holds exactly the positions
+      // the single query may attend to, so both the triangle and the window
+      // admit every column and the kernel would write nothing.
+      if ((sq > 1 || local_window_size > 0) && !no_causal && !ring_read) {
         HIP_CHECK(hip_gqa_causal_mask_f32(
             stream, d_S_f32, static_cast<int>(B * H), static_cast<int>(kv_span),
             static_cast<int>(c), scoreBatchStride,

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -1442,7 +1442,8 @@ static int gqa_forward_hipblaslt(
       // buffer means the graph and the runtime disagree about the cache. The
       // ring block further down re-checks the capacity against the window
       // before letting anything wrap.
-      const bool short_ok = (local_window_size > 0 && present_seq >= local_window_size);
+      const bool short_ok =
+          (local_window_size > 0 && present_seq >= local_window_size);
       if (total_seq < 1 || past_len < 0 ||
           ((total_seq > present_seq || past_len > past_buf_seq) && !short_ok)) {
         fprintf(stderr,
@@ -1577,13 +1578,14 @@ static int gqa_forward_hipblaslt(
   const bool ring_cache = (present_key != nullptr && present_seq < total_seq);
   if (ring_cache) {
     if (local_window_size <= 0 || present_seq != local_window_size) {
-      fprintf(stderr,
-              "gqa_forward_hipblaslt: present KV buffer (%lld) is shorter than "
-              "the context (%lld), which is only supported for a sliding-window "
-              "layer whose cache is right-sized to exactly the window, but "
-              "local_window_size=%lld\n",
-              (long long)present_seq, (long long)total_seq,
-              (long long)local_window_size);
+      fprintf(
+          stderr,
+          "gqa_forward_hipblaslt: present KV buffer (%lld) is shorter than "
+          "the context (%lld), which is only supported for a sliding-window "
+          "layer whose cache is right-sized to exactly the window, but "
+          "local_window_size=%lld\n",
+          (long long)present_seq, (long long)total_seq,
+          (long long)local_window_size);
       return -1;
     }
     if (past_key != present_key) {
@@ -1990,10 +1992,11 @@ static int gqa_forward_hipblaslt(
     if (!use_no_expand) {
       // A ring prefill expands out of the full-length workspace copy, whose
       // batch stride is total_seq rather than the ring's capacity.
-      const void *kCache = ring_prefill ? (ws + off_Kfull)
-                                        : (present_key ? present_key : key);
-      const void *vCache = ring_prefill ? (ws + off_Vfull)
-                                        : (present_value ? present_value : value);
+      const void *kCache =
+          ring_prefill ? (ws + off_Kfull) : (present_key ? present_key : key);
+      const void *vCache = ring_prefill
+                               ? (ws + off_Vfull)
+                               : (present_value ? present_value : value);
       int kvSrcStride =
           static_cast<int>((ring_prefill ? total_seq : present_seq) * d);
       int kvDstStride = static_cast<int>(total_seq * d);
@@ -2021,8 +2024,9 @@ static int gqa_forward_hipblaslt(
     // for the same reason the expand step above does: the ring holds only the
     // window, and a prefill scores against everything before it.
     const size_t kv_byte_off = static_cast<size_t>(kv_lo) * d * elem_sz;
-    const char *noExpandK = ring_prefill ? (ws + off_Kfull)
-                                         : static_cast<const char *>(present_key);
+    const char *noExpandK = ring_prefill
+                                ? (ws + off_Kfull)
+                                : static_cast<const char *>(present_key);
     const char *noExpandV = ring_prefill
                                 ? (ws + off_Vfull)
                                 : static_cast<const char *>(present_value);

--- a/schemas/CMakeLists.txt
+++ b/schemas/CMakeLists.txt
@@ -43,6 +43,12 @@ add_custom_target(HipSchemas ALL DEPENDS ${GENERATED_HEADERS})
 # flatbuffers::Parser for JSON<->binary conversion without a separate schema file.
 foreach(schema ${FBS_SCHEMAS})
     get_filename_component(schema_name ${schema} NAME_WE)
+    # file(READ) happens at CONFIGURE time, unlike the flatc custom command
+    # above which reruns on build. Without this the embedded schema silently
+    # keeps whatever the last configure saw, so a new field parses fine in C++
+    # and then fails at runtime with "unknown field" from the JSON parser --
+    # the two halves of the same .fbs disagreeing.
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${schema})
     file(READ ${schema} schema_content)
     file(CONFIGURE
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${schema_name}_schema.h

--- a/schemas/compilation_options.fbs
+++ b/schemas/compilation_options.fbs
@@ -14,6 +14,11 @@ table CompilationOptions {
   verbose: bool = false;
   constants_file: string = "constants.bin";
   skip_constant_data: bool = false;
+  // present_key/value name the same allocation as past_key/value, so the
+  // present buffer's capacity is the past extent rather than past+current.
+  // Set from the `kv_share_buffer` provider option; must agree with
+  // past_present_share_buffer in the model's genai_config.json.
+  kv_share_buffer: bool = false;
 }
 
 root_type CompilationOptions;

--- a/test/lit/Conversion/onnx-to-hip/test_onnx_attention_share_buffer.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_onnx_attention_share_buffer.mlir
@@ -3,8 +3,11 @@
 
 // ============================================================================
 // TEST PURPOSE:
-// Cover the present-capacity rule under HIPDNN_EP_KV_SHARE_BUFFER, which says
-// present IS the past allocation rather than a freshly grown past+current.
+// Cover the present-capacity rule under the convert-onnx-to-hip pass option
+// `kv-share-buffer`, which says present IS the past allocation rather than a
+// freshly grown past+current. In a session the option is set from the
+// `kv_share_buffer` provider option, which has to agree with
+// past_present_share_buffer in the model's genai_config.json.
 //
 // The default rule is capacity = max(past extent, valid total). That is right
 // for a separately allocated present, and right for a shared one too as long
@@ -13,7 +16,7 @@
 // than the context -- right-sizing a sliding-window layer's cache to its
 // window -- where max(1024, 2240) asks ORT for a present the bound buffer
 // cannot satisfy. Nothing in the operand shapes distinguishes the two
-// deployments (both have past < total), so the flag supplies the fact.
+// deployments (both have past < total), so the option supplies the fact.
 //
 // Two shapes of present reach this code and they take different paths:
 //
@@ -22,7 +25,7 @@
 //     takes; its present is tensor<?x8x?x256xf16>.
 //
 //   static present seq dim -> capacity is a constant read straight off the
-//     result type and the computation is skipped entirely, so the flag has
+//     result type and the computation is skipped entirely, so the option has
 //     nothing to act on. That silent bypass is what section 2 pins: under the
 //     flag a present pinned to an extent the shared past does not have is a
 //     contradiction in the graph, so the converter declines instead of
@@ -35,9 +38,9 @@
 
 // RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip \
 // RUN:   --split-input-file | FileCheck %s --check-prefix=DEFAULT
-// RUN: env HIPDNN_EP_KV_SHARE_BUFFER=1 hip-mlir-opt %s --hip-add-context-arg \
-// RUN:   --convert-onnx-to-hip --split-input-file | FileCheck %s \
-// RUN:   --check-prefix=SHARE
+// RUN: hip-mlir-opt %s --hip-add-context-arg \
+// RUN:   --convert-onnx-to-hip=kv-share-buffer=true --split-input-file \
+// RUN:   | FileCheck %s --check-prefix=SHARE
 
 // Section 1 -- dynamic present, the real decoder's shape.
 //

--- a/test/lit/Conversion/onnx-to-hip/test_onnx_attention_share_buffer.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_onnx_attention_share_buffer.mlir
@@ -1,0 +1,180 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Cover the present-capacity rule under HIPDNN_EP_KV_SHARE_BUFFER, which says
+// present IS the past allocation rather than a freshly grown past+current.
+//
+// The default rule is capacity = max(past extent, valid total). That is right
+// for a separately allocated present, and right for a shared one too as long
+// as the shared buffer is allocated to max_length, where the past extent
+// dominates. It breaks only when a buffer is deliberately allocated SHORTER
+// than the context -- right-sizing a sliding-window layer's cache to its
+// window -- where max(1024, 2240) asks ORT for a present the bound buffer
+// cannot satisfy. Nothing in the operand shapes distinguishes the two
+// deployments (both have past < total), so the flag supplies the fact.
+//
+// Two shapes of present reach this code and they take different paths:
+//
+//   dynamic present seq dim -> capacity is computed in IR, and the flag picks
+//     dim(past_key, 2) over the max(). This is the path the real decoder
+//     takes; its present is tensor<?x8x?x256xf16>.
+//
+//   static present seq dim -> capacity is a constant read straight off the
+//     result type and the computation is skipped entirely, so the flag has
+//     nothing to act on. That silent bypass is what section 2 pins: under the
+//     flag a present pinned to an extent the shared past does not have is a
+//     contradiction in the graph, so the converter declines instead of
+//     emitting a capacity it knows to be wrong.
+//
+// The absence of any static-present case is what let the bypass go unnoticed:
+// every capacity assertion in test_onnx_attention.mlir exercises the dynamic
+// path, so the suite stayed green on a path the model never took.
+// ============================================================================
+
+// RUN: hip-mlir-opt %s --hip-add-context-arg --convert-onnx-to-hip \
+// RUN:   --split-input-file | FileCheck %s --check-prefix=DEFAULT
+// RUN: env HIPDNN_EP_KV_SHARE_BUFFER=1 hip-mlir-opt %s --hip-add-context-arg \
+// RUN:   --convert-onnx-to-hip --split-input-file | FileCheck %s \
+// RUN:   --check-prefix=SHARE
+
+// Section 1 -- dynamic present, the real decoder's shape.
+//
+// Default: capacity is max(past extent, mask kv extent).
+// Shared:  capacity is the past extent alone, so no max() is emitted at all.
+module {
+  func.func @main_graph(
+      %query: tensor<?x?x4096xf16>,
+      %key: tensor<?x?x2048xf16>,
+      %value: tensor<?x?x2048xf16>,
+      %attn_mask: tensor<?x1x?x?xf16>,
+      %past_key: tensor<?x8x?x256xf16>,
+      %past_value: tensor<?x8x?x256xf16>)
+      -> (tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>,
+          tensor<?x8x?x256xf16>) {
+
+    // DEFAULT-LABEL: func.func @main_graph
+    // DEFAULT: %[[PAST:.*]] = tensor.dim %{{.*}}, %c2
+    // DEFAULT: %[[MASKKV:.*]] = tensor.dim %{{.*}}, %c3
+    // DEFAULT: %[[CAP:.*]] = arith.maxsi %[[PAST]], %[[MASKKV]]
+    // DEFAULT: tensor.empty(%{{.*}}, %[[CAP]]) : tensor<?x8x?x256xf16>
+    // DEFAULT: hip.gqa
+
+    // SHARE-LABEL: func.func @main_graph
+    // SHARE-NOT: arith.maxsi
+    // SHARE: %[[SPAST:.*]] = tensor.dim %{{.*}}, %c2
+    // SHARE: tensor.empty(%{{.*}}, %[[SPAST]]) : tensor<?x8x?x256xf16>
+    // SHARE: hip.gqa
+
+    %out:3 = "onnx.Attention"(%query, %key, %value, %attn_mask, %past_key,
+                              %past_value)
+        {q_num_heads = 16 : si64,
+         kv_num_heads = 8 : si64,
+         is_causal = 1 : si64,
+         scale = 1.000000e+00 : f32,
+         softcap = 0.000000e+00 : f32}
+        : (tensor<?x?x4096xf16>, tensor<?x?x2048xf16>, tensor<?x?x2048xf16>,
+           tensor<?x1x?x?xf16>, tensor<?x8x?x256xf16>,
+           tensor<?x8x?x256xf16>)
+        -> (tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>,
+            tensor<?x8x?x256xf16>)
+
+    return %out#0, %out#1, %out#2
+        : tensor<?x?x4096xf16>, tensor<?x8x?x256xf16>,
+          tensor<?x8x?x256xf16>
+  }
+}
+
+// -----
+
+// Section 2 -- static present (2240) that does NOT match the shared past
+// buffer (1024). This is the bypass: the capacity is a constant lifted from
+// the result type, so the flag never gets a say.
+//
+// Default: unchanged, capacity 2240, because a separately allocated present
+//          really is past+current and the graph is self-consistent.
+// Shared:  declined. present and past are one allocation and cannot have two
+//          different extents; the type cannot be rewritten here either,
+//          because present is a function result whose signature still says
+//          2240. onnx.Attention survives unconverted.
+module {
+  func.func @main_graph(
+      %query: tensor<1x2240x4096xf16>,
+      %key: tensor<1x2240x2048xf16>,
+      %value: tensor<1x2240x2048xf16>,
+      %attn_mask: tensor<1x1x2240x2240xf16>,
+      %past_key: tensor<1x8x1024x256xf16>,
+      %past_value: tensor<1x8x1024x256xf16>)
+      -> (tensor<1x2240x4096xf16>, tensor<1x8x2240x256xf16>,
+          tensor<1x8x2240x256xf16>) {
+
+    // DEFAULT-LABEL: func.func @main_graph
+    // DEFAULT: arith.constant dense<2240> : tensor<i32>
+    // DEFAULT: hip.gqa
+
+    // SHARE-LABEL: func.func @main_graph
+    // SHARE: onnx.Attention
+    // SHARE-NOT: hip.gqa
+
+    %out:3 = "onnx.Attention"(%query, %key, %value, %attn_mask, %past_key,
+                              %past_value)
+        {q_num_heads = 16 : si64,
+         kv_num_heads = 8 : si64,
+         is_causal = 1 : si64,
+         scale = 1.000000e+00 : f32,
+         softcap = 0.000000e+00 : f32}
+        : (tensor<1x2240x4096xf16>, tensor<1x2240x2048xf16>,
+           tensor<1x2240x2048xf16>, tensor<1x1x2240x2240xf16>,
+           tensor<1x8x1024x256xf16>, tensor<1x8x1024x256xf16>)
+        -> (tensor<1x2240x4096xf16>, tensor<1x8x2240x256xf16>,
+            tensor<1x8x2240x256xf16>)
+
+    return %out#0, %out#1, %out#2
+        : tensor<1x2240x4096xf16>, tensor<1x8x2240x256xf16>,
+          tensor<1x8x2240x256xf16>
+  }
+}
+
+// -----
+
+// Section 3 -- static present that DOES match the shared past buffer, i.e. a
+// right-sized window cache the exporter already spelled correctly. Nothing to
+// disagree about, so both runs convert identically and the flag is inert.
+module {
+  func.func @main_graph(
+      %query: tensor<1x2240x4096xf16>,
+      %key: tensor<1x2240x2048xf16>,
+      %value: tensor<1x2240x2048xf16>,
+      %attn_mask: tensor<1x1x2240x2240xf16>,
+      %past_key: tensor<1x8x1024x256xf16>,
+      %past_value: tensor<1x8x1024x256xf16>)
+      -> (tensor<1x2240x4096xf16>, tensor<1x8x1024x256xf16>,
+          tensor<1x8x1024x256xf16>) {
+
+    // DEFAULT-LABEL: func.func @main_graph
+    // DEFAULT: arith.constant dense<1024> : tensor<i32>
+    // DEFAULT: hip.gqa
+
+    // SHARE-LABEL: func.func @main_graph
+    // SHARE: arith.constant dense<1024> : tensor<i32>
+    // SHARE: hip.gqa
+
+    %out:3 = "onnx.Attention"(%query, %key, %value, %attn_mask, %past_key,
+                              %past_value)
+        {q_num_heads = 16 : si64,
+         kv_num_heads = 8 : si64,
+         is_causal = 1 : si64,
+         scale = 1.000000e+00 : f32,
+         softcap = 0.000000e+00 : f32}
+        : (tensor<1x2240x4096xf16>, tensor<1x2240x2048xf16>,
+           tensor<1x2240x2048xf16>, tensor<1x1x2240x2240xf16>,
+           tensor<1x8x1024x256xf16>, tensor<1x8x1024x256xf16>)
+        -> (tensor<1x2240x4096xf16>, tensor<1x8x1024x256xf16>,
+            tensor<1x8x1024x256xf16>)
+
+    return %out#0, %out#1, %out#2
+        : tensor<1x2240x4096xf16>, tensor<1x8x1024x256xf16>,
+          tensor<1x8x1024x256xf16>
+  }
+}


### PR DESCRIPTION
# feat(gqa): ring append for a right-sized sliding-window KV cache — DRAFT

Draft, stacked on PR A (`perf/kv-alias`), which is itself stacked on #795.
Marked draft because the payoff is memory at a small cost in decode throughput,
and because the shape contract it relies on is worth arguing about before it
lands.

| commit | what |
|---|---|
| `5ff8aacb` | `feat(gqa)`: ring append for a right-sized sliding-window KV cache |
| `3fdfde4c` | `feat(attention)`: present takes the past extent under a shared KV buffer |
| `c8a5d18d` | `fix(attention)`: refuse a static present that contradicts the shared buffer |
| `83c9a69d` | `feat(attention)`: drive the shared KV buffer from a provider option |
| `17599640` | `test(gqa)`: pin the ring append's wrap arithmetic |
| `1046a782` | `style(gqa)`: reflow the ring paths to clang-format |

## The idea

A sliding-window layer can only ever attend to the newest `window` positions,
so its KV cache does not need `max_length` cells. OGA already knows how to
allocate it to the window (`kv_cache.cpp`, gated on the device). What was
missing was a runtime that tolerates `present_seq < total_seq`: the append now
writes position `p` at `p % capacity` and the decode reads the whole ring.

On Gemma-4 that is **25 of 30 layers** — indices 0-4, 6-10, 12-16, 18-22,
24-28, i.e. every layer except each sixth one (5, 11, 17, 23, 29), which are
the global-attention layers and keep their full-length cache.

## Capacity must equal the window exactly

This is a correctness condition, not a tuning knob, and it is the part worth
reviewing.

A ring of exactly `window` cells holds precisely the set of positions the
current query may attend to, so the causal and window masks have nothing left
to reject and are skipped. That matters because the mask kernel derives a
column's position from its column index, and a ring hands it those positions
rotated. One cell more than the window and the oldest slot falls outside the
window with no way left to say so.

The same argument makes the overwrite safe: when position `p` is written to
slot `p % window`, the slot's previous occupant is `p - window`, which is
exactly the position that just left the window.

It is enforced in three places: the runtime rejects `present_seq !=
local_window_size` and rejects an unaliased past/present
(`lib/Runtime/real/gqa.cpp`), and the converter now refuses a static present
extent that contradicts the shared past buffer (`c8a5d18d`) — the case that
previously slipped through, because only the dynamic-dim branch consulted the
capacity logic.

## The flag lives next to the flag it must agree with

`83c9a69d` replaces the `HIPDNN_EP_KV_SHARE_BUFFER` env var with a provider
option, threaded through `CompilationConfig` -> JSON -> flatbuffer -> pipeline
-> a pass option on `ConvertOnnxToHipPass`. It is read as
`ep.hipgpu.kv_share_buffer` from the decoder's `session_options`, so it now
sits in the same `genai_config.json` as `past_present_share_buffer`.

That pairing is the point. The graph cannot disambiguate on its own — a
right-sized shared buffer and a growing separate one both present `past <
total` — so the fact has to come from outside, and the two settings disagreeing
produces a shape rejection at the first decode:

```
The output OrtValue provided for output 'present.0.key' ... has shape
{1,8,1024,256} but the computed output shape for this run is {1,8,2240,256}
```

The env var still seeds the option so existing scripts keep working; the
provider option overrides it when present.

## Numbers — memory bought with a little decode

Same setup as PR A (Gemma-4 26B-A4B-it FP16/W4 qmoe, gfx1151, `max_length`
16512, 64 tokens, 3 reps after 1 warmup). Baseline here is PR A, not main.

| prompt | PR A p50 | ring p50 | Δ | PR A peak | ring peak | Δ peak |
|---:|---:|---:|---:|---:|---:|---:|
| 513 | 19.99 | 21.11 | +1.12 | 6771 MB | 3742 MB | -3029 MB |
| 2240 | 22.46 | 22.73 | +0.27 | 6926 MB | 3896 MB | -3030 MB |
| 4097 | 21.98 | 22.98 | +1.00 | 7108 MB | 4078 MB | -3030 MB |
| 8181 | 22.91 | 23.91 | +1.00 | 7492 MB | 4468 MB | -3024 MB |
| 16241 | 24.99 | 25.50 | +0.51 | 8265 MB | 5240 MB | -3025 MB |

ms/token. The 16241 row's baseline was re-measured on the same build as the ring
arm; the shorter rows are against a PR A build from the day before, and on the
evidence of that re-measurement they likely flatter the ring by a few tenths of
a millisecond too. Peak reproduced to within 3 MB across builds (8268 -> 8265),
so only the latency column is affected.

**Roughly 3.0 GB off an 8.3 GB peak at 16K**, and the same 3.0 GB at
every context — which is what a right-sized cache should do, since the saving
is the unused tail of the allocation and does not depend on how much of it the
prompt fills:

```
25 layers x (16512 - 1024) positions x 8 kv heads x 256 head_dim x 2 B x 2 (K,V)
  = 3,025 MiB
```

against 3,024-3,030 MiB measured.

**The ring costs throughput, it does not win any.** #795 already narrowed the
decode read to the window, so the ring removes footprint the kernel had stopped
reading anyway — there was no read traffic left to save. What it adds is roughly
+0.5 to +1.0 ms/token across the whole range, including +0.51 at 16K on a
same-build comparison. That is 2-4%, and it is not yet explained; the modulo in
the append is not a plausible cost at this scale, so the suspect is the decode
reading the full `capacity` slots (`kv_lo=0`, `kv_span=present_seq`) where the
narrowed path reads the same count but as one contiguous run. Worth settling
before this leaves draft, since the trade is now explicitly memory for a few
percent of decode rather than memory for free.

## Ring output is not bit-identical once the context passes the window

Worth stating plainly. Both a ring and a full-length buffer attend to the same
set of keys, but the ring presents them rotated, so the fp16 reduction
reassociates. This is the same standard the narrowed decode read in #795
already set, but it is visible in generated text.

Measured against a control that changes storage and nothing else — the buffer
sized to 4096 instead of 1024, which `kv_cache.cpp` uses only for allocation
while the graph's own `local_window_size=1024` continues to set the mask:

- **below the window** (513-token prompt, no wrap): byte-identical text
- **above it** (2240-token prompt, wraps): text diverges, and the ring's own
  output is byte-identical across repeated runs, so this is a systematic
  reassociation difference rather than noise. Both outputs are coherent and
  describe the input correctly.

The dispatch logs show the mechanism directly. At decode, both arms score 1024
keys; the full-length buffer reads them at `kv_lo=1217` in position order,
while the ring reads slots 0-1023 holding those same positions rotated.

## Validation

- lit: 392 passed, 12 unsupported, 0 failed, including new coverage for a
  static present dim with and without the flag — the gap that let the bypass
  through, since every prior capacity assertion exercised the dynamic
  `arith.maxsi` path the real model never takes
- pre-commit: clean
- numeric: 20 pre-existing failures, byte-identical set before and after,
  confirmed by building the parent commit and re-running the same six files
- kernel-level: `lib/Runtime/Kernels/test/example/gqa/ring/` pins the wrap
  arithmetic — prefill writes each slot exactly once, decode lands at
  `(total-1) % capacity`, each position carrying its own index as payload.
  11 checks; negative control confirmed by removing the drop rule from
  `kv_ring_slot` and watching it fail
- converter IR on the real graph: the option removes exactly 30 `arith.maxsi`
  capacity computations, one per attention layer, and sizes present from
  `tensor.dim %past_key, %c2`. With the option off the original shape rejection
  reappears, so the option is load-bearing rather than incidental

## Not covered

The numeric harness allocates `present` itself, so past and present can never
alias there, and the ring hard-requires aliasing
(`lib/Runtime/real/gqa.cpp:1591`). A ring wrap case cannot be expressed in that
harness without changing how it binds outputs. Coverage is the kernel-level
test plus the end-to-end text comparison above; if reviewers want it in
`test_attention_sliding_window.py`, the harness change should be its own PR.
