### PR TITLE
feat(hipsr): convert onnx.Unsqueeze to a hipsr.compute

### DIFF
--- a/include/hip/Conversion/OnnxToHipsr/OnnxToHipsr.h
+++ b/include/hip/Conversion/OnnxToHipsr/OnnxToHipsr.h
@@ -50,6 +50,10 @@ void populateReshapeConversionPatterns(
     const ::mlir::TypeConverter &typeConverter,
     ::mlir::RewritePatternSet &patterns, ::mlir::MLIRContext *ctx);
 
+void populateUnsqueezeConversionPatterns(
+    const ::mlir::TypeConverter &typeConverter,
+    ::mlir::RewritePatternSet &patterns, ::mlir::MLIRContext *ctx);
+
 void populateReturnConversionPatterns(
     const ::mlir::TypeConverter &typeConverter,
     ::mlir::RewritePatternSet &patterns, ::mlir::MLIRContext *ctx);

--- a/lib/Conversion/OnnxToHipsr/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHipsr/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(OnnxToHipsr STATIC
   ExpandConversion.cpp
   ShapeConversion.cpp
   ReshapeConversion.cpp
+  UnsqueezeConversion.cpp
   ReturnConversion.cpp
 )
 

--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
@@ -120,6 +120,7 @@ struct ConvertOnnxToHipsrPass
     populateExpandConversionPatterns(converter, patterns, &getContext());
     populateShapeConversionPatterns(converter, patterns, &getContext());
     populateReshapeConversionPatterns(converter, patterns, &getContext());
+    populateUnsqueezeConversionPatterns(converter, patterns, &getContext());
     populateReturnConversionPatterns(converter, patterns, &getContext());
     populateFunctionOpInterfaceTypeConversionPattern<func::FuncOp>(patterns,
                                                                    converter);

