### PR TITLE
perf(gqa): run a masked decode on a ring cache, +7.3% TPS at 16K

### DIFF
--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -1425,12 +1425,20 @@ hipdnn_wmma_f32_16x16x16_f16_w32_unavailable(half16, half16, float8 c) {
 //   - HPG=8  (gpt-oss-20b at d=64; 64 q heads / 8 kv heads)
 //
 // Constraints (asserted at launcher):
-//   - D must be 64, 128 or 256 (EPT = D/32 in 1..8; D=256 -> BKV=16 to keep
-//     the LDS tile ~16KB). The scalar kernel is otherwise D-generic.
+//   - D must be 64, 128, 256 or 512 (EPT = D/32 in 1..16; BKV is chosen per D
+//     to hold the LDS tile at its budget). The scalar kernel is otherwise
+//     D-generic.
 //   - RDNA wave32 (uses __shfl_xor across 32 lanes).
 //===----------------------------------------------------------------------===//
 
 static constexpr int FLASH_DECODE_BKV     = 64;
+
+// D=512's KV tile height, overridable at compile time only so the choice below
+// can be re-measured without editing this file. See the BKV comment in the
+// kernel for why 4 rather than 8.
+#ifndef FLASH_DECODE_BKV_D512
+#define FLASH_DECODE_BKV_D512 4
+#endif
 
 // Partial layout per (b, h_q, k_split): {m: float, l: float, O[D]: float}
 __device__ __forceinline__ size_t flash_decode_partial_offset(
@@ -1494,12 +1502,31 @@ gqa_flash_decode_kernel(
   // Going further the wrong way in either direction is worse: BKV=32 costs 37%
   // on the 9B (halved residency), and BKV=4 costs 6% on the 35B (the tile stops
   // amortizing the per-tile __syncthreads and staging setup).
-  constexpr int BKV = (D >= 256) ? 8 : (D == 128) ? 32 : FLASH_DECODE_BKV;
+  //
+  // D=512 (Gemma-4's global-attention layers) keeps that same 8KB budget rather
+  // than the row count, so BKV halves to 4. Inheriting BKV=8 would put the tile
+  // at 16KB and halve resident blocks, which is the mistake the D>=256 rule was
+  // introduced to avoid in the first place. Measured on gfx1151 at Gemma-4's
+  // global geometry (H16 G2 hpg8 D512), --iters 400, min of 3 runs:
+  //             BKV=2     BKV=4     BKV=8     BKV=16
+  //   skv 2241  0.0270    0.0258    0.0274    0.0296 ms
+  //   skv 16241 0.3087    0.2963    0.3012    0.3126 ms
+  // 4 wins at both ends, and the shape of the curve is the budget argument:
+  // 8 and 16 lose residency, 2 stops amortizing the per-tile __syncthreads.
+  constexpr int BKV = (D >= 512)  ? FLASH_DECODE_BKV_D512
+                    : (D == 256)  ? 8
+                    : (D == 128)  ? 32
+                                  : FLASH_DECODE_BKV;
   constexpr int THREADS = HPG * WAVE_SIZE;  // total threads in block
   constexpr int EPT = D / WAVE_SIZE;  // elements-per-thread along d
 
   static_assert(D % WAVE_SIZE == 0, "D must be a multiple of WAVE_SIZE");
-  static_assert(EPT >= 1 && EPT <= 8, "EPT must be 1..8");
+  // The bound is a register-pressure budget, not a correctness one: Q_f and
+  // O_acc are both EPT floats per lane, so EPT=16 (D=512) holds 32 VGPRs of
+  // accumulator before the unrolled inner loop's temporaries. That still fits
+  // the occupancy this bandwidth-bound kernel needs on RDNA; EPT=32 (D=1024)
+  // would not, and no shipped geometry asks for it.
+  static_assert(EPT >= 1 && EPT <= 16, "EPT must be 1..16");
 
   const int batch     = __builtin_amdgcn_readfirstlane(blockIdx.x / G);
   const int head_kv   = __builtin_amdgcn_readfirstlane(blockIdx.x % G);
@@ -2335,7 +2362,8 @@ static inline void launchFlashDecodeConfig(
               bias_kv_stride)
     #define LAUNCH_SCALAR(HPG_)                                                \
       do {                                                                     \
-        if (d == 256)      LAUNCH_SCALAR_D(256, HPG_);                         \
+        if (d == 512)      LAUNCH_SCALAR_D(512, HPG_);                         \
+        else if (d == 256) LAUNCH_SCALAR_D(256, HPG_);                         \
         else if (d == 128) LAUNCH_SCALAR_D(128, HPG_);                         \
         else               LAUNCH_SCALAR_D(64, HPG_);                          \
       } while (0)
@@ -2356,7 +2384,10 @@ static inline void launchFlashDecodeConfig(
   // Reduce: one block per query head, block dim D. seqlens_k / sliding-window /
   // head_sink / smooth_softmax are all folded in here (not the partials).
   dim3 grid_reduce(B * H);
-  if (d == 256)
+  if (d == 512)
+    gqa_flash_decode_reduce_kernel<512><<<grid_reduce, 512, 0, stream>>>(
+        hP, hO, H, hSink, H, use_smooth_softmax, splits);
+  else if (d == 256)
     gqa_flash_decode_reduce_kernel<256><<<grid_reduce, 256, 0, stream>>>(
         hP, hO, H, hSink, H, use_smooth_softmax, splits);
   else if (d == 128)
@@ -2695,9 +2726,9 @@ extern "C" int hip_gqa_flash_decode(
             hpg, H, G);
     return -1;
   }
-  if (d != 64 && d != 128 && d != 256) {
+  if (d != 64 && d != 128 && d != 256 && d != 512) {
     fprintf(stderr,
-            "hip_gqa_flash_decode: unsupported d=%d (must be 64/128/256)\n",
+            "hip_gqa_flash_decode: unsupported d=%d (must be 64/128/256/512)\n",
             d);
     return -1;
   }

--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -1483,7 +1483,13 @@ gqa_flash_decode_kernel(
     // (sq == 1 on this path). Extent 1 on either leading dim broadcasts. Null
     // when the model supplies no mask.
     const __half* __restrict__ attn_bias = nullptr,
-    int bias_batch = 1, int bias_heads = 1, int bias_kv_stride = 0) {
+    int bias_batch = 1, int bias_heads = 1, int bias_kv_stride = 0,
+    // Right-sized sliding-window cache. ring_cap is the buffer's capacity in
+    // positions and ring_base the oldest position it still holds, so slot s
+    // carries the one position in [ring_base, ring_base + ring_cap) congruent
+    // to s mod ring_cap. ring_cap == 0 is a linear cache, where slot IS
+    // position and both are ignored.
+    int ring_base = 0, int ring_cap = 0) {
   constexpr bool KV_I8 = (FMT == KvDtype::kI8);
   using KVt = std::conditional_t<KV_I8, int8_t, __half>;
   // Size the K+V LDS tile for block residency, since this kernel is bandwidth
@@ -1548,17 +1554,27 @@ gqa_flash_decode_kernel(
   // window <= 0 the attention is full (kv_lo = 0). gpt-oss-20b alternates
   // sliding (local_window_size=128) and full layers; clamping kv_lo here lets
   // sliding layers skip the full KV cache scan and process only ~window slots.
+  //
+  // A ring holds exactly the positions this query may attend to and nothing
+  // else, so the whole buffer is the range and the window has nothing left to
+  // narrow: scan every slot from 0. Stated rather than derived. eff_skv would
+  // already clamp to max_seq == ring_cap and leave kv_lo at 0, but only because
+  // capacity happens to equal the window, and a reader cannot see that
+  // coincidence from here.
   int kv_lo = 0;
-  if (local_window_size > 0 && eff_skv > local_window_size) {
+  int kv_hi = eff_skv;
+  if (ring_cap > 0) {
+    kv_hi = ring_cap;
+  } else if (local_window_size > 0 && eff_skv > local_window_size) {
     kv_lo = eff_skv - local_window_size;
   }
-  const int kv_range = eff_skv - kv_lo;
+  const int kv_range = kv_hi - kv_lo;
 
   // Partition KV range into K_SPLITS roughly-equal chunks.
   const int chunk    = (kv_range + K_SPLITS - 1) / K_SPLITS;
   const int kv_start = kv_lo + chunk * split_idx;
   int kv_end_tmp     = kv_start + chunk;
-  if (kv_end_tmp > eff_skv) kv_end_tmp = eff_skv;
+  if (kv_end_tmp > kv_hi) kv_end_tmp = kv_hi;
   const int kv_end   = kv_end_tmp;
 
   // Output partials destination for THIS wave's query head.
@@ -1734,7 +1750,19 @@ gqa_flash_decode_kernel(
       // the [B,H,K_SPLITS,D+2] partials layout and the sink term stay correct.
       float score = dot_partial * scale_log2e;
       if (bias_row) {
-        score = fmaf(__half2float(bias_row[tile_start + t]), LOG2E, score);
+        // The mask is indexed by absolute position. On a linear cache the slot
+        // is the position; on a ring it is that position mod capacity, so undo
+        // the rotation before reading. Getting this wrong is silent -- every
+        // entry lands on a key some fixed distance from the one it describes,
+        // the attention still sums over the right SET of keys, and the model
+        // emits fluent nonsense rather than a NaN.
+        int bias_col = tile_start + t;
+        if (ring_cap > 0) {
+          int off = (bias_col - ring_base) % ring_cap;
+          if (off < 0) off += ring_cap;
+          bias_col = ring_base + off;
+        }
+        score = fmaf(__half2float(bias_row[bias_col]), LOG2E, score);
         // A -inf mask entry contributes nothing, and letting it reach the
         // rescale below would form (-inf) - (-inf) = NaN for as long as every
         // key seen so far in this split is masked -- routine for a sliding
@@ -1823,7 +1851,7 @@ gqa_flash_decode_kernel(
 //
 // Grid: (G, K_SPLITS, B). Block: 32 (one wave). M=16 rows == HPG query heads
 // (rows >= HPG are inert / never written). Split math mirrors the scalar
-// kernel exactly (eff_skv, kv_lo, chunk).
+// kernel exactly (eff_skv, kv_lo, kv_hi, chunk).
 //===----------------------------------------------------------------------===//
 // FMT==kF16: fp16 K/V cache (k_scale/v_scale ignored, pass nullptr).
 // FMT==kI8 : symmetric per-channel INT8 K/V cache -- the int8 tile is loaded
@@ -1844,7 +1872,8 @@ gqa_flash_decode_wmma_kernel(
     int H, int G, int max_seq, float scale,
     const int* __restrict__ seqlens_k,
     int local_window_size,
-    int K_SPLITS) {  // runtime split-K count (was a template param)
+    int K_SPLITS,     // runtime split-K count (was a template param)
+    int ring_cap = 0) {  // right-sized window cache; 0 == linear (see scalar)
   constexpr bool KV_I8 = (FMT == KvDtype::kI8);
   using KVt = std::conditional_t<KV_I8, int8_t, __half>;
   constexpr int DSTR    = D + 2;
@@ -1873,15 +1902,22 @@ gqa_flash_decode_wmma_kernel(
       : max_seq;
   const int eff_skv = (raw_skv > 0)
       ? (raw_skv < max_seq ? raw_skv : max_seq) : 0;
+  // Ring: the whole buffer is in-window by construction, so scan every slot and
+  // let the window narrow nothing (mirrors the scalar kernel). No ring_base
+  // here because this kernel applies no mask -- the rotation is invisible to
+  // attention itself, which is a sum over an unordered set of keys.
   int kv_lo = 0;
-  if (local_window_size > 0 && eff_skv > local_window_size) {
+  int kv_hi = eff_skv;
+  if (ring_cap > 0) {
+    kv_hi = ring_cap;
+  } else if (local_window_size > 0 && eff_skv > local_window_size) {
     kv_lo = eff_skv - local_window_size;
   }
-  const int kv_range = eff_skv - kv_lo;
+  const int kv_range = kv_hi - kv_lo;
   const int chunk    = (kv_range + K_SPLITS - 1) / K_SPLITS;
   const int kv_start = kv_lo + chunk * split;
   int kv_end_tmp     = kv_start + chunk;
-  if (kv_end_tmp > eff_skv) kv_end_tmp = eff_skv;
+  if (kv_end_tmp > kv_hi) kv_end_tmp = kv_hi;
   const int kv_end   = kv_end_tmp;
 
   // Empty slice: emit identity partials so the reduce ignores this split.
@@ -2316,7 +2352,7 @@ static inline void launchFlashDecodeConfig(
     const int* iSeq, int local_window_size,
     const __half* hSink, int use_smooth_softmax,
     const __half* hBias = nullptr, int bias_batch = 1, int bias_heads = 1,
-    int bias_kv_stride = 0) {
+    int bias_kv_stride = 0, int ring_base = 0, int ring_cap = 0) {
   const int splits = cfg.splits;
   // Only the scalar kernel applies the additive mask; the WMMA variant has no
   // bias support, so a masked call must not select it or the mask would be
@@ -2339,7 +2375,7 @@ static inline void launchFlashDecodeConfig(
       gqa_flash_decode_wmma_kernel<D_, HPG_, BKV_, FMT>                        \
           <<<grid_wmma, 32, smem_bytes(D_, BKV_), stream>>>(                   \
               hQ, hK, hV, kSc, vSc, hP, H, G, max_seq, scale, iSeq,            \
-              local_window_size, splits)
+              local_window_size, splits, ring_cap)
     if (hpg == 4) {
       if (d == 128) LAUNCH_DW(128, 4, 32);
       else if (cfg.bkv == 32) LAUNCH_DW(64, 4, 32);
@@ -2359,7 +2395,7 @@ static inline void launchFlashDecodeConfig(
           <<<grid_main, (HPG_) * WAVE_SIZE, 0, stream>>>(                      \
               hQ, hK, hV, kSc, vSc, hP, H, G, max_seq, scale, iSeq,            \
               local_window_size, splits, hBias, bias_batch, bias_heads,        \
-              bias_kv_stride)
+              bias_kv_stride, ring_base, ring_cap)
     #define LAUNCH_SCALAR(HPG_)                                                \
       do {                                                                     \
         if (d == 512)      LAUNCH_SCALAR_D(512, HPG_);                         \
@@ -2706,7 +2742,14 @@ extern "C" int hip_gqa_flash_decode(
     // is passed explicitly rather than derived from skv so it matches the
     // decomposed path's view of the mask exactly.
     const void* attn_bias,
-    int attn_bias_batch, int attn_bias_heads, int attn_bias_kv_stride) {
+    int attn_bias_batch, int attn_bias_heads, int attn_bias_kv_stride,
+    // Right-sized sliding-window cache: the buffer holds only its newest
+    // ring_cap positions, starting at absolute position ring_base, and slot s
+    // carries position ring_base + ((s - ring_base) mod ring_cap). ring_cap == 0
+    // means a linear cache, where slot IS position. Only the mask cares, but it
+    // cares silently, so the caller states it rather than the kernel guessing
+    // from skv > max_seq.
+    int ring_base, int ring_cap) {
   // HPG = heads-per-group (Q heads sharing one KV head). The kernels are
   // instantiated for HPG=4 (Llama-3.x family at d=64 and d=128), HPG=5
   // (Qwen2.5-14B's 40:8 at d=128) and HPG=8 (gpt-oss-20b at d=64). HPG=8 with
@@ -2753,6 +2796,19 @@ extern "C" int hip_gqa_flash_decode(
             "INT8 KV cache\n");
     return -1;
   }
+  // A ring must be the whole buffer. The scalar kernel scans [0, ring_cap) and
+  // reads the cache with the max_seq stride, so a capacity that is not the
+  // buffer would either skip live slots or read past them, and the mask
+  // rotation would be computed modulo the wrong number. The runtime already
+  // pins capacity to the window; this states the kernel's own requirement so
+  // the two cannot drift apart silently.
+  if (ring_cap < 0 || ring_base < 0 || (ring_cap > 0 && ring_cap != max_seq)) {
+    fprintf(stderr,
+            "hip_gqa_flash_decode: ring_cap=%d must be 0 (linear) or exactly "
+            "max_seq=%d, and ring_base=%d must be non-negative\n",
+            ring_cap, max_seq, ring_base);
+    return -1;
+  }
 
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
   const __half* hQ = static_cast<const __half*>(Q);
@@ -2773,9 +2829,16 @@ extern "C" int hip_gqa_flash_decode(
   // window (e.g. 128), NOT the full context -- they MUST key/tune separately
   // from full-attention layers of the same (B,H,G,d,skv) or they would reuse a
   // large split count and pay reduce/empty-split overhead over a tiny range.
-  const int tune_len = (local_window_size > 0 && eff_skv > local_window_size)
-                           ? local_window_size
-                           : eff_skv;
+  // A ring scans its whole buffer, which IS the window, so it keys on capacity
+  // rather than on eff_skv -- the latter grows with the context while the work
+  // does not, and would spread one steady-state shape across a new cache entry
+  // per bucket, re-tuning each time.
+  const int tune_len =
+      (ring_cap > 0)
+          ? ring_cap
+          : ((local_window_size > 0 && eff_skv > local_window_size)
+                 ? local_window_size
+                 : eff_skv);
   // The autotune cache is keyed on geometry only, so a masked and an unmasked
   // call of the same shape share an entry. That stays correct because the
   // launcher re-checks the mask before selecting WMMA: a cached WMMA config is
@@ -2827,14 +2890,15 @@ extern "C" int hip_gqa_flash_decode(
               launchFlashDecodeConfig<KvDtype::kI8>(
                   c, stream, hQ, hK, hV, kSc, vSc, hO, hP, B, H, G, d, hpg,
                   max_seq, scale, iSeq, local_window_size, hSink,
-                  use_smooth_softmax);
+                  use_smooth_softmax, nullptr, 1, 1, 0, ring_base, ring_cap);
             });
         g_flash_decode_i8_cache[key] = cfg;
       }
     }
     launchFlashDecodeConfig<KvDtype::kI8>(
         cfg, stream, hQ, hK, hV, kSc, vSc, hO, hP, B, H, G, d, hpg, max_seq,
-        scale, iSeq, local_window_size, hSink, use_smooth_softmax);
+        scale, iSeq, local_window_size, hSink, use_smooth_softmax, nullptr, 1,
+        1, 0, ring_base, ring_cap);
     return hipGetLastError();
   }
 
@@ -2854,7 +2918,7 @@ extern "C" int hip_gqa_flash_decode(
                 c, stream, hQ, hK, hV, nullptr, nullptr, hO, hP, B, H, G, d,
                 hpg, max_seq, scale, iSeq, local_window_size, hSink,
                 use_smooth_softmax, hBias, bias_b, bias_h,
-                attn_bias_kv_stride);
+                attn_bias_kv_stride, ring_base, ring_cap);
           });
       g_flash_decode_cache[key] = cfg;
       CUSTOM_KERNELS_DEBUG_LOG(
@@ -2870,7 +2934,7 @@ extern "C" int hip_gqa_flash_decode(
   launchFlashDecodeConfig<KvDtype::kF16>(
       cfg, stream, hQ, hK, hV, nullptr, nullptr, hO, hP, B, H, G, d, hpg,
       max_seq, scale, iSeq, local_window_size, hSink, use_smooth_softmax,
-      hBias, bias_b, bias_h, attn_bias_kv_stride);
+      hBias, bias_b, bias_h, attn_bias_kv_stride, ring_base, ring_cap);
 
   return hipGetLastError();
 }

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -893,7 +893,23 @@ HIP_KERNEL_API int hip_gqa_flash_decode(
      * the scalar kernel only, so a masked call never selects WMMA; rejected
      * outright with an INT8 KV cache, which does not thread it. */
     const void* attn_bias,
-    int attn_bias_batch, int attn_bias_heads, int attn_bias_kv_stride);
+    int attn_bias_batch, int attn_bias_heads, int attn_bias_kv_stride,
+    /* Right-sized sliding-window ("ring") KV cache. When a layer's cache is
+     * allocated to its window rather than to max_length, the append wraps and
+     * the buffer holds only its newest ring_cap positions: slot s carries the
+     * one position in [ring_base, ring_base + ring_cap) congruent to s mod
+     * ring_cap. Pass ring_cap == 0 for a linear cache, where slot IS position.
+     *
+     * ring_cap must equal max_seq when non-zero -- the kernel scans the whole
+     * buffer, which for a right-sized cache is exactly the window, so neither
+     * the window nor seqlens_k narrows it further.
+     *
+     * Only attn_bias reads a position rather than a slot, so a ring is
+     * invisible to an unmasked decode: attention sums over an unordered set of
+     * keys. It is emphatically not invisible to a masked one, and the failure
+     * is silent -- pass these rather than letting the kernel infer a ring from
+     * skv > max_seq. */
+    int ring_base, int ring_cap);
 
 /* =========================================================================
  * Cast (Element Type Conversion)

--- a/lib/Runtime/Kernels/test/example/gqa/decode/README.md
+++ b/lib/Runtime/Kernels/test/example/gqa/decode/README.md
@@ -46,8 +46,34 @@ ALL PASS (0 failing case(s))
 |---|---|
 | `test_gqa_decode.cpp` | fp16 correctness and latency over the full geometry matrix |
 | `test_gqa_decode_i8.cpp` | The same for an INT8 KV cache, plus the fp16/INT8 ratio |
+| `test_gqa_decode_bias.cpp` | Correctness with an additive attention mask, on linear and ring caches |
 
-Both cover correctness and latency; flags select how much of each you get.
+The first two cover correctness and latency; flags select how much of each you
+get. `test_gqa_decode_bias` is correctness only and takes no flags.
+
+### `test_gqa_decode_bias` (additive mask)
+
+The mask is the one input the kernel indexes by absolute KV *position* rather
+than by buffer slot, so it is the only place a right-sized sliding-window cache
+("ring") is visible: the slots arrive rotated and every entry lands on the wrong
+key. That failure is silent — the attention still sums over the right set of
+keys, so the output is plausible rather than NaN — which is why half the cases
+here run on a ring, and why they use a random mask. A window mask cannot detect
+a rotation, because a ring of exactly `window` cells holds only in-window
+positions and all of its live entries are zero.
+
+```bash
+hipcc --offload-arch=gfx1151 -O3 -std=c++17 -Wno-deprecated-declarations \
+  test_gqa_decode_bias.cpp ../../../../hip/gqa_kernel.hip \
+  -I../../../../include -o test_gqa_decode_bias.exe
+./test_gqa_decode_bias.exe
+```
+
+Each line reports the geometry, whether the cache is linear or a ring (with the
+rotation), and `relL2` against an fp32 CPU reference. Healthy fp16 values are
+around `2e-04`; a case passes under `5e-03`. Removing the de-rotation from the
+kernel puts every ring case at `~1e+00` and leaves every linear case passing,
+which is the check that the ring cases are load-bearing rather than decorative.
 
 ### `test_gqa_decode` (fp16)
 

--- a/lib/Runtime/Kernels/test/example/gqa/decode/README.md
+++ b/lib/Runtime/Kernels/test/example/gqa/decode/README.md
@@ -51,7 +51,7 @@ Both cover correctness and latency; flags select how much of each you get.
 
 ### `test_gqa_decode` (fp16)
 
-Sweeps MHA and GQA at HpG 1/2/3/4/5/8/16, head_dim 64/128/256 and
+Sweeps MHA and GQA at HpG 1/2/3/4/5/8/16, head_dim 64/128/256/512 and
 `len` 512..32768, including sliding-window, head-sink and smooth-softmax
 variants. Each case is checked against an fp32 CPU reference and against the
 other kernel implementation (WMMA versus scalar), then timed.

--- a/lib/Runtime/Kernels/test/example/gqa/decode/test_gqa_decode.cpp
+++ b/lib/Runtime/Kernels/test/example/gqa/decode/test_gqa_decode.cpp
@@ -60,7 +60,11 @@ extern "C" int hip_gqa_flash_decode(
     // passes NULL. Declared to match the entry point exactly -- extern "C" is
     // unmangled, so a short declaration here would link and then read garbage.
     const void* attn_bias,
-    int attn_bias_batch, int attn_bias_heads, int attn_bias_kv_stride);
+    int attn_bias_batch, int attn_bias_heads, int attn_bias_kv_stride,
+    // Ring cache; linear here (0). Only the mask reads a position rather than
+    // a slot, so an unmasked decode cannot tell a ring from a linear cache --
+    // test_gqa_decode_bias owns that coverage.
+    int ring_base, int ring_cap);
 
 // Legacy one-block-per-head fused decode (the ORIGINAL baseline that the
 // OPTIMIZATION.md 10-20x figure was measured against). No window/sink/split-K.
@@ -234,7 +238,7 @@ static double run_kernel(DecodeMode mode, const Case& c, float scale,
   HIP_CHECK((hipError_t)hip_gqa_flash_decode(
       nullptr, dQ, dK, dV, dO, dPart, B, H, G, D, c.total, max_seq, MAX_SPLITS,
       scale, dSeq, c.window, sinkp, c.smooth, HIP_KV_DTYPE_FP16, nullptr,
-      nullptr, nullptr, 1, 1, 0));
+      nullptr, nullptr, 1, 1, 0, 0, 0));
   HIP_CHECK(hipDeviceSynchronize());
   host_O.resize((size_t)B * H * D);
   {
@@ -252,7 +256,7 @@ static double run_kernel(DecodeMode mode, const Case& c, float scale,
     hip_gqa_flash_decode(nullptr, dQ, dK, dV, dO, dPart, B, H, G, D, c.total,
                             max_seq, MAX_SPLITS, scale, dSeq, c.window, sinkp,
                             c.smooth, HIP_KV_DTYPE_FP16, nullptr, nullptr,
-                            nullptr, 1, 1, 0);
+                            nullptr, 1, 1, 0, 0, 0);
   }
   HIP_CHECK(hipEventRecord(b));
   HIP_CHECK(hipEventSynchronize(b));

--- a/lib/Runtime/Kernels/test/example/gqa/decode/test_gqa_decode.cpp
+++ b/lib/Runtime/Kernels/test/example/gqa/decode/test_gqa_decode.cpp
@@ -480,7 +480,7 @@ int main(int argc, char** argv) {
   int fails = 0;
   if (all || !have_single) {
     // B=1 single-stream decode. Coverage: real models + a geometry sweep over
-    // MHA (HpG==1) and GQA (HpG in {2,4,5,8,16}) x head_dim in {64,128,256}.
+    // MHA (HpG==1) and GQA (HpG in {2,4,5,8,16}) x head_dim in {64,128,256,512}.
     const int lens[] = {512, 2048, 8192, 32768};
     auto maybe = [&](const Case& c) {
       if (!g_only.empty() &&
@@ -516,6 +516,16 @@ int main(int argc, char** argv) {
       maybe({"GQA hpg8 D128",       1, 64,  8, 128, L, L,   0, 0, 0});
       maybe({"GQA hpg16 D64",       1, 32,  2,  64, L, L,   0, 0, 0});
       maybe({"GQA hpg4 D256",       1, 32,  8, 256, L, L,   0, 0, 0});
+      // ---- D512: Gemma-4's 5 global-attention layers ----
+      // Twice the head width of its 25 sliding layers, which is why they are
+      // the only ones the geometry gate used to reject. EPT=16 here, the widest
+      // the scalar kernel templates, so this is also the register-pressure
+      // boundary case. The sliding sibling is covered so both halves of the
+      // same model run through this kernel.
+      maybe({"gemma-4-26b global",  1, 16,  8, 512, L, L,   0, 0, 0});
+      maybe({"gemma-4-26b sliding", 1, 16,  8, 256, L, L, 1024, 0, 0});
+      maybe({"MHA hpg1 D512",       1,  8,  8, 512, L, L,   0, 0, 0});
+      maybe({"GQA hpg4 D512",       1, 32,  8, 512, L, L,   0, 0, 0});
       if (!g_md) printf("\n");
     }
   } else {

--- a/lib/Runtime/Kernels/test/example/gqa/decode/test_gqa_decode_bias.cpp
+++ b/lib/Runtime/Kernels/test/example/gqa/decode/test_gqa_decode_bias.cpp
@@ -15,6 +15,12 @@
 //   random    - dense small biases, no masking, to catch plain indexing slips.
 //   headwise  - per-head mask (bias_heads == H) rather than the broadcast one.
 //
+// Half the cases run on a RING cache, which is the configuration this file
+// previously could not reach and where a mask indexed by slot instead of by
+// position produces a plausible wrong answer rather than a NaN. See the ring
+// block below the case table for what that costs to set up and why a random
+// bias is the only kind that detects it.
+//
 // Self-contained: random inputs generated in-process, no data files.
 // ============================================================
 
@@ -43,7 +49,8 @@ extern "C" int hip_gqa_flash_decode(
     int use_smooth_softmax,
     int kv_dtype, const void* k_scale, const void* v_scale,
     const void* attn_bias,
-    int attn_bias_batch, int attn_bias_heads, int attn_bias_kv_stride);
+    int attn_bias_batch, int attn_bias_heads, int attn_bias_kv_stride,
+    int ring_base, int ring_cap);
 
 static constexpr int MAX_SPLITS = 64;
 
@@ -65,7 +72,30 @@ struct Case {
   MaskKind kind;
   int window;      // for the window kinds
   int per_head;    // 1 => bias_heads == H, 0 => bias_heads == 1
+  // Right-sized sliding-window cache. 0 leaves the cache linear (max_seq cells,
+  // slot == position). Non-zero means the buffer is exactly `ring` cells and
+  // max_seq must equal it, so slot s holds position ring_base(c) + ((s -
+  // ring_base(c)) mod ring), and only the newest `ring` positions survive.
+  int ring;
 };
+
+// Oldest absolute position the ring still holds. Zero for a linear cache.
+static int ring_base_of(const Case& c) {
+  return c.ring > 0 ? c.total - c.ring : 0;
+}
+
+// Absolute position stored in buffer slot `s`. On a linear cache the slot IS
+// the position; on a ring it is the unique position in [base, base + cap)
+// congruent to s mod cap. This is the mapping the kernel has to undo before it
+// reads the mask, so the test states it independently rather than reusing any
+// device-side helper.
+static int slot_position(const Case& c, int s) {
+  if (c.ring <= 0) return s;
+  const int base = ring_base_of(c);
+  int off = (s - base) % c.ring;
+  if (off < 0) off += c.ring;
+  return base + off;
+}
 
 // Build the [bias_batch, bias_heads, 1, total] mask in fp32 (host reference
 // units); the device copy is the fp16 narrowing of exactly these values.
@@ -97,8 +127,10 @@ static void build_bias(const Case& c, int bias_heads, std::mt19937& rng,
   }
 }
 
-// CPU fp32 reference: plain softmax over [0, eff) with the bias added to the
-// pre-softmax score, matching the decomposed pipeline's Step 8b + Step 9.
+// CPU fp32 reference: plain softmax over the live buffer slots with the bias
+// added to the pre-softmax score, matching the decomposed pipeline's Step 8b +
+// Step 9. The sum runs over SLOTS and the bias is read at each slot's POSITION,
+// which on a linear cache is the same index twice and on a ring is not.
 static void cpu_reference(const Case& c, int bias_heads,
                           const std::vector<float>& Q,
                           const std::vector<float>& K,
@@ -111,7 +143,8 @@ static void cpu_reference(const Case& c, int bias_heads,
   O.assign((size_t)B * H * D, 0.0f);
   for (int b = 0; b < B; ++b) {
     int raw = seqlens[b] + 1;
-    int eff = raw < 0 ? 0 : (raw > max_seq ? max_seq : raw);
+    // A ring scans its whole buffer; a linear cache scans up to seqlens_k.
+    int eff = c.ring > 0 ? c.ring : (raw < 0 ? 0 : (raw > max_seq ? max_seq : raw));
     for (int h = 0; h < H; ++h) {
       int g = h / hpg;
       const float* q = &Q[((size_t)b * H + h) * D];
@@ -124,7 +157,7 @@ static void cpu_reference(const Case& c, int bias_heads,
         const float* k = &K[(((size_t)b * G + g) * max_seq + kv) * D];
         float dot = 0.0f;
         for (int e = 0; e < D; ++e) dot += q[e] * k[e];
-        s[kv] = dot * scale + brow[kv];
+        s[kv] = dot * scale + brow[slot_position(c, kv)];
         if (s[kv] > m) m = s[kv];
       }
       float* o = &O[((size_t)b * H + h) * D];
@@ -164,28 +197,55 @@ int main() {
   // Gemma-4 26B-A4B local-attention geometry (25 of 30 layers) plus two
   // smaller shapes that exercise other instantiated (D, HpG) kernels.
   std::vector<Case> cases = {
-      {"gemma4-local zero      ", 1, 16, 8, 256, 16384, 2051, MASK_ZERO, 0, 0},
-      {"gemma4-local random    ", 1, 16, 8, 256, 16384, 2051, MASK_RANDOM, 0, 0},
-      {"gemma4-local window1024", 1, 16, 8, 256, 16384, 2051, MASK_WINDOW, 1024, 0},
-      {"gemma4-local window-inf", 1, 16, 8, 256, 16384, 2051, MASK_WINDOW_INF, 1024, 0},
-      {"gemma4-local 12k wininf", 1, 16, 8, 256, 16384, 12279, MASK_WINDOW_INF, 1024, 0},
-      {"gemma4-local 12k window", 1, 16, 8, 256, 16384, 12279, MASK_WINDOW, 1024, 0},
-      {"gemma4-local per-head  ", 1, 16, 8, 256, 16384, 2051, MASK_RANDOM, 0, 1},
+      {"gemma4-local zero      ", 1, 16, 8, 256, 16384, 2051, MASK_ZERO, 0, 0, 0},
+      {"gemma4-local random    ", 1, 16, 8, 256, 16384, 2051, MASK_RANDOM, 0, 0, 0},
+      {"gemma4-local window1024", 1, 16, 8, 256, 16384, 2051, MASK_WINDOW, 1024, 0, 0},
+      {"gemma4-local window-inf", 1, 16, 8, 256, 16384, 2051, MASK_WINDOW_INF, 1024, 0, 0},
+      {"gemma4-local 12k wininf", 1, 16, 8, 256, 16384, 12279, MASK_WINDOW_INF, 1024, 0, 0},
+      {"gemma4-local 12k window", 1, 16, 8, 256, 16384, 12279, MASK_WINDOW, 1024, 0, 0},
+      {"gemma4-local per-head  ", 1, 16, 8, 256, 16384, 2051, MASK_RANDOM, 0, 1, 0},
       // Gemma-4's other 5 layers: global attention at twice the head width.
       // These carry the mask too -- the model exports is_causal=0 and folds
       // causal and padding into the bias on every layer, not just the sliding
       // ones -- so d=512 has to be correct WITH a bias, not merely reachable.
-      {"gemma4-global zero     ", 1, 16, 8, 512, 16384, 2051, MASK_ZERO, 0, 0},
-      {"gemma4-global random   ", 1, 16, 8, 512, 16384, 2051, MASK_RANDOM, 0, 0},
-      {"gemma4-global 12k rand ", 1, 16, 8, 512, 16384, 12279, MASK_RANDOM, 0, 0},
-      {"gemma4-global per-head ", 1, 16, 8, 512, 16384, 2051, MASK_RANDOM, 0, 1},
+      {"gemma4-global zero     ", 1, 16, 8, 512, 16384, 2051, MASK_ZERO, 0, 0, 0},
+      {"gemma4-global random   ", 1, 16, 8, 512, 16384, 2051, MASK_RANDOM, 0, 0, 0},
+      {"gemma4-global 12k rand ", 1, 16, 8, 512, 16384, 12279, MASK_RANDOM, 0, 0, 0},
+      {"gemma4-global per-head ", 1, 16, 8, 512, 16384, 2051, MASK_RANDOM, 0, 1, 0},
       // The window/bias agreement check at d=512: the same window expressed
       // twice must agree, which is what pins the bias indexing to absolute kv
       // position rather than split-relative at the widest EPT.
-      {"gemma4-global window-inf", 1, 16, 8, 512, 16384, 2051, MASK_WINDOW_INF, 1024, 0},
-      {"llama-3.1-8b random    ", 1, 32, 8, 128, 16384, 4096, MASK_RANDOM, 0, 0},
-      {"llama-3.1-8b window-inf", 1, 32, 8, 128, 16384, 4096, MASK_WINDOW_INF, 512, 0},
-      {"d64 hpg8 window-inf    ", 1, 64, 8, 64, 16384, 8192, MASK_WINDOW_INF, 256, 0},
+      {"gemma4-global window-inf", 1, 16, 8, 512, 16384, 2051, MASK_WINDOW_INF, 1024, 0, 0},
+      {"llama-3.1-8b random    ", 1, 32, 8, 128, 16384, 4096, MASK_RANDOM, 0, 0, 0},
+      {"llama-3.1-8b window-inf", 1, 32, 8, 128, 16384, 4096, MASK_WINDOW_INF, 512, 0, 0},
+      {"d64 hpg8 window-inf    ", 1, 64, 8, 64, 16384, 8192, MASK_WINDOW_INF, 256, 0, 0},
+
+      // ---- Ring cache (max_seq == ring, the right-sized window) ------------
+      //
+      // Only a mask that VARIES with position can detect a rotation, so these
+      // are MASK_RANDOM. A window mask cannot: a ring of exactly `window` cells
+      // holds only in-window positions, so its every live entry is 0 and any
+      // permutation of them agrees. That is also why the production
+      // configuration hid the bug -- Gemma-4's mask is mostly window -- and why
+      // "the sliding cases pass" was not evidence.
+      //
+      // The slot-to-position map is an offset plus a wraparound, and the pair
+      // below separates them. At rot = total mod ring == 0 the ring is in
+      // order, positions ascending with the slot, so only the base offset is
+      // wrong if you ignore the ring; rot != 0 adds the wraparound on top. A
+      // kernel that applied the offset and forgot the modulo would pass the
+      // first and fail the second.
+      {"ring rot0   random     ", 1, 16, 8, 256, 1024, 2048, MASK_RANDOM, 1024, 0, 1024},
+      {"ring rot193 random     ", 1, 16, 8, 256, 1024, 2241, MASK_RANDOM, 1024, 0, 1024},
+      // The production shape at 16K: 16241 mod 1024 = 881.
+      {"ring rot881 16k random ", 1, 16, 8, 256, 1024, 16241, MASK_RANDOM, 1024, 0, 1024},
+      // Per-head, so a de-rotation that leaked the head index into the column
+      // (or vice versa) shows up.
+      {"ring rot193 per-head   ", 1, 16, 8, 256, 1024, 2241, MASK_RANDOM, 1024, 1, 1024},
+      // A second (D, HpG) instantiation, and a ring whose capacity is not a
+      // multiple of the KV tile height, so the last tile is ragged.
+      {"ring d64 hpg8 ragged   ", 1, 64, 8, 64, 1000, 3333, MASK_RANDOM, 1000, 0, 1000},
+      {"ring d128 hpg4 rot     ", 1, 32, 8, 128, 512, 5000, MASK_RANDOM, 512, 0, 512},
   };
 
   std::mt19937 rng(1234);
@@ -196,16 +256,27 @@ int main() {
     const int B = c.B, H = c.H, G = c.G, D = c.D, max_seq = c.max_seq;
     const int bias_heads = c.per_head ? H : 1;
     const float scale = 1.0f / std::sqrt((float)D);
+    // The kernel requires it, and a case table that quietly disagreed would
+    // just be rejected at the entry point with no indication of which row.
+    if (c.ring > 0 && c.ring != max_seq) {
+      fprintf(stderr, "%s: ring=%d must equal max_seq=%d\n", c.name, c.ring,
+              max_seq);
+      ++failures;
+      continue;
+    }
+    // Slots holding a live key: the whole buffer on a ring, the context so far
+    // on a linear cache.
+    const int live = c.ring > 0 ? c.ring : c.total;
 
     std::vector<float> Q((size_t)B * H * D);
     std::vector<float> K((size_t)B * G * max_seq * D);
     std::vector<float> V((size_t)B * G * max_seq * D);
     for (auto& x : Q) x = dist(rng);
-    // Only [0, total) is ever read; leave the tail zeroed to keep the host
+    // Only [0, live) is ever read; leave the tail zeroed to keep the host
     // allocation cheap at max_seq = 16384.
     for (int b = 0; b < B; ++b)
       for (int g = 0; g < G; ++g)
-        for (int kv = 0; kv < c.total; ++kv)
+        for (int kv = 0; kv < live; ++kv)
           for (int e = 0; e < D; ++e) {
             size_t i = (((size_t)b * G + g) * max_seq + kv) * D + e;
             K[i] = dist(rng);
@@ -260,7 +331,8 @@ int main() {
     HIP_CHECK((hipError_t)hip_gqa_flash_decode(
         nullptr, dQ, dK, dV, dO, dPart, B, H, G, D, c.total, max_seq,
         MAX_SPLITS, scale, dSeq, 0, nullptr, 0, HIP_KV_DTYPE_FP16, nullptr,
-        nullptr, dBias, /*bias_batch=*/B, bias_heads, /*bias_kv_stride=*/c.total));
+        nullptr, dBias, /*bias_batch=*/B, bias_heads, /*bias_kv_stride=*/c.total,
+        ring_base_of(c), c.ring));
     HIP_CHECK(hipDeviceSynchronize());
 
     std::vector<float> got((size_t)B * H * D);
@@ -275,8 +347,13 @@ int main() {
     bool nan_out = has_nonfinite(got);
     bool ok = !nan_out && err < 5e-3;
     if (!ok) ++failures;
-    printf("%s B%d H%d G%d(hpg%d) D%-3d total=%-6d bias_heads=%d | relL2=%.2e%s  %s\n",
-           c.name, B, H, G, H / G, D, c.total, bias_heads, err,
+    std::string cache = "linear";
+    if (c.ring > 0)
+      cache = "ring " + std::to_string(c.ring) + " rot" +
+              std::to_string(c.total % c.ring);
+    printf("%s B%d H%d G%d(hpg%d) D%-3d total=%-6d bias_heads=%d %-15s| "
+           "relL2=%.2e%s  %s\n",
+           c.name, B, H, G, H / G, D, c.total, bias_heads, cache.c_str(), err,
            nan_out ? "  NON-FINITE OUTPUT" : "", ok ? "PASS" : "FAIL");
 
     HIP_CHECK(hipFree(dQ));

--- a/lib/Runtime/Kernels/test/example/gqa/decode/test_gqa_decode_bias.cpp
+++ b/lib/Runtime/Kernels/test/example/gqa/decode/test_gqa_decode_bias.cpp
@@ -171,6 +171,18 @@ int main() {
       {"gemma4-local 12k wininf", 1, 16, 8, 256, 16384, 12279, MASK_WINDOW_INF, 1024, 0},
       {"gemma4-local 12k window", 1, 16, 8, 256, 16384, 12279, MASK_WINDOW, 1024, 0},
       {"gemma4-local per-head  ", 1, 16, 8, 256, 16384, 2051, MASK_RANDOM, 0, 1},
+      // Gemma-4's other 5 layers: global attention at twice the head width.
+      // These carry the mask too -- the model exports is_causal=0 and folds
+      // causal and padding into the bias on every layer, not just the sliding
+      // ones -- so d=512 has to be correct WITH a bias, not merely reachable.
+      {"gemma4-global zero     ", 1, 16, 8, 512, 16384, 2051, MASK_ZERO, 0, 0},
+      {"gemma4-global random   ", 1, 16, 8, 512, 16384, 2051, MASK_RANDOM, 0, 0},
+      {"gemma4-global 12k rand ", 1, 16, 8, 512, 16384, 12279, MASK_RANDOM, 0, 0},
+      {"gemma4-global per-head ", 1, 16, 8, 512, 16384, 2051, MASK_RANDOM, 0, 1},
+      // The window/bias agreement check at d=512: the same window expressed
+      // twice must agree, which is what pins the bias indexing to absolute kv
+      // position rather than split-relative at the widest EPT.
+      {"gemma4-global window-inf", 1, 16, 8, 512, 16384, 2051, MASK_WINDOW_INF, 1024, 0},
       {"llama-3.1-8b random    ", 1, 32, 8, 128, 16384, 4096, MASK_RANDOM, 0, 0},
       {"llama-3.1-8b window-inf", 1, 32, 8, 128, 16384, 4096, MASK_WINDOW_INF, 512, 0},
       {"d64 hpg8 window-inf    ", 1, 64, 8, 64, 16384, 8192, MASK_WINDOW_INF, 256, 0},

--- a/lib/Runtime/Kernels/test/example/gqa/decode/test_gqa_decode_i8.cpp
+++ b/lib/Runtime/Kernels/test/example/gqa/decode/test_gqa_decode_i8.cpp
@@ -44,7 +44,7 @@ extern "C" int hip_gqa_flash_decode(
     const void* head_sink, int use_smooth_softmax,
     int kv_dtype, const void* k_scale, const void* v_scale,
     const void* attn_bias, int attn_bias_batch, int attn_bias_heads,
-    int attn_bias_kv_stride);
+    int attn_bias_kv_stride, int ring_base, int ring_cap);
 
 static constexpr int MAX_SPLITS = 64;
 
@@ -265,7 +265,7 @@ static Result run_case(const Case& c, int iters, unsigned seed) {
   HIP_CHECK((hipError_t)hip_gqa_flash_decode(
       nullptr, dQ, dK8, dV8, dO8, dPart, B, H, G, D, c.total, max_seq,
       MAX_SPLITS, scale, dSeq, 0, nullptr, 0, HIP_KV_DTYPE_INT8, dKsc, dVsc,
-      nullptr, 1, 1, 0));
+      nullptr, 1, 1, 0, 0, 0));
   HIP_CHECK(hipDeviceSynchronize());
   std::vector<float> O_int8((size_t)B * H * D);
   {
@@ -278,7 +278,7 @@ static Result run_case(const Case& c, int iters, unsigned seed) {
   HIP_CHECK((hipError_t)hip_gqa_flash_decode(
       nullptr, dQ, dKh, dVh, dO16, dPart, B, H, G, D, c.total, max_seq,
       MAX_SPLITS, scale, dSeq, 0, nullptr, 0, HIP_KV_DTYPE_FP16, nullptr,
-      nullptr, nullptr, 1, 1, 0));
+      nullptr, nullptr, 1, 1, 0, 0, 0));
   HIP_CHECK(hipDeviceSynchronize());
 
   auto bench = [&](auto&& launch) -> double {
@@ -301,12 +301,12 @@ static Result run_case(const Case& c, int iters, unsigned seed) {
   double ms_int8 = bench([&]() {
     hip_gqa_flash_decode(nullptr, dQ, dK8, dV8, dO8, dPart, B, H, G, D,
                             c.total, max_seq, MAX_SPLITS, scale, dSeq, 0,
-                            nullptr, 0, HIP_KV_DTYPE_INT8, dKsc, dVsc, nullptr, 1, 1, 0);
+                            nullptr, 0, HIP_KV_DTYPE_INT8, dKsc, dVsc, nullptr, 1, 1, 0, 0, 0);
   });
   double ms_fp16 = bench([&]() {
     hip_gqa_flash_decode(nullptr, dQ, dKh, dVh, dO16, dPart, B, H, G, D,
                             c.total, max_seq, MAX_SPLITS, scale, dSeq, 0,
-                            nullptr, 0, HIP_KV_DTYPE_FP16, nullptr, nullptr, nullptr, 1, 1, 0);
+                            nullptr, 0, HIP_KV_DTYPE_FP16, nullptr, nullptr, nullptr, 1, 1, 0, 0, 0);
   });
 
   Result r;

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -511,6 +511,39 @@ static int gqa_forward_fused(
     // quantize-and-append with the static per-channel scale; fp16 cache: plain
     // append. update_kv_cache dispatches on kv_format internally.
     //
+    // Right-sized sliding-window cache, same contract the decomposed path
+    // states in full at its ring block: OGA may allocate a windowed layer's
+    // buffer to the window rather than to max_length, and capacity is then
+    // required to equal the window exactly, so the buffer holds precisely the
+    // positions this query may attend to. total_seq is host-known here only via
+    // the B==1 pre-read, which is the shape the caller admits.
+    const int64_t decode_total_seq =
+        (seqlens_k_pre != kSeqlensKNotRead && seqlens_k_pre >= 0)
+            ? static_cast<int64_t>(seqlens_k_pre) + 1
+            : past_len + sq;
+    const bool ring_cache = present_seq < decode_total_seq;
+    if (ring_cache) {
+      if (local_window_size <= 0 || present_seq != local_window_size) {
+        fprintf(stderr,
+                "gqa_forward_fused (decode): present KV buffer (%lld) is "
+                "shorter than the context (%lld), which is only supported for "
+                "a sliding-window layer whose cache is right-sized to exactly "
+                "the window, but local_window_size=%lld\n",
+                (long long)present_seq, (long long)decode_total_seq,
+                (long long)local_window_size);
+        return -1;
+      }
+      if (past_key != present_key) {
+        fprintf(stderr,
+                "gqa_forward_fused (decode): a right-sized sliding-window "
+                "cache needs past and present aliased "
+                "(past_present_share_buffer), but they differ\n");
+        return -1;
+      }
+    }
+    const int64_t ring_base = ring_cache ? decode_total_seq - present_seq : 0;
+    const int64_t ring_cap = ring_cache ? present_seq : 0;
+
     // copy_lo stays 0 here even though this path knows its window. Narrowing
     // the concat needs a separate growing present buffer, and this path never
     // gets one: seq_len_kv reaches the runtime as the present_key memref's
@@ -525,8 +558,8 @@ static int gqa_forward_fused(
             static_cast<int>(sq), static_cast<int>(G), static_cast<int>(d),
             static_cast<int>(past_buf_seq), static_cast<int>(present_seq),
             seqlens_k_ptr, static_cast<int>(elem_sz), /*copy_lo=*/0,
-            /*ring=*/0, /*no_causal=*/false, /*skv=*/-1, kv_format, k_scale,
-            v_scale) != 0)
+            /*ring=*/ring_cache ? 1 : 0, /*no_causal=*/false, /*skv=*/-1,
+            kv_format, k_scale, v_scale) != 0)
       return -1;
 
     {
@@ -554,21 +587,7 @@ static int gqa_forward_fused(
                   "total_seq, but seqlens_k could not be pre-read\n");
           return -1;
         }
-        bias_kv_stride = static_cast<int64_t>(seqlens_k_pre) + 1;
-        // The caller's predicate excludes a ring cache structurally (it cannot
-        // read total_seq that early). Re-check it here, where total_seq IS
-        // known, because the two disagreeing is silent: the kernel would index
-        // the mask by ring slot instead of absolute position and return a
-        // plausible-looking wrong answer rather than an error.
-        if (bias_kv_stride > present_seq) {
-          fprintf(stderr,
-                  "gqa_forward_fused (decode): attention_bias with a ring cache "
-                  "(total_seq=%lld > present_seq=%lld) indexes the mask by ring "
-                  "slot, not position; this call should have been routed to the "
-                  "decomposed pipeline\n",
-                  (long long)bias_kv_stride, (long long)present_seq);
-          return -1;
-        }
+        bias_kv_stride = decode_total_seq;
       }
       int drc = hip_gqa_flash_decode(
           stream, qSrc, present_key, present_value, output, partials,
@@ -580,16 +599,19 @@ static int gqa_forward_fused(
           kv_quantized ? k_scale : nullptr, kv_quantized ? v_scale : nullptr,
           attention_bias, static_cast<int>(attn_bias_batch),
           static_cast<int>(attn_bias_num_heads),
-          static_cast<int>(bias_kv_stride));
+          static_cast<int>(bias_kv_stride), static_cast<int>(ring_base),
+          static_cast<int>(ring_cap));
       if (drc != 0)
         return -1;
       RUNTIME_DEBUG_LOG(
           "[REAL] flash GQA decode (%s): B=%lld skv=%lld H=%lld G=%lld "
-          "d=%lld max_splits=%d window=%lld sink=%d smooth=%d\n",
+          "d=%lld max_splits=%d window=%lld sink=%d smooth=%d ring_base=%lld "
+          "ring_cap=%lld\n",
           kv_quantized ? "quant" : "fp16", (long long)B, (long long)skv,
           (long long)H, (long long)G, (long long)d, kFlashDecodeMaxSplits,
           (long long)local_window_size, static_cast<int>(head_sink != nullptr),
-          static_cast<int>(use_smooth_softmax));
+          static_cast<int>(use_smooth_softmax), (long long)ring_base,
+          (long long)ring_cap);
     }
     return 0;
   }
