### PR TITLE
ci(windows): add Qwen VLM benchmark to gpu-test

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1075,6 +1075,63 @@ jobs:
             2>&1 | Tee-Object -FilePath "oga-smoke-results\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml.txt"
           exit $LASTEXITCODE
 
+      - name: Run VLM benchmark (Python + C++ bin)
+        if: always()
+        timeout-minutes: 40
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $PSNativeCommandUseErrorActionPreference = $false
+
+          $vlmRoot = "${{ vars.GPU_TEST_ASSET_ROOT || runner.workspace }}\amdgpu-vlm-models"
+          $vlmImage = "${{ vars.GPU_TEST_ASSET_ROOT || runner.workspace }}\amdgpu-vlm-images\dog.jpg"
+          if (-not (Test-Path $vlmRoot)) { Write-Host "[SKIP] VLM model dir not found: $vlmRoot"; exit 0 }
+          if (-not (Test-Path $vlmImage)) { Write-Host "[SKIP] VLM image not found: $vlmImage"; exit 0 }
+
+          $bin = "$PWD\gpu-test-package\bin"
+          $script = "$PWD\wheelpkg\vlm_benchmark.py"
+          if (-not (Test-Path $script)) { Write-Host "[SKIP] vlm_benchmark.py not found: $script"; exit 0 }
+
+          $venv = "$PWD\vlm-venv"
+          if (Test-Path $venv) { Remove-Item $venv -Recurse -Force }
+          python -m venv $venv
+          $py = "$venv\Scripts\python.exe"
+          Push-Location "$PWD\gpu-test-package\wheels"
+          & $py -m pip install --quiet `
+            (Get-Item onnxruntime_directml-*.whl).Name `
+            (Get-Item onnxruntime_genai_directml-*.whl).Name `
+            Pillow numpy psutil
+          Pop-Location
+          if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] wheel install failed"; exit 1 }
+
+          $launcher = "$PWD\run_vlm.py"
+          @'
+          import ctypes, os, runpy, sys
+          BIN = sys.argv[1]
+          os.add_dll_directory(BIN)
+          os.environ["PATH"] = BIN + os.pathsep + os.environ.get("PATH", "")
+          ctypes.CDLL(os.path.join(BIN, "onnxruntime.dll"))
+          sys.argv = sys.argv[2:]
+          runpy.run_path(sys.argv[0], run_name="__main__")
+          '@ | Set-Content -Path $launcher -Encoding UTF8
+
+          New-Item -ItemType Directory -Force -Path "vlm-results" | Out-Null
+          $failed = 0
+          foreach ($modelDir in (Get-ChildItem $vlmRoot -Directory)) {
+            if (-not (Test-Path (Join-Path $modelDir.FullName "genai_config.json"))) {
+              Write-Host "[SKIP] No genai_config.json in $($modelDir.Name)"
+              continue
+            }
+            $outFile = "vlm-results\$($modelDir.Name).txt"
+            Write-Host "=== VLM Benchmark: $($modelDir.Name) ==="
+            & $py $launcher $bin $script `
+              -m $modelDir.FullName -i $vlmImage -p "Describe this image in detail." `
+              --max_tokens 128 --max_length 4096 -n 3 -w 1 -v `
+              2>&1 | Tee-Object -FilePath $outFile
+            if ($LASTEXITCODE -ne 0) { $failed = 1 }
+          }
+          exit $failed
+
       # -----------------------------------------------------------------------
       # L2 accuracy test: compare MorphiZen EP vs CPU output for each model
       # in l2-test-models/. Skipped gracefully when directory does not exist.
@@ -1328,8 +1385,37 @@ jobs:
                             $smokeRows
           }
 
+          # --- VLM benchmark (vlm_benchmark.py) results ---
+          $vlmRows = ""
+          foreach ($f in (Get-ChildItem "vlm-results/*.txt" -ErrorAction SilentlyContinue)) {
+            $model = $f.BaseName
+            $content = Get-Content $f.FullName -Raw
+            $ttftMatch = [regex]::Match($content, 'Time To First Token \(TTFT\):\s*\n\s*Average:\s+([\d.]+)\s*ms')
+            $tpsMatch  = [regex]::Match($content, 'TPS:\s+([\d.]+)\s*tokens/sec')
+            $ttft = if ($ttftMatch.Success) { "{0:F1}" -f [double]$ttftMatch.Groups[1].Value } else { "-" }
+            $tps  = if ($tpsMatch.Success) { "{0:F1}" -f [double]$tpsMatch.Groups[1].Value } else { "-" }
+            $genMatch = [regex]::Match($content, '(?s)Generated output:\s*\n\s*-{10,}\s*\n(.*?)\n\s*-{10,}')
+            $gen = if ($genMatch.Success) {
+              $g = $genMatch.Groups[1].Value.Trim()
+              if ($g.Length -gt 128) { $g = $g.Substring(0, 128) }
+              ($g -replace '\r?\n', ' ' -replace '\|', '\|').Trim()
+            } else { "-" }
+            if ($ttftMatch.Success) {
+              $vlmRows += "| $model | $ttft | $tps | $gen |`n"
+            } else {
+              $vlmRows += "| $model | failed | - | $gen |`n"
+            }
+          }
+          $vlmSection = ""
+          if ($vlmRows) {
+            $vlmSection = "`n## VLM Benchmark Results`n`n" +
+                          "| Model | TTFT (ms) | TPS | Output |`n" +
+                          "|-------|----:|----:|-------|`n" +
+                          $vlmRows
+          }
+
           $footer = "`nRun: [${{ github.run_number }}]($runUrl) - Commit: ``$sha``"
-          $summary = $header + $tableRows + $epctxSection + $ogaSection + $smokeSection + $footer
+          $summary = $header + $tableRows + $epctxSection + $ogaSection + $smokeSection + $vlmSection + $footer
 
           # Always write to step summary and log
           Write-Host $summary


### PR DESCRIPTION
## Summary

Cherry-pick of [f5c0081](https://github.com/ROCm/hip-ep/commit/f5c0081f7617d5b64f2ce84054b76f80da417646) from #776: add a Qwen VLM `vlm_benchmark.py` gate to the Windows `gpu-test` job and publish TTFT/TPS/output in the perf step summary.

## Related issue or design

None

## Why

VLM coverage was added on the #776 TheRock 7.14 branch but is independent of the ROCm dist bump; landing it on main separately lets gpu-test exercise Qwen vision models without waiting for the full #776 stack.

## What

- New `Run VLM benchmark (Python + C++ bin)` step after OGA wheel smoke: installs ORT/OGA wheels into a venv, runs `wheelpkg/vlm_benchmark.py` against each model under `amdgpu-vlm-models` with `dog.jpg`, writes `vlm-results/*.txt`.
- `Publish perf results` parses TTFT/TPS/generated output into a VLM Benchmark Results table.

## Test plan

- [ ] Windows Build `gpu-test` job green on StrixHalo with `amdgpu-vlm-models` and `amdgpu-vlm-images/dog.jpg` present under `GPU_TEST_ASSET_ROOT`
- [ ] Step summary shows VLM Benchmark Results when models run; skips gracefully when assets are missing

## Notes for reviewers

Standalone extraction from #776 (`fix/hipblaslt-dll-name`); no TheRock 7.14 or rocBLAS staging changes included.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [ ] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