--- a/lib/Conversion/OnnxToHipsr/UnsqueezeConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/UnsqueezeConversion.cpp
@@ -1,0 +1,261 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- UnsqueezeConversion.cpp - Convert onnx.Unsqueeze to hipsr.compute -===//
+//
+// onnx.Unsqueeze inserts unit-length axes without moving data, so the body is a
+// tensor.expand_shape. It bufferizes to a memref that aliases its source, so
+// nothing runs on the device.
+//
+// The result type comes from the operands, not the type ONNX declared: the axes
+// place the unit dimensions, the input gives the rest along with the element
+// type and memory space. Reading the axes also resolves a dimension the
+// declared type leaves dynamic.
+//
+// Before, with %axes the constant [-1]:
+//   %r = "onnx.Unsqueeze"(%x, %axes)
+//       : (tensor<2x3xf16, #hipsr.mem<device>>, tensor<1xi64>)
+//       -> tensor<2x3x?xf16, #hipsr.mem<device>>
+//
+// After, with region types left out. The axes put the unit last, so the
+// dimension the declared type left dynamic comes out as 1:
+//   %init = hipsr.placeholder(%ctx) ins(%x)
+//       {placeholder_type = #hipsr.placeholder_type<normal>}
+//       : tensor<2x3x1xf16, #hipsr.mem<device>> shape_region {
+//   ^bb0(%x_shape):
+//     %c2 = arith.constant 2 : index
+//     %c3 = arith.constant 3 : index
+//     %c1 = arith.constant 1 : index
+//     %s = shape.from_extents %c2, %c3, %c1
+//     hipsr.shape_yield %s
+//   }
+//   %r = hipsr.compute(%ctx) ins(%x) outs(%init) {
+//   ^bb0(%body_ctx, %in, %dest):
+//     %out = tensor.expand_shape %in [[0], [1, 2]] output_shape [2, 3, 1]
+//     hipsr.compute_yield %out
+//   } : tensor<2x3x1xf16, #hipsr.mem<device>>
+//
+// A dynamic input dimension is read off %x_shape in the region. The body reads
+// it off %dest, which already carries the result dimensions.
+//
+//===----------------------------------------------------------------------===//
+
+#include "OnnxToHipsrUtils.h"
+
+#include "hip/Conversion/OnnxToHipsr/OnnxToHipsr.h"
+#include "hip/Dialect/Hipsr/IR/HipsrOps.h"
+#include "hip/Dialect/Hipsr/IR/HipsrShapeRegionPopulationUtils.h"
+#include "hip/Dialect/Onnx/IR/OnnxOps.h"
+
+#include "mlir/Dialect/Arith/Utils/Utils.h"
+#include "mlir/Dialect/Shape/IR/Shape.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include "llvm/ADT/Sequence.h"
+#include "llvm/ADT/SmallBitVector.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/SmallVectorExtras.h"
+
+#include <cassert>
+#include <optional>
+
+namespace mlir {
+namespace hipsr {
+namespace {
+
+//===----------------------------------------------------------------------===//
+// The result type
+//===----------------------------------------------------------------------===//
+
+// The result type: the axes place the unit dimensions, the input gives the rest
+// along with the element type and memory space.
+FailureOr<RankedTensorType>
+inferResultType(onnx::UnsqueezeOp op, RankedTensorType inputType, Value axes,
+                ConversionPatternRewriter &rewriter) {
+  // TODO: Support axes that only hold their value at runtime.
+  DenseIntElementsAttr folded;
+  if (!matchPattern(axes, m_Constant(&folded))) {
+    return rewriter.notifyMatchFailure(op,
+                                       "expected axes that fold to a constant");
+  }
+  int64_t resultRank = inputType.getRank() + folded.size();
+
+  // ONNX counts a negative axis from the end of the result and leaves the order
+  // of the axes open, so only which positions they name matters.
+  llvm::SmallBitVector inserted(resultRank);
+  for (const APInt &entry : folded.getValues<APInt>()) {
+    int64_t axis = entry.getSExtValue();
+    if (axis < 0) {
+      axis += resultRank;
+    }
+    if (axis < 0 || axis >= resultRank) {
+      return rewriter.notifyMatchFailure(
+          op, "expected every axis within the result rank");
+    }
+    if (inserted.test(axis)) {
+      return rewriter.notifyMatchFailure(op, "expected no repeated axis");
+    }
+    inserted.set(axis);
+  }
+
+  // An inserted position holds a unit, and the input's dimensions fill the rest
+  // in order.
+  SmallVector<int64_t> dims;
+  dims.reserve(resultRank);
+  int64_t inputAxis = 0;
+  for (int64_t axis : llvm::seq<int64_t>(0, resultRank)) {
+    dims.push_back(inserted[axis] ? 1 : inputType.getDimSize(inputAxis++));
+  }
+  return RankedTensorType::get(dims, inputType.getElementType(),
+                               inputType.getEncoding());
+}
+
+//===----------------------------------------------------------------------===//
+// The destination
+//===----------------------------------------------------------------------===//
+
+// The input's dimensions for the expand's inference: a stated one is a
+// constant, a dynamic one is read off the input's shape.
+SmallVector<OpFoldResult> buildInputDims(OpBuilder &builder, Location loc,
+                                         Value inputShape,
+                                         RankedTensorType inputType) {
+  return llvm::map_to_vector(
+      llvm::seq<int64_t>(0, inputType.getRank()),
+      [&](int64_t axis) -> OpFoldResult {
+        if (!inputType.isDynamicDim(axis)) {
+          return builder.getIndexAttr(inputType.getDimSize(axis));
+        }
+        // shape.get_extent returns a `!shape.size`, which converts to index
+        // because it can hold an error.
+        Value size = shape::GetExtentOp::create(builder, loc, inputShape, axis);
+        Value dim = shape::SizeToIndexOp::create(builder, loc,
+                                                 builder.getIndexType(), size);
+        return dim;
+      });
+}
+
+// One dimension per result axis, from tensor.expand_shape's own inference: it
+// places the input's dimensions and takes the rest from the result type. The
+// division it would need is by the unit axes, so it folds away and leaves an
+// unused constant for canonicalization.
+void populateShapeRegion(OpBuilder &builder, PlaceholderOp placeholder,
+                         RankedTensorType inputType,
+                         RankedTensorType resultType,
+                         ArrayRef<ReassociationIndices> reassociation) {
+  OpBuilder::InsertionGuard guard(builder);
+  Block &block = createPlaceholderShapeBlock(builder, placeholder);
+  builder.setInsertionPointToStart(&block);
+
+  Location loc = placeholder.getLoc();
+  Value inputShape = PlaceholderShapeRegionArgs{block}.in(0);
+  SmallVector<OpFoldResult> inputDims =
+      buildInputDims(builder, loc, inputShape, inputType);
+  FailureOr<SmallVector<OpFoldResult>> resultDims =
+      tensor::ExpandShapeOp::inferOutputShape(builder, loc, resultType,
+                                              reassociation, inputDims);
+  assert(succeeded(resultDims) &&
+         "a group holds one input dimension, so only it can be dynamic");
+  Value shape = shape::FromExtentsOp::create(
+      builder, loc, shape::ShapeType::get(builder.getContext()),
+      getValueOrCreateConstantIndexOp(builder, loc, *resultDims));
+  ShapeYieldOp::create(builder, loc, ValueRange{shape});
+}
+
+//===----------------------------------------------------------------------===//
+// The compute body
+//===----------------------------------------------------------------------===//
+
+// The destination already carries the result dimensions, so the expand takes
+// them off it rather than computing them again.
+void populateComputeBody(OpBuilder &builder, ComputeOp computeOp,
+                         ArrayRef<ReassociationIndices> reassociation) {
+  OpBuilder::InsertionGuard guard(builder);
+  Location loc = computeOp.getLoc();
+
+  // The body's arguments are the operands: ctx, the inputs, then the outputs.
+  TypeRange argTypes = computeOp->getOperandTypes();
+  SmallVector<Location> argLocs(argTypes.size(), loc);
+  Block *body =
+      builder.createBlock(&computeOp.getBody(), {}, argTypes, argLocs);
+  builder.setInsertionPointToStart(body);
+
+  Value input = body->getArgument(1);
+  Value dest = body->getArguments().back();
+  Value expanded = tensor::ExpandShapeOp::create(
+      builder, loc, dest.getType(), input, reassociation,
+      tensor::getMixedSizes(builder, loc, dest));
+  ComputeYieldOp::create(builder, loc, ValueRange{expanded});
+}
+
+//===----------------------------------------------------------------------===//
+// The pattern
+//===----------------------------------------------------------------------===//
+
+struct UnsqueezeToHipsr : public OpConversionPattern<onnx::UnsqueezeOp> {
+  // The converter goes unused: the result type depends on the axes operand,
+  // which a type conversion never sees. Taken for a uniform setup.
+  UnsqueezeToHipsr(const TypeConverter &, MLIRContext *ctx)
+      : OpConversionPattern(ctx) {}
+
+  LogicalResult
+  matchAndRewrite(onnx::UnsqueezeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value input = adaptor.getData();
+    auto inputType = dyn_cast<RankedTensorType>(input.getType());
+    if (!inputType) {
+      return rewriter.notifyMatchFailure(op, "expected a ranked tensor input");
+    }
+    FailureOr<RankedTensorType> inferred =
+        inferResultType(op, inputType, adaptor.getAxes(), rewriter);
+    if (failed(inferred)) {
+      return failure();
+    }
+    RankedTensorType resultType = *inferred;
+
+    // An unsqueeze with no axes inserts nothing and needs no destination.
+    if (inputType == resultType) {
+      rewriter.replaceOp(op, input);
+      return success();
+    }
+    std::optional<SmallVector<ReassociationIndices>> reassociation =
+        getReassociationIndicesForReshape(inputType, resultType);
+    assert(reassociation &&
+           "the result is the input's dimensions with unit axes inserted");
+    FailureOr<Value> ctx = getHipsrContextArg(op, rewriter);
+    if (failed(ctx)) {
+      return failure();
+    }
+
+    // The region needs only constants and the input's shape, so a normal
+    // placeholder is enough.
+    Location loc = op.getLoc();
+    auto init =
+        PlaceholderOp::create(rewriter, loc, TypeRange{resultType}, *ctx,
+                              ValueRange{input}, PlaceholderType::Normal);
+    populateShapeRegion(rewriter, init, inputType, resultType, *reassociation);
+
+    auto computeOp =
+        ComputeOp::create(rewriter, loc, TypeRange{resultType}, *ctx,
+                          ValueRange{input}, ValueRange{init.getResult(0)});
+    populateComputeBody(rewriter, computeOp, *reassociation);
+    rewriter.replaceOp(op, computeOp.getResult(0));
+    return success();
+  }
+};
+
+} // namespace
+
+void populateUnsqueezeConversionPatterns(const TypeConverter &typeConverter,
+                                         RewritePatternSet &patterns,
+                                         MLIRContext *ctx) {
+  patterns.add<UnsqueezeToHipsr>(typeConverter, ctx);
+}
+
+} // namespace hipsr
+} // namespace mlir

