### PR TITLE
ci: trigger workflows on branches containing release

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   push:
-    branches: [main, "release/**"]
+    branches: [main, "**/*release*"]
 
 permissions:
   contents: read
@@ -577,7 +577,7 @@ jobs:
         with:
           name: linux-gpu-test-package
           path: staging/
-          retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 14 || 3 }}
+          retention-days: ${{ (github.ref == 'refs/heads/main' || contains(github.ref, 'release')) && 14 || 3 }}
 
       - name: Save sccache directory
         if: always() && github.ref_name == 'main'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,7 +7,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [main, "release/**"]
+    branches: [main, "**/*release*"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/windows-build-mock.yml
+++ b/.github/workflows/windows-build-mock.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   push:
-    branches: [main, "release/**"]
+    branches: [main, "**/*release*"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   push:
-    branches: [main, "release/**"]
+    branches: [main, "**/*release*"]
 
 permissions:
   contents: read
@@ -638,7 +638,7 @@ jobs:
         with:
           name: gpu-test-package
           path: staging/
-          retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 14 || 3 }}
+          retention-days: ${{ (github.ref == 'refs/heads/main' || contains(github.ref, 'release')) && 14 || 3 }}
 
       - name: Stage Python wheel package
         shell: bash
@@ -670,7 +670,7 @@ jobs:
         with:
           name: hip-python-package
           path: wheelpkg/
-          retention-days: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 14 || 3 }}
+          retention-days: ${{ (github.ref == 'refs/heads/main' || contains(github.ref, 'release')) && 14 || 3 }}
 
       - name: Save sccache directory
         if: always() && github.ref_name == 'main'


### PR DESCRIPTION
## Summary

Extend push CI triggers to branches whose names contain `release`, so gpuep release lines such as `gpuep/releases/gpuep-rel-2610` build automatically on push.

## Related issue or design

None

## Why

Push triggers currently use `release/**`, which matches `release/release_0_3_0` but not `gpuep/releases/gpuep-rel-2610` or top-level `release_0_X_0` branches. Gpuep release branches need the same Windows/Linux build and artifact retention as other release lines.

## What

- Replace `push.branches: [main, "release/**"]` with `[main, "**/*release*"]` in windows-build, linux-build, pre-commit, and windows-build-mock workflows.
- Align artifact retention (14 days vs 3 for PRs) using `contains(github.ref, 'release')` instead of `startsWith(..., 'refs/heads/release/')`.

## Test plan

- [ ] pre-commit green on this PR
- [ ] After merge, push to `gpuep/releases/gpuep-rel-2610` triggers Windows Build (and linux-build / pre-commit / windows-build-mock on push)
- [ ] Release-branch artifacts use 14-day retention

## Notes for reviewers

None

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
