### PR TITLE
perf(cumsum): scan a long axis with a block instead of a thread, +3.5% TPS at 16K

### DIFF
--- a/lib/Runtime/Kernels/hip/cumsum_kernel.hip
+++ b/lib/Runtime/Kernels/hip/cumsum_kernel.hip
@@ -9,10 +9,23 @@
  *   axis_size = shape[axis]
  *   inner     = product(shape[axis+1:])
  *
- * One thread per (outer, inner) slice. Each thread sequentially scans
- * `axis_size` elements with stride `inner`. This is O(axis_size) per slice
- * but maximally parallel across slices, which is the right shape for the
- * way CumSum is used in vision models (large outer*inner, small axis).
+ * Two strategies, chosen on the shape:
+ *
+ *   slice-parallel (many slices): one thread per (outer, inner) slice, each
+ *     sequentially scanning `axis_size` elements with stride `inner`.
+ * O(axis_size) dependent adds per slice, but maximally parallel across slices,
+ * which is the right shape for the way CumSum is used in vision models (large
+ *     outer*inner, small axis).
+ *
+ *   slice-cooperative (few slices, long axis): one block per slice, scanning
+ * the axis in tiles through LDS. The slice-parallel form only wins while there
+ *     are enough slices to fill the machine; below that its per-thread serial
+ *     latency is fully exposed. A decoder's attention mask is the pathological
+ *     case -- [1, context] scanned on axis 1 collapses to outer = inner = 1, so
+ *     ONE thread serially scanned the entire context. An SQTT capture of
+ *     Gemma-4 26B-A4B on gfx1151 put that at 61 us at 2 240 and 501 us at
+ *     16 241, growing linearly with context, for an op the model issues once
+ *     per decode token.
  *
  * Attribute handling:
  *   exclusive=0 (default): y[k] = sum(x[0..k])
@@ -67,6 +80,61 @@ __device__ inline void cumsum_one_slice(const T *__restrict__ x_slice,
   }
 }
 
+// One slice, scanned cooperatively by a whole block in BLOCK-sized tiles.
+//
+// Each tile is scanned in LDS with Hillis-Steele (log2(BLOCK) steps) and the
+// running total is carried across tiles, so the dependent-step count per slice
+// falls from axis_size to (axis_size / BLOCK) * log2(BLOCK) -- at BLOCK=256 and
+// a 16 241-long axis, from 16 241 to roughly 512.
+//
+// Numerics are unchanged for the integer types. For float the summation order
+// within a tile differs from the serial scan, which is the usual reassociation
+// a parallel scan implies.
+template <typename T, typename ACC, int BLOCK>
+__device__ inline void
+cumsum_slice_cooperative(const T *__restrict__ x_slice, T *__restrict__ y_slice,
+                         int64_t axis_size, int64_t inner, bool exclusive,
+                         bool reverse) {
+  __shared__ ACC tile[BLOCK];
+  const int tid = static_cast<int>(threadIdx.x);
+  ACC carry = ACC(0);
+
+  for (int64_t tile_base = 0; tile_base < axis_size; tile_base += BLOCK) {
+    const int64_t k = tile_base + tid;
+    const bool active = (k < axis_size);
+    // A reverse scan is the same scan over the slice read from the far end, so
+    // mapping logical position k to physical element axis_size-1-k lets both
+    // directions share everything below.
+    const int64_t phys = reverse ? (axis_size - 1 - k) : k;
+    const ACC v = active ? static_cast<ACC>(x_slice[phys * inner]) : ACC(0);
+
+    tile[tid] = v;
+    __syncthreads();
+    for (int off = 1; off < BLOCK; off <<= 1) {
+      const ACC add = (tid >= off) ? tile[tid - off] : ACC(0);
+      __syncthreads();
+      tile[tid] += add;
+      __syncthreads();
+    }
+
+    // tile[] now holds the tile-local inclusive scan, so tile[tid - 1] is this
+    // thread's exclusive value exactly. Taking it from the array rather than
+    // subtracting v back off the inclusive result keeps the float path free of
+    // the cancellation that inclusive-minus-self would introduce.
+    if (active) {
+      const ACC prefix =
+          exclusive ? (tid == 0 ? ACC(0) : tile[tid - 1]) : tile[tid];
+      y_slice[phys * inner] = static_cast<T>(carry + prefix);
+    }
+    // Inactive lanes contributed zero, so this stays correct on the ragged
+    // tile.
+    carry += tile[BLOCK - 1];
+    // Ordered against the next iteration's write to tile[tid], not the reads
+    // above, which the scan loop already synchronised.
+    __syncthreads();
+  }
+}
+
 // FP16 accumulates in float -- matches reduce_sum's fp16-precision handling
 // in the same file family and avoids loss for long axes.
 __global__ void hip_cumsum_kernel_f16(const __half *__restrict__ x,
@@ -101,6 +169,34 @@ __global__ void hip_cumsum_kernel(const T *__restrict__ x, T *__restrict__ y,
                          reverse);
 }
 