--- a/test/lit/Conversion/onnx-to-hipsr/unsqueeze-invalid.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/unsqueeze-invalid.mlir
@@ -1,0 +1,64 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+//===----------------------------------------------------------------------===//
+// onnx.Unsqueeze forms the conversion rejects for good: axes ONNX calls an
+// error, and an unranked input. Forms that are only unimplemented are not here;
+// TODOs mark those in the conversion.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --onnx-dialect=modeled --convert-onnx-to-hipsr --split-input-file --verify-diagnostics %s
+
+// ONNX calls a repeated axis an error, and it would leave an input dimension
+// with nowhere to go.
+func.func @repeated_axis(%ctx: !hipsr.context,
+                         %input: tensor<4xf16>) -> tensor<1x1x4xf16> {
+  %axes = "onnx.Constant"() {value = dense<[0, 0]> : tensor<2xi64>}
+      : () -> tensor<2xi64>
+  // expected-error @+1 {{failed to legalize operation 'onnx.Unsqueeze'}}
+  %0 = "onnx.Unsqueeze"(%input, %axes)
+      : (tensor<4xf16>, tensor<2xi64>) -> tensor<1x1x4xf16>
+  return %0 : tensor<1x1x4xf16>
+}
+
+// -----
+
+// The axes and the input rank fix the result rank at 2, so axis 2 names no
+// position in it.
+func.func @axis_out_of_range(%ctx: !hipsr.context,
+                             %input: tensor<4xf16>) -> tensor<1x4xf16> {
+  %axes = "onnx.Constant"() {value = dense<2> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+  // expected-error @+1 {{failed to legalize operation 'onnx.Unsqueeze'}}
+  %0 = "onnx.Unsqueeze"(%input, %axes)
+      : (tensor<4xf16>, tensor<1xi64>) -> tensor<1x4xf16>
+  return %0 : tensor<1x4xf16>
+}
+
+// -----
+
+// A negative axis counts from the end of the result, which has rank 2 here, so
+// -3 reaches past its start.
+func.func @negative_axis_out_of_range(%ctx: !hipsr.context,
+                                      %input: tensor<4xf16>) -> tensor<1x4xf16> {
+  %axes = "onnx.Constant"() {value = dense<-3> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+  // expected-error @+1 {{failed to legalize operation 'onnx.Unsqueeze'}}
+  %0 = "onnx.Unsqueeze"(%input, %axes)
+      : (tensor<4xf16>, tensor<1xi64>) -> tensor<1x4xf16>
+  return %0 : tensor<1x4xf16>
+}
+
+// -----
+
+// Every dimension the axes do not insert comes from the input, so the input has
+// to be ranked.
+func.func @unranked_input(%ctx: !hipsr.context,
+                          %input: tensor<*xf16>) -> tensor<1x4xf16> {
+  %axes = "onnx.Constant"() {value = dense<0> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+  // expected-error @+1 {{failed to legalize operation 'onnx.Unsqueeze'}}
+  %0 = "onnx.Unsqueeze"(%input, %axes)
+      : (tensor<*xf16>, tensor<1xi64>) -> tensor<1x4xf16>
+  return %0 : tensor<1x4xf16>
+}

--- a/test/lit/Conversion/onnx-to-hipsr/unsqueeze.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/unsqueeze.mlir
@@ -1,0 +1,180 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+//===----------------------------------------------------------------------===//
+// onnx.Unsqueeze becomes a hipsr.compute holding a tensor.expand_shape, with a
+// placeholder whose shape region resolves the destination. The result type comes
+// from the operands, not from the type ONNX declared: the axes place the unit
+// dimensions and the input gives the rest. Rejected forms are in
+// unsqueeze-invalid.mlir.
+//
+// The result aliases the input, so it keeps the input's memory space.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt %s --onnx-dialect=modeled --split-input-file -allow-unregistered-dialect -convert-onnx-to-hipsr | FileCheck %s
+
+// A trailing axis on a fully dynamic input, which is what an embedding graph
+// inserts on a token mask. Every dynamic dimension is read off the input's
+// shape, and the expand takes its dimensions off the destination.
+// CHECK-LABEL: func.func @trailing_axis(
+// CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
+// CHECK-SAME:    %[[INPUT:.*]]: tensor<?x?xi1, #hipsr.mem<device>>) -> tensor<?x?x1xi1, #hipsr.mem<device>> {
+// CHECK-NEXT:    %{{.*}} = hipsr.constant {value = dense<-1> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?xi1, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x?x1xi1, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:    ^bb0(%[[IN_SHAPE:.*]]: !shape.shape):
+// CHECK-NEXT:      %[[AXIS0:.*]] = shape.const_size 0
+// CHECK-NEXT:      %[[SIZE0:.*]] = shape.get_extent %[[IN_SHAPE]], %[[AXIS0]]
+// CHECK-NEXT:      %[[ROWS:.*]] = shape.size_to_index %[[SIZE0]] : !shape.size
+// CHECK-NEXT:      %[[AXIS1:.*]] = shape.const_size 1
+// CHECK-NEXT:      %[[SIZE1:.*]] = shape.get_extent %[[IN_SHAPE]], %[[AXIS1]]
+// CHECK-NEXT:      %[[COLS:.*]] = shape.size_to_index %[[SIZE1]] : !shape.size
+// One unused divisor per dynamic group, left by the expand's shape inference.
+// CHECK-NEXT:      arith.constant 1 : index
+// CHECK-NEXT:      arith.constant 1 : index
+// CHECK-NEXT:      %[[ONE:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[ROWS]], %[[COLS]], %[[ONE]] : index, index, index
+// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?xi1, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x?x1xi1, #hipsr.mem<device>>) {
+// CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x?xi1, #hipsr.mem<device>>, %[[DEST:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>):
+// CHECK-NEXT:      %[[C0:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[DEST_ROWS:.*]] = tensor.dim %[[DEST]], %[[C0]] : tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[C1:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[DEST_COLS:.*]] = tensor.dim %[[DEST]], %[[C1]] : tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[OUT:.*]] = tensor.expand_shape %[[IN]] {{\[}}[0], [1, 2]] output_shape {{\[}}%[[DEST_ROWS]], %[[DEST_COLS]], 1] : tensor<?x?xi1, #hipsr.mem<device>> into tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.compute_yield %[[OUT]] : tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:    } : tensor<?x?x1xi1, #hipsr.mem<device>>{{$}}
+// CHECK-NEXT:    return %[[RESULT]] : tensor<?x?x1xi1, #hipsr.mem<device>>
+func.func @trailing_axis(%ctx: !hipsr.context,
+                         %input: tensor<?x?xi1>) -> tensor<?x?x1xi1> {
+  %axes = "onnx.Constant"() {value = dense<-1> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+  %0 = "onnx.Unsqueeze"(%input, %axes)
+      : (tensor<?x?xi1>, tensor<1xi64>) -> tensor<?x?x1xi1>
+  "onnx.Return"(%0) : (tensor<?x?x1xi1>) -> ()
+}
+
+// -----
+
+// The axes resolve a dimension the declared tensor<?x?x?xi1> leaves dynamic.
+// The unit lands between the two dimensions the input gives, so the destination
+// carries its dynamic dimensions at axes 0 and 2.
+// CHECK-LABEL: func.func @interior_axis(
+// CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
+// CHECK-SAME:    %[[INPUT:.*]]: tensor<?x?xi1, #hipsr.mem<device>>) -> tensor<?x1x?xi1, #hipsr.mem<device>> {
+// CHECK-NEXT:    %{{.*}} = hipsr.constant {value = dense<1> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?xi1, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x1x?xi1, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:    ^bb0(%[[IN_SHAPE:.*]]: !shape.shape):
+// CHECK-NEXT:      %[[AXIS0:.*]] = shape.const_size 0
+// CHECK-NEXT:      %[[SIZE0:.*]] = shape.get_extent %[[IN_SHAPE]], %[[AXIS0]]
+// CHECK-NEXT:      %[[ROWS:.*]] = shape.size_to_index %[[SIZE0]] : !shape.size
+// CHECK-NEXT:      %[[AXIS1:.*]] = shape.const_size 1
+// CHECK-NEXT:      %[[SIZE1:.*]] = shape.get_extent %[[IN_SHAPE]], %[[AXIS1]]
+// CHECK-NEXT:      %[[COLS:.*]] = shape.size_to_index %[[SIZE1]] : !shape.size
+// One unused divisor per dynamic group, then the inserted unit.
+// CHECK-NEXT:      arith.constant 1 : index
+// CHECK-NEXT:      arith.constant 1 : index
+// CHECK-NEXT:      %[[ONE:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[ROWS]], %[[ONE]], %[[COLS]] : index, index, index
+// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?xi1, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x1x?xi1, #hipsr.mem<device>>) {
+// CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x?xi1, #hipsr.mem<device>>, %[[DEST:.*]]: tensor<?x1x?xi1, #hipsr.mem<device>>):
+// CHECK-NEXT:      %[[C0:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[DEST_ROWS:.*]] = tensor.dim %[[DEST]], %[[C0]] : tensor<?x1x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[C2:.*]] = arith.constant 2 : index
+// CHECK-NEXT:      %[[DEST_COLS:.*]] = tensor.dim %[[DEST]], %[[C2]] : tensor<?x1x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[OUT:.*]] = tensor.expand_shape %[[IN]] {{\[}}[0], [1, 2]] output_shape {{\[}}%[[DEST_ROWS]], 1, %[[DEST_COLS]]] : tensor<?x?xi1, #hipsr.mem<device>> into tensor<?x1x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.compute_yield %[[OUT]] : tensor<?x1x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:    } : tensor<?x1x?xi1, #hipsr.mem<device>>{{$}}
+// CHECK-NEXT:    return %[[RESULT]] : tensor<?x1x?xi1, #hipsr.mem<device>>
+func.func @interior_axis(%ctx: !hipsr.context,
+                         %input: tensor<?x?xi1>) -> tensor<?x?x?xi1> {
+  %axes = "onnx.Constant"() {value = dense<1> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+  %0 = "onnx.Unsqueeze"(%input, %axes)
+      : (tensor<?x?xi1>, tensor<1xi64>) -> tensor<?x?x?xi1>
+  "onnx.Return"(%0) : (tensor<?x?x?xi1>) -> ()
+}
+
+// -----
+
+// A leading axis on a static host input. The chain stays in #hipsr.mem<host>,
+// and a static result reads nothing off the input's shape: the region is
+// constants and the expand states its dimensions.
+// CHECK-LABEL: func.func @host_input(
+// CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
+// CHECK-SAME:    %[[INPUT:.*]]: tensor<2xi64, #hipsr.mem<host>>) -> tensor<1x2xi64, #hipsr.mem<host>> {
+// CHECK-NEXT:    %{{.*}} = hipsr.constant {value = dense<0> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<2xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<1x2xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:    ^bb0(%{{.*}}: !shape.shape):
+// CHECK-NEXT:      %[[D0:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[D1:.*]] = arith.constant 2 : index
+// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[D0]], %[[D1]] : index, index
+// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<2xi64, #hipsr.mem<host>>) outs(%[[INIT]] : tensor<1x2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<2xi64, #hipsr.mem<host>>, %{{.*}}: tensor<1x2xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:      %[[OUT:.*]] = tensor.expand_shape %[[IN]] {{\[}}[0, 1]] output_shape {{\[}}1, 2] : tensor<2xi64, #hipsr.mem<host>> into tensor<1x2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      hipsr.compute_yield %[[OUT]] : tensor<1x2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:    } : tensor<1x2xi64, #hipsr.mem<host>>{{$}}
+// CHECK-NEXT:    return %[[RESULT]] : tensor<1x2xi64, #hipsr.mem<host>>
+func.func @host_input(%ctx: !hipsr.context,
+                      %input: tensor<2xi64, #hipsr.mem<host>>)
+    -> tensor<1x2xi64> {
+  %axes = "onnx.Constant"() {value = dense<0> : tensor<1xi64>}
+      : () -> tensor<1xi64>
+  %0 = "onnx.Unsqueeze"(%input, %axes)
+      : (tensor<2xi64, #hipsr.mem<host>>, tensor<1xi64>) -> tensor<1x2xi64>
+  "onnx.Return"(%0) : (tensor<1x2xi64>) -> ()
+}
+
+// -----
+
+// Two axes given out of order, which ONNX allows. They bracket the input, so
+// each of its dimensions groups with one unit.
+// CHECK-LABEL: func.func @two_axes(
+// CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
+// CHECK-SAME:    %[[INPUT:.*]]: tensor<3x4xf16, #hipsr.mem<device>>) -> tensor<1x3x4x1xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:    %{{.*}} = hipsr.constant {value = dense<[3, 0]> : tensor<2xi64>} : tensor<2xi64, #hipsr.mem<device>>
+// CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<3x4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<1x3x4x1xf16, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:    ^bb0(%{{.*}}: !shape.shape):
+// CHECK-NEXT:      %[[D0:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[D1:.*]] = arith.constant 3 : index
+// CHECK-NEXT:      %[[D2:.*]] = arith.constant 4 : index
+// CHECK-NEXT:      %[[D3:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[D0]], %[[D1]], %[[D2]], %[[D3]] : index, index, index, index
+// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<3x4xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<1x3x4x1xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<3x4xf16, #hipsr.mem<device>>, %{{.*}}: tensor<1x3x4x1xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:      %[[OUT:.*]] = tensor.expand_shape %[[IN]] {{\[}}[0, 1], [2, 3]] output_shape {{\[}}1, 3, 4, 1] : tensor<3x4xf16, #hipsr.mem<device>> into tensor<1x3x4x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.compute_yield %[[OUT]] : tensor<1x3x4x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    } : tensor<1x3x4x1xf16, #hipsr.mem<device>>{{$}}
+// CHECK-NEXT:    return %[[RESULT]] : tensor<1x3x4x1xf16, #hipsr.mem<device>>
+func.func @two_axes(%ctx: !hipsr.context,
+                    %input: tensor<3x4xf16>) -> tensor<1x3x4x1xf16> {
+  %axes = "onnx.Constant"() {value = dense<[3, 0]> : tensor<2xi64>}
+      : () -> tensor<2xi64>
+  %0 = "onnx.Unsqueeze"(%input, %axes)
+      : (tensor<3x4xf16>, tensor<2xi64>) -> tensor<1x3x4x1xf16>
+  "onnx.Return"(%0) : (tensor<1x3x4x1xf16>) -> ()
+}
+
+// -----
+
+// Empty axes insert nothing, so the input stands as the result and no
+// destination is built.
+// CHECK-LABEL: func.func @no_axes(
+// CHECK-SAME:    %{{.*}}: !hipsr.context,
+// CHECK-SAME:    %[[INPUT:.*]]: tensor<2x3xf16, #hipsr.mem<device>>) -> tensor<2x3xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:    %{{.*}} = hipsr.constant {value = dense<> : tensor<0xi64>} : tensor<0xi64, #hipsr.mem<device>>
+// CHECK-NEXT:    return %[[INPUT]] : tensor<2x3xf16, #hipsr.mem<device>>
+func.func @no_axes(%ctx: !hipsr.context,
+                   %input: tensor<2x3xf16>) -> tensor<2x3xf16> {
+  %axes = "onnx.Constant"() {value = dense<> : tensor<0xi64>}
+      : () -> tensor<0xi64>
+  %0 = "onnx.Unsqueeze"(%input, %axes)
+      : (tensor<2x3xf16>, tensor<0xi64>) -> tensor<2x3xf16>
+  "onnx.Return"(%0) : (tensor<2x3xf16>) -> ()
+}


### PR DESCRIPTION
## Summary

Converts `onnx.Unsqueeze` into a `hipsr.compute` holding a `tensor.expand_shape`, with the placeholder's shape region populated inline. The expansion bufferizes to a memref that aliases its source, so the unsqueeze costs nothing at runtime.

## What it does

The result type is inferred from the operands rather than taken from the type ONNX declared, which shape inference is not required to have filled in. The `axes` operand places the unit dimensions and the input gives the rest, along with the element type and the memory space an alias has to share with its source. This is the model #806 uses for its target shape. Reading the axes also resolves a dimension the declared type leaves dynamic: a declared `tensor<?x?x?xi1>` with axes `[1]` over a `tensor<?x?xi1>` input infers `tensor<?x1x?xi1>`.

`getReassociationIndicesForReshape` recovers the grouping from the two shapes and `tensor::ExpandShapeOp::inferOutputShape` builds the result dimensions from the input's, so the region needs no dimension arithmetic of its own. The body's expand takes its `output_shape` off the destination, as #806's does, so those dimensions are resolved once.

Rejected with a TODO: axes that only hold their value at runtime, which is the TODO #806 carries for a runtime target shape. Rejected for good: a repeated axis and an axis outside the result rank, both of which ONNX itself calls errors, and an unranked input, which has no dimensions for the result to take.

A rank-0 input is out of scope. The pass leaves a host root without a memory space and an aliasing expansion cannot name one, so the result names no space and the pass's own type rules turn it away. The form converts once its producer names a space.

## Notes for reviewers

Rebased onto `main` after #806 landed, so the single commit sits directly on it.

No HipsrToLLVM lowering yet, so `--hipsr-pipeline` cannot run this end to end.

Cursor (Claude Opus 5) assisted with the conversion, the tests, and the comments. I reviewed the result and understand it.
