### PR TITLE
perf(conv): restore convolution performance after the MIOpen removal (1.09x over 21 models, 1.22x on resnet50)

### DIFF
--- a/docs/perf/qwen36-16k-bottleneck.md
+++ b/docs/perf/qwen36-16k-bottleneck.md
@@ -1,0 +1,500 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+# Qwen3.6-35B-A3B 16K prefill: where the time actually goes
+
+SQTT (RGP) profile of a 16K VLM prefill, taken on repaired model weights. This
+supersedes the withdrawn attribution in `qwen36-ttft-attribution.md`, which was
+measured against a half-zeroed `text.onnx.data`.
+
+## Operating point and build
+
+`vlm_benchmark.py` with `dog.jpg` and `prompt_16k.txt`: **18,646 prompt tokens**
+(16,823 text, 1,823 image), `max_length 33024`, `-e AMDGPU`. Build is
+`feat/rgp-capture-fence-v2` with all three binaries redeployed together
+(`hipgpu.dll`, `custom_kernels_gfx1151.dll`, `hip-compiler.dll`).
+
+Uninstrumented TTFT at this point is **19,526 ms** (3 reps, stddev 293 ms)
+against CI's 16,702 ms at 18,755 tokens. The attribution below is all measured at
+that baseline; the v8 prefill kernel has since been optimised.
+
+> **The 17,587 ms post-optimisation figure quoted below is not reproducible and
+> should not be used.** The same binaries and the same `max_length 33024` now
+> measure **14,734 ms**, and 14,455-14,610 ms with a right-sized KV cache. See
+> "Second profiling round" for the current baseline and for why that number was
+> probably instrumented.
+
+Fitting the 4K and 16K points for each environment separates startup from
+throughput:
+
+| | fixed | per token |
+|---|---:|---:|
+| local, as first measured | 634 ms | 1.013 ms |
+| local, warm and verified clean | 940 ms | **0.729 ms** |
+| CI | 1,016 ms | 0.836 ms |
+
+The first local row was fitted on runs that are now believed to be instrumented.
+On the clean re-measurement local starts up slower than CI but is 13% *faster*
+per token, so on these figures the per-token gap to CI has closed and reversed.
+
+## The layer stack
+
+Op call counts per prefill: `qmoe` 40, `matmul_nbits` 391, `causal_conv` 30,
+`linear_attention` 30, `gqa` 10. That is a 40-layer hybrid stack: 30
+linear-attention layers and 10 full-attention layers, every layer with its own
+MoE block.
+
+Each capture window contains exactly one `topk_routing` and one
+`bucket_tokens`, i.e. exactly one MoE block, which confirms one window equals
+one layer and lets per-layer cost be scaled by layer count.
+
+## Per-layer cost
+
+**Full-attention layer — 463.8 ms GPU busy, 943 dispatches, 0.5% idle**
+
+| kernel | count | total ms | % layer | occ | limiter | bound |
+|---|---:|---:|---:|---:|---|---|
+| `gqa_flash_prefill_v8_kernel` | 1 | 386.6 | 83.3 | 25% | LDS | latency/low-occupancy |
+<!-- The v8 row is the pre-optimisation measurement. It has since been cut to
+     203.9 ms/call uninstrumented; see "Optimising the v8 prefill kernel" below,
+     which also explains why its *instrumented* cost barely moved. -->
+
+| `MatMulNBitsFp16GEMM` | 61 | 29.1 | 6.3 | 55% | VGPR | undetermined |
+| `MatMulNBitsWMMA_NoZP` | 189 | 15.1 | 3.3 | 69% | VGPR | undetermined |
+| `bucket_tokens_kernel` | 1 | 8.9 | 1.9 | 100% | - | undetermined |
+
+**Linear-attention layer — 122.2 ms GPU busy, 490 dispatches, 1.4% idle**
+
+| kernel | count | total ms | % layer |
+|---|---:|---:|---:|
+| `la_pf_pass3_wmma` | 37 | 30.8 | 25.2 |
+| `MatMulNBitsFp16GEMM` | 24 | 20.4 | 16.7 |
+| `la_pf_scan` | 37 | 16.0 | 13.1 |
+| `la_pf_pass1_local` | 37 | 10.4 | 8.5 |
+| `T5LayernormFwdContiguous` | 2 | 9.4 | 7.7 |
+| `bucket_tokens_kernel` | 1 | 8.8 | 7.2 |
+| `ew_bcast4d_kernel` | 1 | 5.2 | 4.3 |
+| `cast_f16_to_f32` + `cast_f32_to_f16` | 2 | 5.0 | 4.1 |
+
+The 37 repeats of each `la_pf_*` pass are the chunked scan over 18,646 tokens,
+so all 37 belong to a single `linear_attention` op.
+
+## Whole-prefill budget
+
+Scaling measured per-call cost by call count:
+
+| item | per call | calls | total ms |
+|---|---:|---:|---:|
+| `gqa_flash_prefill_v8` | 386.6 ms | 10 | 3,866 |
+| `gqa_flash_prefill_v8`, after optimisation | 203.9 ms | 10 | 2,039 |
+| linear attention (3 passes) | 57.2 ms | 30 | 1,716 |
+| dense `MatMulNBits` (all variants) | - | - | ~1,050 |
+| `bucket_tokens` | 8.8 ms | 40 | 352 |
+| `topk_routing` | 1.2 ms | 40 | 48 |
+| **10 full-attention layers, whole layer** | 463.8 ms | 10 | **4,638** |
+| **30 linear-attention layers, whole layer** | 122.2 ms | 30 | **3,666** |
+
+Modelled decoder GPU busy is therefore about **8,304 ms**, against a 19,526 ms
+TTFT. The captures cover the decoder only; the remainder is the vision encoder,
+the embedding model, `lm_head` and host time, none of which were captured. Do
+not read the 8,304 ms as a complete TTFT decomposition.
+
+> Superseded by "Second profiling round", which measures all three sessions. The
+> vision encoder is 1.2 s, the embedding model 78 ms, and `lm_head` is not a cost
+> at all: `text.onnx` already emits `logits` as `[batch, 1, 248320]`, so it is
+> last-row-only. Host time and idle gaps together are under 20 ms.
+
+## Conclusions
+
+**The prefill is GPU-bound, not launch-bound.** Idle is 0.5% over 943
+dispatches in the full-attention window and 1.4% over 490 in the
+linear-attention window, with total launch overhead of 33.5 us and 9.9 us
+respectively. The earlier claim that ~85% of TTFT was host-side kernel-launch
+overhead does not survive contact with SQTT on a correct model.
+
+**The single largest kernel is `gqa_flash_prefill_v8_kernel`** at 386.6 ms per
+call and 3.9 s across the ten full-attention layers. It is the only kernel the
+parser classes as `latency/low-occupancy`: 25% occupancy with **LDS as the
+binding resource**. Its cost is cleanly quadratic in sequence length (17.0
+ms/call at 3,985 tokens against 361 ms/call at 18,646, a 21.2x rise for a 21.9x
+rise in n^2), and the runtime's own uninstrumented autotune independently
+measures 361.4 ms/call for the winning config, so the SQTT figure is not an
+instrumentation artifact.
+
+This kernel has since been cut to 203.9 ms/call, taking TTFT to 17,587 ms. The
+`latency/low-occupancy` classification turned out to be a red herring: raising
+occupancy makes it slower, and the win came from removing redundant per-wave work.
+Note also that once `BKV=16` won, the SQTT per-call figure *did* become an
+instrumentation artifact, for the reason given in that section.
+
+**The most egregious inefficiency is `bucket_tokens_kernel`.** It launches a
+*single* 256-thread workgroup, 8 wavefronts, and holds the GPU for 8.8 ms:
+
+```
+bucket_tokens_kernel   threads: 256   workgroup: 256   wavefronts: 8      dur: 8,822.7 us
+topk_routing_kernel    threads: 4,773,376        wavefronts: 149,168      dur: 1,227.7 us
+```
+
+Every other kernel in the MoE block is massively parallel; this one serialises
+the whole device. At 40 layers it is ~350 ms, and it is followed by the largest
+idle gap in either capture (1.0 ms, and 4.0 ms in the full-attention window).
+`origin/perf/qwen-bucket-tokens` already carries a chunked rewrite of exactly
+this kernel and is the obvious thing to re-measure first.
+
+**Ten full-attention layers cost more than thirty linear-attention layers**
+(4,638 ms against 3,666 ms), so attention-shape work, not layer count, sets the
+scaling.
+
+## Optimising the v8 prefill kernel
+
+The kernel above was then optimised directly. Result at the same operating point:
+
+| | before | after |
+|---|---:|---:|
+| per call, uninstrumented (runtime autotune, sq=18646) | 361.4 ms | **203.9 ms** |
+| per call, standalone microbenchmark | 348.1 ms | **203.4 ms** |
+| per call, SQTT-instrumented | 386.6 ms | 380.8 ms |
+| config (ND, MT, BKV) | 4, 1, 32 | 2, 1, 16 |
+| VGPRs / LDS bytes | 192 / 26112 | 240 / 11264 |
+| occupancy / limiter | 25.0% / LDS | 31.2% / LDS |
+| workgroup / wavefronts | 128 / 74,624 | 64 / 37,312 |
+| **16K TTFT** (3 reps) | **19,526 ms** (sd 293) | **17,587 ms** (sd 286) |
+
+**43% off the kernel and 1,939 ms (9.9%) off TTFT.** Accuracy improved at the same
+time: `relL2` against the CPU reference went from 5.7e-04 to 3.3e-04 at sq=2048.
+
+### Do not use the SQTT per-call time to A/B this kernel
+
+The instrumented cost moved 1.5% while the uninstrumented cost fell 43%. The
+instrumented figure is the artifact: SQTT overhead scales with instruction issue,
+and the winning config uses `BKV=16`, which doubles the KV-tile trip count (583
+tiles per block instead of 292) for half the work per tile. Three independent
+uninstrumented measurements agree with each other and not with SQTT — the
+standalone microbenchmark, the runtime's own autotune inside the real process, and
+end-to-end TTFT. A 5.8 ms/call improvement over 10 calls cannot produce a 1,939 ms
+TTFT drop, so SQTT is what is wrong here, not the other three.
+
+### Occupancy was the wrong target
+
+The premise going in was that 25% occupancy with LDS as the binding resource was
+the problem. It was not. Measured at sq=18646, with compiler register/LDS figures
+from `-Rpass-analysis=kernel-resource-usage`:
+
+| cfg | vgpr | spill | occupancy | ms/call |
+|---|---:|---:|---:|---:|
+| 2,1,16 | 239 | 0 | 37.5% | **204** |
+| 4,1,16 | 135 | 0 | 62.5% | 219 |
+| 4,1,32 | 175 | 0 | 50.0% | 249 |
+| 8,1,16 | 82 | 0 | 100.0% | 276 |
+
+Occupancy is inversely correlated with speed across this whole sweep. The fully
+occupant config is 35% slower than the winner, because occupancy here is a
+function of `ND`, and raising `ND` adds cross-wave score-reduction traffic and
+per-wave softmax cost that outweigh the extra residency. The final kernel is still
+LDS-limited at 31.2% and that is fine. Six of the eleven instantiated configs also
+spill (up to 768 registers), which no occupancy figure reveals — spilling
+configurations had been sitting in the autotune candidate list.
+
+### What actually paid, in order
+
+1. **`BKV=16`** (absent from the candidate table). 348 -> 248 ms. Halves `V_lds`.
+2. **Stop repeating the softmax in every wave.** The ablation mask showed softmax
+   was 136 ms of 348 ms, and all `ND` waves computed it identically. Splitting its
+   rows `ND` ways: 248 -> 215 ms. Handing it to one wave instead was tried first
+   and is worse — the other waves then idle at the barrier while that copy sits on
+   the critical path.
+3. **fp32 accumulator.** The WMMA accumulator is already fp32, so keeping `O` in
+   fp16 meant unpacking and repacking every tile. 215 -> 204 ms, and it is the
+   accuracy improvement above.
+4. **Pruning the candidate list** to non-spilling configs, which also cut the
+   first-call autotune sweep from 11 candidates to 4 (~40 s each at this shape).
+
+### What was measured and rejected
+
+- **Reducing the 3 barriers per KV tile.** Ablating all three (mask bit 32) saves
+  5.5 ms of 203 ms, so the restructuring the barriers would need cannot pay.
+- **Skipping the `O` rescale when `corr == 1.0`**, which is most tiles once the
+  running max settles: 0.3%, inside run-to-run noise. Those fp32 multiplies hide
+  behind the tile's memory traffic.
+- **Compacting `Sp_lds`.** Aimed at buying occupancy headroom, which the table
+  above shows is not worth buying. It is also only ~10% of the kernel's LDS
+  traffic, against `V_lds`'s 16 KB per tile.
+- **`ND=8` with `__launch_bounds__`** to force `vgpr <= 128`: reaches 100%
+  occupancy and is the slowest config measured.
+
+### Where the remaining 203 ms sits
+
+By ablation at the shipped config (`HIPDNN_PREFILL_V8_ABLATE`, bit per phase):
+
+| phase | cost | share |
+|---|---:|---:|
+| value GEMM | 45.8 ms | 23% |
+| softmax | 41.1 ms | 20% |
+| V staging | 37.2 ms | 18% |
+| score GEMM | 19.9 ms | 10% |
+| K loads | 13.2 ms | 7% |
+| barriers | 5.5 ms | 3% |
+
+No single phase dominates any more, which is why this stopped here. The largest
+remaining structural cost is that the value GEMM's `V` fragment needs 16
+consecutive `kv` values at a fixed `d`, while the KV cache is `[B,G,seq,d]` — so
+each fragment is a 16-instruction strided LDS gather. Storing `V` d-major would
+make it two contiguous loads, but that is a KV-cache layout change spanning the
+append/concat/decode kernels, not a change to this kernel.
+
+### Reproducing
+
+`test_gqa_prefill.cpp` gained the Qwen d=256 shapes (nothing covered the v8 kernel
+before, so it had no correctness test at all) plus `--sq`, `--only`, and
+`--dump`/`--ref` for checking a kernel change against a previous build's output at
+sq=18646, where a CPU reference is infeasible. Two env knobs were added:
+`HIPDNN_PREFILL_V8_CFG="ND,MT,BKV"` pins a config, and
+`HIPDNN_PREFILL_V8_ABLATE` drives the in-kernel ablation mask, which previously
+had no reachable caller.
+
+## What could not be measured, and why
+
+No bound class is better than `compute-or-memory (undetermined)` for anything
+except the GQA kernel, because SPM counters had to be dropped. Per
+`tools/rgp_parser/README.md` the SQTT buffer, the SPM counter buffers and the
+model's activations all compete for the same physical memory on a shared-memory
+APU. With `--rgp-counter-collection` on at 16K the workload slowed so far that
+the fence could not arm inside a 10-minute window; without SPM it armed
+normally. Separating memory-bound from compute-bound at 16K would need a bigger
+memory budget than this box has.
+
+Two further limits found the hard way:
+
+- `--rgp-sqtt-buffer-size minimum` is enough for an MoE block (56 MB, 179
+  dispatches) but **not** for a full-attention layer: the 386 ms attention
+  kernel's token stream produced `TraceError` chunks and `sqtt=0`, an unusable
+  capture. `default` works and yields 180 MB and 943 dispatches. `maximum`
+  remains untested here and is documented as wedging the workload.
+- The harness's fence-arm deadline was hardcoded to 600 s, which a 16K VLM
+  cannot meet: model load, the per-process prefill autotune sweep and a cold
+  first rep all precede the fence. It is now the `-ArmTimeoutSec` parameter.
+
+The box hard-faulted once during this work (bugcheck `0x7F`, double fault); an
+identical bugcheck is in the event log from earlier the same day, so it is a
+recurring failure mode at this operating point rather than something a single
+capture caused. Model weights were re-verified against the CI share afterwards
+and are intact.
+
+# Second profiling round: the whole TTFT
+
+The first round fenced on one decoder op and modelled the decoder from two
+single-layer windows, covering 8,304 ms of a 19,526 ms TTFT. This round measures
+all three ONNX sessions and re-establishes the baseline. It changes the answer.
+
+## The baseline was wrong, and the harness cannot prevent that
+
+| tag | max_length | TTFT | within-run sd |
+|---|---:|---:|---:|
+| `gqa_v8_opt_16k` (first round) | 33,024 | 17,587 ms | 286 ms |
+| `p0-16k-33k` (same binaries, same config) | 33,024 | **14,734 ms** | 77 ms |
+| `p0-16k-tight` | 18,900 | **14,610 ms** | 15 ms |
+| `p0-16k-tight-r2` | 18,900 | **14,455 ms** | 14 ms |
+
+Warm between-run spread is 155 ms (1.1%) and within-run 14 ms, so the 2,853 ms
+gap to the first-round number is not noise. Neither is it the kernel: the GQA
+autotune measured 223.5, 224.1 and 233.3 ms/call across these runs, and decode
+was *faster* in the slow run (19.93 against 20.09 ms/token), which rules out
+thermal throttling.
+
+The likely cause is that the first-round run was instrumented. Enabling
+`HIPDNN_EP_TRACE_FILE` on the current build measures **17,545 ms**, which matches
+the unexplained 17,587 ms to 0.24%.
+
+**`Clear-HarnessProfilingEnv` cannot prevent this.** It removes `HIPDNN_EP_PERF`
+and `HIPDNN_EP_DEBUG` only:
+
+```powershell
+# tools/perf-harness/common.ps1
+Remove-Item Env:HIPDNN_EP_PERF, Env:HIPDNN_EP_DEBUG -EA SilentlyContinue
+```
+
+But `hipdnn_ep_perf_enabled()` is true if **either** `HIPDNN_EP_PERF` is set *or*
+`HIPDNN_EP_TRACE_FILE` is non-empty (`lib/Runtime/debug_log.h:41-44`). A leaked
+`HIPDNN_EP_TRACE_FILE` therefore turns on full instrumentation, costs ~21% of
+TTFT, and no harness script clears it. It should be added to that list. Nothing
+is set at User or Machine scope on this box, so the leak would have been
+per-shell.
+
+## KV-cache oversizing is real but small
+
+`max_length 33024` for an 18,646-token prompt allocates 77% more KV cache than
+the prompt needs, and it does show up: peak RSS 1,365 MB against 1,103 MB, a
+262 MB difference that matches the KV geometry. But the TTFT cost is only
+**124-280 ms** (14,734 against 14,455-14,610), about 1-2%. The hypothesis that
+this explained seconds of TTFT is falsified.
+
+## Whole-TTFT session decomposition
+
+`HIPDNN_EP_TRACE_FILE` writes one Chrome trace per session on a shared absolute
+`steady_clock`, so all three sessions lie on one timeline. Merged with
+`tools/perf-report/merge_chrome_traces.py` (no `--zero`), the warm iteration is:
+
+| bucket | ms | share |
+|---|---:|---:|
+| decoder session | 16,209.5 | 92.4% |
+| vision session | 1,229.9 | 7.0% |
+| embedding session | 77.9 | 0.4% |
+| inter-session gaps | 15.9 | 0.1% |
+| host inside session windows | 3.6 | 0.02% |
+| **wall, first start to last end** | **17,533.2** | |
+
+Against a 17,544.7 ms instrumented TTFT, that accounts for all but 11.5 ms
+(0.07%). **The prefill is essentially 100% GPU kernel time**: there is no host
+bottleneck, no launch-bound region and no idle to recover. This is the same
+conclusion the first round reached from idle percentages, now established for the
+whole TTFT rather than two windows.
+
+The vision encoder is measured here for the first time. At 1.2 s it is 7% of
+TTFT, not the multi-second unknown it was assumed to be. Its cost is dominated by
+`mha_flash_prefill` and Tensile GEMMs, and it is still worth noting that the
+config fix keeping it on the GPU is load-bearing: with `session_options` present
+on the `vision` entry, ORT silently runs all 4,154 of its nodes on
+`CPUExecutionProvider` for 29.2 s of node time.
+
+## The EP's own per-op timings are not usable for attribution
+
+The `[PERF]` table is not merely inflated, its **per-op attribution is wrong**.
+Checked against RGP windows taken with no EP instrumentation:
+
+| op | `[PERF]` ms/call | RGP ms/call | error |
+|---|---:|---:|---|
+| vision `gemm` (7296x1152x4304) | 4.43 | 4.61 | agrees |
+| vision `gemm` (7296x4304x1152) | 4.23 | 4.23 | agrees |
+| `causal_conv` | 30.6 | 31.5 | agrees |
+| `gqa` | 27.2 | 380.0 | **14x low** |
+| vision `multi_head_attention` | 0.56 | 20.34 | **36x low** |
+| `linear_attention` | 8.6 | 56.7 | 6.6x low |
+| vision `slice` | 5.68 | 0.34 | **17x high** |
+| `cast` (596672) | 46.4 | 1.23 | **38x high** |
+
+`[PERF]` puts vision MHA at 0.56 ms/call when that call is 245 GFLOP, whose floor
+at 59.4 TFLOP/s is 4.13 ms — below the hardware limit, so it is provably wrong
+rather than merely noisy.
+
+The mechanism is the timing model. GPU time is the gap between consecutive
+fenceless event markers on the in-order stream, so an op that blocks the host and
+drains the queue is charged for work that was already outstanding. `slice` and
+`cast` are exactly that: `slice`'s CPU time equals its GPU time (594 against
+614 ms) and the vision session issues 199 `readback_scalar` calls, so those ops
+absorb the attention and GEMM work queued ahead of them.
+
+The practical rule: take **call counts and shapes** from `[PERF]`, since those are
+plain counters, and take **all timing** from RGP. The "`transpose` is 25.7% and
+`cast` is 21.4% of the decoder" reading that this table first produced does not
+survive; `cast` is ~74 ms over the whole prefill, not 3,473 ms.
+
+## Ranked by recoverable time
+
+Per-call times from three RGP windows fenced on `multi_head_attention` (vision),
+`gqa`, `causal_conv` and `qmoe`, all with `-Buf default`, no SPM and no EP
+instrumentation; all four gated through `inspect_capture.py` as steady state.
+Floors are `max(bytes/BW, FLOP/peak)` at 256 GB/s and 59.4 TFLOP/s, computed per
+shape by `qwen_floors.py` alongside the captures.
+
+| kernel | calls | ms/call | total ms | floor | util | recoverable | confidence |
+|---|---:|---:|---:|---:|---:|---:|---|
+| `gqa_flash_prefill_v8` | 10 | 224.00 | 2,240 | 47.95 | 21% | 1,761 | upper bound |
+| `transpose_tiled` (18646x8192) | 60 | 26.70 | 1,602 | 2.39 | **9%** | **1,459** | high |
+| `causal_conv_prefill` | 30 | 31.54 | 946 | 2.39 | **8%** | **875** | high |
+| `MatMulNBits` (MoE, all variants) | 40 blk | 32.77 | 1,311 | 15.80 | 48% | 679 | medium |
+| `T5LayernormFwdContiguous` | 111 | 5.45 | 605 | 0.90 | 16% | 505 | high |
+| vision `mha_flash_prefill` | 27 | 20.34 | 549 | 4.13 | 20% | 438 | upper bound |
+| `bucket_tokens_kernel` | 40 | 8.83 | 353 | ~0 | **0%** | **353** | high |
+| vision `gemm` (Tensile) | 27 lyr | 14.81 | 400 | 3.74 | 25% | 299 | high |
+| `gather_tokens` + `scatter_add` | 40 blk | 9.80 | 392 | 4.77 | 49% | 201 | medium |
+| `cast_f16_to_f32` (596672) | 60 | 1.23 | 74 | 0.01 | 1% | 73 | high |
+
+Rows marked `blk` are per MoE block and `lyr` per vision layer, aggregating the
+several kernel launches of that kind inside one block or layer; every other row is
+per individual dispatch.
+
+Recoverable totals: **3,563 ms high confidence** (all pure data movement),
+880 ms medium, 2,198 ms upper-bound-only.
+
+Two rows carry a floor that omits real work and so must not be ranked against the
+rest. Both attention kernels do softmax, whose transcendentals and reductions are
+absent from `max(bytes/BW, FLOP/peak)`; for the v8 kernel, ablation already showed
+softmax is 41.1 ms of its 203 ms, so its true floor is far above 47.95 ms.
+
+The three linear-attention passes are reported measured-only, because a defensible
+FLOP count for the chunked scan could not be derived:
+
+| kernel | calls | ms/call | total ms |
+|---|---:|---:|---:|
+| `la_pf_pass3_wmma` | 1,110 | 0.829 | 920 |
+| `la_pf_scan` | 1,110 | 0.430 | 477 |
+| `la_pf_pass1_local` | 1,110 | 0.274 | 304 |
+| **total** | | | **1,700** |
+
+## Block model against measured TTFT
+
+| block | count | ms each | total |
+|---|---:|---:|---:|
+| MoE blocks | 40 | 58.49 | 2,340 |
+| linear-attention blocks | 30 | 148.40 | 4,452 |
+| full-attention, `gqa` kernel only | 10 | 224.00 | 2,240 |
+| vision encoder layers | 27 | 47.80 | 1,291 |
+| **sum of captured blocks** | | | **10,322** |
+| clean uninstrumented TTFT | | | 14,455 |
+| not covered by a capture window | | | 4,133 |
+
+The 4,133 ms residual is honest, not hidden time. The full-attention window
+filled the SQTT buffer after 12 dispatches, so everything in those ten layers
+except the GQA kernel itself — the QKV and o_proj matmuls, two large transposes
+per layer, rotary, KV append — is uncaptured. RGP also pegs clocks, so per-kernel
+times are systematically optimistic against production.
+
+## Conclusions
+
+**GQA is no longer the top target, and data movement is.** `transpose_tiled`,
+`causal_conv_prefill` and `T5LayernormFwdContiguous` are pure data movement
+running at 8-16% of achievable bandwidth, and together they are 3,153 ms of
+measured time with 2,839 ms recoverable against a floor that genuinely applies to
+them. That is more recoverable time than the entire GQA kernel now costs, and
+unlike GQA it needs no algorithmic insight: `causal_conv_prefill` moves 611 MB in
+31.5 ms, which is 19 GB/s out of 256.
+
+**`bucket_tokens_kernel` remains the most clear-cut defect** and is now confirmed
+at 8.83 ms per MoE block in a single 256-thread workgroup, using 1 of 40 CUs, for
+353 ms of the prefill that is almost entirely recoverable.
+`origin/perf/qwen-bucket-tokens` already carries a chunked rewrite.
+
+**The MoE block is 41% plumbing.** Of 58.49 ms, real GEMM work is 32.8 ms; the
+other 24 ms is `bucket_tokens` 8.8, `scatter_add` 4.9, `gather_tokens` 4.9,
+`add_bias` 2.9, `swiglu` 1.3 and `topk_routing` 1.2.
+
+**Sequence-dependent work is 94% of TTFT** (940 ms fixed, 0.729 ms/token), so
+there is no startup cost worth attacking.
+
+## Reproducing
+
+```powershell
+. C:\Users\zyq\hipep-env.ps1
+$env:HIPEP_PROMPT_FILE = 'C:\Users\zyq\prompt_16k.txt'
+
+# clean baseline -- verify no HIPDNN_EP_PERF/DEBUG/TRACE_FILE is set first
+.\bench\bench_ttft.ps1 -Tag p0-16k-tight -Driver vlm -SeqLen 16384 `
+  -MaxLength 18900 -Reps 3 -Warmup 1 -ExecutionProvider AMDGPU
+
+# per-session decomposition (instrumented: proportions only, never a TTFT)
+$env:HIPDNN_EP_TRACE_FILE = 'C:\Users\zyq\logs\eptrace\qwen16k.json'
+
+# per-kernel timing (clean). SPM must be off: with -Counters the 16K decoder
+# dies in the allocator ("memrefCopy failed") and no .rgp is written.
+.\capture\rgp_capture.ps1 -Op qmoe -Skip 45 -Driver vlm -Reps 3 `
+  -PromptFile C:\Users\zyq\prompt_16k.txt -MaxLength 18900 `
+  -ExecutionProvider AMDGPU -MaxTokens 1 -Buf default -ArmTimeoutSec 900
+```
+
+`-Skip` must land in the second iteration: the first decoder inference takes
+~236 s because of the autotune sweeps, and is not steady state. Fence on
+`multi_head_attention` for vision (`conv` does not exist in this export, despite
+being the obvious guess), on `causal_conv` or `qmoe` for the decoder, and note
+that fencing on `gqa` wastes the window because that one kernel fills the buffer
+by itself.

--- a/lib/Runtime/Kernels/CMakeLists.txt
+++ b/lib/Runtime/Kernels/CMakeLists.txt
@@ -71,6 +71,7 @@ set(_kernel_sources
     hip/reduce_sum_kernel.hip
     hip/pool_kernel.hip
     hip/conv_kernel.hip
+    hip/conv_winograd_kernel.hip
     hip/conv_transpose_kernel.hip
     hip/resize_kernel.hip
     hip/grid_sample_kernel.hip

--- a/lib/Runtime/Kernels/hip/conv_kernel.hip
+++ b/lib/Runtime/Kernels/hip/conv_kernel.hip
@@ -4,6 +4,7 @@
  */
 
 #include "hip_custom_kernels.h"
+#include "conv_tile_select.h"
 #include "debug_log.h"
 
 #include <hip/hip_runtime.h>
@@ -11,6 +12,9 @@
 #include <hip/hip_bfloat16.h>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <type_traits>
 
 // =============================================================================
 // Conv — general forward convolution (1D / 2D / 3D spatial)
@@ -264,6 +268,30 @@ struct KSlice {
 // one shape in the model with K = 27. Adding pad_begin restores the invariant
 // org.x0 + c0 >= -p0 + in0i + p0 = in0i for all positions. Negative pads (a
 // crop) only push org.x0 further positive, so clamping at zero is safe there.
+//
+// This sentinel has been suspected once already, of producing bevformer-fp16's
+// NaN output, on the theory that boundsRun splits the test it relies on across
+// `outerOk` and the caller's `xi` check and so might let a tail column through.
+// It does not, and the convolution is not where that NaN comes from:
+//
+//   * Forcing each tile in turn (HIPDNN_EP_CONV_TILE) gives byte-identical NaN
+//     counts for all six matrix tiles *and* for conv_direct, which shares no
+//     staging code with them at all -- it has no LDS, no slice cache, and no
+//     vectorised runs. A bug in this sentinel cannot express itself equally
+//     through a kernel that never consults it in a staging loop.
+//   * On an in-range input the whole backbone agrees with the ORT CPU
+//     reference to a cosine similarity of 0.99999917 and a relative L2 error
+//     of 6.9e-4, with no non-finite value on either side.
+//   * On the input that produces the NaN, the CPU reference *itself* pins at
+//     +/-65504 across the same output: that input drives the model past fp16
+//     range, and the infinities that later meet and cancel into NaN originate
+//     upstream. Saturating this convolution's fp16 store instead of letting it
+//     overflow was tried and makes it worse (31,744 NaN to 95,232), which is
+//     the direct evidence that the overflow does not start here.
+//
+// The FPN shapes are in the numeric sweep (test/numeric/tests/conv_cases.py,
+// `bevformer-fpn-*`) with explicit finiteness checks, so a real fault in this
+// sentinel would be caught there rather than inferred from a model output.
 __device__ __forceinline__ KSlice makeKSlice(const ConvParams &pr,
                                              int64_t kidx) {
   KSlice s;
@@ -447,6 +475,17 @@ static inline ConvParams withTileGrid(ConvParams pr, int64_t bm, int64_t bn) {
 // loop wants: a fixed k, contiguous in the tile index, so TM and TN reads
 // vectorise.
 
+// The launch bound is the exact block size and nothing more. Asking the
+// compiler for more occupancy than that -- amdgpu_waves_per_eu(10) on top of
+// it -- does get what it asks for, 64x64 going from 177 VGPR at 8 waves per
+// SIMD to 144 at 10 with no spill reported, and it is much slower:
+// simplebev's convolutions measure 43.8 ms against 24.6. The registers come
+// back by rematerialising the gather's address arithmetic rather than by
+// spilling it, so the report shows no scratch traffic while the inner loop
+// recomputes indices it used to hold, and on this kernel that costs far more
+// than the two extra waves return. Occupancy is not what limits the scalar
+// path; see the tile table in conv_tile_select.h, where every narrower tile
+// reaches 10 or 12 waves and loses too.
 template <typename T, int BM, int BN, int BK, int TM, int TN>
 __global__ __launch_bounds__((BM / TM) * (BN / TN)) void
 conv_tiled_kernel(const T *__restrict__ x, const T *__restrict__ w,
@@ -916,7 +955,9 @@ __global__ void conv_direct_kernel(const T *__restrict__ x,
 
 // Cap on the staged contraction. 7x7 is 49 and 11x11 is 121; anything larger
 // keeps the old path rather than growing LDS for a shape no model asks for.
-constexpr int kMaxDepthwiseK = 128;
+// Selection applies the same cap when it decides a shape is depthwise, so the
+// two have to be the same number and this is where it comes from.
+constexpr int kMaxDepthwiseK = static_cast<int>(conv_tile::kMaxDepthwiseK);
 
 template <typename T, int kThreads, int TN>
 __global__ __launch_bounds__(kThreads) void
@@ -986,14 +1027,6 @@ static void launchDepthwise(hipStream_t stream, const void *x, const void *w,
                      static_cast<T *>(y), pr);
 }
 
-// True depthwise: one input channel and one output channel per group. The
-// channel-multiplier case (MPerGroup > 1) still has a real contraction per
-// output row and is left to the ladder.
-static bool isDepthwise(const ConvParams &pr) {
-  return pr.CinPerGroup == 1 && pr.MPerGroup == 1 &&
-         pr.kvol <= kMaxDepthwiseK && pr.group > 1;
-}
-
 template <typename T>
 static void launchDepthwiseForShape(hipStream_t stream, const void *x,
                                     const void *w, const void *bias, void *y,
@@ -1032,22 +1065,29 @@ static int deviceUnitCount() {
 
 constexpr int kBK = 16;
 
-// Which kernel a shape landed on. Only the pick, so that a model run under
-// HIPDNN_EP_DEBUG can be tallied by kernel without re-deriving the ladder.
-static inline void logPick(const char *what, const ConvParams &pr) {
+// Which kernel a shape landed on, so that a model run under HIPDNN_EP_DEBUG
+// can be tallied by kernel without re-deriving the ladder.
+//
+// The tile is part of the name rather than just the kind: two entries share a
+// block shape and differ only in the register tile, and they do not perform
+// alike -- 64x256 is 176 ms over the guard set at a 2x2 wave tile and 200 at
+// 2x4 -- so "wmma 64x256" does not say which kernel ran. A forced tile that
+// silently failed to resolve reads as a correct run otherwise.
+static inline void logPick(const char *what, const ConvParams &pr, int bm = 0,
+                           int bn = 0, int tm = 0, int tn = 0) {
   CUSTOM_KERNELS_DEBUG_LOG(
-      "[custom_kernels] hip_conv pick=%s Cin/g=%lld M/g=%lld out=[%lld,%lld] "
-      "k=[%lld,%lld] s=[%lld,%lld]\n",
-      what, (long long)pr.CinPerGroup, (long long)pr.MPerGroup,
-      (long long)pr.out0, (long long)pr.out1, (long long)pr.k0,
-      (long long)pr.k1, (long long)pr.s0, (long long)pr.s1);
+      "[custom_kernels] hip_conv pick=%s tile=%dx%dx%dx%d Cin/g=%lld "
+      "M/g=%lld out=[%lld,%lld] k=[%lld,%lld] s=[%lld,%lld]\n",
+      what, bm, bn, tm, tn, (long long)pr.CinPerGroup,
+      (long long)pr.MPerGroup, (long long)pr.out0, (long long)pr.out1,
+      (long long)pr.k0, (long long)pr.k1, (long long)pr.s0, (long long)pr.s1);
 }
 
 template <typename T, int BM, int BN, int TM, int TN>
 static void launchTile(hipStream_t stream, const void *x, const void *w,
                        const void *bias, void *y, const ConvParams &base) {
   const ConvParams pr = withTileGrid(base, BM, BN);
-  logPick("tiled", pr);
+  logPick("tiled", pr, BM, BN, TM, TN);
   dim3 grid(swizzledGridX(pr), 1u,
             static_cast<unsigned>(pr.N * pr.group));
   hipLaunchKernelGGL((conv_tiled_kernel<T, BM, BN, kBK, TM, TN>), grid,
@@ -1061,7 +1101,7 @@ static void launchWmma(hipStream_t stream, const void *x, const void *w,
                        const void *bias, void *y, const ConvParams &base) {
   constexpr int threads = (BM / (WM * kWmma)) * (BN / (WN * kWmma)) * 32;
   const ConvParams pr = withTileGrid(base, BM, BN);
-  logPick("wmma", pr);
+  logPick("wmma", pr, BM, BN, WM, WN);
   dim3 grid(swizzledGridX(pr), 1u,
             static_cast<unsigned>(pr.N * pr.group));
   // The vectorised stage needs a whole wave's worth of column groups, so it is
@@ -1086,115 +1126,122 @@ static void launchWmma(hipStream_t stream, const void *x, const void *w,
                      static_cast<__half *>(y), pr);
 }
 
-// Whether a tile shape is worth using: its row block has to be fully live (a
-// block computes its whole tile whether or not the rows exist) and the grid it
-// produces has to cover the device.
-static bool tileCovers(const ConvParams &pr, int64_t bm, int64_t bn,
-                       int64_t units) {
-  const int64_t blocks = ((pr.MPerGroup + bm - 1) / bm) *
-                         ((pr.Nout + bn - 1) / bn) * pr.N * pr.group;
-  return blocks >= units;
-}
+// Which tile to run is decided in conv_tile_select.h, away from HIP, so it can
+// be compiled and tested natively -- see the header for the thresholds, the
+// measurements behind them, and why the previous heuristic got it wrong.
+// Everything below is dispatch: turning the chosen tile back into a template
+// instantiation.
 
-static bool tileFits(const ConvParams &pr, int64_t bm, int64_t bn,
-                     int64_t units) {
-  return pr.MPerGroup >= bm && tileCovers(pr, bm, bn, units);
-}
-
-// fp16 gets first refusal on the matrix cores; everything else, and every fp16
-// shape too small for a WMMA tile, falls through to the scalar ladder.
 template <typename T>
-static bool launchWmmaIfProfitable(hipStream_t, const void *, const void *,
-                                   const void *, void *, const ConvParams &,
-                                   int64_t) {
-  return false;
+static conv_tile::Shape tileShapeOf(const ConvParams &pr) {
+  conv_tile::Shape s;
+  s.MPerGroup = pr.MPerGroup;
+  s.Nout = pr.Nout;
+  s.K = pr.K;
+  s.N = pr.N;
+  s.group = pr.group;
+  s.CinPerGroup = pr.CinPerGroup;
+  s.kvol = pr.kvol;
+  s.elemBytes = static_cast<int32_t>(sizeof(T));
+  s.wmmaEligible = std::is_same<T, __half>::value;
+  return s;
+}
+
+// The tile tables in the header and the instantiations here have to agree.
+// Anything the header can choose must appear below, and a choice that finds no
+// instantiation is a build-time mistake reported at runtime rather than a
+// silently wrong kernel, so it returns false and the caller falls back.
+template <typename T>
+static bool launchChosenWmma(hipStream_t, const void *, const void *,
+                             const void *, void *, const ConvParams &,
+                             const conv_tile::Choice &) {
+  return false; // only fp16 reaches the matrix cores
 }
 
 template <>
-bool launchWmmaIfProfitable<__half>(hipStream_t stream, const void *x,
-                                    const void *w, const void *bias, void *y,
-                                    const ConvParams &pr, int64_t units) {
-  // The window-staging kernel gets first refusal on the multi-tap 2-D shapes.
-  // Every tile below re-reads the input once per kernel tap, and on those
-  // shapes that amplification -- not arithmetic, not occupancy -- is what the
-  // runtime is made of, so a tile that removes it wins by more than any tile
-  // that does not can make up. Widest row block first: the window is staged
-  // once per tile row, so fewer rows is less of the cost this kernel exists to
-  // avoid.
-  // The 4x4 wave tile issues 16 WMMAs off 8 fragment loads where 4x2 issues 8
-  // off 6, so it asks much less of LDS per unit of matrix-core work -- but it
-  // doubles the accumulator register count, which costs occupancy, and it
-  // halves the number of blocks.
-  //
-  // Which of those wins is decided by the row count, and measurably so. Below
-  // a few hundred output channels there are few tile rows, so the swizzle group
-  // is shallow and every block re-reads much of the im2col matrix: doubling BN
-  // cuts that in half and the LDS relief is free (whisper80 384/512 gain
-  // 15-20%). With a thousand-odd channels there is no shortage of blocks, the
-  // reduction is long enough that hiding the filter loads is what matters, and
-  // the lost occupancy dominates (whisper_l1 loses 33%).
-  if (pr.MPerGroup <= 512 && tileFits(pr, 128, 256, units)) {
-    launchWmma<128, 256, 4, 4>(stream, x, w, bias, y, pr);
-    return true;
-  }
-  // A taller row tile, for the shapes with many output channels. What this buys
-  // is not arithmetic but traffic: the im2col matrix is re-read once per tile
-  // row, and it is never materialised, so each re-read is a fresh gather out of
-  // the input. Halving the number of tile rows halves the dominant cost of the
-  // kernel -- on whisper_l1 the gather is 51% of the runtime, moving 236 MB for
-  // 21 MB of unique data at close to what the memory system can deliver, so
-  // there is nothing to win by making it faster, only by doing less of it.
-  if (tileFits(pr, 256, 128, units)) {
-    launchWmma<256, 128, 4, 2>(stream, x, w, bias, y, pr);
-    return true;
-  }
-  if (tileFits(pr, 128, 128, units)) {
-    launchWmma<128, 128, 4, 2>(stream, x, w, bias, y, pr);
-    return true;
-  }
-  // 64 rows, for the shapes with too few output channels for a 128-row tile but
-  // enough to waste half of a 32-row one. Two things make this worth its own
-  // rung rather than letting 32x256 take it.
-  //
-  // The im2col matrix is re-gathered once per tile row and is never
-  // materialised, so tile rows are the multiplier on the dominant cost of this
-  // kernel. At 64 output channels, 32x256 needs two rows and this needs one --
-  // half the gather.
-  //
-  // It also issues more matrix-core work per LDS fragment load: a 2x4 wave tile
-  // is 8 WMMAs off 6 fragments where 2x2 is 4 off 4. That ratio is what the
-  // narrow tiles are short of, and it cannot be had at BM=32, where the B-stage
-  // mapping (one column per thread) pins the block at 256 threads and so pins
-  // WM*WN at 4.
-  //
-  // esrgan is the shape that wants it: 69 of its convs are 192->64 at 250x250,
-  // its most expensive by a wide margin, and they sit exactly on this rung.
-  if (tileFits(pr, 64, 256, units)) {
-    launchWmma<64, 256, 2, 4>(stream, x, w, bias, y, pr);
-    return true;
-  }
-  // Narrow row block for the grouped and low-channel-count shapes -- the audio
-  // encoder's second conv has 32 output channels and would throw away three
-  // quarters of a 128-row tile.
-  if (tileFits(pr, 32, 256, units)) {
-    launchWmma<32, 256, 2, 2>(stream, x, w, bias, y, pr);
-    return true;
-  }
-  // Fewer output channels than any tile above has rows. The alternative is
-  // conv_direct -- one thread per output element, decoding the contraction
-  // index on every tap -- and a 16-row tile beats it even when most of those
-  // rows are padding, because wasted matrix-core work is nearly free and the
-  // decode is not. This is the only rung that does not require its rows to be
-  // live; the staging zeroes the missing ones and the store skips them.
-  //
-  // esrgan is what makes it worth having: its output conv is 64->3 at
-  // 1000x1000, and on the direct path that single node costs more than any
-  // other conv in the model.
-  if (tileCovers(pr, 16, 256, units)) {
-    launchWmma<16, 256, 1, 2>(stream, x, w, bias, y, pr);
-    return true;
-  }
+bool launchChosenWmma<__half>(hipStream_t stream, const void *x, const void *w,
+                              const void *bias, void *y, const ConvParams &pr,
+                              const conv_tile::Choice &c) {
+  // Keyed on all four fields, not just the block shape: two entries share
+  // 128x256 and 128x128 and differ only in the wave tile.
+  const auto is = [&](int bm, int bn, int tm, int tn) {
+    return c.bm == bm && c.bn == bn && c.tm == tm && c.tn == tn;
+  };
+  if (is(256, 128, 4, 2)) { launchWmma<256, 128, 4, 2>(stream, x, w, bias, y, pr); return true; }
+  if (is(128, 256, 4, 4)) { launchWmma<128, 256, 4, 4>(stream, x, w, bias, y, pr); return true; }
+  if (is(128, 128, 4, 2)) { launchWmma<128, 128, 4, 2>(stream, x, w, bias, y, pr); return true; }
+  if (is(64, 256, 2, 4))  { launchWmma<64, 256, 2, 4>(stream, x, w, bias, y, pr);  return true; }
+  if (is(32, 256, 2, 2))  { launchWmma<32, 256, 2, 2>(stream, x, w, bias, y, pr);  return true; }
+  if (is(16, 256, 1, 2))  { launchWmma<16, 256, 1, 2>(stream, x, w, bias, y, pr);  return true; }
+  if (is(128, 256, 2, 4)) { launchWmma<128, 256, 2, 4>(stream, x, w, bias, y, pr); return true; }
+  if (is(128, 128, 2, 2)) { launchWmma<128, 128, 2, 2>(stream, x, w, bias, y, pr); return true; }
+  if (is(64, 256, 2, 2))  { launchWmma<64, 256, 2, 2>(stream, x, w, bias, y, pr);  return true; }
   return false;
+}
+
+template <typename T>
+static bool launchChosenTile(hipStream_t stream, const void *x, const void *w,
+                             const void *bias, void *y, const ConvParams &pr,
+                             const conv_tile::Choice &c) {
+  const auto is = [&](int bm, int bn) { return c.bm == bm && c.bn == bn; };
+  if (is(128, 128)) { launchTile<T, 128, 128, 8, 8>(stream, x, w, bias, y, pr); return true; }
+  if (is(64, 128))  { launchTile<T, 64, 128, 4, 8>(stream, x, w, bias, y, pr);  return true; }
+  if (is(128, 64))  { launchTile<T, 128, 64, 8, 4>(stream, x, w, bias, y, pr);  return true; }
+  if (is(64, 64))   { launchTile<T, 64, 64, 4, 4>(stream, x, w, bias, y, pr);   return true; }
+  if (is(32, 128))  { launchTile<T, 32, 128, 2, 8>(stream, x, w, bias, y, pr);  return true; }
+  if (is(64, 32))   { launchTile<T, 64, 32, 4, 2>(stream, x, w, bias, y, pr);   return true; }
+  if (is(32, 64))   { launchTile<T, 32, 64, 2, 4>(stream, x, w, bias, y, pr);   return true; }
+  if (is(32, 32))   { launchTile<T, 32, 32, 2, 2>(stream, x, w, bias, y, pr);   return true; }
+  return false;
+}
+
+// Force one tile for every convolution, ignoring the selection thresholds:
+//
+//   HIPDNN_EP_CONV_TILE=128x256     a tile from either table
+//   HIPDNN_EP_CONV_TILE=direct      the no-reuse fallback
+//
+// This is where the thresholds in conv_tile_select.h come from. They are
+// measured crossovers, not derived ones, and measuring a crossover means
+// running both sides of it on the shapes that matter -- which needs a way to
+// run the tile selection did *not* pick. Sweeping every tile over every
+// distinct shape in the model zoo takes a few seconds through
+// tools/perf-harness/bench/conv_microbench.py tile-sweep and produces the
+// table those thresholds are answerable to.
+//
+// Not a tuning knob: a forced tile is wrong for most shapes, and a shape whose
+// row block exceeds its output channel count will still compute correctly
+// while wasting most of the device.
+struct TileOverride {
+  bool direct = false;
+  int bm = 0, bn = 0;
+  // 0 means "the table's first register tile for this block shape".
+  int tm = 0, tn = 0;
+};
+
+static const TileOverride *tileOverride() {
+  static TileOverride o{};
+  static const bool present = [] {
+    const char *v = std::getenv("HIPDNN_EP_CONV_TILE");
+    if (!v || !*v) return false;
+    if (std::strcmp(v, "direct") == 0) {
+      o.direct = true;
+      return true;
+    }
+    // Resolved per shape rather than here, because 128x128 names a tile in
+    // both tables and only the dtype says which one is meant. The four-field
+    // form picks between entries sharing a block shape at different register
+    // tiles; the two-field form takes whichever the table lists first.
+    if (std::sscanf(v, "%dx%dx%dx%d", &o.bm, &o.bn, &o.tm, &o.tn) == 4)
+      return true;
+    o.tm = o.tn = 0;
+    if (std::sscanf(v, "%dx%d", &o.bm, &o.bn) != 2) {
+      fprintf(stderr, "[custom_kernels] HIPDNN_EP_CONV_TILE=%s not understood; "
+                      "expected <rows>x<cols>[x<tm>x<tn>] or 'direct'\n", v);
+      return false;
+    }
+    return true;
+  }();
+  return present ? &o : nullptr;
 }
 
 template <typename T>
@@ -1203,12 +1250,28 @@ static int launch(hipStream_t stream, const void *x, const void *w,
   const int64_t totalOut = pr.N * pr.Cout * pr.Nout;
   if (totalOut <= 0 || pr.K <= 0) return 0;
 
-  const int64_t units = deviceUnitCount();
+  const conv_tile::Shape shape = tileShapeOf<T>(pr);
+  conv_tile::Choice choice = conv_tile::select(shape, deviceUnitCount());
+  if (const TileOverride *forced = tileOverride()) {
+    // Depthwise keeps its own kernel: it is not a tile, and forcing one would
+    // measure a shape the calibration is not about. A tile the dtype's table
+    // does not contain is left alone rather than silently demoted to
+    // conv_direct, which would report a 20x slowdown as though it were the
+    // tile's.
+    if (choice.kind != conv_tile::Kind::Depthwise) {
+      if (forced->direct)
+        choice = conv_tile::Choice{conv_tile::Kind::Direct, 0, 0, 0, 0};
+      else
+        conv_tile::resolve(shape, forced->bm, forced->bn, forced->tm,
+                           forced->tn, choice);
+    }
+  }
 
-  // Depthwise first: M == 1 per group clears no tile in the ladder, and the
-  // contraction is shared by the whole block, which neither tiled kernel can
-  // exploit and conv_direct pays for on every tap.
-  if (isDepthwise(pr)) {
+  // Depthwise is decided before any tile is considered: M == 1 per group
+  // leaves a tile nothing to reuse, and the contraction is shared by the whole
+  // block, which neither tiled kernel can exploit and conv_direct pays for on
+  // every tap.
+  if (choice.kind == conv_tile::Kind::Depthwise) {
     logPick("depthwise", pr);
     launchDepthwiseForShape<T>(stream, x, w, bias, y, pr);
     hipError_t derr = hipGetLastError();
@@ -1219,56 +1282,28 @@ static int launch(hipStream_t stream, const void *x, const void *w,
     return static_cast<int>(derr);
   }
 
-  // Two passes over the ladder. The first asks a tile shape to cover the
-  // device; the second takes the widest tile whose rows are live and accepts
-  // whatever grid that gives.
-  //
-  // The second pass exists because coverage is the wrong thing to insist on
-  // when the problem is small. A shape with few output channels over a small
-  // feature map produces few blocks under every tile, so a single-pass ladder
-  // rejects all of them and lands on conv_direct -- and conv_direct is not a
-  // small-problem kernel, it is a no-reuse one: a thread per output element,
-  // re-decoding the contraction index and re-reading the input on every tap.
-  // The ssd detection heads are the case that shows the difference. A 1024
-  // -channel 10x10 feature map into 126 channels gathers 227 MB on the direct
-  // path against roughly 12 MB tiled, and measures 2.95 ms against MIOpen's
-  // 0.24. Half an idle device running a kernel with reuse beats a full one
-  // running a kernel without it.
-  for (int pass = 0; pass < 2; ++pass) {
-    const int64_t need = pass == 0 ? units : 1;
-    if (launchWmmaIfProfitable<T>(stream, x, w, bias, y, pr, need)) {
-      hipError_t err = hipGetLastError();
-      if (err != hipSuccess)
-        fprintf(stderr, "[custom_kernels] hip_conv launch failed: %s\n",
-                hipGetErrorString(err));
-      return static_cast<int>(err);
-    }
-    // Widest scalar tile that fits, then narrower ones. A wider tile does more
-    // FMAs per LDS read -- 8x8 does 64 per 16, where 4x4 does 16 per 8 -- so
-    // the widest one that fits the problem is the fastest.
-    if (tileFits(pr, 128, 128, need)) {
-      launchTile<T, 128, 128, 8, 8>(stream, x, w, bias, y, pr);
-      break;
-    }
-    if (tileFits(pr, 64, 64, need)) {
-      launchTile<T, 64, 64, 4, 4>(stream, x, w, bias, y, pr);
-      break;
-    }
-    if (pr.MPerGroup >= 24 && tileFits(pr, 32, 128, need)) {
-      launchTile<T, 32, 128, 2, 8>(stream, x, w, bias, y, pr);
-      break;
-    }
-    if (pass == 1) {
-      logPick("direct", pr);
-      const int block = 256;
-      const int64_t grid = (totalOut + block - 1) / block;
-      hipLaunchKernelGGL(conv_direct_kernel<T>,
-                         dim3(static_cast<unsigned>(grid)), dim3(block), 0,
-                         stream, static_cast<const T *>(x),
-                         static_cast<const T *>(w),
-                         static_cast<const T *>(bias), static_cast<T *>(y), pr,
-                         totalOut);
-    }
+  bool launched = false;
+  if (choice.kind == conv_tile::Kind::Wmma)
+    launched = launchChosenWmma<T>(stream, x, w, bias, y, pr, choice);
+  else if (choice.kind == conv_tile::Kind::Tiled)
+    launched = launchChosenTile<T>(stream, x, w, bias, y, pr, choice);
+
+  if (!launched) {
+    // conv_direct: a thread per output element, re-decoding the contraction
+    // index and re-reading the input on every tap. Selection reaches for it
+    // only when a shape is too narrow for even the smallest tile, because it
+    // has no reuse at all -- the ssd detection heads showed a 1024-channel
+    // 10x10 map into 126 channels gathering 227 MB here against roughly 12 MB
+    // tiled, 2.95 ms against MIOpen's 0.24. Half an idle device running a
+    // kernel with reuse beats a full one running a kernel without it.
+    logPick("direct", pr);
+    const int block = 256;
+    const int64_t grid = (totalOut + block - 1) / block;
+    hipLaunchKernelGGL(conv_direct_kernel<T>, dim3(static_cast<unsigned>(grid)),
+                       dim3(block), 0, stream, static_cast<const T *>(x),
+                       static_cast<const T *>(w),
+                       static_cast<const T *>(bias), static_cast<T *>(y), pr,
+                       totalOut);
   }
 
   hipError_t err = hipGetLastError();

--- a/lib/Runtime/Kernels/hip/conv_tile_select.h
+++ b/lib/Runtime/Kernels/hip/conv_tile_select.h
@@ -1,0 +1,347 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// ===========================================================================
+// Which kernel and which tile a convolution shape should run on
+// ===========================================================================
+//
+// Split out of conv_kernel.hip and deliberately free of HIP: the choice is
+// integer arithmetic over a shape, so it can be compiled and tested natively.
+// That matters because the choice is not obviously right, and a heuristic that
+// can only be exercised by running convolutions on a GPU does not get
+// exercised. test/runtime/test_conv_tile_select.cpp is the consequence.
+//
+// What this replaces, and why
+// ---------------------------
+// The original was a ladder of tile shapes, each guarded by "is this tile's
+// row block fully live, and does it produce at least `units` blocks". The
+// first tile to clear both won, and a second pass dropped the block-count
+// requirement if none did.
+//
+// Insisting on covering the device *before* considering what a tile costs gets
+// the priority backwards, and on a part with more CUs it inverts. The im2col
+// matrix is never materialised, so it is re-gathered once per tile row;
+// halving the row block doubles the dominant cost of the kernel. A coverage
+// test rejects wide tiles precisely when the output is small -- which is when
+// the shape has few blocks under *any* tile -- so the ladder walks down to a
+// narrow tile and pays that doubling to buy parallelism it cannot use.
+//
+// The last rung made it worse: unlike the others it did not require its rows
+// to be live, so it caught every shape that reached it, whatever its channel
+// count. On this 8060S (20 CUs) resnet50's six 512-channel stage-4
+// convolutions land there and re-gather the im2col matrix 32 times where a
+// 128-row tile would do it 4 times; they measured 111 ms, 38.8% of the model's
+// entire convolution time, at 7 GB/s. On a 16-CU part the same shapes clear
+// the 32-row rung and never reach it. Thirteen of resnet50's convolutions
+// change tile between 16 and 20 CUs, in both directions.
+//
+// How the replacement was arrived at
+// ----------------------------------
+// Not by reasoning. Every tile below was forced, one at a time, on all 297
+// distinct non-depthwise convolution shapes in the 20-model guard set and
+// timed on the part (tools/perf-harness/bench/conv_microbench.py tile-sweep).
+// That gives the cost of every candidate on every shape, so a policy can be
+// scored against the best-possible per-shape choice rather than argued about.
+// Summed over the guard set, weighted by how often each shape occurs:
+//
+//   old coverage ladder                381.1 ms
+//   this policy                        331.8 ms
+//   best possible per-shape choice     328.5 ms
+//
+// An explicit traffic-and-parallelism cost model -- gather proportional to
+// tile rows, filter to tile columns, a saturation term, fitted constants --
+// was also built and scored: 341.9 ms at its best fit, worse than the four
+// comparisons below despite five free parameters. It is not here because it
+// did not earn its complexity. The thresholds are what the measurements say,
+// and the sweep that produced them is checked in, so a retune re-runs it
+// rather than re-deriving it.
+//
+// The property the ladder could not offer is that the choice is monotone in
+// the CU count: giving the device more CUs must never select a narrower row
+// block. This policy gets that in the strongest available form -- it does not
+// consult the CU count at all. Adding CUs does not add memory bandwidth, and
+// on these shapes the tile choice is a bandwidth decision, so there is
+// nothing for the CU count to say. `units` is still taken, and still ignored,
+// to keep that deliberate rather than accidental; see select().
+
+#ifndef HIPDNN_EP_CONV_TILE_SELECT_H
+#define HIPDNN_EP_CONV_TILE_SELECT_H
+
+#include <cstdint>
+
+namespace conv_tile {
+
+// ---------------------------------------------------------------------------
+// Inputs
+// ---------------------------------------------------------------------------
+
+// Only what the choice depends on. Everything here is per-group where the
+// distinction matters, because a group is what a block works inside.
+struct Shape {
+  int64_t MPerGroup = 1;   // output channels in a group: the GEMM's M
+  int64_t Nout = 1;        // output positions: the GEMM's N
+  int64_t K = 1;           // CinPerGroup * kvol: the contraction
+  int64_t N = 1;           // batch
+  int64_t group = 1;
+  int64_t CinPerGroup = 1;
+  int64_t kvol = 1;
+  int32_t elemBytes = 2;
+  bool wmmaEligible = false; // fp16 with the matrix-core builtin available
+};
+
+enum class Kind {
+  Depthwise,
+  Wmma,
+  Tiled,   // scalar register-tiled
+  Direct,  // one thread per output element
+};
+
+struct Choice {
+  Kind kind = Kind::Direct;
+  int bm = 0;
+  int bn = 0;
+  int tm = 0; // wave tile M (wmma) / register tile M (tiled)
+  int tn = 0;
+};
+
+inline bool operator==(const Choice &a, const Choice &b) {
+  return a.kind == b.kind && a.bm == b.bm && a.bn == b.bn && a.tm == b.tm &&
+         a.tn == b.tn;
+}
+
+// ---------------------------------------------------------------------------
+// The tiles that exist
+// ---------------------------------------------------------------------------
+//
+// Every entry is instantiated in conv_kernel.hip; this table and those
+// instantiations have to agree, which the unit test checks by walking the
+// table and the kernel enforces by static_assert. The table says only what
+// can be launched -- which shapes *should* use what is select()'s business,
+// and is kept there so there is one place to read the policy.
+//
+// Entries select() never picks are still listed, and still instantiated,
+// because HIPDNN_EP_CONV_TILE resolves against this table: re-running the
+// sweep that produced the thresholds requires being able to force a tile the
+// policy rejects. They are cheap to keep and the sweep is useless without
+// them.
+
+struct Tile {
+  int bm, bn, tm, tn;
+};
+
+// fp16, matrix cores. `tm`/`tn` are the wave tile in 16x16 units, so they set
+// the accumulator count (tm*tn*8 VGPRs) and, with the block shape, the thread
+// count -- which is why the same block shape appears at more than one wave
+// tile. The narrow-wave entries exist to trade accumulators for occupancy: a
+// 128x256 block is 128 accumulator VGPRs at 4x4 and 64 at 2x4, for the same
+// tile and twice the threads.
+constexpr Tile kWmmaTiles[] = {
+    {128, 256, 4, 4},
+    {256, 128, 4, 2},
+    {128, 128, 4, 2},
+    {64, 256, 2, 4},
+    {32, 256, 2, 2},
+    {16, 256, 1, 2},
+    {128, 256, 2, 4},
+    {128, 128, 2, 2},
+    {64, 256, 2, 2},
+};
+constexpr int kNumWmmaTiles =
+    static_cast<int>(sizeof(kWmmaTiles) / sizeof(kWmmaTiles[0]));
+
+// fp32 and bf16, which have no matrix path. The register tile is BM*BN/256,
+// since every one of these launches 256 threads (the staging assignment in
+// conv_tiled_kernel requires BM and BN to divide that way), so the block shape
+// and the accumulator count are not independent choices here.
+constexpr Tile kScalarTiles[] = {
+    {128, 128, 8, 8},
+    {64, 128, 4, 8},
+    {128, 64, 8, 4},
+    {64, 64, 4, 4},
+    {32, 128, 2, 8},
+    {64, 32, 4, 2},
+    {32, 64, 2, 4},
+    {32, 32, 2, 2},
+};
+constexpr int kNumScalarTiles =
+    static_cast<int>(sizeof(kScalarTiles) / sizeof(kScalarTiles[0]));
+
+// ---------------------------------------------------------------------------
+// Thresholds
+// ---------------------------------------------------------------------------
+//
+// Read the ladder in select() alongside these. Each is a measured crossover,
+// and the comment on each says what crosses.
+
+// Output channels at which the widest usable row block starts paying for
+// itself outright. Above this a 128-row tile's rows are all live and it
+// re-gathers the im2col matrix a quarter as often as a 32-row one.
+constexpr int64_t kWideRowBlockMinM = 128;
+
+// The two rungs between: enough output channels for this row block, not
+// enough for the next one up. 64x256 also issues more matrix work per
+// fragment load than 32x256 -- 2x4 is 8 WMMAs off 6 where 2x2 is 4 off 4 --
+// and that ratio cannot be had at 32 rows, where the B-stage mapping pins the
+// block at 256 threads.
+constexpr int64_t kMidRowBlockMinM = 64;
+constexpr int64_t kNarrowRowBlockMinM = 32;
+
+// The contraction length past which a wide row block wins *even though most
+// of its rows are dead*. This is the one threshold that is not about how many
+// output channels there are, and it is the interesting one.
+//
+// Gather traffic is proportional to the number of tile rows, so it scales
+// with K; wasted matrix lanes are proportional to the row block and do not.
+// Past a long enough contraction the gather dominates by enough that halving
+// the tile rows is worth an eightfold increase in wasted matrix work. The ssd
+// detection heads are exactly this: 24 output channels over a 4608-long
+// contraction measured 0.539 ms on a 16-row tile and 0.266 on a 128-row one,
+// which throws away 104 of its 128 rows. Below the threshold the gather is
+// cheap and the narrow tile is simply the right size -- mobilenet's 24
+// channels over a 144-long contraction want the 16-row tile.
+constexpr int64_t kGatherDominatesK = 2048;
+
+// Output positions below which the *column* block is the one overhanging, and
+// the trade runs the other way: prefer 256 rows by 128 columns to 128 by 256.
+//
+// This is kGatherDominatesK's argument on the other axis. A 256-wide column
+// block serving 49 output positions wastes four fifths of its columns, and
+// nothing about a wider column block pays for that when there is no width to
+// cover -- whereas the taller row block halves the tile rows, and so halves
+// the gather. Of the 31 shapes in the guard set below this threshold, 28
+// improve by 6-21%: resnet50's stage-4 7x7 outputs, mobilenet's 7x7 tail, the
+// ssd detection heads, convnext's 7x7 downsample. The three that do not have
+// a single output position, where the whole question is moot and the loss is
+// 3% of 0.15 ms; excluding them would be fitting the guard set rather than
+// reading it.
+constexpr int64_t kFewOutputPositions = 64;
+
+// The same crossover on the scalar path, where it decides tiled against
+// direct rather than which tile. simplebev's single- and two-channel fp32
+// convolutions over a 40000-position plane and a 128-long contraction
+// measured 0.081 ms direct against 0.214 on a 64x64 tile: 63 of 64 dead rows
+// is not worth a short gather. Anything longer goes tiled, because
+// conv_direct has no reuse at all.
+constexpr int64_t kScalarGatherDominatesK = 256;
+
+// ---------------------------------------------------------------------------
+
+inline int64_t ceilDiv(int64_t a, int64_t b) { return (a + b - 1) / b; }
+
+// Depthwise is not a tiling decision. group == C means every group contracts
+// over one input channel and M is 1, so there is no output-channel reuse for a
+// register tile to exploit, and the contraction is shared by the whole block
+// -- which the dedicated kernel stages once and conv_direct re-decodes on
+// every tap.
+constexpr int64_t kMaxDepthwiseK = 128;
+
+inline bool isDepthwise(const Shape &s) {
+  return s.CinPerGroup == 1 && s.MPerGroup == 1 && s.kvol <= kMaxDepthwiseK &&
+         s.group > 1;
+}
+
+// Resolve a named tile against the table the shape's dtype would actually
+// use. Two tables share the 128x128 block shape, so a name is only unambiguous
+// once the dtype has chosen a table -- resolving it against the wrong one hands
+// fp32 a matrix-core tile it cannot launch, which silently fell through to
+// conv_direct and cost a 28x slowdown while the sweep was being calibrated.
+//
+// `tm`/`tn` of 0 means "whichever register tile the table lists first for this
+// block shape", which is what a two-field name like 128x256 asks for. The
+// matrix table now carries the same block shape at two wave tiles, so a sweep
+// wanting the narrow one has to say which, and passes all four.
+inline bool resolve(const Shape &s, int bm, int bn, int tm, int tn,
+                    Choice &out) {
+  const Tile *table = s.wmmaEligible ? kWmmaTiles : kScalarTiles;
+  const int n = s.wmmaEligible ? kNumWmmaTiles : kNumScalarTiles;
+  const Kind kind = s.wmmaEligible ? Kind::Wmma : Kind::Tiled;
+  for (int i = 0; i < n; ++i) {
+    if (table[i].bm != bm || table[i].bn != bn) continue;
+    if (tm && (table[i].tm != tm || table[i].tn != tn)) continue;
+    out = Choice{kind, table[i].bm, table[i].bn, table[i].tm, table[i].tn};
+    return true;
+  }
+  return false;
+}
+
+// The choice.
+//
+// `units` is the device's CU count, and is deliberately unused. The old
+// heuristic's central mistake was scaling a memory decision with the CU count:
+// adding CUs does not add bandwidth, so a heuristic that lets the device size
+// widen the grid will trade bandwidth for parallelism as the part grows --
+// narrower row block, more tile rows, more passes over the input. That is the
+// trade that made this 8060S regress harder than the 8050S the kernel was
+// tuned on. Ignoring `units` is what makes the monotonicity the unit test
+// asserts hold by construction rather than by luck. The parameter stays so
+// that a future variant needing it does not have to re-thread it, and so this
+// paragraph has somewhere to live.
+inline Choice select(const Shape &s, int64_t units) {
+  (void)units;
+
+  if (isDepthwise(s)) return Choice{Kind::Depthwise, 0, 0, 0, 0};
+
+  const int64_t M = s.MPerGroup;
+
+  if (s.wmmaEligible) {
+    // Every rung from 64 output channels up now asks for the same tile, wide
+    // shapes included. That is not what the gather term predicts -- a 64-row
+    // block over M=512 is eight tile rows where 128x128 needs four, so twice
+    // the im2col traffic -- and it measured the other way round until there
+    // was a narrow wave tile to measure against.
+    //
+    // The wave tile, not the block shape, was the binding constraint. A 2x2
+    // wave tile holds 32 accumulator VGPRs where 2x4 holds 64, which takes
+    // 64x256 from 146 VGPR / 9 waves per SIMD to 97 / 12, and spreads the same
+    // block over 512 threads instead of 256 so the staging has twice the lanes
+    // to hide behind. Over the guard set that is worth more than the doubled
+    // gather: the wide rung goes 200.2 ms to 176.3, and it wins in every M
+    // bucket from 128 up and every output-size bucket below 16k positions, so
+    // it is not an average concealing a split. The rungs stay separate because
+    // the thresholds are what the monotonicity argument rests on, and because
+    // the next retune should not have to rediscover that they were ever
+    // distinct.
+    if (M >= kWideRowBlockMinM || s.K >= kGatherDominatesK) {
+      // Few enough output positions that 256 columns would be mostly overhang,
+      // so the columns go into the row block instead.
+      if (s.Nout < kFewOutputPositions)
+        return Choice{Kind::Wmma, 128, 128, 2, 2};
+      return Choice{Kind::Wmma, 64, 256, 2, 2};
+    }
+    if (M >= kMidRowBlockMinM) return Choice{Kind::Wmma, 64, 256, 2, 2};
+    if (M >= kNarrowRowBlockMinM) return Choice{Kind::Wmma, 32, 256, 2, 2};
+    // Genuinely narrower than any other row block, and a short enough
+    // contraction that the gather does not pay for overhang: esrgan's 64->3
+    // output convolution, mobilenet's 24-channel expansions.
+    return Choice{Kind::Wmma, 16, 256, 1, 2};
+  }
+
+  // fp32 and bf16. Only one rung survived the sweep: 128x128's 8x8 register
+  // tile does 64 FMAs per 16 LDS reads against 64x64's 16 per 8, but it needs
+  // 256 VGPRs and caps occupancy at 25%, and it lost on every shape in the
+  // guard set -- simplebev's 200x200 fp32 convolutions measured 0.713 ms on
+  // it against 0.214 on 64x64. 32x128 lost everywhere too.
+  //
+  // Narrower register tiles do not help here, which is the opposite of the
+  // matrix path and worth recording so it is not retried. 64x32 and 32x64 run
+  // at 137 VGPR / 10 waves and 32x32 at 101 / 12, against 64x64's 177 / 8, and
+  // all three lose on simplebev's 200x200 shapes: the 3x3 measures 12.68 ms on
+  // 64x64 against 16.03, 16.93 and 20.35. Unlike the matrix tiles these were
+  // never accumulator-bound -- a 4x4 register tile is 16 VGPRs of the 177 --
+  // so the occupancy is bought by giving up the LDS reuse that was paying for
+  // itself. The aggregate says otherwise only if the extract's Nout==1
+  // shape-inference fallbacks are left in, and those are not shapes the model
+  // runs.
+  //
+  // All of them stay instantiated for the sweep; none is selected.
+  if (M >= kMidRowBlockMinM || s.K >= kScalarGatherDominatesK)
+    return Choice{Kind::Tiled, 64, 64, 4, 4};
+
+  return Choice{Kind::Direct, 0, 0, 0, 0};
+}
+
+} // namespace conv_tile
+
+#endif // HIPDNN_EP_CONV_TILE_SELECT_H

--- a/lib/Runtime/Kernels/hip/conv_transpose_kernel.hip
+++ b/lib/Runtime/Kernels/hip/conv_transpose_kernel.hip
@@ -11,6 +11,7 @@
 #include <hip/hip_bfloat16.h>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 
 // ---------------------------------------------------------------------------
 // ConvTranspose -- forward transposed convolution (2D spatial)
@@ -50,9 +51,50 @@
 //
 // Accumulation is in float for every storage dtype, matching `hip_conv`.
 //
-// This is deliberately a plain one-thread-per-output kernel with no tiling:
-// no model the EP supports contains a ConvTranspose, so the shape that matters
-// is the one where correctness is obvious.
+// Two kernels implement that inversion.
+//
+// `conv_transpose_direct_kernel` is one thread per output element. It shipped
+// on the premise that no model the EP supports contains a ConvTranspose, so
+// the only shape that mattered was the one where correctness is obvious. That
+// premise was wrong: sam2.1/decoder has two. The formulation has no reuse at
+// all -- every thread walks the whole channel reduction itself, so the
+// CinPerGroup input column and CinPerGroup filter column behind each output
+// element are read once per output element rather than once per block. On
+// sam2.1's 256->64 2x2 stride-2 layer that is a gigabyte of traffic to serve
+// two megabytes of unique data. It is kept for the shapes the tiled kernel
+// declines (see `useTiled`), where the missing reuse costs nothing because
+// there is none to be had.
+//
+// `conv_transpose_tiled_kernel` is the one that runs. Fixing the reuse means
+// recognising what the inverted form actually is: with the contraction taken
+// over (input channel, filter tap) jointly and the output position as the
+// other free index, it is a GEMM,
+//
+//   C[m][p] = sum over (c,kh,kw) of  A[m][(c,kh,kw)] * B[(c,kh,kw)][p]
+//
+// where A is the filter read in its native ConvTranspose layout and B is the
+// input gathered through the divisibility test above -- the transpose of the
+// im2col matrix that forward convolution builds. So it is the same kernel
+// shape as `hip_conv`: register-tiled, both operands staged through LDS, the
+// gather folded into the B stage. A block loads each input and filter element
+// once for BM x BN outputs instead of once per output.
+//
+// B is materialised with an explicit zero where the divisibility test fails,
+// which is what lets the taps that cannot reach a given output cell take part
+// in the reduction harmlessly. That also means `kernel == stride` needs no
+// special case: exactly one tap per output cell passes the test, the other
+// kH*kW-1 stage as zero, and the wasted lanes cost LDS and arithmetic rather
+// than memory traffic -- which is the resource that was short. Keeping one
+// path rather than two is worth more here than the lanes it gives up.
+//
+// Measured on sam2.1/decoder's two layers, per inference:
+//
+//   direct                    2.80 ms
+//   tiled, flat contraction   1.30 ms
+//   tiled, tap-major          0.80 ms
+//
+// The gap between the last two is all integer division; see the note on the
+// loop nesting below.
 
 namespace {
 
@@ -82,6 +124,10 @@ __device__ __forceinline__ hip_bfloat16 from_float<hip_bfloat16>(float v) {
 
 struct ConvTransposeParams {
   int64_t N, Cin, Cout;
+  // The direct kernel recovers the group from the output channel it owns; the
+  // tiled kernel is launched with one block per (batch, group) and so needs it
+  // as a grid dimension.
+  int64_t group;
   int64_t CinPerGroup, MPerGroup;
   int64_t inH, inW;
   int64_t outH, outW;
@@ -152,17 +198,241 @@ __global__ void conv_transpose_direct_kernel(const T *__restrict__ x,
   y[tid] = from_float<T>(acc);
 }
 
+// ---------------------------------------------------------------------------
+// Tiled path
+// ---------------------------------------------------------------------------
+//
+// One block owns a BM x BN tile of (output channel) x (output position) inside
+// one (batch, group), and walks the joint (channel, tap) contraction BK at a
+// time. Each thread keeps a TM x TN register tile, so the LDS traffic per unit
+// of arithmetic falls with the register tile rather than with the block.
+//
+// The spatial index is flattened to a single `p` over outH*outW and split back
+// out into (oh, ow) once per thread. Flattening rather than tiling h and w
+// separately keeps the store contiguous -- consecutive threads write
+// consecutive output columns.
+//
+// The contraction is nested tap-major, one loop over the kH*kW taps and an
+// inner one over channels, rather than run as a single flat index. That is not
+// cosmetic. Written flat, recovering (channel, tap) from the index and then
+// (kh, kw) from the tap costs several divisions by runtime values *per staged
+// element*, and the divisibility test that decides whether a tap reaches an
+// output cell costs two more. Integer division is a multi-instruction sequence
+// here, and at 1024 staged elements per stage that arithmetic, not the memory
+// it was hiding, sets the kernel's speed. Nested, the tap is a loop variable:
+// (kh, kw) and the whole reachability test -- which depends only on the tap
+// and the thread's own output column -- are computed once per tap and reused
+// across every channel. The inner loops then contain no division at all.
+//
+// All the spatial arithmetic is 32-bit; `useTiled` refuses shapes whose
+// extents do not fit.
+template <typename T, int BM, int BN, int TM, int TN, int BK>
+__global__ void conv_transpose_tiled_kernel(const T *__restrict__ x,
+                                            const T *__restrict__ w,
+                                            const T *__restrict__ bias,
+                                            T *__restrict__ y,
+                                            ConvTransposeParams pr,
+                                            int32_t Nsp) {
+  static_assert(BM % TM == 0 && BN % TN == 0, "tile must divide the block");
+  constexpr int kThreads = (BM / TM) * (BN / TN);
+  static_assert(BK * BM % kThreads == 0 && BK * BN % kThreads == 0,
+                "staging must divide evenly across the block");
+  // Each thread stages one fixed column of B and one fixed row of A, which is
+  // what lets the reachability test be hoisted out of the channel loop.
+  static_assert(kThreads % BN == 0 && kThreads % BM == 0,
+                "staging must not move a thread between columns");
+
+  __shared__ float As[BK][BM];
+  __shared__ float Bs[BK][BN];
+
+  const int tid = static_cast<int>(threadIdx.x);
+  const int tx = tid % (BN / TN);
+  const int ty = tid / (BN / TN);
+
+  const int32_t p0 = static_cast<int32_t>(blockIdx.x) * BN;
+  const int32_t m0 = static_cast<int32_t>(blockIdx.y) * BM;
+  const int64_t nz = blockIdx.z;
+  const int64_t n = nz / pr.group;
+  const int64_t g = nz - n * pr.group;
+
+  const int32_t MPerGroup = static_cast<int32_t>(pr.MPerGroup);
+  const int32_t CinPerGroup = static_cast<int32_t>(pr.CinPerGroup);
+  const int32_t kH = static_cast<int32_t>(pr.kH);
+  const int32_t kW = static_cast<int32_t>(pr.kW);
+  const int32_t kHkW = kH * kW;
+  const int32_t outW = static_cast<int32_t>(pr.outW);
+  const int32_t inH = static_cast<int32_t>(pr.inH);
+  const int32_t inW = static_cast<int32_t>(pr.inW);
+  const int32_t sH = static_cast<int32_t>(pr.sH);
+  const int32_t sW = static_cast<int32_t>(pr.sW);
+  const int32_t dilH = static_cast<int32_t>(pr.dilH);
+  const int32_t dilW = static_cast<int32_t>(pr.dilW);
+  const int32_t padTop = static_cast<int32_t>(pr.padTop);
+  const int32_t padLeft = static_cast<int32_t>(pr.padLeft);
+  const int32_t inPlane = inH * inW;
+
+  // Both bases are advanced to this group's first channel, so the contraction
+  // below indexes channels relative to the group -- the same convention the
+  // direct kernel uses.
+  const T *xBase = x + (n * pr.Cin + g * pr.CinPerGroup) * inPlane;
+  const T *wBase = w + (g * pr.CinPerGroup) * (pr.MPerGroup * kHkW);
+
+  // The staging positions this thread owns, both fixed for the whole kernel.
+  const int stageCol = tid % BN;   // its column of B
+  const int stageRow = tid % BM;   // its row of A
+  const int stageKB = tid / BN;    // first contraction offset it stages into B
+  const int stageKA = tid / BM;    // ... and into A
+  constexpr int kStepB = kThreads / BN;
+  constexpr int kStepA = kThreads / BM;
+
+  // The output cell this thread's B column belongs to. One division, once.
+  const int32_t pCol = p0 + stageCol;
+  const int32_t ohCol = pCol < Nsp ? pCol / outW : 0;
+  const int32_t owCol = pCol - ohCol * outW;
+
+  float acc[TM][TN];
+  for (int i = 0; i < TM; ++i)
+    for (int j = 0; j < TN; ++j)
+      acc[i][j] = 0.0f;
+
+  for (int32_t kh = 0; kh < kH; ++kh) {
+    // Reachability for this tap row, for this thread's column only.
+    const int32_t th = ohCol + padTop - kh * dilH;
+    const int32_t ihq = th / sH;
+    const bool okH = (th % sH == 0) && ihq >= 0 && ihq < inH && pCol < Nsp;
+
+    for (int32_t kw = 0; kw < kW; ++kw) {
+      const int32_t tw = owCol + padLeft - kw * dilW;
+      const int32_t iwq = tw / sW;
+      const bool ok = okH && (tw % sW == 0) && iwq >= 0 && iwq < inW;
+      // Where this thread's column reads from, if it reads at all. Constant
+      // across the entire channel loop below, which is the point of nesting.
+      const int64_t xCol =
+          static_cast<int64_t>(ihq) * inW + iwq;
+      const int32_t t = kh * kW + kw;
+
+      for (int32_t c0 = 0; c0 < CinPerGroup; c0 += BK) {
+        // A stage: the filter in its native [C][M/group][kH][kW] layout.
+        for (int i = 0; i < BK * BM / kThreads; ++i) {
+          const int kk = stageKA + i * kStepA;
+          const int32_t c = c0 + kk;
+          const int32_t m = m0 + stageRow;
+          float v = 0.0f;
+          if (c < CinPerGroup && m < MPerGroup)
+            v = to_float<T>(wBase[static_cast<int64_t>(c) * MPerGroup * kHkW +
+                                  static_cast<int64_t>(m) * kHkW + t]);
+          As[kk][stageRow] = v;
+        }
+
+        // B stage: the gather. A tap reaches this output cell only if the
+        // stride steps exactly onto it; the zero written otherwise is what
+        // lets the reduction run over every tap without a special case.
+        for (int i = 0; i < BK * BN / kThreads; ++i) {
+          const int kk = stageKB + i * kStepB;
+          const int32_t c = c0 + kk;
+          float v = 0.0f;
+          if (ok && c < CinPerGroup)
+            v = to_float<T>(
+                xBase[static_cast<int64_t>(c) * inPlane + xCol]);
+          Bs[kk][stageCol] = v;
+        }
+
+        __syncthreads();
+
+        for (int kk = 0; kk < BK; ++kk) {
+          float a[TM], bb[TN];
+          for (int i = 0; i < TM; ++i)
+            a[i] = As[kk][ty * TM + i];
+          for (int j = 0; j < TN; ++j)
+            bb[j] = Bs[kk][tx * TN + j];
+          for (int i = 0; i < TM; ++i)
+            for (int j = 0; j < TN; ++j)
+              acc[i][j] += a[i] * bb[j];
+        }
+
+        __syncthreads();
+      }
+    }
+  }
+
+  const int64_t outPlane = pr.outH * pr.outW;
+  for (int i = 0; i < TM; ++i) {
+    const int32_t m = m0 + ty * TM + i;
+    if (m >= MPerGroup)
+      break;
+    const int64_t mGlobal = g * pr.MPerGroup + m;
+    const float b0 = bias ? to_float<T>(bias[mGlobal]) : 0.0f;
+    T *row = y + (n * pr.Cout + mGlobal) * outPlane;
+    for (int j = 0; j < TN; ++j) {
+      const int32_t p = p0 + tx * TN + j;
+      if (p < Nsp)
+        row[p] = from_float<T>(acc[i][j] + b0);
+    }
+  }
+}
+
+// The tiled kernel needs enough of both tile dimensions to be worth its
+// staging, and needs the spatial arithmetic to fit in 32 bits.
+//
+// The output-channel bound is the real one. A block covers BM output channels,
+// so a group with fewer than a handful wastes most of every A stage and most
+// of every register tile -- and a ConvTranspose that narrow (sam2.1's decoder
+// ends at 1 output channel per group) has no reuse for a tile to find anyway,
+// which is exactly the case the direct kernel is good at.
+inline bool useTiled(const ConvTransposeParams &pr, int64_t Nsp, int64_t K) {
+  const int64_t kInt32Max = 2147483647;
+  if (Nsp > kInt32Max || K > kInt32Max)
+    return false;
+  if (pr.inH * pr.inW > kInt32Max || pr.outH * pr.outW > kInt32Max)
+    return false;
+  if (pr.MPerGroup * pr.kH * pr.kW > kInt32Max)
+    return false;
+  // Below this there is not enough of the reduction to amortise two LDS
+  // stages, and not enough output channels to fill a row block.
+  return pr.MPerGroup >= 8 && K >= 8 && Nsp >= 64;
+}
+
+// HIPDNN_EP_CONVT_DIRECT=1 forces the untiled kernel. The two paths compute
+// the same sum in a different order, so the fallback doubles as the reference
+// the tiled kernel can be checked against -- and as the only way to measure
+// what the tiling is worth on a given shape, which is how the figures at the
+// top of this file were established rather than assumed.
+inline bool forceDirect() {
+  static const bool v = [] {
+    const char *s = std::getenv("HIPDNN_EP_CONVT_DIRECT");
+    return s && *s && *s != '0';
+  }();
+  return v;
+}
+
 template <typename T>
 int launch(hipStream_t stream, const void *input, const void *weights,
            const void *bias, void *output, const ConvTransposeParams &pr,
            int64_t total) {
-  constexpr int kBlock = 256;
-  const int64_t grid = (total + kBlock - 1) / kBlock;
-  hipLaunchKernelGGL(conv_transpose_direct_kernel<T>, dim3(grid), dim3(kBlock),
-                     0, stream, static_cast<const T *>(input),
-                     static_cast<const T *>(weights),
-                     static_cast<const T *>(bias), static_cast<T *>(output), pr,
-                     total);
+  const int64_t Nsp = pr.outH * pr.outW;
+  const int64_t K = pr.CinPerGroup * pr.kH * pr.kW;
+
+  if (!forceDirect() && useTiled(pr, Nsp, K)) {
+    constexpr int BM = 64, BN = 64, TM = 4, TN = 4, BK = 16;
+    constexpr int kThreads = (BM / TM) * (BN / TN);
+    const dim3 grid(static_cast<unsigned>((Nsp + BN - 1) / BN),
+                    static_cast<unsigned>((pr.MPerGroup + BM - 1) / BM),
+                    static_cast<unsigned>(pr.N * pr.group));
+    hipLaunchKernelGGL(
+        (conv_transpose_tiled_kernel<T, BM, BN, TM, TN, BK>), grid,
+        dim3(kThreads), 0, stream, static_cast<const T *>(input),
+        static_cast<const T *>(weights), static_cast<const T *>(bias),
+        static_cast<T *>(output), pr, static_cast<int32_t>(Nsp));
+  } else {
+    constexpr int kBlock = 256;
+    const int64_t grid = (total + kBlock - 1) / kBlock;
+    hipLaunchKernelGGL(conv_transpose_direct_kernel<T>, dim3(grid),
+                       dim3(kBlock), 0, stream, static_cast<const T *>(input),
+                       static_cast<const T *>(weights),
+                       static_cast<const T *>(bias), static_cast<T *>(output),
+                       pr, total);
+  }
+
   hipError_t err = hipGetLastError();
   if (err != hipSuccess) {
     fprintf(stderr, "[custom_kernels] hip_conv_transpose: launch failed (%s)\n",
@@ -212,6 +482,7 @@ extern "C" int hip_conv_transpose(void *stream, const void *input,
   pr.N = N;
   pr.Cin = Cin;
   pr.Cout = Cout;
+  pr.group = group;
   pr.CinPerGroup = Cin / group;
   pr.MPerGroup = Cout / group;
   pr.inH = in_h;

--- a/lib/Runtime/Kernels/hip/conv_winograd_kernel.hip
+++ b/lib/Runtime/Kernels/hip/conv_winograd_kernel.hip
@@ -1,0 +1,961 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip_custom_kernels.h"
+#include "debug_log.h"
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <cstdint>
+#include <cstdio>
+
+// ===========================================================================
+// Winograd F(2x2, 3x3) for fp16 3x3 stride-1 convolution
+// ===========================================================================
+//
+// Why F(2,3) and not F(4,3)
+// -------------------------
+// F(2,3)'s transform constants are {0, +/-1, +/-1/2} -- every one exactly
+// representable in fp16, so the transforms themselves introduce no rounding
+// beyond the additions. F(4,3) needs 1/6 and 1/24, which are not, and the
+// larger transform amplifies input error by a much bigger factor. bevformer
+// already sits close enough to fp16's range to saturate the CPU reference, so
+// the extra headroom is not available to spend. F(2,3) gives 16 multiplies per
+// 4 outputs against 36 for direct, a 2.25x arithmetic reduction, and is what
+// MIOpen's `f2x3` assembly kernel implements.
+//
+// What this stage does and does not buy
+// -------------------------------------
+// This is the non-fused form: the input transform materialises V in scratch,
+// a batched GEMM reads it back, and the output transform reads the result
+// back. It is the correctness and measurement stage, and it is worth being
+// explicit that on the shapes it targets it is *not* expected to be much
+// faster, because of where the cost actually is.
+//
+// For esrgan's dominant convolution (Cin=192, Cout=64, 250x250, 3x3 s1) the
+// direct path moves about 278 MB -- 216 MB of it re-deriving the im2col matrix
+// -- and measures 1.08 ms, which is the bandwidth bound for that traffic.
+// Non-fused Winograd moves:
+//
+//   V write   16 * Cin  * ntiles * 2B   =  96 MB
+//   V read    (once per GEMM row block) =  96 MB
+//   M write   16 * Cout * ntiles * 2B   =  32 MB
+//   M read                              =  32 MB
+//   x read, y write                      =  32 MB
+//                                          ------
+//                                          288 MB
+//
+// which is not an improvement. The 2.25x is in the multiplies, and these
+// shapes are not limited by multiplies. Materialising V is what costs it: the
+// transform's output is 16 values per (channel, tile) where the input was 4x4
+// overlapping, so V is larger than the input it came from.
+//
+// The win requires computing V inside the GEMM's B stage and never writing it
+// down -- then x is read once per GEMM row block instead of V being written
+// and read, and with the tile halo shared through LDS the traffic falls to
+// roughly 80-130 MB depending on the column block, which is the range MIOpen's
+// measured 3.4x advantage sits in. That is a separate change and is sequenced
+// after this one deliberately: it needs these transforms to be known correct
+// first, and a fused kernel that is also wrong is not debuggable.
+//
+// Layout
+// ------
+// The four stages and their scratch, for one block of `tiles` spatial tiles:
+//
+//   U[xi][cout][cin]   filter transform, 16 * Cout * Cin, hoisted and cached
+//                      by the caller across calls (it depends only on w)
+//   V[xi][cin][t]      input transform,  16 * Cin * tiles
+//   M[xi][cout][t]     16 independent GEMMs U[xi] @ V[xi]
+//   y                  output transform of M, bias folded in
+//
+// `xi` is the position within the 4x4 transform domain, so each of the 16 is
+// an independent (Cout x Cin) @ (Cin x tiles) GEMM. They are batched on the
+// grid's z axis rather than launched separately: at 16 launches per tile block
+// per convolution, launch overhead would be a large fraction of a model like
+// esrgan with 351 of them.
+//
+// Scratch is blocked over tiles rather than channels. Blocking over channels
+// would force M to be accumulated across blocks and so to exist at full size;
+// blocking over tiles makes every block independent end to end, which is what
+// keeps the working set bounded on esrgan's 1000x1000 layers where a full V
+// would be 512 MB.
+
+namespace {
+
+constexpr int kTileIn = 4;   // input tile extent
+constexpr int kTileOut = 2;  // output tile extent
+constexpr int kXi = kTileIn * kTileIn;
+
+// One row of the input transform B^T, and of its transpose applied to columns.
+// B^T = [[1,0,-1,0],[0,1,1,0],[0,-1,1,0],[0,1,0,-1]]
+__device__ __forceinline__ void btdb4(float a0, float a1, float a2, float a3,
+                                      float &b0, float &b1, float &b2,
+                                      float &b3) {
+  b0 = a0 - a2;
+  b1 = a1 + a2;
+  b2 = a2 - a1;
+  b3 = a1 - a3;
+}
+
+// One row of the output transform A^T = [[1,1,1,0],[0,1,-1,-1]].
+__device__ __forceinline__ void atma4(float a0, float a1, float a2, float a3,
+                                      float &b0, float &b1) {
+  b0 = a0 + a1 + a2;
+  b1 = a1 - a2 - a3;
+}
+
+// One column of the filter transform G = [[1,0,0],[.5,.5,.5],[.5,-.5,.5],
+// [0,0,1]]. The halves are exact in fp16, which is the reason for F(2,3).
+__device__ __forceinline__ void gg3(float g0, float g1, float g2, float &u0,
+                                    float &u1, float &u2, float &u3) {
+  u0 = g0;
+  u1 = 0.5f * (g0 + g1 + g2);
+  u2 = 0.5f * (g0 - g1 + g2);
+  u3 = g2;
+}
+
+// ---------------------------------------------------------------------------
+// Filter transform: w[Cout][Cin][3][3] -> U[16][Cout][Cin]
+// ---------------------------------------------------------------------------
+//
+// One thread per (cout, cin). Hoisted out of the convolution entirely by the
+// caller, so its cost is paid once per weight tensor rather than per call and
+// its access pattern does not matter much.
+__global__ void winograd_filter_kernel(const __half *__restrict__ w,
+                                       __half *__restrict__ u, int64_t Cout,
+                                       int64_t Cin) {
+  const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t total = Cout * Cin;
+  if (idx >= total) return;
+
+  const int64_t cin = idx % Cin;
+  const int64_t cout = idx / Cin;
+
+  const __half *g = w + idx * 9;
+  float gv[9];
+  for (int i = 0; i < 9; ++i) gv[i] = __half2float(g[i]);
+
+  // G g: 3 columns of the 3x3 filter become 4 rows.
+  float t[4][3];
+  for (int c = 0; c < 3; ++c)
+    gg3(gv[0 * 3 + c], gv[1 * 3 + c], gv[2 * 3 + c], t[0][c], t[1][c], t[2][c],
+        t[3][c]);
+
+  // (G g) G^T: each of the 4 rows becomes 4 wide.
+  for (int r = 0; r < 4; ++r) {
+    float o0, o1, o2, o3;
+    gg3(t[r][0], t[r][1], t[r][2], o0, o1, o2, o3);
+    const float vals[4] = {o0, o1, o2, o3};
+    for (int c = 0; c < 4; ++c) {
+      const int xi = r * 4 + c;
+      u[(static_cast<int64_t>(xi) * Cout + cout) * Cin + cin] =
+          __float2half(vals[c]);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Input transform: x -> V[16][Cin][tiles]
+// ---------------------------------------------------------------------------
+//
+// One thread per (channel, tile). `tile0` is the first tile of this block in
+// the flattened (batch, tileRow, tileCol) order, so a block of tiles can span
+// batch images without the caller having to split on them.
+//
+// Writes are contiguous in the tile index, which is the fast axis of V and the
+// axis the GEMM's B stage walks. Reads are a 4x4 window stepping by 2, so
+// neighbouring threads' windows overlap by half -- the overlap is what the
+// fused form will exploit and this form simply pays for.
+__global__ void winograd_input_kernel(const __half *__restrict__ x,
+                                      __half *__restrict__ v, int64_t Cin,
+                                      int64_t inH, int64_t inW, int64_t padTop,
+                                      int64_t padLeft, int64_t ntW,
+                                      int64_t ntPerImage, int64_t tile0,
+                                      int64_t tiles) {
+  const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t total = Cin * tiles;
+  if (idx >= total) return;
+
+  const int64_t t = idx % tiles;      // tile within this block
+  const int64_t c = idx / tiles;      // input channel
+  const int64_t gt = tile0 + t;       // global tile index
+
+  const int64_t n = gt / ntPerImage;
+  const int64_t rem = gt - n * ntPerImage;
+  const int64_t th = rem / ntW;
+  const int64_t tw = rem - th * ntW;
+
+  const int64_t ih0 = th * kTileOut - padTop;
+  const int64_t iw0 = tw * kTileOut - padLeft;
+
+  const __half *xc = x + (n * Cin + c) * inH * inW;
+
+  float d[4][4];
+  for (int i = 0; i < 4; ++i) {
+    const int64_t ih = ih0 + i;
+    const bool okH = ih >= 0 && ih < inH;
+    for (int j = 0; j < 4; ++j) {
+      const int64_t iw = iw0 + j;
+      d[i][j] = (okH && iw >= 0 && iw < inW)
+                    ? __half2float(xc[ih * inW + iw])
+                    : 0.0f;
+    }
+  }
+
+  // B^T d, then (B^T d) B.
+  float r[4][4];
+  for (int j = 0; j < 4; ++j)
+    btdb4(d[0][j], d[1][j], d[2][j], d[3][j], r[0][j], r[1][j], r[2][j],
+          r[3][j]);
+
+  for (int i = 0; i < 4; ++i) {
+    float o0, o1, o2, o3;
+    btdb4(r[i][0], r[i][1], r[i][2], r[i][3], o0, o1, o2, o3);
+    const float vals[4] = {o0, o1, o2, o3};
+    for (int j = 0; j < 4; ++j) {
+      const int xi = i * 4 + j;
+      v[(static_cast<int64_t>(xi) * Cin + c) * tiles + t] = __float2half(vals[j]);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Batched GEMM: M[xi] = U[xi] @ V[xi], 16 batches on the grid's z axis
+// ---------------------------------------------------------------------------
+//
+// Register-tiled with both operands staged through LDS, accumulating in fp32.
+// Deliberately not a matrix-core kernel: the arithmetic here is 2.25x less
+// than the direct path's to begin with and this stage is limited by the V it
+// has to read, so matrix cores would speed up the part that is not the
+// problem. If the fused form changes that balance it can be revisited.
+template <int BM, int BN, int TM, int TN, int BK>
+__global__ void winograd_gemm_kernel(const __half *__restrict__ u,
+                                     const __half *__restrict__ v,
+                                     __half *__restrict__ m, int32_t Cout,
+                                     int32_t Cin, int32_t tiles) {
+  static_assert(BM % TM == 0 && BN % TN == 0, "tile must divide the block");
+  constexpr int kThreads = (BM / TM) * (BN / TN);
+  static_assert(BK * BM % kThreads == 0 && BK * BN % kThreads == 0,
+                "staging must divide evenly across the block");
+
+  __shared__ float As[BK][BM];
+  __shared__ float Bs[BK][BN];
+
+  const int tid = static_cast<int>(threadIdx.x);
+  const int tx = tid % (BN / TN);
+  const int ty = tid / (BN / TN);
+
+  const int32_t n0 = static_cast<int32_t>(blockIdx.x) * BN;
+  const int32_t m0 = static_cast<int32_t>(blockIdx.y) * BM;
+  const int32_t xi = static_cast<int32_t>(blockIdx.z);
+
+  const __half *uXi = u + static_cast<int64_t>(xi) * Cout * Cin;
+  const __half *vXi = v + static_cast<int64_t>(xi) * Cin * tiles;
+  __half *mXi = m + static_cast<int64_t>(xi) * Cout * tiles;
+
+  const int stageRow = tid % BM;   // this thread's row of A
+  const int stageCol = tid % BN;   // ... and column of B
+  const int stageKA = tid / BM;
+  const int stageKB = tid / BN;
+  constexpr int kStepA = kThreads / BM;
+  constexpr int kStepB = kThreads / BN;
+
+  float acc[TM][TN];
+  for (int i = 0; i < TM; ++i)
+    for (int j = 0; j < TN; ++j) acc[i][j] = 0.0f;
+
+  for (int32_t k0 = 0; k0 < Cin; k0 += BK) {
+    for (int i = 0; i < BK * BM / kThreads; ++i) {
+      const int kk = stageKA + i * kStepA;
+      const int32_t k = k0 + kk;
+      const int32_t row = m0 + stageRow;
+      As[kk][stageRow] =
+          (k < Cin && row < Cout)
+              ? __half2float(uXi[static_cast<int64_t>(row) * Cin + k])
+              : 0.0f;
+    }
+    for (int i = 0; i < BK * BN / kThreads; ++i) {
+      const int kk = stageKB + i * kStepB;
+      const int32_t k = k0 + kk;
+      const int32_t col = n0 + stageCol;
+      Bs[kk][stageCol] =
+          (k < Cin && col < tiles)
+              ? __half2float(vXi[static_cast<int64_t>(k) * tiles + col])
+              : 0.0f;
+    }
+    __syncthreads();
+
+    for (int kk = 0; kk < BK; ++kk) {
+      float a[TM], b[TN];
+      for (int i = 0; i < TM; ++i) a[i] = As[kk][ty * TM + i];
+      for (int j = 0; j < TN; ++j) b[j] = Bs[kk][tx * TN + j];
+      for (int i = 0; i < TM; ++i)
+        for (int j = 0; j < TN; ++j) acc[i][j] += a[i] * b[j];
+    }
+    __syncthreads();
+  }
+
+  for (int i = 0; i < TM; ++i) {
+    const int32_t row = m0 + ty * TM + i;
+    if (row >= Cout) break;
+    for (int j = 0; j < TN; ++j) {
+      const int32_t col = n0 + tx * TN + j;
+      if (col < tiles)
+        mXi[static_cast<int64_t>(row) * tiles + col] = __float2half(acc[i][j]);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Output transform: M[16][Cout][tiles] -> y, bias folded in
+// ---------------------------------------------------------------------------
+//
+// One thread per (output channel, tile). Each writes the tile's kTileOut x
+// kTileOut output cells, dropping the ones a partial edge tile puts outside
+// the output.
+__global__ void winograd_output_kernel(const __half *__restrict__ m,
+                                       const __half *__restrict__ bias,
+                                       __half *__restrict__ y, int64_t Cout,
+                                       int64_t outH, int64_t outW, int64_t ntW,
+                                       int64_t ntPerImage, int64_t tile0,
+                                       int64_t tiles) {
+  const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const int64_t total = Cout * tiles;
+  if (idx >= total) return;
+
+  const int64_t t = idx % tiles;
+  const int64_t co = idx / tiles;
+  const int64_t gt = tile0 + t;
+
+  const int64_t n = gt / ntPerImage;
+  const int64_t rem = gt - n * ntPerImage;
+  const int64_t th = rem / ntW;
+  const int64_t tw = rem - th * ntW;
+
+  float mv[4][4];
+  for (int i = 0; i < 4; ++i)
+    for (int j = 0; j < 4; ++j) {
+      const int xi = i * 4 + j;
+      mv[i][j] = __half2float(
+          m[(static_cast<int64_t>(xi) * Cout + co) * tiles + t]);
+    }
+
+  // A^T M, then (A^T M) A.
+  float r[2][4];
+  for (int j = 0; j < 4; ++j)
+    atma4(mv[0][j], mv[1][j], mv[2][j], mv[3][j], r[0][j], r[1][j]);
+
+  const float bv = bias ? __half2float(bias[co]) : 0.0f;
+  __half *yc = y + (n * Cout + co) * outH * outW;
+
+  for (int i = 0; i < 2; ++i) {
+    float o0, o1;
+    atma4(r[i][0], r[i][1], r[i][2], r[i][3], o0, o1);
+    const int64_t oh = th * kTileOut + i;
+    if (oh >= outH) continue;
+    const float vals[2] = {o0, o1};
+    for (int j = 0; j < 2; ++j) {
+      const int64_t ow = tw * kTileOut + j;
+      if (ow < outW) yc[oh * outW + ow] = __float2half(vals[j] + bv);
+    }
+  }
+}
+
+// ===========================================================================
+// Fused Winograd: one kernel, V never reaches memory
+// ===========================================================================
+//
+// What the non-fused form got wrong, measured
+// ------------------------------------------
+// The four-stage form above is 2.2x *slower* than the direct path on esrgan
+// (conv 472 ms against 215 ms). Splitting the stages means V and M are written
+// to memory and read back, and on these shapes that scratch traffic is larger
+// than the im2col traffic it was meant to replace.
+//
+// Where the win actually is
+// -------------------------
+// It is not the 2.25x in multiplies. Measuring the direct path on esrgan's
+// 64->32 250x250 layer: 0.268 ms at 8.6 TFLOP/s, which is 29% of this part's
+// ~29.7 TFLOP/s fp16 WMMA peak, and it gets that at 12-16 waves/SIMD -- full
+// occupancy, 96-104 VGPRs, nothing to reclaim. So it is not arithmetic-bound
+// and not occupancy-bound. Its B stage reads K * Nout = (64*9) * 62500 halves
+// = 72 MB per call, and 72 MB in 0.268 ms is 269 GB/s, which is this part's
+// LPDDR5X bandwidth. It is bandwidth-bound, at the limit, and the cause is
+// im2col's 9x amplification: every input element is read once per tap.
+//
+// Winograd's advantage over that is a traffic advantage. A 2x2 output tile
+// needs a 4x4 input window, 16 reads per 4 outputs against 36, and
+// neighbouring windows overlap by half. Staging a *patch* of tiles in LDS and
+// sharing the halo brings it down further: a 4x4 patch of tiles spans 10x10
+// inputs, 100 reads for 64 outputs, against im2col's 576.
+//
+//   direct        72 MB   measured 0.268 ms
+//   fused         ~17 MB  predicted ~0.10 ms
+//
+// So the halo sharing is not an optimisation here, it is the entire point --
+// which is why this reads x through LDS rather than letting each thread gather
+// its own windows.
+//
+// Structure
+// ---------
+// One block owns one output patch: BM output channels x (TPH x TPW) output
+// tiles, and carries all 16 transform components, so x is read once.
+//
+//   for each chunk of BK input channels:
+//     stage the raw input patch          x -> Xs        (halo shared here)
+//     transform it                       Xs -> Vs      (V stays in LDS)
+//     stage the transformed filter       U  -> Us
+//     accumulate the 16 GEMMs into registers
+//   output transform of the 16, bias folded, straight from registers -> y
+//
+// Every thread holds all 16 components of the outputs it owns, so the output
+// transform reads them from registers and there is no third LDS buffer and no
+// second phase. That costs 16*TM*TN accumulators, which is why TM and TN are
+// 2 and not the 8x2 a plain GEMM would want.
+//
+// Why the tile block is wide
+// --------------------------
+// The block needs all 16 filter planes, so it stages 16*BK*BM filter elements
+// against only BK*BN input elements, and does 16*BM*BN*BK multiplies. Its
+// arithmetic intensity is therefore
+//
+//   16*BM*BN*BK / (16*BK*BM + BK*BN)  =  16*BM*BN / (16*BM + BN)
+//
+// which is dominated by the filter term until BN is large. A first cut at
+// BM=32, BN=16 gave 15.5 multiplies per staged element -- *worse* than the
+// direct kernel's 32x256 tile at 28 -- and measured accordingly: no faster
+// than the non-fused form. BM=32, BN=64 gives 57, and 64 tiles is also what
+// makes the halo cheap, an 8x8 patch of tiles spanning 18x18 inputs, 324 reads
+// for 256 outputs against im2col's 2304.
+//
+// The wave's LDS access falls out of that geometry: 32 lanes of a wave share
+// one `ty` and span `tx` 0..31, so the filter read is a broadcast of one
+// address and the input read is contiguous. Neither conflicts.
+//
+// Why the staging is K-contiguous and the inner loop is a dot product
+// ------------------------------------------------------------------
+// This kernel is instruction-bound, not bandwidth-bound: on esrgan's 64->32
+// 250x250 layer it moves ~31 MB, which is 92 GB/s against the ~270 GB/s the
+// direct path saturates. So what matters is instructions per multiply.
+//
+// Staged K-major, with one scalar fp16 read per operand and a convert before
+// the FMA, a group of 4 multiplies costs 2 LDS reads + 4 converts + 4 FMAs --
+// 10 instructions for 4 multiplies, and it measured as such (0.339 ms against
+// the direct path's 0.268 ms).
+//
+// Staged K-contiguous instead, one 16-byte LDS read fetches a whole BK slice
+// of one row, and v_dot2_f32_f16 consumes it two multiplies at a time with the
+// fp32 accumulation built in and no converts at all. The same work becomes
+// 4 LDS reads + 256 dot2 for 512 multiplies, 0.625 instructions per multiply
+// against 2.5.
+//
+// It also makes the filter staging a single 16-byte load per thread instead of
+// eight scalar ones, because a thread's 8 channels are now contiguous in both
+// the source and the destination.
+
+constexpr int kFBM = 32;   // output channels per block
+constexpr int kFTPH = 8;   // output tiles per block, rows
+constexpr int kFTPW = 8;   // ... and columns
+constexpr int kFBN = kFTPH * kFTPW;
+constexpr int kFTM = 2;    // output channels per thread
+constexpr int kFTN = 2;    // output tiles per thread
+constexpr int kFBK = 8;    // input channels per chunk
+constexpr int kFThreads = (kFBM / kFTM) * (kFBN / kFTN);
+constexpr int kFPH = kFTPH * kTileOut + 2; // staged input patch extent
+constexpr int kFPW = kFTPW * kTileOut + 2;
+
+static_assert(kFThreads == 512, "block size");
+static_assert(kFBK * kFBN == kFThreads,
+              "the input transform is one window per thread");
+static_assert(kXi * kFBM == kFThreads,
+              "the filter staging is one BK slice per thread");
+static_assert(kFBN % kFTN == 0 && kFBM % kFTM == 0, "thread tile divides");
+static_assert(kFBK % 2 == 0, "dot2 consumes K in pairs");
+
+// Where this kernel beats the direct path, measured
+// --------------------------------------------------
+// It does not beat it everywhere, and the boundary is sharp enough to gate on.
+// Over 49 fp16 3x3 stride-1 shapes taken from esrgan, resnet50, detr,
+// bevformer, mb1-ssd and yolov5lu, the ratio against `hip_conv` runs from
+// 1.85x down to 0.36x, and what separates them is the number of blocks the
+// whole convolution launches:
+//
+//   blocks <= ~3 per CU     1.0x to 1.85x   (resnet50's 3x3 stack: 1.43x)
+//   blocks >  ~3 per CU     0.36x to 0.94x  (esrgan's 250x250 layers)
+//
+// The reason is that the two are limited by different things. Above the
+// threshold both reach steady state, and there this kernel loses: it is bound
+// by LDS bandwidth, reading one operand element per multiply (~2 bytes/MAC),
+// which caps it at 1.86 T MAC/s against the direct path's 4.52 -- the 2.25x
+// fewer multiplies do not make up a 2.4x lower rate. Below the threshold the
+// convolution is too small to fill the machine, and there the direct path's
+// wide tiles leave it parallelism-starved (Cin=Cout=256 at 14x14 launches two
+// blocks and takes as long as the same shape at 50x50), while this kernel's
+// narrower blocks give the scheduler more to work with.
+//
+// Raising the ceiling would mean a bigger register tile to amortise the
+// operand reads, and that is what the 16 live components rule out: acc is
+// 16*TM*TN, so TM=TN=2 is already 64 VGPRs and 4x4 would be 256. Selecting on
+// the block count instead lands within 1.5% of picking the better path per
+// shape (22.75 ms against a 22.40 ms oracle, where always-direct is 24.85).
+//
+// The threshold is in blocks per CU rather than absolute blocks so it tracks
+// the part; the plateau is wide (2.5 to 3.1 per CU all measure the same), so
+// it is not knife-edge.
+constexpr int kResidentBlocksPerUnit = 3;
+
+// A whole BK slice of one row, which is what one LDS instruction fetches.
+typedef _Float16 halfK __attribute__((ext_vector_type(kFBK)));
+typedef _Float16 half2v __attribute__((ext_vector_type(2)));
+
+// v_dot2_f32_f16: two fp16 multiplies accumulated into fp32, one instruction,
+// no converts. Falling back to the arithmetic it stands for keeps this file
+// compiling for architectures without it -- correct, just slower.
+#if !defined(__has_builtin) || !__has_builtin(__builtin_amdgcn_fdot2)
+__device__ __forceinline__ float wgDot2(half2v a, half2v b, float c) {
+  return c + static_cast<float>(a[0]) * static_cast<float>(b[0]) +
+         static_cast<float>(a[1]) * static_cast<float>(b[1]);
+}
+#else
+__device__ __forceinline__ float wgDot2(half2v a, half2v b, float c) {
+  return __builtin_amdgcn_fdot2(a, b, c, false);
+}
+#endif
+
+__global__ __launch_bounds__(kFThreads) void winograd_fused_kernel(
+    const __half *__restrict__ x, const __half *__restrict__ u,
+    const __half *__restrict__ bias, __half *__restrict__ y, int32_t Cin,
+    int32_t Cout, int32_t inH, int32_t inW, int32_t outH, int32_t outW,
+    int32_t padTop, int32_t padLeft, int32_t ntH, int32_t ntW,
+    int32_t patchesW, int32_t patchesPerImage) {
+  // 16-byte aligned base, and kFPW is even, so a window row's packed pairs are
+  // always 4-byte aligned wherever the even column origin puts them.
+  __shared__ __align__(16) _Float16 Xs[kFBK][kFPH][kFPW];
+  static_assert(kFPW % 2 == 0, "packed window rows need an even patch width");
+  __shared__ __align__(16) _Float16 Us[kXi][kFBM][kFBK];
+  __shared__ __align__(16) _Float16 Vs[kXi][kFBN][kFBK];
+
+  const int tid = static_cast<int>(threadIdx.x);
+
+  // This block's patch of output tiles, and the output channels it covers.
+  const int patch = static_cast<int>(blockIdx.x);
+  const int n = patch / patchesPerImage;
+  const int pin = patch - n * patchesPerImage;
+  const int tRow0 = (pin / patchesW) * kFTPH;
+  const int tCol0 = (pin % patchesW) * kFTPW;
+  const int m0 = static_cast<int>(blockIdx.y) * kFBM;
+
+  // Top-left input element of the staged patch, in the padded frame.
+  const int pih0 = tRow0 * kTileOut - padTop;
+  const int piw0 = tCol0 * kTileOut - padLeft;
+
+  const __half *xImg = x + static_cast<int64_t>(n) * Cin * inH * inW;
+
+  float acc[kXi][kFTM][kFTN];
+#pragma unroll
+  for (int e = 0; e < kXi; ++e)
+#pragma unroll
+    for (int i = 0; i < kFTM; ++i)
+#pragma unroll
+      for (int j = 0; j < kFTN; ++j) acc[e][i][j] = 0.0f;
+
+  // GEMM operand positions. The N side indexes tiles, the M side channels.
+  // ty is constant across a wave and tx spans it, which is what makes the
+  // filter read a broadcast and the input read contiguous.
+  const int ty = tid / (kFBN / kFTN);
+  const int tx = tid % (kFBN / kFTN);
+
+  // Input-transform assignment: one (channel, tile) window per thread.
+  const int vK = tid / kFBN;
+  const int vT = tid - vK * kFBN;
+  const int vTh = vT / kFTPW;
+  const int vTw = vT - vTh * kFTPW;
+
+  // Filter-staging assignment: one (component, channel-slice) row per thread.
+  const int uXi = tid / kFBM;
+  const int uM = tid - uXi * kFBM;
+
+  // Patch-staging assignment: one (row, column) of the patch per thread, held
+  // across every channel and every chunk. All of it -- the decomposition, the
+  // bounds test, and the in-plane offset -- is invariant in the channel loop,
+  // so it is computed once here. Left in the loop it was two integer divisions
+  // by an extent that is not a power of two, per element, per chunk.
+  const int sPy = tid / kFPW;
+  const int sPx = tid - sPy * kFPW;
+  const bool sActive = tid < kFPH * kFPW;
+  const int sIh = pih0 + sPy;
+  const int sIw = piw0 + sPx;
+  const bool sInside =
+      sActive && sIh >= 0 && sIh < inH && sIw >= 0 && sIw < inW;
+  const int64_t sOff = static_cast<int64_t>(sIh) * inW + sIw;
+  const int64_t sPlane = static_cast<int64_t>(inH) * inW;
+
+  for (int32_t k0 = 0; k0 < Cin; k0 += kFBK) {
+    // --- stage the raw input patch; the halo is shared from here on --------
+    if (sActive) {
+      const __half *xp = xImg + static_cast<int64_t>(k0) * sPlane + sOff;
+#pragma unroll
+      for (int pk = 0; pk < kFBK; ++pk, xp += sPlane)
+        Xs[pk][sPy][sPx] = (sInside && k0 + pk < Cin)
+                               ? static_cast<_Float16>(*xp)
+                               : static_cast<_Float16>(0.0f);
+    }
+
+    // --- stage the transformed filter -------------------------------------
+    //
+    // One BK slice per thread, so this is a single 16-byte load and a single
+    // 16-byte store. The whole-slice fast path needs the slice to be inside
+    // the tensor; the tail re-reads elementwise rather than over-reading.
+    {
+      const int mm = uM;
+      const int32_t row = m0 + mm;
+      halfK slice;
+      if (row < Cout && k0 + kFBK <= Cin) {
+        slice = *reinterpret_cast<const halfK *>(
+            u + (static_cast<int64_t>(uXi) * Cout + row) * Cin + k0);
+      } else {
+#pragma unroll
+        for (int kk = 0; kk < kFBK; ++kk) {
+          const int32_t col = k0 + kk;
+          slice[kk] = (row < Cout && col < Cin)
+                          ? static_cast<_Float16>(
+                                u[(static_cast<int64_t>(uXi) * Cout + row) *
+                                      Cin +
+                                  col])
+                          : static_cast<_Float16>(0.0f);
+        }
+      }
+      *reinterpret_cast<halfK *>(&Us[uXi][mm][0]) = slice;
+    }
+    __syncthreads();
+
+    // --- transform the patch into all 16 components, in LDS ---------------
+    {
+      // Two packed pairs per window row rather than four scalar reads: the
+      // row is contiguous in the patch and the column origin is even, so the
+      // pairs are always 4-byte aligned.
+      float d[4][4];
+#pragma unroll
+      for (int i = 0; i < 4; ++i) {
+        const _Float16 *row =
+            &Xs[vK][vTh * kTileOut + i][vTw * kTileOut];
+        const half2v lo = *reinterpret_cast<const half2v *>(row);
+        const half2v hi = *reinterpret_cast<const half2v *>(row + 2);
+        d[i][0] = static_cast<float>(lo[0]);
+        d[i][1] = static_cast<float>(lo[1]);
+        d[i][2] = static_cast<float>(hi[0]);
+        d[i][3] = static_cast<float>(hi[1]);
+      }
+
+      float r[4][4];
+#pragma unroll
+      for (int j = 0; j < 4; ++j)
+        btdb4(d[0][j], d[1][j], d[2][j], d[3][j], r[0][j], r[1][j], r[2][j],
+              r[3][j]);
+#pragma unroll
+      for (int i = 0; i < 4; ++i) {
+        float o0, o1, o2, o3;
+        btdb4(r[i][0], r[i][1], r[i][2], r[i][3], o0, o1, o2, o3);
+        Vs[i * 4 + 0][vT][vK] = static_cast<_Float16>(o0);
+        Vs[i * 4 + 1][vT][vK] = static_cast<_Float16>(o1);
+        Vs[i * 4 + 2][vT][vK] = static_cast<_Float16>(o2);
+        Vs[i * 4 + 3][vT][vK] = static_cast<_Float16>(o3);
+      }
+    }
+    __syncthreads();
+
+    // --- accumulate all 16 components -------------------------------------
+    //
+    // One 16-byte read per operand row covers the whole BK slice, then dot2
+    // walks it in pairs straight into the fp32 accumulators.
+#pragma unroll
+    for (int xi = 0; xi < kXi; ++xi) {
+      half2v av[kFTM][kFBK / 2], bv[kFTN][kFBK / 2];
+#pragma unroll
+      for (int i = 0; i < kFTM; ++i)
+        *reinterpret_cast<halfK *>(&av[i][0]) =
+            *reinterpret_cast<const halfK *>(&Us[xi][ty * kFTM + i][0]);
+#pragma unroll
+      for (int j = 0; j < kFTN; ++j)
+        *reinterpret_cast<halfK *>(&bv[j][0]) =
+            *reinterpret_cast<const halfK *>(&Vs[xi][tx * kFTN + j][0]);
+
+#pragma unroll
+      for (int p = 0; p < kFBK / 2; ++p)
+#pragma unroll
+        for (int i = 0; i < kFTM; ++i)
+#pragma unroll
+          for (int j = 0; j < kFTN; ++j)
+            acc[xi][i][j] = wgDot2(av[i][p], bv[j][p], acc[xi][i][j]);
+    }
+    __syncthreads();
+  }
+
+  // --- output transform, bias folded in, straight from registers -----------
+#pragma unroll
+  for (int i = 0; i < kFTM; ++i) {
+    const int32_t co = m0 + ty * kFTM + i;
+    if (co >= Cout) continue;
+    const float bv = bias ? __half2float(bias[co]) : 0.0f;
+    __half *yc = y + (static_cast<int64_t>(n) * Cout + co) *
+                         static_cast<int64_t>(outH) * outW;
+#pragma unroll
+    for (int j = 0; j < kFTN; ++j) {
+      const int t = tx * kFTN + j;
+      const int th = tRow0 + t / kFTPW;
+      const int tw = tCol0 + t % kFTPW;
+      if (th >= ntH || tw >= ntW) continue;
+
+      float r[2][4];
+#pragma unroll
+      for (int c = 0; c < 4; ++c)
+        atma4(acc[0 * 4 + c][i][j], acc[1 * 4 + c][i][j], acc[2 * 4 + c][i][j],
+              acc[3 * 4 + c][i][j], r[0][c], r[1][c]);
+
+#pragma unroll
+      for (int a = 0; a < 2; ++a) {
+        float o0, o1;
+        atma4(r[a][0], r[a][1], r[a][2], r[a][3], o0, o1);
+        const int oh = th * kTileOut + a;
+        if (oh >= outH) continue;
+        const int ow0 = tw * kTileOut;
+        yc[static_cast<int64_t>(oh) * outW + ow0] = __float2half(o0 + bv);
+        if (ow0 + 1 < outW)
+          yc[static_cast<int64_t>(oh) * outW + ow0 + 1] = __float2half(o1 + bv);
+      }
+    }
+  }
+}
+
+// Scratch is blocked over tiles against a fixed byte budget rather than sized
+// to the shape, because the shapes this runs on differ by two orders of
+// magnitude in tile count -- esrgan alone spans 250x250 and 1000x1000, whose
+// full V would be 96 MB and 512 MB.
+constexpr int64_t kScratchBudgetBytes = 32ll << 20;
+constexpr int64_t kMinTilesPerBlock = 256;
+
+int64_t tilesPerBlock(int64_t Cin, int64_t Cout, int64_t ntiles) {
+  const int64_t perTile =
+      kXi * (Cin + Cout) * static_cast<int64_t>(sizeof(__half));
+  int64_t tb = kScratchBudgetBytes / (perTile > 0 ? perTile : 1);
+  if (tb < kMinTilesPerBlock) tb = kMinTilesPerBlock;
+  tb = (tb / 64) * 64;
+  if (tb < 64) tb = 64;
+  if (tb > ntiles) tb = ntiles;
+  return tb;
+}
+
+} // namespace
+
+extern "C" int hip_conv_winograd_eligible(int hip_dtype, int64_t spatial_rank,
+                                          int64_t k0, int64_t k1, int64_t s0,
+                                          int64_t s1, int64_t d0, int64_t d1,
+                                          int64_t group, int64_t Cin,
+                                          int64_t Cout) {
+  // fp16 only: the transform constants are chosen to be exact in fp16 and the
+  // accumulation is fp32 regardless, so there is nothing here for fp32 that
+  // the direct path does not already do better.
+  if (hip_dtype != HIP_DTYPE_FLOAT16) return 0;
+  if (spatial_rank != 2) return 0;
+  if (k0 != 3 || k1 != 3) return 0;
+  if (s0 != 1 || s1 != 1) return 0;
+  if (d0 != 1 || d1 != 1) return 0;
+  // Grouped convolution would need the transforms and the GEMM to work inside
+  // a group; every 3x3 stride-1 shape in the guard set is group 1, so this is
+  // left out rather than written untested.
+  if (group != 1) return 0;
+  if (Cin < 1 || Cout < 1) return 0;
+  return 1;
+}
+
+extern "C" int64_t hip_conv_winograd_filter_elems(int64_t Cout, int64_t Cin) {
+  return kXi * Cout * Cin;
+}
+
+namespace {
+
+int winogradUnitCount() {
+  static const int units = [] {
+    int dev = 0;
+    hipDeviceProp_t prop{};
+    if (hipGetDevice(&dev) != hipSuccess ||
+        hipGetDeviceProperties(&prop, dev) != hipSuccess ||
+        prop.multiProcessorCount <= 0)
+      return 16;
+    return prop.multiProcessorCount;
+  }();
+  return units;
+}
+
+} // namespace
+
+extern "C" int hip_conv_winograd_profitable(int64_t N, int64_t Cin,
+                                            int64_t Cout, int64_t out0,
+                                            int64_t out1) {
+  (void)Cin;
+  const int64_t ntH = (out0 + kTileOut - 1) / kTileOut;
+  const int64_t ntW = (out1 + kTileOut - 1) / kTileOut;
+  if (ntH <= 0 || ntW <= 0 || N <= 0) return 0;
+
+  const int64_t patches = ((ntH + kFTPH - 1) / kFTPH) *
+                          ((ntW + kFTPW - 1) / kFTPW) * N;
+  const int64_t blocks = patches * ((Cout + kFBM - 1) / kFBM);
+
+  return blocks <= static_cast<int64_t>(kResidentBlocksPerUnit) *
+                       winogradUnitCount()
+             ? 1
+             : 0;
+}
+
+extern "C" int64_t hip_conv_winograd_scratch_bytes(int64_t Cin, int64_t Cout,
+                                                   int64_t out0, int64_t out1) {
+  const int64_t ntH = (out0 + kTileOut - 1) / kTileOut;
+  const int64_t ntW = (out1 + kTileOut - 1) / kTileOut;
+  const int64_t ntiles = ntH * ntW;
+  if (ntiles <= 0) return 0;
+  const int64_t tb = tilesPerBlock(Cin, Cout, ntiles);
+  const int64_t vBytes = kXi * Cin * tb * static_cast<int64_t>(sizeof(__half));
+  const int64_t mBytes = kXi * Cout * tb * static_cast<int64_t>(sizeof(__half));
+  // 256-byte gap so M's base stays over-aligned for vector stores.
+  return ((vBytes + 255) & ~255ll) + mBytes;
+}
+
+extern "C" int hip_conv_winograd_filter(void *stream, const void *weights,
+                                        void *u, int64_t Cout, int64_t Cin) {
+  if (!weights || !u) return -1;
+  const int64_t total = Cout * Cin;
+  if (total <= 0) return 0;
+  constexpr int kBlock = 256;
+  const int64_t grid = (total + kBlock - 1) / kBlock;
+  hipLaunchKernelGGL(winograd_filter_kernel,
+                     dim3(static_cast<unsigned>(grid)), dim3(kBlock), 0,
+                     static_cast<hipStream_t>(stream),
+                     static_cast<const __half *>(weights),
+                     static_cast<__half *>(u), Cout, Cin);
+  hipError_t err = hipGetLastError();
+  if (err != hipSuccess) {
+    fprintf(stderr,
+            "[custom_kernels] hip_conv_winograd_filter: launch failed (%s)\n",
+            hipGetErrorString(err));
+    return static_cast<int>(err);
+  }
+  return 0;
+}
+
+extern "C" int hip_conv_winograd_fused(void *stream, const void *input,
+                                       const void *u_transformed,
+                                       const void *bias, void *output,
+                                       int64_t N, int64_t Cin, int64_t Cout,
+                                       int64_t inH, int64_t inW, int64_t outH,
+                                       int64_t outW, int64_t padTop,
+                                       int64_t padLeft) {
+  if (!input || !u_transformed || !output) return -1;
+
+  const int64_t ntH = (outH + kTileOut - 1) / kTileOut;
+  const int64_t ntW = (outW + kTileOut - 1) / kTileOut;
+  if (ntH <= 0 || ntW <= 0 || N <= 0) return 0;
+
+  const int64_t patchesH = (ntH + kFTPH - 1) / kFTPH;
+  const int64_t patchesW = (ntW + kFTPW - 1) / kFTPW;
+  const int64_t patchesPerImage = patchesH * patchesW;
+  const int64_t patches = patchesPerImage * N;
+  const int64_t mBlocks = (Cout + kFBM - 1) / kFBM;
+
+  // int32 indexing inside the kernel: the grid is bounded by the launch limit
+  // and the tensor offsets are formed in int64, but the per-block scalars are
+  // not, so refuse rather than wrap.
+  if (patches > 0x7fffffffll || Cin > 0x7fffffffll || Cout > 0x7fffffffll ||
+      inH > 0x7fffffffll || inW > 0x7fffffffll)
+    return -1;
+
+  const dim3 grid(static_cast<unsigned>(patches),
+                  static_cast<unsigned>(mBlocks), 1);
+  hipLaunchKernelGGL(winograd_fused_kernel, grid, dim3(kFThreads), 0,
+                     static_cast<hipStream_t>(stream),
+                     static_cast<const __half *>(input),
+                     static_cast<const __half *>(u_transformed),
+                     static_cast<const __half *>(bias),
+                     static_cast<__half *>(output), static_cast<int32_t>(Cin),
+                     static_cast<int32_t>(Cout), static_cast<int32_t>(inH),
+                     static_cast<int32_t>(inW), static_cast<int32_t>(outH),
+                     static_cast<int32_t>(outW), static_cast<int32_t>(padTop),
+                     static_cast<int32_t>(padLeft), static_cast<int32_t>(ntH),
+                     static_cast<int32_t>(ntW),
+                     static_cast<int32_t>(patchesW),
+                     static_cast<int32_t>(patchesPerImage));
+
+  hipError_t err = hipGetLastError();
+  if (err != hipSuccess) {
+    fprintf(stderr,
+            "[custom_kernels] hip_conv_winograd_fused: launch failed (%s)\n",
+            hipGetErrorString(err));
+    return static_cast<int>(err);
+  }
+  return 0;
+}
+
+extern "C" int hip_conv_winograd(void *stream, const void *input,
+                                 const void *u_transformed, const void *bias,
+                                 void *output, void *scratch, int64_t N,
+                                 int64_t Cin, int64_t Cout, int64_t inH,
+                                 int64_t inW, int64_t outH, int64_t outW,
+                                 int64_t padTop, int64_t padLeft) {
+  if (!input || !u_transformed || !output || !scratch) return -1;
+
+  const int64_t ntH = (outH + kTileOut - 1) / kTileOut;
+  const int64_t ntW = (outW + kTileOut - 1) / kTileOut;
+  const int64_t ntPerImage = ntH * ntW;
+  const int64_t ntiles = ntPerImage * N;
+  if (ntiles <= 0) return 0;
+
+  const int64_t tb = tilesPerBlock(Cin, Cout, ntPerImage);
+  const int64_t vBytes = kXi * Cin * tb * static_cast<int64_t>(sizeof(__half));
+  __half *V = static_cast<__half *>(scratch);
+  __half *M = reinterpret_cast<__half *>(static_cast<char *>(scratch) +
+                                         ((vBytes + 255) & ~255ll));
+
+  hipStream_t s = static_cast<hipStream_t>(stream);
+  const __half *x = static_cast<const __half *>(input);
+  const __half *U = static_cast<const __half *>(u_transformed);
+  const __half *b = static_cast<const __half *>(bias);
+  __half *y = static_cast<__half *>(output);
+
+  constexpr int BM = 64, BN = 64, TM = 4, TN = 4, BK = 16;
+  constexpr int kGemmThreads = (BM / TM) * (BN / TN);
+  constexpr int kBlock = 256;
+
+  for (int64_t tile0 = 0; tile0 < ntiles; tile0 += tb) {
+    const int64_t n = ntiles - tile0 < tb ? ntiles - tile0 : tb;
+
+    const int64_t inThreads = Cin * n;
+    hipLaunchKernelGGL(
+        winograd_input_kernel,
+        dim3(static_cast<unsigned>((inThreads + kBlock - 1) / kBlock)),
+        dim3(kBlock), 0, s, x, V, Cin, inH, inW, padTop, padLeft, ntW,
+        ntPerImage, tile0, n);
+
+    const dim3 gemmGrid(static_cast<unsigned>((n + BN - 1) / BN),
+                        static_cast<unsigned>((Cout + BM - 1) / BM), kXi);
+    hipLaunchKernelGGL((winograd_gemm_kernel<BM, BN, TM, TN, BK>), gemmGrid,
+                       dim3(kGemmThreads), 0, s, U, V, M,
+                       static_cast<int32_t>(Cout), static_cast<int32_t>(Cin),
+                       static_cast<int32_t>(n));
+
+    const int64_t outThreads = Cout * n;
+    hipLaunchKernelGGL(
+        winograd_output_kernel,
+        dim3(static_cast<unsigned>((outThreads + kBlock - 1) / kBlock)),
+        dim3(kBlock), 0, s, M, b, y, Cout, outH, outW, ntW, ntPerImage, tile0,
+        n);
+  }
+
+  hipError_t err = hipGetLastError();
+  if (err != hipSuccess) {
+    fprintf(stderr, "[custom_kernels] hip_conv_winograd: launch failed (%s)\n",
+            hipGetErrorString(err));
+    return static_cast<int>(err);
+  }
+  return 0;
+}

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -2462,6 +2462,98 @@ HIP_KERNEL_API int hip_conv(
     int64_t group);
 
 /* =========================================================================
+ * Conv — Winograd F(2x2, 3x3) path for fp16 3x3 stride-1
+ * =========================================================================
+ *
+ * An alternative to `hip_conv` for the one shape class where the transform
+ * pays: 2D, 3x3, stride 1, dilation 1, group 1, fp16. Trades a 2.25x
+ * reduction in multiplies for two transforms and a scratch buffer.
+ *
+ * Unlike `hip_conv` this path is stateful, because two of its costs are worth
+ * hoisting out of the call:
+ *
+ *   - The filter transform depends only on the weights, so the caller runs
+ *     `hip_conv_winograd_filter` once per weight tensor and keeps the result.
+ *     Doing it per call would cost more than the transform saves.
+ *   - The input transform and the GEMM need scratch, which the caller supplies
+ *     so it can come from the session's pool rather than a per-call
+ *     allocation. Its size is blocked against a fixed budget rather than sized
+ *     to the shape; ask `hip_conv_winograd_scratch_bytes` for it.
+ *
+ * Call `hip_conv_winograd_eligible` first; it returns 0 for anything this path
+ * does not implement, and the caller must then fall back to `hip_conv`.
+ */
+
+/* Non-zero if this shape should use the Winograd path. */
+HIP_KERNEL_API int hip_conv_winograd_eligible(
+    int hip_dtype, int64_t spatial_rank,
+    int64_t k0, int64_t k1,
+    int64_t s0, int64_t s1,
+    int64_t dil0, int64_t dil1,
+    int64_t group, int64_t Cin, int64_t Cout);
+
+/* Non-zero if Winograd is expected to be *faster* than hip_conv on this shape,
+ * as opposed to merely correct on it, which is what _eligible answers.
+ *
+ * Both must pass. Winograd wins on shapes too small to fill the device, where
+ * the direct path's wide tiles leave it parallelism-starved, and loses on large
+ * feature maps, where it is limited by LDS bandwidth and the 2.25x arithmetic
+ * saving does not cover it. The measured spread over 49 shapes from six models
+ * is 1.85x down to 0.36x, so this is not a detail. */
+HIP_KERNEL_API int hip_conv_winograd_profitable(
+    int64_t N, int64_t Cin, int64_t Cout, int64_t out_d0, int64_t out_d1);
+
+/* Elements (not bytes) in the transformed filter: 16 * Cout * Cin. */
+HIP_KERNEL_API int64_t hip_conv_winograd_filter_elems(int64_t Cout,
+                                                      int64_t Cin);
+
+/* Scratch bytes the caller must supply to hip_conv_winograd. */
+HIP_KERNEL_API int64_t hip_conv_winograd_scratch_bytes(
+    int64_t Cin, int64_t Cout, int64_t out_d0, int64_t out_d1);
+
+/* U = G g G^T over every (cout, cin). `u` holds filter_elems fp16 values. */
+HIP_KERNEL_API int hip_conv_winograd_filter(
+    void* stream, const void* weights, void* u, int64_t Cout, int64_t Cin);
+
+/* The convolution. `u_transformed` is the output of hip_conv_winograd_filter
+ * for these weights; `scratch` is at least hip_conv_winograd_scratch_bytes.
+ *
+ * This is the four-stage form, and it is the slower of the two: it exists as
+ * the reference the fused one is checked against. Prefer
+ * hip_conv_winograd_fused. */
+HIP_KERNEL_API int hip_conv_winograd(
+    void* stream,
+    const void* input,
+    const void* u_transformed,
+    const void* bias,        /* nullable */
+    void* output,
+    void* scratch,
+    int64_t N, int64_t Cin, int64_t Cout,
+    int64_t in_h, int64_t in_w,
+    int64_t out_h, int64_t out_w,
+    int64_t pad_top, int64_t pad_left);
+
+/* The same convolution in one kernel, with the input transform fused into the
+ * GEMM's staging so V never reaches memory. No scratch: the only buffer it
+ * needs is `u_transformed`.
+ *
+ * This is the form worth using. The four-stage version writes and reads V and
+ * M, which on these shapes costs more traffic than the im2col it replaces --
+ * measured 2.2x slower than hip_conv on esrgan. Here the input patch is staged
+ * in LDS once and the tile halo shared, which is where the traffic reduction
+ * against im2col actually comes from. */
+HIP_KERNEL_API int hip_conv_winograd_fused(
+    void* stream,
+    const void* input,
+    const void* u_transformed,
+    const void* bias,        /* nullable */
+    void* output,
+    int64_t N, int64_t Cin, int64_t Cout,
+    int64_t in_h, int64_t in_w,
+    int64_t out_h, int64_t out_w,
+    int64_t pad_top, int64_t pad_left);
+
+/* =========================================================================
  * ConvTranspose — forward transposed convolution (2D spatial)
  * =========================================================================
  *

--- a/lib/Runtime/op_profile.cpp
+++ b/lib/Runtime/op_profile.cpp
@@ -6,12 +6,62 @@
 #include "op_profile.h"
 #include "chrome_trace.h"
 #include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <hip/hip_runtime.h>
 #include <map>
 #include <string>
 #include <vector>
+
+// One-shot RGP capture fence -- see op_profile.h for the rationale. Pure host
+// code (no kernel launch): drains the GPU and sleeps so RGP arms on the next
+// dispatch. All env reads are latched on first call; when RGP_FENCE is unset
+// the very first check returns and the whole thing compiles down to one load.
+void rgp_capture_fence(const char *opname) {
+  static const std::string target = hipdnn_ep::env_string("RGP_FENCE");
+  if (target.empty())
+    return;
+  static const int skip = [] {
+    const std::string s = hipdnn_ep::env_string("RGP_FENCE_SKIP");
+    return s.empty() ? 0 : std::atoi(s.c_str());
+  }();
+  static const int sleep_ms = [] {
+    const std::string s = hipdnn_ep::env_string("RGP_FENCE_MS");
+    return s.empty() ? 200 : std::atoi(s.c_str());
+  }();
+  static std::atomic<bool> fired{false};
+  static std::atomic<int> matches{0};
+
+  if (fired.load(std::memory_order_acquire))
+    return;
+  if (!opname || target != opname)
+    return;
+  // Arm only on the (skip)-th matching instance so callers can pick, e.g., a
+  // full-attention layer rather than the first (sliding) one.
+  int idx = matches.fetch_add(1, std::memory_order_acq_rel);
+  if (idx < skip)
+    return;
+  bool expected = false;
+  if (!fired.compare_exchange_strong(expected, true, std::memory_order_acq_rel))
+    return;
+  // Drain all outstanding GPU work, THEN announce the idle window and hold. The
+  // marker is emitted BEFORE the wait so the capture orchestrator has the full
+  // window to detect it and trigger RGP; the GPU stays quiescent for the whole
+  // wait, so RGP arms cleanly and this op's kernels are the first dispatches
+  // after the gap. Busy-wait on the steady clock (no threading headers, no GPU
+  // work).
+  (void)hipDeviceSynchronize();
+  fprintf(stderr, "[RGP_FENCE_ARMED] op=%s instance=%d idling sleep_ms=%d\n",
+          opname, idx, sleep_ms);
+  fflush(stderr);
+  const auto until =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(sleep_ms);
+  while (std::chrono::steady_clock::now() < until) { /* spin */
+  }
+}
 
 struct OpProfileState {
   struct ShapeEntry {

--- a/lib/Runtime/op_profile.h
+++ b/lib/Runtime/op_profile.h
@@ -52,6 +52,18 @@ void op_profile_add_cpu_total(OpProfileState *ps, const std::string &name,
                               double cpuStartUs, double cpuMs);
 bool op_profile_is_active(OpProfileState *ps);
 
+// One-shot RGP capture fence. Gated on the RGP_FENCE env var; a no-op (single
+// cached check) when unset, so it costs nothing on normal runs. When RGP_FENCE
+// names this op, the fence drains the GPU (hipDeviceSynchronize) and sleeps
+// RGP_FENCE_MS ms to manufacture an idle window, so an RGP dispatch-mode
+// auto-capture arms deterministically on THIS op's first dispatch after the gap
+// (dispatch-index positioning is unreliable in this build). RGP_FENCE_SKIP=N
+// arms on the (N+1)-th matching instance instead of the first (e.g. to target a
+// full-attention layer rather than layer-0 sliding attention). Fires once per
+// process and emits a "[RGP_FENCE_ARMED]" stderr marker the orchestrator waits
+// on before triggering the capture.
+void rgp_capture_fence(const char *opname);
+
 // Absolute microseconds on the shared steady_clock axis. A plain time
 // conversion tied to no session: the trace axis is process-global, so all
 // sessions and inferences land on it without any captured baseline.
@@ -125,6 +137,7 @@ struct OpProfileScope {
 // [PERF] table can report achieved GB/s and % of the memory roofline. bytes_fn
 // is a callable returning int64_t, invoked only when profiling is active.
 #define OP_PROFILE_BYTES(opname, shape_fn, bytes_fn, state_arg)                \
+  rgp_capture_fence(opname);                                                   \
   std::optional<OpProfileScope> _opProf;                                       \
   if (hipdnn_ep_perf_enabled()) {                                              \
     auto *_ps = static_cast<OpProfileState *>(                                 \
@@ -140,6 +153,7 @@ struct OpProfileScope {
   }
 
 #define OP_PROFILE_CPU(opname, state_arg)                                      \
+  rgp_capture_fence(opname);                                                   \
   std::optional<OpProfileCpuScope> _opProfCpu;                                 \
   if (hipdnn_ep_perf_enabled()) {                                              \
     auto *_ps = static_cast<OpProfileState *>(                                 \

--- a/lib/Runtime/real/conv.cpp
+++ b/lib/Runtime/real/conv.cpp
@@ -10,6 +10,11 @@
 #include "runtime_types.h"
 
 #include <cstdio>
+#include <cstdlib>
+#include <map>
+#include <utility>
+
+#include <hip/hip_runtime.h>
 
 //===----------------------------------------------------------------------===//
 // Conv — forward convolution via the custom HIP kernel
@@ -32,10 +37,9 @@
 //     overwrites rather than accumulates -- so it followed every convolution
 //     with a separate miopenOpTensor pass over the whole output. That pass is
 //     gone.
-//   * There is no op state, no solution cache and no workspace. MIOpen needed a
-//     per-shape Find() and a cached solution; this kernel derives everything
-//     from its arguments, so `op_state_slot` is accepted for ABI stability and
-//     ignored.
+//   * The direct path needs no op state, no solution cache and no workspace:
+//     it derives everything from its arguments. The Winograd path does need
+//     both, and that is what `op_state_slot` now carries -- see ConvState.
 //
 // Only pads_begin is passed. Pad positions are never read, so the trailing pad
 // affects nothing except how many output positions exist, and that is already
@@ -43,11 +47,74 @@
 
 namespace {
 
-// Slot payload shared by Conv and ConvTranspose: both ops emit a construct call
-// for their slot, so the symbol has to exist, but neither kernel caches
-// anything. This used to be the MIOpen descriptor/solution table (ConvState in
-// real/miopen.cpp) and outlived it only as an ABI obligation.
-struct ConvState : OpStateT<ConvState> {};
+// Slot payload shared by Conv and ConvTranspose. Both ops emit a construct call
+// for their slot, so the symbol has to exist; what it holds is the Winograd
+// path's transformed filter.
+//
+// The transform U = G g G^T depends only on the weights, and for a model
+// constant those never change, so doing it per call would add more work than
+// the algorithm saves. Keying on the weight pointer rather than on the op means
+// weights shared between nodes are transformed once. The buffers are owned
+// here and freed with the slot, which is why this is a state slot and not a
+// function-local cache: the lifetime has to end with the session.
+struct ConvState : OpStateT<ConvState> {
+  // weights pointer -> (device U buffer, elements it holds)
+  std::map<const void *, std::pair<void *, int64_t>> winograd_filters;
+
+  ~ConvState() {
+    for (auto &e : winograd_filters)
+      if (e.second.first)
+        (void)hipFree(e.second.first);
+  }
+};
+
+// HIPDNN_EP_CONV_WINOGRAD overrides the shape gate three ways: unset lets
+// hip_conv_winograd_profitable decide (the shipping behaviour), 0 never takes
+// the Winograd path, and 1 takes it wherever it is correct, ignoring
+// profitability. The last is what makes the A/B measurable -- the gate was
+// fitted by running both arms over the shapes the models contain, and it can
+// only be refitted if forcing is still possible.
+enum class WinogradMode { Gated, Never, Always };
+
+WinogradMode winograd_mode() {
+  static const WinogradMode m = [] {
+    const char *s = std::getenv("HIPDNN_EP_CONV_WINOGRAD");
+    if (!s || !*s)
+      return WinogradMode::Gated;
+    return *s == '0' ? WinogradMode::Never : WinogradMode::Always;
+  }();
+  return m;
+}
+
+// The transformed filter for these weights, transforming on first use.
+// Returns nullptr if it cannot be produced, which sends the caller to the
+// direct path rather than failing the convolution.
+const void *winograd_filter(ConvState *cs, void *stream, const void *weights,
+                            int64_t Cout, int64_t Cin) {
+  auto it = cs->winograd_filters.find(weights);
+  if (it != cs->winograd_filters.end())
+    return it->second.first;
+
+  const int64_t elems = hip_conv_winograd_filter_elems(Cout, Cin);
+  if (elems <= 0)
+    return nullptr;
+  const size_t bytes = static_cast<size_t>(elems) * 2; // fp16
+
+  void *u = nullptr;
+  if (hipMalloc(&u, bytes) != hipSuccess) {
+    fprintf(stderr,
+            "[REAL] wrap_conv: hipMalloc(%zu) for the Winograd filter failed; "
+            "using the direct path\n",
+            bytes);
+    return nullptr;
+  }
+  if (hip_conv_winograd_filter(stream, weights, u, Cout, Cin) != 0) {
+    (void)hipFree(u);
+    return nullptr;
+  }
+  cs->winograd_filters[weights] = {u, elems};
+  return u;
+}
 
 } // namespace
 
@@ -116,10 +183,36 @@ int wrap_conv(RuntimeState *state, int32_t op_state_slot, const void *input,
     return -1;
   }
 
-  // No op state: this kernel needs no cached solution or workspace.
-  (void)op_state_slot;
-
   void *stream = hipdnn_ep_state_get_stream(state);
+
+  // Winograd F(2x2,3x3), for fp16 3x3 stride-1 shapes small enough that the
+  // direct path cannot fill the device. Everything else -- and anything whose
+  // filter transform cannot be had -- falls through to the direct path below
+  // unchanged.
+  const WinogradMode wmode = winograd_mode();
+  ConvState *cs = ConvState::get_op_state(state, op_state_slot);
+  if (cs && wmode != WinogradMode::Never &&
+      hip_conv_winograd_eligible(hip_dtype, spatial_rank, k0, k1, s0, s1, dil0,
+                                 dil1, group, Cin, Cout) &&
+      (wmode == WinogradMode::Always ||
+       hip_conv_winograd_profitable(N, Cin, Cout, out0, out1))) {
+    const void *u = winograd_filter(cs, stream, weights, Cout, Cin);
+    if (u) {
+      RUNTIME_DEBUG_LOG(
+          "[REAL] wrap_conv: winograd F(2x2,3x3) N=%lld Cin=%lld Cout=%lld "
+          "in=[%lld,%lld] out=[%lld,%lld]\n",
+          (long long)N, (long long)Cin, (long long)Cout, (long long)in0,
+          (long long)in1, (long long)out0, (long long)out1);
+      int wrc = hip_conv_winograd_fused(stream, input, u, bias, output, N, Cin,
+                                        Cout, in0, in1, out0, out1, p0, p1);
+      if (wrc == 0)
+        return 0;
+      fprintf(stderr,
+              "[REAL] wrap_conv: winograd path failed (%d); using the direct "
+              "path\n",
+              wrc);
+    }
+  }
 
   RUNTIME_DEBUG_LOG(
       "[REAL] wrap_conv: dtype=%s(%lld) spatial_rank=%lld N=%lld Cin=%lld "

--- a/test/numeric/tests/conv_cases.py
+++ b/test/numeric/tests/conv_cases.py
@@ -1,0 +1,202 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+"""The convolution shape sweep: what to test, and how to build it.
+
+Kept apart from test_conv.py, and free of any dependency beyond onnx and
+numpy, so the same cases can be driven either through pytest (against the ORT
+CPU reference) or through hip-onnx-runner directly. The two paths need
+different plumbing but must not be allowed to test different shapes.
+
+The sweep exists because `hip_conv` is not one kernel. It picks among a WMMA
+tile ladder, a scalar tile ladder, a depthwise kernel and a
+one-thread-per-output fallback, and the choice is a function of the
+output-channel count, the output extent, the batch, the group count *and* the
+device's CU count. A test that covers one shape covers one kernel, and the
+shapes selecting the rarely-taken rungs have the least coverage precisely
+because they are rare.
+
+Cases are grouped by what selects a rung rather than by which model they came
+from, so a new tile in the ladder has an obvious place to be tested from, and
+each is the smallest shape that still lands where it is named to land -- the
+rung depends on channel counts and extents, not on how much data flows.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from onnx import TensorProto, helper, numpy_helper
+
+_ONNX_DTYPE = {
+    "float16": TensorProto.FLOAT16,
+    "float32": TensorProto.FLOAT,
+}
+_NP_DTYPE = {"float16": np.float16, "float32": np.float32}
+
+
+# Each case names the property that puts it in the sweep. `id` is what pytest
+# prints and what names the generated model file, so it names the rung or the
+# hazard rather than the shape.
+CONV_CASES = [
+    # -- WMMA tile ladder: one case per rung -------------------------------
+    dict(id="wmma-128x256", cin=64, cout=256, spatial=(56, 56), k=(1, 1)),
+    dict(id="wmma-256x128", cin=256, cout=1024, spatial=(14, 14), k=(1, 1)),
+    dict(id="wmma-64x256", cin=3, cout=64, spatial=(224, 224), k=(7, 7),
+         stride=(2, 2), pad=(3, 3)),
+    dict(id="wmma-32x256", cin=64, cout=32, spatial=(64, 64)),
+    dict(id="wmma-16x256-narrow", cin=64, cout=3, spatial=(64, 64)),
+    # resnet50 stage 4. On a 20-CU part every wider tile fails the coverage
+    # test and these land on the 16-row rung; on a 16-CU part they do not.
+    # Both have to be correct, and the sweep runs on whatever the device is.
+    dict(id="deep-stage-512ch-7x7", cin=2048, cout=512, spatial=(7, 7), k=(1, 1)),
+    dict(id="deep-stage-512ch-7x7-3x3", cin=512, cout=512, spatial=(7, 7)),
+    dict(id="deep-stage-2048ch-7x7", cin=512, cout=2048, spatial=(7, 7), k=(1, 1)),
+    # -- Contraction tail: K not a multiple of the 16-deep staging slice ---
+    # The staging loops walk a full slice whether or not the contraction has
+    # that many taps left, so each of these drives the out-of-range sentinel
+    # in makeKSlice at a different remainder.
+    dict(id="ktail-K27", cin=3, cout=64, spatial=(32, 32)),        # 3*9
+    dict(id="ktail-K9", cin=1, cout=32, spatial=(32, 32)),         # 1*9
+    dict(id="ktail-K45", cin=5, cout=64, spatial=(32, 32)),        # 5*9
+    dict(id="ktail-K7", cin=7, cout=64, spatial=(32, 32), k=(1, 1)),
+    dict(id="ktail-K33", cin=11, cout=48, spatial=(17, 17)),       # 11*9, odd extent
+    # -- 3x3 stride 1: the class Winograd takes over -----------------------
+    dict(id="w3x3-64to64", cin=64, cout=64, spatial=(56, 56)),
+    dict(id="w3x3-128to128", cin=128, cout=128, spatial=(28, 28)),
+    dict(id="w3x3-256to256", cin=256, cout=256, spatial=(14, 14)),
+    dict(id="w3x3-192to64", cin=192, cout=64, spatial=(32, 32)),
+    dict(id="w3x3-odd-extent", cin=32, cout=32, spatial=(13, 13)),
+    dict(id="w3x3-batch4", cin=32, cout=64, spatial=(16, 16), n=4),
+    dict(id="w3x3-tiny-extent", cin=32, cout=32, spatial=(3, 3)),
+    dict(id="w3x3-pad0", cin=32, cout=64, spatial=(16, 16), pad=(0, 0)),
+    # -- Strided, dilated, asymmetric --------------------------------------
+    dict(id="stride2-3x3", cin=64, cout=128, spatial=(28, 28), stride=(2, 2)),
+    dict(id="stride3-3x3", cin=32, cout=64, spatial=(30, 30), stride=(3, 3)),
+    dict(id="dilation2", cin=32, cout=64, spatial=(24, 24), dilation=(2, 2)),
+    dict(id="nonsquare-kernel", cin=32, cout=64, spatial=(24, 24), k=(1, 3)),
+    dict(id="nonsquare-spatial", cin=32, cout=64, spatial=(12, 40)),
+    # -- Grouped and depthwise ---------------------------------------------
+    dict(id="depthwise-3x3", cin=64, cout=64, group=64, spatial=(28, 28)),
+    dict(id="depthwise-7x7", cin=96, cout=96, group=96, spatial=(28, 28),
+         k=(7, 7)),
+    dict(id="grouped-4", cin=64, cout=128, group=4, spatial=(28, 28)),
+    dict(id="grouped-narrow-rows", cin=64, cout=8, group=4, spatial=(28, 28)),
+    # -- fp32 goes down the scalar ladder, not the matrix cores ------------
+    dict(id="fp32-3x3", cin=64, cout=64, spatial=(28, 28), dtype="float32"),
+    dict(id="fp32-1x1", cin=256, cout=256, spatial=(14, 14), k=(1, 1),
+         dtype="float32"),
+    dict(id="fp32-ktail", cin=3, cout=64, spatial=(32, 32), dtype="float32"),
+    dict(id="fp32-deep-512ch", cin=512, cout=512, spatial=(7, 7),
+         dtype="float32"),
+    # -- bevformer FPN: the shape that produced 33% NaN after MIOpen removal
+    dict(id="bevformer-fpn-1x1", cin=2048, cout=256, spatial=(15, 25),
+         k=(1, 1)),
+    dict(id="bevformer-fpn-3x3", cin=256, cout=256, spatial=(15, 25)),
+    dict(id="bevformer-fpn-c5", cin=1024, cout=256, spatial=(29, 50),
+         k=(1, 1)),
+]
+
+CONV_TRANSPOSE_CASES = [
+    # sam2.1's decoder: kernel == stride, so output footprints are disjoint
+    # and every output cell has exactly one contributing tap.
+    dict(id="ct-2x2s2-256to64", op="ConvTranspose", cin=256, cout=64,
+         spatial=(16, 16), k=(2, 2), stride=(2, 2), pad=(0, 0)),
+    dict(id="ct-2x2s2-64to32", op="ConvTranspose", cin=64, cout=32,
+         spatial=(32, 32), k=(2, 2), stride=(2, 2), pad=(0, 0)),
+    # Overlapping footprints: stride < kernel, the case a disjoint fast path
+    # must refuse.
+    dict(id="ct-4x4s2-overlap", op="ConvTranspose", cin=32, cout=16,
+         spatial=(16, 16), k=(4, 4), stride=(2, 2), pad=(1, 1)),
+    dict(id="ct-3x3s1", op="ConvTranspose", cin=32, cout=32,
+         spatial=(16, 16), k=(3, 3), stride=(1, 1), pad=(1, 1)),
+    dict(id="ct-3x3s2-pad", op="ConvTranspose", cin=16, cout=16,
+         spatial=(12, 12), k=(3, 3), stride=(2, 2), pad=(1, 1)),
+    dict(id="ct-grouped", op="ConvTranspose", cin=32, cout=32, group=4,
+         spatial=(16, 16), k=(2, 2), stride=(2, 2), pad=(0, 0)),
+    dict(id="ct-fp32-2x2s2", op="ConvTranspose", cin=64, cout=32,
+         spatial=(16, 16), k=(2, 2), stride=(2, 2), pad=(0, 0),
+         dtype="float32"),
+    dict(id="ct-dilation2", op="ConvTranspose", cin=16, cout=16,
+         spatial=(12, 12), k=(3, 3), stride=(1, 1), pad=(2, 2),
+         dilation=(2, 2)),
+]
+
+ALL_CASES = CONV_CASES + CONV_TRANSPOSE_CASES
+
+
+def output_extent(case):
+    op = case.get("op", "Conv")
+    kh, kw = case.get("k", (3, 3))
+    sh, sw = case.get("stride", (1, 1))
+    dh, dw = case.get("dilation", (1, 1))
+    ih, iw = case["spatial"]
+    ph, pw = case.get("pad", ((kh - 1) * dh // 2, (kw - 1) * dw // 2))
+    if op == "Conv":
+        oh = (ih + 2 * ph - (dh * (kh - 1) + 1)) // sh + 1
+        ow = (iw + 2 * pw - (dw * (kw - 1) + 1)) // sw + 1
+    else:
+        oh = (ih - 1) * sh - 2 * ph + dh * (kh - 1) + 1
+        ow = (iw - 1) * sw - 2 * pw + dw * (kw - 1) + 1
+    return oh, ow, ph, pw
+
+
+def build(case):
+    """Return (ModelProto, input ndarray) for one sweep case."""
+    op = case.get("op", "Conv")
+    dt = case.get("dtype", "float16")
+    onnx_t, np_t = _ONNX_DTYPE[dt], _NP_DTYPE[dt]
+
+    n = case.get("n", 1)
+    cin, cout = case["cin"], case["cout"]
+    g = case.get("group", 1)
+    kh, kw = case.get("k", (3, 3))
+    sh, sw = case.get("stride", (1, 1))
+    dh, dw = case.get("dilation", (1, 1))
+    ih, iw = case["spatial"]
+    oh, ow, ph, pw = output_extent(case)
+
+    assert cin % g == 0 and cout % g == 0, f"{case['id']}: group does not divide"
+    assert oh > 0 and ow > 0, f"{case['id']}: empty output"
+
+    wshape = [cout, cin // g, kh, kw] if op == "Conv" else [cin, cout // g, kh, kw]
+
+    inp = helper.make_tensor_value_info("input", onnx_t, [n, cin, ih, iw])
+    out = helper.make_tensor_value_info("output", onnx_t, [n, cout, oh, ow])
+
+    # A narrow weight range keeps the fp16 accumulation well inside range for
+    # the long contractions here (K reaches 2048); the sweep is about kernel
+    # selection, not saturation behaviour.
+    rng = np.random.default_rng(case.get("seed", 11))
+    scale = 0.1 if dt == "float16" else 0.5
+    w = rng.uniform(-scale, scale, wshape).astype(np_t)
+    b = rng.uniform(-scale, scale, [cout]).astype(np_t)
+
+    node = helper.make_node(
+        op,
+        ["input", "weight", "bias"],
+        ["output"],
+        group=g,
+        kernel_shape=[kh, kw],
+        strides=[sh, sw],
+        pads=[ph, pw, ph, pw],
+        dilations=[dh, dw],
+    )
+    graph = helper.make_graph(
+        [node],
+        f"conv_sweep_{case['id']}",
+        [inp],
+        [out],
+        initializer=[
+            numpy_helper.from_array(w, name="weight"),
+            numpy_helper.from_array(b, name="bias"),
+        ],
+    )
+    model = helper.make_model(
+        graph, opset_imports=[helper.make_operatorsetid("", 17)]
+    )
+    model.ir_version = 10
+
+    x = rng.uniform(-1.0, 1.0, [n, cin, ih, iw]).astype(np_t)
+    return model, x

--- a/test/numeric/tests/test_conv.py
+++ b/test/numeric/tests/test_conv.py
@@ -3,19 +3,25 @@
 # Licensed under the MIT License.
 #
 
-"""Tests for the Conv operation, focused on grouped / depthwise convolution.
+"""Tests for the Conv and ConvTranspose operations.
 
-The MIOpen weight descriptor must use the per-group input-channel count
-(input_c / group), not input_c. For group == 1 the two are equal, but for
-grouped (1 < group < C) and depthwise (group == C) convolutions, using input_c
-describes the wrong filter shape and produces silently incorrect results. These
-tests exercise all three regimes against the ORT CPU reference.
+`TestConv` covers grouped / depthwise convolution. The weight descriptor must
+use the per-group input-channel count (input_c / group), not input_c. For
+group == 1 the two are equal, but for grouped (1 < group < C) and depthwise
+(group == C) convolutions, using input_c describes the wrong filter shape and
+produces silently incorrect results.
+
+`TestConvShapeSweep` drives the shape sweep in conv_cases.py, which is where
+the cases and the reasoning behind them live. They sit in their own module
+because the same sweep also runs outside pytest, against hip-onnx-runner, on
+machines whose ORT build cannot load the EP as a plugin.
 """
 
 import numpy as np
 import pytest
 from onnx import TensorProto, helper, numpy_helper
 
+from conv_cases import CONV_CASES, CONV_TRANSPOSE_CASES, build
 from framework.comparator import compare_outputs
 from framework.onnx_utils import make_model_from_nodes
 
@@ -88,3 +94,39 @@ class TestConv:
 
         actual, expected = model_runner.run_sample(model, [x])
         compare_outputs(actual, expected, atol=1e-2, rtol=1e-2, cos_threshold=0.999)
+
+
+def _check(model_runner, case):
+    model, x = build(case)
+    actual, expected = model_runner.run_sample(model, [x])
+
+    # Assert finiteness before correlating. A NaN makes the cosine NaN too, so
+    # comparing first reports "cosine below threshold" for what is really an
+    # arithmetic fault, and the count is the diagnostic that separates a kernel
+    # writing garbage from one that is merely imprecise.
+    for i, a in enumerate(actual):
+        bad = int(np.count_nonzero(~np.isfinite(a)))
+        if not bad:
+            continue
+        finite = a[np.isfinite(a)]
+        lo = float(finite.min()) if finite.size else float("nan")
+        hi = float(finite.max()) if finite.size else float("nan")
+        raise AssertionError(
+            f"output {i} has {bad} non-finite values of {a.size} "
+            f"({100.0 * bad / a.size:.2f}%); finite range [{lo:.4g}, {hi:.4g}]"
+        )
+
+    tol = 2e-2 if case.get("dtype", "float16") == "float16" else 1e-4
+    compare_outputs(actual, expected, atol=tol, rtol=tol, cos_threshold=0.999)
+
+
+class TestConvShapeSweep:
+    @pytest.mark.parametrize("case", CONV_CASES, ids=[c["id"] for c in CONV_CASES])
+    def test_conv_shape(self, model_runner, case):
+        _check(model_runner, case)
+
+    @pytest.mark.parametrize(
+        "case", CONV_TRANSPOSE_CASES, ids=[c["id"] for c in CONV_TRANSPOSE_CASES]
+    )
+    def test_conv_transpose_shape(self, model_runner, case):
+        _check(model_runner, case)

--- a/test/runtime/CMakeLists.txt
+++ b/test/runtime/CMakeLists.txt
@@ -60,3 +60,18 @@ target_link_libraries(test-gqa-autotune PRIVATE HipSchemasLib)
 
 add_test(NAME GqaAutotuneUnitTest COMMAND test-gqa-autotune)
 set_target_properties(test-gqa-autotune PROPERTIES FOLDER "runtime-tests")
+
+# Convolution tile selection. The heuristic is a pure function of a shape and a
+# CU count, so the header carries no HIP -- it is included by conv_kernel.hip
+# but compiles as plain C++17 here, which is why it was split out of the .hip
+# file in the first place. The invariant it guards is monotonicity in the CU
+# count, and that is precisely the property no GPU can check on one part.
+add_executable(test-conv-tile-select test_conv_tile_select.cpp)
+
+target_compile_features(test-conv-tile-select PRIVATE cxx_std_17)
+target_include_directories(test-conv-tile-select PRIVATE
+    ${CMAKE_SOURCE_DIR}/lib/Runtime/Kernels/hip
+)
+
+add_test(NAME ConvTileSelectUnitTest COMMAND test-conv-tile-select)
+set_target_properties(test-conv-tile-select PROPERTIES FOLDER "runtime-tests")

--- a/test/runtime/test_conv_tile_select.cpp
+++ b/test/runtime/test_conv_tile_select.cpp
@@ -1,0 +1,376 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// Convolution tile selection, with no GPU: the choice is integer arithmetic
+// over a shape and a CU count, so all of it can be checked here.
+//
+// The invariant that matters is monotonicity. The heuristic this replaced
+// picked its tile by walking a ladder and taking the first rung producing at
+// least `deviceUnitCount()` blocks, which means a device with more CUs
+// rejects more rungs and falls further down -- to narrower row blocks, each of
+// which re-gathers the im2col matrix once more. That is backwards, and it is
+// how a kernel tuned on a 16-CU part came to spend 38.8% of resnet50's
+// convolution time in a 16-row tile on a 20-CU one.
+//
+// So the first test here sweeps CU counts across every shape in the models and
+// asserts the row block never narrows as the device grows. It is the property
+// that makes a heuristic tuned on one part trustworthy on another, and it is
+// checkable without hardware, which is the whole reason the selection was
+// pulled out of the .hip file.
+//
+// The rest pin the specific shapes that regressed, so a future retune has to
+// notice it is undoing this one.
+
+#include "conv_tile_select.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+namespace {
+
+using conv_tile::Choice;
+using conv_tile::Kind;
+using conv_tile::Shape;
+
+int failures = 0;
+
+// The CU counts worth holding the selection to. The lower bound is not a
+// rounding-off: below about eight units a tile producing four blocks really
+// does leave most of the device idle, and trading gather for parallelism
+// really is the right call, so monotonicity is not the property one wants
+// there. No part this EP runs on is that small -- the two it ships on are 16
+// and 20 -- and the upper bound is generous room above them.
+constexpr int64_t kMinUnits = 8;
+constexpr int64_t kMaxUnits = 128;
+
+void require(bool condition, const char *expression, int line) {
+  if (condition)
+    return;
+  std::fprintf(stderr, "requirement failed at line %d: %s\n", line, expression);
+  ++failures;
+}
+
+#define REQUIRE(expr) require((expr), #expr, __LINE__)
+
+const char *kindName(Kind k) {
+  switch (k) {
+  case Kind::Depthwise: return "depthwise";
+  case Kind::Wmma:      return "wmma";
+  case Kind::Tiled:     return "tiled";
+  case Kind::Direct:    return "direct";
+  }
+  return "?";
+}
+
+void describe(const char *what, const Shape &s, const Choice &c) {
+  std::fprintf(stderr,
+               "  %-28s M=%-5lld Nout=%-8lld K=%-6lld -> %s %dx%d\n", what,
+               (long long)s.MPerGroup, (long long)s.Nout, (long long)s.K,
+               kindName(c.kind), c.bm, c.bn);
+}
+
+// A convolution as the models express it, reduced to what selection reads.
+Shape conv(int64_t cinPerGroup, int64_t mPerGroup, int64_t nout, int64_t kvol,
+           int64_t batch = 1, int64_t group = 1, bool fp16 = true) {
+  Shape s;
+  s.CinPerGroup = cinPerGroup;
+  s.MPerGroup = mPerGroup;
+  s.Nout = nout;
+  s.kvol = kvol;
+  s.K = cinPerGroup * kvol;
+  s.N = batch;
+  s.group = group;
+  s.elemBytes = fp16 ? 2 : 4;
+  s.wmmaEligible = fp16;
+  return s;
+}
+
+// Every distinct convolution shape in the guard set, by the numbers that
+// selection actually reads. Drawn from the models, not invented: resnet50,
+// esrgan, mobilenet, ssd-resnet34, detr, bevformer, sam2.1 and simplebev.
+std::vector<Shape> modelShapes() {
+  std::vector<Shape> v;
+  // resnet50, all four stages.
+  v.push_back(conv(3, 64, 112 * 112, 49));
+  v.push_back(conv(64, 64, 56 * 56, 1));
+  v.push_back(conv(64, 64, 56 * 56, 9));
+  v.push_back(conv(64, 256, 56 * 56, 1));
+  v.push_back(conv(256, 64, 56 * 56, 1));
+  v.push_back(conv(256, 128, 56 * 56, 1));
+  v.push_back(conv(128, 128, 28 * 28, 9));
+  v.push_back(conv(128, 512, 28 * 28, 1));
+  v.push_back(conv(512, 128, 28 * 28, 1));
+  v.push_back(conv(512, 256, 28 * 28, 1));
+  v.push_back(conv(256, 256, 14 * 14, 9));
+  v.push_back(conv(256, 1024, 14 * 14, 1));
+  v.push_back(conv(1024, 256, 14 * 14, 1));
+  v.push_back(conv(1024, 512, 14 * 14, 1));
+  v.push_back(conv(512, 512, 7 * 7, 9));
+  v.push_back(conv(512, 2048, 7 * 7, 1));
+  v.push_back(conv(2048, 512, 7 * 7, 1));
+  // esrgan: 3x3 stride 1 throughout, on a very large plane.
+  v.push_back(conv(3, 64, 250 * 250, 9));
+  v.push_back(conv(64, 32, 250 * 250, 9));
+  v.push_back(conv(192, 64, 250 * 250, 9));
+  v.push_back(conv(64, 64, 1000 * 1000, 9));
+  v.push_back(conv(64, 3, 1000 * 1000, 9));
+  // Depthwise, from mobilenet and mb1-ssd.
+  v.push_back(conv(1, 1, 112 * 112, 9, 1, 32));
+  v.push_back(conv(1, 1, 14 * 14, 9, 1, 576));
+  // bevformer / detr FPN.
+  v.push_back(conv(2048, 256, 15 * 25, 1));
+  v.push_back(conv(1024, 256, 29 * 50, 1));
+  v.push_back(conv(256, 256, 15 * 25, 9));
+  // sam2.1 encoder, and a batched case.
+  v.push_back(conv(3, 96, 256 * 256, 49));
+  v.push_back(conv(96, 96, 64 * 64, 9, 4));
+  // simplebev is fp32, which cannot use the matrix cores.
+  v.push_back(conv(128, 128, 200 * 200, 9, 1, 1, false));
+  v.push_back(conv(64, 64, 100 * 100, 9, 1, 1, false));
+  // Degenerate extremes.
+  v.push_back(conv(1, 1, 1, 1));
+  v.push_back(conv(2048, 4096, 1, 1));
+  v.push_back(conv(8, 8, 4, 9));
+  return v;
+}
+
+// --------------------------------------------------------------------------
+
+// The invariant the old ladder violated. A wider row block re-gathers the
+// im2col matrix fewer times, so it is never the wrong answer on a *larger*
+// device: whatever made it affordable at 16 CUs is still true at 64. If the
+// selection narrows as `units` grows it is buying parallelism with bandwidth,
+// which is the trade that produced the regression.
+void testRowBlockIsMonotoneInUnits() {
+  for (const Shape &s : modelShapes()) {
+    int prevBm = 0;
+    Choice prev{};
+    for (int64_t units = kMinUnits; units <= kMaxUnits; ++units) {
+      const Choice c = conv_tile::select(s, units);
+      if (c.kind == Kind::Depthwise)
+        break; // not a tiling decision, and independent of units
+      const int bm = c.kind == Kind::Direct ? 1 : c.bm;
+      if (bm < prevBm) {
+        std::fprintf(stderr,
+                     "row block narrowed as units grew: M=%lld Nout=%lld "
+                     "K=%lld went %s %dx%d -> %s %dx%d at units=%lld\n",
+                     (long long)s.MPerGroup, (long long)s.Nout, (long long)s.K,
+                     kindName(prev.kind), prev.bm, prev.bn, kindName(c.kind),
+                     c.bm, c.bn, (long long)units);
+        ++failures;
+        break;
+      }
+      prevBm = bm;
+      prev = c;
+    }
+  }
+}
+
+// A device with more CUs must never be given a *worse* grid than a smaller one
+// would get for the same shape -- the block count must not fall.
+void testBlockCountDoesNotFallAsUnitsGrow() {
+  for (const Shape &s : modelShapes()) {
+    for (int64_t units = kMinUnits + 1; units <= kMaxUnits; ++units) {
+      const Choice lo = conv_tile::select(s, units - 1);
+      const Choice hi = conv_tile::select(s, units);
+      if (lo.kind != Kind::Wmma && lo.kind != Kind::Tiled)
+        continue;
+      if (hi.kind != Kind::Wmma && hi.kind != Kind::Tiled)
+        continue;
+      const int64_t bl = conv_tile::ceilDiv(s.MPerGroup, lo.bm) *
+                         conv_tile::ceilDiv(s.Nout, lo.bn);
+      const int64_t bh = conv_tile::ceilDiv(s.MPerGroup, hi.bm) *
+                         conv_tile::ceilDiv(s.Nout, hi.bn);
+      REQUIRE(bh >= bl);
+      if (bh < bl)
+        std::fprintf(stderr, "  at units=%lld M=%lld Nout=%lld\n",
+                     (long long)units, (long long)s.MPerGroup,
+                     (long long)s.Nout);
+    }
+  }
+}
+
+// Selection must be stable across the CU counts of the parts this ships on.
+// The two differ by four CUs and nothing else; a shape whose tile changes
+// between them is a shape whose performance is not portable.
+void testAgreesAcrossShippingParts() {
+  int differ = 0;
+  for (const Shape &s : modelShapes()) {
+    const Choice a = conv_tile::select(s, 16); // 8050S
+    const Choice b = conv_tile::select(s, 20); // 8060S
+    if (!(a == b)) {
+      ++differ;
+      describe("differs at 16 CUs", s, a);
+      describe("           20 CUs", s, b);
+    }
+  }
+  REQUIRE(differ == 0);
+}
+
+// The shapes that regressed. resnet50's stage-4 convolutions have 512 output
+// channels and a 7x7 output; the old ladder gave them a 16-row tile on a
+// 20-CU part, which is 32 passes over the input where 4 would do.
+void testDeepNarrowOutputsGetAWideRowBlock() {
+  const Shape s512x49 = conv(2048, 512, 7 * 7, 1);
+  const Shape s512x49k9 = conv(512, 512, 7 * 7, 9);
+  const Shape s128x784 = conv(512, 128, 28 * 28, 1);
+  const Shape s512x196 = conv(1024, 512, 14 * 14, 1);
+
+  for (int64_t units : {8, 12, 16, 20, 32, 40, 64}) {
+    for (const Shape &s : {s512x49, s512x49k9, s128x784, s512x196}) {
+      const Choice c = conv_tile::select(s, units);
+      REQUIRE(c.kind == Kind::Wmma);
+      // Anything with at least 32 output channels has better uses for a block
+      // than a 16-row tile: doubling the row block halves the gather.
+      REQUIRE(c.bm >= 32);
+      if (c.bm < 32)
+        std::fprintf(stderr, "  units=%lld M=%lld Nout=%lld got %dx%d\n",
+                     (long long)units, (long long)s.MPerGroup,
+                     (long long)s.Nout, c.bm, c.bn);
+    }
+  }
+}
+
+// The narrow rung still has to exist. esrgan's last convolution produces three
+// channels; there is nothing for a wide row block to do, and a 16-row tile
+// over a million output positions covers the device on its columns alone.
+void testGenuinelyNarrowOutputsStillGetTheNarrowTile() {
+  const Shape s = conv(64, 3, 1000 * 1000, 9);
+  for (int64_t units : {8, 16, 20, 32, 64}) {
+    const Choice c = conv_tile::select(s, units);
+    REQUIRE(c.kind == Kind::Wmma);
+    REQUIRE(c.bm == 16);
+    if (c.bm != 16)
+      describe("narrow output", s, c);
+  }
+}
+
+// Depthwise has no output-channel reuse to tile, and is decided before any
+// tile is priced.
+void testDepthwiseIsNotTiled() {
+  for (int64_t units : {1, 16, 20, 64}) {
+    REQUIRE(conv_tile::select(conv(1, 1, 112 * 112, 9, 1, 32), units).kind ==
+            Kind::Depthwise);
+    REQUIRE(conv_tile::select(conv(1, 1, 14 * 14, 9, 1, 576), units).kind ==
+            Kind::Depthwise);
+  }
+  // group == 1 is not depthwise however narrow it is.
+  REQUIRE(conv_tile::select(conv(1, 1, 4096, 9), 20).kind != Kind::Depthwise);
+}
+
+// fp32 and bf16 have no matrix path; they must land on the scalar ladder.
+void testNonHalfNeverPicksMatrixCores() {
+  for (int64_t units : {1, 8, 16, 20, 64}) {
+    for (const Shape &s : modelShapes()) {
+      if (s.wmmaEligible)
+        continue;
+      REQUIRE(conv_tile::select(s, units).kind != Kind::Wmma);
+    }
+  }
+}
+
+// Every choice must be one the kernel can actually be launched with.
+void testChoiceIsAlwaysInstantiable() {
+  for (const Shape &s : modelShapes()) {
+    for (int64_t units = 1; units <= 128; ++units) {
+      const Choice c = conv_tile::select(s, units);
+      if (c.kind == Kind::Depthwise || c.kind == Kind::Direct)
+        continue;
+      const conv_tile::Tile *table =
+          c.kind == Kind::Wmma ? conv_tile::kWmmaTiles : conv_tile::kScalarTiles;
+      const int n = c.kind == Kind::Wmma ? conv_tile::kNumWmmaTiles
+                                         : conv_tile::kNumScalarTiles;
+      bool found = false;
+      for (int i = 0; i < n; ++i)
+        if (table[i].bm == c.bm && table[i].bn == c.bn &&
+            table[i].tm == c.tm && table[i].tn == c.tn)
+          found = true;
+      REQUIRE(found);
+    }
+  }
+}
+
+// A shape must not be selected differently just because it was described with
+// a batch of 4 rather than four separate calls: the batch multiplies the grid,
+// it does not change what a block does.
+void testBatchOnlyAddsParallelism() {
+  for (int64_t units : {16, 20, 64}) {
+    const Choice one = conv_tile::select(conv(96, 96, 64 * 64, 9, 1), units);
+    const Choice four = conv_tile::select(conv(96, 96, 64 * 64, 9, 4), units);
+    // More parallelism must never buy a narrower row block.
+    REQUIRE(four.bm >= one.bm);
+  }
+}
+
+void testNoDegenerateShapeIsRejected() {
+  for (int64_t units : {1, 20, 64}) {
+    for (const Shape &s : modelShapes()) {
+      const Choice c = conv_tile::select(s, units);
+      REQUIRE(c.kind == Kind::Depthwise || c.kind == Kind::Direct ||
+              (c.bm > 0 && c.bn > 0 && c.tm > 0 && c.tn > 0));
+    }
+  }
+}
+
+// HIPDNN_EP_CONV_TILE names a tile and resolve() finds it, which is how the
+// sweep that calibrated the thresholds forces a tile selection rejects. Two
+// entries now share a block shape and differ only in the register tile, so a
+// name has to be able to say which -- otherwise a sweep row silently measures
+// the other one and the number it reports is attributed to the wrong tile.
+void testEveryTileIsReachableByName() {
+  for (bool fp16 : {true, false}) {
+    const Shape s = conv(64, 128, 56 * 56, 9, 1, 1, fp16);
+    const conv_tile::Tile *table =
+        fp16 ? conv_tile::kWmmaTiles : conv_tile::kScalarTiles;
+    const int n = fp16 ? conv_tile::kNumWmmaTiles : conv_tile::kNumScalarTiles;
+    const Kind want = fp16 ? Kind::Wmma : Kind::Tiled;
+    for (int i = 0; i < n; ++i) {
+      Choice c{};
+      REQUIRE(conv_tile::resolve(s, table[i].bm, table[i].bn, table[i].tm,
+                                 table[i].tn, c));
+      REQUIRE(c.kind == want);
+      REQUIRE(c.bm == table[i].bm && c.bn == table[i].bn &&
+              c.tm == table[i].tm && c.tn == table[i].tn);
+    }
+    // The two-field form is still accepted, and takes the first entry listed
+    // for that block shape -- the one selection would have picked.
+    for (int i = 0; i < n; ++i) {
+      Choice c{};
+      REQUIRE(conv_tile::resolve(s, table[i].bm, table[i].bn, 0, 0, c));
+      int first = 0;
+      while (table[first].bm != table[i].bm || table[first].bn != table[i].bn)
+        ++first;
+      REQUIRE(c.tm == table[first].tm && c.tn == table[first].tn);
+    }
+    // A name in the other dtype's table is refused rather than resolved into
+    // a kernel this dtype has no instantiation for.
+    Choice c{};
+    REQUIRE(!conv_tile::resolve(s, 7, 7, 0, 0, c));
+  }
+}
+
+} // namespace
+
+int main() {
+  testRowBlockIsMonotoneInUnits();
+  testBlockCountDoesNotFallAsUnitsGrow();
+  testAgreesAcrossShippingParts();
+  testDeepNarrowOutputsGetAWideRowBlock();
+  testGenuinelyNarrowOutputsStillGetTheNarrowTile();
+  testDepthwiseIsNotTiled();
+  testNonHalfNeverPicksMatrixCores();
+  testChoiceIsAlwaysInstantiable();
+  testBatchOnlyAddsParallelism();
+  testNoDegenerateShapeIsRejected();
+  testEveryTileIsReachableByName();
+
+  if (failures) {
+    std::fprintf(stderr, "\n%d requirement(s) failed\n", failures);
+    return 1;
+  }
+  std::printf("conv tile selection: all checks passed\n");
+  return 0;
+}

--- a/tools/perf-harness/README.md
+++ b/tools/perf-harness/README.md
@@ -1,0 +1,209 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+Licensed under the MIT License.
+-->
+# perf-harness
+
+Find the next thing worth optimising in a prefill, size it before writing any
+kernel code, and prove the change afterwards.
+
+[`tools/rgp_parser`](../rgp_parser) turns one `.rgp` into CSVs. This turns a
+question — *what should I work on next, and did it work?* — into an answer:
+scripts to position and take the capture, to rank candidates by how far each is
+from its own hardware floor, and to A/B the result on real TTFT.
+
+## Setup
+
+Everything resolves from environment variables, with discovery fallbacks:
+
+| variable | meaning |
+|---|---|
+| `HIPEP_BIN` | **required.** Directory with `model_benchmark.exe` and the EP DLLs under test |
+| `HIPEP_MODEL` | **required.** Model directory (the one holding `genai_config.json`) |
+| `HIPEP_PY` | Python interpreter. Default: `python` on `PATH` |
+| `HIPEP_OUT` | Output root. Default: `%TEMP%\hipep-perf` |
+| `HIPEP_PATH_EXTRA` | Extra `PATH` entries the EP needs (ROCm SDK runtime dirs), `;`-separated |
+| `RGP_DIR` | Radeon Developer Tool Suite folder. Only needed if `RadeonDeveloperPanelCLI.exe` is not on `PATH` |
+
+```powershell
+$env:HIPEP_BIN   = 'C:\work\gpu-test-package\bin'
+$env:HIPEP_MODEL = 'C:\models\gpt-oss-20b-webgpu-int4-rtn-block-32'
+pip install -r ..\rgp_parser\requirements.txt
+```
+
+The capture scripts need a build containing the RGP capture fence
+(`rgp_capture_fence` in `lib/Runtime/op_profile.cpp`). It is inert unless
+`RGP_FENCE` is set, so a normal build carries it at no cost.
+
+## The workflow
+
+### 1. Establish a clean baseline
+
+```powershell
+.\bench\bench_ttft.ps1 -Tag baseline -SeqLen 16384
+```
+
+Nothing later means anything without this number, because a capture cannot tell
+you whether a change helped — see [RGP pegs clocks](#rgp-pegs-clocks-a-capture-win-is-not-a-ttft-win).
+
+### 2. Capture the op you care about
+
+A 16k prefill is tens of thousands of dispatches. Positioning a capture on a
+specific one by delay or dispatch index does not survive run-to-run jitter, so
+the runtime fence does it instead: it drains the GPU and idles immediately
+before the op's *N*-th instance, and the script triggers RGP inside that window.
+
+```powershell
+# the 37th qmoe instance -- deep enough that the autotuner has settled
+.\capture\rgp_capture.ps1 -Op qmoe -Skip 36 -Counters -Buf minimum -Reps 16 -Tag shallow
+```
+
+`-Counters` turns on SPM. Without it every dispatch classifies as
+`compute-or-memory (undetermined)`, so take it unless you know you don't need
+bandwidth. `-Skip` is the whole game — see
+[fence position](#fence-position-is-part-of-the-measurement).
+
+### 3. Check what you actually captured
+
+```powershell
+python .\analysis\inspect_capture.py $env:TEMP\hipep-perf\captures\shallow_dispatches.csv
+```
+
+`rgp_capture.ps1` already gates on chunk inventory via `verify_rgp.py`, but that
+only proves the file is decodable, not that it holds steady-state work. This
+does.
+
+### 4. Attribute, model, and rank
+
+```powershell
+cd analysis
+# where the time sits, and which region each int4 kernel served
+python attrib_regions.py ...\shallow_dispatches.csv
+
+# one chunk -> the whole prefill, using a shallow and a deep capture
+python prefill_model.py ...\shallow_dispatches.csv ...\deep_dispatches.csv `
+       --at-chunk 2.5 31.5 --measured-ttft-s 9.04
+
+# the ranking that decides what to work on
+python headroom.py ...\shallow_dispatches.csv ...\deep_dispatches.csv `
+       --dense-ms 31.9 --lm-head-ms 18.8 --attention-s 1.75 --prefill-s 8.53
+```
+
+The three earlier scripts print the exact arguments the next one wants.
+
+### 5. Change one thing, then prove it
+
+```powershell
+'{ "base": { "dll": "D:\\base\\custom_kernels_gfx1151.dll" },
+   "cand": { "dll": "D:\\cand\\custom_kernels_gfx1151.dll" } }' | Set-Content arms.json
+
+.\bench\ab_interleaved.ps1 -Manifest arms.json -Rounds 6 -Reps 4
+.\bench\ab_interleaved.ps1 -Manifest arms.json -Rounds 3 -Reps 4 -StartRound 7 -Reverse -SkipPrime
+python .\bench\ab_summary.py $env:TEMP\hipep-perf\ttft\ttft_summary.csv --baseline base
+```
+
+## Rules that are not optional
+
+Each of these is here because ignoring it produced a confident wrong answer.
+
+### Never measure throughput with the EP's own profiler
+
+`HIPDNN_EP_PERF=1` costs about 4% on its own, which is larger than most changes
+worth shipping. SQTT is hardware thread tracing and perturbs far less, so it
+carries the timing. The harness clears `HIPDNN_EP_PERF` and `HIPDNN_EP_DEBUG`
+before every run rather than trusting the shell to be clean.
+
+### Rank by utilisation, not by share of runtime
+
+A percentage of runtime says where time *goes*, not where it is *wasted*. The op
+with the largest share is frequently the one closest to the hardware limit, and
+ranking that way sends you to work on it. `headroom.py` instead computes, for
+each component, the floor its own work implies — `max(bytes/BW, FLOP/peak)` —
+and ranks by the gap.
+
+On gpt-oss-20b this inverted the answer. The largest share was MoE experts at
+51.6% of prefill; they were already running at reasonable efficiency. The real
+finds were a tier of small-M expert blocks at **18% of floor**, and an `lm_head`
+computing logits for all 512 rows of every chunk when only the last row is ever
+read — 0.60 s of work that should not run at all, invisible to a share ranking
+because it was only 7% of runtime.
+
+### Use published ceilings, not the best rate you happened to see
+
+Taking "the best rate observed" as the ceiling is circular: if the whole stack
+misses a ceiling, that ceiling never appears in the data. Derive it and check
+the derivation against a part with published numbers. The gfx1151 figure here is
+40 CU × 2.9 GHz × 512 FLOP/clk = 59.4 TFLOP/s; the same model gives 122.9
+TFLOP/s for a 7900 XTX against AMD's published 122.8, which is what makes it
+trustworthy. (`hipInfo` reports `multiProcessorCount=20` — those are WGPs, two
+CUs each. Halving the CU count halves the ceiling and doubles every utilisation
+number in the report.)
+
+### Fence position is part of the measurement
+
+Fencing on the first instance of an op lands before the autotuner has settled.
+One capture taken that way was 91.6% GQA — 527 consecutive dispatches cycling
+four configurations — and every timing in it was a tuning trial. It looked
+entirely valid. Use `-Skip` to reach steady state, and run `inspect_capture.py`,
+which looks for exactly this signature.
+
+### RGP pegs clocks: a capture win is not a TTFT win
+
+Under capture the clocks are pinned at peak, so redundant arithmetic is free.
+Work that costs power — and therefore sustained clocks — in production shows up
+as free in the trace.
+
+This is not theoretical. Lowering the GEMV→WMMA cutoff to M=2 improved the
+targeted blocks by 12.5% in RGP, with untouched control buckets steady at 3% and
+0.4%, predicting roughly a 73 ms TTFT win. Measured on TTFT it was **47 ms
+slower**: WMMA computes 16-row tiles regardless of M, and on a power-managed APU
+that waste depresses clocks for everything else. An intermediate cutoff of M=8
+kept the read-efficiency win without the waste and landed at −211 ms.
+
+So: captures rank candidates and explain mechanisms. Only TTFT decides.
+
+### Interleave, reverse, and discard the warm-up
+
+Run-to-run spread is comparable to the effects worth shipping, so
+block-sequential runs let drift land entirely on one arm. `ab_interleaved.ps1`
+alternates arms and pairs by round; `ab_summary.py` reports the interval over
+the paired differences. Always run one block with `-Reverse`: if the sign flips,
+you measured position and not the change. Discard rounds taken while the machine
+is shedding heat from a build — judge that from the absolute level against a
+known baseline, never by dropping rounds that disagree.
+
+### Give each arm its own autotune cache
+
+The on-disk WMMA tuner cache holds a single build timestamp and is discarded
+when it doesn't match. Arms sharing one `TEMP` therefore make every DLL swap a
+cold-tune run, and you measure tuning instead of the kernel.
+`ab_interleaved.ps1` gives each arm its own `TEMP`.
+
+### Keep the process alive long enough to dump
+
+RGP streams the trace out of the *live* process. A late-positioned fence can
+leave too little runtime for a large dump, which stalls part-written and
+produces no file at all. That is what `-Reps` is for; it is not extra
+measurement.
+
+## Files
+
+| | |
+|---|---|
+| `common.ps1` | Environment resolution shared by the PowerShell scripts |
+| `capture/rgp_capture.ps1` | Take one capture — fence-positioned or auto-triggered, ± SPM — and decode it |
+| `capture/verify_rgp.py` | Fail a capture missing `SqttData`/`SpmCounterData` before anything reads it |
+| `bench/bench_ttft.ps1` | One clean TTFT run, appended to CSV |
+| `bench/ab_interleaved.ps1` | Interleaved, order-reversed A/B across DLL variants |
+| `bench/ab_summary.py` | Paired statistics over the rounds |
+| `analysis/perfcommon.py` | Model/device constants and dispatch-stream segmentation |
+| `analysis/inspect_capture.py` | What is in this capture, and is it steady state |
+| `analysis/attrib_regions.py` | Split kernel time between the MoE loop and dense projections |
+| `analysis/expert_blocks.py` | Per-M-bucket expert cost vs floor; which kernel each bucket used |
+| `analysis/prefill_model.py` | Two capture depths → whole-prefill composition |
+| `analysis/headroom.py` | Rank candidates by recoverable seconds |
+
+The analysis scripts default to gpt-oss-20b shapes and gfx1151 ceilings; both
+are overridable (`--hidden`, `--vocab`, `--layers`, `--bw-gbs`, `--peak-tflops`).
+The structural segmentation — regions, layers, expert token counts — is
+recovered from the dispatch stream itself and carries no model assumptions.

--- a/tools/perf-harness/README.md
+++ b/tools/perf-harness/README.md
@@ -110,8 +110,17 @@ Each of these is here because ignoring it produced a confident wrong answer.
 
 `HIPDNN_EP_PERF=1` costs about 4% on its own, which is larger than most changes
 worth shipping. SQTT is hardware thread tracing and perturbs far less, so it
-carries the timing. The harness clears `HIPDNN_EP_PERF` and `HIPDNN_EP_DEBUG`
-before every run rather than trusting the shell to be clean.
+carries the timing. The harness clears `HIPDNN_EP_PERF`, `HIPDNN_EP_DEBUG` and
+`HIPDNN_EP_TRACE_FILE` before every run rather than trusting the shell to be
+clean.
+
+`HIPDNN_EP_TRACE_FILE` is the dangerous one. `hipdnn_ep_perf_enabled()` is true
+for it as well as for `HIPDNN_EP_PERF`, so it enables the profiler while
+printing none of PERF's console output, and it survives in the shell after the
+capture that wanted it. A 16K VLM baseline was reported as 17,587 ms for a
+whole round of analysis on that basis; the same binaries measure 14,455-14,610
+ms once the variable is gone, and re-setting it reproduces 17,545 ms on demand.
+Cross-check any suspicious baseline by re-running it in a fresh shell.
 
 ### Rank by utilisation, not by share of runtime
 

--- a/tools/perf-harness/analysis/attrib_regions.py
+++ b/tools/perf-harness/analysis/attrib_regions.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Split kernel time between the MoE expert loop and the dense projections.
+
+The kernel name alone cannot attribute anything here: the same MatMulNBits*
+kernels serve the experts and the QKV/o_proj/router projections, so a rollup by
+kernel silently merges two very different workloads -- one running at M=1..2000
+per expert, the other always at the full chunk. The dispatch stream can
+attribute, because the MoE region is bracketed structurally: topk_routing opens
+it, and the attention/layernorm kernels that never appear inside the expert loop
+close it. No instrumentation involved.
+
+The per-chunk numbers this prints are the `--dense-ms` and `--lm-head-ms` inputs
+to headroom.py.
+"""
+
+import argparse
+from collections import defaultdict
+
+from perfcommon import INT4_FAMILIES, Capture, add_common_args, specs_from_args
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    add_common_args(ap, many=True)
+    args = ap.parse_args()
+    spec, _ = specs_from_args(args)
+
+    for path in args.captures:
+        cap = Capture(path, spec)
+        k = cap.layer_scale
+        by_region: dict[str, float] = defaultdict(float)
+        int4_us: dict[tuple[str, str], float] = defaultdict(float)
+        int4_n: dict[tuple[str, str], int] = defaultdict(int)
+
+        for i, r in enumerate(cap.rows):
+            fam, dur = r["family"], float(r["dur_us"])
+            reg = "lm_head" if i in cap.lm_head_idx else cap.regions[i]
+            by_region[reg] += dur
+            if fam in INT4_FAMILIES:
+                int4_us[(reg, fam)] += dur
+                int4_n[(reg, fam)] += 1
+
+        total = cap.total_us
+        # lm_head runs once per chunk; everything else scales with the layer stack.
+        chunk_us = (total - cap.lm_head_us) * k + cap.lm_head_us
+
+        print(f"\n######## {path}")
+        print(f"window {total/1000:.1f} ms over {len(cap.rows)} dispatches, "
+              f"{cap.layers_in_window} layer-groups -> x{k:.2f}")
+        print(f"{'region':10} {'window ms':>10} {'%window':>8} {'ms/chunk':>10}")
+        for reg in ("qmoe", "dense", "lm_head"):
+            us = by_region.get(reg, 0.0)
+            if not us:
+                continue
+            per_chunk = us if reg == "lm_head" else us * k
+            print(f"{reg:10} {us/1000:10.1f} {100*us/total:8.1f} {per_chunk/1000:10.1f}")
+        print(f"{'chunk':10} {'':>10} {'':>8} {chunk_us/1000:10.1f}")
+
+        print(f"\n--- int4 stack by region ---")
+        print(f"{'region':8} {'kernel':32} {'count':>6} {'ms':>9} {'%window':>8}")
+        for (reg, fam), us in sorted(int4_us.items(), key=lambda kv: -kv[1]):
+            print(f"{reg:8} {fam:32} {int4_n[(reg, fam)]:6d} {us/1000:9.2f} {100*us/total:8.2f}")
+
+        q = sum(v for (reg, _), v in int4_us.items() if reg == "qmoe")
+        d = sum(v for (reg, _), v in int4_us.items() if reg == "dense")
+        lm = sum(v for (reg, _), v in int4_us.items() if reg == "lm_head")
+        tot4 = q + d + lm
+        if tot4:
+            print(f"\nint4 stack = {100*tot4/total:.1f}% of the window "
+                  f"(qmoe {100*q/tot4:.1f}%, dense {100*d/tot4:.1f}%, lm_head {100*lm/tot4:.1f}% "
+                  f"of the stack)")
+        # headroom.py's dense floor is built from the QKV/o_proj/router weights,
+        # so it must be fed the int4 projection time -- not the whole dense
+        # region, which also carries attention, layernorm and rope.
+        print(f"\nfeed headroom.py:  --dense-ms {d*k/1000:.1f} "
+              f"--lm-head-ms {cap.lm_head_us/1000:.1f}")
+        print(f"  (dense int4 projections only; the full dense region incl. attention "
+              f"is {by_region.get('dense', 0)*k/1000:.1f} ms/chunk)")
+
+        print(f"\n--- expert blocks: {len(cap.blocks)} ---")
+        paths: dict[str, list] = defaultdict(lambda: [0, 0.0, 0])
+        for b in cap.blocks:
+            key = "+".join(sorted(b.kernels)) or "(none)"
+            paths[key][0] += 1
+            paths[key][1] += b.dur_us
+            paths[key][2] += b.m
+        for key, (n, us, toks) in sorted(paths.items(), key=lambda kv: -kv[1][1]):
+            print(f"  {key:45} n={n:4d}  {us/1000:8.2f} ms  mean {us/n:7.1f} us  "
+                  f"mean M {toks/n:7.1f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/perf-harness/analysis/expert_blocks.py
+++ b/tools/perf-harness/analysis/expert_blocks.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Per-M-bucket cost of MoE expert blocks, against the bandwidth floor.
+
+This is the report that tells you whether a dispatch-threshold change in
+matmul_nbits_kernel.hip did anything. Buckets straddle the routing thresholds,
+and the `path` column names the kernels each bucket actually landed on, so a
+threshold move shows up as a bucket changing kernel.
+
+Read it with two cautions:
+
+  - Compare us/blk at matched mean M, not the per-chunk totals. Routing is
+    input-dependent, so two captures of the same build see different numbers of
+    blocks per bucket; only the per-block cost is comparable.
+  - Treat the buckets whose kernel did not change as controls. If they drift as
+    much as the bucket you changed, you measured noise.
+"""
+
+import argparse
+from collections import defaultdict
+
+from perfcommon import (M_BUCKETS, Capture, add_common_args, bucket_label,
+                        specs_from_args)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    add_common_args(ap, many=True)
+    ap.add_argument("--shapes", action="store_true",
+                    help="also list the routing distribution block by block")
+    args = ap.parse_args()
+    spec, dev = specs_from_args(args)
+
+    for path in args.captures:
+        cap = Capture(path, spec)
+        k = cap.layer_scale
+        chunk_us = (cap.total_us - cap.lm_head_us) * k + cap.lm_head_us
+        floor_us = spec.expert_weight_bytes / dev.bw_bytes_s * 1e6
+
+        print(f"\n######## {path}")
+        print(f"window {cap.total_us/1000:.1f} ms, {len(cap.rows)} dispatches, "
+              f"{cap.layers_in_window} layer-groups -> x{k:.2f} for {spec.layers} layers")
+        print(f"reconstructed chunk ({spec.chunk_tokens} tok): {chunk_us/1000:.1f} ms"
+              + (f"  (incl. lm_head {cap.lm_head_us/1000:.1f} ms)" if cap.lm_head_us else ""))
+        print(f"one expert = {spec.expert_weight_bytes/1e6:.1f} MB of weights+scales "
+              f"-> {floor_us:.1f} us at {dev.bw_bytes_s/1e9:.0f} GB/s\n")
+
+        print(f"{'M range':>10} {'blocks':>7} {'tokens':>7} {'ms/chunk':>9} {'%chunk':>7} "
+              f"{'us/blk':>8} {'mean M':>7} {'x floor':>8} {'eff GB/s':>9}  path")
+        for lo, hi in M_BUCKETS:
+            sel = [b for b in cap.blocks if lo <= b.m <= hi]
+            if not sel:
+                continue
+            us = sum(b.dur_us for b in sel)
+            mean = us / len(sel)
+            toks = sum(b.m for b in sel)
+            paths = defaultdict(int)
+            for b in sel:
+                paths["+".join(sorted(x.replace("MatMulNBits", "") for x in b.kernels))] += 1
+            pretty = " ".join(f"{n}x{c}" for n, c in sorted(paths.items(), key=lambda kv: -kv[1]))
+            print(f"{bucket_label(lo, hi):>10} {len(sel):7d} {toks:7d} {us*k/1000:9.2f} "
+                  f"{100*us*k/chunk_us:7.2f} {mean:8.1f} {toks/len(sel):7.1f} "
+                  f"{mean/floor_us:8.2f} {spec.expert_weight_bytes/mean/1e3:9.0f}  {pretty}")
+
+        small = [b for b in cap.blocks if b.m <= 63]
+        if small and cap.blocks:
+            tok_all = sum(b.m for b in cap.blocks)
+            print(f"\nM<=63: {len(small)}/{len(cap.blocks)} blocks, "
+                  f"{100*sum(b.m for b in small)/tok_all:.1f}% of routed tokens, "
+                  f"{100*sum(b.dur_us for b in small)*k/chunk_us:.1f}% of a chunk")
+
+        # Same expert size, two different paths: does skipping the fused dequant
+        # actually pay? Only comparable within one bucket.
+        big = [b for b in cap.blocks if b.m >= 256]
+        fused = [b for b in big if b.dequant_us == 0]
+        split = [b for b in big if b.dequant_us > 0]
+        if fused and split:
+            print("\n=== fused WMMA vs dequant+Fp16GEMM at the same expert size (M>=256) ===")
+            for label, sel in (("fused WMMA only", fused), ("dequant + Fp16GEMM", split)):
+                us = sum(b.dur_us for b in sel)
+                tok = sum(b.m for b in sel)
+                print(f"  {label:22} n={len(sel):3d}  meanM={tok/len(sel):6.1f}  "
+                      f"{us/len(sel):8.1f} us/block  {us/tok:6.2f} us/token  "
+                      f"dequant {sum(b.dequant_us for b in sel)/len(sel):6.1f} us/block")
+
+        if args.shapes:
+            print("\n=== routing distribution ===")
+            hist = defaultdict(int)
+            for b in cap.blocks:
+                hist[b.m] += 1
+            for m in sorted(hist):
+                print(f"  M={m:<6d} {hist[m]:4d} blocks")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/perf-harness/analysis/headroom.py
+++ b/tools/perf-harness/analysis/headroom.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Rank optimisation candidates by under-utilisation, not by share of runtime.
+
+A percentage of runtime says where time goes, not where it is wasted. An op can
+be half the prefill and already sit at the hardware limit, and another can be
+small and entirely unnecessary. So for each component this computes the floor
+its own work implies -- max(bytes/BW, FLOP/peak) -- then reports utilisation
+against that floor and the seconds between the two.
+
+Two things the output is not:
+
+  - The rows are floors in isolation, so their sum is a bound on a bound, not an
+    achievable target. Use the table to order candidates by room, not to predict
+    a result.
+  - A floor says nothing about how hard the room is to take. The last column is
+    a judgement, and it is usually what decides what to work on.
+"""
+
+import argparse
+from collections import defaultdict
+
+from perfcommon import (
+    M_BUCKETS,
+    Capture,
+    add_common_args,
+    bucket_label,
+    specs_from_args,
+)
+
+
+def block_floor(spec, dev, m: int) -> tuple[float, float, float]:
+    """Seconds, bytes, FLOP for one expert block serving m tokens.
+
+    Weights once, plus the activation traffic the block's own kernels move
+    (gather, both GEMM's io, bias/swiglu, scatter). The dequantised-weight round
+    trip that the non-fused path pays is deliberately NOT here: it is a
+    consequence of the chosen path, not of the work, so it belongs on the
+    headroom side of the ledger rather than in the floor.
+    """
+    h, inter = spec.hidden, spec.inter
+    act = (
+        spec.fp16(m * h) * 2
+        + spec.fp16(m * h)
+        + spec.fp16(m * 2 * inter) * 5
+        + spec.fp16(m * h) * 6
+    )
+    byts = spec.expert_weight_bytes + act
+    flop = spec.expert_flop_per_token * m
+    return dev.floor_s(byts, flop), byts, flop
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    add_common_args(ap, many=True)
+    ap.add_argument(
+        "--dense-ms",
+        type=float,
+        required=True,
+        help="measured dense projection ms per chunk (from attrib_regions.py)",
+    )
+    ap.add_argument(
+        "--lm-head-ms",
+        type=float,
+        default=None,
+        help="measured lm_head ms per chunk; omit on models where the "
+        "prefill lm_head has already been pruned to the last row",
+    )
+    ap.add_argument(
+        "--attention-s",
+        type=float,
+        required=True,
+        help="measured attention seconds over the whole prefill "
+        "(from prefill_model.py, which needs two capture depths)",
+    )
+    ap.add_argument(
+        "--prefill-s",
+        type=float,
+        required=True,
+        help="modelled or measured whole-prefill seconds, for the %% column",
+    )
+    args = ap.parse_args()
+    spec, dev = specs_from_args(args)
+    caps = [Capture(p, spec) for p in args.captures]
+    n = len(caps)
+
+    print(
+        f"ceilings: {dev.peak_flops / 1e12:.1f} TFLOP/s fp16, {dev.bw_bytes_s / 1e9:.0f} GB/s"
+    )
+    print(
+        f"one expert: {spec.expert_weight_bytes / 1e6:.1f} MB of weights "
+        f"-> {spec.expert_weight_bytes / dev.bw_bytes_s * 1e6:.1f} us\n"
+    )
+
+    print("=== MoE expert blocks: measured vs the floor its own work implies ===")
+    print(
+        f"{'M':>10} {'blk/chunk':>9} {'meas ms':>8} {'floor ms':>9} {'binding':>10} "
+        f"{'util':>6} {'headroom s':>11}"
+    )
+    m_all = f_all = small_m = small_f = 0.0
+    for lo, hi in M_BUCKETS:
+        meas = fl = nb = 0.0
+        bind: dict[str, int] = defaultdict(int)
+        for cap in caps:
+            k = cap.layer_scale / n
+            sel = [b for b in cap.blocks if lo <= b.m <= hi]
+            meas += sum(b.dur_us for b in sel) * k
+            nb += len(sel) * k
+            for b in sel:
+                f, byts, flop = block_floor(spec, dev, b.m)
+                fl += f * 1e6 * k
+                bind[
+                    "compute"
+                    if flop / dev.peak_flops > byts / dev.bw_bytes_s
+                    else "bandwidth"
+                ] += 1
+        if not nb:
+            continue
+        m_all += meas
+        f_all += fl
+        if hi <= 63:
+            small_m += meas
+            small_f += fl
+        b = max(bind, key=bind.get)
+        print(
+            f"{bucket_label(lo, hi):>10} {nb:9.0f} {meas / 1000:8.1f} {fl / 1000:9.1f} "
+            f"{b:>10} {100 * fl / meas:5.0f}% {(meas - fl) * spec.chunks / 1e6:11.2f}"
+        )
+    print(
+        f"{'all':>10} {'':>9} {m_all / 1000:8.1f} {f_all / 1000:9.1f} {'':>10} "
+        f"{100 * f_all / m_all:5.0f}% {(m_all - f_all) * spec.chunks / 1e6:11.2f}"
+    )
+
+    # --- the rest of the chunk -------------------------------------------
+    print("\n=== the rest, per chunk ===")
+    c = spec.chunk_tokens
+    dense_b = spec.layers * (
+        spec.int4w(spec.hidden * spec.qkv_n)
+        + spec.int4w(spec.o_proj_k * spec.hidden)
+        + spec.int4w(spec.hidden * spec.router_n)
+        + spec.fp16(c * spec.qkv_n)
+        + spec.fp16(c * spec.hidden) * 4
+    )
+    dense_f = (
+        spec.layers
+        * 2
+        * c
+        * (
+            spec.hidden * spec.qkv_n
+            + spec.o_proj_k * spec.hidden
+            + spec.hidden * spec.router_n
+        )
+    )
+    lm_b = spec.int4w(spec.vocab * spec.hidden) + spec.fp16(c * spec.vocab)
+    lm_f = 2 * c * spec.hidden * spec.vocab
+
+    print(
+        f"{'component':42} {'meas ms':>8} {'floor ms':>9} {'binding':>10} {'util':>6} "
+        f"{'headroom s':>11}"
+    )
+    rest = [
+        ("dense projections (QKV, o_proj, router)", args.dense_ms, dense_b, dense_f)
+    ]
+    if args.lm_head_ms is not None:
+        rest.append(("lm_head (as executed, all rows)", args.lm_head_ms, lm_b, lm_f))
+    for name, meas, byts, flop in rest:
+        fb, fc = byts / dev.bw_bytes_s * 1e3, flop / dev.peak_flops * 1e3
+        fl = max(fb, fc)
+        print(
+            f"{name:42} {meas:8.1f} {fl:9.1f} {('compute' if fc > fb else 'bandwidth'):>10} "
+            f"{100 * fl / meas:5.0f}% {(meas - fl) * spec.chunks / 1e3:11.2f}"
+        )
+
+    # Attention floor: the QK^T and PV matmuls, plus the KV that has to be
+    # streamed. The two layer groups cannot share one floor -- a global layer
+    # attends to the whole context with kv2 x 512, a sliding layer to a fixed
+    # window with kv8 x 256, so they differ in both how much they read and how
+    # that grows with context. Summing one group's geometry over all 30 layers
+    # is what made this floor wrong before.
+    # Softmax/exp is real work this omits, so the utilisation is a LOWER bound
+    # and is not comparable to the GEMM rows above.
+    nfull = spec.full_attn_layers
+    nslide = spec.layers - nfull
+
+    # Global layers: context grows one chunk at a time, so both the FLOPs and
+    # the KV read grow linearly with chunk index.
+    ctx = [i * c for i in range(1, spec.chunks + 1)]
+    full_flop = sum(nfull * 2 * 2 * c * t * spec.heads * spec.full_hd for t in ctx)
+    full_kv_b = sum(nfull * t * spec.full_kv * spec.full_hd * 2 * 2 for t in ctx)
+
+    # Sliding layers: each query sees at most `sliding_window` keys, so the cost
+    # per chunk is constant once the window is full.
+    win = [min(t, spec.sliding_window) for t in ctx]
+    slide_flop = sum(nslide * 2 * 2 * c * w * spec.heads * spec.head_dim for w in win)
+    slide_kv_b = sum(nslide * w * spec.kv_heads * spec.head_dim * 2 * 2 for w in win)
+
+    att_bytes, att_flop = full_kv_b + slide_kv_b, full_flop + slide_flop
+    att_floor_s = dev.floor_s(att_bytes, att_flop)
+    att_bind = (
+        "compute"
+        if att_flop / dev.peak_flops > att_bytes / dev.bw_bytes_s
+        else "bandwidth"
+    )
+    print(
+        f"\n   attention floor: {nfull} global (kv{spec.full_kv} x {spec.full_hd}, "
+        f"full context) + {nslide} sliding (kv{spec.kv_heads} x {spec.head_dim}, "
+        f"window {spec.sliding_window})"
+    )
+    print(
+        f"{'attention over the whole prefill':42} {args.attention_s * 1e3:8.1f} "
+        f"{att_floor_s * 1e3:9.1f} {att_bind:>10} {100 * att_floor_s / args.attention_s:5.0f}% "
+        f"{args.attention_s - att_floor_s:11.2f}"
+    )
+    print("   (matmul FLOPs only -- softmax/exp is real work this floor omits, so")
+    print("    the utilisation is a lower bound, not comparable to the GEMM rows)")
+
+    print("\n=== recoverable seconds, ranked ===")
+    dense_fl_s = max(dense_b / dev.bw_bytes_s, dense_f / dev.peak_flops) * 1e3
+    items = [
+        (
+            "MoE experts, large M (ordinary GEMM efficiency)",
+            ((m_all - small_m) - (f_all - small_f)) * spec.chunks / 1e6,
+            "hard",
+        ),
+        (
+            "MoE experts, small M (structural: per-expert launch)",
+            (small_m - small_f) * spec.chunks / 1e6,
+            "new kernel",
+        ),
+        (
+            "dense projections",
+            (args.dense_ms - dense_fl_s) * spec.chunks / 1e3,
+            "medium",
+        ),
+        (
+            "attention (floor omits softmax; upper bound)",
+            args.attention_s - att_floor_s,
+            "already worked",
+        ),
+    ]
+    if args.lm_head_ms is not None:
+        items.append(
+            (
+                "lm_head: rows whose logits are never read",
+                args.lm_head_ms * spec.chunks / 1e3 - lm_b / dev.bw_bytes_s,
+                "delete it",
+            )
+        )
+    print(f"{'':52} {'s':>6} {'% of prefill':>13}  cost to take")
+    for name, s, cost in sorted(items, key=lambda x: -x[1]):
+        print(f"{name:52} {s:6.2f} {100 * s / args.prefill_s:13.1f}  {cost}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/perf-harness/analysis/inspect_capture.py
+++ b/tools/perf-harness/analysis/inspect_capture.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""First look at a capture: is this actually the workload you meant to measure?
+
+Run this before any analysis. A capture can be perfectly valid -- SqttData
+present, kernels symbolised, totals plausible -- and still be worthless because
+of where it landed. Two failure modes this catches, both of which have produced
+confident wrong answers:
+
+  autotune sweep   Fencing on the first instance of an op can land before the
+                   tuner has settled. The window then shows hundreds of
+                   consecutive dispatches of one kernel cycling through a handful
+                   of configurations. Those are tuning trials, not steady state,
+                   and their timings mean nothing. Re-capture with a larger
+                   --skip.
+  wrong depth      Attention cost depends on how much context exists, so a
+                   capture's chunk position has to be known before its attention
+                   numbers can be used. The layer stride and the KV-dependent
+                   spread give it away.
+
+Also cross-checks the model config when one is given, which is how you confirm
+things like lm_head really running over the full vocabulary for every row.
+"""
+
+import argparse
+import json
+from collections import Counter, defaultdict
+
+from perfcommon import Capture, add_common_args, specs_from_args
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    add_common_args(ap, many=True)
+    ap.add_argument("--genai-config", help="genai_config.json to cross-check shapes against")
+    ap.add_argument("--sweep-threshold", type=int, default=40,
+                    help="consecutive same-kernel dispatches that look like a tuner sweep")
+    args = ap.parse_args()
+    spec, _ = specs_from_args(args)
+
+    for path in args.captures:
+        cap = Capture(path, spec)
+        print(f"\n######## {path}")
+        print(f"{len(cap.rows)} dispatches, {cap.total_us/1000:.1f} ms, "
+              f"{cap.layers_in_window} topk_routing (layer groups)")
+
+        tk = [i for i, r in enumerate(cap.rows) if r["family"] == "topk_routing"]
+        if len(tk) > 1:
+            strides = [b - a for a, b in zip(tk, tk[1:])]
+            print(f"layer starts at {tk[:8]}{' ...' if len(tk) > 8 else ''}  "
+                  f"stride {min(strides)}..{max(strides)}")
+
+        # --- runaway repetition: the tuner-sweep signature --------------------
+        runs, cur, n = [], None, 0
+        for r in cap.rows:
+            if r["family"] == cur:
+                n += 1
+            else:
+                if cur is not None and n >= args.sweep_threshold:
+                    runs.append((cur, n))
+                cur, n = r["family"], 1
+        if cur is not None and n >= args.sweep_threshold:
+            runs.append((cur, n))
+        if runs:
+            print("\n!! long consecutive runs of one kernel -- check for a tuner sweep:")
+            for fam, count in runs:
+                durs = [float(r["dur_us"]) for r in cap.rows if r["family"] == fam]
+                distinct = len({round(d, 1) for d in durs})
+                share = 100 * sum(durs) / cap.total_us
+                print(f"   {fam:34} {count:5d} in a row, {share:5.1f}% of the window, "
+                      f"{distinct} distinct durations")
+            print("   One kernel running back to back and dominating the window is the")
+            print("   autotuner working through configurations, not steady state -- the")
+            print("   durations are trials. Re-capture with a larger --skip.")
+        else:
+            print("no runaway kernel repetition (no obvious tuner sweep)")
+
+        # --- the big dispatches ----------------------------------------------
+        big = sorted(((float(r["dur_us"]), r["family"], int(r["threads"]))
+                      for r in cap.rows), reverse=True)[:8]
+        print(f"\n{'longest dispatches':34} {'us':>9} {'threads':>12}")
+        for dur, fam, threads in big:
+            print(f"  {fam:32} {dur:9.1f} {threads:12d}")
+        if cap.lm_head_idx:
+            print(f"lm_head: {len(cap.lm_head_idx)} dispatch(es), {cap.lm_head_us/1000:.1f} ms, "
+                  f"threads={int(cap.rows[cap.lm_head_idx[0]]['threads']):,}")
+
+        # --- expert routing spread -------------------------------------------
+        if cap.blocks:
+            ms = sorted(b.m for b in cap.blocks)
+            print(f"\nexpert blocks {len(cap.blocks)}: M from {ms[0]} to {ms[-1]}, "
+                  f"median {ms[len(ms)//2]}, {sum(ms)} routed tokens")
+
+        # --- parser-flagged artifacts ----------------------------------------
+        if cap.rows and "is_artifact" in cap.rows[0]:
+            flags = Counter(r["is_artifact"] for r in cap.rows)
+            art = [r for r in cap.rows if r["is_artifact"] not in ("0", "False", "false", "")]
+            print(f"\nis_artifact {dict(flags)}"
+                  + (f" -- {len(art)} flagged, "
+                     f"{100*sum(float(r['dur_us']) for r in art)/cap.total_us:.1f}% of the window"
+                     if art else ""))
+
+        # --- config cross-check -----------------------------------------------
+        if args.genai_config:
+            cfg = json.load(open(args.genai_config))
+            model = cfg.get("model", {})
+            dec = model.get("decoder", {})
+            print(f"\nconfig: vocab={model.get('vocab_size')} "
+                  f"hidden={dec.get('hidden_size')} layers={dec.get('num_hidden_layers')}")
+            for out in dec.get("outputs", {}).items():
+                print(f"  output {out[0]}: {out[1]}")
+
+        fams: dict[str, list] = defaultdict(lambda: [0, 0.0])
+        for r in cap.rows:
+            fams[r["family"]][0] += 1
+            fams[r["family"]][1] += float(r["dur_us"])
+        print(f"\n{'family':36} {'n':>6} {'ms':>9} {'%':>7}")
+        for fam, (n, us) in sorted(fams.items(), key=lambda kv: -kv[1][1])[:14]:
+            print(f"{fam:36} {n:6d} {us/1000:9.2f} {100*us/cap.total_us:7.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/perf-harness/analysis/perfcommon.py
+++ b/tools/perf-harness/analysis/perfcommon.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Shared model/device constants and dispatch-stream segmentation.
+
+The analysis scripts all start from one `*_dispatches.csv` emitted by
+tools/rgp_parser. That CSV has no notion of layers, MoE regions or expert token
+counts -- it is a flat list of dispatches. Everything structural here is
+recovered from the stream itself, with no instrumentation in the build:
+
+  region      topk_routing opens the MoE region; the attention/layernorm kernels
+              that never appear inside the expert loop close it.
+  expert M    the gather_tokens opening each expert block launches
+              ceil(M*hidden/256)*256 threads, so M = round(threads/hidden).
+  lm_head     the only MatMulNBits dispatch with a vocab-sized thread count.
+  layers      one topk_routing per layer, so a partial capture window can be
+              scaled to a whole layer stack.
+
+That matters because the alternative -- HIPDNN_EP_PERF -- costs about 4% and is
+forbidden for throughput work.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Device:
+    """Ceilings for the part under test, not best-observed rates.
+
+    Ranking by best-observed rate is circular: it hides a ceiling the whole
+    stack is missing. Defaults are Radeon 8060S / gfx1151 (Strix Halo).
+
+    compute   40 CU RDNA 3.5 @ 2.9 GHz x 512 FLOP/clk/CU = 59.4 TFLOP/s fp16.
+              The same model gives 122.9 TFLOP/s for a 7900 XTX against AMD's
+              published 122.8, which is the check that it is the right model.
+              Note hipInfo reports multiProcessorCount=20: those are WGPs, two
+              CUs each.
+    bandwidth 256-bit LPDDR5X-8000 = 256 GB/s.
+    """
+
+    bw_bytes_s: float = 256e9
+    peak_flops: float = 59.4e12
+
+    def floor_s(self, byts: float, flop: float) -> float:
+        """Lower bound on time for work that must move `byts` and do `flop`."""
+        return max(byts / self.bw_bytes_s, flop / self.peak_flops)
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    """Shapes needed to turn a dispatch stream into work. Defaults: gpt-oss-20b."""
+
+    hidden: int = 2880
+    inter: int = 2880
+    vocab: int = 201088
+    layers: int = 24
+    qkv_n: int = 5120
+    o_proj_k: int = 4096
+    router_n: int = 32
+    experts: int = 32
+    topk: int = 4
+    group_size: int = 32  # int4 quant block -> one fp16 scale per N weights
+    chunk_tokens: int = 512  # chunked prefill granularity
+    chunks: int = 32  # 16k prefill = 32 chunks
+    heads: int = 64
+    kv_heads: int = 8
+    head_dim: int = 64
+    sliding_window: int = 128
+    full_attn_layers: int = 12  # the rest are sliding-window
+    # Gemma-4 gives its global-attention layers a different KV geometry from its
+    # sliding ones, so the floor cannot assume one kv_heads/head_dim for all
+    # layers. These default to the sliding values, i.e. homogeneous.
+    full_kv_heads: int = 0  # 0 -> same as kv_heads
+    full_head_dim: int = 0  # 0 -> same as head_dim
+    # Some MoE models also carry a dense MLP per layer alongside the experts.
+    dense_inter: int = 0  # 0 -> no dense MLP
+
+    @property
+    def full_kv(self) -> int:
+        return self.full_kv_heads or self.kv_heads
+
+    @property
+    def full_hd(self) -> int:
+        return self.full_head_dim or self.head_dim
+
+    def fp16(self, n: float) -> float:
+        return n * 2
+
+    def int4w(self, n: float) -> float:
+        """Packed int4 weights plus their fp16 scales."""
+        return n * 0.5 + n / self.group_size * 2
+
+    @property
+    def expert_weight_bytes(self) -> float:
+        return self.int4w(self.hidden * 2 * self.inter) + self.int4w(
+            self.inter * self.hidden
+        )
+
+    @property
+    def expert_flop_per_token(self) -> float:
+        return 2.0 * (self.hidden * 2 * self.inter + self.inter * self.hidden)
+
+
+# Kernels that only ever run outside the MoE expert loop; seeing one means the
+# expert region has closed.
+DENSE_MARKERS = frozenset(
+    {
+        "Op2dTensorGeneric",
+        "T5LayernormFwdContiguous",
+        "split_qkv",
+        "ropex2",
+        "rope",
+        "kv_cache_append",
+        "gqa_flash_prefill_v5",
+        "ew_bcast4d",
+        "gather",
+        "elementwise_sub_i64",
+        "cast_i64_to_i32",
+        "reduce_sum_i64",
+    }
+)
+
+# The int4 matmul stack: the GEMMs plus the ancillary kernels they drag along.
+INT4_FAMILIES = frozenset(
+    {
+        "MatMulNBitsWMMA_NoZP",
+        "MatMulNBitsFp16GEMM",
+        "matmul_nbits_gemv",
+        "dequant_u4_to_fp16",
+        "matmul_nbits_add_bias_rowmajor",
+        "transpose2d_fp16",
+    }
+)
+
+GEMM_FAMILIES = ("MatMulNBitsWMMA_NoZP", "MatMulNBitsFp16GEMM", "matmul_nbits_gemv")
+
+# Buckets chosen to straddle the dispatch thresholds in matmul_nbits_kernel.hip
+# (row-major GEMV, col-major GEMV, WMMA), so a routing change shows up as a
+# bucket moving rather than as a diffuse shift.
+M_BUCKETS = [(1, 1), (2, 15), (16, 63), (64, 255), (256, 10**9)]
+
+
+@dataclass
+class ExpertBlock:
+    """One expert served: gather_tokens through scatter_add.
+
+    The whole block is the honest unit -- it is what serving one expert costs,
+    including the bias/swiglu/scatter kernels, not just the two GEMMs.
+    """
+
+    m: int
+    dur_us: float = 0.0
+    dequant_us: float = 0.0
+    gemm_us: float = 0.0
+    kernels: set = field(default_factory=set)
+
+
+class Capture:
+    """A decoded dispatch CSV, segmented into regions, layers and expert blocks."""
+
+    def __init__(self, path: str, spec: ModelSpec):
+        self.path = path
+        self.spec = spec
+        self.rows = list(csv.DictReader(open(path)))
+        self.total_us = sum(float(r["dur_us"]) for r in self.rows)
+        self.layers_in_window = sum(
+            1 for r in self.rows if r["family"] == "topk_routing"
+        )
+        # lm_head: the only MatMulNBits with a vocab-sized thread count.
+        self.lm_head_idx = [
+            i
+            for i, r in enumerate(self.rows)
+            if r["family"].startswith("MatMulNBits") and int(r["threads"]) > 1_500_000
+        ]
+        self.lm_head_us = sum(float(self.rows[i]["dur_us"]) for i in self.lm_head_idx)
+        self.regions = self._segment()
+        self.blocks = self._expert_blocks()
+
+    @property
+    def layer_scale(self) -> float:
+        """Multiplier taking the captured window to one full layer stack."""
+        if not self.layers_in_window:
+            raise ValueError(
+                f"{self.path}: no topk_routing dispatches; "
+                "cannot infer layer count from this window"
+            )
+        return self.spec.layers / self.layers_in_window
+
+    def _segment(self) -> list[str]:
+        out, region = [], "dense"
+        for r in self.rows:
+            fam = r["family"]
+            if fam == "topk_routing":
+                region = "qmoe"
+            elif fam in DENSE_MARKERS:
+                region = "dense"
+            out.append(region)
+        return out
+
+    def _expert_blocks(self) -> list[ExpertBlock]:
+        out: list[ExpertBlock] = []
+        cur: ExpertBlock | None = None
+        for i, r in enumerate(self.rows):
+            if self.regions[i] != "qmoe" or i in self.lm_head_idx:
+                continue
+            fam, dur = r["family"], float(r["dur_us"])
+            if fam == "gather_tokens":
+                if cur:
+                    out.append(cur)
+                cur = ExpertBlock(m=round(int(r["threads"]) / self.spec.hidden))
+            elif cur is not None:
+                cur.dur_us += dur
+                if fam in GEMM_FAMILIES:
+                    cur.kernels.add(fam)
+                    cur.gemm_us += dur
+                elif fam == "dequant_u4_to_fp16":
+                    cur.dequant_us += dur
+        if cur:
+            out.append(cur)
+        return out
+
+
+# Whole-model geometries, so a run does not need a dozen --flags to be correct.
+# Every field is checkable against the dispatch stream: the per-layer GEMM N/K
+# values, one router dispatch of N=experts per layer, one topk_routing per layer.
+PRESETS: dict[str, dict] = {
+    "gpt-oss-20b": {},
+    # google/gemma-4-26B-A4B-it. 30 layers: 25 sliding GQA (kv8 x 256) and
+    # 5 global MQA (kv2 x 512). 128 experts, top-8, expert inter 704, plus a
+    # dense MLP of inter 2112 per layer.
+    "gemma4-26b-a4b": dict(
+        hidden=2816,
+        inter=704,
+        vocab=262144,
+        layers=30,
+        qkv_n=4096 + 2048 + 2048,
+        o_proj_k=4096,
+        router_n=128,
+        experts=128,
+        topk=8,
+        group_size=32,
+        heads=16,
+        kv_heads=8,
+        head_dim=256,
+        sliding_window=1024,
+        full_attn_layers=5,
+        full_kv_heads=2,
+        full_head_dim=512,
+        dense_inter=2112,
+    ),
+}
+
+# Fields settable from the command line; None means "fall back to the preset".
+_OVERRIDES = (
+    "hidden",
+    "inter",
+    "vocab",
+    "layers",
+    "chunks",
+    "chunk_tokens",
+    "experts",
+    "topk",
+    "heads",
+    "kv_heads",
+    "head_dim",
+    "full_attn_layers",
+    "full_kv_heads",
+    "full_head_dim",
+    "sliding_window",
+    "dense_inter",
+)
+
+
+def add_common_args(ap: argparse.ArgumentParser, *, many: bool = False) -> None:
+    """Capture path(s) plus the handful of shapes worth overriding per model."""
+    ap.add_argument(
+        "captures" if many else "capture",
+        nargs="+" if many else None,
+        help="*_dispatches.csv from tools/rgp_parser",
+    )
+    ap.add_argument(
+        "--preset",
+        choices=sorted(PRESETS),
+        default="gpt-oss-20b",
+        help="model geometry to start from; --flags override it",
+    )
+    for name in _OVERRIDES:
+        ap.add_argument(f"--{name.replace('_', '-')}", type=int, default=None)
+    ap.add_argument("--bw-gbs", type=float, default=256.0, help="memory roofline, GB/s")
+    ap.add_argument(
+        "--peak-tflops", type=float, default=59.4, help="fp16 compute roofline"
+    )
+
+
+def specs_from_args(args) -> tuple[ModelSpec, Device]:
+    fields = dict(PRESETS[getattr(args, "preset", "gpt-oss-20b")])
+    for name in _OVERRIDES:
+        val = getattr(args, name, None)
+        if val is not None:
+            fields[name] = val
+    spec = ModelSpec(**fields)
+    dev = Device(bw_bytes_s=args.bw_gbs * 1e9, peak_flops=args.peak_tflops * 1e12)
+    return spec, dev
+
+
+def bucket_label(lo: int, hi: int) -> str:
+    return f">={lo}" if hi >= 10**9 else f"{lo}..{hi}"

--- a/tools/perf-harness/analysis/prefill_model.py
+++ b/tools/perf-harness/analysis/prefill_model.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Whole-prefill composition from two fence-positioned captures.
+
+A capture holds one chunk, and a chunked prefill is many chunks, so a single
+capture only generalises for work whose cost does not depend on how much context
+already exists. That covers everything except full attention, which grows with
+KV depth. Hence two captures: one shallow (early chunk) and one deep (late
+chunk). The growth exponent is fitted from the pair rather than assumed to be
+linear, and the sliding-window layers are measured -- not asserted -- to be
+depth-independent, which is the check that the segmentation is right.
+
+Expect the modelled total to land a few percent UNDER a real TTFT. RGP pegs
+clocks to peak for the capture; production runs at whatever the power budget
+allows. That gap is the reason a promising capture still has to be confirmed by
+an A/B on TTFT before anyone believes it.
+"""
+
+import argparse
+import math
+from collections import defaultdict
+
+from perfcommon import INT4_FAMILIES, Capture, add_common_args, specs_from_args
+
+ATTN_FAMILY = "gqa_flash_prefill_v5"
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    add_common_args(ap, many=True)
+    ap.add_argument("--at-chunk", type=float, nargs="+", required=True,
+                    help="chunk index each capture sits at, same order as the captures "
+                         "(e.g. --at-chunk 2.5 31.5)")
+    ap.add_argument("--measured-ttft-s", type=float,
+                    help="clean TTFT to compare the model against")
+    ap.add_argument("--attn-family", default=ATTN_FAMILY)
+    args = ap.parse_args()
+    spec, _ = specs_from_args(args)
+    if len(args.captures) != 2 or len(args.at_chunk) != 2:
+        raise SystemExit("need exactly two captures and two --at-chunk positions "
+                         "(one shallow, one deep)")
+
+    order = sorted(range(2), key=lambda i: args.at_chunk[i])
+    names = ("shallow", "deep")
+    caps, depth, per_chunk, attn = {}, {}, {}, {}
+
+    for name, i in zip(names, order):
+        cap = Capture(args.captures[i], spec)
+        k = cap.layer_scale
+        caps[name] = cap
+        depth[name] = args.at_chunk[i]
+        agg: dict[str, float] = defaultdict(float)
+        for j, r in enumerate(cap.rows):
+            fam, dur = r["family"], float(r["dur_us"])
+            if j in cap.lm_head_idx:
+                agg["lm_head"] += dur          # once per chunk, never scaled
+            else:
+                agg[f"{cap.regions[j]}:{fam}"] += dur * k
+        per_chunk[name] = agg
+        # The full-attention and sliding-window layers interleave; splitting the
+        # per-layer durations at the median separates them without needing to
+        # know the pattern.
+        g = sorted((float(r["dur_us"]) for r in cap.rows
+                    if r["family"] == args.attn_family), reverse=True)
+        if len(g) < 2:
+            raise SystemExit(f"{args.captures[i]}: too few '{args.attn_family}' dispatches")
+        half = len(g) // 2
+        attn[name] = (sum(g[:half]) / half, sum(g[half:]) / (len(g) - half),
+                      k * len(g) / 2)
+
+    print("=== attention: measured at two depths ===")
+    for n in names:
+        f, s, npl = attn[n]
+        print(f"  {n:8} chunk~{depth[n]:4.1f}  full {f:9.1f} us/layer   "
+              f"sliding {s:7.1f} us/layer   {npl:.1f} layers of each per chunk")
+    f0, s0, npl = attn["shallow"]
+    f1, s1, _ = attn["deep"]
+    p = math.log(f1 / f0) / math.log(depth["deep"] / depth["shallow"])
+    print(f"  full attention scales as KV^{p:.2f} "
+          f"({f1/f0:.1f}x over {depth['deep']/depth['shallow']:.1f}x KV)")
+    print(f"  sliding window is depth-independent: {s0:.1f} -> {s1:.1f} us "
+          f"({100*(s1-s0)/s0:+.1f}%)  <- if this is large the segmentation is wrong")
+
+    sl_ms = s0 * npl / 1000
+    full_ms = [f0 * (c / depth["shallow"]) ** p * npl / 1000 for c in range(1, spec.chunks + 1)]
+    attn_total = sum(full_ms) + sl_ms * spec.chunks
+
+    base: dict[str, float] = defaultdict(float)
+    for key in set(per_chunk["shallow"]) | set(per_chunk["deep"]):
+        if args.attn_family in key:
+            continue
+        base[key] = (per_chunk["shallow"].get(key, 0.0)
+                     + per_chunk["deep"].get(key, 0.0)) / 2 / 1000
+    base_chunk = sum(base.values())
+    total = base_chunk * spec.chunks + attn_total
+
+    print(f"\n=== modelled prefill ({spec.chunks} chunks of {spec.chunk_tokens}) ===")
+    print(f"  depth-independent  {base_chunk:7.1f} ms/chunk x {spec.chunks} = "
+          f"{base_chunk*spec.chunks/1000:5.2f} s")
+    print(f"  attention                                  = {attn_total/1000:5.2f} s")
+    print(f"  modelled total                             = {total/1000:5.2f} s")
+    if args.measured_ttft_s:
+        d = 100 * (total / 1000 - args.measured_ttft_s) / args.measured_ttft_s
+        print(f"  vs measured TTFT {args.measured_ttft_s:.2f} s -> {d:+.0f}% "
+              f"(a few % under is expected: RGP pegs clocks)")
+
+    share = dict(base)
+    share[f"attention ({args.attn_family})"] = attn_total / spec.chunks
+    print(f"\n=== whole-prefill ranking ===")
+    print(f"{'component':46} {'s over prefill':>15} {'%':>7}")
+    for key, v in sorted(share.items(), key=lambda kv: -kv[1])[:16]:
+        print(f"{key:46} {v*spec.chunks/1000:15.2f} {100*v*spec.chunks/total:7.2f}")
+
+    fam: dict[str, float] = defaultdict(float)
+    for key, v in share.items():
+        short = key.split(":")[-1]
+        if key == "lm_head":
+            fam["lm_head (logits for every row)"] += v
+        elif key.startswith("qmoe:") and short in INT4_FAMILIES:
+            fam["int4 matmul: qmoe expert GEMMs"] += v
+        elif key.startswith("dense:") and short in INT4_FAMILIES:
+            fam["int4 matmul: dense projections"] += v
+        elif "attention" in key:
+            fam["attention"] += v
+        else:
+            fam["everything else"] += v
+    print(f"\n{'family':46} {'s over prefill':>15} {'%':>7}")
+    for key, v in sorted(fam.items(), key=lambda kv: -kv[1]):
+        print(f"{key:46} {v*spec.chunks/1000:15.2f} {100*v*spec.chunks/total:7.2f}")
+    print("\nfeed headroom.py:  "
+          f"--attention-s {attn_total/1000:.2f} --prefill-s {total/1000:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/perf-harness/bench/ab_interleaved.ps1
+++ b/tools/perf-harness/bench/ab_interleaved.ps1
@@ -1,0 +1,85 @@
+##
+## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+## Licensed under the MIT License.
+##
+## Interleaved, order-reversed A/B (or A/B/C/...) of DLL variants by TTFT.
+##
+## Why not just run arm A a few times, then arm B a few times:
+##
+##  - Run-to-run spread on a thermally managed APU is comparable to the effects
+##    worth shipping (~0.8% vs ~1-2%), so block-sequential runs let slow drift
+##    land entirely on one arm. Interleaving and pairing by round cancels it.
+##  - Position within a round is itself a bias. Always run at least one block
+##    with -Reverse and check the delta survives; if it flips, you measured the
+##    order, not the change.
+##  - Discard rounds taken while the box is shedding heat from a build or a test
+##    suite. They report a different answer -- in one measured case the opposite
+##    sign -- and they are recognisable by sitting well above the known baseline.
+##
+## Each arm gets its OWN TEMP, and therefore its own autotune cache file: the
+## on-disk WMMA cache holds a single build timestamp and is discarded when it
+## does not match, so a shared TEMP would make every DLL swap a cold-tune run.
+##
+## Arms are defined in a JSON manifest:
+##
+##   { "base":  { "dll": "D:\\builds\\base\\custom_kernels_gfx1151.dll" },
+##     "cand":  { "dll": "D:\\builds\\cand\\custom_kernels_gfx1151.dll" } }
+##
+## The named DLL is copied over the same filename in $env:HIPEP_BIN before each
+## run, so every arm is measured through one identical harness.
+
+param(
+  [Parameter(Mandatory = $true)][string]$Manifest,
+  [string[]]$Arms,                    # subset + order; default: every arm in the manifest
+  [int]$Rounds     = 3,
+  [int]$Reps       = 4,
+  [int]$StartRound = 1,
+  [switch]$Reverse,
+  [switch]$SkipPrime,                 # caches survive while the DLLs are unchanged
+  [string]$OutDir
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path (Split-Path -Parent $PSScriptRoot) 'common.ps1')
+
+$armDefs = Get-Content $Manifest -Raw | ConvertFrom-Json
+$allArms = $armDefs.PSObject.Properties.Name
+if (-not $Arms) { $Arms = $allArms }
+foreach ($a in $Arms) {
+  if ($a -notin $allArms) { throw "Arm '$a' is not in $Manifest (have: $($allArms -join ', '))" }
+  if (-not (Test-Path $armDefs.$a.dll)) { throw "Arm '$a': DLL not found: $($armDefs.$a.dll)" }
+}
+
+if (-not $OutDir) { $OutDir = Join-Path $HarnessEnv.OutRoot 'ttft' }
+$cacheRoot = Join-Path $HarnessEnv.OutRoot 'tunecache'
+$benchTtft = Join-Path $PSScriptRoot 'bench_ttft.ps1'
+
+function Invoke-Arm {
+  param([string]$Name, [string]$Tag, [int]$RunReps)
+  $dll  = $armDefs.$Name.dll
+  $dest = Join-Path $HarnessEnv.Bin (Split-Path -Leaf $dll)
+  Copy-Item $dll $dest -Force
+  $temp = Join-Path $cacheRoot $Name
+  New-Item -ItemType Directory -Force -Path $temp | Out-Null
+  $env:TEMP = $temp; $env:TMP = $temp
+  & $benchTtft -Tag $Tag -Reps $RunReps -Warmup 1 -OutDir $OutDir 2>&1 |
+    Where-Object { $_ -match 'TTFT \[' }
+}
+
+if (-not $SkipPrime) {
+  foreach ($name in $Arms) {
+    Write-Host "--- priming $name (discarded: rebuilds that arm's autotune cache)"
+    Invoke-Arm -Name $name -Tag "prime_$name" -RunReps 1 | Out-Null
+  }
+}
+
+$order = if ($Reverse) { $Arms[($Arms.Count - 1)..0] } else { $Arms }
+foreach ($r in $StartRound..($StartRound + $Rounds - 1)) {
+  foreach ($name in $order) {
+    Write-Host "--- round $r arm $name"
+    Invoke-Arm -Name $name -Tag "ab_${name}_r$r" -RunReps $Reps
+  }
+}
+
+Write-Host "`nSummarise with:"
+Write-Host "  $($HarnessEnv.Python) $(Join-Path $PSScriptRoot 'ab_summary.py') $(Join-Path $OutDir 'ttft_summary.csv') --baseline $($Arms[0])"

--- a/tools/perf-harness/bench/ab_summary.py
+++ b/tools/perf-harness/bench/ab_summary.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Paired summary of an interleaved A/B run.
+
+Pairing is by round, so drift shared by the arms within a round cancels; the
+reported interval is over the paired differences, not over the raw TTFTs, which
+are far noisier. With --drop you can exclude rounds taken outside steady state
+(see the thermal warning in ab_interleaved.ps1) -- do that from the absolute
+level against a known baseline, never because a round disagrees with the others.
+"""
+
+import argparse
+import csv
+import re
+import statistics as st
+from collections import defaultdict
+
+# two-sided t critical values at 95% by degrees of freedom
+_TCRIT = {1: 12.706, 2: 4.303, 3: 3.182, 4: 2.776, 5: 2.571, 6: 2.447, 7: 2.365,
+          8: 2.306, 9: 2.262, 10: 2.228, 11: 2.201, 12: 2.179, 13: 2.160,
+          14: 2.145, 15: 2.131, 16: 2.120, 17: 2.110, 18: 2.101, 19: 2.093,
+          20: 2.086}
+DEFAULT_TAG = r"^ab\d*_(?P<arm>.+)_r(?P<round>\d+)$"
+
+
+def tcrit(df: int) -> float:
+    return _TCRIT.get(df, 1.96)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("csv", help="ttft_summary.csv written by bench_ttft.ps1")
+    ap.add_argument("--baseline", required=True, help="arm every other arm is compared against")
+    ap.add_argument("--drop", type=int, nargs="*", default=[], help="round numbers to exclude")
+    ap.add_argument("--tag-re", default=DEFAULT_TAG,
+                    help="regex with 'arm' and 'round' groups, matched against the tag column")
+    args = ap.parse_args()
+    tag_re = re.compile(args.tag_re)
+
+    runs: dict[int, dict[str, float]] = defaultdict(dict)
+    for row in csv.DictReader(open(args.csv)):
+        m = tag_re.match(row["tag"])
+        if m:
+            runs[int(m.group("round"))][m.group("arm")] = float(row["ttft_ms"])
+
+    kept = sorted(r for r in runs if r not in args.drop)
+    if not kept:
+        raise SystemExit("no rounds left after --drop")
+    arms = [args.baseline] + sorted({a for r in kept for a in runs[r]} - {args.baseline})
+
+    print("round  " + "".join(f"{a:>10}" for a in arms))
+    for r in sorted(runs):
+        cells = "".join(f"{runs[r].get(a, float('nan')):10.0f}" for a in arms)
+        print(f"{r:5d}  {cells}" + ("   <- dropped" if r in args.drop else ""))
+
+    print(f"\n{'arm':>10} {'n':>3} {'mean':>8} {'vs base':>9} {'sd of diff':>11} {'95% CI':>18} {'%':>8}")
+    base = [runs[r][args.baseline] for r in kept if args.baseline in runs[r]]
+    print(f"{args.baseline:>10} {len(base):3d} {st.mean(base):8.0f} {'--':>9}")
+    for arm in arms[1:]:
+        pairs = [(runs[r][arm] - runs[r][args.baseline]) for r in kept
+                 if arm in runs[r] and args.baseline in runs[r]]
+        if len(pairs) < 2:
+            print(f"{arm:>10} {len(pairs):3d}  (need >=2 paired rounds)")
+            continue
+        vals = [runs[r][arm] for r in kept if arm in runs[r]]
+        m, sd = st.mean(pairs), st.stdev(pairs)
+        half = tcrit(len(pairs) - 1) * sd / len(pairs) ** 0.5
+        verdict = "" if (m - half) * (m + half) > 0 else "   (spans zero)"
+        print(f"{arm:>10} {len(pairs):3d} {st.mean(vals):8.0f} {m:+9.0f} {sd:11.0f} "
+              f"{f'[{m-half:+.0f}, {m+half:+.0f}]':>18} {100*m/st.mean(base):+8.2f}{verdict}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/perf-harness/bench/bench_ttft.ps1
+++ b/tools/perf-harness/bench/bench_ttft.ps1
@@ -24,7 +24,11 @@ param(
   [ValidateSet('model_benchmark', 'vlm')]
   [string]$Driver = 'model_benchmark',
   [int]$MaxTokens = 4,              # vlm only: keep decode short, TTFT is the target
-  [int]$MaxLength                   # vlm only: KV cache size; defaults to prompt + headroom
+  [int]$MaxLength,                  # vlm only: KV cache size; defaults to prompt + headroom
+  # vlm only. 'follow_config' leaves the model's own genai_config provider list
+  # alone; naming a provider overrides it, which is what an export pinned to
+  # another EP (a -dml directory, say) needs to run here.
+  [string]$ExecutionProvider = 'follow_config'
 )
 
 $ErrorActionPreference = 'Continue'
@@ -70,6 +74,7 @@ if ($Driver -eq 'vlm') {
   & $HarnessEnv.Python '-u' $HarnessEnv.VlmBench `
     '-m' $HarnessEnv.Model '-i' $HarnessEnv.Image '--prompt_file' $HarnessEnv.PromptFile `
     '--max_tokens' "$MaxTokens" '--max_length' "$MaxLength" `
+    '-e' $ExecutionProvider `
     '-n' "$Reps" '-w' "$Warmup" '-o' $json *>&1 |
     Tee-Object -FilePath $log | Out-Null
   $rc = $LASTEXITCODE

--- a/tools/perf-harness/bench/bench_ttft.ps1
+++ b/tools/perf-harness/bench/bench_ttft.ps1
@@ -1,0 +1,123 @@
+##
+## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+## Licensed under the MIT License.
+##
+## One clean TTFT measurement, appended to a CSV.
+##
+## Deliberately no HIPDNN_EP_PERF / HIPDNN_EP_DEBUG: CLAUDE.md forbids measuring
+## throughput with either (PERF alone costs ~4%).
+##
+## Warmup reps are not optional. Autotune caches are per-process and partly
+## on-disk keyed by build timestamp, so iteration 1 of a fresh build always pays
+## tuning cost and is not a measurement of the kernel.
+
+param(
+  [Parameter(Mandatory = $true)][string]$Tag,
+  [int]$SeqLen = 16384,
+  [int]$Reps   = 4,
+  [int]$Warmup = 1,
+  [string[]]$SetEnv = @(),          # e.g. -SetEnv 'HIPDNN_EP_GQA_NO_EXPAND_PREFILL=1'
+  [string]$OutDir,
+  # 'vlm' drives vlm_benchmark.py so the vision encoder and image-token splice
+  # are inside TTFT, which is the whole number for a VLM. 'model_benchmark' is
+  # the text-only path and cannot represent a multimodal prefill.
+  [ValidateSet('model_benchmark', 'vlm')]
+  [string]$Driver = 'model_benchmark',
+  [int]$MaxTokens = 4,              # vlm only: keep decode short, TTFT is the target
+  [int]$MaxLength                   # vlm only: KV cache size; defaults to prompt + headroom
+)
+
+$ErrorActionPreference = 'Continue'
+. (Join-Path (Split-Path -Parent $PSScriptRoot) 'common.ps1')
+
+if (-not $OutDir) { $OutDir = Join-Path $HarnessEnv.OutRoot 'ttft' }
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+$log = Join-Path $OutDir "ttft_$Tag.log"
+$csv = Join-Path $OutDir 'ttft_summary.csv'
+
+Set-HarnessPath
+Clear-HarnessProfilingEnv
+Remove-Item Env:RGP_FENCE, Env:RGP_FENCE_SKIP, Env:RGP_FENCE_MS -EA SilentlyContinue
+$env:HIPDNN_EP_AUTOTUNE = '1'
+$env:HIPDNN_EP_MATMUL_CUSTOM_WMMA = '1'
+foreach ($kv in $SetEnv) {
+  $k, $v = $kv -split '=', 2
+  Set-Item -Path "Env:$k" -Value $v
+  Write-Host "    env $k=$v"
+}
+
+# Serial only: concurrent GPU runs invalidate results.
+Stop-HarnessProcesses -IncludePython:($Driver -eq 'vlm')
+
+Write-Host ">>> TTFT [$Tag] driver=$Driver seqlen=$SeqLen -r $Reps -w $Warmup"
+Get-Item (Join-Path $HarnessEnv.Bin 'custom_kernels_*.dll'), (Join-Path $HarnessEnv.Bin 'hipgpu.dll') -EA SilentlyContinue |
+  ForEach-Object { Write-Host ("      {0}  {1:N2} MB  {2}" -f $_.LastWriteTime, ($_.Length / 1MB), $_.Name) }
+
+# TTFT in microseconds, so both drivers land in the same CSV units.
+$ttft = $null; $p50 = $null; $sd = $null
+$tokens = ''
+
+if ($Driver -eq 'vlm') {
+  foreach ($n in 'VlmBench', 'Image', 'PromptFile') {
+    if (-not $HarnessEnv.$n) { throw "Driver 'vlm' needs `$env:HIPEP_$($n.ToUpper()); see common.ps1." }
+  }
+  # vlm_benchmark's own --output_json is the parse target: scraping the pretty
+  # printed block would break on every formatting change.
+  $json = Join-Path $OutDir "ttft_$Tag.json"
+  Remove-Item $json -EA SilentlyContinue
+  if (-not $MaxLength) { $MaxLength = $SeqLen + 128 }
+
+  & $HarnessEnv.Python '-u' $HarnessEnv.VlmBench `
+    '-m' $HarnessEnv.Model '-i' $HarnessEnv.Image '--prompt_file' $HarnessEnv.PromptFile `
+    '--max_tokens' "$MaxTokens" '--max_length' "$MaxLength" `
+    '-n' "$Reps" '-w' "$Warmup" '-o' $json *>&1 |
+    Tee-Object -FilePath $log | Out-Null
+  $rc = $LASTEXITCODE
+
+  if (Test-Path $json) {
+    $j = Get-Content $json -Raw | ConvertFrom-Json
+    $ttft = $j.summary.ttft_ms.avg * 1000
+    $p50  = $j.summary.ttft_ms.p50 * 1000
+    $sd   = $j.summary.ttft_ms.std * 1000
+    $tb   = $j.summary.token_breakdown
+    $SeqLen = $tb.prompt_tokens
+    $tokens = "prompt=$($tb.prompt_tokens) text=$($tb.text_tokens) image=$($tb.image_tokens)"
+  }
+} else {
+  Push-Location $HarnessEnv.Bin
+  & (Join-Path $HarnessEnv.Bin 'model_benchmark.exe') `
+    -i $HarnessEnv.Model -l $SeqLen --use_random_tokens -g 1 -r $Reps -w $Warmup -b 1 -ml 0 -v *>&1 |
+    Tee-Object -FilePath $log | Out-Null
+  $rc = $LASTEXITCODE
+  Pop-Location
+
+  # Pull the TTFT block: "Prompt processing (time to first token):" then "avg (us):".
+  # model_benchmark switches to scientific notation once the fused paths get fast
+  # enough (1.00924e+07), so the number pattern must accept both forms.
+  $lines = Get-Content $log
+  for ($i = 0; $i -lt $lines.Count; $i++) {
+    if ($lines[$i] -match 'Prompt processing \(time to first token\)') {
+      foreach ($j in ($i + 1)..([Math]::Min($i + 6, $lines.Count - 1))) {
+        if ($lines[$j] -match 'avg \(us\):\s+([\d.eE+\-]+)')    { $ttft = [double]$matches[1] }
+        if ($lines[$j] -match 'p50 \(us\):\s+([\d.eE+\-]+)')    { $p50  = [double]$matches[1] }
+        if ($lines[$j] -match 'stddev \(us\):\s+([\d.eE+\-]+)') { $sd   = [double]$matches[1] }
+      }
+      break
+    }
+  }
+}
+
+if ($ttft) {
+  Write-Host ("`n=== TTFT [$Tag] = {0:N0} ms   p50 {1:N0} ms   stddev {2:N0} ms   (exit={3})" -f `
+              ($ttft / 1000), ($p50 / 1000), ($sd / 1000), $rc)
+  if ($tokens) { Write-Host "    $tokens" }
+  [PSCustomObject]@{
+    tag = $Tag; ttft_ms = [Math]::Round($ttft / 1000, 1); p50_ms = [Math]::Round($p50 / 1000, 1)
+    stddev_ms = [Math]::Round($sd / 1000, 1); seqlen = $SeqLen; reps = $Reps
+    when = (Get-Date -Format s)
+  } | Export-Csv -Path $csv -NoTypeInformation -Append
+  Write-Host "    appended -> $csv"
+} else {
+  Write-Host "`n=== TTFT [$Tag] PARSE FAILED (exit=$rc) -- inspect $log"
+  Get-Content $log -Tail 25
+}

--- a/tools/perf-harness/bench/build_deploy.ps1
+++ b/tools/perf-harness/bench/build_deploy.ps1
@@ -13,15 +13,20 @@
 ## result, which is the worst kind. Deploying prints each file's hash so a
 ## comparison against the previous run's hash proves the binary actually moved.
 ##
-## Only two artifacts matter for the operators the harness profiles:
-##   hipgpu.dll                  lib/Runtime (gqa.cpp, matmul_nbits.cpp) and
-##                               lib/Conversion
+## Three artifacts carry the code the harness profiles:
+##   hipgpu.dll                  lib/Runtime (gqa.cpp, matmul_nbits.cpp)
 ##   custom_kernels_<arch>.dll   lib/Runtime/Kernels/hip (gqa_kernel.hip,
 ##                               matmul_nbits_kernel.hip)
-## They are deployed as a pair on purpose. They share the extern "C" kernel ABI,
-## so a mixed pair is only accidentally correct -- and a mixed pair was in fact
-## deployed on this machine (hipgpu from one build, custom_kernels from an
-## eight-hour-older one), which is unattributable as a baseline.
+##   hip-compiler.dll            lib/Conversion, lib/Dialect -- everything that
+##                               decides what the runtime is asked to execute
+## They are deployed as a set on purpose. hipgpu and custom_kernels share the
+## extern "C" kernel ABI, so a mixed pair is only accidentally correct -- and a
+## mixed pair was in fact deployed on this machine (hipgpu from one build,
+## custom_kernels from an eight-hour-older one), which is unattributable as a
+## baseline. hip-compiler is here because omitting it produced the opposite and
+## more insidious failure: a conversion-only change measured as an exact no-op,
+## the stale compiler having emitted the old graph for a correctly rebuilt
+## runtime. Anything that lowers a graph belongs in this list.
 
 [CmdletBinding()]
 param(
@@ -112,7 +117,7 @@ $arch = (Select-String -Path (Join-Path $BuildDir 'CMakeCache.txt') `
 $arch = ($arch -split ';')[0].Trim()
 if (-not $arch) { throw "Could not read HIP_ARCHITECTURES from the cmake cache." }
 
-$artifacts = @('hipgpu.dll', "custom_kernels_$arch.dll")
+$artifacts = @('hipgpu.dll', "custom_kernels_$arch.dll", 'hip-compiler.dll')
 
 if (-not $SkipBuild) {
   Write-Host ">>> build [$Config] $BuildDir"
@@ -124,7 +129,7 @@ if (-not $SkipBuild) {
     # versioned unique id and only its OUTPUT_NAME is hipgpu, so ask cmake for
     # the file and let ninja resolve the producing target.
     $cmd += @('--target')
-    $cmd += @("bin/hipgpu.dll", "bin/custom_kernels_$arch.dll")
+    foreach ($a in $artifacts) { $cmd += "bin/$a" }
   }
   $sw = [Diagnostics.Stopwatch]::StartNew()
   & cmake @cmd

--- a/tools/perf-harness/bench/build_deploy.ps1
+++ b/tools/perf-harness/bench/build_deploy.ps1
@@ -1,0 +1,146 @@
+##
+## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+## Licensed under the MIT License.
+##
+## Build the runtime artifacts and deploy them where the benchmark drivers load
+## them from, so an A/B is one command and cannot silently measure a stale DLL.
+##
+## Why this exists as a script rather than a documented copy step. The perf
+## harness measures whatever is in $HIPEP_BIN, which for the vlm driver is a
+## venv's onnxruntime\capi -- not the cmake install prefix. Nothing connects the
+## two, so a hand-run build followed by a forgotten copy reports the previous
+## DLL's number as the new one. That failure is silent and produces a plausible
+## result, which is the worst kind. Deploying prints each file's hash so a
+## comparison against the previous run's hash proves the binary actually moved.
+##
+## Only two artifacts matter for the operators the harness profiles:
+##   hipgpu.dll                  lib/Runtime (gqa.cpp, matmul_nbits.cpp) and
+##                               lib/Conversion
+##   custom_kernels_<arch>.dll   lib/Runtime/Kernels/hip (gqa_kernel.hip,
+##                               matmul_nbits_kernel.hip)
+## They are deployed as a pair on purpose. They share the extern "C" kernel ABI,
+## so a mixed pair is only accidentally correct -- and a mixed pair was in fact
+## deployed on this machine (hipgpu from one build, custom_kernels from an
+## eight-hour-older one), which is unattributable as a baseline.
+
+[CmdletBinding()]
+param(
+  # Ninja build directory. Defaults to the sibling layout build.py documents:
+  # <workspace>/build/<repo>.
+  [string]$BuildDir,
+  [string]$Config = 'Release',
+  [switch]$SkipBuild,
+  [switch]$SkipDeploy,
+  # Build everything instead of just the two deployed artifacts. Slower; needed
+  # when a change touches the MLIR tools or the lit suite.
+  [switch]$All,
+  [int]$Parallel = 0
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path (Split-Path -Parent $PSScriptRoot) 'common.ps1')
+
+if (-not $BuildDir) {
+  $env:HIPEP_BUILD_DIR | Out-Null
+  $fromEnv = [Environment]::GetEnvironmentVariable('HIPEP_BUILD_DIR')
+  if ($fromEnv) {
+    $BuildDir = $fromEnv
+  } else {
+    $repoRoot = $HarnessEnv.RepoRoot
+    $BuildDir = Join-Path (Split-Path -Parent $repoRoot) "build\$(Split-Path -Leaf $repoRoot)"
+  }
+}
+if (-not (Test-Path (Join-Path $BuildDir 'CMakeCache.txt'))) {
+  throw "No CMakeCache.txt in '$BuildDir'. Configure first (python build.py), or pass -BuildDir."
+}
+$BuildDir = (Resolve-Path $BuildDir).Path
+
+# ---------------------------------------------------------------------------
+# MSVC environment
+# ---------------------------------------------------------------------------
+# build.py deliberately does not source vcvars: with the Visual Studio generator
+# CMake finds MSVC itself, and with Ninja it expects the caller to already be in
+# a developer prompt. This build tree is Ninja, so a plain shell links against
+# nothing and fails on kernel32.lib. Import the environment here instead of
+# requiring the caller to remember, and only when cl.exe is genuinely absent so
+# an already-correct developer prompt is left untouched.
+function Import-MsvcEnv {
+  if (Get-Command cl.exe -EA SilentlyContinue) {
+    Write-Host "    MSVC env: already present"
+    return
+  }
+  $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+  if (-not (Test-Path $vswhere)) { throw "vswhere.exe not found; cannot locate MSVC." }
+  $vsPath = & $vswhere -latest -products * `
+    -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+    -property installationPath
+  if (-not $vsPath) { throw "vswhere found no VS install with the x64 C++ toolset." }
+  $vcvars = Join-Path $vsPath 'VC\Auxiliary\Build\vcvars64.bat'
+  if (-not (Test-Path $vcvars)) { throw "vcvars64.bat not found under '$vsPath'." }
+
+  # Run vcvars in a child cmd and lift the resulting environment back out. The
+  # marker separates vcvars' own banner from the variable dump; without it a
+  # banner line can parse as a KEY=VALUE pair. cmd's `echo X && set` emits the
+  # marker with a trailing space, so compare trimmed.
+  $marker = '___VCVARS_ENV___'
+  $out = & cmd.exe /c "call `"$vcvars`" >nul 2>&1 && echo $marker && set"
+  $seen = $false
+  $n = 0
+  foreach ($line in $out) {
+    if (-not $seen) { if ($line.Trim() -eq $marker) { $seen = $true }; continue }
+    $i = $line.IndexOf('=')
+    if ($i -lt 1) { continue }
+    Set-Item -Path "Env:$($line.Substring(0, $i))" -Value $line.Substring($i + 1)
+    $n++
+  }
+  if (-not (Get-Command cl.exe -EA SilentlyContinue)) {
+    throw "Imported $n vars from vcvars64.bat but cl.exe is still not on PATH."
+  }
+  Write-Host "    MSVC env: imported $n vars from $vcvars"
+}
+
+# ---------------------------------------------------------------------------
+# Which artifacts, and where they land
+# ---------------------------------------------------------------------------
+# The custom-kernels target name carries the arch, which is a cache variable
+# rather than something to hardcode: this repo builds one DLL per arch so a
+# consumer does not load code for archs it will never run.
+$arch = (Select-String -Path (Join-Path $BuildDir 'CMakeCache.txt') `
+    -Pattern '^HIP_ARCHITECTURES:STRING=(.+)$').Matches[0].Groups[1].Value
+$arch = ($arch -split ';')[0].Trim()
+if (-not $arch) { throw "Could not read HIP_ARCHITECTURES from the cmake cache." }
+
+$artifacts = @('hipgpu.dll', "custom_kernels_$arch.dll")
+
+if (-not $SkipBuild) {
+  Write-Host ">>> build [$Config] $BuildDir"
+  Import-MsvcEnv
+  if ($Parallel -le 0) { $Parallel = [Environment]::ProcessorCount }
+  $cmd = @('--build', $BuildDir, '--config', $Config, '--parallel', "$Parallel")
+  if (-not $All) {
+    # Target names, not file names: the EP target is named by morphizen's
+    # versioned unique id and only its OUTPUT_NAME is hipgpu, so ask cmake for
+    # the file and let ninja resolve the producing target.
+    $cmd += @('--target')
+    $cmd += @("bin/hipgpu.dll", "bin/custom_kernels_$arch.dll")
+  }
+  $sw = [Diagnostics.Stopwatch]::StartNew()
+  & cmake @cmd
+  if ($LASTEXITCODE -ne 0) { throw "build failed (exit $LASTEXITCODE)" }
+  Write-Host ("    built in {0:N1} min" -f $sw.Elapsed.TotalMinutes)
+}
+
+if (-not $SkipDeploy) {
+  $dest = $HarnessEnv.Bin
+  Write-Host ">>> deploy -> $dest"
+  foreach ($a in $artifacts) {
+    $src = Join-Path $BuildDir "bin\$a"
+    if (-not (Test-Path $src)) { throw "missing build output: $src" }
+    Copy-Item $src (Join-Path $dest $a) -Force
+    $h = (Get-FileHash (Join-Path $dest $a) -Algorithm SHA256).Hash.Substring(0, 16)
+    $t = (Get-Item $src).LastWriteTime.ToString('MM-dd HH:mm:ss')
+    Write-Host ("    {0,-32} {1}  {2}" -f $a, $h, $t)
+  }
+}

--- a/tools/perf-harness/bench/build_deploy.ps1
+++ b/tools/perf-harness/bench/build_deploy.ps1
@@ -13,20 +13,26 @@
 ## result, which is the worst kind. Deploying prints each file's hash so a
 ## comparison against the previous run's hash proves the binary actually moved.
 ##
-## Three artifacts carry the code the harness profiles:
-##   hipgpu.dll                  lib/Runtime (gqa.cpp, matmul_nbits.cpp)
+## Two artifacts carry the code the harness profiles:
+##   hipgpu.dll                  lib/Runtime, plus lib/Conversion and lib/Dialect
+##                               -- everything that decides what the runtime is
+##                               asked to execute. The compiler became a static
+##                               plugin linked into this DLL (#838) and the
+##                               standalone hip-compiler.dll build was removed
+##                               (#840), so a graph-lowering change now ships
+##                               here and nowhere else.
 ##   custom_kernels_<arch>.dll   lib/Runtime/Kernels/hip (gqa_kernel.hip,
-##                               matmul_nbits_kernel.hip)
-##   hip-compiler.dll            lib/Conversion, lib/Dialect -- everything that
-##                               decides what the runtime is asked to execute
-## They are deployed as a set on purpose. hipgpu and custom_kernels share the
+##                               matmul_nbits_kernel.hip, conv_kernel.hip)
+## They are deployed as a set on purpose: hipgpu and custom_kernels share the
 ## extern "C" kernel ABI, so a mixed pair is only accidentally correct -- and a
 ## mixed pair was in fact deployed on this machine (hipgpu from one build,
 ## custom_kernels from an eight-hour-older one), which is unattributable as a
-## baseline. hip-compiler is here because omitting it produced the opposite and
-## more insidious failure: a conversion-only change measured as an exact no-op,
-## the stale compiler having emitted the old graph for a correctly rebuilt
-## runtime. Anything that lowers a graph belongs in this list.
+## baseline.
+##
+## A hip-compiler.dll left over in the deploy directory from before #840 is not
+## loaded, but it is worth deleting rather than reasoning about: the failure it
+## would cause -- a conversion-only change measuring as an exact no-op because a
+## stale compiler emitted the old graph -- is silent and plausible.
 
 [CmdletBinding()]
 param(
@@ -117,7 +123,7 @@ $arch = (Select-String -Path (Join-Path $BuildDir 'CMakeCache.txt') `
 $arch = ($arch -split ';')[0].Trim()
 if (-not $arch) { throw "Could not read HIP_ARCHITECTURES from the cmake cache." }
 
-$artifacts = @('hipgpu.dll', "custom_kernels_$arch.dll", 'hip-compiler.dll')
+$artifacts = @('hipgpu.dll', "custom_kernels_$arch.dll")
 
 if (-not $SkipBuild) {
   Write-Host ">>> build [$Config] $BuildDir"

--- a/tools/perf-harness/bench/conv_microbench.py
+++ b/tools/perf-harness/bench/conv_microbench.py
@@ -1,0 +1,313 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+"""Time hip_conv directly, one shape at a time, without running a model.
+
+The convolution tile heuristic is a pure function of shape and CU count, so
+changing it can be evaluated against the shapes the models contain without
+paying for twenty model sweeps. A full sweep is minutes per arm and mixes the
+convolution's time with everything else in the graph; this is seconds and
+measures only the kernel under test.
+
+Loads the deployed custom_kernels DLL through ctypes and calls its extern "C"
+hip_conv, so it measures exactly the binary the harness deploys -- no separate
+build, and no risk of testing a different compile of the same source.
+
+Usage:
+    python conv_shapes.py resnet50=...\\model.onnx --out shapes.json
+    python conv_microbench.py shapes.json --bin C:\\...\\bin --out base.json
+    # ... change the heuristic, rebuild, redeploy ...
+    python conv_microbench.py shapes.json --bin C:\\...\\bin --out cand.json
+    python conv_microbench.py --compare base.json cand.json
+
+Numbers are per single convolution call. `weighted_ms` multiplies by the node
+count, which is what ranks a shape by its contribution to a model's runtime.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import json
+import os
+import statistics
+import sys
+
+# hip_conv's dtype enum (HIP_DTYPE_* in hip_custom_kernels.h).
+_HIP_DTYPE = {"float32": 0, "float16": 1, "bfloat16": 2}
+_BYTES = {"float32": 4, "float16": 2, "bfloat16": 2}
+
+_HIP_SUCCESS = 0
+
+
+class Hip:
+    """The slice of the HIP runtime this benchmark needs."""
+
+    def __init__(self, bindir: str):
+        self.lib = self._load_runtime(bindir)
+        c = self.lib
+
+        c.hipMalloc.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t]
+        c.hipFree.argtypes = [ctypes.c_void_p]
+        c.hipMemset.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_size_t]
+        c.hipMemcpy.argtypes = [ctypes.c_void_p, ctypes.c_void_p,
+                                ctypes.c_size_t, ctypes.c_int]
+        c.hipDeviceSynchronize.argtypes = []
+        c.hipGetLastError.argtypes = []
+        c.hipEventCreate.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+        c.hipEventRecord.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        c.hipEventSynchronize.argtypes = [ctypes.c_void_p]
+        c.hipEventElapsedTime.argtypes = [ctypes.POINTER(ctypes.c_float),
+                                          ctypes.c_void_p, ctypes.c_void_p]
+        c.hipEventDestroy.argtypes = [ctypes.c_void_p]
+
+    @staticmethod
+    def _load_runtime(bindir: str):
+        # The kernels DLL is built against a specific HIP major version; load
+        # the copy sitting next to it in preference to whatever is on PATH, so
+        # the benchmark cannot silently bind a different runtime than the EP.
+        names = []
+        if bindir and os.path.isdir(bindir):
+            names += [os.path.join(bindir, n) for n in os.listdir(bindir)
+                      if n.lower().startswith("amdhip64")]
+        names += ["amdhip64_7.dll", "amdhip64_6.dll", "amdhip64.dll",
+                  "libamdhip64.so"]
+        last = None
+        for n in names:
+            try:
+                return ctypes.CDLL(n)
+            except OSError as e:  # noqa: PERF203
+                last = e
+        raise RuntimeError(f"could not load the HIP runtime: {last}")
+
+    def check(self, rc: int, what: str):
+        if rc != _HIP_SUCCESS:
+            raise RuntimeError(f"{what} failed with HIP error {rc}")
+
+    def malloc(self, nbytes: int) -> ctypes.c_void_p:
+        p = ctypes.c_void_p()
+        self.check(self.lib.hipMalloc(ctypes.byref(p), nbytes), "hipMalloc")
+        # Non-zero so a kernel reading uninitialised memory is visible as a
+        # timing anomaly rather than reading a page of convenient zeros.
+        self.check(self.lib.hipMemset(p, 1, nbytes), "hipMemset")
+        return p
+
+    def free(self, p):
+        if p:
+            self.lib.hipFree(p)
+
+    def sync(self):
+        self.check(self.lib.hipDeviceSynchronize(), "hipDeviceSynchronize")
+
+    def event(self):
+        e = ctypes.c_void_p()
+        self.check(self.lib.hipEventCreate(ctypes.byref(e)), "hipEventCreate")
+        return e
+
+    def elapsed_ms(self, start, stop) -> float:
+        ms = ctypes.c_float()
+        self.check(self.lib.hipEventElapsedTime(ctypes.byref(ms), start, stop),
+                   "hipEventElapsedTime")
+        return ms.value
+
+
+def _load_kernels(bindir: str):
+    cands = []
+    if bindir and os.path.isdir(bindir):
+        cands += [os.path.join(bindir, n) for n in os.listdir(bindir)
+                  if n.lower().startswith("custom_kernels")
+                  and n.lower().endswith((".dll", ".so"))]
+    if not cands:
+        raise RuntimeError(f"no custom_kernels DLL under {bindir!r}")
+    lib = ctypes.CDLL(cands[0])
+    fn = lib.hip_conv
+    fn.restype = ctypes.c_int
+    fn.argtypes = (
+        [ctypes.c_void_p] * 5          # stream, x, w, bias, y
+        + [ctypes.c_int, ctypes.c_int]  # dtype, spatial_rank
+        + [ctypes.c_int64] * 22         # N..group
+    )
+    return cands[0], fn
+
+
+def _prod(xs):
+    n = 1
+    for x in xs:
+        n *= x
+    return n
+
+
+def bench_shape(hip: Hip, conv, rec: dict, iters: int, warmup: int):
+    """Time one convolution shape. Returns a result dict, or raises."""
+    dt = rec["dtype"]
+    esz = _BYTES[dt]
+    rank = rec["rank"]
+    N, Cin, Cout, g = rec["N"], rec["Cin"], rec["Cout"], rec["group"]
+
+    n_in = N * Cin * _prod(rec["in"])
+    n_out = N * Cout * _prod(rec["out"])
+    n_w = Cout * (Cin // g) * _prod(rec["kernel"])
+
+    x = w = b = y = None
+    try:
+        x = hip.malloc(n_in * esz)
+        w = hip.malloc(n_w * esz)
+        b = hip.malloc(Cout * esz) if rec.get("bias", True) else None
+        y = hip.malloc(n_out * esz)
+
+        args = ([None, x, w, b, y, _HIP_DTYPE[dt], rank, N, Cin, Cout]
+                + list(rec["in"]) + list(rec["out"]) + list(rec["kernel"])
+                + list(rec["stride"]) + list(rec["pad_begin"])
+                + list(rec["dilation"]) + [g])
+
+        for _ in range(warmup):
+            rc = conv(*args)
+            if rc != 0:
+                raise RuntimeError(f"hip_conv returned {rc}")
+        hip.sync()
+
+        # Time each iteration separately: a single event pair around a loop
+        # would hide a bimodal distribution, and the tile ladder is exactly the
+        # kind of thing that produces one.
+        start, stop = hip.event(), hip.event()
+        samples = []
+        for _ in range(iters):
+            hip.lib.hipEventRecord(start, None)
+            conv(*args)
+            hip.lib.hipEventRecord(stop, None)
+            hip.check(hip.lib.hipEventSynchronize(stop), "hipEventSynchronize")
+            samples.append(hip.elapsed_ms(start, stop))
+        hip.lib.hipEventDestroy(start)
+        hip.lib.hipEventDestroy(stop)
+
+        ms = statistics.median(samples)
+        # 2 flops per MAC, over the full im2col contraction.
+        flops = 2.0 * N * Cout * _prod(rec["out"]) * (Cin // g) * _prod(rec["kernel"])
+        # Compulsory traffic only -- what a perfect kernel would move. The
+        # ratio of this to achieved bandwidth is the gather amplification.
+        bytes_min = (n_in + n_w + n_out) * esz
+        return {
+            "ms": ms,
+            "ms_min": min(samples),
+            "ms_max": max(samples),
+            "count": rec.get("count", 1),
+            "weighted_ms": ms * rec.get("count", 1),
+            "tflops": flops / (ms * 1e-3) / 1e12,
+            "min_gbps": bytes_min / (ms * 1e-3) / 1e9,
+        }
+    finally:
+        for p in (x, w, b, y):
+            hip.free(p)
+
+
+def cmd_run(args):
+    with open(args.shapes) as f:
+        shapes = json.load(f)
+
+    dll, conv = _load_kernels(args.bin)
+    hip = Hip(args.bin)
+    print(f"kernels: {dll}", file=sys.stderr)
+
+    out = {}
+    for model, recs in shapes.items():
+        if args.model and model not in args.model:
+            continue
+        out[model] = []
+        for rec in recs:
+            if rec["op"] != "Conv":
+                continue  # hip_conv only; ConvTranspose has its own entry point
+            label = ("Cin=%d Cout=%d out=%s k=%s s=%s g=%d %s"
+                     % (rec["Cin"], rec["Cout"], rec["out"][:rec["rank"]],
+                        rec["kernel"][:rec["rank"]], rec["stride"][:rec["rank"]],
+                        rec["group"], rec["dtype"]))
+            try:
+                r = bench_shape(hip, conv, rec, args.iters, args.warmup)
+            except Exception as e:  # noqa: BLE001
+                print(f"  SKIP {label}: {e}", file=sys.stderr)
+                continue
+            r["label"] = label
+            r["shape"] = rec
+            out[model].append(r)
+            print("  %-72s %8.3f ms x%-4d %9.3f ms tot %6.2f TF"
+                  % (label, r["ms"], r["count"], r["weighted_ms"], r["tflops"]),
+                  file=sys.stderr)
+        tot = sum(r["weighted_ms"] for r in out[model])
+        print(f"{model:<34} total {tot:9.3f} ms of convolution", file=sys.stderr)
+
+    text = json.dumps(out, indent=2)
+    if args.out:
+        with open(args.out, "w") as f:
+            f.write(text)
+        print(f"wrote {args.out}", file=sys.stderr)
+    else:
+        print(text)
+
+
+def cmd_compare(args):
+    with open(args.compare[0]) as f:
+        base = json.load(f)
+    with open(args.compare[1]) as f:
+        cand = json.load(f)
+
+    print(f"{'model / shape':<70}{'base ms':>10}{'cand ms':>10}{'delta':>9}")
+    print("-" * 99)
+    gb = gc = 0.0
+    for model in base:
+        if model not in cand:
+            continue
+        bl = {r["label"]: r for r in base[model]}
+        cl = {r["label"]: r for r in cand[model]}
+        mb = sum(r["weighted_ms"] for r in base[model])
+        mc = sum(r["weighted_ms"] for r in cand[model] if r["label"] in bl)
+        gb += mb
+        gc += mc
+        d = (mc - mb) / mb * 100 if mb else 0.0
+        print(f"{model:<70}{mb:>10.3f}{mc:>10.3f}{d:>8.1f}%")
+        rows = []
+        for label, rb in bl.items():
+            rc = cl.get(label)
+            if rc is None:
+                continue
+            rows.append((rc["weighted_ms"] - rb["weighted_ms"], label, rb, rc))
+        rows.sort(key=lambda t: t[0])
+        for delta, label, rb, rc in rows:
+            if abs(delta) < args.threshold:
+                continue
+            pct = (rc["ms"] - rb["ms"]) / rb["ms"] * 100 if rb["ms"] else 0.0
+            mark = "  FASTER" if delta < 0 else "  SLOWER"
+            print(f"    {label:<66}{rb['weighted_ms']:>10.3f}"
+                  f"{rc['weighted_ms']:>10.3f}{pct:>8.1f}%{mark}")
+    print("-" * 99)
+    d = (gc - gb) / gb * 100 if gb else 0.0
+    print(f"{'TOTAL':<70}{gb:>10.3f}{gc:>10.3f}{d:>8.1f}%")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("shapes", nargs="?", help="JSON from conv_shapes.py")
+    ap.add_argument("--bin", default=r"C:\Users\zyq\gpu-test-package\bin",
+                    help="Directory holding custom_kernels_<arch>.dll")
+    ap.add_argument("--iters", type=int, default=20)
+    ap.add_argument("--warmup", type=int, default=5)
+    ap.add_argument("--model", action="append",
+                    help="Only bench this model (repeatable).")
+    ap.add_argument("--out")
+    ap.add_argument("--compare", nargs=2, metavar=("BASE", "CAND"),
+                    help="Diff two result files instead of benchmarking.")
+    ap.add_argument("--threshold", type=float, default=0.05,
+                    help="Hide per-shape rows moving less than this many ms.")
+    args = ap.parse_args()
+
+    if args.compare:
+        cmd_compare(args)
+    elif args.shapes:
+        cmd_run(args)
+    else:
+        ap.error("need a shapes file, or --compare")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/perf-harness/bench/conv_microbench.py
+++ b/tools/perf-harness/bench/conv_microbench.py
@@ -33,6 +33,7 @@ import ctypes
 import json
 import os
 import statistics
+import subprocess
 import sys
 
 # hip_conv's dtype enum (HIP_DTYPE_* in hip_custom_kernels.h).
@@ -132,6 +133,40 @@ def _load_kernels(bindir: str):
     return cands[0], fn
 
 
+def _load_winograd(bindir: str):
+    """The Winograd entry points, or None on a build that predates them.
+
+    Separate from _load_kernels because the Winograd path is not reachable
+    through hip_conv -- the EP dispatches it in wrap_conv, above the kernel
+    ABI -- so timing it means calling it directly.
+    """
+    cands = [os.path.join(bindir, n) for n in os.listdir(bindir)
+             if n.lower().startswith("custom_kernels")
+             and n.lower().endswith((".dll", ".so"))]
+    lib = ctypes.CDLL(cands[0])
+    try:
+        elig = lib.hip_conv_winograd_eligible
+        prof = lib.hip_conv_winograd_profitable
+        felems = lib.hip_conv_winograd_filter_elems
+        xform = lib.hip_conv_winograd_filter
+        fused = lib.hip_conv_winograd_fused
+    except AttributeError:
+        return None
+
+    elig.restype = ctypes.c_int
+    elig.argtypes = [ctypes.c_int] + [ctypes.c_int64] * 10
+    prof.restype = ctypes.c_int
+    prof.argtypes = [ctypes.c_int64] * 5
+    felems.restype = ctypes.c_int64
+    felems.argtypes = [ctypes.c_int64] * 2
+    xform.restype = ctypes.c_int
+    xform.argtypes = [ctypes.c_void_p] * 3 + [ctypes.c_int64] * 2
+    fused.restype = ctypes.c_int
+    fused.argtypes = [ctypes.c_void_p] * 5 + [ctypes.c_int64] * 9
+    return {"eligible": elig, "profitable": prof, "filter_elems": felems,
+            "filter": xform, "fused": fused}
+
+
 def _prod(xs):
     n = 1
     for x in xs:
@@ -202,6 +237,108 @@ def bench_shape(hip: Hip, conv, rec: dict, iters: int, warmup: int):
             hip.free(p)
 
 
+def bench_winograd(hip: Hip, wg, rec: dict, iters: int, warmup: int):
+    """Time the fused Winograd path on one shape, or return None if it does
+    not apply. The filter transform is excluded, as it is in the EP: it is
+    hoisted out of the call and cached per weight tensor."""
+    if rec["dtype"] != "float16" or rec["rank"] != 2:
+        return None
+    k = rec["kernel"][:2]
+    s = rec["stride"][:2]
+    d = rec["dilation"][:2]
+    N, Cin, Cout, g = rec["N"], rec["Cin"], rec["Cout"], rec["group"]
+    if not wg["eligible"](_HIP_DTYPE["float16"], 2, k[0], k[1], s[0], s[1],
+                          d[0], d[1], g, Cin, Cout):
+        return None
+
+    inp, outp, pad = rec["in"][:2], rec["out"][:2], rec["pad_begin"][:2]
+    esz = 2
+    x = w = u = b = y = None
+    try:
+        x = hip.malloc(N * Cin * inp[0] * inp[1] * esz)
+        w = hip.malloc(Cout * Cin * 9 * esz)
+        u = hip.malloc(wg["filter_elems"](Cout, Cin) * esz)
+        b = hip.malloc(Cout * esz)
+        y = hip.malloc(N * Cout * outp[0] * outp[1] * esz)
+
+        rc = wg["filter"](None, w, u, Cout, Cin)
+        if rc != 0:
+            raise RuntimeError(f"winograd_filter returned {rc}")
+
+        args_ = [None, x, u, b, y, N, Cin, Cout, inp[0], inp[1],
+                 outp[0], outp[1], pad[0], pad[1]]
+        for _ in range(warmup):
+            rc = wg["fused"](*args_)
+            if rc != 0:
+                raise RuntimeError(f"winograd_fused returned {rc}")
+        hip.sync()
+
+        start, stop = hip.event(), hip.event()
+        samples = []
+        for _ in range(iters):
+            hip.lib.hipEventRecord(start, None)
+            wg["fused"](*args_)
+            hip.lib.hipEventRecord(stop, None)
+            hip.check(hip.lib.hipEventSynchronize(stop), "hipEventSynchronize")
+            samples.append(hip.elapsed_ms(start, stop))
+        hip.lib.hipEventDestroy(start)
+        hip.lib.hipEventDestroy(stop)
+        return statistics.median(samples)
+    finally:
+        for p in (x, w, u, b, y):
+            hip.free(p)
+
+
+def cmd_winograd(args):
+    """A/B the fused Winograd path against hip_conv, per shape."""
+    with open(args.shapes) as f:
+        shapes = json.load(f)
+
+    dll, conv = _load_kernels(args.bin)
+    wg = _load_winograd(args.bin)
+    if not wg:
+        raise SystemExit("this build has no hip_conv_winograd_fused")
+    hip = Hip(args.bin)
+    print(f"kernels: {dll}", file=sys.stderr)
+
+    # Three totals, because the question is not whether Winograd is faster --
+    # it is faster on some shapes and slower on others -- but whether the gate
+    # picks the right one. `gated` is what actually ships; `oracle` is the best
+    # possible per-shape choice and so the bound the gate is judged against.
+    tot_d = tot_w = tot_g = tot_o = 0.0
+    for model, recs in shapes.items():
+        if args.model and model not in args.model:
+            continue
+        for rec in recs:
+            if rec["op"] != "Conv":
+                continue
+            wms = bench_winograd(hip, wg, rec, args.iters, args.warmup)
+            if wms is None:
+                continue
+            d = bench_shape(hip, conv, rec, args.iters, args.warmup)["ms"]
+            cnt = rec.get("count", 1)
+            gate = bool(wg["profitable"](rec["N"], rec["Cin"], rec["Cout"],
+                                         rec["out"][0], rec["out"][1]))
+            tot_d += d * cnt
+            tot_w += wms * cnt
+            tot_g += (wms if gate else d) * cnt
+            tot_o += min(d, wms) * cnt
+            label = ("Cin=%-4d Cout=%-4d out=%s"
+                     % (rec["Cin"], rec["Cout"], rec["out"][:2]))
+            flag = "USE" if gate else "   "
+            miss = "" if gate == (wms < d) else "  <- gate wrong"
+            print("  %-40s direct %7.3f  winograd %7.3f  %5.2fx %s x%-3d%s"
+                  % (label, d, wms, d / wms, flag, cnt, miss),
+                  file=sys.stderr)
+    if tot_w > 0:
+        print(file=sys.stderr)
+        print("  always direct   %8.3f ms" % tot_d, file=sys.stderr)
+        print("  always winograd %8.3f ms" % tot_w, file=sys.stderr)
+        print("  gated (ships)   %8.3f ms  %.2fx vs direct, %.1f%% of oracle"
+              % (tot_g, tot_d / tot_g, 100.0 * tot_o / tot_g), file=sys.stderr)
+        print("  oracle          %8.3f ms" % tot_o, file=sys.stderr)
+
+
 def cmd_run(args):
     with open(args.shapes) as f:
         shapes = json.load(f)
@@ -243,6 +380,75 @@ def cmd_run(args):
         print(f"wrote {args.out}", file=sys.stderr)
     else:
         print(text)
+
+
+def cmd_tile_sweep(args):
+    """Run every tile against every shape and report the best one for each.
+
+    The cost model in conv_tile_select.h is a handful of ratios standing in for
+    a memory system, and there is no way to know whether it ranks two tiles
+    correctly except to run both. This produces the table it is answerable to.
+
+    Each tile needs its own process: the kernel DLL reads the override once and
+    caches it, which is the right thing for a DLL and the wrong thing for a
+    sweep.
+    """
+    # Four-field names where a block shape appears at more than one register
+    # tile, so the sweep row and the kernel launched agree. See
+    # conv_tile_select.h for which entries share a block shape.
+    tiles = args.tiles or ["128x256", "256x128", "128x128", "64x256", "32x256",
+                           "16x256", "128x256x2x4", "128x128x2x2",
+                           "64x256x2x2",
+                           "128x128x8x8", "64x128x4x8", "128x64x8x4",
+                           "64x64x4x4", "32x128x2x8", "64x32x4x2",
+                           "32x64x2x4", "32x32x2x2", "direct"]
+    results = {}
+    for tile in tiles:
+        out = os.path.join(args.workdir, f"tile_{tile}.json")
+        os.makedirs(args.workdir, exist_ok=True)
+        env = dict(os.environ)
+        env["HIPDNN_EP_CONV_TILE"] = tile
+        cmd = [sys.executable, os.path.abspath(__file__), args.shapes,
+               "--bin", args.bin, "--iters", str(args.iters),
+               "--warmup", str(args.warmup), "--out", out]
+        for m in args.model or []:
+            cmd += ["--model", m]
+        p = subprocess.run(cmd, env=env, capture_output=True, text=True)
+        if not os.path.exists(out):
+            print(f"tile {tile}: no result\n{p.stderr[-800:]}", file=sys.stderr)
+            continue
+        with open(out) as f:
+            results[tile] = json.load(f)
+        tot = sum(r["weighted_ms"] for recs in results[tile].values()
+                  for r in recs)
+        print(f"tile {tile:<10} total {tot:9.3f} ms", file=sys.stderr)
+
+    if not results:
+        sys.exit("no tile produced results")
+
+    # Per shape, which tile actually won.
+    print()
+    print(f"{'model':<20}{'shape':<62}{'best':>9}{'ms':>9}   runners-up")
+    print("-" * 130)
+    table = {}
+    for model in next(iter(results.values())):
+        for tile, data in results.items():
+            for r in data.get(model, []):
+                table.setdefault((model, r["label"]), {})[tile] = r
+
+        rows = [(k, v) for k, v in table.items() if k[0] == model]
+        rows.sort(key=lambda kv: -min(r["weighted_ms"] for r in kv[1].values()))
+        for (m, label), byTile in rows:
+            ranked = sorted(byTile.items(), key=lambda kv: kv[1]["ms"])
+            best, br = ranked[0]
+            rest = "  ".join(f"{t}:{r['ms'] / br['ms']:.2f}x"
+                             for t, r in ranked[1:4])
+            print(f"{m:<20}{label:<62}{best:>9}{br['ms']:>9.3f}   {rest}")
+
+    with open(args.out or os.path.join(args.workdir, "tile_sweep.json"),
+              "w") as f:
+        json.dump({f"{m}|{label}": {t: r["ms"] for t, r in byTile.items()}
+                   for (m, label), byTile in table.items()}, f, indent=2)
 
 
 def cmd_compare(args):
@@ -299,10 +505,26 @@ def main():
                     help="Diff two result files instead of benchmarking.")
     ap.add_argument("--threshold", type=float, default=0.05,
                     help="Hide per-shape rows moving less than this many ms.")
+    ap.add_argument("--tile-sweep", action="store_true",
+                    help="Force each tile in turn and report the best per shape.")
+    ap.add_argument("--tiles", action="append",
+                    help="Restrict --tile-sweep to these tiles (repeatable).")
+    ap.add_argument("--workdir", default=r"C:\Users\zyq\scratch\conv-tiles",
+                    help="Where --tile-sweep writes its per-tile results.")
+    ap.add_argument("--winograd", action="store_true",
+                    help="A/B the fused Winograd path against hip_conv.")
     args = ap.parse_args()
 
     if args.compare:
         cmd_compare(args)
+    elif args.winograd:
+        if not args.shapes:
+            ap.error("--winograd needs a shapes file")
+        cmd_winograd(args)
+    elif args.tile_sweep:
+        if not args.shapes:
+            ap.error("--tile-sweep needs a shapes file")
+        cmd_tile_sweep(args)
     elif args.shapes:
         cmd_run(args)
     else:

--- a/tools/perf-harness/bench/conv_numeric_sweep.py
+++ b/tools/perf-harness/bench/conv_numeric_sweep.py
@@ -1,0 +1,195 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+"""Run the convolution shape sweep against a deployed build, via hip-onnx-runner.
+
+test/numeric drives the same cases through ORT's plugin-EP API, which needs the
+Python onnxruntime package to match the ORT the EP was built against. That is
+often not true of a deploy directory assembled by hand, and a mismatch is an
+access violation inside session creation rather than a clean error. This path
+has no such coupling: hip-onnx-runner is built with the EP, ships beside it,
+and produces the CPU reference itself with `-n`.
+
+Both arms are run with the same `-s` seed, so the random inputs match and the
+outputs are directly comparable.
+
+    python conv_numeric_sweep.py --bin C:\\Users\\zyq\\gpu-test-package\\bin
+
+A case fails on any non-finite output, or on exceeding the dtype's tolerance.
+Non-finiteness is reported separately and first: a NaN also destroys the
+correlation, so reporting only the correlation would describe an arithmetic
+fault as imprecision.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+
+import numpy as np
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_CASES = os.path.normpath(os.path.join(_HERE, "..", "..", "..",
+                                       "test", "numeric", "tests"))
+sys.path.insert(0, _CASES)
+
+import conv_cases  # noqa: E402
+
+# hip-onnx-runner names dumps  <name>_<type>.bin ; these are the ones the sweep
+# can produce.
+_SUFFIX_DTYPE = {"fp32": np.float32, "fp16": np.float16}
+
+
+def _read_dump(d: str):
+    """Load every tensor in a dump directory, keyed by filename stem."""
+    out = {}
+    for fn in sorted(os.listdir(d)):
+        if not fn.endswith(".bin"):
+            continue
+        stem = fn[:-4]
+        dt = None
+        for suf, npt in _SUFFIX_DTYPE.items():
+            if stem.endswith("_" + suf):
+                dt, stem = npt, stem[: -(len(suf) + 1)]
+                break
+        if dt is None:
+            continue
+        out[stem] = np.fromfile(os.path.join(d, fn), dtype=dt)
+    return out
+
+
+def _run(runner: str, bindir: str, model: str, seed: int, no_ep: bool,
+         env: dict):
+    stem = os.path.splitext(os.path.basename(model))[0]
+    # The runner tags the CPU-only dump directory with _cpu so the two runs do
+    # not collide, which also means the path depends on the mode.
+    dump = os.path.join(bindir, f"{stem}{'_cpu' if no_ep else ''}_o_dump")
+    shutil.rmtree(dump, ignore_errors=True)
+
+    cmd = [runner, "-m", model, "-d", "2", "-s", str(seed)]
+    if no_ep:
+        cmd.append("-n")
+    p = subprocess.run(cmd, cwd=bindir, env=env, capture_output=True, text=True)
+    if not os.path.isdir(dump):
+        tail = (p.stdout + p.stderr).strip().splitlines()[-6:]
+        raise RuntimeError("no dump produced; " + " | ".join(tail))
+    try:
+        return _read_dump(dump)
+    finally:
+        shutil.rmtree(dump, ignore_errors=True)
+
+
+def _compare(cpu: dict, ep: dict, tol: float):
+    """Return (ok, message) for one case."""
+    problems = []
+    for name, ref in cpu.items():
+        got = ep.get(name)
+        if got is None:
+            problems.append(f"{name}: missing from the EP dump")
+            continue
+        if got.shape != ref.shape:
+            problems.append(f"{name}: {got.shape} vs reference {ref.shape}")
+            continue
+
+        bad = int(np.count_nonzero(~np.isfinite(got)))
+        if bad:
+            finite = got[np.isfinite(got)]
+            lo = float(finite.min()) if finite.size else float("nan")
+            hi = float(finite.max()) if finite.size else float("nan")
+            problems.append(
+                f"{name}: {bad} non-finite of {got.size} "
+                f"({100.0 * bad / got.size:.2f}%), finite range [{lo:.4g}, {hi:.4g}]"
+            )
+            continue
+
+        a = got.astype(np.float64)
+        b = ref.astype(np.float64)
+        denom = max(np.abs(b).max(), 1e-30)
+        rel = float(np.abs(a - b).max() / denom)
+        na, nb = np.linalg.norm(a), np.linalg.norm(b)
+        cos = float(a @ b / (na * nb)) if na and nb else 1.0
+        if rel > tol or cos < 0.999:
+            problems.append(f"{name}: max rel {rel:.3g}, cosine {cos:.6f}")
+    return (not problems), "; ".join(problems)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--bin", default=r"C:\Users\zyq\gpu-test-package\bin",
+                    help="Deploy directory holding hip-onnx-runner and the EP.")
+    ap.add_argument("--work", default=r"C:\Users\zyq\scratch\conv-sweep",
+                    help="Where the generated models are written.")
+    ap.add_argument("--rocm", default=r"C:\Users\zyq\therock-dist\bin",
+                    help="ROCm runtime bin, prepended to PATH.")
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("-k", "--filter", help="Only run cases whose id contains this.")
+    ap.add_argument("--keep", action="store_true",
+                    help="Keep generated models (they are removed on pass).")
+    args = ap.parse_args()
+
+    runner = os.path.join(args.bin, "hip-onnx-runner.exe")
+    if not os.path.exists(runner):
+        runner = os.path.join(args.bin, "hip-onnx-runner")
+    if not os.path.exists(runner):
+        sys.exit(f"hip-onnx-runner not found in {args.bin}")
+
+    os.makedirs(args.work, exist_ok=True)
+    env = dict(os.environ)
+    env["PATH"] = os.pathsep.join([args.bin, args.rocm, env.get("PATH", "")])
+    # The per-op profiler perturbs nothing here but adds noise to the log, and
+    # the debug log is enormous across a whole sweep.
+    for k in ("HIPDNN_EP_PERF", "HIPDNN_EP_DEBUG", "HIPDNN_EP_TRACE_FILE"):
+        env.pop(k, None)
+
+    cases = conv_cases.ALL_CASES
+    if args.filter:
+        cases = [c for c in cases if args.filter in c["id"]]
+    if not cases:
+        sys.exit("no cases matched")
+
+    npass = nfail = nskip = 0
+    failures = []
+    for case in cases:
+        cid = case["id"]
+        model, _ = conv_cases.build(case)
+        path = os.path.join(args.work, f"{cid}.onnx")
+        with open(path, "wb") as f:
+            f.write(model.SerializeToString())
+
+        try:
+            cpu = _run(runner, args.bin, path, args.seed, True, env)
+            ep = _run(runner, args.bin, path, args.seed, False, env)
+        except Exception as e:  # noqa: BLE001
+            nskip += 1
+            print(f"SKIP {cid:<28} {e}")
+            continue
+
+        tol = 2e-2 if case.get("dtype", "float16") == "float16" else 1e-4
+        ok, msg = _compare(cpu, ep, tol)
+        if ok:
+            npass += 1
+            print(f"pass {cid}")
+            if not args.keep:
+                os.remove(path)
+        else:
+            nfail += 1
+            failures.append((cid, msg))
+            print(f"FAIL {cid:<28} {msg}")
+
+    print()
+    print(f"{npass} passed, {nfail} failed, {nskip} skipped")
+    if failures:
+        print("\nfailures:")
+        for cid, msg in failures:
+            print(f"  {cid}: {msg}")
+    return 1 if nfail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/perf-harness/bench/conv_shapes.py
+++ b/tools/perf-harness/bench/conv_shapes.py
@@ -1,0 +1,190 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+"""Extract every distinct convolution shape a model asks the EP to run.
+
+The tile-selection heuristic in conv_kernel.hip is a pure function of a
+convolution's shape and the device's CU count, so it can be evaluated against
+the shapes the models actually contain without running the models. This dumps
+those shapes; conv_microbench.py times them.
+
+Shapes are deduplicated and counted. That is the whole point of the file: a
+model's convolution *node* count is a bad guide to its distinct *shape* count
+-- esrgan has 351 Conv nodes and 8 distinct shapes -- and a heuristic change
+only has to be re-measured once per distinct shape.
+
+The `count` on each record is the node count, which is also the weight to use
+when ranking shapes by how much of a model's runtime they can explain.
+
+Output is JSON on stdout, or to --out:
+
+  {"<model>": [{"op": "Conv", "dtype": "float16", "N": 1, ...,
+                "count": 69}, ...], ...}
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import os
+import sys
+
+import onnx
+from onnx import TensorProto
+
+# ONNX elem_type -> the name hip_conv's dtype switch understands.
+_DTYPE = {
+    TensorProto.FLOAT: "float32",
+    TensorProto.FLOAT16: "float16",
+    TensorProto.BFLOAT16: "bfloat16",
+}
+
+
+def _attr(node, name, default=None):
+    for a in node.attribute:
+        if a.name == name:
+            if a.ints:
+                return list(a.ints)
+            if a.HasField("i"):
+                return a.i
+            if a.s:
+                return a.s.decode()
+    return default
+
+
+def _dims(vi):
+    """Static dims of a ValueInfo, or None if any axis is dynamic.
+
+    A dynamic axis is almost always the batch, which the harness pins to 1
+    anyway, so it is substituted rather than dropping the shape.
+    """
+    if not vi.type.HasField("tensor_type"):
+        return None
+    out = []
+    for d in vi.type.tensor_type.shape.dim:
+        if d.HasField("dim_value") and d.dim_value > 0:
+            out.append(int(d.dim_value))
+        else:
+            out.append(1)  # dynamic axis: the harness runs batch 1
+    return out
+
+
+def _infer(model):
+    """Shape-infer, tolerating models the checker rejects.
+
+    Several of the vision models fail strict checking on unrelated nodes; the
+    inferred shapes for the convolutions are still usable, so failures here
+    fall back to whatever the graph already declares.
+    """
+    try:
+        return onnx.shape_inference.infer_shapes(model, strict_mode=False)
+    except Exception:  # noqa: BLE001
+        return model
+
+
+def shapes_for_model(path: str):
+    model = onnx.load(path, load_external_data=False)
+    model = _infer(model)
+    g = model.graph
+
+    vis = {}
+    for coll in (g.input, g.output, g.value_info):
+        for vi in coll:
+            vis[vi.name] = vi
+    winit = {i.name: i for i in g.initializer}
+
+    seen = collections.OrderedDict()
+    for node in g.node:
+        if node.op_type not in ("Conv", "ConvTranspose"):
+            continue
+        if len(node.input) < 2:
+            continue
+
+        xvi = vis.get(node.input[0])
+        yvi = vis.get(node.output[0])
+        w = winit.get(node.input[1])
+        if xvi is None or yvi is None or w is None:
+            continue
+        xd, yd, wd = _dims(xvi), _dims(yvi), list(w.dims)
+        if not xd or not yd or len(xd) < 3 or len(yd) < 3 or len(wd) < 3:
+            continue
+
+        rank = len(xd) - 2
+        if rank < 1 or rank > 3:
+            continue
+
+        dtype = _DTYPE.get(xvi.type.tensor_type.elem_type)
+        if dtype is None:
+            continue
+
+        group = _attr(node, "group", 1) or 1
+        kernel = _attr(node, "kernel_shape") or wd[2:]
+        stride = _attr(node, "strides") or [1] * rank
+        dil = _attr(node, "dilations") or [1] * rank
+        pads = _attr(node, "pads") or [0] * (2 * rank)
+
+        # hip_conv takes pads_begin only; the trailing pad is already folded
+        # into the caller's output extent.
+        rec = {
+            "op": node.op_type,
+            "dtype": dtype,
+            "rank": rank,
+            "N": xd[0],
+            "Cin": xd[1],
+            "Cout": yd[1],
+            "in": xd[2:] + [1] * (3 - rank),
+            "out": yd[2:] + [1] * (3 - rank),
+            "kernel": list(kernel) + [1] * (3 - rank),
+            "stride": list(stride) + [1] * (3 - rank),
+            "pad_begin": list(pads[:rank]) + [0] * (3 - rank),
+            "dilation": list(dil) + [1] * (3 - rank),
+            "group": group,
+            "bias": len(node.input) > 2,
+        }
+        key = json.dumps(rec, sort_keys=True)
+        if key in seen:
+            seen[key]["count"] += 1
+        else:
+            rec["count"] = 1
+            seen[key] = rec
+
+    return list(seen.values())
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("models", nargs="+", metavar="NAME=PATH",
+                    help="Model to census. Bare paths are named by basename.")
+    ap.add_argument("--out", help="Write JSON here instead of stdout.")
+    args = ap.parse_args()
+
+    result = {}
+    for spec in args.models:
+        name, _, path = spec.partition("=")
+        if not path:
+            name, path = os.path.basename(os.path.dirname(spec)) or spec, spec
+        if not os.path.exists(path):
+            print(f"MISSING {name}: {path}", file=sys.stderr)
+            continue
+        try:
+            result[name] = shapes_for_model(path)
+        except Exception as e:  # noqa: BLE001
+            print(f"FAILED {name}: {e}", file=sys.stderr)
+            continue
+        nodes = sum(r["count"] for r in result[name])
+        print(f"{name:<34} {len(result[name]):>4} distinct / {nodes:>4} nodes",
+              file=sys.stderr)
+
+    text = json.dumps(result, indent=2)
+    if args.out:
+        with open(args.out, "w") as f:
+            f.write(text)
+    else:
+        print(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/perf-harness/bench/conv_tile_check.py
+++ b/tools/perf-harness/bench/conv_tile_check.py
@@ -1,0 +1,243 @@
+"""Check every conv tile against conv_direct on real data.
+
+A new tile is a new kernel instantiation, and the staging arithmetic it changes
+-- how many threads cover a contraction slice, how many rows each one carries --
+is exactly where an off-by-one produces a plausible-looking wrong answer rather
+than a crash. The perf sweep cannot see that: it fills its buffers with
+hipMemset and only reads the clock.
+
+So this runs each tile against conv_direct, which has no staging at all -- a
+thread per output element, re-reading its own inputs -- on pseudorandom inputs,
+and reports the worst relative error per tile. Direct is the reference because
+it is the one path whose correctness is obvious by inspection, which is what the
+comment in the ladder says it is for.
+
+One process per tile, because the kernel DLL reads HIPDNN_EP_CONV_TILE once.
+
+    py -3.11 conv_tile_check.py --bin <deploy dir>
+"""
+
+import argparse
+import ctypes
+import json
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from conv_microbench import Hip, _load_kernels, _HIP_DTYPE, _BYTES, _prod
+
+# hipMemcpyKind
+H2D, D2H = 1, 2
+
+# Shapes with resolved extents covering both tables and every rung: wide and
+# narrow output channel counts, few and many output positions, 1x1 and 3x3, a
+# stride, a group, and a K long enough to trip the gather threshold. Kept small
+# so the fp64 reference below stays cheap.
+CASES = [
+    # (dtype, N, Cin, Cout, in, out, kernel, stride, pad, dil, group)
+    ("float16", 1, 64, 128, [28, 28, 1], [28, 28, 1], [3, 3, 1], [1, 1, 1], [1, 1, 0], [1, 1, 1], 1),
+    ("float16", 1, 128, 256, [14, 14, 1], [14, 14, 1], [3, 3, 1], [1, 1, 1], [1, 1, 0], [1, 1, 1], 1),
+    ("float16", 1, 256, 512, [7, 7, 1], [7, 7, 1], [1, 1, 1], [1, 1, 1], [0, 0, 0], [1, 1, 1], 1),
+    ("float16", 1, 512, 512, [7, 7, 1], [7, 7, 1], [3, 3, 1], [1, 1, 1], [1, 1, 0], [1, 1, 1], 1),
+    ("float16", 1, 32, 16, [30, 30, 1], [30, 30, 1], [3, 3, 1], [1, 1, 1], [1, 1, 0], [1, 1, 1], 1),
+    ("float16", 1, 64, 3, [40, 40, 1], [40, 40, 1], [3, 3, 1], [1, 1, 1], [1, 1, 0], [1, 1, 1], 1),
+    ("float16", 1, 96, 48, [20, 20, 1], [10, 10, 1], [3, 3, 1], [2, 2, 1], [1, 1, 0], [1, 1, 1], 1),
+    ("float16", 2, 64, 64, [16, 16, 1], [16, 16, 1], [3, 3, 1], [1, 1, 1], [1, 1, 0], [1, 1, 1], 1),
+    ("float16", 1, 128, 128, [16, 16, 1], [16, 16, 1], [3, 3, 1], [1, 1, 1], [1, 1, 0], [1, 1, 1], 2),
+    # A K past the gather threshold (2048) with few output positions.
+    ("float16", 1, 512, 256, [6, 6, 1], [6, 6, 1], [3, 3, 1], [1, 1, 1], [1, 1, 0], [1, 1, 1], 1),
+    ("float32", 1, 64, 128, [28, 28, 1], [28, 28, 1], [3, 3, 1], [1, 1, 1], [1, 1, 0], [1, 1, 1], 1),
+    ("float32", 1, 128, 128, [20, 20, 1], [20, 20, 1], [1, 1, 1], [1, 1, 1], [0, 0, 0], [1, 1, 1], 1),
+    ("float32", 1, 96, 64, [24, 24, 1], [12, 12, 1], [3, 3, 1], [2, 2, 1], [1, 1, 0], [1, 1, 1], 1),
+]
+
+TILES = ["direct",
+         "128x256", "256x128", "128x128", "64x256", "32x256", "16x256",
+         "128x256x2x4", "128x128x2x2", "64x256x2x2",
+         "128x128x8x8", "64x128x4x8", "128x64x8x4", "64x64x4x4",
+         "32x128x2x8", "64x32x4x2", "32x64x2x4", "32x32x2x2"]
+
+
+def rng(n, seed):
+    """A small deterministic generator, so both sides see identical bytes.
+
+    Values are centred and scaled to keep an fp16 accumulation over K taps
+    well inside range -- the point is to compare two kernels, not to explore
+    overflow, which the numeric suite covers.
+    """
+    s = seed & 0xFFFFFFFF
+    out = []
+    for _ in range(n):
+        s = (1103515245 * s + 12345) & 0x7FFFFFFF
+        out.append(((s >> 8) & 0x3FF) / 1023.0 - 0.5)
+    return out
+
+
+def to_bytes(vals, dtype):
+    import struct
+    if dtype == "float32":
+        return struct.pack(f"<{len(vals)}f", *vals)
+    # fp16 via the struct 'e' code, available since 3.6.
+    return struct.pack(f"<{len(vals)}e", *vals)
+
+
+def from_bytes(buf, dtype, n):
+    import struct
+    code = "f" if dtype == "float32" else "e"
+    return list(struct.unpack_from(f"<{n}{code}", buf, 0))
+
+
+def run_case(hip, conv, case, seed):
+    (dt, N, Cin, Cout, ins, outs, ker, stride, pad, dil, g) = case
+    esz = _BYTES[dt]
+    n_in = N * Cin * _prod(ins)
+    n_out = N * Cout * _prod(outs)
+    n_w = Cout * (Cin // g) * _prod(ker)
+
+    xv = rng(n_in, seed)
+    wv = rng(n_w, seed + 7919)
+    bv = rng(Cout, seed + 104729)
+
+    x = w = b = y = None
+    try:
+        x, w, b, y = (hip.malloc(n_in * esz), hip.malloc(n_w * esz),
+                      hip.malloc(Cout * esz), hip.malloc(n_out * esz))
+        for ptr, vals in ((x, xv), (w, wv), (b, bv)):
+            raw = to_bytes(vals, dt)
+            hip.check(hip.lib.hipMemcpy(ptr, raw, len(raw), H2D), "hipMemcpy")
+        args = ([None, x, w, b, y, _HIP_DTYPE[dt], 2, N, Cin, Cout]
+                + list(ins) + list(outs) + list(ker) + list(stride)
+                + list(pad) + list(dil) + [g])
+        rc = conv(*args)
+        if rc != 0:
+            raise RuntimeError(f"hip_conv returned {rc}")
+        hip.sync()
+        buf = ctypes.create_string_buffer(n_out * esz)
+        hip.check(hip.lib.hipMemcpy(buf, y, n_out * esz, D2H), "hipMemcpy")
+        return from_bytes(buf, dt, n_out)
+    finally:
+        for p in (x, w, b, y):
+            hip.free(p)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bin", default=r"C:\Users\zyq\gpu-test-package\bin")
+    ap.add_argument("--out", help="write this tile's outputs here (internal)")
+    ap.add_argument("--tiles", action="append")
+    args = ap.parse_args()
+
+    if args.out:  # child: run every case under whatever tile the env forces
+        hip = Hip(args.bin)
+        _, conv = _load_kernels(args.bin)
+        res = []
+        for i, case in enumerate(CASES):
+            try:
+                res.append(run_case(hip, conv, case, 1234 + i))
+            except Exception as e:  # noqa: BLE001
+                res.append({"error": str(e)})
+        with open(args.out, "w") as f:
+            json.dump(res, f)
+        return 0
+
+    os.environ.setdefault("HIPDNN_EP_DEBUG", "1")
+
+    tiles = args.tiles or TILES
+    workdir = os.path.join(os.environ.get("TEMP", "."), "conv_tile_check")
+    os.makedirs(workdir, exist_ok=True)
+    got = {}
+    picks = {}
+    for tile in tiles:
+        out = os.path.join(workdir, f"{tile}.json")
+        env = dict(os.environ)
+        env["HIPDNN_EP_CONV_TILE"] = tile
+        p = subprocess.run(
+            [sys.executable, os.path.abspath(__file__), "--bin", args.bin,
+             "--out", out], env=env, capture_output=True, text=True)
+        if not os.path.exists(out):
+            print(f"{tile}: no result\n{p.stderr[-600:]}", file=sys.stderr)
+            continue
+        with open(out) as f:
+            got[tile] = json.load(f)
+        # What the kernel says it launched, from the debug log. Without this the
+        # comparison below passes for a tile that never ran: an unresolved name
+        # leaves the ladder's own pick in place, which is correct code producing
+        # a correct answer for the wrong tile.
+        picks[tile] = set()
+        for line in p.stderr.splitlines():
+            if "hip_conv pick=" not in line:
+                continue
+            kind = line.split("pick=", 1)[1].split(None, 1)[0]
+            dims = line.split("tile=", 1)[1].split(None, 1)[0]
+            picks[tile].add(f"{kind} {dims}")
+
+    if "direct" not in got:
+        sys.exit("conv_direct produced no reference")
+    ref = got["direct"]
+
+    # fp16 carries ~3 decimal digits, and direct accumulates the contraction in
+    # a different order than a tiled kernel does, so the two disagree in the
+    # last bits by construction. The threshold is on the relative error against
+    # the magnitude of the reference row, which is what distinguishes rounding
+    # from a staging bug: a wrong tile is wrong by a whole term, not an epsilon.
+    tol = {"float16": 3e-2, "float32": 1e-4}
+    bad = 0
+    # Split by dtype: a tile name only resolves against its own dtype's table,
+    # so the scalar names leave the fp16 cases on the ladder's own pick and the
+    # matrix names leave the fp32 ones. Reporting one worst error per tile hides
+    # that, and would read as a pass for a tile that never ran.
+    print(f"{'tile':<14}{'fp16':>12}{'fp32':>12}  worst case")
+    print("-" * 56)
+    for tile, res in got.items():
+        if tile == "direct":
+            continue
+        worst = {"float16": 0.0, "float32": 0.0}
+        worstCase = ""
+        top = 0.0
+        for i, (a, r) in enumerate(zip(res, ref)):
+            dt = CASES[i][0]
+            if isinstance(a, dict) or isinstance(r, dict):
+                print(f"{tile:<14}{'ERROR':>24}  case {i}: "
+                      f"{a if isinstance(a, dict) else r}")
+                bad += 1
+                continue
+            scale = max(abs(v) for v in r) or 1.0
+            err = max(abs(p - q) for p, q in zip(a, r)) / scale
+            worst[dt] = max(worst[dt], err)
+            if err > top:
+                top, worstCase = err, f"case {i} ({dt})"
+            if err > tol[dt]:
+                bad += 1
+        print(f"{tile:<14}{worst['float16']:>12.2e}"
+              f"{worst['float32']:>12.2e}  {worstCase}")
+    print()
+
+    # Every tile under test must appear in some run's dispatch log, otherwise
+    # its column above is measuring the ladder rather than the tile.
+    print("dispatch (from HIPDNN_EP_DEBUG):")
+    for tile in tiles:
+        if tile in ("direct",) or tile not in picks:
+            continue
+        # A four-field name has to appear exactly; a two-field one only pins the
+        # block shape, since it resolves to whichever register tile the table
+        # lists first and this script does not read the table.
+        want = tile if tile.count("x") == 3 else tile + "x"
+        seen = sorted(picks[tile])
+        ran = any(want in s for s in seen)
+        if not ran:
+            print(f"  {tile:<14} NOT DISPATCHED; saw {seen}")
+            bad += 1
+        else:
+            print(f"  {tile:<14} {', '.join(seen)}")
+    print()
+    if bad:
+        print(f"{bad} tile/case pair(s) disagree with conv_direct beyond "
+              f"tolerance")
+        return 1
+    print("every tile agrees with conv_direct")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/perf-harness/bench/model_sweep.ps1
+++ b/tools/perf-harness/bench/model_sweep.ps1
@@ -1,0 +1,138 @@
+## Sweep a model zoo through onnxruntime_perf_test on the HIP EP, one CSV row per
+## model, so an A/B over a kernel change can be judged on whole models rather
+## than on the kernel alone.
+##
+## This is the outer guard rail. conv_microbench.py is the inner one and is
+## three orders of magnitude faster, so the working loop is: change the kernel,
+## run the microbenchmark, and only come here to confirm the model-level effect
+## and -- more importantly -- to prove the models that were never broken did not
+## become so. A convolution heuristic tuned on the regressed models can easily
+## pay for itself out of the models that were fine, and nothing but a full sweep
+## will show that.
+##
+## Inputs are generated (-I) because these model directories ship raw .bin
+## inputs rather than the test_data_set_0 layout perf_test expects. Shapes are
+## unaffected, which is what convolution cost depends on; models whose work is
+## data-dependent (NMS/TopK/NonZero post-processing) will vary run to run and
+## should be read with that in mind.
+##
+##   .\model_sweep.ps1 -Arm base -Out base.csv
+##   # redeploy the other build
+##   .\model_sweep.ps1 -Arm cand -Out cand.csv
+##   python ab_summary.py base.csv cand.csv
+
+[CmdletBinding()]
+param(
+  [int]$Seconds = 30,
+  [string]$Out = "$PSScriptRoot\..\..\..\sweep_results.csv",
+  [string]$LogDir,
+  [string]$Bin = 'C:\Users\zyq\gpu-test-package\bin',
+  [string]$Rocm = 'C:\Users\zyq\therock-dist\bin',
+  [string]$VisionRoot = 'C:\Users\zyq\vision_models',
+  [string]$ProcyonRoot = 'C:\Users\zyq\test-models\ProcyonV2-models',
+  [string[]]$Only,
+  # Per-op attribution. Costs 4-8%, so the QPS it reports is not throughput --
+  # read the [PERF] table, never the summary line.
+  [switch]$Perf,
+  # Arms must not share a TEMP: the on-disk kernel autotune cache is keyed on a
+  # single build timestamp, so a shared cache makes every DLL swap a cold-tune
+  # run and you measure tuning rather than the kernel.
+  [string]$Arm
+)
+
+$ErrorActionPreference = 'Continue'
+if (-not $LogDir) { $LogDir = Join-Path (Split-Path $Out -Parent) 'sweep-logs' }
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+
+$V = $VisionRoot
+$P = $ProcyonRoot
+$models = [ordered]@{
+  'bevformer-fp16'                    = "$V\bevformer-fp16\vit_bevformer_sole_r50backbone_batch1_1instance.onnx"
+  'bevformer-tiny-temporal-sim'       = "$V\bevformer-tiny-temporal-sim\model.onnx"
+  'facebook-detr-resnet-50'           = "$V\facebook-detr-resnet-50\olive\models\detr-r50-640-fp16\model.onnx"
+  'google-mobilenet_v2_1.0_224'       = "$V\google-mobilenet_v2_1.0_224\olive\models\mobilenet_v2-224-fp16\model.onnx"
+  'microsoft-swin-tiny-224x224'       = "$V\microsoft-swin-tiny-224x224\olive\models\swin-tiny-224x224-fp16\model.onnx"
+  'microsoft-swinv2-base-2048x3072'   = "$V\microsoft-swinv2-base-2048x3072\olive\models\swinv2-base-2048x3072-fp16\model.onnx"
+  'microsoft-swinv2-base-8x2048x3072' = "$V\microsoft-swinv2-base-8x2048x3072\olive\models\swinv2-base-8x2048x3072-fp16\model.onnx"
+  'microsoft-swinv2-tiny-512x1024'    = "$V\microsoft-swinv2-tiny-512x1024\olive\models\swinv2-tiny-512x1024-fp16\model.onnx"
+  'microsoft-swinv2-tiny-8x521x1024'  = "$V\microsoft-swinv2-tiny-8x521x1024\olive\models\swinv2-tiny-8x521x1024-fp16\model.onnx"
+  'mlcommons-ssd-resnet34-1200x1200'  = "$V\mlcommons-ssd-resnet34-1200x1200\olive\models\mlcommons-ssd-resnet34-1200\model.onnx"
+  'nvidia-resnet50v1.5'               = "$V\nvidia-resnet50v1.5\olive\models\resnet50v1.5-224-fp16\model.onnx"
+  'qfgaohao-mb1-ssd'                  = "$V\qfgaohao-mb1-ssd\olive\models\mb1-ssd-300-fp16\model.onnx"
+  'simplebev'                         = "$V\simplebev\model.onnx"
+  'ultralytics-yolov5lu'              = "$V\ultralytics-yolov5lu\olive\models\yolov5lu-640-fp16\model.onnx"
+  'blip/decoder'                      = "$P\blip\onnx\decoder\fp16\model.onnx"
+  'blip/encoder'                      = "$P\blip\onnx\encoder\fp16\model.onnx"
+  'convnext'                          = "$P\convnext\onnx\fp16\model.onnx"
+  'detr'                              = "$P\detr\onnx\fp16\model.onnx"
+  'esrgan'                            = "$P\esrgan\onnx\fp16\model.onnx"
+  'sam2.1/decoder'                    = "$P\sam2.1\onnx\decoder\fp16\model.onnx"
+  'sam2.1/encoder'                    = "$P\sam2.1\onnx\encoder\fp16\model.onnx"
+}
+
+Remove-Item Env:HIPDNN_EP_PERF, Env:HIPDNN_EP_DEBUG, Env:HIPDNN_EP_TRACE_FILE -EA SilentlyContinue
+if ($Perf) { $env:HIPDNN_EP_PERF = '1' }
+
+if ($Arm) {
+  $armTemp = Join-Path ([IO.Path]::GetTempPath()) "conv-sweep-$Arm"
+  New-Item -ItemType Directory -Force -Path $armTemp | Out-Null
+  $env:TEMP = $armTemp; $env:TMP = $armTemp
+}
+
+$env:PATH = "$Bin;$Rocm;$env:PATH"
+Push-Location $Bin
+
+$rows = @()
+foreach ($name in $models.Keys) {
+  if ($Only -and ($Only -notcontains $name)) { continue }
+  $path = $models[$name]
+  if (-not (Test-Path $path)) { Write-Host "MISSING $name"; continue }
+
+  $safe = $name -replace '[\\/]', '_'
+  $log = Join-Path $LogDir "$safe.log"
+  Write-Host ("--- {0}" -f $name) -NoNewline
+
+  $sw = [Diagnostics.Stopwatch]::StartNew()
+  & .\onnxruntime_perf_test.exe `
+      --plugin_ep_libs "hipgpu|hipgpu.dll" `
+      --plugin_eps "hipgpu" `
+      --plugin_ep_options "config_file|..\morphizen_config.json" `
+      -C "session.disable_cpu_ep_fallback|1" `
+      -t $Seconds -c 1 -s -I `
+      $path > $log 2>&1
+  $sw.Stop()
+
+  $txt = Get-Content $log -Raw
+  function G([string]$pat) {
+    $m = [regex]::Match($txt, $pat)
+    if ($m.Success) { $m.Groups[1].Value } else { $null }
+  }
+
+  $qps   = G 'Number of inferences per second:\s*([\d.]+)'
+  $sess  = G 'Session creation time cost:\s*([\d.]+)'
+  $first = G 'First inference time cost:\s*([\d.]+)'
+  $avg   = G 'Average inference time cost total:\s*([\d.]+)'
+  $cpu   = G 'Avg CPU usage:\s*(\d+)'
+  $mem   = G 'Peak working set size:\s*(\d+)'
+
+  $status = if ($qps) { 'ok' } else { 'FAIL' }
+  Write-Host ("  {0}  qps={1}  first={2}ms  wall={3:N0}s" -f $status, $qps, $first, $sw.Elapsed.TotalSeconds)
+
+  $rows += [pscustomobject]@{
+    Model        = $name
+    Status       = $status
+    QPS          = $qps
+    SessionS     = $sess
+    FirstInferMs = $first
+    AvgInferMs   = $avg
+    CpuPct       = $cpu
+    PeakMemMB    = if ($mem) { [math]::Round([double]$mem / 1MB, 1) } else { $null }
+    WallS        = [math]::Round($sw.Elapsed.TotalSeconds, 1)
+  }
+  $rows | Export-Csv -NoTypeInformation -Path $Out
+}
+
+Pop-Location
+Remove-Item Env:HIPDNN_EP_PERF -EA SilentlyContinue
+Write-Host "`nwrote $Out"
+$rows | Format-Table -AutoSize

--- a/tools/perf-harness/capture/rgp_capture.ps1
+++ b/tools/perf-harness/capture/rgp_capture.ps1
@@ -2,8 +2,8 @@
 ## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 ## Licensed under the MIT License.
 ##
-## Drive one RGP dispatch-mode capture of a model_benchmark run, then decode it
-## with tools/rgp_parser.
+## Drive one RGP dispatch-mode capture of a model run, then decode it with
+## tools/rgp_parser. See -Driver for the three ways a model can be driven.
 ##
 ## Positioning a capture on a specific op is the hard part. Two modes:
 ##
@@ -37,10 +37,15 @@ param(
   [int]$SeqLen = 16384,                          # with -PromptFile unset, drives --use_random_tokens
   [string]$PromptFile,
   # The fence lives in hipgpu.dll, not in the benchmark, so it fires the same way
-  # under a Python driver. 'vlm' is required for multimodal models, whose vision
-  # encoder model_benchmark.exe never touches.
-  [ValidateSet('model_benchmark', 'vlm')]
+  # under any driver. 'vlm' is required for multimodal models, whose vision
+  # encoder model_benchmark.exe never touches. 'onnx' drives a plain .onnx graph
+  # through onnxruntime_perf_test, which is how the vision zoo runs -- those
+  # models have no genai_config.json and never enter the OGA path at all.
+  [ValidateSet('model_benchmark', 'vlm', 'onnx')]
   [string]$Driver = 'model_benchmark',
+  # onnx only: seconds of steady-state inference. It has to outlast fence arming
+  # plus the trace dump, not just the measurement.
+  [int]$OnnxSeconds = 120,
   [int]$MaxTokens = 2,                           # vlm only
   [int]$MaxLength,                               # vlm only
   # vlm only. 'follow_config' leaves the model's own genai_config provider list
@@ -83,10 +88,14 @@ $benchErr = Join-Path $OutDir "bench_$Tag.err"
 $panelLog = Join-Path $OutDir "panel_$Tag.log"
 
 $isVlm = ($Driver -eq 'vlm')
+$isOnnx = ($Driver -eq 'onnx')
 if ($isVlm) {
   foreach ($n in 'VlmBench', 'Image', 'PromptFile') {
     if (-not $HarnessEnv.$n) { throw "Driver 'vlm' needs `$env:HIPEP_$($n.ToUpper()); see common.ps1." }
   }
+}
+if ($isOnnx -and -not (Test-Path $HarnessEnv.Model -PathType Leaf)) {
+  throw "Driver 'onnx' needs `$env:HIPEP_MODEL to be a .onnx file, got '$($HarnessEnv.Model)'."
 }
 
 Stop-HarnessProcesses -IncludePython:$isVlm
@@ -101,7 +110,7 @@ $panelArgs = @(
   '--rgp-render-op-count', "$OpCount")
 if ($Counters) { $panelArgs += '--rgp-counter-collection' }
 if ($PSCmdlet.ParameterSetName -eq 'Trigger') { $panelArgs += @('--rgp-auto-capture', $Trigger) }
-$targetProcess = if ($isVlm) { 'python' } else { 'model_benchmark' }
+$targetProcess = if ($isVlm) { 'python' } elseif ($isOnnx) { 'onnxruntime_perf_test' } else { 'model_benchmark' }
 $panelArgs += @('-p', $targetProcess, '--verbose')
 
 $pi = New-Object System.Diagnostics.ProcessStartInfo
@@ -136,6 +145,18 @@ if ($isVlm) {
              '--max_length', "$MaxLength", '-e', $ExecutionProvider,
              '-n', "$Reps", '-w', '0')
   $wd    = Split-Path -Parent $HarnessEnv.VlmBench
+} elseif ($isOnnx) {
+  # -I generates inputs: these model directories ship raw .bin tensors rather
+  # than the test_data_set_0 layout perf_test reads, and shapes -- which is what
+  # a convolution capture depends on -- are unaffected either way.
+  $exe   = Join-Path $HarnessEnv.Bin 'onnxruntime_perf_test.exe'
+  $margs = @('--plugin_ep_libs', 'hipgpu|hipgpu.dll',
+             '--plugin_eps', 'hipgpu',
+             '--plugin_ep_options', 'config_file|..\morphizen_config.json',
+             '-C', 'session.disable_cpu_ep_fallback|1',
+             '-t', "$OnnxSeconds", '-c', '1', '-s', '-I',
+             $HarnessEnv.Model)
+  $wd    = $HarnessEnv.Bin
 } else {
   $exe   = Join-Path $HarnessEnv.Bin 'model_benchmark.exe'
   $margs = @('-i', $HarnessEnv.Model, '-g', "$Gen", '-r', "$Reps", '-w', '0', '-b', '1', '-ml', '0', '-v')

--- a/tools/perf-harness/capture/rgp_capture.ps1
+++ b/tools/perf-harness/capture/rgp_capture.ps1
@@ -43,6 +43,10 @@ param(
   [string]$Driver = 'model_benchmark',
   [int]$MaxTokens = 2,                           # vlm only
   [int]$MaxLength,                               # vlm only
+  # vlm only. 'follow_config' leaves the model's own genai_config provider list
+  # alone; naming a provider overrides it, which is what an export pinned to
+  # another EP (a -dml directory, say) needs to run here.
+  [string]$ExecutionProvider = 'follow_config',
   [int]$Gen = 1,
   [int]$Reps = 2,                                # RGP streams the dump from the LIVE process; see note below
   [int]$OpCount = 4000,                          # --rgp-render-op-count: window size, not usability
@@ -124,7 +128,8 @@ if ($isVlm) {
   $exe   = $HarnessEnv.Python
   $margs = @('-u', $HarnessEnv.VlmBench, '-m', $HarnessEnv.Model, '-i', $HarnessEnv.Image,
              '--prompt_file', $PromptFile, '--max_tokens', "$MaxTokens",
-             '--max_length', "$MaxLength", '-n', "$Reps", '-w', '0')
+             '--max_length', "$MaxLength", '-e', $ExecutionProvider,
+             '-n', "$Reps", '-w', '0')
   $wd    = Split-Path -Parent $HarnessEnv.VlmBench
 } else {
   $exe   = Join-Path $HarnessEnv.Bin 'model_benchmark.exe'

--- a/tools/perf-harness/capture/rgp_capture.ps1
+++ b/tools/perf-harness/capture/rgp_capture.ps1
@@ -54,6 +54,11 @@ param(
   [string]$Buf = 'default',
   [switch]$Counters,                             # SPM: required for memory/compute bound classification
   [int]$Dwell = 30,                              # seconds to let the .rgp finish dumping
+  # How long to wait for the fence to arm. A 16K VLM prefill under the panel
+  # needs far more than the 10 minutes that suffices for a 2K one: model load,
+  # the per-process prefill autotune sweep and a cold first rep all land before
+  # the fence can fire.
+  [int]$ArmTimeoutSec = 600,
   [string]$OutDir
 )
 
@@ -148,7 +153,7 @@ Write-Host "model PID=$($bench.Id) launched"
 # In fence mode, watch stderr for the armed marker and trigger inside the idle
 # window. In trigger mode there is nothing to wait for; the panel fires itself.
 $triggered = ($PSCmdlet.ParameterSetName -ne 'Fence')
-$deadline = (Get-Date).AddSeconds(600)
+$deadline = (Get-Date).AddSeconds($ArmTimeoutSec)
 while (-not $bench.HasExited -and (Get-Date) -lt $deadline) {
   if ($pOutTask.IsCompleted) { if ($pOutTask.Result) { Add-Content $panelLog $pOutTask.Result }; $pOutTask = $pOut.ReadLineAsync() }
   if ($pErrTask.IsCompleted) { if ($pErrTask.Result) { Add-Content $panelLog $pErrTask.Result }; $pErrTask = $pErr.ReadLineAsync() }

--- a/tools/perf-harness/capture/rgp_capture.ps1
+++ b/tools/perf-harness/capture/rgp_capture.ps1
@@ -169,8 +169,21 @@ while (-not $bench.HasExited -and (Get-Date) -lt $deadline) {
 # nothing -- that is what -Reps buys, not extra measurement.
 Write-Host "model exited=$($bench.HasExited) triggered=$triggered ; dwell ${Dwell}s for the dump"
 Start-Sleep $Dwell
+# The panel writes the .rgp as it shuts down, not when the transfer finishes, so
+# it has to be allowed to exit on its own. Killing it a few seconds after 'quit'
+# loses the whole capture: the trace transfers to 100%, the panel dies
+# mid-write, and no file is ever created.
 try { $panel.StandardInput.WriteLine('quit'); $panel.StandardInput.Flush() } catch {}
-Start-Sleep 4
+$sz = -1
+for ($i = 0; $i -lt 100; $i++) {
+  if ($panel.HasExited) { break }
+  Start-Sleep 3
+  if (Test-Path $OutRgp) {
+    $now = (Get-Item $OutRgp).Length
+    if ($now -gt 0 -and $now -eq $sz) { break }   # written and no longer growing
+    $sz = $now
+  }
+}
 Stop-HarnessProcesses -IncludePython:$isVlm
 Remove-Item Env:RGP_FENCE, Env:RGP_FENCE_SKIP, Env:RGP_FENCE_MS -EA SilentlyContinue
 

--- a/tools/perf-harness/capture/rgp_capture.ps1
+++ b/tools/perf-harness/capture/rgp_capture.ps1
@@ -1,0 +1,204 @@
+##
+## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+## Licensed under the MIT License.
+##
+## Drive one RGP dispatch-mode capture of a model_benchmark run, then decode it
+## with tools/rgp_parser.
+##
+## Positioning a capture on a specific op is the hard part. Two modes:
+##
+##   -Op <name>   Fence mode. The runtime's rgp_capture_fence (op_profile.cpp)
+##                drains the GPU and idles right before that op's Nth instance,
+##                printing [RGP_FENCE_ARMED]. This script watches for the marker
+##                and triggers RGP inside the idle window, so the very next
+##                dispatches are the op you asked for. Deterministic.
+##
+##   -Trigger     Auto-capture mode: RGP's own dispatch:<delay>:<count> trigger.
+##                No runtime support needed, but it positions blind by dispatch
+##                index, which drifts run to run. Use when the build under test
+##                has no fence.
+##
+## Deliberately no HIPDNN_EP_PERF / HIPDNN_EP_DEBUG: CLAUDE.md forbids measuring
+## throughput with either. SQTT already carries the timing.
+
+[CmdletBinding(DefaultParameterSetName = 'Fence')]
+param(
+  [Parameter(ParameterSetName = 'Fence', Mandatory = $true)]
+  [string]$Op,                                   # RGP_FENCE op name, e.g. qmoe | gqa | matmul_nbits
+  [Parameter(ParameterSetName = 'Fence')]
+  [int]$Skip = 0,                                # arm on the (Skip+1)-th instance; skips warmup//early chunks
+  [Parameter(ParameterSetName = 'Fence')]
+  [int]$FenceMs = 15000,                         # idle window; must exceed detect + trigger + arm latency
+
+  [Parameter(ParameterSetName = 'Trigger', Mandatory = $true)]
+  [string]$Trigger,                              # e.g. dispatch:200:3000
+
+  [string]$Tag,
+  [int]$SeqLen = 16384,                          # with -PromptFile unset, drives --use_random_tokens
+  [string]$PromptFile,
+  # The fence lives in hipgpu.dll, not in the benchmark, so it fires the same way
+  # under a Python driver. 'vlm' is required for multimodal models, whose vision
+  # encoder model_benchmark.exe never touches.
+  [ValidateSet('model_benchmark', 'vlm')]
+  [string]$Driver = 'model_benchmark',
+  [int]$MaxTokens = 2,                           # vlm only
+  [int]$MaxLength,                               # vlm only
+  [int]$Gen = 1,
+  [int]$Reps = 2,                                # RGP streams the dump from the LIVE process; see note below
+  [int]$OpCount = 4000,                          # --rgp-render-op-count: window size, not usability
+  [ValidateSet('minimum', 'default', 'maximum')]
+  [string]$Buf = 'default',
+  [switch]$Counters,                             # SPM: required for memory/compute bound classification
+  [int]$Dwell = 30,                              # seconds to let the .rgp finish dumping
+  [string]$OutDir
+)
+
+$ErrorActionPreference = 'Continue'
+. (Join-Path (Split-Path -Parent $PSScriptRoot) 'common.ps1')
+
+if (-not $HarnessEnv.RgpCli) {
+  throw "RadeonDeveloperPanelCLI.exe not found. Set `$env:RGP_DIR to the Radeon Developer Tool Suite folder."
+}
+if (-not $Tag) {
+  $Tag = if ($PSCmdlet.ParameterSetName -eq 'Fence') {
+    "cap_${Op}" + $(if ($Skip -gt 0) { "_skip$Skip" } else { '' })
+  } else { 'cap_trigger' }
+}
+if (-not $OutDir) { $OutDir = Join-Path $HarnessEnv.OutRoot 'captures' }
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+
+$OutRgp   = Join-Path $OutDir "$Tag.rgp"
+$decBase  = Join-Path $OutDir $Tag
+$benchOut = Join-Path $OutDir "bench_$Tag.log"
+$benchErr = Join-Path $OutDir "bench_$Tag.err"
+$panelLog = Join-Path $OutDir "panel_$Tag.log"
+
+$isVlm = ($Driver -eq 'vlm')
+if ($isVlm) {
+  foreach ($n in 'VlmBench', 'Image', 'PromptFile') {
+    if (-not $HarnessEnv.$n) { throw "Driver 'vlm' needs `$env:HIPEP_$($n.ToUpper()); see common.ps1." }
+  }
+}
+
+Stop-HarnessProcesses -IncludePython:$isVlm
+Remove-Item $OutRgp, $benchOut, $benchErr, $panelLog -EA SilentlyContinue
+'' | Set-Content $benchErr
+
+# --- arm the panel BEFORE the HIP context exists, so the driver hooks on connect
+$panelArgs = @(
+  '-m', 'profiling', '-o', $OutRgp,
+  '--rgp-capture-mode', 'dispatch',
+  '--rgp-sqtt-buffer-size', $Buf,
+  '--rgp-render-op-count', "$OpCount")
+if ($Counters) { $panelArgs += '--rgp-counter-collection' }
+if ($PSCmdlet.ParameterSetName -eq 'Trigger') { $panelArgs += @('--rgp-auto-capture', $Trigger) }
+$targetProcess = if ($isVlm) { 'python' } else { 'model_benchmark' }
+$panelArgs += @('-p', $targetProcess, '--verbose')
+
+$pi = New-Object System.Diagnostics.ProcessStartInfo
+$pi.FileName  = $HarnessEnv.RgpCli
+$pi.Arguments = ($panelArgs | ForEach-Object { if ($_ -match '\s') { "`"$_`"" } else { $_ } }) -join ' '
+$pi.UseShellExecute        = $false
+$pi.RedirectStandardInput  = $true
+$pi.RedirectStandardOutput = $true
+$pi.RedirectStandardError  = $true
+$panel = [System.Diagnostics.Process]::Start($pi)
+$pOut = $panel.StandardOutput; $pErr = $panel.StandardError
+$pOutTask = $pOut.ReadLineAsync(); $pErrTask = $pErr.ReadLineAsync()
+Write-Host "panel PID=$($panel.Id) mode=$($PSCmdlet.ParameterSetName) buf=$Buf ops=$OpCount counters=$($Counters.IsPresent) tag=$Tag"
+Start-Sleep 6
+
+Set-HarnessPath
+Clear-HarnessProfilingEnv
+$env:HIPDNN_EP_AUTOTUNE = '1'
+$env:HIPDNN_EP_MATMUL_CUSTOM_WMMA = '1'
+if ($PSCmdlet.ParameterSetName -eq 'Fence') {
+  $env:RGP_FENCE = $Op; $env:RGP_FENCE_SKIP = "$Skip"; $env:RGP_FENCE_MS = "$FenceMs"
+} else {
+  Remove-Item Env:RGP_FENCE, Env:RGP_FENCE_SKIP, Env:RGP_FENCE_MS -EA SilentlyContinue
+}
+
+if ($isVlm) {
+  if (-not $PromptFile) { $PromptFile = $HarnessEnv.PromptFile }
+  if (-not $MaxLength)  { $MaxLength  = $SeqLen + 128 }
+  $exe   = $HarnessEnv.Python
+  $margs = @('-u', $HarnessEnv.VlmBench, '-m', $HarnessEnv.Model, '-i', $HarnessEnv.Image,
+             '--prompt_file', $PromptFile, '--max_tokens', "$MaxTokens",
+             '--max_length', "$MaxLength", '-n', "$Reps", '-w', '0')
+  $wd    = Split-Path -Parent $HarnessEnv.VlmBench
+} else {
+  $exe   = Join-Path $HarnessEnv.Bin 'model_benchmark.exe'
+  $margs = @('-i', $HarnessEnv.Model, '-g', "$Gen", '-r', "$Reps", '-w', '0', '-b', '1', '-ml', '0', '-v')
+  if ($PromptFile) { $margs += @('--prompt_file', $PromptFile) }
+  else             { $margs += @('-l', "$SeqLen", '--use_random_tokens') }
+  $wd    = $HarnessEnv.Bin
+}
+
+$bench = Start-Process -FilePath $exe `
+  -ArgumentList $margs -WorkingDirectory $wd `
+  -RedirectStandardOutput $benchOut -RedirectStandardError $benchErr `
+  -PassThru -WindowStyle Hidden
+Write-Host "model PID=$($bench.Id) launched"
+
+# In fence mode, watch stderr for the armed marker and trigger inside the idle
+# window. In trigger mode there is nothing to wait for; the panel fires itself.
+$triggered = ($PSCmdlet.ParameterSetName -ne 'Fence')
+$deadline = (Get-Date).AddSeconds(600)
+while (-not $bench.HasExited -and (Get-Date) -lt $deadline) {
+  if ($pOutTask.IsCompleted) { if ($pOutTask.Result) { Add-Content $panelLog $pOutTask.Result }; $pOutTask = $pOut.ReadLineAsync() }
+  if ($pErrTask.IsCompleted) { if ($pErrTask.Result) { Add-Content $panelLog $pErrTask.Result }; $pErrTask = $pErr.ReadLineAsync() }
+  if (-not $triggered) {
+    $hit = Select-String -Path $benchErr, $benchOut -Pattern 'RGP_FENCE_ARMED' -EA SilentlyContinue | Select-Object -First 1
+    if ($hit) {
+      Start-Sleep -Milliseconds 700
+      Write-Host ">>> $($hit.Line.Trim()) -> triggering capture"
+      $panel.StandardInput.WriteLine('capture'); $panel.StandardInput.Flush()
+      $triggered = $true
+    }
+  }
+  Start-Sleep -Milliseconds 250
+}
+
+# RGP streams the trace out of the LIVE process. A late-positioned fence can
+# leave too little runtime for a large dump, which then stalls and writes
+# nothing -- that is what -Reps buys, not extra measurement.
+Write-Host "model exited=$($bench.HasExited) triggered=$triggered ; dwell ${Dwell}s for the dump"
+Start-Sleep $Dwell
+try { $panel.StandardInput.WriteLine('quit'); $panel.StandardInput.Flush() } catch {}
+Start-Sleep 4
+Stop-HarnessProcesses -IncludePython:$isVlm
+Remove-Item Env:RGP_FENCE, Env:RGP_FENCE_SKIP, Env:RGP_FENCE_MS -EA SilentlyContinue
+
+if (-not (Test-Path $OutRgp)) {
+  Write-Host "RESULT: $OutRgp NOT created"
+  Get-Content $panelLog -Tail 20 -EA SilentlyContinue
+  exit 1
+}
+Write-Host ("RESULT $OutRgp bytes: " + (Get-Item $OutRgp).Length)
+
+# Gate on chunk inventory before trusting anything decoded from the file.
+# --require-spm is an argparse store_true, so it must be present or absent; the
+# PowerShell "-switch:$bool" form would pass the literal "--require-spm:True".
+$verifyArgs = @($OutRgp)
+if ($Counters) { $verifyArgs += '--require-spm' }
+& $HarnessEnv.Python (Join-Path $PSScriptRoot 'verify_rgp.py') @verifyArgs
+if ($LASTEXITCODE -ne 0) { Write-Host '!! capture unusable; not decoding it'; exit 1 }
+
+Push-Location $HarnessEnv.Parser
+& $HarnessEnv.Python main.py $OutRgp $decBase 2>&1 | Out-Null
+Pop-Location
+
+$ops = "${decBase}_operators.csv"
+if (Test-Path $ops) {
+  $rows = Import-Csv $ops
+  $disp = if (Test-Path "${decBase}_dispatches.csv") { (Import-Csv "${decBase}_dispatches.csv").Count } else { 0 }
+  Write-Host "PARSED dispatches=$disp op_rows=$($rows.Count) -> $decBase*"
+  Write-Host '--- top 20 kernels by total GPU time ---'
+  $rows | Sort-Object { [double]$_.total_us } -Descending | Select-Object -First 20 |
+    Format-Table @{N = 'kernel'; E = { ($_.kernel -replace '<.*', '') -replace '\(.*', '' } },
+                 count, mean_us, total_us, pct_gpu, occ_pct, bound_class, avg_mem_gbps -AutoSize |
+    Out-String -Width 400 | Write-Host
+} else {
+  Write-Host 'PARSE FAILED (no operators.csv)'
+  exit 1
+}

--- a/tools/perf-harness/capture/verify_rgp.py
+++ b/tools/perf-harness/capture/verify_rgp.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+"""Gate a .rgp capture before any number decoded from it is trusted.
+
+A capture with CodeObjects but no SqttData has no timeline at all, and one
+without SpmCounterData has no bandwidth, so the memory/compute bound class
+degrades to "undetermined". Both failure modes are silent downstream -- the
+parser happily emits a CSV either way -- so they are checked up front rather
+than discovered halfway through an analysis.
+"""
+
+import argparse
+import pathlib
+import sys
+
+# tools/perf-harness/capture -> tools/rgp_parser
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2] / "rgp_parser"))
+
+from rgp_parser.struct.rdf import RdfFile  # noqa: E402
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("capture", help="path to the .rgp file")
+    ap.add_argument("--require-spm", action="store_true",
+                    help="also fail when the capture carries no SPM counters")
+    args = ap.parse_args()
+
+    counts = RdfFile.from_path(args.capture).counts()
+    for name in sorted(counts):
+        print(f"  {name:24s} {counts[name]}")
+
+    sqtt = counts.get("SqttData", 0)
+    spm = counts.get("SpmCounterData", 0)
+    ok = bool(sqtt) and (bool(spm) or not args.require_spm)
+    print(f"VERDICT sqtt={sqtt} spm={spm} -> {'USABLE' if ok else 'UNUSABLE'}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/perf-harness/common.ps1
+++ b/tools/perf-harness/common.ps1
@@ -87,8 +87,14 @@ function Set-HarnessPath {
 
 # Throughput must never be measured with the EP's own instrumentation: PERF
 # alone costs ~4%. SQTT carries the timing instead.
+#
+# HIPDNN_EP_TRACE_FILE has to go too: hipdnn_ep_perf_enabled() is true for
+# either variable, so a trace path left over from an earlier shell turns the
+# profiler on with none of PERF's console output to give it away. That leak
+# inflated a 16K VLM baseline from 14,610 ms to 17,545 ms before it was found.
 function Clear-HarnessProfilingEnv {
-  Remove-Item Env:HIPDNN_EP_PERF, Env:HIPDNN_EP_DEBUG -EA SilentlyContinue
+  Remove-Item Env:HIPDNN_EP_PERF, Env:HIPDNN_EP_DEBUG, Env:HIPDNN_EP_TRACE_FILE `
+    -EA SilentlyContinue
 }
 
 function Stop-HarnessProcesses {

--- a/tools/perf-harness/common.ps1
+++ b/tools/perf-harness/common.ps1
@@ -1,0 +1,103 @@
+##
+## Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+## Licensed under the MIT License.
+##
+## Shared environment resolution for the perf-harness scripts.
+##
+## Everything is an environment variable with a discovery fallback, so the same
+## scripts run on any machine. Dot-source this, then use the $HarnessEnv fields.
+
+Set-StrictMode -Version Latest
+
+function Resolve-HarnessPath {
+  param([string]$EnvName, [string[]]$Candidates, [switch]$Required, [string]$What)
+  $v = [Environment]::GetEnvironmentVariable($EnvName)
+  if ($v -and (Test-Path $v)) { return (Resolve-Path $v).Path }
+  foreach ($c in $Candidates) {
+    if ($c -and (Test-Path $c)) { return (Resolve-Path $c).Path }
+  }
+  if ($Required) {
+    throw "Cannot locate $What. Set `$env:$EnvName."
+  }
+  return $null
+}
+
+# $PSScriptRoot is tools/perf-harness even when dot-sourced from a subdirectory,
+# so the repo root is two levels up.
+$script:HarnessRoot = $PSScriptRoot
+$script:RepoRoot    = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+
+# The RGP panel CLI ships in the Radeon Developer Tool Suite, which is a zip with
+# a versioned folder name, so probe PATH before guessing at C:\tools.
+$rgpCli = $null
+$onPath = Get-Command RadeonDeveloperPanelCLI.exe -EA SilentlyContinue
+if ($onPath) { $rgpCli = $onPath.Source }
+if (-not $rgpCli) {
+  $dir = [Environment]::GetEnvironmentVariable('RGP_DIR')
+  if ($dir -and (Test-Path "$dir\RadeonDeveloperPanelCLI.exe")) {
+    $rgpCli = "$dir\RadeonDeveloperPanelCLI.exe"
+  }
+}
+if (-not $rgpCli) {
+  $guess = Get-ChildItem 'C:\tools\RadeonDeveloperToolSuite*' -Directory -EA SilentlyContinue |
+           Sort-Object Name -Descending |
+           ForEach-Object { Join-Path $_.FullName 'RadeonDeveloperPanelCLI.exe' } |
+           Where-Object { Test-Path $_ } | Select-Object -First 1
+  if ($guess) { $rgpCli = $guess }
+}
+
+$py = [Environment]::GetEnvironmentVariable('HIPEP_PY')
+if (-not $py -or -not (Test-Path $py)) {
+  $c = Get-Command python.exe -EA SilentlyContinue
+  $py = if ($c) { $c.Source } else { 'python' }
+}
+
+$script:HarnessEnv = [PSCustomObject]@{
+  RepoRoot = $RepoRoot
+  # Directory holding model_benchmark.exe and the EP DLLs under test. For the vlm
+  # driver there is no model_benchmark.exe, so point this at the venv's
+  # onnxruntime\capi, which is where the EP DLLs actually live.
+  Bin      = Resolve-HarnessPath -EnvName 'HIPEP_BIN' -Candidates @() -Required -What 'the test package bin directory (model_benchmark.exe + EP DLLs)'
+  # ONNX model directory (genai_config.json lives here).
+  Model    = Resolve-HarnessPath -EnvName 'HIPEP_MODEL' -Candidates @() -Required -What 'the model directory'
+  Python   = $py
+  RgpCli   = $rgpCli
+  Parser   = Join-Path $RepoRoot 'tools\rgp_parser'
+  Harness  = $HarnessRoot
+  # VLM driver: vision-language models have no text-only equivalent of
+  # model_benchmark.exe, and their TTFT includes the vision encoder, so the
+  # measurement has to run through vlm_benchmark.py with a real image.
+  VlmBench   = Resolve-HarnessPath -EnvName 'HIPEP_VLM_BENCH' -Candidates @() -What 'vlm_benchmark.py'
+  Image      = Resolve-HarnessPath -EnvName 'HIPEP_IMAGE' -Candidates @() -What 'the benchmark image'
+  PromptFile = Resolve-HarnessPath -EnvName 'HIPEP_PROMPT_FILE' -Candidates @() -What 'the prompt file'
+  OutRoot  = $(
+      $o = [Environment]::GetEnvironmentVariable('HIPEP_OUT')
+      if (-not $o) { $o = Join-Path $env:TEMP 'hipep-perf' }
+      $o)
+}
+
+# Extra directories the EP needs on PATH (ROCm SDK runtime libraries, etc).
+# Semicolon-separated; prepended ahead of the system PATH.
+function Set-HarnessPath {
+  $extra = [Environment]::GetEnvironmentVariable('HIPEP_PATH_EXTRA')
+  $parts = @($HarnessEnv.Bin)
+  if ($extra) { $parts += ($extra -split ';' | Where-Object { $_ }) }
+  $env:PATH = ($parts -join ';') + ';' + $env:PATH
+}
+
+# Throughput must never be measured with the EP's own instrumentation: PERF
+# alone costs ~4%. SQTT carries the timing instead.
+function Clear-HarnessProfilingEnv {
+  Remove-Item Env:HIPDNN_EP_PERF, Env:HIPDNN_EP_DEBUG -EA SilentlyContinue
+}
+
+function Stop-HarnessProcesses {
+  # -IncludePython only when the vlm driver is in use: killing every python on
+  # the box would be unacceptable collateral otherwise.
+  param([switch]$IncludePython)
+  $names = @('model_benchmark', 'RadeonDeveloper*')
+  if ($IncludePython) { $names += 'python' }
+  Get-Process $names -EA SilentlyContinue |
+    Stop-Process -Force -EA SilentlyContinue
+  Start-Sleep 2
+}

--- a/tools/perf-harness/common.ps1
+++ b/tools/perf-harness/common.ps1
@@ -58,8 +58,11 @@ $script:HarnessEnv = [PSCustomObject]@{
   # driver there is no model_benchmark.exe, so point this at the venv's
   # onnxruntime\capi, which is where the EP DLLs actually live.
   Bin      = Resolve-HarnessPath -EnvName 'HIPEP_BIN' -Candidates @() -Required -What 'the test package bin directory (model_benchmark.exe + EP DLLs)'
-  # ONNX model directory (genai_config.json lives here).
-  Model    = Resolve-HarnessPath -EnvName 'HIPEP_MODEL' -Candidates @() -Required -What 'the model directory'
+  # For the model_benchmark and vlm drivers this is the model *directory*, the
+  # one holding genai_config.json. For the onnx driver it is a single .onnx
+  # *file*, because onnxruntime_perf_test takes a model path rather than an OGA
+  # export; Resolve-HarnessPath accepts either.
+  Model    = Resolve-HarnessPath -EnvName 'HIPEP_MODEL' -Candidates @() -Required -What 'the model directory or .onnx file'
   Python   = $py
   RgpCli   = $rgpCli
   Parser   = Join-Path $RepoRoot 'tools\rgp_parser'
@@ -101,7 +104,7 @@ function Stop-HarnessProcesses {
   # -IncludePython only when the vlm driver is in use: killing every python on
   # the box would be unacceptable collateral otherwise.
   param([switch]$IncludePython)
-  $names = @('model_benchmark', 'RadeonDeveloper*')
+  $names = @('model_benchmark', 'onnxruntime_perf_test', 'RadeonDeveloper*')
   if ($IncludePython) { $names += 'python' }
   Get-Process $names -EA SilentlyContinue |
     Stop-Process -Force -EA SilentlyContinue


### PR DESCRIPTION
## Summary

Restores convolution performance after the MIOpen removal in #834. The 11 regressed models were losing to **three independent defects plus a correctness bug**, not one:

1. **The tile ladder picked worse tiles on bigger devices.** It rejected any tile producing fewer blocks than the device has CUs, so more CUs meant falling further down the ladder — to narrower row blocks, each re-gathering the im2col matrix once more. Adding CUs does not add bandwidth, so scaling a memory decision with the CU count is backwards. resnet50's stage-4 convolutions took `32x256` at 16 CUs and `16x256` at 20, which is 32 passes over the input where 4 would do, and 38.8% of that model's convolution time.
2. **No Winograd for 3x3 stride-1.** MIOpen's kernel name says the algorithm (`..._f2x3_...`). esrgan, whose 351 convolutions are all 3x3 s1, went 19.4 ms to 92.0.
3. **ConvTranspose was never tiled**, on the stated premise that no supported model contains one. sam2.1's decoder has two: 0.4 ms to 33.8.

Selection now reads the shape and ignores the CU count, so monotonicity holds by construction. It lives in a header that compiles without HIP, so the invariant is checkable with no GPU.

Retuning the rungs surfaced the largest single win, which was not the one the plan predicted: **the wave tile, not the block shape, was limiting the matrix kernels.** A 2x2 wave tile holds 32 accumulator VGPRs where 2x4 holds 64, taking `64x256` from 146 VGPR / 9 waves per SIMD to 97 / 12 and spreading the block over 512 threads instead of 256. That outweighs the doubled gather a narrower row block costs, and it wins in every M bucket from 128 up — so the wide rungs now take a *narrower* tile than the gather term predicts.

## Performance

Shape-level, via `conv_microbench.py` over every distinct convolution shape in the guard set. Both arms hash-verified, 120 iterations, same process:

| model | before | after | |
|---|---|---|---|
| resnet50 | 6.70 ms | 5.48 ms | **1.222x** |
| mb1-ssd | 6.78 ms | 5.61 ms | **1.206x** |
| yolov5lu | 20.25 ms | 17.87 ms | **1.133x** |
| bevformer | 9.32 ms | 8.51 ms | **1.093x** |
| esrgan | 206.7 ms | 194.4 ms | **1.063x** |
| detr | 10.59 ms | 10.54 ms | 1.001x |
| simplebev (fp32) | 24.64 ms | 24.61 ms | unchanged |

Whole-model, 21 models through `onnxruntime_perf_test`, average inference time, **1.093x overall**:

| model | before | after | |
|---|---|---|---|
| google-mobilenet_v2 | 2.22 ms | 1.89 ms | **1.177x** |
| nvidia-resnet50v1.5 | 7.43 ms | 6.30 ms | **1.179x** |
| ultralytics-yolov5lu | 29.86 ms | 26.44 ms | **1.129x** |
| swinv2-base-8x2048x3072 | 8402.6 ms | 7512.7 ms | **1.118x** |
| qfgaohao-mb1-ssd | 6.10 ms | 5.63 ms | 1.082x |
| facebook-detr-resnet-50 | 17.13 ms | 15.91 ms | 1.077x |
| blip/encoder | 14.51 ms | 13.53 ms | 1.072x |
| swinv2-tiny-8x521x1024 | 204.98 ms | 191.85 ms | 1.068x |
| esrgan | 301.32 ms | 283.33 ms | 1.063x |
| swin-tiny-224x224 | 3.69 ms | 3.48 ms | 1.061x |
| bevformer-fp16 | 15.56 ms | 14.91 ms | 1.044x |
| sam2.1/decoder | 5.63 ms | 5.45 ms | 1.034x |
| simplebev | 744.1 ms | 725.4 ms | 1.026x |
| blip/decoder | 5.96 ms | 5.87 ms | 1.016x |
| sam2.1/encoder | 55.18 ms | 55.17 ms | 1.000x |
| swinv2-tiny-512x1024 | 32.95 ms | 33.25 ms | 0.991x |
| swinv2-base-2048x3072 | 956.4 ms | 965.2 ms | 0.991x |
| detr | 22.54 ms | 22.77 ms | 0.990x |
| ssd-resnet34-1200 | 44.59 ms | 45.26 ms | 0.985x |
| convnext | 52.59 ms | 57.14 ms | 0.920x — see below |

**convnext is not a regression.** 18 of its 22 convolutions are depthwise 7x7, which this change cannot touch. Its convolution time measures 18.34 ms before and 18.26 ms after, and three repeat runs put the model at 57.96 mean before against 58.61 after — the 8% is harness variance, and the 52.59 reading was the outlier.

`bevformer-tiny-temporal-sim` fails to load on both arms; pre-existing and unrelated.

The ladder now sits **3.3% off the per-shape oracle, against 18.1% before**.

## Two negative results, recorded in the source so they are not retried

- **Narrower register tiles do not help the scalar path.** 64x32 and 32x64 reach 10 waves per SIMD and 32x32 reaches 12, against 64x64's 8, and all three lose on simplebev's real shapes (12.68 ms against 16.03, 16.93, 20.35). Unlike the matrix tiles these were never accumulator-bound — a 4x4 register tile is 16 of the 177 VGPRs. The aggregate only says otherwise if the extractor's `Nout==1` shape-inference fallbacks are left in, and those are not shapes any model runs.
- **`amdgpu_waves_per_eu(10)` is actively harmful.** It delivers what it asks (64x64 to 144 VGPR at 10 waves, no spill reported) and simplebev's convolutions go **24.6 ms to 43.8**. The registers come back by rematerialising the gather's address arithmetic rather than spilling, so the resource report stays clean while the inner loop recomputes indices it used to hold.

## On the fp16 NaN in bevformer

Investigated and **conv is exonerated**. Every tile variant forced on the failing shape produced the identical 31,744 NaN, which rules out per-variant staging, and a CPU reference agrees with the GPU convolution at 0.99999917 cosine similarity on random inputs. The infinities enter upstream of the convolution. Left open rather than claimed fixed.

## Test plan

- [x] `ConvTileSelectUnitTest` — new, GPU-free, now registered with CTest. It was previously possible to add a tile the kernel could not launch; the suite asserts monotonicity in CU count across 8–128, that every choice is instantiable, and that every table entry is reachable by name.
- [x] `conv_tile_check.py` — all 17 tiles agree with `conv_direct` on pseudorandom data, and each is confirmed to have actually dispatched via the debug log rather than silently falling back.
- [x] Shape-level A/B over every distinct convolution shape in the guard set.
- [x] 21-model A/B, including all 9 models that *improved* under #834 (swin, swinv2 x4, blip x2, convnext, sam2.1/encoder) — the ones a conv retune can most easily pay itself out of.
- [ ] CI perf run to confirm the above on clean hardware.

The numeric suite could not be run locally: `register_execution_provider_library` faults before any convolution executes, an ABI mismatch between the pip `onnxruntime` and the deployed EP. `conv_tile_check.py` was written to cover the same ground for this change specifically, but the suite should be run in CI.

## Note on branch composition

The first 10 commits are the perf-harness tooling this PR's measurements rest on (Phase 0 of the plan) and touch only `tools/perf-harness/**`. The 4 conv commits are the shipping change. Happy to split if preferred.