+template <int BLOCK>
+__global__ __launch_bounds__(BLOCK) void hip_cumsum_long_axis_kernel_f16(
+    const __half *__restrict__ x, __half *__restrict__ y, int64_t outer,
+    int64_t axis_size, int64_t inner, bool exclusive, bool reverse) {
+  int64_t slice = static_cast<int64_t>(blockIdx.x);
+  if (slice >= outer * inner)
+    return;
+  int64_t o = slice / inner;
+  int64_t i = slice % inner;
+  int64_t base = o * axis_size * inner + i;
+  cumsum_slice_cooperative<__half, float, BLOCK>(x + base, y + base, axis_size,
+                                                 inner, exclusive, reverse);
+}
+
+template <typename T, int BLOCK>
+__global__ __launch_bounds__(BLOCK) void hip_cumsum_long_axis_kernel(
+    const T *__restrict__ x, T *__restrict__ y, int64_t outer,
+    int64_t axis_size, int64_t inner, bool exclusive, bool reverse) {
+  int64_t slice = static_cast<int64_t>(blockIdx.x);
+  if (slice >= outer * inner)
+    return;
+  int64_t o = slice / inner;
+  int64_t i = slice % inner;
+  int64_t base = o * axis_size * inner + i;
+  cumsum_slice_cooperative<T, T, BLOCK>(x + base, y + base, axis_size, inner,
+                                        exclusive, reverse);
+}
+
 extern "C" int hip_cumsum(void *stream, const void *x, void *y,
                           int64_t outer, int64_t axis_size, int64_t inner,
                           int hip_dtype, int exclusive, int reverse) {
@@ -116,40 +212,82 @@ extern "C" int hip_cumsum(void *stream, const void *x, void *y,
   bool excl = exclusive != 0;
   bool rev = reverse != 0;
 
+  // Selection is on the axis alone. Above the floor the cooperative kernel wins
+  // regardless of slice count -- it stays ahead even when there are thousands
+  // of slices to spread across the machine, because each of those slices still
+  // pays the full serial latency of its own axis -- so a slice-count term would
+  // only cost throughput.
+  //
+  // The floor itself is conservative rather than a measured crossover: a
+  // 256-thread block scanning a short axis leaves most of its lanes idle and
+  // pays the syncs anyway, and the vision shape this kernel was written for
+  // (4096x16) is already fast on the existing path, which is not worth risking
+  // to chase.
+  constexpr int64_t kMinAxisForCooperative = 512;
+  // One block per slice, so the slice count has to be expressible as a grid.
+  constexpr int64_t kMaxCooperativeSlices = 1 << 30;
+  const bool cooperative = axis_size >= kMinAxisForCooperative &&
+                           num_slices <= kMaxCooperativeSlices;
+  const int coop_grid = static_cast<int>(num_slices);
+
   CUSTOM_KERNELS_DEBUG_LOG(
       "[custom_kernels] hip_cumsum: dtype=%d, outer=%lld, axis=%lld, "
-      "inner=%lld, exclusive=%d, reverse=%d\n",
+      "inner=%lld, exclusive=%d, reverse=%d, path=%s\n",
       hip_dtype, (long long)outer, (long long)axis_size, (long long)inner,
-      exclusive, reverse);
+      exclusive, reverse, cooperative ? "cooperative" : "slice-parallel");
 
   switch (hip_dtype) {
   case HIP_DTYPE_FLOAT16:
-    hipLaunchKernelGGL(hip_cumsum_kernel_f16, dim3(grid_size),
-                       dim3(kBlockSize), 0, hip_stream,
-                       static_cast<const __half *>(x),
-                       static_cast<__half *>(y), outer, axis_size, inner, excl,
-                       rev);
+    if (cooperative)
+      hipLaunchKernelGGL(
+          HIP_KERNEL_NAME(hip_cumsum_long_axis_kernel_f16<kBlockSize>),
+          dim3(coop_grid), dim3(kBlockSize), 0, hip_stream,
+          static_cast<const __half *>(x), static_cast<__half *>(y), outer,
+          axis_size, inner, excl, rev);
+    else
+      hipLaunchKernelGGL(
+          hip_cumsum_kernel_f16, dim3(grid_size), dim3(kBlockSize), 0,
+          hip_stream, static_cast<const __half *>(x), static_cast<__half *>(y),
+          outer, axis_size, inner, excl, rev);
     break;
   case HIP_DTYPE_FLOAT32:
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_cumsum_kernel<float>),
-                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
-                       static_cast<const float *>(x),
-                       static_cast<float *>(y), outer, axis_size, inner, excl,
-                       rev);
+    if (cooperative)
+      hipLaunchKernelGGL(
+          HIP_KERNEL_NAME(hip_cumsum_long_axis_kernel<float, kBlockSize>),
+          dim3(coop_grid), dim3(kBlockSize), 0, hip_stream,
+          static_cast<const float *>(x), static_cast<float *>(y), outer,
+          axis_size, inner, excl, rev);
+    else
+      hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_cumsum_kernel<float>),
+                         dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
+                         static_cast<const float *>(x), static_cast<float *>(y),
+                         outer, axis_size, inner, excl, rev);
     break;
   case HIP_DTYPE_INT32:
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_cumsum_kernel<int32_t>),
-                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
-                       static_cast<const int32_t *>(x),
-                       static_cast<int32_t *>(y), outer, axis_size, inner, excl,
-                       rev);
+    if (cooperative)
+      hipLaunchKernelGGL(
+          HIP_KERNEL_NAME(hip_cumsum_long_axis_kernel<int32_t, kBlockSize>),
+          dim3(coop_grid), dim3(kBlockSize), 0, hip_stream,
+          static_cast<const int32_t *>(x), static_cast<int32_t *>(y), outer,
+          axis_size, inner, excl, rev);
+    else
+      hipLaunchKernelGGL(
+          HIP_KERNEL_NAME(hip_cumsum_kernel<int32_t>), dim3(grid_size),
+          dim3(kBlockSize), 0, hip_stream, static_cast<const int32_t *>(x),
+          static_cast<int32_t *>(y), outer, axis_size, inner, excl, rev);
     break;
   case HIP_DTYPE_INT64:
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(hip_cumsum_kernel<int64_t>),
-                       dim3(grid_size), dim3(kBlockSize), 0, hip_stream,
-                       static_cast<const int64_t *>(x),
-                       static_cast<int64_t *>(y), outer, axis_size, inner, excl,
-                       rev);
+    if (cooperative)
+      hipLaunchKernelGGL(
+          HIP_KERNEL_NAME(hip_cumsum_long_axis_kernel<int64_t, kBlockSize>),
+          dim3(coop_grid), dim3(kBlockSize), 0, hip_stream,
+          static_cast<const int64_t *>(x), static_cast<int64_t *>(y), outer,
+          axis_size, inner, excl, rev);
+    else
+      hipLaunchKernelGGL(
+          HIP_KERNEL_NAME(hip_cumsum_kernel<int64_t>), dim3(grid_size),
+          dim3(kBlockSize), 0, hip_stream, static_cast<const int64_t *>(x),
+          static_cast<int64_t *>(y), outer, axis_size, inner, excl, rev);
     break;
   default:
     fprintf(stderr, "[custom_kernels] hip_cumsum: unsupported dtype=%d\n",

--- a/lib/Runtime/Kernels/test/example/cumsum/README.md
+++ b/lib/Runtime/Kernels/test/example/cumsum/README.md
@@ -1,0 +1,52 @@
+# CumSum scan test
+
+Checks `hip_cumsum` against a CPU reference across both of its launch
+strategies, and reports the per-call time of the path it selects.
+
+`hip_cumsum` picks between a per-thread serial scan (one thread per
+`(outer, inner)` slice) and a block-cooperative tiled scan (one block per slice,
+scanned through LDS). The choice is made on the axis length, crossing over at
+512.
+
+The cooperative path exists because the serial one degenerates on the shape a
+decoder actually uses. An attention mask is `[1, context]` scanned on axis 1,
+which collapses to `outer = inner = 1`: one slice, one thread, and the whole
+context scanned serially by it. That op runs once per generated token and grows
+with context.
+
+## Build and run
+
+From this directory:
+
+```bash
+hipcc -std=c++17 -O3 --offload-arch=gfx1151 \
+  test_cumsum_scan.cpp ../../../hip/cumsum_kernel.hip \
+  -I../../../include -o test_cumsum_scan.exe
+./test_cumsum_scan.exe            # correctness
+./test_cumsum_scan.exe --bench    # per-call wall time
+```
+
+Substitute your own `--offload-arch`. Exit status is 0 when every check passes,
+1 otherwise, and each failure prints the first worst index with the value found
+and the value expected.
+
+Both strategies are covered in a single run, because the case list straddles the
+selection boundary: the short-axis cases stay on the serial scan and the
+long-axis ones take the cooperative path.
+
+## What it checks
+
+Numerics are exact for the integer types and for fp16 here, so the comparison is
+bit-exact rather than toleranced. The payload is 0/1 -- what a mask carries, and
+small enough that every fp16 partial sum at these axis lengths is integral and
+under 2048. Output buffers are poisoned before each call, so a kernel that
+writes nothing fails instead of matching a zeroed buffer.
+
+| Case | Why it can break |
+|---|---|
+| Axis 511 and 512 | Straddles the selection boundary in both directions. The pair also reads as the mechanism's own before/after, since the two do near-identical work and land on opposite paths. |
+| Axis 256, 257, 1000, 16241 | Tile edges. Exactly one tile, one past it, and ragged tails -- where the inactive lanes of the final tile must contribute zero to the carry rather than garbage. |
+| `exclusive` x `reverse`, all four | On the serial path these live inside one thread's loop. On the cooperative path the exclusive shift and the reversed traversal each have to compose with the carry threaded between tiles. |
+| `inner > 1` (2x1000x3) | The cooperative kernel indexes its slice with the same stride arithmetic; a block that assumed contiguity passes every `inner == 1` case. |
+| 4096x16 (vision-shaped) | Regression guard on the pre-existing path, which is still the right one for short axes and must keep being selected. |
+| 8192x1024 | Many slices *and* a long axis. This is the case that decides whether the selection needs a slice-count term: the cooperative path stays well ahead even here, so it does not. |

--- a/lib/Runtime/Kernels/test/example/cumsum/test_cumsum_scan.cpp
+++ b/lib/Runtime/Kernels/test/example/cumsum/test_cumsum_scan.cpp
@@ -1,0 +1,256 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ *
+ * hip_cumsum against a CPU reference, across both of its launch strategies.
+ *
+ * The interesting shapes are the ones with FEW slices and a LONG axis. That is
+ * the decoder attention mask -- [1, context] scanned on axis 1, which collapses
+ * to outer = inner = 1 -- and it is the case the slice-parallel kernel handles
+ * with a single thread. Nothing in test/numeric reaches it: the longest axis
+ * there is 128 and every case has outer*inner > 1.
+ *
+ * The cases below therefore straddle the selection boundary in both directions,
+ * cover the ragged final tile, and keep a vision-shaped case (many slices,
+ * short axis) as a regression guard on the path that was already there.
+ *
+ * Build and run:
+ *   hipcc --offload-arch=gfx1151 -O3 -std=c++17 \
+ *       test_cumsum_scan.cpp ../../../hip/cumsum_kernel.hip \
+ *       -I../../../include -o test_cumsum_scan.exe
+ *   ./test_cumsum_scan.exe
+ */
+
+#include "hip_custom_kernels.h"
+
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#define HIP_CHECK(cmd)                                                         \
+  do {                                                                         \
+    hipError_t e_ = (cmd);                                                     \
+    if (e_ != hipSuccess) {                                                    \
+      std::printf("HIP error %s at line %d\n", hipGetErrorString(e_),          \
+                  __LINE__);                                                   \
+      std::exit(2);                                                            \
+    }                                                                          \
+  } while (0)
+
+static int g_failures = 0;
+
+// Deterministic, so a failure reproduces exactly.
+static uint32_t rng_state = 0x2545F491u;
+static uint32_t next_rand() {
+  rng_state ^= rng_state << 13;
+  rng_state ^= rng_state >> 17;
+  rng_state ^= rng_state << 5;
+  return rng_state;
+}
+
+struct Shape {
+  const char *name;
+  int64_t outer, axis, inner;
+};
+
+// Mirrors the kernel's own selection so the report can say which path ran. Kept
+// deliberately as a copy: if the launcher's rule changes without this one, the
+// coverage claim these cases make silently stops being true.
+static bool expects_cooperative(const Shape &s) { return s.axis >= 512; }
+
+template <typename T, typename ACC>
+static void cpu_reference(const std::vector<T> &x, std::vector<T> &y,
+                          int64_t outer, int64_t axis, int64_t inner, bool excl,
+                          bool rev) {
+  for (int64_t o = 0; o < outer; ++o) {
+    for (int64_t i = 0; i < inner; ++i) {
+      const int64_t base = o * axis * inner + i;
+      ACC acc = ACC(0);
+      for (int64_t n = 0; n < axis; ++n) {
+        const int64_t k = rev ? (axis - 1 - n) : n;
+        const int64_t idx = base + k * inner;
+        if (excl) {
+          y[idx] = static_cast<T>(acc);
+          acc += static_cast<ACC>(x[idx]);
+        } else {
+          acc += static_cast<ACC>(x[idx]);
+          y[idx] = static_cast<T>(acc);
+        }
+      }
+    }
+  }
+}
+
+template <typename T> static double to_double(T v) {
+  return static_cast<double>(v);
+}
+template <> double to_double<__half>(__half v) {
+  return static_cast<double>(__half2float(v));
+}
+
+template <typename T, typename ACC>
+static void run_case(const Shape &s, int hip_dtype, const char *dtype_name,
+                     bool excl, bool rev, double tol) {
+  const int64_t n = s.outer * s.axis * s.inner;
+  std::vector<T> h_x(static_cast<size_t>(n));
+  for (int64_t i = 0; i < n; ++i) {
+    // 0/1 payload: it is what a mask carries, it keeps the fp16 sums exact for
+    // these axis lengths, and it makes an off-by-one in the scan obvious in the
+    // output rather than lost in rounding.
+    h_x[static_cast<size_t>(i)] = static_cast<T>((next_rand() & 3u) ? 1 : 0);
+  }
+  std::vector<T> h_ref(static_cast<size_t>(n));
+  cpu_reference<T, ACC>(h_x, h_ref, s.outer, s.axis, s.inner, excl, rev);
+
+  T *d_x = nullptr, *d_y = nullptr;
+  HIP_CHECK(hipMalloc(&d_x, sizeof(T) * static_cast<size_t>(n)));
+  HIP_CHECK(hipMalloc(&d_y, sizeof(T) * static_cast<size_t>(n)));
+  HIP_CHECK(hipMemcpy(d_x, h_x.data(), sizeof(T) * static_cast<size_t>(n),
+                      hipMemcpyHostToDevice));
+  // Poison the output so a kernel that silently writes nothing fails loudly
+  // instead of inheriting a zeroed buffer that happens to match.
+  HIP_CHECK(hipMemset(d_y, 0x5A, sizeof(T) * static_cast<size_t>(n)));
+
+  int rc = hip_cumsum(nullptr, d_x, d_y, s.outer, s.axis, s.inner, hip_dtype,
+                      excl ? 1 : 0, rev ? 1 : 0);
+  HIP_CHECK(hipDeviceSynchronize());
+
+  std::vector<T> h_y(static_cast<size_t>(n));
+  HIP_CHECK(hipMemcpy(h_y.data(), d_y, sizeof(T) * static_cast<size_t>(n),
+                      hipMemcpyDeviceToHost));
+  HIP_CHECK(hipFree(d_x));
+  HIP_CHECK(hipFree(d_y));
+
+  double worst = 0.0;
+  int64_t worst_at = -1;
+  for (int64_t i = 0; i < n; ++i) {
+    const double a = to_double<T>(h_y[static_cast<size_t>(i)]);
+    const double b = to_double<T>(h_ref[static_cast<size_t>(i)]);
+    const double d =
+        std::fabs(a - b) / (std::fabs(b) > 1.0 ? std::fabs(b) : 1.0);
+    if (d > worst) {
+      worst = d;
+      worst_at = i;
+    }
+  }
+
+  const bool ok = (rc == 0) && (worst <= tol);
+  if (!ok)
+    ++g_failures;
+  std::printf("  %-24s %-6s %-9s %-5s  %-14s  worst %.3e  %s\n", s.name,
+              dtype_name, excl ? "excl" : "incl", rev ? "rev" : "fwd",
+              expects_cooperative(s) ? "cooperative" : "slice-parallel", worst,
+              ok ? "PASS" : "FAIL");
+  if (!ok && worst_at >= 0) {
+    std::printf("      rc=%d first-worst index %lld: got %.6f want %.6f\n", rc,
+                (long long)worst_at,
+                to_double<T>(h_y[static_cast<size_t>(worst_at)]),
+                to_double<T>(h_ref[static_cast<size_t>(worst_at)]));
+  }
+}
+
+// Wall time for one shape, i64, the decode mask's own dtype. Reported so the
+// selection boundary can be read as a cliff: 511 and 512 do near-identical work
+// and differ only in which kernel runs.
+static void bench_case(const Shape &s, int iters) {
+  const int64_t n = s.outer * s.axis * s.inner;
+  std::vector<int64_t> h_x(static_cast<size_t>(n), 1);
+  int64_t *d_x = nullptr, *d_y = nullptr;
+  HIP_CHECK(hipMalloc(&d_x, sizeof(int64_t) * static_cast<size_t>(n)));
+  HIP_CHECK(hipMalloc(&d_y, sizeof(int64_t) * static_cast<size_t>(n)));
+  HIP_CHECK(hipMemcpy(d_x, h_x.data(), sizeof(int64_t) * static_cast<size_t>(n),
+                      hipMemcpyHostToDevice));
+
+  for (int i = 0; i < 20; ++i)
+    hip_cumsum(nullptr, d_x, d_y, s.outer, s.axis, s.inner, HIP_DTYPE_INT64, 0,
+               0);
+  HIP_CHECK(hipDeviceSynchronize());
+
+  hipEvent_t t0, t1;
+  HIP_CHECK(hipEventCreate(&t0));
+  HIP_CHECK(hipEventCreate(&t1));
+  HIP_CHECK(hipEventRecord(t0));
+  for (int i = 0; i < iters; ++i)
+    hip_cumsum(nullptr, d_x, d_y, s.outer, s.axis, s.inner, HIP_DTYPE_INT64, 0,
+               0);
+  HIP_CHECK(hipEventRecord(t1));
+  HIP_CHECK(hipEventSynchronize(t1));
+  float ms = 0.0f;
+  HIP_CHECK(hipEventElapsedTime(&ms, t0, t1));
+  HIP_CHECK(hipEventDestroy(t0));
+  HIP_CHECK(hipEventDestroy(t1));
+  HIP_CHECK(hipFree(d_x));
+  HIP_CHECK(hipFree(d_y));
+
+  std::printf("  %-24s slices %-8lld axis %-8lld %-14s %9.2f us\n", s.name,
+              (long long)(s.outer * s.inner), (long long)s.axis,
+              expects_cooperative(s) ? "cooperative" : "slice-parallel",
+              1000.0 * ms / iters);
+}
+
+int main(int argc, char **argv) {
+  bool bench = false;
+  for (int i = 1; i < argc; ++i)
+    if (std::string(argv[i]) == "--bench")
+      bench = true;
+
+  const Shape shapes[] = {
+      // The decode attention mask, at both ends of the context range measured.
+      {"mask 1x2240x1", 1, 2240, 1},
+      {"mask 1x16241x1", 1, 16241, 1},
+      // Selection boundary, one either side, single slice.
+      {"boundary axis 511", 1, 511, 1},
+      {"boundary axis 512", 1, 512, 1},
+      // Selection boundary on slice count, with a long axis.
+      {"boundary slices 1023", 1023, 600, 1},
+      {"boundary slices 1024", 1024, 600, 1},
+      // Tile edges: exactly one tile, one past it, and a ragged tail.
+      {"tile exact 256", 1, 256, 1},
+      {"tile 257", 1, 257, 1},
+      {"tile ragged 1000", 1, 1000, 1},
+      // Strided: inner > 1 exercises the slice stride on the cooperative path.
+      {"strided 2x1000x3", 2, 1000, 3},
+      // Vision-shaped regression guard for the pre-existing path.
+      {"vision 4096x16x1", 4096, 16, 1},
+      // Many slices AND a long axis: the case that decides whether the
+      // selection needs a slice-count term at all.
+      {"wide+long 8192x1024", 8192, 1024, 1},
+  };
+
+  if (bench) {
+    std::printf("hip_cumsum: wall time per call, i64, inclusive forward\n");
+    for (const Shape &s : shapes)
+      bench_case(s, 200);
+    return 0;
+  }
+
+  std::printf(
+      "hip_cumsum: CPU-reference check across both launch strategies\n");
+  for (const Shape &s : shapes) {
+    for (int e = 0; e < 2; ++e) {
+      for (int r = 0; r < 2; ++r) {
+        const bool excl = (e != 0), rev = (r != 0);
+        // int64 is the decode mask's own dtype; the scan is exact, so any
+        // difference at all is a bug.
+        run_case<int64_t, int64_t>(s, HIP_DTYPE_INT64, "i64", excl, rev, 0.0);
+        run_case<int32_t, int32_t>(s, HIP_DTYPE_INT32, "i32", excl, rev, 0.0);
+        run_case<float, double>(s, HIP_DTYPE_FLOAT32, "f32", excl, rev, 1e-6);
+        // fp16 accumulates in float in the kernel; with a 0/1 payload every
+        // partial sum here is integral and under 2048, so it is exact too.
+        if (s.axis <= 2048)
+          run_case<__half, float>(s, HIP_DTYPE_FLOAT16, "f16", excl, rev, 0.0);
+      }
+    }
+  }
+
+  std::printf("\n%s (%d failing case(s))\n",
+              g_failures == 0 ? "ALL PASS" : "FAILURES", g_failures);
+  return g_failures == 0 ? 0 : 1;
+}

--- a/test/numeric/tests/test_cumsum.py
+++ b/test/numeric/tests/test_cumsum.py
@@ -13,7 +13,9 @@ The runtime supports f16, f32, i32, i64 inputs.
 
 Real-model footprint: attention-mask position-id computation in
 Llama / Qwen graphs uses a single CumSum on int64 [1, S] along axis=1
-(exclusive=0, reverse=0).
+(exclusive=0, reverse=0). That shape collapses to one slice, so the runtime
+scans it with a block-cooperative kernel rather than the per-slice serial one it
+uses for vision shapes; cases below are chosen to cover both.
 """
 
 from __future__ import annotations
@@ -25,7 +27,12 @@ from onnx import helper, numpy_helper
 from framework.comparator import compare_outputs
 from framework.onnx_utils import make_model_from_nodes, np_to_onnx_type
 
-SEQ_LENS = [1, 128]
+# The runtime picks between a per-thread serial scan and a block-cooperative
+# tiled scan on the axis length, crossing over at 512. These straddle it: 511
+# stays serial, 513 is cooperative with a ragged final tile, and 2240 is a real
+# decode context length. Without them CI only ever sees the serial path, which
+# is how a single thread came to be scanning an entire 16 241-long mask.
+SEQ_LENS = [1, 128, 511, 513, 2240]
 
 
 def _make_cumsum_model(
@@ -80,9 +87,14 @@ class TestCumSum:
 
     @pytest.mark.parametrize("exclusive", [0, 1])
     @pytest.mark.parametrize("reverse", [0, 1])
-    def test_cumsum_flag_combinations(self, model_runner, exclusive, reverse):
-        """All four (exclusive, reverse) combinations on i64 [3, 6]."""
-        shape = [3, 6]
+    # [3, 6] is the serial scan; [1, 1000] is the cooperative one, where the
+    # exclusive shift and the reversed traversal both have to compose with the
+    # running carry between tiles rather than living in one thread's loop.
+    @pytest.mark.parametrize(
+        "shape", [[3, 6], [1, 1000]], ids=["serial", "cooperative"]
+    )
+    def test_cumsum_flag_combinations(self, model_runner, shape, exclusive, reverse):
+        """All four (exclusive, reverse) combinations on i64, both scan paths."""
         model = _make_cumsum_model(
             np.int64,
             shape,


### PR DESCRIPTION
## Summary

`hip_cumsum` gives one thread per `(outer, inner)` slice and scans the axis
serially inside it. That is the right shape for the vision models it was written
for, and it degenerates exactly on a decoder: an attention mask is
`[1, context]` scanned on axis 1, so `outer = inner = 1` and a single thread
scans the whole context, once per generated token. An SQTT capture of Gemma-4
26B-A4B measured 61 us at 2 240 tokens and **501 us at 16 241**, growing
linearly with context.

This adds a second strategy rather than replacing the first: one block per
slice, scanning the axis in `BLOCK`-sized tiles through LDS with the running
total carried between tiles. Dependent steps per slice fall from `axis_size` to
`(axis_size / BLOCK) * log2(BLOCK)` — at a 16 241-long axis, from 16 241 to
about 512.

## Related issue or design

Part of the Gemma-4 26B-A4B decode series on top of #808, with #851 and #852.
Independent of both: this touches only `cumsum_kernel.hip` and can land in any
order relative to them.

## Why

Selection is on the axis length alone. A slice-count term looks tempting and
measures worse — above the floor the cooperative kernel wins whatever the slice
count, including 8 192 slices where it runs 624.65 us against 13 742.05 us. The
floor is set at 512 as a conservative bound rather than a measured crossover: a
256-thread block on a short axis idles most of its lanes and pays the syncs
anyway, and the vision shape this kernel exists for (4096x16) runs 5.91 us
serial and is not worth risking.

Numerics are unchanged for the integer types, which is what the mask uses. The
exclusive value is read from the scanned array as `tile[tid - 1]` rather than
subtracted back off the inclusive result, so the float path does not acquire a
cancellation the serial scan never had.

## What

- Cooperative block-per-slice scan path in `cumsum_kernel.hip`, selected on axis
  length, with the serial path retained below the floor. The choice is
  unconditional: there is no runtime switch, so a given shape always takes the
  same path.

## Test plan

Coverage went to where the bug was. `test/numeric` only ever ran this op with
`outer*inner > 1` and an axis of at most 128, so the degenerate shape was never
exercised.

- `test/numeric` `SEQ_LENS` now straddles the crossover, and the flag
  combinations run on both paths.
- The standalone test additionally covers the tile edges and the strided
  (`inner > 1`) case, and reports per-call times so the boundary reads as its own
  before/after: axis 511 and 512 do near-identical work at **28.00 us and
  3.91 us**. Both paths are covered in one run, since the case list straddles
  the floor in both directions.

## Performance

Gemma-4 26B-A4B, gfx1151 (Radeon 8060S), 16 241-token prompt, 6 paired rounds x
3 reps, both orderings.

| Metric | Serial | Cooperative |
|---|---:|---:|
| ms/token | 24.98 | 24.14 |
| tok/s | 40.04 | 41.43 |

Paired delta **-0.837 ms/token**, sd 0.509, n = 6, t = -4.03 (**+3.5% TPS**).
Every round moved the same way and the reversed block did not flip the sign, so
this is not run order. The effect is about twice the kernel's own measured time;
that excess is not explained here and is not claimed as part of the result.

How the two arms were obtained: while the measurements were taken, the branch
carried a `HIPDNN_CUMSUM_SERIAL` escape hatch that forced a long axis back onto
the serial scan, so both arms ran byte-identical DLLs and differed only in that
variable. The hatch has since been removed from the branch, since a merged
kernel should not ship a switch that exists only to measure it. The table is
therefore a record of what was measured rather than something a reader can
repeat as-is; repeating it now means building the two commits separately. The
same applies to the serial columns quoted under "Why", which were taken the same
way. A separate run against this exact branch, after the hatch was removed,
reproduced the direction and magnitude at **-0.811 ms/token**.

## Notes for reviewers

The kernel-time saving (501 us -> tens of us at 16K) is smaller than the
end-to-end saving, which suggests the serial scan was also holding up dispatch
behind it. Unproven, so the number above is stated as measured rather than
attributed.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.

Developed with substantial AI assistance (Cursor). The measurements, the
selection floor and the test shapes were reviewed by hand.