@@ -2498,29 +2520,18 @@ int wrap_group_query_attention(
   // Flash prefill has no bias support at all, so a masked prefill must keep
   // going decomposed or the mask would be silently dropped.
   //
-  // A ring cache is the fourth condition, and it is not a limitation of the
-  // mask so much as of indexing. flash decode reads the present buffer slot by
-  // slot and indexes the mask by that slot, which is only the key's absolute
-  // position while the buffer is linear. A cache right-sized to a sliding
-  // window holds position p at p % capacity, so once the context passes the
-  // window the slots arrive rotated and every mask entry lands on the wrong
-  // key. The decomposed path already knows this -- it passes a ring base and
-  // capacity into hip_gqa_add_attention_bias_f32 and skips its causal/window
-  // kernel entirely under ring_read, for exactly this reason -- and the fused
-  // path has no equivalent yet.
-  //
-  // The test is structural rather than a comparison against total_seq, which is
-  // not host-known this early: the ring block in gqa_forward_hipblaslt admits a
-  // short buffer ONLY when it is right-sized to the window exactly, so a buffer
-  // longer than the window can never rotate. That makes this conservative by
-  // one phase -- a right-sized layer is excluded even before the context
-  // exceeds its window, where slot and position still agree -- which costs a
-  // few early tokens on the decomposed path and needs no device read.
-  const bool ring_cache_possible =
-      local_window_size > 0 && seq_len_kv <= local_window_size;
+  // A ring cache used to be a fourth condition and no longer is. A cache
+  // right-sized to its sliding window holds position p at p % capacity, so the
+  // slots arrive rotated and a mask indexed by slot lands on the wrong key
+  // every time. flash decode now takes a ring base and capacity and undoes the
+  // rotation where it reads the mask, the same correction
+  // hip_gqa_add_attention_bias_f32 has always applied on the decomposed path.
+  // The condition it replaces was structural (window > 0 && seq_len_kv <=
+  // window) because total_seq is not host-known this early; the kernel does not
+  // need that guess, since gqa_forward_fused reads total_seq before it decides.
   const bool bias_ok =
       attention_bias == nullptr ||
-      (is_decode && batch_size == 1 && !kv_quantized && !ring_cache_possible &&
+      (is_decode && batch_size == 1 && !kv_quantized &&
        !gqa_fused_decode_bias_disabled());
   // no_causal on a masked decode is likewise safe: is_causal=0 exports (Gemma-4)
   // carry causal, padding AND any sliding window inside the additive mask, and

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -166,16 +166,38 @@ static int32_t read_seqlens_k_for_dispatch(hipStream_t stream,
 // FA-2 split-K decode workspace capacity, in splits (matches gqa_kernel.hip).
 static constexpr int kFlashDecodeMaxSplits = 64;
 
+// Env-var gate to keep a d=512 decode on the decomposed pipeline, i.e. to undo
+// just the head_dim admission in flash_decode_geometry_ok below. Set
+// HIPDNN_EP_GQA_DISABLE_FUSED_DECODE_D512=1 to A/B the fused and decomposed
+// implementations of Gemma-4's 5 global layers from ONE build. That matters
+// more here than usual: adding the d=512 instantiations changes the kernels
+// DLL's code-object layout, which moves even untouched kernels by around a
+// microsecond, so a two-build A/B would not isolate the routing change.
+//
+// The gate lives inside flash_decode_geometry_ok rather than at the two call
+// sites so both agree. Gating only the wrap_ predicate would let the fused
+// entry still be reached and then fail its own geometry check with an fprintf.
+static bool gqa_fused_decode_d512_disabled() {
+  static const bool disabled = [] {
+    const char *v = std::getenv("HIPDNN_EP_GQA_DISABLE_FUSED_DECODE_D512");
+    return v && std::strcmp(v, "0") != 0;
+  }();
+  return disabled;
+}
+
 // Geometry gate for the flash_decode kernel template instantiations. The scalar
 // decode kernel is templated for HpG in {1,2,3,4,5,8,16} (so it covers MHA and
-// the common GQA ratios, incl. Qwen2.5-14B's 40:8=5) at d in {64,128,256}
-// (d=256 covers Qwen3-family 16:4 heads); WMMA is layered on top inside the
-// kernel where it helps (d<=128 only). Anything outside this set has no decode
-// kernel.
+// the common GQA ratios, incl. Qwen2.5-14B's 40:8=5) at d in {64,128,256,512}
+// (d=256 covers Qwen3-family 16:4 heads; d=512 is Gemma-4's global-attention
+// layers, which are twice as wide as its 25 sliding ones); WMMA is layered on
+// top inside the kernel where it helps (d<=128 only). Anything outside this set
+// has no decode kernel.
 static inline bool flash_decode_geometry_ok(int64_t H, int64_t G, int64_t d) {
   if (G <= 0)
     return false;
-  if (d != 64 && d != 128 && d != 256)
+  if (d != 64 && d != 128 && d != 256 && d != 512)
+    return false;
+  if (d == 512 && gqa_fused_decode_d512_disabled())
     return false;
   int64_t hpg = H / G;
   if (hpg * G != H)
@@ -426,7 +448,7 @@ static int gqa_forward_fused(
     if (!flash_decode_geometry_ok(H, G, d)) {
       fprintf(stderr,
               "gqa_forward_fused (decode): unsupported geometry H=%lld G=%lld "
-              "d=%lld (HpG must be 1/2/3/4/5/8/16 and d 64/128/256)\n",
+              "d=%lld (HpG must be 1/2/3/4/5/8/16 and d 64/128/256/512)\n",
               (long long)H, (long long)G, (long long)d);
       return -1;
     }
@@ -2429,18 +2451,19 @@ int wrap_group_query_attention(
 
   //===------------------------------------------------------------------===//
   // Path selection. The optimized fused/flash kernels are fp16 causal GQA with
-  // head_dim in {64,128,256} and a templated decode geometry (HpG in
-  // {1,2,3,4,5,8,16}). Decode supports sink/window for every templated
-  // geometry; prefill v3 supports them at head_dim == 64. Everything else uses
-  // the feature-complete decomposed hipBLASLt fallback.
+  // a templated head_dim and decode geometry (HpG in {1,2,3,4,5,8,16}). Decode
+  // supports sink/window for every templated geometry; prefill v3 supports them
+  // at head_dim == 64. Everything else uses the feature-complete decomposed
+  // hipBLASLt fallback.
   //===------------------------------------------------------------------===//
   const bool is_decode = (seq_len_q == 1);
   const bool decode_geometry_ok =
       !is_decode || flash_decode_geometry_ok(num_heads, kv_num_heads, head_dim);
-  // head_dim gate: the fused WMMA prefill (v7) and the scalar flash-decode
-  // kernels both cover d in {64,128,256} now (d=256 for Qwen3-family 16:4). For
-  // decode, flash_decode_geometry_ok already validates d; for prefill we clamp
-  // to the templated set here.
+  // head_dim gate: the scalar flash-decode kernel covers d in {64,128,256,512},
+  // the fused WMMA prefill (v7) only {64,128,256}. For decode,
+  // flash_decode_geometry_ok already validates d; for prefill we clamp to the
+  // narrower prefill set here, which is why d=512 fuses at decode and stays
+  // decomposed at prefill.
   const bool head_dim_ok =
       is_decode ? true : (head_dim == 64 || head_dim == 128 || head_dim == 256);
   // attention_bias (onnx.Attention external mask) is only applied by the legacy


### PR DESCRIPTION
## Summary

Gemma-4's 25 sliding layers were the last thing on the decomposed decode path,
and they were there for one reason: their KV cache is right-sized to the window,
so the buffer wraps and flash decode read the mask by buffer slot as if it were
absolute position. #851 blocked them for that. **This teaches
the kernel the rotation instead, and all 30 layers now fuse at decode: +7.3% TPS
at 16K.**

Two commits. The head_dim 512 one is a prerequisite — it is what lets the 5
global layers fuse at all — and it is honest about reaching no clock on its own;
see the disclosure below.

## Related issue or design

Stacked on #851, which is stacked on #808. Last of the three-PR Gemma-4 decode
series; #850 is independent of both.

## Why

A right-sized cache stores position `p` at `p % capacity`, so slot `s` carries
the one position in `[ring_base, ring_base + ring_cap)` congruent to
`s mod ring_cap`. Inverting that before indexing the mask is exactly what
`hip_gqa_add_attention_bias_f32` has always done on the decomposed path;
`hip_gqa_flash_decode` now takes the same two numbers. The correction is three
lines.

Two smaller things follow from a ring rather than being separate choices:

- **Range.** Capacity *is* the window, so the buffer holds precisely the
  positions the query may attend to: scan every slot and let neither the window
  nor `seqlens_k` narrow it. The old expressions already produced this, since
  `eff_skv` clamps to `max_seq == capacity` and `kv_lo` then stays 0, but only
  because two independent quantities happened to be equal. It is stated now. The
  WMMA kernel gets the range and not the base — it applies no mask, and attention
  is a sum over an unordered set of keys, so the rotation is invisible to it.
- **Autotune key.** A ring's work is fixed at capacity while its context keeps
  growing, so keying on `eff_skv` would spread one steady-state shape across a
  fresh cache entry per skv bucket and re-tune at each. Keys on capacity.

Also fixed here: the fused path's own append was passing `ring=0`, which would
have written the new token to the unwrapped slot. `update_kv_cache` has taken a
ring flag since the right-sizing work; only this call site had not been given it.

## What

- `perf(gqa): extend flash decode to head_dim 512` — split-D instantiation for
  Gemma-4's 5 global layers, `BKV=4` at `D>=512` to hold the LDS budget at 8 KB,
  EPT bound raised to 16, `flash_decode_geometry_ok` admits `d=512`. Gated by
  `HIPDNN_EP_GQA_DISABLE_FUSED_DECODE_D512`.
- `perf(gqa): run a masked decode on a ring cache` — `ring_base`/`ring_cap` on
  `hip_gqa_flash_decode`, de-rotation before the mask lookup, the range and
  autotune-key changes above, removal of the previous PR's routing guard, and
  the `ring=1` append fix.

## Test plan

**Numeric.** `test_gqa_decode_bias` can now reach a ring, which is the point:
before this there was no parameter to set, and its linear cache made the bug
unreachable by construction. Six ring cases — rotation 0 and non-zero (a kernel
that applied the base offset and forgot the modulo passes the first and fails the
second), at 16K, per-head, ragged capacity, and a second `(D, HpG)` — plus five
new `d=512` cases. All ring cases are `MASK_RANDOM`, because a window mask
**cannot** detect a rotation: a ring of exactly `window` cells holds only
in-window positions, so every live entry is 0 and any permutation of them agrees.
That is why the production configuration hid this and why "the sliding cases
pass" was never evidence.

The cases are load-bearing, not decorative: with the de-rotation removed from the
kernel, all six ring cases go to relL2 ~1e+00 and all fifteen linear cases still
pass. 21/21 pass as committed; `test_gqa_decode` (52 cases) and
`test_gqa_decode_i8` also pass.

**End-to-end, and specifically the kind of correctness a relL2 cannot see.**
Generating 64 greedy tokens with the fusion on and off must produce identical
text, at 2K where the rotation is 193 slots and at 16K where it is 881. Both
identical, to the character. That check is what caught the original bug, when the
fused arm degenerated into "The image of the image of the image of the provided
in the image" against a coherent reference.

**Independence from the d512 commit.** Because that commit reaches no clock, I
checked whether the throughput here depends on it: cherry-picking the ring commit
straight onto #851's head, with d512 absent, builds clean and passes
16/16 bias cases (10 linear + 6 ring), 52/52 fp16 and the int8 suite. The ring
gate acts on the 25 sliding layers and d512 on the 5 global ones, so they are
disjoint — but the throughput below was measured with both present and is not
re-measured without.

## Performance

Gemma-4 26B-A4B, gfx1151 (Radeon 8060S), 16 241-token prompt. 8 paired rounds x
3 reps, both orderings; both arms run byte-identical DLLs and differ only in the
ring fusion gate.

| Metric | Ring fusion off | Ring fusion on |
|---|---:|---:|
| ms/token | 25.3 | 23.6 |
| tok/s | 39.5 | 42.4 |
| GPU ms/token, the 25 sliding layers | 4.9 | 3.3 |

Paired delta **-1.72 ms/token**, sd 0.27, n = 8, t = -17.99 (**+7.3% TPS**).
Forward -1.75 (sd 0.28) and reversed -1.68 (sd 0.12), so this is not run order.
It is the ratio that is worth reading: the wall saving is at least as large as
the GPU saving it came from, which is what puts this work on the critical path.

## Notes for reviewers

**Disclosure on the d512 commit.** Its own A/B is null: +0.09 ms/token, sd 0.246,
t = +1.0 — indistinguishable from zero, or -0.4% if you read the point estimate.
It does take real GPU work off the 5 global layers (3.05 -> 2.30 ms/token), so
the work was not on the critical path. It is in this PR because it is the
prerequisite for "all 30 layers fuse", not because it is fast. Its commit subject
says so. I am happy to split it out if you would rather review it separately.

That contrast is the useful part of the series: d512 removed 0.6 ms/token of GPU
time and moved the clock by nothing, while the ring commit removed 1.6 ms/token
of GPU time on layers that were holding up the clock and moved it by 1.7 ms.
Sequencing the two the other way round would have credited d512 with part of
this.

Ordering constraint: merge after #851, which this one depends on and whose
routing guard it removes.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.

Developed with substantial AI assistance (Cursor). The de-rotation, the ring test
shapes and the text-equivalence protocol were reviewed by hand; the A/B rig runs
both orderings specifically because an earlier version of this series produced a
confident wrong number.
