### PR TITLE
perf(gqa): apply the additive attention mask in flash decode

### DIFF
--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -2718,7 +2718,7 @@ extern "C" int hip_gqa_flash_decode(
   // decomposed pipeline, which applies the bias for every cache format.
   if (kv_i8 && attn_bias != nullptr) {
     fprintf(stderr,
-            "hip_gqa_flash_decode_v2: attention_bias is not supported with an "
+            "hip_gqa_flash_decode: attention_bias is not supported with an "
             "INT8 KV cache\n");
     return -1;
   }

--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -1470,7 +1470,12 @@ gqa_flash_decode_kernel(
     float scale,
     const int* __restrict__ seqlens_k,
     int local_window_size,
-    int K_SPLITS) {  // runtime split-K count (was a template param)
+    int K_SPLITS,                          // runtime split-K count
+    // Additive attention mask, dense [bias_batch, bias_heads, 1, bias_kv_stride]
+    // (sq == 1 on this path). Extent 1 on either leading dim broadcasts. Null
+    // when the model supplies no mask.
+    const __half* __restrict__ attn_bias = nullptr,
+    int bias_batch = 1, int bias_heads = 1, int bias_kv_stride = 0) {
   constexpr bool KV_I8 = (FMT == KvDtype::kI8);
   using KVt = std::conditional_t<KV_I8, int8_t, __half>;
   // Size the K+V LDS tile for block residency, since this kernel is bandwidth
@@ -1593,6 +1598,16 @@ gqa_flash_decode_kernel(
 
   const float scale_log2e = scale * LOG2E;
 
+  // Row of the additive mask this wave's query head reads, with extent-1
+  // broadcast on batch and heads. Loop-invariant, so the null test below is
+  // hoisted out of the KV loop.
+  const __half* bias_row = nullptr;
+  if (attn_bias) {
+    const int bb = (bias_batch > 1) ? batch : 0;
+    const int bh = (bias_heads > 1) ? head_q : 0;
+    bias_row = attn_bias + ((size_t)bb * bias_heads + bh) * (size_t)bias_kv_stride;
+  }
+
   // Online softmax accumulators (per query head, in registers).
   float m_acc = -INFINITY;
   float l_acc = 0.0f;
@@ -1686,7 +1701,22 @@ gqa_flash_decode_kernel(
       for (int offset = WAVE_SIZE >> 1; offset > 0; offset >>= 1)
         dot_partial += __shfl_xor(dot_partial, offset);
 
-      const float score = dot_partial * scale_log2e;
+      // scores = q.k * scale + bias, carried in the log2 domain for exp2f. The
+      // mask is folded in BEFORE the running max, so the FA-2 invariant (m_acc
+      // is the max over every score seen so far) holds and the split merge,
+      // the [B,H,K_SPLITS,D+2] partials layout and the sink term stay correct.
+      float score = dot_partial * scale_log2e;
+      if (bias_row) {
+        score = fmaf(__half2float(bias_row[tile_start + t]), LOG2E, score);
+        // A -inf mask entry contributes nothing, and letting it reach the
+        // rescale below would form (-inf) - (-inf) = NaN for as long as every
+        // key seen so far in this split is masked -- routine for a sliding
+        // window, whose leading splits are entirely outside the window. score
+        // is wave-uniform (dot_partial is an all-reduce and the mask row is
+        // shared), so this skip never diverges.
+        if (score == -INFINITY)
+          continue;
+      }
       const float m_new = fmaxf(m_acc, score);
       const float correction = exp2f(m_acc - m_new);
       const float p = exp2f(score - m_new);
@@ -2257,9 +2287,16 @@ static inline void launchFlashDecodeConfig(
     const float* kSc, const float* vSc, __half* hO, float* hP,
     int B, int H, int G, int d, int hpg, int max_seq, float scale,
     const int* iSeq, int local_window_size,
-    const __half* hSink, int use_smooth_softmax) {
+    const __half* hSink, int use_smooth_softmax,
+    const __half* hBias = nullptr, int bias_batch = 1, int bias_heads = 1,
+    int bias_kv_stride = 0) {
   const int splits = cfg.splits;
-  const bool use_wmma = cfg.use_wmma && flash_decode_wmma_supported(d, hpg);
+  // Only the scalar kernel applies the additive mask; the WMMA variant has no
+  // bias support, so a masked call must not select it or the mask would be
+  // silently dropped. WMMA covers d in {64,128} only, so this costs nothing at
+  // the d=256 geometries that actually carry a mask here.
+  const bool use_wmma =
+      cfg.use_wmma && !hBias && flash_decode_wmma_supported(d, hpg);
   if (use_wmma) {
     // BKV: D=64 has both 16 and 32 instantiated and cfg.bkv picks between them;
     // D=128 has only 32. Grid (G, splits, B), one wave per block.
@@ -2294,7 +2331,8 @@ static inline void launchFlashDecodeConfig(
       gqa_flash_decode_kernel<D_, HPG_, FMT>                                   \
           <<<grid_main, (HPG_) * WAVE_SIZE, 0, stream>>>(                      \
               hQ, hK, hV, kSc, vSc, hP, H, G, max_seq, scale, iSeq,            \
-              local_window_size, splits)
+              local_window_size, splits, hBias, bias_batch, bias_heads,        \
+              bias_kv_stride)
     #define LAUNCH_SCALAR(HPG_)                                                \
       do {                                                                     \
         if (d == 256)      LAUNCH_SCALAR_D(256, HPG_);                         \
@@ -2550,12 +2588,15 @@ static float timeDecodeCandidate(hipStream_t stream, LaunchFn&& launch) {
 template <typename LaunchFn>
 static FlashDecodeCfg tuneFlashDecodeConfig(
     hipStream_t stream, int d, int hpg, int skv, int max_splits,
-    const char* tag, LaunchFn&& launch) {
+    bool wmma_allowed, const char* tag, LaunchFn&& launch) {
   int split_set[7]; int n_splits = 0;
   flashDecodeCandidateSplits(skv, max_splits, split_set, n_splits);
   const bool impls[2] = {false, true};  // {scalar, WMMA}; geometry is identical
 
-  const bool wmma_ok = flash_decode_wmma_supported(d, hpg);
+  // wmma_allowed is the caller's veto: only the scalar kernel applies the
+  // additive mask, so a masked call must not spend tuning iterations on a
+  // candidate the launcher would then refuse to use.
+  const bool wmma_ok = wmma_allowed && flash_decode_wmma_supported(d, hpg);
   FlashDecodeCfg best{wmma_ok && (d == 64), split_set[0]};
   float best_ms = 1e30f;
 
@@ -2627,7 +2668,14 @@ extern "C" int hip_gqa_flash_decode(
     int use_smooth_softmax,
     int kv_dtype,
     const void* k_scale,
-    const void* v_scale) {
+    const void* v_scale,
+    // Additive attention mask (onnx.Attention external mask), dense
+    // [attn_bias_batch, attn_bias_heads, 1, attn_bias_kv_stride] fp16. Null when
+    // the model has no mask. Extent 1 on batch/heads broadcasts. The kv stride
+    // is passed explicitly rather than derived from skv so it matches the
+    // decomposed path's view of the mask exactly.
+    const void* attn_bias,
+    int attn_bias_batch, int attn_bias_heads, int attn_bias_kv_stride) {
   // HPG = heads-per-group (Q heads sharing one KV head). The kernels are
   // instantiated for HPG=4 (Llama-3.x family at d=64 and d=128), HPG=5
   // (Qwen2.5-14B's 40:8 at d=128) and HPG=8 (gpt-oss-20b at d=64). HPG=8 with
@@ -2665,6 +2713,15 @@ extern "C" int hip_gqa_flash_decode(
             "hip_gqa_flash_decode: INT8 KV requires k_scale and v_scale\n");
     return -1;
   }
+  // The int8 launcher does not thread the mask, so a masked int8 call would
+  // drop it silently. Reject instead: the caller can fall back to the
+  // decomposed pipeline, which applies the bias for every cache format.
+  if (kv_i8 && attn_bias != nullptr) {
+    fprintf(stderr,
+            "hip_gqa_flash_decode_v2: attention_bias is not supported with an "
+            "INT8 KV cache\n");
+    return -1;
+  }
 
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
   const __half* hQ = static_cast<const __half*>(Q);
@@ -2672,6 +2729,9 @@ extern "C" int hip_gqa_flash_decode(
   float* hP = static_cast<float*>(partials_workspace);
   const int* iSeq = static_cast<const int*>(seqlens_k);
   const __half* hSink = static_cast<const __half*>(head_sink);
+  const __half* hBias = static_cast<const __half*>(attn_bias);
+  const int bias_b = attn_bias_batch > 0 ? attn_bias_batch : 1;
+  const int bias_h = attn_bias_heads > 0 ? attn_bias_heads : 1;
 
   int cap = max_splits;
   if (cap < 1) cap = 1;
@@ -2685,6 +2745,11 @@ extern "C" int hip_gqa_flash_decode(
   const int tune_len = (local_window_size > 0 && eff_skv > local_window_size)
                            ? local_window_size
                            : eff_skv;
+  // The autotune cache is keyed on geometry only, so a masked and an unmasked
+  // call of the same shape share an entry. That stays correct because the
+  // launcher re-checks the mask before selecting WMMA: a cached WMMA config is
+  // demoted to scalar for a masked call, and a scalar config cached by a masked
+  // call is merely conservative for an unmasked one.
 
   // --- Config selection: env override > autotune cache > one-shot tune ---
   // Heuristic default favours WMMA at d==64, but only where it is templated;
@@ -2722,9 +2787,12 @@ extern "C" int hip_gqa_flash_decode(
       if (it != g_flash_decode_i8_cache.end()) {
         cfg = it->second;
       } else {
+        // The INT8 launcher does not thread the mask at all -- gqa.cpp's bias_ok
+        // rejects a masked call with a quantized cache -- so WMMA is never
+        // vetoed here.
         cfg = tuneFlashDecodeConfig(
-            stream, d, hpg, tune_len, cap, "flash_decode_i8",
-            [&](const FlashDecodeCfg& c) {
+            stream, d, hpg, tune_len, cap, /*wmma_allowed=*/true,
+            "flash_decode_i8", [&](const FlashDecodeCfg& c) {
               launchFlashDecodeConfig<KvDtype::kI8>(
                   c, stream, hQ, hK, hV, kSc, vSc, hO, hP, B, H, G, d, hpg,
                   max_seq, scale, iSeq, local_window_size, hSink,
@@ -2749,12 +2817,13 @@ extern "C" int hip_gqa_flash_decode(
       cfg = it->second;
     } else {
       cfg = tuneFlashDecodeConfig(
-          stream, d, hpg, tune_len, cap, "flash_decode",
-          [&](const FlashDecodeCfg& c) {
+          stream, d, hpg, tune_len, cap, /*wmma_allowed=*/hBias == nullptr,
+          "flash_decode", [&](const FlashDecodeCfg& c) {
             launchFlashDecodeConfig<KvDtype::kF16>(
                 c, stream, hQ, hK, hV, nullptr, nullptr, hO, hP, B, H, G, d,
                 hpg, max_seq, scale, iSeq, local_window_size, hSink,
-                use_smooth_softmax);
+                use_smooth_softmax, hBias, bias_b, bias_h,
+                attn_bias_kv_stride);
           });
       g_flash_decode_cache[key] = cfg;
       CUSTOM_KERNELS_DEBUG_LOG(
@@ -2769,7 +2838,8 @@ extern "C" int hip_gqa_flash_decode(
   // buffers holding the last candidate's result).
   launchFlashDecodeConfig<KvDtype::kF16>(
       cfg, stream, hQ, hK, hV, nullptr, nullptr, hO, hP, B, H, G, d, hpg,
-      max_seq, scale, iSeq, local_window_size, hSink, use_smooth_softmax);
+      max_seq, scale, iSeq, local_window_size, hSink, use_smooth_softmax,
+      hBias, bias_b, bias_h, attn_bias_kv_stride);
 
   return hipGetLastError();
 }

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -884,7 +884,16 @@ HIP_KERNEL_API int hip_gqa_flash_decode(
     int use_smooth_softmax,
     int kv_dtype,
     const void* k_scale,
-    const void* v_scale);
+    const void* v_scale,
+    /* Additive attention mask (onnx.Attention attn_mask), dense fp16
+     * [attn_bias_batch, attn_bias_heads, 1, attn_bias_kv_stride]; sq == 1 on
+     * this path. NULL when the model has no mask. Extent 1 on either leading
+     * dim broadcasts across it. The kv stride is explicit rather than derived
+     * from skv so it matches the decomposed path's view of the mask. Applied by
+     * the scalar kernel only, so a masked call never selects WMMA; rejected
+     * outright with an INT8 KV cache, which does not thread it. */
+    const void* attn_bias,
+    int attn_bias_batch, int attn_bias_heads, int attn_bias_kv_stride);
 
 /* =========================================================================
  * Cast (Element Type Conversion)

--- a/lib/Runtime/Kernels/test/example/gqa/decode/test_gqa_decode.cpp
+++ b/lib/Runtime/Kernels/test/example/gqa/decode/test_gqa_decode.cpp
@@ -55,7 +55,12 @@ extern "C" int hip_gqa_flash_decode(
     int local_window_size,
     const void* head_sink,
     int use_smooth_softmax,
-    int kv_dtype, const void* k_scale, const void* v_scale);
+    int kv_dtype, const void* k_scale, const void* v_scale,
+    // Additive attention mask; this test exercises the unmasked path, so it
+    // passes NULL. Declared to match the entry point exactly -- extern "C" is
+    // unmangled, so a short declaration here would link and then read garbage.
+    const void* attn_bias,
+    int attn_bias_batch, int attn_bias_heads, int attn_bias_kv_stride);
 
 // Legacy one-block-per-head fused decode (the ORIGINAL baseline that the
 // OPTIMIZATION.md 10-20x figure was measured against). No window/sink/split-K.
@@ -229,7 +234,7 @@ static double run_kernel(DecodeMode mode, const Case& c, float scale,
   HIP_CHECK((hipError_t)hip_gqa_flash_decode(
       nullptr, dQ, dK, dV, dO, dPart, B, H, G, D, c.total, max_seq, MAX_SPLITS,
       scale, dSeq, c.window, sinkp, c.smooth, HIP_KV_DTYPE_FP16, nullptr,
-      nullptr));
+      nullptr, nullptr, 1, 1, 0));
   HIP_CHECK(hipDeviceSynchronize());
   host_O.resize((size_t)B * H * D);
   {
@@ -246,7 +251,8 @@ static double run_kernel(DecodeMode mode, const Case& c, float scale,
   for (int it = 0; it < iters; ++it) {
     hip_gqa_flash_decode(nullptr, dQ, dK, dV, dO, dPart, B, H, G, D, c.total,
                             max_seq, MAX_SPLITS, scale, dSeq, c.window, sinkp,
-                            c.smooth, HIP_KV_DTYPE_FP16, nullptr, nullptr);
+                            c.smooth, HIP_KV_DTYPE_FP16, nullptr, nullptr,
+                            nullptr, 1, 1, 0);
   }
   HIP_CHECK(hipEventRecord(b));
   HIP_CHECK(hipEventSynchronize(b));

--- a/lib/Runtime/Kernels/test/example/gqa/decode/test_gqa_decode_bias.cpp
+++ b/lib/Runtime/Kernels/test/example/gqa/decode/test_gqa_decode_bias.cpp
@@ -1,7 +1,7 @@
 // ============================================================
 // custom_kernels GQA flash *decode* with an additive attention mask.
 //
-// Covers the path branch 2 opens up: hip_gqa_flash_decode_v2 with a dense
+// Covers the path branch 2 opens up: hip_gqa_flash_decode with a dense
 // [bias_batch, bias_heads, 1, total_seq] fp16 bias folded into the online
 // softmax. Verified against a CPU fp32 reference over the mask shapes the
 // Gemma-4 26B graph actually emits:
@@ -30,7 +30,7 @@
 
 enum { HIP_KV_DTYPE_FP16 = 0, HIP_KV_DTYPE_INT8 = 1 };
 
-extern "C" int hip_gqa_flash_decode_v2(
+extern "C" int hip_gqa_flash_decode(
     void* stream,
     const void* Q, const void* Kcache, const void* Vcache,
     void* O,
@@ -245,7 +245,7 @@ int main() {
                         hipMemcpyHostToDevice));
 
     // window is carried entirely by the mask, so the kernel runs unwindowed.
-    HIP_CHECK((hipError_t)hip_gqa_flash_decode_v2(
+    HIP_CHECK((hipError_t)hip_gqa_flash_decode(
         nullptr, dQ, dK, dV, dO, dPart, B, H, G, D, c.total, max_seq,
         MAX_SPLITS, scale, dSeq, 0, nullptr, 0, HIP_KV_DTYPE_FP16, nullptr,
         nullptr, dBias, /*bias_batch=*/B, bias_heads, /*bias_kv_stride=*/c.total));

--- a/lib/Runtime/Kernels/test/example/gqa/decode/test_gqa_decode_bias.cpp
+++ b/lib/Runtime/Kernels/test/example/gqa/decode/test_gqa_decode_bias.cpp
@@ -1,0 +1,282 @@
+// ============================================================
+// custom_kernels GQA flash *decode* with an additive attention mask.
+//
+// Covers the path branch 2 opens up: hip_gqa_flash_decode_v2 with a dense
+// [bias_batch, bias_heads, 1, total_seq] fp16 bias folded into the online
+// softmax. Verified against a CPU fp32 reference over the mask shapes the
+// Gemma-4 26B graph actually emits:
+//
+//   zero      - all-zero mask; must reproduce the unmasked result exactly.
+//   window    - sliding window, masked entries at the fp16 minimum (-65504),
+//               which is what an HF export writes for a finite dtype min.
+//   window_inf- sliding window, masked entries at -inf. This is the dangerous
+//               one: a split whose keys are ALL masked leaves the FA-2 running
+//               max at -inf, and (-inf) - (-inf) is NaN in the rescale.
+//   random    - dense small biases, no masking, to catch plain indexing slips.
+//   headwise  - per-head mask (bias_heads == H) rather than the broadcast one.
+//
+// Self-contained: random inputs generated in-process, no data files.
+// ============================================================
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <random>
+#include <string>
+#include <vector>
+
+enum { HIP_KV_DTYPE_FP16 = 0, HIP_KV_DTYPE_INT8 = 1 };
+
+extern "C" int hip_gqa_flash_decode_v2(
+    void* stream,
+    const void* Q, const void* Kcache, const void* Vcache,
+    void* O,
+    void* partials_workspace,
+    int B, int H, int G, int d, int skv, int max_seq, int max_splits,
+    float scale,
+    const void* seqlens_k,
+    int local_window_size,
+    const void* head_sink,
+    int use_smooth_softmax,
+    int kv_dtype, const void* k_scale, const void* v_scale,
+    const void* attn_bias,
+    int attn_bias_batch, int attn_bias_heads, int attn_bias_kv_stride);
+
+static constexpr int MAX_SPLITS = 64;
+
+#define HIP_CHECK(expr)                                                        \
+  do {                                                                         \
+    hipError_t _e = (expr);                                                    \
+    if (_e != hipSuccess) {                                                    \
+      fprintf(stderr, "HIP error %s at %s:%d\n", hipGetErrorString(_e),        \
+              __FILE__, __LINE__);                                             \
+      std::exit(1);                                                            \
+    }                                                                          \
+  } while (0)
+
+enum MaskKind { MASK_ZERO, MASK_WINDOW, MASK_WINDOW_INF, MASK_RANDOM };
+
+struct Case {
+  const char* name;
+  int B, H, G, D, max_seq, total;
+  MaskKind kind;
+  int window;      // for the window kinds
+  int per_head;    // 1 => bias_heads == H, 0 => bias_heads == 1
+};
+
+// Build the [bias_batch, bias_heads, 1, total] mask in fp32 (host reference
+// units); the device copy is the fp16 narrowing of exactly these values.
+static void build_bias(const Case& c, int bias_heads, std::mt19937& rng,
+                       std::vector<float>& bias) {
+  std::uniform_real_distribution<float> small(-2.0f, 2.0f);
+  bias.assign((size_t)c.B * bias_heads * c.total, 0.0f);
+  const float kHalfMin = -65504.0f;
+  for (int b = 0; b < c.B; ++b) {
+    for (int h = 0; h < bias_heads; ++h) {
+      float* row = &bias[((size_t)b * bias_heads + h) * c.total];
+      for (int kv = 0; kv < c.total; ++kv) {
+        switch (c.kind) {
+          case MASK_ZERO:
+            row[kv] = 0.0f;
+            break;
+          case MASK_RANDOM:
+            row[kv] = small(rng);
+            break;
+          case MASK_WINDOW:
+            row[kv] = (kv < c.total - c.window) ? kHalfMin : 0.0f;
+            break;
+          case MASK_WINDOW_INF:
+            row[kv] = (kv < c.total - c.window) ? -INFINITY : 0.0f;
+            break;
+        }
+      }
+    }
+  }
+}
+
+// CPU fp32 reference: plain softmax over [0, eff) with the bias added to the
+// pre-softmax score, matching the decomposed pipeline's Step 8b + Step 9.
+static void cpu_reference(const Case& c, int bias_heads,
+                          const std::vector<float>& Q,
+                          const std::vector<float>& K,
+                          const std::vector<float>& V,
+                          const std::vector<float>& bias,
+                          const std::vector<int>& seqlens, float scale,
+                          std::vector<float>& O) {
+  const int B = c.B, H = c.H, G = c.G, D = c.D, max_seq = c.max_seq;
+  const int hpg = H / G;
+  O.assign((size_t)B * H * D, 0.0f);
+  for (int b = 0; b < B; ++b) {
+    int raw = seqlens[b] + 1;
+    int eff = raw < 0 ? 0 : (raw > max_seq ? max_seq : raw);
+    for (int h = 0; h < H; ++h) {
+      int g = h / hpg;
+      const float* q = &Q[((size_t)b * H + h) * D];
+      const float* brow =
+          &bias[((size_t)b * bias_heads + (bias_heads == 1 ? 0 : h)) * c.total];
+
+      float m = -INFINITY;
+      std::vector<float> s(eff);
+      for (int kv = 0; kv < eff; ++kv) {
+        const float* k = &K[(((size_t)b * G + g) * max_seq + kv) * D];
+        float dot = 0.0f;
+        for (int e = 0; e < D; ++e) dot += q[e] * k[e];
+        s[kv] = dot * scale + brow[kv];
+        if (s[kv] > m) m = s[kv];
+      }
+      float* o = &O[((size_t)b * H + h) * D];
+      if (!std::isfinite(m)) continue;  // every key masked out
+
+      float l = 0.0f;
+      std::vector<float> acc(D, 0.0f);
+      for (int kv = 0; kv < eff; ++kv) {
+        const float* v = &V[(((size_t)b * G + g) * max_seq + kv) * D];
+        float p = std::exp(s[kv] - m);
+        l += p;
+        for (int e = 0; e < D; ++e) acc[e] += p * v[e];
+      }
+      float inv = 1.0f / (l < 1e-6f ? 1e-6f : l);
+      for (int e = 0; e < D; ++e) o[e] = acc[e] * inv;
+    }
+  }
+}
+
+static double rel_l2(const std::vector<float>& a, const std::vector<float>& b) {
+  double num = 0.0, den = 0.0;
+  for (size_t i = 0; i < a.size(); ++i) {
+    double d = (double)a[i] - (double)b[i];
+    num += d * d;
+    den += (double)b[i] * (double)b[i];
+  }
+  return std::sqrt(num / (den + 1e-12));
+}
+
+static bool has_nonfinite(const std::vector<float>& a) {
+  for (float v : a)
+    if (!std::isfinite(v)) return true;
+  return false;
+}
+
+int main() {
+  // Gemma-4 26B-A4B local-attention geometry (25 of 30 layers) plus two
+  // smaller shapes that exercise other instantiated (D, HpG) kernels.
+  std::vector<Case> cases = {
+      {"gemma4-local zero      ", 1, 16, 8, 256, 16384, 2051, MASK_ZERO, 0, 0},
+      {"gemma4-local random    ", 1, 16, 8, 256, 16384, 2051, MASK_RANDOM, 0, 0},
+      {"gemma4-local window1024", 1, 16, 8, 256, 16384, 2051, MASK_WINDOW, 1024, 0},
+      {"gemma4-local window-inf", 1, 16, 8, 256, 16384, 2051, MASK_WINDOW_INF, 1024, 0},
+      {"gemma4-local 12k wininf", 1, 16, 8, 256, 16384, 12279, MASK_WINDOW_INF, 1024, 0},
+      {"gemma4-local 12k window", 1, 16, 8, 256, 16384, 12279, MASK_WINDOW, 1024, 0},
+      {"gemma4-local per-head  ", 1, 16, 8, 256, 16384, 2051, MASK_RANDOM, 0, 1},
+      {"llama-3.1-8b random    ", 1, 32, 8, 128, 16384, 4096, MASK_RANDOM, 0, 0},
+      {"llama-3.1-8b window-inf", 1, 32, 8, 128, 16384, 4096, MASK_WINDOW_INF, 512, 0},
+      {"d64 hpg8 window-inf    ", 1, 64, 8, 64, 16384, 8192, MASK_WINDOW_INF, 256, 0},
+  };
+
+  std::mt19937 rng(1234);
+  std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+  int failures = 0;
+
+  for (const Case& c : cases) {
+    const int B = c.B, H = c.H, G = c.G, D = c.D, max_seq = c.max_seq;
+    const int bias_heads = c.per_head ? H : 1;
+    const float scale = 1.0f / std::sqrt((float)D);
+
+    std::vector<float> Q((size_t)B * H * D);
+    std::vector<float> K((size_t)B * G * max_seq * D);
+    std::vector<float> V((size_t)B * G * max_seq * D);
+    for (auto& x : Q) x = dist(rng);
+    // Only [0, total) is ever read; leave the tail zeroed to keep the host
+    // allocation cheap at max_seq = 16384.
+    for (int b = 0; b < B; ++b)
+      for (int g = 0; g < G; ++g)
+        for (int kv = 0; kv < c.total; ++kv)
+          for (int e = 0; e < D; ++e) {
+            size_t i = (((size_t)b * G + g) * max_seq + kv) * D + e;
+            K[i] = dist(rng);
+            V[i] = dist(rng);
+          }
+
+    std::vector<float> bias;
+    build_bias(c, bias_heads, rng, bias);
+
+    std::vector<int> seqlens(B, c.total - 1);
+
+    // Narrow to fp16 on the host so the reference sees exactly the values the
+    // kernel reads (otherwise fp16 rounding shows up as a false mismatch).
+    auto to_half = [](const std::vector<float>& src) {
+      std::vector<__half> dst(src.size());
+      for (size_t i = 0; i < src.size(); ++i) dst[i] = __float2half(src[i]);
+      return dst;
+    };
+    std::vector<__half> Qh = to_half(Q), Kh = to_half(K), Vh = to_half(V),
+                        Bh = to_half(bias);
+    for (size_t i = 0; i < Q.size(); ++i) Q[i] = __half2float(Qh[i]);
+    for (size_t i = 0; i < K.size(); ++i) K[i] = __half2float(Kh[i]);
+    for (size_t i = 0; i < V.size(); ++i) V[i] = __half2float(Vh[i]);
+    for (size_t i = 0; i < bias.size(); ++i) bias[i] = __half2float(Bh[i]);
+
+    std::vector<float> ref;
+    cpu_reference(c, bias_heads, Q, K, V, bias, seqlens, scale, ref);
+
+    __half *dQ, *dK, *dV, *dO, *dBias;
+    float* dPart;
+    int* dSeq;
+    HIP_CHECK(hipMalloc(&dQ, Qh.size() * sizeof(__half)));
+    HIP_CHECK(hipMalloc(&dK, Kh.size() * sizeof(__half)));
+    HIP_CHECK(hipMalloc(&dV, Vh.size() * sizeof(__half)));
+    HIP_CHECK(hipMalloc(&dBias, Bh.size() * sizeof(__half)));
+    HIP_CHECK(hipMalloc(&dO, (size_t)B * H * D * sizeof(__half)));
+    HIP_CHECK(hipMalloc(&dPart,
+                        (size_t)B * H * MAX_SPLITS * (D + 2) * sizeof(float)));
+    HIP_CHECK(hipMalloc(&dSeq, B * sizeof(int)));
+    HIP_CHECK(hipMemcpy(dQ, Qh.data(), Qh.size() * sizeof(__half),
+                        hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(dK, Kh.data(), Kh.size() * sizeof(__half),
+                        hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(dV, Vh.data(), Vh.size() * sizeof(__half),
+                        hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(dBias, Bh.data(), Bh.size() * sizeof(__half),
+                        hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(dSeq, seqlens.data(), B * sizeof(int),
+                        hipMemcpyHostToDevice));
+
+    // window is carried entirely by the mask, so the kernel runs unwindowed.
+    HIP_CHECK((hipError_t)hip_gqa_flash_decode_v2(
+        nullptr, dQ, dK, dV, dO, dPart, B, H, G, D, c.total, max_seq,
+        MAX_SPLITS, scale, dSeq, 0, nullptr, 0, HIP_KV_DTYPE_FP16, nullptr,
+        nullptr, dBias, /*bias_batch=*/B, bias_heads, /*bias_kv_stride=*/c.total));
+    HIP_CHECK(hipDeviceSynchronize());
+
+    std::vector<float> got((size_t)B * H * D);
+    {
+      std::vector<__half> tmp(got.size());
+      HIP_CHECK(hipMemcpy(tmp.data(), dO, tmp.size() * sizeof(__half),
+                          hipMemcpyDeviceToHost));
+      for (size_t i = 0; i < tmp.size(); ++i) got[i] = __half2float(tmp[i]);
+    }
+
+    double err = rel_l2(got, ref);
+    bool nan_out = has_nonfinite(got);
+    bool ok = !nan_out && err < 5e-3;
+    if (!ok) ++failures;
+    printf("%s B%d H%d G%d(hpg%d) D%-3d total=%-6d bias_heads=%d | relL2=%.2e%s  %s\n",
+           c.name, B, H, G, H / G, D, c.total, bias_heads, err,
+           nan_out ? "  NON-FINITE OUTPUT" : "", ok ? "PASS" : "FAIL");
+
+    HIP_CHECK(hipFree(dQ));
+    HIP_CHECK(hipFree(dK));
+    HIP_CHECK(hipFree(dV));
+    HIP_CHECK(hipFree(dBias));
+    HIP_CHECK(hipFree(dO));
+    HIP_CHECK(hipFree(dPart));
+    HIP_CHECK(hipFree(dSeq));
+  }
+
+  printf("\n%s (%d failing case(s))\n", failures ? "FAILURES" : "ALL PASS",
+         failures);
+  return failures ? 1 : 0;
+}

--- a/lib/Runtime/Kernels/test/example/gqa/decode/test_gqa_decode_i8.cpp
+++ b/lib/Runtime/Kernels/test/example/gqa/decode/test_gqa_decode_i8.cpp
@@ -42,7 +42,9 @@ extern "C" int hip_gqa_flash_decode(
     int B, int H, int G, int d, int skv, int max_seq, int max_splits,
     float scale, const void* seqlens_k, int local_window_size,
     const void* head_sink, int use_smooth_softmax,
-    int kv_dtype, const void* k_scale, const void* v_scale);
+    int kv_dtype, const void* k_scale, const void* v_scale,
+    const void* attn_bias, int attn_bias_batch, int attn_bias_heads,
+    int attn_bias_kv_stride);
 
 static constexpr int MAX_SPLITS = 64;
 
@@ -262,7 +264,8 @@ static Result run_case(const Case& c, int iters, unsigned seed) {
   // Warmup + correctness fetch for the int8 kernel (kv_dtype = INT8).
   HIP_CHECK((hipError_t)hip_gqa_flash_decode(
       nullptr, dQ, dK8, dV8, dO8, dPart, B, H, G, D, c.total, max_seq,
-      MAX_SPLITS, scale, dSeq, 0, nullptr, 0, HIP_KV_DTYPE_INT8, dKsc, dVsc));
+      MAX_SPLITS, scale, dSeq, 0, nullptr, 0, HIP_KV_DTYPE_INT8, dKsc, dVsc,
+      nullptr, 1, 1, 0));
   HIP_CHECK(hipDeviceSynchronize());
   std::vector<float> O_int8((size_t)B * H * D);
   {
@@ -275,7 +278,7 @@ static Result run_case(const Case& c, int iters, unsigned seed) {
   HIP_CHECK((hipError_t)hip_gqa_flash_decode(
       nullptr, dQ, dKh, dVh, dO16, dPart, B, H, G, D, c.total, max_seq,
       MAX_SPLITS, scale, dSeq, 0, nullptr, 0, HIP_KV_DTYPE_FP16, nullptr,
-      nullptr));
+      nullptr, nullptr, 1, 1, 0));
   HIP_CHECK(hipDeviceSynchronize());
 
   auto bench = [&](auto&& launch) -> double {
@@ -298,12 +301,12 @@ static Result run_case(const Case& c, int iters, unsigned seed) {
   double ms_int8 = bench([&]() {
     hip_gqa_flash_decode(nullptr, dQ, dK8, dV8, dO8, dPart, B, H, G, D,
                             c.total, max_seq, MAX_SPLITS, scale, dSeq, 0,
-                            nullptr, 0, HIP_KV_DTYPE_INT8, dKsc, dVsc);
+                            nullptr, 0, HIP_KV_DTYPE_INT8, dKsc, dVsc, nullptr, 1, 1, 0);
   });
   double ms_fp16 = bench([&]() {
     hip_gqa_flash_decode(nullptr, dQ, dKh, dVh, dO16, dPart, B, H, G, D,
                             c.total, max_seq, MAX_SPLITS, scale, dSeq, 0,
-                            nullptr, 0, HIP_KV_DTYPE_FP16, nullptr, nullptr);
+                            nullptr, 0, HIP_KV_DTYPE_FP16, nullptr, nullptr, nullptr, 1, 1, 0);
   });
 
   Result r;

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -350,7 +350,11 @@ static int gqa_forward_fused(
     const void *k_scale = nullptr, const void *v_scale = nullptr,
     KvCacheFormat kv_format = KvCacheFormat::Fp16,
     const void *head_sink = nullptr, bool use_smooth_softmax = false,
-    int local_window_size = -1) {
+    int local_window_size = -1,
+    // Additive attention mask, applied by flash decode only (sq == 1). Prefill
+    // has no bias support on this path and is gated out by the caller.
+    const void *attention_bias = nullptr, int64_t attn_bias_batch = 1,
+    int64_t attn_bias_num_heads = 1) {
 
   // Any non-fp16 cache reads/writes quantized bytes on the concat/append/decode
   // path; the specific scheme is carried by kv_format (extensible to INT4/FP8).
@@ -513,6 +517,23 @@ static int gqa_forward_fused(
       // Decode structurally clamps kv_lo to the requested local window. This
       // keeps sliding layers on the fused autotuned path rather than treating
       // the window as a decomposed score-mask operation.
+      //
+      // The mask is dense [bias_batch, bias_heads, 1, total_seq], so its kv
+      // stride is the VALID total length, not the present buffer stride --
+      // those differ whenever past and present share a max_length buffer. The
+      // decomposed path strides it by total_seq for the same reason (Step 8b).
+      // total_seq is only host-known here via the B==1 pre-read, which is
+      // exactly the shape the caller admits a masked decode for.
+      int64_t bias_kv_stride = 0;
+      if (attention_bias) {
+        if (seqlens_k_pre == kSeqlensKNotRead || seqlens_k_pre < 0) {
+          fprintf(stderr,
+                  "gqa_forward_fused (decode): attention_bias needs a host-side "
+                  "total_seq, but seqlens_k could not be pre-read\n");
+          return -1;
+        }
+        bias_kv_stride = static_cast<int64_t>(seqlens_k_pre) + 1;
+      }
       int drc = hip_gqa_flash_decode(
           stream, qSrc, present_key, present_value, output, partials,
           static_cast<int>(B), static_cast<int>(H), static_cast<int>(G),
@@ -520,7 +541,10 @@ static int gqa_forward_fused(
           static_cast<int>(present_seq), kFlashDecodeMaxSplits, scale,
           seqlens_k_ptr, static_cast<int>(local_window_size), head_sink,
           static_cast<int>(use_smooth_softmax), kv_dtype_abi(kv_format),
-          kv_quantized ? k_scale : nullptr, kv_quantized ? v_scale : nullptr);
+          kv_quantized ? k_scale : nullptr, kv_quantized ? v_scale : nullptr,
+          attention_bias, static_cast<int>(attn_bias_batch),
+          static_cast<int>(attn_bias_num_heads),
+          static_cast<int>(bias_kv_stride));
       if (drc != 0)
         return -1;
       RUNTIME_DEBUG_LOG(
@@ -818,6 +842,22 @@ static bool gqa_fused_decode_disabled() {
   }();
   return disabled;
 }
+
+// Env-var gate to keep a MASKED decode on the decomposed pipeline, i.e. to undo
+// just the additive-bias admission in fused_supported below. Set
+// HIPDNN_EP_GQA_DISABLE_FUSED_DECODE_BIAS=1 to A/B the two implementations of
+// the same masking from one build. That comparison is the only way to check the
+// bias is really applied: a dropped or misindexed mask shows up as a changed
+// answer only where the mask actually removes keys, e.g. Gemma-4's 1024-wide
+// sliding-window layers past 1024 tokens of context.
+static bool gqa_fused_decode_bias_disabled() {
+  static const bool disabled = [] {
+    const char *v = std::getenv("HIPDNN_EP_GQA_DISABLE_FUSED_DECODE_BIAS");
+    return v && std::strcmp(v, "0") != 0;
+  }();
+  return disabled;
+}
+
 
 // Smart-dispatch threshold for the legacy GQA decode (sq == 1). When total_seq
 // exceeds this value, dispatch routes through the decomposed hipBLASLt pipeline
@@ -2410,9 +2450,30 @@ int wrap_group_query_attention(
   // trap on CDNA (wave64, e.g. MI350). Route wave64 to the decomposed hipBLASLt
   // pipeline below (MFMA GEMMs + wave-portable scalar kernels), which is
   // feature-complete and correct on both wave sizes. RDNA is unaffected.
+  // A masked decode CAN take the fused path: flash decode folds the additive
+  // mask into its online softmax. Three conditions make that sound, and all
+  // three are decode-only, which is why prefill stays excluded:
+  //   - sq == 1, so the mask is a single row and the kernel's dense
+  //     [bias_batch, bias_heads, 1, total_seq] view is exact;
+  //   - batch 1, so total_seq (the mask's kv stride) is host-known from the
+  //     seqlens_k pre-read;
+  //   - fp16 KV, since the int8 launcher does not thread the mask.
+  // Flash prefill has no bias support at all, so a masked prefill must keep
+  // going decomposed or the mask would be silently dropped.
+  const bool bias_ok =
+      attention_bias == nullptr ||
+      (is_decode && batch_size == 1 && !kv_quantized &&
+       !gqa_fused_decode_bias_disabled());
+  // no_causal on a masked decode is likewise safe: is_causal=0 exports (Gemma-4)
+  // carry causal, padding AND any sliding window inside the additive mask, and
+  // the built-in causal triangle is a documented no-op at sq == 1 anyway (see
+  // Step 9), so admitting these costs no masking. Unmasked no_causal is
+  // bidirectional attention and still belongs on the decomposed path.
+  const bool causal_ok =
+      no_causal == 0 || (is_decode && attention_bias != nullptr);
   const bool fused_supported =
-      element_size_bytes == 2 && no_causal == 0 && window_ok && sink_ok &&
-      head_dim_ok && decode_geometry_ok && attention_bias == nullptr &&
+      element_size_bytes == 2 && causal_ok && window_ok && sink_ok &&
+      head_dim_ok && decode_geometry_ok && bias_ok &&
       !hipdnn_device_is_wave64();
 
   // The quantized-cache kernels live exclusively on the fused path, which is
@@ -2489,7 +2550,8 @@ int wrap_group_query_attention(
       cos_cache, sin_cache, output, present_key, present_value, batch_size,
       seq_len_q, seq_len_kv, past_buf_seq, num_heads, kv_num_heads, head_dim,
       scale, do_rotary, k_scale, v_scale, kv_format, head_sink,
-      has_smooth_softmax, static_cast<int>(local_window_size));
+      has_smooth_softmax, static_cast<int>(local_window_size), attention_bias,
+      attn_bias_batch, attn_bias_num_heads);
   if (rc != 0)
     fprintf(stderr,
             "wrap_group_query_attention: gqa_forward_fused failed "

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -533,6 +533,20 @@ static int gqa_forward_fused(
           return -1;
         }
         bias_kv_stride = static_cast<int64_t>(seqlens_k_pre) + 1;
+        // The caller's predicate excludes a ring cache structurally (it cannot
+        // read total_seq that early). Re-check it here, where total_seq IS
+        // known, because the two disagreeing is silent: the kernel would index
+        // the mask by ring slot instead of absolute position and return a
+        // plausible-looking wrong answer rather than an error.
+        if (bias_kv_stride > present_seq) {
+          fprintf(stderr,
+                  "gqa_forward_fused (decode): attention_bias with a ring cache "
+                  "(total_seq=%lld > present_seq=%lld) indexes the mask by ring "
+                  "slot, not position; this call should have been routed to the "
+                  "decomposed pipeline\n",
+                  (long long)bias_kv_stride, (long long)present_seq);
+          return -1;
+        }
       }
       int drc = hip_gqa_flash_decode(
           stream, qSrc, present_key, present_value, output, partials,
@@ -2460,9 +2474,30 @@ int wrap_group_query_attention(
   //   - fp16 KV, since the int8 launcher does not thread the mask.
   // Flash prefill has no bias support at all, so a masked prefill must keep
   // going decomposed or the mask would be silently dropped.
+  //
+  // A ring cache is the fourth condition, and it is not a limitation of the
+  // mask so much as of indexing. flash decode reads the present buffer slot by
+  // slot and indexes the mask by that slot, which is only the key's absolute
+  // position while the buffer is linear. A cache right-sized to a sliding
+  // window holds position p at p % capacity, so once the context passes the
+  // window the slots arrive rotated and every mask entry lands on the wrong
+  // key. The decomposed path already knows this -- it passes a ring base and
+  // capacity into hip_gqa_add_attention_bias_f32 and skips its causal/window
+  // kernel entirely under ring_read, for exactly this reason -- and the fused
+  // path has no equivalent yet.
+  //
+  // The test is structural rather than a comparison against total_seq, which is
+  // not host-known this early: the ring block in gqa_forward_hipblaslt admits a
+  // short buffer ONLY when it is right-sized to the window exactly, so a buffer
+  // longer than the window can never rotate. That makes this conservative by
+  // one phase -- a right-sized layer is excluded even before the context
+  // exceeds its window, where slot and position still agree -- which costs a
+  // few early tokens on the decomposed path and needs no device read.
+  const bool ring_cache_possible =
+      local_window_size > 0 && seq_len_kv <= local_window_size;
   const bool bias_ok =
       attention_bias == nullptr ||
-      (is_decode && batch_size == 1 && !kv_quantized &&
+      (is_decode && batch_size == 1 && !kv_quantized && !ring_cache_possible &&
        !gqa_fused_decode_bias_disabled());
   // no_causal on a masked decode is likewise safe: is_causal=0 exports (Gemma-4)
   // carry causal, padding AND any sliding window inside the additive mask, and


### PR DESCRIPTION
## Summary

Teaches flash decode to apply an external additive attention mask, and then
keeps it away from the one configuration where doing so is wrong.

Models that carry their masking in an additive mask rather than in `is_causal` —
Gemma-4 folds causal, padding **and** a 1024-wide sliding window into mask
values — failed the fused predicate, so every decode step ran the decomposed
hipBLASLt pipeline: MT96x96x32 Tensile GEMMs on a single-row problem. The mask
now folds into the online softmax as one FMA at the score site.

**This PR is groundwork and claims no throughput on its own.** In the
right-sized-cache configuration of #808 nothing fuses at decode after the third
commit: the 25 sliding layers are excluded by the new ring guard and the 5
global layers by their head_dim. The throughput arrives in the stacked follow-up,
which teaches the kernel the ring rotation instead of refusing it.

## Related issue or design

Stacked on #808. Prerequisite for #852, which is stacked on this one and carries
the +7.3% at 16K. #850 is a third, independent branch in the same series.

## Why

The math is one FMA before the running max, which keeps the FA-2 invariant and
leaves the `[B,H,K_SPLITS,D+2]` partials layout, the split merge and the sink
term untouched. Fully-masked splits are handled by the merge already: their
local max is ~-94510 in the log2 domain, so `exp2(m_local - m_global)`
underflows to zero and they contribute nothing.

Admitting these calls is decode-only and needs three conditions, all of which
fail for prefill — which must stay decomposed, since flash prefill has no bias
support and would silently drop the mask:

- `sq == 1`, so the mask is one row and the kernel's dense
  `[bias_batch, bias_heads, 1, total_seq]` view is exact;
- batch 1, so the mask's kv stride is host-known from the `seqlens_k` pre-read;
- fp16 KV, since the int8 launcher does not thread the mask (rejected).

`no_causal` is admitted only together with a mask, because the built-in causal
triangle is a documented no-op at `sq == 1` while unmasked `no_causal` is genuine
bidirectional attention.

A masked call never selects WMMA, which has no bias support, so the launcher and
the autotuner both demote to the scalar kernel. Correctness rests on
`launchFlashDecodeConfig`, which independently refuses WMMA whenever a bias is
present; the tuner's `wmma_allowed` veto is only an efficiency measure, so a
caller that forgot it would waste tuning iterations rather than silently drop
the mask.

### Why the third commit takes the win back

Flash decode walks the present buffer slot by slot and reads the mask at
`bias_row[tile_start + t]`, i.e. it uses the slot index as the key's absolute
position. That holds only while the buffer is linear. OGA can size a
sliding-window layer's cache to the window instead of `max_length` — 25 of
Gemma-4's 30 layers, 3.0 GB — and the append then wraps, storing position `p` at
`p % capacity`. Past the window the slots arrive rotated (at 2 241 tokens into a
1 024-cell ring, by 193), so every mask entry lands on a key ~193 positions from
the one it describes. Attention still sums over the right *set* of keys, so the
output is plausible rather than obviously broken.

The decomposed path has always known this: it passes a ring base and capacity
into `hip_gqa_add_attention_bias_f32` and skips its causal/window kernel under
`ring_read`, with the reason spelled out at the ring block. The fused path had
no equivalent, so it must not be offered these calls until it does.

**A retraction, stated plainly.** The second commit measured -1.09 ms/token at
16K over 6 paired rounds and it looked solid on every statistic available —
consistent sign, both orderings, t = 6.13. It was wrong. On a right-sized cache
those calls compute the wrong answer, and the saving was the mask being
misapplied rather than applied faster. That number is retracted, and no
replacement is claimed for this branch.

## What

1. `perf(gqa)`: fold the additive mask into the online softmax; adds
   `HIPDNN_EP_GQA_DISABLE_FUSED_DECODE_BIAS` and `test_gqa_decode_bias.cpp`.
2. `fix(gqa)`: point the masked decode at `hip_gqa_flash_decode` (the entry point
   #808 folded `_v2` into), thread the bias through the FMT-generic
   `LAUNCH_SCALAR_D` macro, and make the WMMA veto an explicit
   `wmma_allowed` parameter now that the tuner takes the candidate launch as a
   callable. Forwards `local_window_size` rather than pinning it to 0, since
   #808 taught this path to clamp `kv_lo`.
3. `fix(gqa)`: refuse a masked fused decode when the cache is a ring. The guard
   is structural rather than a `total_seq` comparison, because `total_seq` is not
   host-known where the routing decision is made: the ring block admits a short
   buffer **only** when it is right-sized to the window exactly, so
   `local_window_size > 0 && seq_len_kv <= local_window_size` is sufficient. It
   is conservative by one phase — a right-sized layer is excluded even before its
   context exceeds the window, where slot and position still agree — and needs no
   device read. `gqa_forward_fused` re-checks it where `total_seq` *is* known and
   fails loudly, because the two predicates disagreeing is otherwise silent, and
   silence is the whole problem here.

## Test plan

`test_gqa_decode_bias.cpp` is the only coverage for this path. Beyond checking
the masked kernel against an fp32 CPU reference it expresses the same sliding
window twice — once as `local_window_size`, once as -inf bias values — and
requires the two to agree, which is what pins down that the bias is read and
indexed by absolute kv position. A dropped or split-relative bias still produces
plausible model output, so an end-to-end run cannot catch it.

At Gemma-4's local geometry (H=16 G=8 D=256, total 2049, window 1024):

| Check | relL2 |
|---|---:|
| unmasked vs CPU ref | 2.06e-04 |
| masked vs CPU ref | 2.09e-04 |
| bias-window vs kernel-window | 1.60e-05 |
| separation (masked vs unmasked) | 9.99e-01 |

The separation figure is reported so a pass cannot be mistaken for a mask that
was ignored. Also verified at total 512/1025/4097 and window 0. All 10 cases
pass; `test_gqa_decode` and `test_gqa_decode_i8` still pass, so neither the
unmasked nor the quantized path regressed.

**End-to-end, which is what caught the ring bug.** Generating 48 tokens with
`HIPDNN_EP_GQA_DISABLE_FUSED_DECODE_BIAS=1` and without it must produce
identical text. Before the third commit the fused arm degenerated into "The
image of the image of the image of the provided in the image the image the
image..." against a reference reading "The image shows a white dog sitting on
grass. ...". Reproducible, not a tie-break: two processes at the same setting
agreed to the character. After it, the two settings agree to the character.

Routing on Gemma-4 26B-A4B, full-length caches: 25 of 30 decode layers move to
flash decode, up from none. The other 5 are the global-attention layers at
head_dim 512, which flash decode does not template.

## Notes for reviewers

- Read the three commits in order; the second's performance claim is retracted by
  the third and the commit messages say so.
- The original 2K measurement in the first commit (34.78 -> 32.73 ms/token,
  -5.9%) was taken on full-length caches, before the ring work existed. It is
  not a claim about the configuration in #808.
- The end-to-end text-equivalence check is worth its cost on any branch that
  changes which attention implementation a layer uses, because the failure it
  catches is a plausible answer rather than a crash or a NaN, and a relL2
  against a CPU reference on a hand-built shape cannot see it.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.

Developed with substantial AI assistance (Cursor). The retraction above was
found by hand-checking the routing against the ring append, not by the tests.
