### PR TITLE
build(therock): pin Windows dist to gfx1151 7.14.0 rebuild

### DIFF
--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -17,5 +17,5 @@ flatbuffers;https://github.com/google/flatbuffers.git;v25.12.19
 ## Crash-backtrace helper (always FetchContent; no find_package path).
 cpptrace;https://github.com/jeremy-rifkin/cpptrace.git;v0.8.3
 ##
-therock_windows;https://github.com/ROCm/hip-ep/releases/download/v0.3.0;therock-dist-windows-gfx115X-all-7.11.0
+therock_windows;https://github.com/ROCm/hip-ep/releases/download/v0.3.0;therock-dist-windows-gfx1151-7.14.0
 therock_linux;https://repo.amd.com/rocm/tarball;7.11.0

--- a/lib/Runtime/Kernels/hip/multi_head_attention_kernel.hip
+++ b/lib/Runtime/Kernels/hip/multi_head_attention_kernel.hip
@@ -87,8 +87,14 @@ __device__ __forceinline__ half16_t mha_load_dtile(const _Float16 *row, int dt,
 // is shared block-wide (V in LDS, K streamed from global), and each K/V
 // fragment feeds all MT M-tiles so LDS/global K/V traffic is amortized MT x.
 // ---------------------------------------------------------------------------
+// The softmax state (Q fragments, O accumulators, per-row m/l) must stay
+// register-resident; an explicit occupancy target stops the backend from buying
+// extra waves with scratch traffic. The bound tracks register demand, which
+// grows with the D_PAD / kWmmaTile tile count.
 template <int NW, int BKV, int D_PAD, int MT>
-__global__ void __launch_bounds__(NW * 32) mha_flash_prefill_kernel(
+__global__ void __launch_bounds__(NW * 32)
+__attribute__((amdgpu_waves_per_eu(D_PAD <= 32 ? 9 : (D_PAD <= 48 ? 7 : 6))))
+mha_flash_prefill_kernel(
     const _Float16 *__restrict__ Q,       // [B, sq, N, d]
     const _Float16 *__restrict__ Kcache,  // [B, N, max_seq, d]
     const _Float16 *__restrict__ Vcache,  // [B, N, max_seq, d]
@@ -179,6 +185,7 @@ __global__ void __launch_bounds__(NW * 32) mha_flash_prefill_kernel(
       const int key = kv0 + sj * kWmmaTile + wmma_lane;
       const bool kvalid = key < skv;
       const _Float16 *k_row = &Kcache[kv_base + (size_t)(kvalid ? key : 0) * d];
+#pragma unroll  // static tk keeps Q_reg[][] register-resident
       for (int tk = 0; tk < D_TILES; ++tk) {
         half16_t k_frag = kvalid ? mha_load_dtile(k_row, tk, d) : half16_t{};
 #pragma unroll
@@ -244,6 +251,7 @@ __global__ void __launch_bounds__(NW * 32) mha_flash_prefill_kernel(
     __syncthreads();  // P_lds produced; V_lds staged -> both read below
 
     // ---- value GEMM: V gathered once per (tj,tk), reused across MT ----
+#pragma unroll  // static tj keeps O_h[][] register-resident
     for (int tj = 0; tj < D_TILES; ++tj) {
       float8_t Of[MT];
 #pragma unroll


### PR DESCRIPTION
## Summary

Pin `therock_windows` in `cmake/deps.txt` to the self-built `therock-dist-windows-gfx1151-7.14.0` release asset, and fix the `mha_flash_prefill_kernel` register spill that the 7.14 backend introduces. Library naming compatibility lives in #776.

## Related issue or design

Depends on #776

## Why

Upstream ROCm 7.14.0 Windows dist ships rocBLAS without Tensile kernel data and a monolithic ~470 MB MIOpen.dll. The gfx1151 rebuild bundles Tensile-enabled rocBLAS plus gfx1151 library data and a slimmer MIOpen core that dlopen's the gfx1151 grouped-conv plugin. #776 adds dual 7.11/7.14 library naming in source and CI staging so the dist bump itself is a deps-only change.

The kernel fix rides along because the dist pin cannot land without it. `mha_flash_prefill_kernel` holds its softmax state — the Q fragments `Q_reg[MT][D_TILES]`, the O accumulators `O_h[MT][D_TILES]`, and the per-row `m` / `l` — in registers across the entire KV main loop. That residency is the whole point of the kernel: spill it and a compute-bound WMMA loop turns memory-bound. GPU registers have no addresses, so an array stays in them only while every subscript is a compile-time constant, which requires the loops over `D_TILES` to be fully unrolled. `D_TILES` is a constexpr here, so full unroll is always legal, but whether it happens is left to the backend's unroll heuristic.

The 7.14 backend declines that unroll, and independently raises its occupancy target. These are two separate failures. Rolled `tk` / `tj` loops make the subscripts dynamic, which demotes `Q_reg` and `O_h` out of registers outright — an addressability failure, so no register budget can rescue it. The raised occupancy target then shrinks the per-wave VGPR budget (`D_PAD=80` drops from 256 to 197 VGPRs so a 7th wave fits) and spills whatever survived — a capacity failure. Scratch lives in device memory, so on a unified-memory APU each former register access becomes a memory round-trip in the hottest loop of the kernel.

Measured on the `D_PAD=80` instantiation the Qwen3.5-35B-A3B vision encoder uses: scratch goes 0 → 644 B/lane with 368 scratch accesses landing inside the KV main loop, vision prefill wall 1.6 s → 10.6 s, TTFT 4103 ms → 13377 ms. Localized to this single translation unit by relinking `custom_kernels_gfx1151.dll` from the 7.14 objects with only `multi_head_attention_kernel.obj` substituted.

## What

- `cmake/deps.txt`: `therock_windows` hash column `therock-dist-windows-gfx115X-all-7.11.0` → `therock-dist-windows-gfx1151-7.14.0` (existing `v0.3.0` release host).
- `multi_head_attention_kernel.hip`: force full unroll on the two `D_TILES` loops so the subscripts stay compile-time constant, and pin `amdgpu_waves_per_eu` per `D_PAD` so the backend keeps the register budget instead of buying waves with spills. Both are required and they cover different instantiations: unrolling alone still spills at `D_PAD >= 112`, and the occupancy bound alone leaves the loops rolled at `D_PAD` 48/64/80. The bound is tiered rather than flat because register demand grows with `D_PAD / kWmmaTile`, and small `D_PAD` should keep its higher occupancy.

## Test plan

- [ ] Merge #776 first, then rebase this branch onto `main` if needed
- [ ] `build-windows` green on cold cache with the new dist
- [ ] `gpu-test` green: staging resolves 7.14 DLL/lib names; perf / native smoke / EPContext paths pass
- [ ] `gpu-test` perf: Qwen3.5-35B-A3B vision prefill TTFT back in the pre-7.14 band (~4.1 s, vs 13.4 s on the unpatched 7.14 dist)
- [ ] Linux build green: the kernel change is shared source and `therock_linux` still pins 7.11.0

## Notes for reviewers

- Do not merge until #776 is on `main`; without its JIT/link/staging compatibility, CI breaks on 7.14 library names.
- gfx1151-only Tensile/MIOpen plugin data: gfx1150/1152/1153 builds still use include/ and lib/ only and are unaffected.
- Linux `therock_linux` unchanged (7.11.0). The kernel change is toolchain-independent source, so the Linux job is the gate for it being neutral there.
- Occupancy trade at `D_PAD=80`: 7 waves / 197 VGPRs / 644 B scratch becomes 6 waves / 233 VGPRs / no scratch. Across all nine `D_PAD` instantiations the in-loop scratch count ends at or below the 7.11 numbers, so this is not a revert to 7.11 codegen — 7.11 also spilled at `D_PAD >= 80`, just outside the hottest loop.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [ ] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
