### PR TITLE
ci: fix push triggers for gpuep release branches

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   push:
-    branches: [main, "**/*release*"]
+    branches: [main, "release/**", "gpuep/releases/**"]
 
 permissions:
   contents: read

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,7 +7,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [main, "**/*release*"]
+    branches: [main, "release/**", "gpuep/releases/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/windows-build-mock.yml
+++ b/.github/workflows/windows-build-mock.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   push:
-    branches: [main, "**/*release*"]
+    branches: [main, "release/**", "gpuep/releases/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   push:
-    branches: [main, "**/*release*"]
+    branches: [main, "release/**", "gpuep/releases/**"]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Fix push CI branch filters so `gpuep/releases/gpuep-rel-2610` and similar gpuep release branches actually trigger builds. Replace the broken `**/*release*` glob with explicit `release/**` and `gpuep/releases/**` patterns.

## Related issue or design

Follow-up to #856 / #857.

## Why

GitHub Actions branch globs treat `*` as single-path-segment only. `**/*release*` matches `release/foo` but not `gpuep/releases/gpuep-rel-2610` because the last segment is `gpuep-rel-2610` (no `release` substring). That branch has had zero push-triggered Windows Build runs despite #857 landing the same glob there.

## What

- Set `push.branches` to `[main, "release/**", "gpuep/releases/**"]` in windows-build, linux-build, pre-commit, and windows-build-mock workflows.
- Leave artifact `retention-days` unchanged (`contains(github.ref, 'release')` already covers gpuep release refs).

## Test plan

- [ ] pre-commit green on this PR
- [ ] After merge, push to `gpuep/releases/gpuep-rel-2610` triggers Windows Build on push
- [ ] `release/release_0_3_0` push still triggers CI

## Notes for reviewers

None

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
