### PR TITLE
fix(onnx-to-hip): revert #782 slice dynamic extent computation

### DIFF
--- a/lib/Conversion/OnnxToHip/SliceConversion.cpp
+++ b/lib/Conversion/OnnxToHip/SliceConversion.cpp
@@ -32,26 +32,11 @@ namespace {
 //     at compile time.
 //
 //   * SliceToHip (benefit=1) — fallback for non-constant indices or negative
-//     steps. Produces a native `hip.slice` DPS op, executed by `wrap_slice` in
-//     Runtime/real/slice.cpp since #284 (this comment claimed a throwing stub
-//     long after that landed). Worth knowing when reading the extent logic
-//     below: that runtime D2Hs starts/ends/axes/steps and synchronizes the
-//     stream on every call, so this op already costs a host sync per
-//     execution. Dynamic output dims are computed from
-//     the slice bounds when those are host-resolvable, and otherwise fall back
-//     to `tensor.dim` on `data` (an upper bound — Slice cannot widen any axis).
-//
-// That fallback is only an upper bound, and an upper bound is not a safe
-// stand-in for the extent: the extent this pattern puts on the `tensor.empty`
-// init IS the output shape as far as everything downstream is concerned, since
-// `tensor.dim` of a DPS result resolves through to the init. A Slice that keeps
-// one row of a 12k-row tensor therefore hands every consumer a 12k-row shape.
-// Gemma-4 26B-A4B decode does exactly this — `Slice(CumSum(attention_mask),
-// Shape(attn)[1] - Shape(ids)[1], Shape(attn)[1])` takes the single current
-// query position — and the inflated extent turned the causal mask from
-// [1, 1, S] into [1, S, S], 60% of a decode step. Hence resolveHostIndex:
-// `ends - starts` is host arithmetic over `onnx.Shape` entries, so the true
-// extent is computable without any device readback.
+//     steps. Produces a native `hip.slice` DPS op whose runtime function is
+//     a stub today (throws); models that hit this path are unsupported until
+//     the runtime is implemented, but the conversion / bufferization pipeline
+//     can still verify and link the IR. Dynamic output dims are sourced from
+//     `tensor.dim` on `data` (an upper bound — Slice cannot widen any axis).
 
 /// Return the dense-elements attribute backing \p value if it can be
 /// determined at compile time. Recognizes arith constants, inspectable
@@ -133,156 +118,6 @@ static mlir::Value normaliseOptional(mlir::Value v) {
   if (defOp && defOp->getName().getStringRef() == "onnx.NoValue")
     return mlir::Value();
   return v;
-}
-
-/// Producer-chain depth walked by `resolveHostIndex`. Shape arithmetic in
-/// exported graphs is a handful of ops deep; the bound only stops a
-/// pathological walk.
-static constexpr int kHostIndexMaxDepth = 8;
-
-/// Resolve element \p idx of an integer shape tensor \p v to a host `index`
-/// SSA value, materializing `arith` ops as needed. Returns a null Value when
-/// the element is not host-computable.
-///
-/// Both the pre- and post-conversion spelling of ONNX shape arithmetic are
-/// accepted, because the greedy driver gives no ordering guarantee between this
-/// pattern and the ones rewriting the producers: `onnx.Shape` may still be
-/// present, or may already be
-/// `tensor.from_elements(arith.index_cast(tensor.dim))`, and `onnx.Sub` may
-/// already be `hip.sub`. On Gemma-4 26B-A4B it is in practice the ONNX
-/// spelling that arrives here, this pattern running first; the post-conversion
-/// spelling is covered by test 10 in test_slice.mlir rather than by a model,
-/// since nothing pins the order and losing either branch silently costs the
-/// extent.
-static mlir::Value resolveHostIndex(mlir::OpBuilder &b, mlir::Location loc,
-                                    mlir::Value v, int64_t idx, int depth) {
-  if (!v || idx < 0 || depth > kHostIndexMaxDepth)
-    return {};
-  auto vType = mlir::dyn_cast<mlir::RankedTensorType>(v.getType());
-  if (!vType || !vType.getElementType().isSignlessInteger())
-    return {};
-  // Bound the request against the value's own extent once, here, rather than in
-  // each producer branch: an out-of-range element must fail rather than resolve
-  // to something plausible. Without this an `onnx.Shape` narrowed by its `end`
-  // attribute would hand back dim(start + idx) for an element it does not have,
-  // which is the same class of silently-wrong extent this file exists to fix.
-  if (vType.hasStaticShape() && idx >= vType.getNumElements())
-    return {};
-
-  if (mlir::DenseElementsAttr dense = getCompileTimeConstantTensor(v)) {
-    if (idx >= dense.getNumElements())
-      return {};
-    return mlir::arith::ConstantIndexOp::create(
-        b, loc,
-        (*(dense.getValues<mlir::APInt>().begin() + idx)).getSExtValue());
-  }
-
-  mlir::Operation *def = v.getDefiningOp();
-  if (!def)
-    return {};
-
-  if (auto fromElems = mlir::dyn_cast<mlir::tensor::FromElementsOp>(def)) {
-    if (idx >= static_cast<int64_t>(fromElems.getElements().size()))
-      return {};
-    mlir::Value elem = fromElems.getElements()[idx];
-    // ShapeToTensorDims index_casts every tensor.dim to i64 to pack it; take
-    // the index back rather than casting a second time.
-    if (auto cast = elem.getDefiningOp<mlir::arith::IndexCastOp>())
-      if (cast.getIn().getType().isIndex())
-        return cast.getIn();
-    return mlir::arith::IndexCastOp::create(b, loc, b.getIndexType(), elem);
-  }
-
-  if (auto cast = mlir::dyn_cast<mlir::tensor::CastOp>(def))
-    return resolveHostIndex(b, loc, cast.getSource(), idx, depth + 1);
-
-  llvm::StringRef opName = def->getName().getStringRef();
-
-  // Unconverted onnx.Shape: element idx is dim (start + idx) of the operand.
-  // `start` is normalized as ShapeToTensorDims normalizes it; `end` only bounds
-  // how many elements exist, which the caller-side extent check above covers.
-  if (opName == "onnx.Shape") {
-    mlir::Value input = def->getOperand(0);
-    auto inType = mlir::dyn_cast<mlir::RankedTensorType>(input.getType());
-    if (!inType)
-      return {};
-    int64_t rank = inType.getRank();
-    int64_t start = 0;
-    if (auto startAttr = def->getAttrOfType<mlir::IntegerAttr>("start"))
-      start = startAttr.getSInt();
-    if (start < 0)
-      start += rank;
-    start = std::max(start, int64_t(0));
-    int64_t dimIdx = start + idx;
-    if (dimIdx < 0 || dimIdx >= rank)
-      return {};
-    if (!inType.isDynamicDim(dimIdx))
-      return mlir::arith::ConstantIndexOp::create(b, loc,
-                                                  inType.getDimSize(dimIdx));
-    return mlir::tensor::DimOp::create(b, loc, input, dimIdx);
-  }
-
-  // Binary shape arithmetic. hip elementwise ops are DPS, so their operands are
-  // (ctx, lhs, rhs, out); the ONNX forms are plain (lhs, rhs).
-  unsigned lhsPos = 0;
-  bool isHip =
-      mlir::isa<mlir::hip::SubOp, mlir::hip::AddOp, mlir::hip::MulOp>(def);
-  if (isHip)
-    lhsPos = 1;
-  else if (opName != "onnx.Sub" && opName != "onnx.Add" && opName != "onnx.Mul")
-    return {};
-
-  mlir::Value lhs = def->getOperand(lhsPos);
-  mlir::Value rhs = def->getOperand(lhsPos + 1);
-  // A rank-0 or single-element operand is broadcast against the other.
-  auto elemIdx = [&](mlir::Value operand) -> int64_t {
-    auto t = mlir::dyn_cast<mlir::RankedTensorType>(operand.getType());
-    return (t && t.hasStaticShape() && t.getNumElements() == 1) ? 0 : idx;
-  };
-  mlir::Value l = resolveHostIndex(b, loc, lhs, elemIdx(lhs), depth + 1);
-  mlir::Value r = resolveHostIndex(b, loc, rhs, elemIdx(rhs), depth + 1);
-  if (!l || !r)
-    return {};
-
-  bool isSub = isHip ? mlir::isa<mlir::hip::SubOp>(def) : opName == "onnx.Sub";
-  bool isAdd = isHip ? mlir::isa<mlir::hip::AddOp>(def) : opName == "onnx.Add";
-  if (isSub)
-    return mlir::arith::SubIOp::create(b, loc, l, r);
-  if (isAdd)
-    return mlir::arith::AddIOp::create(b, loc, l, r);
-  return mlir::arith::MulIOp::create(b, loc, l, r);
-}
-
-/// Emit the number of elements ONNX Slice produces on one axis, given runtime
-/// `start`/`end` bounds and a positive compile-time \p step. Mirrors the
-/// compile-time arithmetic in SliceDecompose; `arith` ops are needed here only
-/// because the bounds are not known until run time.
-static mlir::Value buildSliceExtent(mlir::OpBuilder &b, mlir::Location loc,
-                                    mlir::Value dim, mlir::Value start,
-                                    mlir::Value end, int64_t step) {
-  mlir::Value zero = mlir::arith::ConstantIndexOp::create(b, loc, 0);
-  // A negative bound counts from the end, and the sign is not known until run
-  // time, so both forms are computed and selected between. Neither sentinel
-  // exporters use needs special handling: INT64_MAX ("to the end") stays
-  // positive, so `v + dim` overflows but is never selected, and the clamp
-  // returns `dim`; INT64_MIN ("from the beginning") cannot overflow, since
-  // adding a non-negative `dim` only moves it toward zero.
-  auto normalize = [&](mlir::Value v) -> mlir::Value {
-    mlir::Value shifted = mlir::arith::AddIOp::create(b, loc, v, dim);
-    mlir::Value isNeg = mlir::arith::CmpIOp::create(
-        b, loc, mlir::arith::CmpIPredicate::slt, v, zero);
-    mlir::Value picked =
-        mlir::arith::SelectOp::create(b, loc, isNeg, shifted, v);
-    picked = mlir::arith::MaxSIOp::create(b, loc, picked, zero);
-    return mlir::arith::MinSIOp::create(b, loc, picked, dim);
-  };
-  mlir::Value len =
-      mlir::arith::SubIOp::create(b, loc, normalize(end), normalize(start));
-  len = mlir::arith::MaxSIOp::create(b, loc, len, zero);
-  if (step == 1)
-    return len;
-  return mlir::arith::CeilDivSIOp::create(
-      b, loc, len, mlir::arith::ConstantIndexOp::create(b, loc, step));
 }
 
 struct SliceDecompose : public mlir::RewritePattern {
@@ -488,42 +323,11 @@ struct SliceToHip : public mlir::RewritePattern {
 
     auto dataType = mlir::cast<mlir::RankedTensorType>(data.getType());
 
-    // Which axes are sliced, and with what step. Both must be known to compute
-    // an extent; a non-constant axes/steps operand leaves every dim on the
-    // conservative upper bound below.
-    llvm::SmallVector<int64_t> axesVec, stepsVec;
-    bool haveAxes = true;
-    if (axes)
-      haveAxes = mlir::succeeded(
-          extractSliceParamVector(op, "hipdnn.slice_axes", axes, axesVec));
-    if (haveAxes && axesVec.empty())
-      for (int64_t i : llvm::seq<int64_t>(dataType.getRank()))
-        axesVec.push_back(i);
-    if (steps && haveAxes)
-      haveAxes = mlir::succeeded(
-          extractSliceParamVector(op, "hipdnn.slice_steps", steps, stepsVec));
-    if (haveAxes && stepsVec.empty())
-      stepsVec.assign(axesVec.size(), 1);
-    if (stepsVec.size() != axesVec.size())
-      haveAxes = false;
-
-    // Compute each dynamic output dim from the slice bounds where possible;
-    // see the file header for why the data dim is not an acceptable substitute.
-    // Ops materialized by a resolution that then fails are pure and get DCE'd.
-    //
-    // Where the bounds do not resolve, the fallback keeps the upper bound and
-    // therefore keeps the over-sized shape. It could be exact instead:
-    // CompressConversion solves the same shrinking-extent problem by reading
-    // the true count back from the device with `hip.ReadbackDimOp`. That is not
-    // done here, but not because a readback is unaffordable on this op --
-    // `wrap_slice` already D2Hs its own bounds and syncs the stream every call,
-    // so the sync is paid regardless. It is that a readback would add a second
-    // sync point, in the shape computation ahead of the slice, to serve a case
-    // no model in scope reaches: on Gemma-4 every sliced axis resolves from its
-    // bounds, and host arithmetic is strictly better than a readback wherever
-    // it is available. If a model does land here, revisit it -- the cost is
-    // lower than it looks. Hence the debug line below: the fallback is a known
-    // performance cliff, and it should be findable without an RGP capture.
+    // For each dynamic output dim, source an upper bound from the data
+    // dim at the same position. This is sound because ONNX Slice can
+    // never widen any axis -- output dim i is at most data dim i. The
+    // runtime stub honours `output_shape[i]` as the actual extent so the
+    // over-allocation is benign.
     llvm::SmallVector<mlir::Value> dynSizes;
     for (int64_t i = 0; i < resultType.getRank(); ++i) {
       if (!resultType.isDynamicDim(i))
@@ -531,44 +335,11 @@ struct SliceToHip : public mlir::RewritePattern {
       if (i >= dataType.getRank())
         return rewriter.notifyMatchFailure(
             op, "result rank exceeds data rank — invalid Slice");
-
-      mlir::Value dim =
-          dataType.isDynamicDim(i)
-              ? mlir::tensor::DimOp::create(rewriter, loc, data, i).getResult()
-              : mlir::arith::ConstantIndexOp::create(rewriter, loc,
-                                                     dataType.getDimSize(i))
-                    .getResult();
-
-      mlir::Value extent;
-      // An axis `axes` does not name is not sliced at all, so the data dim is
-      // its exact extent rather than a fallback. Only an axis this op really
-      // slices can land on the upper bound, so only that is worth reporting --
-      // and if `axes` itself was unreadable, any axis might be sliced.
-      bool axisIsSliced = !haveAxes;
-      if (haveAxes) {
-        for (size_t k = 0; k < axesVec.size(); ++k) {
-          int64_t axis =
-              axesVec[k] < 0 ? axesVec[k] + dataType.getRank() : axesVec[k];
-          if (axis != i)
-            continue;
-          axisIsSliced = true;
-          if (stepsVec[k] <= 0)
-            break;
-          mlir::Value s = resolveHostIndex(rewriter, loc, starts, k, 0);
-          mlir::Value e = resolveHostIndex(rewriter, loc, ends, k, 0);
-          if (s && e)
-            extent = buildSliceExtent(rewriter, loc, dim, s, e, stepsVec[k]);
-          break;
-        }
-      }
-      if (!extent && axisIsSliced)
-        LLVM_DEBUG(llvm::dbgs()
-                   << "[" DEBUG_TYPE "] slice extent for dim " << i
-                   << " falls back to the data dim: no host-resolvable bounds "
-                      "(or a non-positive step), so consumers see an upper "
-                      "bound rather than the slice length -- "
-                   << *op << "\n");
-      dynSizes.push_back(extent ? extent : dim);
+      if (dataType.isDynamicDim(i))
+        dynSizes.push_back(mlir::tensor::DimOp::create(rewriter, loc, data, i));
+      else
+        dynSizes.push_back(mlir::arith::ConstantIndexOp::create(
+            rewriter, loc, dataType.getDimSize(i)));
     }
     mlir::Value init =
         mlir::tensor::EmptyOp::create(rewriter, loc, resultType.getShape(),

--- a/test/lit/Conversion/onnx-to-hip/test_slice.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_slice.mlir
@@ -127,9 +127,8 @@ module {
 
   // Test 7: SliceDecompose bails when a sliced axis has a dynamic
   // input dim (ONNX clamping rules need the static dim size); falls
-  // through to hip.slice. The output extent is still the slice length --
-  // clamp(end) - clamp(start) -- not the data dim, which is only an upper
-  // bound and would be handed to every consumer as the shape.
+  // through to hip.slice. The data dim is forwarded as an upper-bound
+  // tensor.dim for the dynamic output dim.
   func.func @test_slice_native_dyn_axis(%input: tensor<?xf32>) -> tensor<?xf32> {
     // CHECK-LABEL: func.func @test_slice_native_dyn_axis
     %starts = arith.constant dense<[1]> : tensor<1xi64>
@@ -141,120 +140,10 @@ module {
            tensor<1xi64>, tensor<1xi64>) -> tensor<?xf32>
 
     // CHECK-NOT: tensor.extract_slice
-    // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
-    // CHECK-DAG: %[[C3:.*]] = arith.constant 3 : index
-    // CHECK-DAG: %[[DIM:.*]] = tensor.dim %{{.*}} : tensor<?xf32>
-    // CHECK: %[[LO:.*]] = arith.minsi %{{.*}}, %[[DIM]] : index
-    // CHECK: %[[HI:.*]] = arith.minsi %{{.*}}, %[[DIM]] : index
-    // CHECK: %[[LEN:.*]] = arith.subi %[[HI]], %[[LO]] : index
-    // CHECK: %[[EXT:.*]] = arith.maxsi %[[LEN]], %{{.*}} : index
-    // CHECK: tensor.empty(%[[EXT]]) : tensor<?xf32>
+    // CHECK-DAG: %[[A0:.*]] = arith.constant 0 : index
+    // CHECK-DAG: %[[DIM:.*]] = tensor.dim %{{.*}}, %[[A0]] : tensor<?xf32>
+    // CHECK: tensor.empty(%[[DIM]]) : tensor<?xf32>
     // CHECK: hip.slice({{.*}}) ins({{.*}}, {{.*}}, {{.*}} : tensor<?xf32>, tensor<1xi64>, tensor<1xi64>)
     return %r : tensor<?xf32>
-  }
-
-  // Test 8: the decode-mask idiom from Gemma-4 26B-A4B. `starts` is
-  // Shape(attn)[1] - Shape(ids)[1] and `ends` is Shape(attn)[1], so the slice
-  // keeps the current query positions only -- one row during decode. Both
-  // bounds are host arithmetic over onnx.Shape, so the extent is computable
-  // with no device readback, and the resulting empty must NOT be sized by the
-  // data dim: that is what inflated the causal mask to [1, S, S] and cost 60%
-  // of a decode step.
-  func.func @test_slice_native_shape_sub_extent(
-      %data: tensor<?x?xi64>, %ids: tensor<?x?xi64>, %attn: tensor<?x?xi64>)
-      -> tensor<?x?xi64> {
-    // CHECK-LABEL: func.func @test_slice_native_shape_sub_extent
-    %axes = arith.constant dense<[1]> : tensor<1xi64>
-    %ids_len  = "onnx.Shape"(%ids)  {start = 1 : si64, end = 2 : si64}
-        : (tensor<?x?xi64>) -> tensor<1xi64>
-    %attn_len = "onnx.Shape"(%attn) {start = 1 : si64, end = 2 : si64}
-        : (tensor<?x?xi64>) -> tensor<1xi64>
-    %starts = "onnx.Sub"(%attn_len, %ids_len)
-        : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
-    %r = "onnx.Slice"(%data, %starts, %attn_len, %axes)
-        : (tensor<?x?xi64>, tensor<1xi64>, tensor<1xi64>,
-           tensor<1xi64>) -> tensor<?x?xi64>
-
-    // SliceToHip fires before the operands are rewritten, so `starts` resolves
-    // through the ONNX spelling (onnx.Sub of two onnx.Shape) and the walker
-    // emits the tensor.dim / arith.subi below itself. That is also the order
-    // Gemma-4 takes in the real pipeline, so this is the production path; test
-    // 10 covers the post-conversion spelling, which the same walk accepts
-    // because the greedy driver does not guarantee either order.
-    // CHECK: %[[D0:.*]] = tensor.dim %arg1, %{{.*}} : tensor<?x?xi64>
-    // CHECK: %[[D1:.*]] = tensor.dim %arg1, %{{.*}} : tensor<?x?xi64>
-    // CHECK: arith.subi %{{.*}}, %{{.*}} : index
-    // CHECK: %[[LO:.*]] = arith.minsi %{{.*}}, %[[D1]] : index
-    // CHECK: %[[HI:.*]] = arith.minsi %{{.*}}, %[[D1]] : index
-    // CHECK: %[[LEN:.*]] = arith.subi %[[HI]], %[[LO]] : index
-    // CHECK: %[[EXT:.*]] = arith.maxsi %[[LEN]], %{{.*}} : index
-    // CHECK: tensor.empty(%[[D0]], %[[EXT]]) : tensor<?x?xi64>
-    // CHECK: hip.slice
-    return %r : tensor<?x?xi64>
-  }
-
-  // Test 9: an opaque `starts` (a graph input, not shape arithmetic) is not
-  // host-resolvable, so the extent falls back to the data dim upper bound
-  // rather than emitting an extent that cannot be justified.
-  func.func @test_slice_native_opaque_starts(
-      %data: tensor<?xi64>, %starts: tensor<1xi64>, %ends: tensor<1xi64>)
-      -> tensor<?xi64> {
-    // CHECK-LABEL: func.func @test_slice_native_opaque_starts
-    %axes = arith.constant dense<[0]> : tensor<1xi64>
-    %r = "onnx.Slice"(%data, %starts, %ends, %axes)
-        : (tensor<?xi64>, tensor<1xi64>, tensor<1xi64>,
-           tensor<1xi64>) -> tensor<?xi64>
-
-    // CHECK-NOT: arith.minsi
-    // CHECK: %[[DIM:.*]] = tensor.dim %arg1, %{{.*}} : tensor<?xi64>
-    // CHECK: tensor.empty(%[[DIM]]) : tensor<?xi64>
-    // CHECK: hip.slice
-    return %r : tensor<?xi64>
-  }
-
-  // Test 10: the same idiom already rewritten into the post-conversion
-  // spelling, which is the other order the greedy driver may produce and which
-  // test 8 therefore does not reach. Feeding it pre-lowered pins that branch of
-  // the walk: `from_elements(index_cast(tensor.dim))` for the shapes and
-  // hip.sub for the arithmetic, with the index_cast unwrapped rather than cast
-  // a second time. Without a test here, an ordering change elsewhere would
-  // silently drop back to the data-dim upper bound and nothing would fail.
-  func.func @test_slice_native_lowered_shape_sub_extent(
-      %ctx: !hip.context, %data: tensor<?x?xi64>, %ids: tensor<?x?xi64>,
-      %attn: tensor<?x?xi64>) -> tensor<?x?xi64> {
-    // CHECK-LABEL: func.func @test_slice_native_lowered_shape_sub_extent
-    %c1 = arith.constant 1 : index
-    %axes = arith.constant dense<[1]> : tensor<1xi64>
-
-    %ids_dim = tensor.dim %ids, %c1 : tensor<?x?xi64>
-    %ids_i64 = arith.index_cast %ids_dim : index to i64
-    %ids_len = tensor.from_elements %ids_i64 : tensor<1xi64>
-
-    %attn_dim = tensor.dim %attn, %c1 : tensor<?x?xi64>
-    %attn_i64 = arith.index_cast %attn_dim : index to i64
-    %attn_len = tensor.from_elements %attn_i64 : tensor<1xi64>
-
-    %sub_init = tensor.empty() : tensor<1xi64>
-    %starts = hip.sub(%ctx) ins(%attn_len, %ids_len : tensor<1xi64>,
-        tensor<1xi64>) outs(%sub_init : tensor<1xi64>) : tensor<1xi64>
-
-    %r = "onnx.Slice"(%data, %starts, %attn_len, %axes)
-        : (tensor<?x?xi64>, tensor<1xi64>, tensor<1xi64>,
-           tensor<1xi64>) -> tensor<?x?xi64>
-
-    // The bounds resolve to the two dims the from_elements were packed from,
-    // with the index_cast unwrapped, so `starts` is an index-domain subi of
-    // them; the extent is then the clamped end minus the clamped start, not the
-    // data dim.
-    // CHECK: %[[D0:.*]] = tensor.dim %arg1, %{{.*}} : tensor<?x?xi64>
-    // CHECK: %[[D1:.*]] = tensor.dim %arg1, %{{.*}} : tensor<?x?xi64>
-    // CHECK: arith.subi %{{.*}}, %{{.*}} : index
-    // CHECK: %[[LO:.*]] = arith.minsi %{{.*}}, %[[D1]] : index
-    // CHECK: %[[HI:.*]] = arith.minsi %{{.*}}, %[[D1]] : index
-    // CHECK: %[[LEN:.*]] = arith.subi %[[HI]], %[[LO]] : index
-    // CHECK: %[[EXT:.*]] = arith.maxsi %[[LEN]], %{{.*}} : index
-    // CHECK: tensor.empty(%[[D0]], %[[EXT]]) : tensor<?x?xi64>
-    // CHECK: hip.slice
-    return %r : tensor<?x?xi64>
   }
 }


### PR DESCRIPTION
## Summary

Revert #782 (`fix(onnx-to-hip): compute dynamic hip.slice extents from the slice bounds`).

## Related issue or design

Reverts #782

## Why

The dynamic `hip.slice` extent computation from slice bounds is being rolled back pending further investigation.

## What

Revert merge commit 86cc6bb0ba0f8888455dec5a2353d436d7b9e989, restoring the prior upper-bound sizing from the data dimension for unresolved dynamic extents in `SliceConversion.cpp` and the pre-#782 lit coverage in `test_slice.mlir`.

## Test plan

- [ ] `build-windows` green on cold cache
- [ ] `onnx-to-hip` lit suite passes (including `test_slice.mlir`)

## Notes for reviewers

None

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [ ] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
