### PR TITLE
build(therock): pin Windows dist to gfx115X-all 7.14.0

### DIFF
--- a/.github/workflows/windows-build-real.yml
+++ b/.github/workflows/windows-build-real.yml
@@ -185,7 +185,7 @@ jobs:
           cp "${{ runner.workspace }}/install/lib/"*.lib staging/lib/ 2>/dev/null || true
 
           THEROCK_DIR="../build/$(basename "$PWD")/_therock"
-          for pat in amdhip64_7.dll rocm_kpack.dll 'amd_comgr*.dll' \
+          for pat in amdhip64_7.dll 'amd_comgr*.dll' \
                      hipblaslt.dll libhipblaslt.dll 'hiprtc*.dll'; do
             cp $THEROCK_DIR/bin/$pat staging/bin/ 2>/dev/null || true
           done

--- a/.github/workflows/windows-build-real.yml
+++ b/.github/workflows/windows-build-real.yml
@@ -185,7 +185,7 @@ jobs:
           cp "${{ runner.workspace }}/install/lib/"*.lib staging/lib/ 2>/dev/null || true
 
           THEROCK_DIR="../build/$(basename "$PWD")/_therock"
-          for pat in amdhip64_7.dll 'amd_comgr*.dll' \
+          for pat in amdhip64_7.dll rocm_kpack.dll 'amd_comgr*.dll' \
                      hipblaslt.dll libhipblaslt.dll 'hiprtc*.dll'; do
             cp $THEROCK_DIR/bin/$pat staging/bin/ 2>/dev/null || true
           done

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -17,5 +17,5 @@ flatbuffers;https://github.com/google/flatbuffers.git;v25.12.19
 ## Crash-backtrace helper (always FetchContent; no find_package path).
 cpptrace;https://github.com/jeremy-rifkin/cpptrace.git;v0.8.3
 ##
-therock_windows;https://github.com/ROCm/hip-ep/releases/download/v0.3.0;therock-dist-windows-gfx1151-7.14.0
+therock_windows;https://github.com/ROCm/hip-ep/releases/download/v0.3.0;therock-dist-windows-gfx115X-all-7.14.0
 therock_linux;https://repo.amd.com/rocm/tarball;7.11.0


### PR DESCRIPTION
## Summary

Bump `therock_windows` in `cmake/deps.txt` from the gfx1151-only 7.14.0 dist to a self-built `therock-dist-windows-gfx115X-all-7.14.0` (hosted on the existing v0.3.0 release). Deps-only one-line change; the 7.11/7.14 library-name compatibility already landed on `main` in #776.

## Related issue or design

None

## Why

Moves the Windows toolchain/runtime SDK to ROCm 7.14.0 for gfx1150/1151/1152/1153. The archive keeps the raw nested TheRock layout (`bin/` runtime DLLs + `lib/llvm` clang toolchain + `lib/cmake` + rocblas/hipblaslt Tensile data), pruned to only the pieces the hip-ep build and runtime consume, so it stays small.

## What

- `cmake/deps.txt`: `therock_windows` hash column `therock-dist-windows-gfx1151-7.14.0` -> `therock-dist-windows-gfx115X-all-7.14.0`.
- Asset contents (pruned from the full 8.9 GB dist to 215 MB tar.gz): core runtime DLLs (`amd_comgr` / `amdhip64_7` / `hiprtc0714` / `MIOpen` / `rocblas` / `libhipblaslt` / `hipdnn_backend`), `hipcc.exe`, minimal `lib/llvm` clang closure (`clang` / `lld` / `clang-offload-bundler` / `amdgpu-arch` / `llvm-objcopy` + `amdgcn/bitcode` + `lib/clang`), rocblas/hipblaslt Tensile data for all four archs, `lib/cmake` and the needed `include` subset. MIOpen CK grouped-conv plugins and unrelated science libs (fftw/rocalution/rocsparse/openblas/gtest/...) are dropped.

## Test plan

- [ ] Local smoke: `hipcc -c cast_kernel.hip --offload-arch=gfx1150/1151/1152/1153` against the pruned dist compiles clean (verified before upload).
- [ ] `build-windows` green on cold cache: `find_package(hip)` + `custom_kernels_*` hipcc compile for all four archs succeed.
- [ ] `gpu-test` green: perf / native smoke / EPContext / OGA paths pass.

## Notes for reviewers

- Local dist lacked `include/hsa` (present in the 7.11 dist); left out since the dist ships without it. If `find_package(hip)` / kernel compile needs hsa headers, will add.
- `libclang.dll` and the extra ~64 `lib/llvm/bin` exes (incl clang++/lld-link) are intentionally dropped; hipcc only invokes clang/lld/clang-offload-bundler.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.

