### PR TITLE
ci(therock): probe Windows dist without rocBLAS Tensile data

### DIFF
--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -17,5 +17,5 @@ flatbuffers;https://github.com/google/flatbuffers.git;v25.12.19
 ## Crash-backtrace helper (always FetchContent; no find_package path).
 cpptrace;https://github.com/jeremy-rifkin/cpptrace.git;v0.8.3
 ##
-therock_windows;https://github.com/ROCm/hip-ep/releases/download/v0.3.0;therock-dist-windows-gfx1151-7.14.0
+therock_windows;https://github.com/ROCm/hip-ep/releases/download/v0.3.0;therock-dist-windows-gfx1151-7.14.0-norocblasdata
 therock_linux;https://repo.amd.com/rocm/tarball;7.11.0


### PR DESCRIPTION
## Summary

Probe experiment, **not for merge**: repoints the Windows TheRock pin at `therock-dist-windows-gfx1151-7.14.0-norocblasdata`, a copy of the #818 dist with `bin/rocblas/library/` removed (150 files, 16 MB of rocBLAS Tensile kernel data). `bin/rocblas.dll` and `lib/rocblas.lib` are kept, so nothing fails to link -- the question is only whether any runtime path needs that kernel data.

## Related issue or design

Probe on top of #818 (`feat/therock-windows-gfx1151-7.14`), which is the baseline this PR is compared against.

## Why

The rocBLAS Tensile data is 16 MB uncompressed / 4.5 MB in the tarball, and nothing in this repo asks for it: hip-ep's sources and CMake never reference rocBLAS, and the only mention anywhere is the staging copy in `.github/workflows/windows-build.yml`. The dependency is indirect -- `MIOpen.dll` statically imports `rocblas.dll`, and `rocblas.dll` is the sole consumer of `bin/rocblas/library/`. `hipblaslt.dll` uses its own `bin/hipblaslt/library/`, which this dist leaves untouched.

If CI is unaffected, the data can be dropped from the shipped dist permanently. If `conv_test_hybrid` regresses, that pins down MIOpen's convolution path as a real consumer, which is worth knowing either way.

## What

- `cmake/deps.txt`: `therock_windows` hash column becomes `therock-dist-windows-gfx1151-7.14.0-norocblasdata`.

The asset itself (804 files / 642 MB unpacked, 212.82 MB tarball, sha256 `9a362d7b7ace3ddd2b72d9115b06463aa1b326a2d775103cedc520743e9e5d81`) is a byte-identical copy of the #818 dist minus that one directory, so this is a single-variable comparison against #818's run.

The staging step in `windows-build.yml` copies `bin/rocblas` with `2>/dev/null || true`, so the missing directory is skipped silently and `build-windows` is expected to stay green. `rocblas.dll` is staged separately by the flat `bin/*.dll` loop and still lands in the GPU test package.

## Test plan

- [ ] `build-windows` green: TheRock downloads and extracts, ORT and OGA build against it
- [ ] `gpu-test` L2 `conv_test_hybrid` matches the #818 baseline of `5.91428E-07` -- the primary observation point, since it is the only case going through MIOpen convolution
- [ ] VLM Qwen3.8-27B TTFT / TPS match the #818 baseline of `5146.2 ms` / `13.8`
- [ ] `full_model_seq128` QPS matches the #818 baseline of `7.04`

## Notes for reviewers

Do not merge. The branch exists to get one CI run, and the `-norocblasdata` asset is temporary and will be deleted from the `v0.3.0` release once the comparison is done. The base is #818's branch rather than `main` so that the MHA flash-prefill fix is present in both rounds; basing on `main` would mix two variables and make the numbers incomparable.
