### PR TITLE
fix(onnx-to-hip): re-land #782 with a zero-length slice extent guard (2.99x decode TPS on Gemma-4 26B-A4B at 12K)

### DIFF
--- a/lib/Conversion/OnnxToHip/SliceConversion.cpp
+++ b/lib/Conversion/OnnxToHip/SliceConversion.cpp
@@ -52,6 +52,18 @@ namespace {
 // [1, 1, S] into [1, S, S], 60% of a decode step. Hence resolveHostIndex:
 // `ends - starts` is host arithmetic over `onnx.Shape` entries, so the true
 // extent is computable without any device readback.
+//
+// The one extent that must NOT shrink is zero. The extent here is also the
+// allocation, and one consumer depends on that allocation being the upper
+// bound: FixLoopAccumulatorOffset.cpp rewrites a growing-Concat accumulator in
+// an outlined `hip.loop` body and, as its header states, "assumes ... v_init is
+// pre-sized to full capacity (the canonical `Slice(x, k, k, axis) -> Loop`
+// pattern)". `Slice(x, k, k, axis)` is the ONNX empty-tensor idiom used to seed
+// such an accumulator; its exact extent is 0, and a zero-capacity init leaves
+// the loop appending chunks into nothing -- on Qwen3.6-VL's windowed attention
+// that surfaced as `memrefCopy(rank-2 strided) failed: invalid pitch argument`,
+// because the append subview's destination pitch was 0. So an extent that
+// evaluates to zero falls back to the data dim; see buildAllocCapacity.
 
 /// Return the dense-elements attribute backing \p value if it can be
 /// determined at compile time. Recognizes arith constants, inspectable
@@ -283,6 +295,22 @@ static mlir::Value buildSliceExtent(mlir::OpBuilder &b, mlir::Location loc,
     return len;
   return mlir::arith::CeilDivSIOp::create(
       b, loc, len, mlir::arith::ConstantIndexOp::create(b, loc, step));
+}
+
+/// Capacity to put on the `tensor.empty` init for a slice length \p len: the
+/// length itself, or \p dim when the length is zero. A zero-length init is a
+/// zero-byte buffer, and the `Slice(x, k, k, axis) -> Loop` accumulator seed
+/// (see the file header) needs full capacity to append into. The compare is
+/// against a run-time value because a bound pair can be equal only at run time;
+/// bounds that are never equal are unaffected, so Gemma-4 -- whose length is
+/// `Shape(attn)[1] - Shape(ids)[1]`, 1 at decode and S at prefill -- still gets
+/// its exact extent.
+static mlir::Value buildAllocCapacity(mlir::OpBuilder &b, mlir::Location loc,
+                                      mlir::Value dim, mlir::Value len) {
+  mlir::Value zero = mlir::arith::ConstantIndexOp::create(b, loc, 0);
+  mlir::Value isEmpty = mlir::arith::CmpIOp::create(
+      b, loc, mlir::arith::CmpIPredicate::eq, len, zero);
+  return mlir::arith::SelectOp::create(b, loc, isEmpty, dim, len);
 }
 
 struct SliceDecompose : public mlir::RewritePattern {
@@ -545,6 +573,7 @@ struct SliceToHip : public mlir::RewritePattern {
       // slices can land on the upper bound, so only that is worth reporting --
       // and if `axes` itself was unreadable, any axis might be sliced.
       bool axisIsSliced = !haveAxes;
+      bool emptyAccumulatorSeed = false;
       if (haveAxes) {
         for (size_t k = 0; k < axesVec.size(); ++k) {
           int64_t axis =
@@ -554,14 +583,24 @@ struct SliceToHip : public mlir::RewritePattern {
           axisIsSliced = true;
           if (stepsVec[k] <= 0)
             break;
+          // One `Value` for both bounds is `Slice(x, k, k, axis)` spelled the
+          // way exporters emit it, so the length is zero without resolving
+          // anything. Take the data dim directly rather than emitting the
+          // arithmetic and the select that would fold back to it.
+          if (starts == ends) {
+            emptyAccumulatorSeed = true;
+            break;
+          }
           mlir::Value s = resolveHostIndex(rewriter, loc, starts, k, 0);
           mlir::Value e = resolveHostIndex(rewriter, loc, ends, k, 0);
           if (s && e)
-            extent = buildSliceExtent(rewriter, loc, dim, s, e, stepsVec[k]);
+            extent = buildAllocCapacity(
+                rewriter, loc, dim,
+                buildSliceExtent(rewriter, loc, dim, s, e, stepsVec[k]));
           break;
         }
       }
-      if (!extent && axisIsSliced)
+      if (!extent && axisIsSliced && !emptyAccumulatorSeed)
         LLVM_DEBUG(llvm::dbgs()
                    << "[" DEBUG_TYPE "] slice extent for dim " << i
                    << " falls back to the data dim: no host-resolvable bounds "

--- a/lib/Conversion/OnnxToHip/SliceConversion.cpp
+++ b/lib/Conversion/OnnxToHip/SliceConversion.cpp
@@ -32,11 +32,26 @@ namespace {
 //     at compile time.
 //
 //   * SliceToHip (benefit=1) — fallback for non-constant indices or negative
-//     steps. Produces a native `hip.slice` DPS op whose runtime function is
-//     a stub today (throws); models that hit this path are unsupported until
-//     the runtime is implemented, but the conversion / bufferization pipeline
-//     can still verify and link the IR. Dynamic output dims are sourced from
-//     `tensor.dim` on `data` (an upper bound — Slice cannot widen any axis).
+//     steps. Produces a native `hip.slice` DPS op, executed by `wrap_slice` in
+//     Runtime/real/slice.cpp since #284 (this comment claimed a throwing stub
+//     long after that landed). Worth knowing when reading the extent logic
+//     below: that runtime D2Hs starts/ends/axes/steps and synchronizes the
+//     stream on every call, so this op already costs a host sync per
+//     execution. Dynamic output dims are computed from
+//     the slice bounds when those are host-resolvable, and otherwise fall back
+//     to `tensor.dim` on `data` (an upper bound — Slice cannot widen any axis).
+//
+// That fallback is only an upper bound, and an upper bound is not a safe
+// stand-in for the extent: the extent this pattern puts on the `tensor.empty`
+// init IS the output shape as far as everything downstream is concerned, since
+// `tensor.dim` of a DPS result resolves through to the init. A Slice that keeps
+// one row of a 12k-row tensor therefore hands every consumer a 12k-row shape.
+// Gemma-4 26B-A4B decode does exactly this — `Slice(CumSum(attention_mask),
+// Shape(attn)[1] - Shape(ids)[1], Shape(attn)[1])` takes the single current
+// query position — and the inflated extent turned the causal mask from
+// [1, 1, S] into [1, S, S], 60% of a decode step. Hence resolveHostIndex:
+// `ends - starts` is host arithmetic over `onnx.Shape` entries, so the true
+// extent is computable without any device readback.
 
 /// Return the dense-elements attribute backing \p value if it can be
 /// determined at compile time. Recognizes arith constants, inspectable
@@ -118,6 +133,156 @@ static mlir::Value normaliseOptional(mlir::Value v) {
   if (defOp && defOp->getName().getStringRef() == "onnx.NoValue")
     return mlir::Value();
   return v;
+}
+
+/// Producer-chain depth walked by `resolveHostIndex`. Shape arithmetic in
+/// exported graphs is a handful of ops deep; the bound only stops a
+/// pathological walk.
+static constexpr int kHostIndexMaxDepth = 8;
+
+/// Resolve element \p idx of an integer shape tensor \p v to a host `index`
+/// SSA value, materializing `arith` ops as needed. Returns a null Value when
+/// the element is not host-computable.
+///
+/// Both the pre- and post-conversion spelling of ONNX shape arithmetic are
+/// accepted, because the greedy driver gives no ordering guarantee between this
+/// pattern and the ones rewriting the producers: `onnx.Shape` may still be
+/// present, or may already be
+/// `tensor.from_elements(arith.index_cast(tensor.dim))`, and `onnx.Sub` may
+/// already be `hip.sub`. On Gemma-4 26B-A4B it is in practice the ONNX
+/// spelling that arrives here, this pattern running first; the post-conversion
+/// spelling is covered by test 10 in test_slice.mlir rather than by a model,
+/// since nothing pins the order and losing either branch silently costs the
+/// extent.
+static mlir::Value resolveHostIndex(mlir::OpBuilder &b, mlir::Location loc,
+                                    mlir::Value v, int64_t idx, int depth) {
+  if (!v || idx < 0 || depth > kHostIndexMaxDepth)
+    return {};
+  auto vType = mlir::dyn_cast<mlir::RankedTensorType>(v.getType());
+  if (!vType || !vType.getElementType().isSignlessInteger())
+    return {};
+  // Bound the request against the value's own extent once, here, rather than in
+  // each producer branch: an out-of-range element must fail rather than resolve
+  // to something plausible. Without this an `onnx.Shape` narrowed by its `end`
+  // attribute would hand back dim(start + idx) for an element it does not have,
+  // which is the same class of silently-wrong extent this file exists to fix.
+  if (vType.hasStaticShape() && idx >= vType.getNumElements())
+    return {};
+
+  if (mlir::DenseElementsAttr dense = getCompileTimeConstantTensor(v)) {
+    if (idx >= dense.getNumElements())
+      return {};
+    return mlir::arith::ConstantIndexOp::create(
+        b, loc,
+        (*(dense.getValues<mlir::APInt>().begin() + idx)).getSExtValue());
+  }
+
+  mlir::Operation *def = v.getDefiningOp();
+  if (!def)
+    return {};
+
+  if (auto fromElems = mlir::dyn_cast<mlir::tensor::FromElementsOp>(def)) {
+    if (idx >= static_cast<int64_t>(fromElems.getElements().size()))
+      return {};
+    mlir::Value elem = fromElems.getElements()[idx];
+    // ShapeToTensorDims index_casts every tensor.dim to i64 to pack it; take
+    // the index back rather than casting a second time.
+    if (auto cast = elem.getDefiningOp<mlir::arith::IndexCastOp>())
+      if (cast.getIn().getType().isIndex())
+        return cast.getIn();
+    return mlir::arith::IndexCastOp::create(b, loc, b.getIndexType(), elem);
+  }
+
+  if (auto cast = mlir::dyn_cast<mlir::tensor::CastOp>(def))
+    return resolveHostIndex(b, loc, cast.getSource(), idx, depth + 1);
+
+  llvm::StringRef opName = def->getName().getStringRef();
+
+  // Unconverted onnx.Shape: element idx is dim (start + idx) of the operand.
+  // `start` is normalized as ShapeToTensorDims normalizes it; `end` only bounds
+  // how many elements exist, which the caller-side extent check above covers.
+  if (opName == "onnx.Shape") {
+    mlir::Value input = def->getOperand(0);
+    auto inType = mlir::dyn_cast<mlir::RankedTensorType>(input.getType());
+    if (!inType)
+      return {};
+    int64_t rank = inType.getRank();
+    int64_t start = 0;
+    if (auto startAttr = def->getAttrOfType<mlir::IntegerAttr>("start"))
+      start = startAttr.getSInt();
+    if (start < 0)
+      start += rank;
+    start = std::max(start, int64_t(0));
+    int64_t dimIdx = start + idx;
+    if (dimIdx < 0 || dimIdx >= rank)
+      return {};
+    if (!inType.isDynamicDim(dimIdx))
+      return mlir::arith::ConstantIndexOp::create(b, loc,
+                                                  inType.getDimSize(dimIdx));
+    return mlir::tensor::DimOp::create(b, loc, input, dimIdx);
+  }
+
+  // Binary shape arithmetic. hip elementwise ops are DPS, so their operands are
+  // (ctx, lhs, rhs, out); the ONNX forms are plain (lhs, rhs).
+  unsigned lhsPos = 0;
+  bool isHip =
+      mlir::isa<mlir::hip::SubOp, mlir::hip::AddOp, mlir::hip::MulOp>(def);
+  if (isHip)
+    lhsPos = 1;
+  else if (opName != "onnx.Sub" && opName != "onnx.Add" && opName != "onnx.Mul")
+    return {};
+
+  mlir::Value lhs = def->getOperand(lhsPos);
+  mlir::Value rhs = def->getOperand(lhsPos + 1);
+  // A rank-0 or single-element operand is broadcast against the other.
+  auto elemIdx = [&](mlir::Value operand) -> int64_t {
+    auto t = mlir::dyn_cast<mlir::RankedTensorType>(operand.getType());
+    return (t && t.hasStaticShape() && t.getNumElements() == 1) ? 0 : idx;
+  };
+  mlir::Value l = resolveHostIndex(b, loc, lhs, elemIdx(lhs), depth + 1);
+  mlir::Value r = resolveHostIndex(b, loc, rhs, elemIdx(rhs), depth + 1);
+  if (!l || !r)
+    return {};
+
+  bool isSub = isHip ? mlir::isa<mlir::hip::SubOp>(def) : opName == "onnx.Sub";
+  bool isAdd = isHip ? mlir::isa<mlir::hip::AddOp>(def) : opName == "onnx.Add";
+  if (isSub)
+    return mlir::arith::SubIOp::create(b, loc, l, r);
+  if (isAdd)
+    return mlir::arith::AddIOp::create(b, loc, l, r);
+  return mlir::arith::MulIOp::create(b, loc, l, r);
+}
+
+/// Emit the number of elements ONNX Slice produces on one axis, given runtime
+/// `start`/`end` bounds and a positive compile-time \p step. Mirrors the
+/// compile-time arithmetic in SliceDecompose; `arith` ops are needed here only
+/// because the bounds are not known until run time.
+static mlir::Value buildSliceExtent(mlir::OpBuilder &b, mlir::Location loc,
+                                    mlir::Value dim, mlir::Value start,
+                                    mlir::Value end, int64_t step) {
+  mlir::Value zero = mlir::arith::ConstantIndexOp::create(b, loc, 0);
+  // A negative bound counts from the end, and the sign is not known until run
+  // time, so both forms are computed and selected between. Neither sentinel
+  // exporters use needs special handling: INT64_MAX ("to the end") stays
+  // positive, so `v + dim` overflows but is never selected, and the clamp
+  // returns `dim`; INT64_MIN ("from the beginning") cannot overflow, since
+  // adding a non-negative `dim` only moves it toward zero.
+  auto normalize = [&](mlir::Value v) -> mlir::Value {
+    mlir::Value shifted = mlir::arith::AddIOp::create(b, loc, v, dim);
+    mlir::Value isNeg = mlir::arith::CmpIOp::create(
+        b, loc, mlir::arith::CmpIPredicate::slt, v, zero);
+    mlir::Value picked =
+        mlir::arith::SelectOp::create(b, loc, isNeg, shifted, v);
+    picked = mlir::arith::MaxSIOp::create(b, loc, picked, zero);
+    return mlir::arith::MinSIOp::create(b, loc, picked, dim);
+  };
+  mlir::Value len =
+      mlir::arith::SubIOp::create(b, loc, normalize(end), normalize(start));
+  len = mlir::arith::MaxSIOp::create(b, loc, len, zero);
+  if (step == 1)
+    return len;
+  return mlir::arith::CeilDivSIOp::create(
+      b, loc, len, mlir::arith::ConstantIndexOp::create(b, loc, step));
 }
 
 struct SliceDecompose : public mlir::RewritePattern {
@@ -323,11 +488,42 @@ struct SliceToHip : public mlir::RewritePattern {
 
     auto dataType = mlir::cast<mlir::RankedTensorType>(data.getType());
 
-    // For each dynamic output dim, source an upper bound from the data
-    // dim at the same position. This is sound because ONNX Slice can
-    // never widen any axis -- output dim i is at most data dim i. The
-    // runtime stub honours `output_shape[i]` as the actual extent so the
-    // over-allocation is benign.
+    // Which axes are sliced, and with what step. Both must be known to compute
+    // an extent; a non-constant axes/steps operand leaves every dim on the
+    // conservative upper bound below.
+    llvm::SmallVector<int64_t> axesVec, stepsVec;
+    bool haveAxes = true;
+    if (axes)
+      haveAxes = mlir::succeeded(
+          extractSliceParamVector(op, "hipdnn.slice_axes", axes, axesVec));
+    if (haveAxes && axesVec.empty())
+      for (int64_t i : llvm::seq<int64_t>(dataType.getRank()))
+        axesVec.push_back(i);
+    if (steps && haveAxes)
+      haveAxes = mlir::succeeded(
+          extractSliceParamVector(op, "hipdnn.slice_steps", steps, stepsVec));
+    if (haveAxes && stepsVec.empty())
+      stepsVec.assign(axesVec.size(), 1);
+    if (stepsVec.size() != axesVec.size())
+      haveAxes = false;
+
+    // Compute each dynamic output dim from the slice bounds where possible;
+    // see the file header for why the data dim is not an acceptable substitute.
+    // Ops materialized by a resolution that then fails are pure and get DCE'd.
+    //
+    // Where the bounds do not resolve, the fallback keeps the upper bound and
+    // therefore keeps the over-sized shape. It could be exact instead:
+    // CompressConversion solves the same shrinking-extent problem by reading
+    // the true count back from the device with `hip.ReadbackDimOp`. That is not
+    // done here, but not because a readback is unaffordable on this op --
+    // `wrap_slice` already D2Hs its own bounds and syncs the stream every call,
+    // so the sync is paid regardless. It is that a readback would add a second
+    // sync point, in the shape computation ahead of the slice, to serve a case
+    // no model in scope reaches: on Gemma-4 every sliced axis resolves from its
+    // bounds, and host arithmetic is strictly better than a readback wherever
+    // it is available. If a model does land here, revisit it -- the cost is
+    // lower than it looks. Hence the debug line below: the fallback is a known
+    // performance cliff, and it should be findable without an RGP capture.
     llvm::SmallVector<mlir::Value> dynSizes;
     for (int64_t i = 0; i < resultType.getRank(); ++i) {
       if (!resultType.isDynamicDim(i))
@@ -335,11 +531,44 @@ struct SliceToHip : public mlir::RewritePattern {
       if (i >= dataType.getRank())
         return rewriter.notifyMatchFailure(
             op, "result rank exceeds data rank — invalid Slice");
-      if (dataType.isDynamicDim(i))
-        dynSizes.push_back(mlir::tensor::DimOp::create(rewriter, loc, data, i));
-      else
-        dynSizes.push_back(mlir::arith::ConstantIndexOp::create(
-            rewriter, loc, dataType.getDimSize(i)));
+
+      mlir::Value dim =
+          dataType.isDynamicDim(i)
+              ? mlir::tensor::DimOp::create(rewriter, loc, data, i).getResult()
+              : mlir::arith::ConstantIndexOp::create(rewriter, loc,
+                                                     dataType.getDimSize(i))
+                    .getResult();
+
+      mlir::Value extent;
+      // An axis `axes` does not name is not sliced at all, so the data dim is
+      // its exact extent rather than a fallback. Only an axis this op really
+      // slices can land on the upper bound, so only that is worth reporting --
+      // and if `axes` itself was unreadable, any axis might be sliced.
+      bool axisIsSliced = !haveAxes;
+      if (haveAxes) {
+        for (size_t k = 0; k < axesVec.size(); ++k) {
+          int64_t axis =
+              axesVec[k] < 0 ? axesVec[k] + dataType.getRank() : axesVec[k];
+          if (axis != i)
+            continue;
+          axisIsSliced = true;
+          if (stepsVec[k] <= 0)
+            break;
+          mlir::Value s = resolveHostIndex(rewriter, loc, starts, k, 0);
+          mlir::Value e = resolveHostIndex(rewriter, loc, ends, k, 0);
+          if (s && e)
+            extent = buildSliceExtent(rewriter, loc, dim, s, e, stepsVec[k]);
+          break;
+        }
+      }
+      if (!extent && axisIsSliced)
+        LLVM_DEBUG(llvm::dbgs()
+                   << "[" DEBUG_TYPE "] slice extent for dim " << i
+                   << " falls back to the data dim: no host-resolvable bounds "
+                      "(or a non-positive step), so consumers see an upper "
+                      "bound rather than the slice length -- "
+                   << *op << "\n");
+      dynSizes.push_back(extent ? extent : dim);
     }
     mlir::Value init =
         mlir::tensor::EmptyOp::create(rewriter, loc, resultType.getShape(),

--- a/lib/Dialect/Transforms/FixLoopAccumulatorOffset.cpp
+++ b/lib/Dialect/Transforms/FixLoopAccumulatorOffset.cpp
@@ -34,6 +34,16 @@
 // `Slice(x, k, k, axis) -> Loop` pattern). Runs after out-param promotion (the
 // alias only exists after that rewrite) and before the pool/hoist passes.
 //
+// The capacity half of that assumption is supplied by SliceToHip in
+// lib/Conversion/OnnxToHip/SliceConversion.cpp, which sizes the seed slice's
+// init at the data dim rather than its exact (zero) extent. #782 briefly made
+// that extent exact and this pass then rewrote offsets into a zero-byte buffer,
+// which Qwen3.6-VL hit as an invalid pitch in the append copy. The capacity is
+// dynamic by the time it reaches this pass -- v_in is `memref<1x?x...>` and the
+// allocation lives in the caller -- so only a statically empty one is visible
+// here; that case is refused below, and SliceConversion.cpp carries the
+// reciprocal note.
+//
 //===----------------------------------------------------------------------===//
 
 #include "hip/Dialect/Transforms/Passes.h"
@@ -150,9 +160,24 @@ struct FixLoopAccumulatorOffsetPass
     SmallVector<memref::DimOp> dimCandidates;
     funcOp.walk([&](memref::DimOp dimOp) {
       auto ba = dyn_cast<BlockArgument>(dimOp.getSource());
-      if (ba && ba.getOwner() == &entry && isVIn(ba) &&
-          dimOp.getConstantIndex())
-        dimCandidates.push_back(dimOp);
+      if (!ba || ba.getOwner() != &entry || !isVIn(ba) ||
+          !dimOp.getConstantIndex())
+        return;
+      // Rewriting an append offset only makes sense into a buffer that has room
+      // for the chunks. A statically empty accumulator axis means the seed was
+      // sized at its exact extent instead of full capacity, so leave the
+      // offsets alone and say why rather than emit subviews past the end.
+      auto memTy = cast<MemRefType>(ba.getType());
+      int64_t d = *dimOp.getConstantIndex();
+      if (d < memTy.getRank() && memTy.getDimSize(d) == 0) {
+        dimOp.emitWarning()
+            << "loop-carried accumulator axis " << d
+            << " has zero capacity; skipping the chunk-append offset rewrite "
+               "(the v_init seed must be pre-sized to the data dim -- see "
+               "SliceToHip in lib/Conversion/OnnxToHip/SliceConversion.cpp)";
+        return;
+      }
+      dimCandidates.push_back(dimOp);
     });
     if (dimCandidates.empty())
       return;

--- a/lib/Runtime/real/slice.cpp
+++ b/lib/Runtime/real/slice.cpp
@@ -40,6 +40,7 @@
 #include "hip_custom_kernels.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cstdio>
 #include <hip/hip_runtime.h>
 #include <vector>
@@ -346,6 +347,25 @@ int wrap_slice(RuntimeState *state, void *data, void *starts, void *ends,
               (long long)start, (long long)end, (long long)step, (long long)dim,
               (long long)data_rank, (long long)K);
       return -1;
+    }
+    // The other direction of the same disagreement. A zero-capacity output on
+    // an axis whose input is non-empty is legal ONNX but is, in every graph
+    // seen so far, the `Slice(x, k, k, axis)` accumulator seed having been
+    // sized at its exact (zero) extent instead of the data dim. Nothing here
+    // can fail: the damage lands later, when the loop appends into the empty
+    // buffer and the strided copy gets a zero pitch. So warn once per axis
+    // rather than abort, and name the shape that has to be fixed upstream in
+    // SliceToHip. See lib/Conversion/OnnxToHip/SliceConversion.cpp.
+    if (output_shape[d] == 0 && dim > 0) {
+      static std::atomic<bool> warned{false};
+      if (!warned.exchange(true)) {
+        fprintf(stderr,
+                "[REAL] wrap_slice: zero-capacity output on sliced axis %d "
+                "with a non-empty input dim (%lld) -- the compile-time extent "
+                "collapsed to 0; a consumer that appends into this buffer "
+                "(e.g. a hip.loop Concat accumulator) will fail\n",
+                d, (long long)dim);
+      }
     }
     logical_extent[d] = expected;
   }

--- a/test/lit/Conversion/onnx-to-hip/test_slice.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_slice.mlir
@@ -127,8 +127,9 @@ module {
 
   // Test 7: SliceDecompose bails when a sliced axis has a dynamic
   // input dim (ONNX clamping rules need the static dim size); falls
-  // through to hip.slice. The data dim is forwarded as an upper-bound
-  // tensor.dim for the dynamic output dim.
+  // through to hip.slice. The output extent is still the slice length --
+  // clamp(end) - clamp(start) -- not the data dim, which is only an upper
+  // bound and would be handed to every consumer as the shape.
   func.func @test_slice_native_dyn_axis(%input: tensor<?xf32>) -> tensor<?xf32> {
     // CHECK-LABEL: func.func @test_slice_native_dyn_axis
     %starts = arith.constant dense<[1]> : tensor<1xi64>
@@ -140,10 +141,120 @@ module {
            tensor<1xi64>, tensor<1xi64>) -> tensor<?xf32>
 
     // CHECK-NOT: tensor.extract_slice
-    // CHECK-DAG: %[[A0:.*]] = arith.constant 0 : index
-    // CHECK-DAG: %[[DIM:.*]] = tensor.dim %{{.*}}, %[[A0]] : tensor<?xf32>
-    // CHECK: tensor.empty(%[[DIM]]) : tensor<?xf32>
+    // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+    // CHECK-DAG: %[[C3:.*]] = arith.constant 3 : index
+    // CHECK-DAG: %[[DIM:.*]] = tensor.dim %{{.*}} : tensor<?xf32>
+    // CHECK: %[[LO:.*]] = arith.minsi %{{.*}}, %[[DIM]] : index
+    // CHECK: %[[HI:.*]] = arith.minsi %{{.*}}, %[[DIM]] : index
+    // CHECK: %[[LEN:.*]] = arith.subi %[[HI]], %[[LO]] : index
+    // CHECK: %[[EXT:.*]] = arith.maxsi %[[LEN]], %{{.*}} : index
+    // CHECK: tensor.empty(%[[EXT]]) : tensor<?xf32>
     // CHECK: hip.slice({{.*}}) ins({{.*}}, {{.*}}, {{.*}} : tensor<?xf32>, tensor<1xi64>, tensor<1xi64>)
     return %r : tensor<?xf32>
+  }
+
+  // Test 8: the decode-mask idiom from Gemma-4 26B-A4B. `starts` is
+  // Shape(attn)[1] - Shape(ids)[1] and `ends` is Shape(attn)[1], so the slice
+  // keeps the current query positions only -- one row during decode. Both
+  // bounds are host arithmetic over onnx.Shape, so the extent is computable
+  // with no device readback, and the resulting empty must NOT be sized by the
+  // data dim: that is what inflated the causal mask to [1, S, S] and cost 60%
+  // of a decode step.
+  func.func @test_slice_native_shape_sub_extent(
+      %data: tensor<?x?xi64>, %ids: tensor<?x?xi64>, %attn: tensor<?x?xi64>)
+      -> tensor<?x?xi64> {
+    // CHECK-LABEL: func.func @test_slice_native_shape_sub_extent
+    %axes = arith.constant dense<[1]> : tensor<1xi64>
+    %ids_len  = "onnx.Shape"(%ids)  {start = 1 : si64, end = 2 : si64}
+        : (tensor<?x?xi64>) -> tensor<1xi64>
+    %attn_len = "onnx.Shape"(%attn) {start = 1 : si64, end = 2 : si64}
+        : (tensor<?x?xi64>) -> tensor<1xi64>
+    %starts = "onnx.Sub"(%attn_len, %ids_len)
+        : (tensor<1xi64>, tensor<1xi64>) -> tensor<1xi64>
+    %r = "onnx.Slice"(%data, %starts, %attn_len, %axes)
+        : (tensor<?x?xi64>, tensor<1xi64>, tensor<1xi64>,
+           tensor<1xi64>) -> tensor<?x?xi64>
+
+    // SliceToHip fires before the operands are rewritten, so `starts` resolves
+    // through the ONNX spelling (onnx.Sub of two onnx.Shape) and the walker
+    // emits the tensor.dim / arith.subi below itself. That is also the order
+    // Gemma-4 takes in the real pipeline, so this is the production path; test
+    // 10 covers the post-conversion spelling, which the same walk accepts
+    // because the greedy driver does not guarantee either order.
+    // CHECK: %[[D0:.*]] = tensor.dim %arg1, %{{.*}} : tensor<?x?xi64>
+    // CHECK: %[[D1:.*]] = tensor.dim %arg1, %{{.*}} : tensor<?x?xi64>
+    // CHECK: arith.subi %{{.*}}, %{{.*}} : index
+    // CHECK: %[[LO:.*]] = arith.minsi %{{.*}}, %[[D1]] : index
+    // CHECK: %[[HI:.*]] = arith.minsi %{{.*}}, %[[D1]] : index
+    // CHECK: %[[LEN:.*]] = arith.subi %[[HI]], %[[LO]] : index
+    // CHECK: %[[EXT:.*]] = arith.maxsi %[[LEN]], %{{.*}} : index
+    // CHECK: tensor.empty(%[[D0]], %[[EXT]]) : tensor<?x?xi64>
+    // CHECK: hip.slice
+    return %r : tensor<?x?xi64>
+  }
+
+  // Test 9: an opaque `starts` (a graph input, not shape arithmetic) is not
+  // host-resolvable, so the extent falls back to the data dim upper bound
+  // rather than emitting an extent that cannot be justified.
+  func.func @test_slice_native_opaque_starts(
+      %data: tensor<?xi64>, %starts: tensor<1xi64>, %ends: tensor<1xi64>)
+      -> tensor<?xi64> {
+    // CHECK-LABEL: func.func @test_slice_native_opaque_starts
+    %axes = arith.constant dense<[0]> : tensor<1xi64>
+    %r = "onnx.Slice"(%data, %starts, %ends, %axes)
+        : (tensor<?xi64>, tensor<1xi64>, tensor<1xi64>,
+           tensor<1xi64>) -> tensor<?xi64>
+
+    // CHECK-NOT: arith.minsi
+    // CHECK: %[[DIM:.*]] = tensor.dim %arg1, %{{.*}} : tensor<?xi64>
+    // CHECK: tensor.empty(%[[DIM]]) : tensor<?xi64>
+    // CHECK: hip.slice
+    return %r : tensor<?xi64>
+  }
+
+  // Test 10: the same idiom already rewritten into the post-conversion
+  // spelling, which is the other order the greedy driver may produce and which
+  // test 8 therefore does not reach. Feeding it pre-lowered pins that branch of
+  // the walk: `from_elements(index_cast(tensor.dim))` for the shapes and
+  // hip.sub for the arithmetic, with the index_cast unwrapped rather than cast
+  // a second time. Without a test here, an ordering change elsewhere would
+  // silently drop back to the data-dim upper bound and nothing would fail.
+  func.func @test_slice_native_lowered_shape_sub_extent(
+      %ctx: !hip.context, %data: tensor<?x?xi64>, %ids: tensor<?x?xi64>,
+      %attn: tensor<?x?xi64>) -> tensor<?x?xi64> {
+    // CHECK-LABEL: func.func @test_slice_native_lowered_shape_sub_extent
+    %c1 = arith.constant 1 : index
+    %axes = arith.constant dense<[1]> : tensor<1xi64>
+
+    %ids_dim = tensor.dim %ids, %c1 : tensor<?x?xi64>
+    %ids_i64 = arith.index_cast %ids_dim : index to i64
+    %ids_len = tensor.from_elements %ids_i64 : tensor<1xi64>
+
+    %attn_dim = tensor.dim %attn, %c1 : tensor<?x?xi64>
+    %attn_i64 = arith.index_cast %attn_dim : index to i64
+    %attn_len = tensor.from_elements %attn_i64 : tensor<1xi64>
+
+    %sub_init = tensor.empty() : tensor<1xi64>
+    %starts = hip.sub(%ctx) ins(%attn_len, %ids_len : tensor<1xi64>,
+        tensor<1xi64>) outs(%sub_init : tensor<1xi64>) : tensor<1xi64>
+
+    %r = "onnx.Slice"(%data, %starts, %attn_len, %axes)
+        : (tensor<?x?xi64>, tensor<1xi64>, tensor<1xi64>,
+           tensor<1xi64>) -> tensor<?x?xi64>
+
+    // The bounds resolve to the two dims the from_elements were packed from,
+    // with the index_cast unwrapped, so `starts` is an index-domain subi of
+    // them; the extent is then the clamped end minus the clamped start, not the
+    // data dim.
+    // CHECK: %[[D0:.*]] = tensor.dim %arg1, %{{.*}} : tensor<?x?xi64>
+    // CHECK: %[[D1:.*]] = tensor.dim %arg1, %{{.*}} : tensor<?x?xi64>
+    // CHECK: arith.subi %{{.*}}, %{{.*}} : index
+    // CHECK: %[[LO:.*]] = arith.minsi %{{.*}}, %[[D1]] : index
+    // CHECK: %[[HI:.*]] = arith.minsi %{{.*}}, %[[D1]] : index
+    // CHECK: %[[LEN:.*]] = arith.subi %[[HI]], %[[LO]] : index
+    // CHECK: %[[EXT:.*]] = arith.maxsi %[[LEN]], %{{.*}} : index
+    // CHECK: tensor.empty(%[[D0]], %[[EXT]]) : tensor<?x?xi64>
+    // CHECK: hip.slice
+    return %r : tensor<?x?xi64>
   }
 }

--- a/test/lit/Conversion/onnx-to-hip/test_slice.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_slice.mlir
@@ -148,7 +148,11 @@ module {
     // CHECK: %[[HI:.*]] = arith.minsi %{{.*}}, %[[DIM]] : index
     // CHECK: %[[LEN:.*]] = arith.subi %[[HI]], %[[LO]] : index
     // CHECK: %[[EXT:.*]] = arith.maxsi %[[LEN]], %{{.*}} : index
-    // CHECK: tensor.empty(%[[EXT]]) : tensor<?xf32>
+    // A length of zero would allocate nothing, so the capacity falls back to
+    // the data dim; here the bounds are 1 and 3, so the select never fires.
+    // CHECK: %[[EMPTY:.*]] = arith.cmpi eq, %[[EXT]], %{{.*}} : index
+    // CHECK: %[[CAP:.*]] = arith.select %[[EMPTY]], %[[DIM]], %[[EXT]] : index
+    // CHECK: tensor.empty(%[[CAP]]) : tensor<?xf32>
     // CHECK: hip.slice({{.*}}) ins({{.*}}, {{.*}}, {{.*}} : tensor<?xf32>, tensor<1xi64>, tensor<1xi64>)
     return %r : tensor<?xf32>
   }
@@ -188,7 +192,12 @@ module {
     // CHECK: %[[HI:.*]] = arith.minsi %{{.*}}, %[[D1]] : index
     // CHECK: %[[LEN:.*]] = arith.subi %[[HI]], %[[LO]] : index
     // CHECK: %[[EXT:.*]] = arith.maxsi %[[LEN]], %{{.*}} : index
-    // CHECK: tensor.empty(%[[D0]], %[[EXT]]) : tensor<?x?xi64>
+    // Gemma-4's length is 1 at decode and S at prefill, never 0, so the
+    // capacity select is dead weight here -- it exists for the seed slices in
+    // test 11.
+    // CHECK: %[[EMPTY:.*]] = arith.cmpi eq, %[[EXT]], %{{.*}} : index
+    // CHECK: %[[CAP:.*]] = arith.select %[[EMPTY]], %[[D1]], %[[EXT]] : index
+    // CHECK: tensor.empty(%[[D0]], %[[CAP]]) : tensor<?x?xi64>
     // CHECK: hip.slice
     return %r : tensor<?x?xi64>
   }
@@ -253,8 +262,36 @@ module {
     // CHECK: %[[HI:.*]] = arith.minsi %{{.*}}, %[[D1]] : index
     // CHECK: %[[LEN:.*]] = arith.subi %[[HI]], %[[LO]] : index
     // CHECK: %[[EXT:.*]] = arith.maxsi %[[LEN]], %{{.*}} : index
-    // CHECK: tensor.empty(%[[D0]], %[[EXT]]) : tensor<?x?xi64>
+    // CHECK: %[[EMPTY:.*]] = arith.cmpi eq, %[[EXT]], %{{.*}} : index
+    // CHECK: %[[CAP:.*]] = arith.select %[[EMPTY]], %[[D1]], %[[EXT]] : index
+    // CHECK: tensor.empty(%[[D0]], %[[CAP]]) : tensor<?x?xi64>
     // CHECK: hip.slice
     return %r : tensor<?x?xi64>
+  }
+
+  // Test 11: the `Slice(x, k, k, axis)` empty-tensor idiom, which Qwen3.6-VL's
+  // windowed attention uses to seed a Concat accumulator that a hip.loop then
+  // appends into. Its exact extent is 0, but the init IS the allocation, and
+  // FixLoopAccumulatorOffset.cpp rewrites the loop's append offsets on the
+  // stated assumption that this seed carries full capacity. Sizing it at 0 --
+  // which is what #782 did before this guard -- gives the append copy a zero
+  // destination pitch and the model dies at runtime. Both bounds being the
+  // same SSA value is recognised without resolving either, so the data dim is
+  // used directly and no extent arithmetic is emitted at all.
+  func.func @test_slice_native_empty_accumulator_seed(
+      %data: tensor<?x?xf16>, %k: tensor<1xi64>) -> tensor<?x?xf16> {
+    // CHECK-LABEL: func.func @test_slice_native_empty_accumulator_seed
+    %axes = arith.constant dense<[1]> : tensor<1xi64>
+    %r = "onnx.Slice"(%data, %k, %k, %axes)
+        : (tensor<?x?xf16>, tensor<1xi64>, tensor<1xi64>,
+           tensor<1xi64>) -> tensor<?x?xf16>
+
+    // CHECK-NOT: arith.minsi
+    // CHECK-NOT: arith.select
+    // CHECK: %[[D0:.*]] = tensor.dim %arg1, %{{.*}} : tensor<?x?xf16>
+    // CHECK: %[[D1:.*]] = tensor.dim %arg1, %{{.*}} : tensor<?x?xf16>
+    // CHECK: tensor.empty(%[[D0]], %[[D1]]) : tensor<?x?xf16>
+    // CHECK: hip.slice
+    return %r : tensor<?x?xf16>
   }
 }


### PR DESCRIPTION
## Summary

Re-lands #782, which #815 reverted, with the zero-extent regression fixed.

#782 sized every host-resolvable `hip.slice` extent exactly. That is right for the Gemma-4 decode mask it targeted and wrong for one value: zero. The extent lands on the `tensor.empty` init, so it is also the allocation, and `Slice(x, k, k, axis)` -- the ONNX empty-tensor idiom -- seeds a growing-Concat accumulator that a `hip.loop` appends into. `FixLoopAccumulatorOffset.cpp` states that dependency in its own header ("v_init is pre-sized to full capacity (the canonical `Slice(x, k, k, axis) -> Loop` pattern)"), but nothing on the producing side did, so the change never surfaced it. Qwen3.6-VL's windowed attention died in `memrefCopy(rank-2 strided) failed: invalid pitch argument`, the append subview's destination pitch being 0.

Commit 1 is `git cherry-pick 86cc6bb0`, verbatim, so the re-land stays reviewable as "exactly what #782 did". Commit 2 is the fix.

`SliceToHip` now takes the data dim whenever the slice length is zero: directly when both bounds are the same SSA value, and via an `arith.select` on the computed length otherwise. Gemma-4's length is `Shape(attn)[1] - Shape(ids)[1]`, 1 at decode and S at prefill, so the select never fires and the 12,277 -> 1 shrink the PR exists for is intact.

The rest is about not losing the invariant again. It lived in a file the original change never opened, so it is now stated from both ends: `SliceConversion.cpp` explains why the allocation is an upper bound and points at the pass, and the pass points back. The pass also refuses a statically empty accumulator axis rather than rewriting offsets into it -- a backstop, since the capacity is dynamic in the case that actually broke. `wrap_slice` warns once when a sliced axis gets a zero-capacity output from a non-empty input, which is the signature the failing model presented.

## Gemma-4 26B-A4B at 12,276 prompt tokens

5 runs, 2 warmup, 68 tokens generated on both arms. Baseline is `origin/main` at `0704691b`.

|                | baseline              | this branch           |         |
| -------------- | --------------------- | --------------------- | ------- |
| decode p50     | 359.59 ms/tok (2.78 TPS) | 120.16 ms/tok (8.32 TPS) | **2.99x** |
| TTFT p50       | 41,582 ms             | 40,693 ms             | unchanged |
| peak memory    | 31.08 GB              | 29.97 GB              | -1.11 GB |

Better than the 2.24x #782 measured, because #787's prefill tiling is in main now.

## Test plan

- [x] `check-hip-mlir-lit`: 391 passed, 0 failed. New test 11 pins the seed slice keeping `tensor.dim`; tests 7, 8 and 10 grow the capacity select.
- [x] All 5 VLM models via `vlm_benchmark.py` on gfx1151, coherent output, no pitch error:
  - `Qwen3.6-27B` (the regression case) 11.93 TPS
  - `Qwen3.6-35B-A3B` 48.90 TPS
  - `Qwen3.5-35B-A3B` 48.80 TPS
  - `Qwen3.5-9B` 32.87 TPS
  - `google-gemma-4-26B-A4B` 40.92 TPS
- [x] All 7 text models via `model_benchmark -l 512 -g 128 -r 3 -w 1`: Llama-3.1-8B 38.36, Mistral-7B 42.08, phi4-14B 21.52, Qwen2.5-14B 22.52, Qwen2.5-Coder-14B 22.89, gpt-oss-20b 60.30, DeepSeek-R1-Distill-Llama-70B 4.93 TPS.
