### PR TITLE
fix(onnx-to-hip): honor ONNX Reshape 0-dim and Expand broadcast-1 semantics

### DIFF
--- a/lib/Conversion/OnnxToHip/ExpandConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ExpandConversion.cpp
@@ -29,15 +29,10 @@ static mlir::Value readShapeEntryToIndex(mlir::PatternRewriter &rewriter,
 /// input tensor (right-aligned with the result rank, NumPy-style); leading
 /// dims that are absent from `shape` fall back to the matching input dim.
 ///
-/// `Expand`'s shape operand is a BROADCAST target, not a literal resize: per
-/// ONNX/NumPy broadcasting, the output extent at a position is
-/// `max(input_dim, shape_dim)`, and a `1` in `shape` at a position where the
-/// input already has a real (possibly >1) extent means "do not broadcast
-/// here", i.e. keep the input's extent. Using the shape entry verbatim
-/// silently collapses any such input dim to 1 whenever the shape operand
-/// says 1 there -- see docs/nemotron-mamba-shape-collapse.md for the mamba
-/// `Expand(_, [1,1,1,16,1])` fallout this caused (batch/seq collapsed to 1,
-/// corrupting the residual stream via a stale-pool-memory read one op later).
+/// `Expand`'s shape operand is a BROADCAST target, not a literal resize: the
+/// output extent at a position is `max(input_dim, shape_dim)`, so a `1` in
+/// `shape` where the input carries a real (possibly >1) extent means "do not
+/// broadcast here", i.e. keep the input's extent -- not "resize to 1".
 struct ExpandToHip : public mlir::RewritePattern {
   ExpandToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Expand", /*benefit=*/1, ctx) {}

--- a/lib/Conversion/OnnxToHip/ExpandConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ExpandConversion.cpp
@@ -28,6 +28,16 @@ static mlir::Value readShapeEntryToIndex(mlir::PatternRewriter &rewriter,
 /// dims in the result we extract the corresponding entry from the `shape`
 /// input tensor (right-aligned with the result rank, NumPy-style); leading
 /// dims that are absent from `shape` fall back to the matching input dim.
+///
+/// `Expand`'s shape operand is a BROADCAST target, not a literal resize: per
+/// ONNX/NumPy broadcasting, the output extent at a position is
+/// `max(input_dim, shape_dim)`, and a `1` in `shape` at a position where the
+/// input already has a real (possibly >1) extent means "do not broadcast
+/// here", i.e. keep the input's extent. Using the shape entry verbatim
+/// silently collapses any such input dim to 1 whenever the shape operand
+/// says 1 there -- see docs/nemotron-mamba-shape-collapse.md for the mamba
+/// `Expand(_, [1,1,1,16,1])` fallout this caused (batch/seq collapsed to 1,
+/// corrupting the residual stream via a stale-pool-memory read one op later).
 struct ExpandToHip : public mlir::RewritePattern {
   ExpandToHip(mlir::MLIRContext *ctx)
       : RewritePattern("onnx.Expand", /*benefit=*/1, ctx) {}
@@ -65,14 +75,32 @@ struct ExpandToHip : public mlir::RewritePattern {
       if (!resultType.isDynamicDim(i))
         continue;
       int64_t shapeIdx = i - (resultRank - shapeLen);
+      int64_t inputIdx = i - (resultRank - inputRank);
       mlir::Value dim;
       if (shapeIdx >= 0) {
         // The shape entry may be GPU-computed; read it back with a stream sync
         // (constants fold) instead of a bare host load of device memory. See
         // readShapeEntryToIndex for the correctness rationale.
-        dim = readShapeEntryToIndex(rewriter, loc, context, shape, shapeIdx);
+        mlir::Value shapeDim =
+            readShapeEntryToIndex(rewriter, loc, context, shape, shapeIdx);
+        if (inputIdx >= 0) {
+          // Broadcast semantics (see the struct doc comment above): a `1`
+          // here means "keep the input's extent", not "resize to 1".
+          mlir::Value inputDim =
+              mlir::tensor::DimOp::create(rewriter, loc, input, inputIdx);
+          mlir::Value one =
+              mlir::arith::ConstantIndexOp::create(rewriter, loc, 1);
+          mlir::Value shapeSaysOne = mlir::arith::CmpIOp::create(
+              rewriter, loc, mlir::arith::CmpIPredicate::eq, shapeDim, one);
+          dim = mlir::arith::SelectOp::create(rewriter, loc, shapeSaysOne,
+                                              inputDim, shapeDim);
+        } else {
+          // No corresponding input dim (this is a purely-broadcast leading
+          // dim absent from the input rank): the shape entry is the literal
+          // extent, nothing to compare it against.
+          dim = shapeDim;
+        }
       } else {
-        int64_t inputIdx = i - (resultRank - inputRank);
         if (inputIdx < 0)
           return rewriter.notifyMatchFailure(
               op, "cannot resolve dynamic dim from input or shape");

--- a/lib/Conversion/OnnxToHip/ReshapeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ReshapeConversion.cpp
@@ -518,31 +518,11 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
         // static feature dim (where the result type already pins the extent
         // and this code never queries the shape operand for it at all) --
         // but that is only an export convention, not an ONNX guarantee.
-        // Nemotron's mamba blocks reshape [bs*ss, H] -> [bs, ss, H] via
-        // `Reshape(_, [0, 0, H])`, putting BOTH non-literal markers on the
-        // dynamic batch/seq dims instead, where they previously WERE read
-        // (and taken as literal 0) -- collapsing every mamba layer's
-        // batch/seq to 0 sized reads that resolved to garbage extents one op
-        // later. See docs/nemotron-mamba-shape-collapse.md.
         //
         // Resolve `0` (like `-1`) here, before tensor.reshape, replacing it
         // with the corresponding input dim BEFORE computing the `-1`
         // inference product below -- otherwise a shape with both `0` and
         // `-1` would divide by the wrong product.
-        //
-        // Before:
-        //   %r = onnx.Reshape %x, %shape :
-        //          (tensor<?x1152xf16>, tensor<6xi64>) ->
-        //          tensor<?x?x2x?x2x?xf16>
-        //   // %shape may contain a literal -1 at some index
-        // After:
-        //   %total  = product of tensor.dim(%x, i) for i in 0..inputRank
-        //   %d[0..outRank-1] = tensor.extract %shape[i]
-        //   %d[i]   = select(%d[i] == 0, tensor.dim(%x, i), %d[i])   // if i <
-        //   inputRank && !allowzero %pp     = product of max(%d[i], 1) for i in
-        //   0..outRank %inf    = %total / %pp %d'[i]  = select(%d[i] == -1,
-        //   %inf, %d[i]) %newsh  = tensor.from_elements %d'[0..outRank-1] :
-        //   tensor<NxI64> %r      = tensor.reshape %x(%newsh)
         mlir::Type elemTy = shapeTy.getElementType();
         unsigned bits = elemTy.getIntOrFloatBitWidth();
         // `allowzero` is emitted as SI64Attr (signed), not a signless/index
@@ -584,12 +564,21 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
           // garbage dim that collapses the reshape. See ReadbackScalar.h.
           mlir::Value v = readbackShapeEntryToHostOrExtract(rewriter, loc, op,
                                                             shapeOperand, i);
-          // Resolve ONNX's `0` ("keep the input's dim here") BEFORE it feeds
-          // the `-1`-inference product below, so a shape with both `0` and
+          // Case handled here -- allowzero=0 and this position has a
+          // corresponding input dim: resolve ONNX's `0` ("keep the input's
+          // dim at this index") to that dim BEFORE it feeds the
+          // `-1`-inference product below, so a shape carrying both `0` and
           // `-1` infers against the real extent instead of dividing as if
-          // this position were size 1. Only applies to positions that have a
-          // corresponding input dim (i < inputRank); allowzero=1 makes `0` a
-          // literal size like any other entry.
+          // this position were size 1.
+          //
+          // The two cases skipped here need no resolution:
+          //   - allowzero=1: `0` is a literal size, so passing the entry
+          //     through unchanged is already the correct output dim. The
+          //     divisor below substitutes 1 for it, leaving `-1` inference
+          //     unaffected.
+          //   - i >= inputRank: `0` names the input dim at the SAME index and
+          //     there is none, so the graph is invalid ONNX; shape inference
+          //     rejects it upstream ("Invalid position of 0.").
           if (!allowzero && i < inputRank) {
             mlir::Value isZero = mlir::arith::CmpIOp::create(
                 rewriter, loc, mlir::arith::CmpIPredicate::eq, v, cZero);

--- a/lib/Conversion/OnnxToHip/ReshapeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ReshapeConversion.cpp
@@ -511,18 +511,26 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
         // arith chain.
         //
         // ONNX `Reshape` also permits a shape entry of literal `0`, meaning
-        // "keep the input's dim at this position unchanged" -- NOT a size-0
-        // dim -- unless the node's `allowzero` attribute is set (opset >=14),
-        // in which case `0` is a literal size like any other entry. This is
-        // easy to miss because `0` and `-1` conventionally sit on a reshape's
-        // static feature dim (where the result type already pins the extent
-        // and this code never queries the shape operand for it at all) --
-        // but that is only an export convention, not an ONNX guarantee.
+        // "keep the input's dim at the SAME index" -- NOT a size-0 dim --
+        // unless the node's `allowzero` attribute is set (opset >= 14), in
+        // which case `0` is a literal size like any other entry. Resolved
+        // below, before the `-1` inference that consumes it.
         //
-        // Resolve `0` (like `-1`) here, before tensor.reshape, replacing it
-        // with the corresponding input dim BEFORE computing the `-1`
-        // inference product below -- otherwise a shape with both `0` and
-        // `-1` would divide by the wrong product.
+        // clang-format off
+        // Before:
+        //   %r = onnx.Reshape %x, %shape :
+        //          (tensor<?x1152xf16>, tensor<6xi64>) -> tensor<?x?x2x?x2x?xf16>
+        //   // %shape may carry a literal -1 and/or 0 at some index
+        // After:
+        //   %total  = product of tensor.dim(%x, i) for i in 0..inputRank
+        //   %d[i]   = tensor.extract %shape[i]                for i in 0..outRank
+        //   %d[i]   = select(%d[i] == 0, tensor.dim(%x, i), %d[i])  // i < inputRank && !allowzero
+        //   %pp     = product of max(%d[i], 1) for i in 0..outRank
+        //   %inf    = %total / %pp
+        //   %d'[i]  = select(%d[i] == -1, %inf, %d[i])
+        //   %newsh  = tensor.from_elements %d'[0..outRank-1] : tensor<Nxi64>
+        //   %r      = tensor.reshape %x(%newsh)
+        // clang-format on
         mlir::Type elemTy = shapeTy.getElementType();
         unsigned bits = elemTy.getIntOrFloatBitWidth();
         // `allowzero` is emitted as SI64Attr (signed), not a signless/index
@@ -565,11 +573,10 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
           mlir::Value v = readbackShapeEntryToHostOrExtract(rewriter, loc, op,
                                                             shapeOperand, i);
           // Case handled here -- allowzero=0 and this position has a
-          // corresponding input dim: resolve ONNX's `0` ("keep the input's
-          // dim at this index") to that dim BEFORE it feeds the
-          // `-1`-inference product below, so a shape carrying both `0` and
-          // `-1` infers against the real extent instead of dividing as if
-          // this position were size 1.
+          // corresponding input dim: resolve the `0` to that input dim BEFORE
+          // it feeds the `-1`-inference product below, so a shape carrying
+          // both `0` and `-1` infers against the real extent instead of
+          // dividing as if this position were size 1.
           //
           // The two cases skipped here need no resolution:
           //   - allowzero=1: `0` is a literal size, so passing the entry

--- a/lib/Conversion/OnnxToHip/ReshapeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ReshapeConversion.cpp
@@ -510,6 +510,26 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
         // zero-copy for the data path; only the shape side gets the extra
         // arith chain.
         //
+        // ONNX `Reshape` also permits a shape entry of literal `0`, meaning
+        // "keep the input's dim at this position unchanged" -- NOT a size-0
+        // dim -- unless the node's `allowzero` attribute is set (opset >=14),
+        // in which case `0` is a literal size like any other entry. This is
+        // easy to miss because `0` and `-1` conventionally sit on a reshape's
+        // static feature dim (where the result type already pins the extent
+        // and this code never queries the shape operand for it at all) --
+        // but that is only an export convention, not an ONNX guarantee.
+        // Nemotron's mamba blocks reshape [bs*ss, H] -> [bs, ss, H] via
+        // `Reshape(_, [0, 0, H])`, putting BOTH non-literal markers on the
+        // dynamic batch/seq dims instead, where they previously WERE read
+        // (and taken as literal 0) -- collapsing every mamba layer's
+        // batch/seq to 0 sized reads that resolved to garbage extents one op
+        // later. See docs/nemotron-mamba-shape-collapse.md.
+        //
+        // Resolve `0` (like `-1`) here, before tensor.reshape, replacing it
+        // with the corresponding input dim BEFORE computing the `-1`
+        // inference product below -- otherwise a shape with both `0` and
+        // `-1` would divide by the wrong product.
+        //
         // Before:
         //   %r = onnx.Reshape %x, %shape :
         //          (tensor<?x1152xf16>, tensor<6xi64>) ->
@@ -518,17 +538,27 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
         // After:
         //   %total  = product of tensor.dim(%x, i) for i in 0..inputRank
         //   %d[0..outRank-1] = tensor.extract %shape[i]
-        //   %pp     = product of max(%d[i], 1) for i in 0..outRank
-        //   %inf    = %total / %pp
-        //   %d'[i]  = select(%d[i] == -1, %inf, %d[i])
-        //   %newsh  = tensor.from_elements %d'[0..outRank-1] : tensor<NxI64>
-        //   %r      = tensor.reshape %x(%newsh)
+        //   %d[i]   = select(%d[i] == 0, tensor.dim(%x, i), %d[i])   // if i <
+        //   inputRank && !allowzero %pp     = product of max(%d[i], 1) for i in
+        //   0..outRank %inf    = %total / %pp %d'[i]  = select(%d[i] == -1,
+        //   %inf, %d[i]) %newsh  = tensor.from_elements %d'[0..outRank-1] :
+        //   tensor<NxI64> %r      = tensor.reshape %x(%newsh)
         mlir::Type elemTy = shapeTy.getElementType();
         unsigned bits = elemTy.getIntOrFloatBitWidth();
+        // `allowzero` is emitted as SI64Attr (signed), not a signless/index
+        // integer, so IntegerAttr::getInt() asserts. Read via getValue()
+        // (APInt) + getSExtValue(), matching every other SI64Attr read in
+        // this codebase (e.g. GqaConversion.cpp, TransposeConversion.cpp).
+        bool allowzero = false;
+        if (auto allowzeroAttr =
+                op->getAttrOfType<mlir::IntegerAttr>("allowzero"))
+          allowzero = allowzeroAttr.getValue().getSExtValue() != 0;
         mlir::Value cMinusOne = mlir::arith::ConstantOp::create(
             rewriter, loc,
             rewriter.getIntegerAttr(elemTy, mlir::APInt(bits, /*val=*/-1,
                                                         /*isSigned=*/true)));
+        mlir::Value cZero = mlir::arith::ConstantOp::create(
+            rewriter, loc, rewriter.getIntegerAttr(elemTy, 0));
         mlir::Value cOne = mlir::arith::ConstantOp::create(
             rewriter, loc, rewriter.getIntegerAttr(elemTy, 1));
 
@@ -554,6 +584,22 @@ struct ReshapeToStdTensor : public mlir::RewritePattern {
           // garbage dim that collapses the reshape. See ReadbackScalar.h.
           mlir::Value v = readbackShapeEntryToHostOrExtract(rewriter, loc, op,
                                                             shapeOperand, i);
+          // Resolve ONNX's `0` ("keep the input's dim here") BEFORE it feeds
+          // the `-1`-inference product below, so a shape with both `0` and
+          // `-1` infers against the real extent instead of dividing as if
+          // this position were size 1. Only applies to positions that have a
+          // corresponding input dim (i < inputRank); allowzero=1 makes `0` a
+          // literal size like any other entry.
+          if (!allowzero && i < inputRank) {
+            mlir::Value isZero = mlir::arith::CmpIOp::create(
+                rewriter, loc, mlir::arith::CmpIPredicate::eq, v, cZero);
+            mlir::Value inputDimIdx =
+                mlir::tensor::DimOp::create(rewriter, loc, data, i);
+            mlir::Value inputDimElemTy = mlir::arith::IndexCastOp::create(
+                rewriter, loc, elemTy, inputDimIdx);
+            v = mlir::arith::SelectOp::create(rewriter, loc, isZero,
+                                              inputDimElemTy, v);
+          }
           dims.push_back(v);
           mlir::Value isPositive = mlir::arith::CmpIOp::create(
               rewriter, loc, mlir::arith::CmpIPredicate::sgt, v, cOne);

--- a/test/lit/Conversion/onnx-to-hip/test_expand.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_expand.mlir
@@ -28,4 +28,34 @@ module {
   // CHECK: tensor.extract
   // CHECK: tensor.empty
   // CHECK: hip.expand({{.*}}) ins({{.*}}, {{.*}} : tensor<3x1xf32>, tensor<3xi64>) outs({{.*}} : tensor<?x3x?xf32>)
+
+  // --- Broadcast-1 must keep the input's extent, not resize to 1 ---
+  // Result dim 0 is a pure rank-broadcast prefix with no input counterpart, so
+  // its shape entry IS the literal extent.  Result dims 1 and 2 do have input
+  // counterparts (extents 3 and 5), so a `1` there means "don't broadcast this
+  // position" and the extent must come from the input.
+  func.func @expand_broadcast_one(%input: tensor<3x5xf32>, %shape: tensor<3xi64>) -> tensor<?x?x?xf32> {
+    %r = "onnx.Expand"(%input, %shape) : (tensor<3x5xf32>, tensor<3xi64>) -> tensor<?x?x?xf32>
+    return %r : tensor<?x?x?xf32>
+  }
+
+  // CHECK-LABEL: func.func @expand_broadcast_one
+  // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+  // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+  // No input dim at result index 0: entry used verbatim, nothing to compare.
+  // CHECK: %[[E0:.*]] = hip.readback_scalar
+  // CHECK-NEXT: %[[D0:.*]] = arith.index_cast %[[E0]] : i64 to index
+  // CHECK: %[[E1:.*]] = hip.readback_scalar
+  // CHECK-NEXT: %[[S1:.*]] = arith.index_cast %[[E1]] : i64 to index
+  // CHECK-NEXT: %[[I0:.*]] = tensor.dim %{{.*}}, %[[C0]] : tensor<3x5xf32>
+  // CHECK-NEXT: %[[ONE1:.*]] = arith.cmpi eq, %[[S1]], %[[C1]] : index
+  // CHECK-NEXT: %[[D1:.*]] = arith.select %[[ONE1]], %[[I0]], %[[S1]] : index
+  // CHECK: %[[E2:.*]] = hip.readback_scalar
+  // CHECK-NEXT: %[[S2:.*]] = arith.index_cast %[[E2]] : i64 to index
+  // CHECK-NEXT: %[[I1:.*]] = tensor.dim %{{.*}}, %[[C1]] : tensor<3x5xf32>
+  // CHECK-NEXT: %[[ONE2:.*]] = arith.cmpi eq, %[[S2]], %[[C1]] : index
+  // CHECK-NEXT: %[[D2:.*]] = arith.select %[[ONE2]], %[[I1]], %[[S2]] : index
+  // Each dynamic extent reaches the init tensor as the value resolved above.
+  // CHECK: tensor.empty(%[[D0]], %[[D1]], %[[D2]]) : tensor<?x?x?xf32>
+  // CHECK: hip.expand
 }

--- a/test/lit/Conversion/onnx-to-hip/test_reshape.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_reshape.mlir
@@ -116,6 +116,27 @@ module {
     %result = "onnx.Reshape"(%data, %shape) {allowzero = 0 : si64} : (tensor<?x2816xf16>, tensor<3xi64>) -> tensor<?x?x2816xf16>
     return %result : tensor<?x?x2816xf16>
   }
+
+  // --- Dynamic fallback: a shape entry of `0` keeps the input's dim ---
+  // A fully-dynamic source gives the reassoc helpers no static dim to anchor
+  // groups against, so this lands on the tensor.reshape fallback where the
+  // shape operand is consumed as literal extents.  memref.reshape (the
+  // bufferization target) carries no ONNX semantics, so the `0` has to be
+  // resolved here.
+  func.func @test_reshape_dyn_zero_dim(%data: tensor<?x?x?xf16>,
+                                       %shape: tensor<4xi64>)
+      -> tensor<?x?x16x72xf16> {
+    %result = "onnx.Reshape"(%data, %shape) {allowzero = 0 : si64} : (tensor<?x?x?xf16>, tensor<4xi64>) -> tensor<?x?x16x72xf16>
+    return %result : tensor<?x?x16x72xf16>
+  }
+
+  // --- Same reshape with allowzero=1: `0` is a literal size ---
+  func.func @test_reshape_dyn_allowzero(%data: tensor<?x?x?xf16>,
+                                        %shape: tensor<4xi64>)
+      -> tensor<?x?x16x72xf16> {
+    %result = "onnx.Reshape"(%data, %shape) {allowzero = 1 : si64} : (tensor<?x?x?xf16>, tensor<4xi64>) -> tensor<?x?x16x72xf16>
+    return %result : tensor<?x?x16x72xf16>
+  }
 }
 
 // CHECK-LABEL: func.func @test_reshape_expand
@@ -179,5 +200,47 @@ module {
 
 // CHECK-LABEL: func.func @test_reshape_expand_multi_dyn_opaque
 // CHECK-NOT: tensor.expand_shape
+// CHECK: tensor.reshape
+// CHECK-NOT: onnx.Reshape
+
+// A `0` entry must resolve to the input dim at the SAME index, and the RESOLVED
+// value -- not the raw entry -- must feed both the `-1` divisor product and the
+// `-1` substitution.  Feeding the raw entry would make `-1` divide as if this
+// position were size 1 and infer an extent that does not preserve the element
+// count.
+// CHECK-LABEL: func.func @test_reshape_dyn_zero_dim
+// CHECK-DAG: %[[CM1:.*]] = arith.constant -1 : i64
+// CHECK-DAG: %[[CZ:.*]] = arith.constant 0 : i64
+// CHECK-DAG: %[[C1I:.*]] = arith.constant 1 : i64
+// CHECK: tensor.extract_slice %{{.*}}[0] [1] [1]
+// CHECK: %[[E0:.*]] = hip.readback_scalar
+// CHECK-NEXT: %[[ISZ:.*]] = arith.cmpi eq, %[[E0]], %[[CZ]] : i64
+// CHECK-NEXT: %[[ID:.*]] = tensor.dim
+// CHECK-NEXT: %[[IDC:.*]] = arith.index_cast %[[ID]] : index to i64
+// CHECK-NEXT: %[[R0:.*]] = arith.select %[[ISZ]], %[[IDC]], %[[E0]] : i64
+// CHECK-NEXT: arith.cmpi sgt, %[[R0]], %[[C1I]] : i64
+// The trailing entry has no input dim at its index, so no `0` can legally
+// appear there and none is resolved: the raw entry goes straight to the
+// divisor.
+// CHECK: tensor.extract_slice %{{.*}}[3] [1] [1]
+// CHECK: %[[E3:.*]] = hip.readback_scalar
+// CHECK-NEXT: arith.cmpi sgt, %[[E3]], %[[C1I]] : i64
+// CHECK: %[[INF:.*]] = arith.divsi
+// CHECK-NEXT: %[[ISM1:.*]] = arith.cmpi eq, %[[R0]], %[[CM1]] : i64
+// CHECK-NEXT: arith.select %[[ISM1]], %[[INF]], %[[R0]] : i64
+// CHECK: tensor.reshape
+// CHECK-NOT: onnx.Reshape
+
+// With allowzero=1 the entry is already the output dim, so nothing is resolved:
+// the raw entry feeds the divisor and the `-1` substitution directly.
+// CHECK-LABEL: func.func @test_reshape_dyn_allowzero
+// CHECK-DAG: %[[CM1:.*]] = arith.constant -1 : i64
+// CHECK-DAG: %[[C1I:.*]] = arith.constant 1 : i64
+// CHECK: tensor.extract_slice %{{.*}}[0] [1] [1]
+// CHECK: %[[E0:.*]] = hip.readback_scalar
+// CHECK-NEXT: arith.cmpi sgt, %[[E0]], %[[C1I]] : i64
+// CHECK: %[[INF:.*]] = arith.divsi
+// CHECK-NEXT: %[[ISM1:.*]] = arith.cmpi eq, %[[E0]], %[[CM1]] : i64
+// CHECK-NEXT: arith.select %[[ISM1]], %[[INF]], %[[E0]] : i64
 // CHECK: tensor.reshape
 // CHECK-NOT: onnx.Reshape

--- a/test/lit/Conversion/onnx-to-hip/test_reshape.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_reshape.mlir
@@ -209,38 +209,58 @@ module {
 // position were size 1 and infer an extent that does not preserve the element
 // count.
 // CHECK-LABEL: func.func @test_reshape_dyn_zero_dim
+// CHECK-SAME: %[[DATA:[^:]*]]: tensor<?x?x?xf16>, %[[SHAPE:[^:]*]]: tensor<4xi64>
+// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
 // CHECK-DAG: %[[CM1:.*]] = arith.constant -1 : i64
 // CHECK-DAG: %[[CZ:.*]] = arith.constant 0 : i64
 // CHECK-DAG: %[[C1I:.*]] = arith.constant 1 : i64
-// CHECK: tensor.extract_slice %{{.*}}[0] [1] [1]
+// Entry 0 resolves against input dim 0 ...
+// CHECK: tensor.extract_slice %[[SHAPE]][0] [1] [1]
 // CHECK: %[[E0:.*]] = hip.readback_scalar
-// CHECK-NEXT: %[[ISZ:.*]] = arith.cmpi eq, %[[E0]], %[[CZ]] : i64
-// CHECK-NEXT: %[[ID:.*]] = tensor.dim
-// CHECK-NEXT: %[[IDC:.*]] = arith.index_cast %[[ID]] : index to i64
-// CHECK-NEXT: %[[R0:.*]] = arith.select %[[ISZ]], %[[IDC]], %[[E0]] : i64
+// CHECK-NEXT: %[[ISZ0:.*]] = arith.cmpi eq, %[[E0]], %[[CZ]] : i64
+// CHECK-NEXT: %[[ID0:.*]] = tensor.dim %[[DATA]], %[[C0]] : tensor<?x?x?xf16>
+// CHECK-NEXT: %[[IDC0:.*]] = arith.index_cast %[[ID0]] : index to i64
+// CHECK-NEXT: %[[R0:.*]] = arith.select %[[ISZ0]], %[[IDC0]], %[[E0]] : i64
 // CHECK-NEXT: arith.cmpi sgt, %[[R0]], %[[C1I]] : i64
+// ... and entry 1 against input dim 1: the dim index tracks the entry index
+// rather than being pinned to one dim.
+// CHECK: tensor.extract_slice %[[SHAPE]][1] [1] [1]
+// CHECK: %[[E1:.*]] = hip.readback_scalar
+// CHECK-NEXT: %[[ISZ1:.*]] = arith.cmpi eq, %[[E1]], %[[CZ]] : i64
+// CHECK-NEXT: %[[ID1:.*]] = tensor.dim %[[DATA]], %[[C1]] : tensor<?x?x?xf16>
+// CHECK-NEXT: %[[IDC1:.*]] = arith.index_cast %[[ID1]] : index to i64
+// CHECK-NEXT: %[[R1:.*]] = arith.select %[[ISZ1]], %[[IDC1]], %[[E1]] : i64
 // The trailing entry has no input dim at its index, so no `0` can legally
 // appear there and none is resolved: the raw entry goes straight to the
 // divisor.
-// CHECK: tensor.extract_slice %{{.*}}[3] [1] [1]
+// CHECK: tensor.extract_slice %[[SHAPE]][3] [1] [1]
 // CHECK: %[[E3:.*]] = hip.readback_scalar
 // CHECK-NEXT: arith.cmpi sgt, %[[E3]], %[[C1I]] : i64
 // CHECK: %[[INF:.*]] = arith.divsi
-// CHECK-NEXT: %[[ISM1:.*]] = arith.cmpi eq, %[[R0]], %[[CM1]] : i64
-// CHECK-NEXT: arith.select %[[ISM1]], %[[INF]], %[[R0]] : i64
-// CHECK: tensor.reshape
+// CHECK-NEXT: %[[ISM0:.*]] = arith.cmpi eq, %[[R0]], %[[CM1]] : i64
+// CHECK-NEXT: %[[F0:.*]] = arith.select %[[ISM0]], %[[INF]], %[[R0]] : i64
+// CHECK-NEXT: %[[ISM1:.*]] = arith.cmpi eq, %[[R1]], %[[CM1]] : i64
+// CHECK-NEXT: %[[F1:.*]] = arith.select %[[ISM1]], %[[INF]], %[[R1]] : i64
+// The resolved dims are what the reshape actually consumes -- the resolution
+// above is live, not dead arithmetic alongside a raw-entry shape vector.
+// CHECK: %[[NEWSH:.*]] = tensor.from_elements %[[F0]], %[[F1]], %{{.*}} : tensor<4xi64>
+// CHECK-NEXT: tensor.reshape %[[DATA]](%[[NEWSH]])
 // CHECK-NOT: onnx.Reshape
 
 // With allowzero=1 the entry is already the output dim, so nothing is resolved:
-// the raw entry feeds the divisor and the `-1` substitution directly.
+// the raw entry feeds the divisor and the `-1` substitution directly, and it is
+// the raw entry that reaches the reshape.
 // CHECK-LABEL: func.func @test_reshape_dyn_allowzero
+// CHECK-SAME: %[[DATA:[^:]*]]: tensor<?x?x?xf16>, %[[SHAPE:[^:]*]]: tensor<4xi64>
 // CHECK-DAG: %[[CM1:.*]] = arith.constant -1 : i64
 // CHECK-DAG: %[[C1I:.*]] = arith.constant 1 : i64
-// CHECK: tensor.extract_slice %{{.*}}[0] [1] [1]
+// CHECK: tensor.extract_slice %[[SHAPE]][0] [1] [1]
 // CHECK: %[[E0:.*]] = hip.readback_scalar
 // CHECK-NEXT: arith.cmpi sgt, %[[E0]], %[[C1I]] : i64
 // CHECK: %[[INF:.*]] = arith.divsi
-// CHECK-NEXT: %[[ISM1:.*]] = arith.cmpi eq, %[[E0]], %[[CM1]] : i64
-// CHECK-NEXT: arith.select %[[ISM1]], %[[INF]], %[[E0]] : i64
-// CHECK: tensor.reshape
+// CHECK-NEXT: %[[ISM:.*]] = arith.cmpi eq, %[[E0]], %[[CM1]] : i64
+// CHECK-NEXT: %[[F0:.*]] = arith.select %[[ISM]], %[[INF]], %[[E0]] : i64
+// CHECK: %[[NEWSH:.*]] = tensor.from_elements %[[F0]], %{{.*}} : tensor<4xi64>
+// CHECK-NEXT: tensor.reshape %[[DATA]](%[[NEWSH]])
 // CHECK-NOT: onnx.Reshape

--- a/tools/hip-onnx-runner/hip-onnx-runner.cpp
+++ b/tools/hip-onnx-runner/hip-onnx-runner.cpp
@@ -1053,6 +1053,15 @@ int main(int argc, char *argv[]) {
     }
     session_opts.AppendExecutionProvider_V2(env, devices, ep_opts);
     session_opts.AddConfigEntry("session.disable_cpu_ep_fallback", "1");
+    // Match the OGA/genai_config.json production setting: without this, ORT's
+    // ahead-of-time local-function inlining (models that define ops like
+    // CausalConvWithState/LinearAttention as ONNX local functions) triggers an
+    // extra hip-ep compile attempt on the not-yet-Level1-optimized, inlined
+    // graph before the normal partitioning pass ever runs. hip-ep's conversion
+    // patterns match those ops as opaque function-call nodes, not their
+    // inlined primitive decomposition, so that extra pre-optimization compile
+    // attempt sees a graph shape the converter never expects.
+    session_opts.AddConfigEntry("session.disable_aot_function_inlining", "1");
   }
 
   // Free-dimension values for symbolic input dims. Each entry is "name:value".

--- a/tools/hip-onnx-runner/hip-onnx-runner.cpp
+++ b/tools/hip-onnx-runner/hip-onnx-runner.cpp
@@ -1053,15 +1053,6 @@ int main(int argc, char *argv[]) {
     }
     session_opts.AppendExecutionProvider_V2(env, devices, ep_opts);
     session_opts.AddConfigEntry("session.disable_cpu_ep_fallback", "1");
-    // Match the OGA/genai_config.json production setting: without this, ORT's
-    // ahead-of-time local-function inlining (models that define ops like
-    // CausalConvWithState/LinearAttention as ONNX local functions) triggers an
-    // extra hip-ep compile attempt on the not-yet-Level1-optimized, inlined
-    // graph before the normal partitioning pass ever runs. hip-ep's conversion
-    // patterns match those ops as opaque function-call nodes, not their
-    // inlined primitive decomposition, so that extra pre-optimization compile
-    // attempt sees a graph shape the converter never expects.
-    session_opts.AddConfigEntry("session.disable_aot_function_inlining", "1");
   }
 
   // Free-dimension values for symbolic input dims. Each entry is "name:value".


### PR DESCRIPTION
## Summary

`ExpandConversion` treated every `shape` entry as a literal target extent, and
`ReshapeConversion` treated a `0` entry as a literal size-0 dim. Both are wrong
per ONNX: `Expand`'s shape operand is a broadcast target (`1` means "do not
broadcast here"), and `Reshape`'s `0` means "keep the input dim at this index"
unless `allowzero=1`. Models that put those markers on dynamic dims had those
dims collapsed to 1.

## Related issue or design

None.

## Why

The two operators each carry a shape-operand convention that this code did not
implement, and the gap only shows up when the marker lands on a *dynamic* dim:

- **`Expand`**: the output extent at a position is `max(input_dim, shape_dim)`.
  A `1` in `shape` where the input carries a real extent means "do not broadcast
  this position", i.e. keep the input's extent. The old code took the entry
  literally, resizing the position to 1.
- **`Reshape`**: a shape entry of literal `0` means "keep the input's dim at the
  same index", not a size-0 dim, unless `allowzero=1` (opset >= 14) makes it a
  literal size like any other entry. The old code passed `0` through as an
  extent, and — worse — fed the raw `0` into the `-1` inference product, so a
  shape carrying both `0` and `-1` divided as if that position were size 1 and
  inferred an extent that does not preserve the element count.

Nemotron mamba blocks hit both at once, reshaping `[bs*ss, H]` to/from
`[bs, ss, H]` via `Reshape(_, [0, 0, H])` and `Expand(_, [1, 1, 1, 16, 1])` —
putting the markers on the dynamic batch/seq dims rather than the static feature
dim this code had only ever seen them on. Both collapsed batch/seq to 1, which
corrupted the residual stream with stale pool memory from layer 0 onward: fp16
overflow, NaN prefill logits, and generation stopping after one token.

For `Reshape` this only matters on the `tensor.reshape` fallback path. The
reassociation helpers handle the shape operand structurally, so the fix belongs
where the operand is consumed as literal extents — and it has to be there
because `memref.reshape`, the bufferization target, carries no ONNX semantics of
its own.

## What

- `lib/Conversion/OnnxToHip/ExpandConversion.cpp`: when a shape entry has a
  corresponding input dim, emit
  `select(shape_dim == 1, input_dim, shape_dim)` instead of using the entry
  verbatim. A leading dim absent from the input rank is pure rank-broadcast, so
  there the entry really is the literal extent and is still used as-is.
- `lib/Conversion/OnnxToHip/ReshapeConversion.cpp`: resolve a `0` entry to
  `tensor.dim(data, i)` *before* it feeds the `-1` inference product, guarded on
  `!allowzero && i < inputRank`. `allowzero` is read via
  `getValue().getSExtValue()` rather than `IntegerAttr::getInt()`, which asserts
  on the signed `SI64Attr` the attribute actually is — matching how other
  conversions in this tree read `SI64Attr`. The two skipped cases need no
  resolution: with `allowzero=1` the entry is already the output dim, and at
  `i >= inputRank` a `0` names a nonexistent input dim, which upstream shape
  inference already rejects.
- The pattern doc comments now state the ONNX semantics the code depends on, and
  the `Before:`/`After:` sketch shows the new resolution step.

## Test plan

LIT coverage was added on the paths that actually consume the shape operand
(`test/lit/Conversion/onnx-to-hip/`, +113 lines):

- [x] `test_reshape_dyn_zero_dim`: a fully-dynamic source, so the reassoc
      helpers find no anchor and this lands on the `tensor.reshape` fallback.
      Asserts entry 0 resolves against input dim 0 *and* entry 1 against input
      dim 1 (so the dim index has to track the entry index rather than being
      pinned to one dim); that the *resolved* value feeds both the `-1` divisor
      and the `-1` substitution; that the trailing entry, having no input dim at
      its index, is left unresolved; and that the resolved dims reach
      `tensor.from_elements` → `tensor.reshape`, so the resolution is live
      rather than dead arithmetic beside a raw-entry shape vector.
- [x] `test_reshape_dyn_allowzero`: the same reshape with `allowzero=1` resolves
      nothing and the raw entry reaches the reshape.
- [x] `test_expand_broadcast_one`: a `1` entry resolves to the input extent
      where an input counterpart exists, and is used verbatim on the
      pure-rank-broadcast prefix dim; each resolved extent reaches
      `tensor.empty`.
- [x] Both holes the first version of these assertions left open (an unbound
      `tensor.dim` index, and no link from the resolved dims to
      `tensor.from_elements`) now fail under mutation.
- [x] Repository CI ran on `db6187a` (accuracy/perf bot results posted on the
      PR, run 5304).
- [ ] Nemotron end-to-end (prefill logits finite, generation past the first
      token) — to be filled in with the run this was originally reproduced and
      fixed against.

## Notes for reviewers

- The first commit's message ends with "See
  `docs/nemotron-mamba-shape-collapse.md`", but that document is not part of
  this PR and does not exist on `main`. Treat this description as the
  root-cause writeup, or land the doc separately.
- That same commit describes a `hip-onnx-runner.cpp`
  `disable_aot_function_inlining` change; it was deliberately dropped in
  `43798581` as unrelated to the conversion fix, so it is not in the diff. If
  that session option is still needed for Nemotron, it needs its own PR.
- The branch is currently 9 commits behind `main`.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.

AI assistance: the fix, the LIT assertions, and this description were developed
with Cursor (trailers on each commit); validation was the LIT coverage above,
including the mutation checks that closed the two gaps in the first version of
the Reshape assertions.
