### PR TITLE
fix(hipsr): pair a placeholder with its consumer through their inputs

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/HipsrOps.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrOps.h
@@ -34,6 +34,15 @@ namespace hipsr {
 // hipsr DPS op. return empty range if op is not a hipsr op.
 ::mlir::OperandRange getHipsrDestinationOperands(::mlir::Operation *op);
 
+// return the data operands of a hipsr op, which sit between the context and
+// the destinations. return empty range if op is not a hipsr op.
+::mlir::OperandRange getHipsrInputOperands(::mlir::Operation *op);
+
+// return the shape-graph value holding value's shape: value itself when it is
+// already a legal placeholder input, otherwise the destination its producer
+// writes into. return value unchanged when no destination matches.
+::mlir::Value getShapeGraphCounterpart(::mlir::Value value);
+
 // compute: use is in Outputs
 // dps: use is in Init
 bool isHipsrDestinationOperand(::mlir::OpOperand &use);

--- a/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
@@ -29,6 +29,12 @@ def Hipsr_PlaceholderOp : Hipsr_Op<
     results, which keeps the shape graph parallel to the data graph.
     `placeholder_type` is `normal` or `barrier`.
 
+    A placeholder and its consumer read the same values, the placeholder on the
+    shape-graph side and the consumer on the data side, even when one of them
+    ignores a value. Matching the two lists is what keeps the pair in one pool
+    domain. Values with no placeholder behind them, such as block arguments and
+    constants, are outside the rule.
+
     The optional `shape_region` computes the result shapes and ends with
     `hipsr.shape_yield`. A `normal` region takes one `!shape.shape` per input
     and omits `ctx`; a `barrier` region takes `ctx` followed by its inputs.
@@ -39,10 +45,12 @@ def Hipsr_PlaceholderOp : Hipsr_Op<
     CSE cannot merge placeholders.
 
     The pool-domain pass requires a placeholder and its consumer to sit
-    directly in the function body, and moves each placeholder before its
-    consumer. Placeholders do not set domain boundaries. A result that a later
-    domain needs is returned from the domain holding it, which keeps the shape
-    graph connected across the boundary.
+    directly in the function body. Both share one destination buffer, so the
+    input rule above keeps them in one pool domain. A `barrier` puts that pair
+    in the domain after the values its shape region reads; a `normal`
+    placeholder sets no boundary. A result that a later domain needs is returned
+    from the domain holding it, which keeps the shape graph connected across the
+    boundary.
 
     This op is temporary: it has no bufferization interface and must be
     replaced before bufferization.

--- a/lib/Conversion/OnnxToHipsr/GatherConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/GatherConversion.cpp
@@ -39,9 +39,10 @@
 //       : (tensor<2xi64, #hipsr.mem<host>>, tensor<i64>) -> tensor<i64>
 //
 // After, with the region types left out:
-//   %init = hipsr.placeholder(%ctx)
+//   %init = hipsr.placeholder(%ctx) ins(%shape)
 //       {placeholder_type = #hipsr.placeholder_type<normal>}
 //       : tensor<i64, #hipsr.mem<host>> shape_region {
+//   ^bb0(%shape_shape):
 //     %s = shape.const_shape []
 //     hipsr.shape_yield %s
 //   }
@@ -209,9 +210,10 @@ LogicalResult replaceWithHostCompute(onnx::GatherOp op, Value data,
                                        "expected every index within the axis");
   }
 
+  // Constant indices fix the shape; the data is there to match the compute.
   Location loc = op.getLoc();
   auto init = PlaceholderOp::create(rewriter, loc, TypeRange{resultType}, ctx,
-                                    ValueRange{}, PlaceholderType::Normal);
+                                    ValueRange{data}, PlaceholderType::Normal);
   populateHostShapeRegion(rewriter, init, resultType.getShape());
 
   auto computeOp =

--- a/lib/Conversion/OnnxToHipsr/NonZeroConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/NonZeroConversion.cpp
@@ -15,10 +15,8 @@
 //   resolve the published column count.
 // - hipsr.compute narrows the search destination to the positions found. Its
 //   placeholder is a barrier reading that host count, so the conversion fills
-//   that shape region itself.
-//
-// The count never becomes a compute operand: the body sizes the slice from its
-// own destination, which the barrier region already resolved.
+//   that shape region itself. The barrier and the compute list the same two
+//   values, each reading the one it needs, so they share a pool domain.
 //
 // Before:
 //   %p = "onnx.NonZero"(%mask) : (tensor<?x?xi8, #hipsr.mem<device>>)
@@ -49,10 +47,13 @@
 //       outs(%host_init : tensor<1xi64, #hipsr.mem<host>>)
 //       : tensor<1xi64, #hipsr.mem<host>>
 //   %init = hipsr.placeholder(%ctx)
-//       ins(%host_init : tensor<1xi64, #hipsr.mem<host>>)
+//       ins(%host_init, %cap_init
+//           : tensor<1xi64, #hipsr.mem<host>>,
+//             tensor<2x?xi64, #hipsr.mem<device>>)
 //       {placeholder_type = #hipsr.placeholder_type<barrier>}
 //       : tensor<2x?xi64, #hipsr.mem<device>> shape_region {
-//   ^bb0(%shape_ctx: !hipsr.context, %host: tensor<1xi64, #hipsr.mem<host>>):
+//   ^bb0(%shape_ctx: !hipsr.context, %host: tensor<1xi64, #hipsr.mem<host>>,
+//        %positions: tensor<2x?xi64, #hipsr.mem<device>>):
 //     %c0 = arith.constant 0 : index
 //     %found = tensor.extract %host[%c0] : tensor<1xi64, #hipsr.mem<host>>
 //     %columns = arith.index_cast %found : i64 to index
@@ -61,9 +62,12 @@
 //     hipsr.shape_yield %shape : !shape.shape
 //   }
 //   %p = hipsr.compute(%ctx)
-//       ins(%cap : tensor<2x?xi64, #hipsr.mem<device>>)
+//       ins(%host_count, %cap
+//           : tensor<1xi64, #hipsr.mem<host>>,
+//             tensor<2x?xi64, #hipsr.mem<device>>)
 //       outs(%init : tensor<2x?xi64, #hipsr.mem<device>>) {
 //   ^bb0(%body_ctx: !hipsr.context,
+//        %count: tensor<1xi64, #hipsr.mem<host>>,
 //        %in: tensor<2x?xi64, #hipsr.mem<device>>,
 //        %dest: tensor<2x?xi64, #hipsr.mem<device>>):
 //     %c1 = arith.constant 1 : index
@@ -151,9 +155,9 @@ void populateNarrowBody(OpBuilder &builder, ComputeOp computeOp) {
       builder.createBlock(&computeOp.getBody(), {}, argTypes, argLocs);
   builder.setInsertionPointToStart(body);
 
-  // The destination carries the count the barrier region resolved, so its own
-  // extents size the slice.
-  Value capacity = body->getArgument(1);
+  // Argument 1 is the count, read only by the barrier's shape region. The
+  // destination it sized gives the slice its extents.
+  Value capacity = body->getArgument(2);
   Value destination = body->getArguments().back();
   SmallVector<OpFoldResult> sizes =
       tensor::getMixedSizes(builder, loc, destination);
@@ -231,14 +235,16 @@ struct NonZeroToHipsr : public OpConversionPattern<onnx::NonZeroOp> {
 
     auto copyOp = createCopyD2H(rewriter, loc, *ctx, searchOp.getResult(1));
 
-    auto init = PlaceholderOp::create(rewriter, loc, TypeRange{resultType},
-                                      *ctx, ValueRange{copyOp.getResult(0)},
-                                      PlaceholderType::Barrier);
+    // One list for both keeps them in one pool domain.
+    SmallVector<Value> narrowInputs{copyOp.getResult(0), searchOp.getResult(0)};
+    auto init =
+        PlaceholderOp::create(rewriter, loc, TypeRange{resultType}, *ctx,
+                              narrowInputs, PlaceholderType::Barrier);
     populateNarrowShapeRegion(rewriter, init, inputType.getRank());
 
-    auto computeOp = ComputeOp::create(rewriter, loc, TypeRange{resultType},
-                                       *ctx, ValueRange{searchOp.getResult(0)},
-                                       ValueRange{init.getResult(0)});
+    auto computeOp =
+        ComputeOp::create(rewriter, loc, TypeRange{resultType}, *ctx,
+                          narrowInputs, ValueRange{init.getResult(0)});
     populateNarrowBody(rewriter, computeOp);
 
     rewriter.replaceOp(op, computeOp.getResult(0));

--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
@@ -36,21 +36,6 @@ namespace hipsr {
 
 namespace {
 
-// Returns the shape-graph value for a placeholder input. A data result becomes
-// the outs operand its producer writes into, which has the same shape.
-Value resolveShapeGraphInput(Value input) {
-  if (PlaceholderOp::isAllowedShapeGraphInput(input)) {
-    return input;
-  }
-  // Block arguments are allowed, so anything left is a result.
-  auto result = cast<OpResult>(input);
-  OperandRange destinations = getHipsrDestinationOperands(result.getOwner());
-  if (result.getResultNumber() >= destinations.size()) {
-    return input;
-  }
-  return destinations[result.getResultNumber()];
-}
-
 // onnx.NoValue stands in for an omitted optional operand, so it only becomes
 // dead once the conversion of its consumer drops that operand. Sweeping it up
 // therefore belongs after the conversion.
@@ -71,7 +56,7 @@ void eraseDeadNoValue(ModuleOp module) {
 void rewirePlaceholderInputs(ModuleOp module) {
   module.walk([](PlaceholderOp placeholder) {
     SmallVector<Value> resolvedInputs =
-        llvm::map_to_vector(placeholder.getInputs(), resolveShapeGraphInput);
+        llvm::map_to_vector(placeholder.getInputs(), getShapeGraphCounterpart);
     placeholder.getInputsMutable().assign(resolvedInputs);
   });
 }

--- a/lib/Conversion/OnnxToHipsr/ScatterNDConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/ScatterNDConversion.cpp
@@ -19,7 +19,7 @@
 //          tensor<?xf16, #hipsr.mem<device>>) -> tensor<?x?x4096xf16>
 //
 // After, with the ins types left out:
-//   %init = hipsr.placeholder(%ctx) ins(%embeds)
+//   %init = hipsr.placeholder(%ctx) ins(%embeds, %positions, %features)
 //       {placeholder_type = #hipsr.placeholder_type<normal>}
 //       : tensor<?x?x4096xf16, #hipsr.mem<device>>
 //   %o = hipsr.scatter_nd(%ctx) ins(%embeds, %positions, %features)
@@ -76,14 +76,15 @@ struct ScatterNDToHipsr : public OpConversionPattern<onnx::ScatterNDOp> {
       return failure();
     }
 
-    // The output takes the data's shape, so the data alone drives the
-    // placeholder.
+    // Only the data shapes the result; the rest is there to match the scatter.
     Location loc = op.getLoc();
     Value data = adaptor.getData();
     resultType = tensorTypeInSpace(resultType, MemorySpace::Device);
     Value init =
-        PlaceholderOp::create(rewriter, loc, TypeRange{resultType}, *ctx,
-                              ValueRange{data}, PlaceholderType::Normal)
+        PlaceholderOp::create(
+            rewriter, loc, TypeRange{resultType}, *ctx,
+            ValueRange{data, adaptor.getIndices(), adaptor.getUpdates()},
+            PlaceholderType::Normal)
             .getResult(0);
     auto scatterOp =
         ScatterNDOp::create(rewriter, loc, TypeRange{resultType}, *ctx, data,

--- a/lib/Conversion/OnnxToHipsr/ShapeConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/ShapeConversion.cpp
@@ -24,8 +24,10 @@
 //
 // After:
 //   %init = hipsr.placeholder(%ctx)
+//       ins(%x : tensor<?x128xf16, #hipsr.mem<device>>)
 //       {placeholder_type = #hipsr.placeholder_type<normal>}
 //       : tensor<2xi64, #hipsr.mem<host>> shape_region {
+//   ^bb0(%x_shape: !shape.shape):
 //     %c2 = arith.constant 2 : index
 //     %shape = shape.from_extents %c2 : index
 //     hipsr.shape_yield %shape : !shape.shape
@@ -185,10 +187,12 @@ struct ShapeToHipsr : public OpConversionPattern<onnx::ShapeOp> {
       return failure();
     }
 
+    // The extent count fixes the shape; the input is there to match the
+    // compute.
     Location loc = op.getLoc();
     auto init =
         PlaceholderOp::create(rewriter, loc, TypeRange{extentsType}, *ctx,
-                              ValueRange{}, PlaceholderType::Normal);
+                              ValueRange{input}, PlaceholderType::Normal);
     populateShapeRegion(rewriter, init, extentsType.getDimSize(0));
 
     auto computeOp =

--- a/lib/Dialect/Hipsr/IR/HipsrOps.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrOps.cpp
@@ -28,6 +28,30 @@ OperandRange mlir::hipsr::getHipsrDestinationOperands(Operation *op) {
   return none;
 }
 
+// A hipsr op orders its operands as context, inputs, then destinations.
+OperandRange mlir::hipsr::getHipsrInputOperands(Operation *op) {
+  OperandRange destinations = getHipsrDestinationOperands(op);
+  if (destinations.empty()) {
+    return OperandRange(nullptr, 0);
+  }
+  unsigned contextAndInputs = destinations.getBeginOperandIndex();
+  return op->getOperands().slice(1, contextAndInputs - 1);
+}
+
+Value mlir::hipsr::getShapeGraphCounterpart(Value value) {
+  if (PlaceholderOp::isAllowedShapeGraphInput(value)) {
+    return value;
+  }
+
+  // Block arguments are allowed, so anything left is a result.
+  auto result = cast<OpResult>(value);
+  OperandRange destinations = getHipsrDestinationOperands(result.getOwner());
+  if (result.getResultNumber() >= destinations.size()) {
+    return value;
+  }
+  return destinations[result.getResultNumber()];
+}
+
 bool mlir::hipsr::isHipsrDestinationOperand(OpOperand &use) {
   OperandRange destinations = getHipsrDestinationOperands(use.getOwner());
   if (destinations.empty())

--- a/lib/Dialect/Hipsr/IR/HipsrPlaceholderOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrPlaceholderOp.cpp
@@ -57,6 +57,45 @@ LogicalResult verifyResultUses(PlaceholderOp op) {
   return success();
 }
 
+// A placeholder and its consumer share one destination buffer, so both must
+// land in the same pool domain. That holds when the two read the same values,
+// the placeholder on the shape-graph side and the consumer on the data side.
+//
+// Only a value another placeholder holds is checked. A block argument or a
+// constant cannot reach a later domain, and inside a pool domain a data value
+// and its counterpart are two block arguments that no longer name each other.
+LogicalResult verifyConsumerTopology(PlaceholderOp op) {
+  Operation *consumer = op.getConsumer();
+  if (!consumer) {
+    return success();
+  }
+
+  SmallVector<Value> counterparts = llvm::map_to_vector(
+      getHipsrInputOperands(consumer), getShapeGraphCounterpart);
+
+  for (auto [index, counterpart] : llvm::enumerate(counterparts)) {
+    if (!counterpart.getDefiningOp<PlaceholderOp>()) {
+      continue;
+    }
+    if (!llvm::is_contained(op.getInputs(), counterpart)) {
+      return op.emitOpError("must read the shape-graph value of input ")
+             << index << " of its consumer '" << consumer->getName() << "'";
+    }
+  }
+
+  for (auto [index, input] : llvm::enumerate(op.getInputs())) {
+    if (!input.getDefiningOp<PlaceholderOp>()) {
+      continue;
+    }
+    if (!llvm::is_contained(counterparts, input)) {
+      return op.emitOpError("input ")
+             << index << " has no matching operand in its consumer '"
+             << consumer->getName() << "'";
+    }
+  }
+  return success();
+}
+
 // The placeholder type sets the shape region's block arguments.
 LogicalResult verifyShapeRegionSignature(PlaceholderOp op) {
   if (op.getBodyRegion().empty()) {
@@ -126,6 +165,9 @@ LogicalResult PlaceholderOp::verify() {
     return failure();
   }
   if (failed(verifyResultUses(*this))) {
+    return failure();
+  }
+  if (failed(verifyConsumerTopology(*this))) {
     return failure();
   }
   if (failed(verifyShapeRegionSignature(*this))) {

--- a/test/lit/Conversion/onnx-to-hipsr/gather.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/gather.mlir
@@ -56,7 +56,8 @@ func.func @negative_axis(%ctx: !hipsr.context, %data: tensor<2x3x4xf16>,
 // CHECK-LABEL: func.func @host_leading_dim(
 // CHECK-SAME:    %[[CTX:.+]]: !hipsr.context,
 // CHECK-SAME:    %[[INPUT:.+]]: tensor<?x4096xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT:    %[[EXTENTS_INIT:.+]] = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:    %[[EXTENTS_INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:    ^bb0(%{{.+}}: !shape.shape):
 // CHECK-NEXT:      %[[LEN:.+]] = arith.constant 2 : index
 // CHECK-NEXT:      %[[EXTENTS_SHAPE:.+]] = shape.from_extents %[[LEN]] : index
 // CHECK-NEXT:      hipsr.shape_yield %[[EXTENTS_SHAPE]] : !shape.shape
@@ -71,7 +72,8 @@ func.func @negative_axis(%ctx: !hipsr.context, %data: tensor<2x3x4xf16>,
 // CHECK-NEXT:      hipsr.compute_yield %[[EXTENTS]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:    } : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:    %{{.+}} = arith.constant dense<0> : tensor<i64>
-// CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<i64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[EXTENTS_INIT]] : tensor<2xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<i64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:    ^bb0(%{{.+}}: !shape.shape):
 // CHECK-NEXT:      %[[RESULT_SHAPE:.+]] = shape.const_shape [] : !shape.shape
 // CHECK-NEXT:      hipsr.shape_yield %[[RESULT_SHAPE]] : !shape.shape
 // CHECK-NEXT:    }
@@ -103,7 +105,8 @@ func.func @host_leading_dim(%ctx: !hipsr.context,
 // CHECK-LABEL: func.func @host_negative_index(
 // CHECK-SAME:    %[[CTX:.+]]: !hipsr.context,
 // CHECK-SAME:    %[[INPUT:.+]]: tensor<?x?x4096xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT:    %[[EXTENTS_INIT:.+]] = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<3xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:    %[[EXTENTS_INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<3xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:    ^bb0(%{{.+}}: !shape.shape):
 // CHECK-NEXT:      %[[LEN:.+]] = arith.constant 3 : index
 // CHECK-NEXT:      %[[EXTENTS_SHAPE:.+]] = shape.from_extents %[[LEN]] : index
 // CHECK-NEXT:      hipsr.shape_yield %[[EXTENTS_SHAPE]] : !shape.shape
@@ -121,7 +124,8 @@ func.func @host_leading_dim(%ctx: !hipsr.context,
 // CHECK-NEXT:      hipsr.compute_yield %[[EXTENTS]] : tensor<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:    } : tensor<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:    %{{.+}} = hipsr.constant {value = dense<[-1, 0]> : tensor<2xi64>} : tensor<2xi64, #hipsr.mem<device>>
-// CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[EXTENTS_INIT]] : tensor<3xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:    ^bb0(%{{.+}}: !shape.shape):
 // CHECK-NEXT:      %[[RESULT_SHAPE:.+]] = shape.const_shape [2] : !shape.shape
 // CHECK-NEXT:      hipsr.shape_yield %[[RESULT_SHAPE]] : !shape.shape
 // CHECK-NEXT:    }

--- a/test/lit/Conversion/onnx-to-hipsr/nonzero.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/nonzero.mlir
@@ -23,10 +23,9 @@
 // CHECK-NEXT:    ^bb0(%[[COUNT_SHAPE:.+]]: !shape.shape):
 // CHECK-NEXT:      hipsr.shape_yield %[[COUNT_SHAPE]] : !shape.shape
 // CHECK-NEXT:    }
-// The copy's own result goes unused: the shape graph names the destination.
-// CHECK-NEXT:    %{{.+}} = hipsr.copy_d2h(%[[CTX]]) ins(%[[SEARCH]]#1 : tensor<1xi64, #hipsr.mem<device>>) outs(%[[HOST_INIT]] : tensor<1xi64, #hipsr.mem<host>>) : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[HOST_INIT]] : tensor<1xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<2x?xi64, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:    ^bb0(%{{.+}}: !hipsr.context, %[[COUNT:.+]]: tensor<1xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:    %[[HOST_COUNT:.+]] = hipsr.copy_d2h(%[[CTX]]) ins(%[[SEARCH]]#1 : tensor<1xi64, #hipsr.mem<device>>) outs(%[[HOST_INIT]] : tensor<1xi64, #hipsr.mem<host>>) : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[HOST_INIT]], %[[INITS]]#0 : tensor<1xi64, #hipsr.mem<host>>, tensor<2x?xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<2x?xi64, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:    ^bb0(%{{.+}}: !hipsr.context, %[[COUNT:.+]]: tensor<1xi64, #hipsr.mem<host>>, %{{.+}}: tensor<2x?xi64, #hipsr.mem<device>>):
 // CHECK-NEXT:      %[[ZERO:.+]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[FOUND:.+]] = tensor.extract %[[COUNT]]{{\[}}%[[ZERO]]] : tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:      %[[COLUMNS:.+]] = arith.index_cast %[[FOUND]] : i64 to index
@@ -34,8 +33,10 @@
 // CHECK-NEXT:      %[[SHAPE:.+]] = shape.from_extents %[[ROWS]], %[[COLUMNS]] : index, index
 // CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
 // CHECK-NEXT:    }
-// CHECK-NEXT:    %[[NARROWED:.+]] = hipsr.compute(%[[CTX]]) ins(%[[SEARCH]]#0 : tensor<2x?xi64, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<2x?xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:    ^bb0(%{{.+}}: !hipsr.context, %[[POSITIONS:.+]]: tensor<2x?xi64, #hipsr.mem<device>>, %[[DEST:.+]]: tensor<2x?xi64, #hipsr.mem<device>>):
+// The compute lists the count the barrier reads, so the two share a pool
+// domain, and ignores it in the body.
+// CHECK-NEXT:    %[[NARROWED:.+]] = hipsr.compute(%[[CTX]]) ins(%[[HOST_COUNT]], %[[SEARCH]]#0 : tensor<1xi64, #hipsr.mem<host>>, tensor<2x?xi64, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<2x?xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:    ^bb0(%{{.+}}: !hipsr.context, %{{.+}}: tensor<1xi64, #hipsr.mem<host>>, %[[POSITIONS:.+]]: tensor<2x?xi64, #hipsr.mem<device>>, %[[DEST:.+]]: tensor<2x?xi64, #hipsr.mem<device>>):
 // CHECK-NEXT:      %[[ONE:.+]] = arith.constant 1 : index
 // CHECK-NEXT:      %[[DIM:.+]] = tensor.dim %[[DEST]], %[[ONE]] : tensor<2x?xi64, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[SLICE:.+]] = tensor.extract_slice %[[POSITIONS]][0, 0] [2, %[[DIM]]] [1, 1] : tensor<2x?xi64, #hipsr.mem<device>> to tensor<2x?xi64, #hipsr.mem<device>>
@@ -63,9 +64,9 @@ func.func @nonzero_mask(%ctx: !hipsr.context,
 // CHECK-NEXT:    ^bb0(%[[COUNT_SHAPE:.+]]: !shape.shape):
 // CHECK-NEXT:      hipsr.shape_yield %[[COUNT_SHAPE]] : !shape.shape
 // CHECK-NEXT:    }
-// CHECK-NEXT:    %{{.+}} = hipsr.copy_d2h(%[[CTX]]) ins(%[[SEARCH]]#1 : tensor<1xi64, #hipsr.mem<device>>) outs(%[[HOST_INIT]] : tensor<1xi64, #hipsr.mem<host>>) : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[HOST_INIT]] : tensor<1xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<1x?xi64, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:    ^bb0(%{{.+}}: !hipsr.context, %[[COUNT:.+]]: tensor<1xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:    %[[HOST_COUNT:.+]] = hipsr.copy_d2h(%[[CTX]]) ins(%[[SEARCH]]#1 : tensor<1xi64, #hipsr.mem<device>>) outs(%[[HOST_INIT]] : tensor<1xi64, #hipsr.mem<host>>) : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[HOST_INIT]], %[[INITS]]#0 : tensor<1xi64, #hipsr.mem<host>>, tensor<1x12xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<1x?xi64, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:    ^bb0(%{{.+}}: !hipsr.context, %[[COUNT:.+]]: tensor<1xi64, #hipsr.mem<host>>, %{{.+}}: tensor<1x12xi64, #hipsr.mem<device>>):
 // CHECK-NEXT:      %[[ZERO:.+]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[FOUND:.+]] = tensor.extract %[[COUNT]]{{\[}}%[[ZERO]]] : tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:      %[[COLUMNS:.+]] = arith.index_cast %[[FOUND]] : i64 to index
@@ -73,8 +74,8 @@ func.func @nonzero_mask(%ctx: !hipsr.context,
 // CHECK-NEXT:      %[[SHAPE:.+]] = shape.from_extents %[[ROWS]], %[[COLUMNS]] : index, index
 // CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
 // CHECK-NEXT:    }
-// CHECK-NEXT:    %[[NARROWED:.+]] = hipsr.compute(%[[CTX]]) ins(%[[SEARCH]]#0 : tensor<1x12xi64, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<1x?xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:    ^bb0(%{{.+}}: !hipsr.context, %[[POSITIONS:.+]]: tensor<1x12xi64, #hipsr.mem<device>>, %[[DEST:.+]]: tensor<1x?xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:    %[[NARROWED:.+]] = hipsr.compute(%[[CTX]]) ins(%[[HOST_COUNT]], %[[SEARCH]]#0 : tensor<1xi64, #hipsr.mem<host>>, tensor<1x12xi64, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<1x?xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:    ^bb0(%{{.+}}: !hipsr.context, %{{.+}}: tensor<1xi64, #hipsr.mem<host>>, %[[POSITIONS:.+]]: tensor<1x12xi64, #hipsr.mem<device>>, %[[DEST:.+]]: tensor<1x?xi64, #hipsr.mem<device>>):
 // CHECK-NEXT:      %[[ONE:.+]] = arith.constant 1 : index
 // CHECK-NEXT:      %[[DIM:.+]] = tensor.dim %[[DEST]], %[[ONE]] : tensor<1x?xi64, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[SLICE:.+]] = tensor.extract_slice %[[POSITIONS]][0, 0] [1, %[[DIM]]] [1, 1] : tensor<1x12xi64, #hipsr.mem<device>> to tensor<1x?xi64, #hipsr.mem<device>>

--- a/test/lit/Conversion/onnx-to-hipsr/scatter_nd.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/scatter_nd.mlir
@@ -9,15 +9,15 @@
 // RUN: hip-mlir-opt %s --onnx-dialect=modeled --split-input-file -allow-unregistered-dialect -convert-onnx-to-hipsr | FileCheck %s
 
 // The embedding graph writes image features into the token embeddings at the
-// positions it found. The output takes the data's shape, so the data alone
-// reaches the placeholder. Its shape region stays empty for
-// hipsr-populate-shape-region to fill in.
+// positions it found. The result takes the data's shape, but the placeholder
+// still lists every scatter operand so the two stay in one pool domain. Its
+// shape region stays empty for hipsr-populate-shape-region to fill in.
 // CHECK-LABEL: func.func @scatter_features(
 // CHECK-SAME:    %[[CTX:.+]]: !hipsr.context,
 // CHECK-SAME:    %[[EMBEDS:.+]]: tensor<?x?x4096xf16, #hipsr.mem<device>>,
 // CHECK-SAME:    %[[POSITIONS:.+]]: tensor<?x3xi64, #hipsr.mem<device>>,
 // CHECK-SAME:    %[[FEATURES:.+]]: tensor<?xf16, #hipsr.mem<device>>) -> tensor<?x?x4096xf16, #hipsr.mem<device>> {
-// CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[EMBEDS]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[EMBEDS]], %[[POSITIONS]], %[[FEATURES]] : tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:    %[[RESULT:.+]] = hipsr.scatter_nd(%[[CTX]]) ins(%[[EMBEDS]], %[[POSITIONS]], %[[FEATURES]] : tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) : tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:    return %[[RESULT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:  }
@@ -41,7 +41,7 @@ func.func @scatter_features(%ctx: !hipsr.context,
 // CHECK-SAME:    %[[DATA:.+]]: tensor<4x8x2xf16, #hipsr.mem<device>>,
 // CHECK-SAME:    %[[IDS:.+]]: tensor<5x1xi64, #hipsr.mem<device>>,
 // CHECK-SAME:    %[[UPDATES:.+]]: tensor<5x8x2xf16, #hipsr.mem<device>>) -> tensor<4x8x2xf16, #hipsr.mem<device>> {
-// CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[DATA]] : tensor<4x8x2xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4x8x2xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[DATA]], %[[IDS]], %[[UPDATES]] : tensor<4x8x2xf16, #hipsr.mem<device>>, tensor<5x1xi64, #hipsr.mem<device>>, tensor<5x8x2xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4x8x2xf16, #hipsr.mem<device>>
 // CHECK-NEXT:    %[[RESULT:.+]] = hipsr.scatter_nd(%[[CTX]]) ins(%[[DATA]], %[[IDS]], %[[UPDATES]] : tensor<4x8x2xf16, #hipsr.mem<device>>, tensor<5x1xi64, #hipsr.mem<device>>, tensor<5x8x2xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<4x8x2xf16, #hipsr.mem<device>>) : tensor<4x8x2xf16, #hipsr.mem<device>>
 // CHECK-NEXT:    return %[[RESULT]] : tensor<4x8x2xf16, #hipsr.mem<device>>
 // CHECK-NEXT:  }

--- a/test/lit/Conversion/onnx-to-hipsr/shape.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/shape.mlir
@@ -10,16 +10,20 @@
 // #hipsr.mem<host>: the placeholder, the destination, the yielded value and the
 // result. Data keeps the #hipsr.mem<device> the pass gives a tensor that names
 // no space.
+//
+// The input's rank fixes the result length, so every shape region below is
+// constant. The placeholder still reads the input, because it mirrors the
+// compute's operands to share a pool domain with it.
 //===----------------------------------------------------------------------===//
 
 // RUN: hip-mlir-opt %s --onnx-dialect=modeled --split-input-file -allow-unregistered-dialect -convert-onnx-to-hipsr | FileCheck %s
 
-// Only a dynamic axis needs a query; a static one is a constant. The shape
-// region is constant too, since the input's rank fixes the result length.
+// Only a dynamic axis needs a query; a static one is a constant.
 // CHECK-LABEL:   func.func @shape_full(
 // CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:      %[[INPUT:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>) -> tensor<3xi64, #hipsr.mem<host>> {
-// CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<3xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<3xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:      ^bb0(%{{.*}}: !shape.shape):
 // CHECK-NEXT:        %[[LEN:.*]] = arith.constant 3 : index
 // CHECK-NEXT:        %[[SHAPE:.*]] = shape.from_extents %[[LEN]] : index
 // CHECK-NEXT:        hipsr.shape_yield %[[SHAPE]] : !shape.shape
@@ -50,7 +54,8 @@ func.func @shape_full(%ctx: !hipsr.context, %input: tensor<?x?x4096xf16>)
 // CHECK-LABEL:   func.func @shape_start(
 // CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:      %[[INPUT:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>) -> tensor<2xi64, #hipsr.mem<host>> {
-// CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:      ^bb0(%{{.*}}: !shape.shape):
 // CHECK-NEXT:        %[[LEN:.*]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[SHAPE:.*]] = shape.from_extents %[[LEN]] : index
 // CHECK-NEXT:        hipsr.shape_yield %[[SHAPE]] : !shape.shape
@@ -79,7 +84,8 @@ func.func @shape_start(%ctx: !hipsr.context, %input: tensor<?x?x4096xf16>)
 // CHECK-LABEL:   func.func @shape_negative_start(
 // CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:      %[[INPUT:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>) -> tensor<1xi64, #hipsr.mem<host>> {
-// CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<1xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<1xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:      ^bb0(%{{.*}}: !shape.shape):
 // CHECK-NEXT:        %[[LEN:.*]] = arith.constant 1 : index
 // CHECK-NEXT:        %[[SHAPE:.*]] = shape.from_extents %[[LEN]] : index
 // CHECK-NEXT:        hipsr.shape_yield %[[SHAPE]] : !shape.shape
@@ -105,7 +111,8 @@ func.func @shape_negative_start(%ctx: !hipsr.context,
 // CHECK-LABEL:   func.func @shape_end(
 // CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:      %[[INPUT:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>) -> tensor<2xi64, #hipsr.mem<host>> {
-// CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:      ^bb0(%{{.*}}: !shape.shape):
 // CHECK-NEXT:        %[[LEN:.*]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[SHAPE:.*]] = shape.from_extents %[[LEN]] : index
 // CHECK-NEXT:        hipsr.shape_yield %[[SHAPE]] : !shape.shape
@@ -136,7 +143,8 @@ func.func @shape_end(%ctx: !hipsr.context, %input: tensor<?x?x4096xf16>)
 // CHECK-LABEL:   func.func @shape_bounds_past_the_ends(
 // CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:      %[[INPUT:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>) -> tensor<3xi64, #hipsr.mem<host>> {
-// CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<3xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<3xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:      ^bb0(%{{.*}}: !shape.shape):
 // CHECK-NEXT:        %[[LEN:.*]] = arith.constant 3 : index
 // CHECK-NEXT:        %[[SHAPE:.*]] = shape.from_extents %[[LEN]] : index
 // CHECK-NEXT:        hipsr.shape_yield %[[SHAPE]] : !shape.shape
@@ -169,7 +177,8 @@ func.func @shape_bounds_past_the_ends(%ctx: !hipsr.context,
 // CHECK-LABEL:   func.func @result_names_no_space(
 // CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:      %[[INPUT:.*]]: tensor<2x3xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<2x3xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:      ^bb0(%{{.*}}: !shape.shape):
 // CHECK-NEXT:        %[[LEN:.*]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[SHAPE:.*]] = shape.from_extents %[[LEN]] : index
 // CHECK-NEXT:        hipsr.shape_yield %[[SHAPE]] : !shape.shape
@@ -203,7 +212,8 @@ func.func @result_names_no_space(%ctx: !hipsr.context,
 // CHECK-LABEL:   func.func @extents_feed_an_expand(
 // CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:      %[[INPUT:.*]]: tensor<?x3xf16, #hipsr.mem<device>>) -> tensor<?x?xf16, #hipsr.mem<device>> {
-// CHECK-NEXT:      %[[EXTENTS_INIT:.*]] = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:      %[[EXTENTS_INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x3xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:      ^bb0(%{{.*}}: !shape.shape):
 // CHECK-NEXT:        %[[LEN:.*]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[SHAPE:.*]] = shape.from_extents %[[LEN]] : index
 // CHECK-NEXT:        hipsr.shape_yield %[[SHAPE]] : !shape.shape

--- a/test/lit/Conversion/onnx-to-hipsr/slice.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/slice.mlir
@@ -17,9 +17,14 @@
 // CHECK-LABEL: func.func @strided_window(
 // CHECK-SAME:    %[[CTX:.+]]: !hipsr.context,
 // CHECK-SAME:    %[[DATA:.+]]: tensor<8x4xf16, #hipsr.mem<device>>) -> tensor<3x4xf16, #hipsr.mem<device>> {
-// CHECK:         %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[DATA]] : tensor<8x4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<3x4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    %{{.+}} = hipsr.constant {value = dense<1> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:    %{{.+}} = hipsr.constant {value = dense<7> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:    %{{.+}} = hipsr.constant {value = dense<0> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:    %{{.+}} = hipsr.constant {value = dense<2> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[DATA]] : tensor<8x4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<3x4xf16, #hipsr.mem<device>>
 // CHECK-NEXT:    %[[RESULT:.+]] = hipsr.slice(%[[CTX]]) ins(%[[DATA]] : tensor<8x4xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<3x4xf16, #hipsr.mem<device>>) {axes_attr = array<i64: 0>, ends_attr = array<i64: 7>, starts_attr = array<i64: 1>, steps_attr = array<i64: 2>} : tensor<3x4xf16, #hipsr.mem<device>>
 // CHECK-NEXT:    return %[[RESULT]] : tensor<3x4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:  }
 func.func @strided_window(%ctx: !hipsr.context,
                           %data: tensor<8x4xf16>) -> tensor<3x4xf16> {
   %starts = "onnx.Constant"() {value = dense<1> : tensor<1xi64>} : () -> tensor<1xi64>
@@ -43,11 +48,25 @@ func.func @strided_window(%ctx: !hipsr.context,
 // CHECK-SAME:    %[[CTX:.+]]: !hipsr.context,
 // CHECK-SAME:    %[[DATA:.+]]: tensor<8xf16, #hipsr.mem<device>>,
 // CHECK-SAME:    %[[OTHER:.+]]: tensor<?x4096xf16, #hipsr.mem<device>>) -> tensor<?xf16, #hipsr.mem<device>> {
-// CHECK:         %[[ENDS_INIT:.+]] = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<1xi64, #hipsr.mem<host>>
-// CHECK:         %[[ENDS:.+]] = hipsr.compute(%[[CTX]]) ins(%[[OTHER]]
-// CHECK:         %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[DATA]], %[[ENDS_INIT]] : tensor<8xf16, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    %[[ENDS_INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[OTHER]] : tensor<?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<1xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:    ^bb0(%{{.+}}: !shape.shape):
+// CHECK-NEXT:      %[[LEN:.+]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[ENDS_SHAPE:.+]] = shape.from_extents %[[LEN]] : index
+// CHECK-NEXT:      hipsr.shape_yield %[[ENDS_SHAPE]] : !shape.shape
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[ENDS:.+]] = hipsr.compute(%[[CTX]]) ins(%[[OTHER]] : tensor<?x4096xf16, #hipsr.mem<device>>) outs(%[[ENDS_INIT]] : tensor<1xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:    ^bb0(%{{.+}}: !hipsr.context, %[[BODY_OTHER:.+]]: tensor<?x4096xf16, #hipsr.mem<device>>, %{{.+}}: tensor<1xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:      %[[AXIS:.+]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[DIM:.+]] = tensor.dim %[[BODY_OTHER]], %[[AXIS]] : tensor<?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[BOUND:.+]] = arith.index_cast %[[DIM]] : index to i64
+// CHECK-NEXT:      %[[BOUND_VECTOR:.+]] = tensor.from_elements %[[BOUND]] : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      hipsr.compute_yield %[[BOUND_VECTOR]] : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:    } : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:    %{{.+}} = hipsr.constant {value = dense<0> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[DATA]], %[[ENDS_INIT]] : tensor<8xf16, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT:    %[[RESULT:.+]] = hipsr.slice(%[[CTX]]) ins(%[[DATA]] : tensor<8xf16, #hipsr.mem<device>>) ends(%[[ENDS]] : tensor<1xi64, #hipsr.mem<host>>) outs(%[[INIT]] : tensor<?xf16, #hipsr.mem<device>>) {axes_attr = array<i64: 0>, starts_attr = array<i64: 0>, steps_attr = array<i64: 1>} : tensor<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT:    return %[[RESULT]] : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:  }
 func.func @computed_bound(%ctx: !hipsr.context, %data: tensor<8xf16>,
                           %other: tensor<?x4096xf16>) -> tensor<?xf16> {
   %ends = "onnx.Shape"(%other) {start = 0 : si64, end = 1 : si64}

--- a/test/lit/Dialect/Hipsr/IR/placeholder.mlir
+++ b/test/lit/Dialect/Hipsr/IR/placeholder.mlir
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 //===----------------------------------------------------------------------===//
-// Verifier and region-trait rules for hipsr.placeholder. Every case but the
-// last is invalid IR that trips one rule.
+// Verifier and region-trait rules for hipsr.placeholder. A case without CHECK
+// lines is invalid IR that trips one rule.
 //===----------------------------------------------------------------------===//
 
 // RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s | FileCheck %s
@@ -35,6 +35,26 @@ func.func @data_result_input(
   %second = hipsr.cast(%ctx) ins(%first : tensor<4x8xf16, #hipsr.mem<device>>)
       outs(%second_init : tensor<4x8xf32, #hipsr.mem<device>>) : tensor<4x8xf32, #hipsr.mem<device>>
   return %second : tensor<4x8xf32, #hipsr.mem<device>>
+}
+
+// -----
+// A placeholder that skips an operand its consumer reads can land in an
+// earlier pool domain than the consumer.
+func.func @input_missing_from_placeholder(
+    %ctx: !hipsr.context, %input: tensor<4x8xf32, #hipsr.mem<device>>) -> tensor<4x8xf32, #hipsr.mem<device>> {
+  %first_init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<4x8xf32, #hipsr.mem<device>>)
+      {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4x8xf32, #hipsr.mem<device>>
+  %first = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32, #hipsr.mem<device>>)
+      outs(%first_init : tensor<4x8xf32, #hipsr.mem<device>>) : tensor<4x8xf32, #hipsr.mem<device>>
+  // expected-error @+1 {{must read the shape-graph value of input 1 of its consumer 'hipsr.add'}}
+  %sum_init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<4x8xf32, #hipsr.mem<device>>)
+      {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4x8xf32, #hipsr.mem<device>>
+  %sum = hipsr.add(%ctx)
+      ins(%input, %first : tensor<4x8xf32, #hipsr.mem<device>>, tensor<4x8xf32, #hipsr.mem<device>>)
+      outs(%sum_init : tensor<4x8xf32, #hipsr.mem<device>>) : tensor<4x8xf32, #hipsr.mem<device>>
+  return %sum : tensor<4x8xf32, #hipsr.mem<device>>
 }
 
 // -----
@@ -210,4 +230,29 @@ func.func @constant_shape_roots(
   %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32, #hipsr.mem<device>>)
       outs(%init : tensor<4x8xf16, #hipsr.mem<device>>) : tensor<4x8xf16, #hipsr.mem<device>>
   return %result : tensor<4x8xf16, #hipsr.mem<device>>
+}
+
+// -----
+// A placeholder that reads a value its consumer skips can land in a later pool
+// domain than the consumer.
+func.func @input_missing_from_consumer(
+    %ctx: !hipsr.context, %input: tensor<4x8xf32, #hipsr.mem<device>>) -> tensor<4x8xf32, #hipsr.mem<device>> {
+  %extra_init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<4x8xf32, #hipsr.mem<device>>)
+      {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16, #hipsr.mem<device>>
+  %extra = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32, #hipsr.mem<device>>)
+      outs(%extra_init : tensor<4x8xf16, #hipsr.mem<device>>) : tensor<4x8xf16, #hipsr.mem<device>>
+  %first_init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<4x8xf32, #hipsr.mem<device>>)
+      {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16, #hipsr.mem<device>>
+  %first = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32, #hipsr.mem<device>>)
+      outs(%first_init : tensor<4x8xf16, #hipsr.mem<device>>) : tensor<4x8xf16, #hipsr.mem<device>>
+  // expected-error @+1 {{input 1 has no matching operand in its consumer 'hipsr.cast'}}
+  %result_init = hipsr.placeholder(%ctx)
+      ins(%first_init, %extra_init
+          : tensor<4x8xf16, #hipsr.mem<device>>, tensor<4x8xf16, #hipsr.mem<device>>)
+      {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4x8xf32, #hipsr.mem<device>>
+  %result = hipsr.cast(%ctx) ins(%first : tensor<4x8xf16, #hipsr.mem<device>>)
+      outs(%result_init : tensor<4x8xf32, #hipsr.mem<device>>) : tensor<4x8xf32, #hipsr.mem<device>>
+  return %result : tensor<4x8xf32, #hipsr.mem<device>>
 }

--- a/test/lit/Dialect/Hipsr/Pipelines/sample_dynamic.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/sample_dynamic.mlir
@@ -57,7 +57,8 @@
 
 // The extent vector's length is still a constant -- the operand's rank fixes it.
 // The dynamic extent appears one level down, as a tensor.dim in the body.
-// CHECK-NEXT:      %[[SHAPE_INIT:.+]] = hipsr.placeholder(%[[D0_CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:      %[[SHAPE_INIT:.+]] = hipsr.placeholder(%[[D0_CTX]]) ins(%[[D0_B]] : tensor<?x4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:      ^bb0(%{{.+}}: !shape.shape):
 // CHECK-NEXT:        %[[RANK:.+]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[RANK_SHAPE:.+]] = shape.from_extents %[[RANK]] : index
 // CHECK-NEXT:        hipsr.shape_yield %[[RANK_SHAPE]] : !shape.shape

--- a/test/lit/Dialect/Hipsr/Pipelines/sample_static.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/sample_static.mlir
@@ -56,7 +56,8 @@
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %[[CAST:.+]] = hipsr.cast(%[[D0_CTX]]) ins(%[[MM1]] : tensor<2x1xf16, #hipsr.mem<device>>) outs(%[[CAST_INIT]] : tensor<2x1xf32, #hipsr.mem<device>>) : tensor<2x1xf32, #hipsr.mem<device>>
 
-// CHECK-NEXT:      %[[SHAPE_INIT:.+]] = hipsr.placeholder(%[[D0_CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:      %[[SHAPE_INIT:.+]] = hipsr.placeholder(%[[D0_CTX]]) ins(%[[D0_B]] : tensor<2x4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:      ^bb0(%{{.+}}: !shape.shape):
 // CHECK-NEXT:        %[[RANK:.+]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[RANK_SHAPE:.+]] = shape.from_extents %[[RANK]] : index
 // CHECK-NEXT:        hipsr.shape_yield %[[RANK_SHAPE]] : !shape.shape


### PR DESCRIPTION
﻿## Summary

```mlir
%x = placeloader ; // mising %y
%d1 = hipsr.cast (%ctx) ins(%y) outs(%x)
```

A `hipsr.placeholder` and its consumer now read the same values, the placeholder on the shape-graph side and the consumer on the data side. Matching the two lists keeps the pair in one pool domain, which they need because they share a destination buffer.

## Why

A placeholder that read fewer values than its consumer could land in an earlier pool domain. The pair then straddled a domain boundary and tripped the placeholder's own result-use rule.

Matching the lists makes the shape graph a copy of the data graph, so the domain walk reaches the same depth from either side. `PartitionPoolDomains` needs no pairing rule of its own and is unchanged here.

Values with no placeholder behind them are outside the rule. A block argument or a constant cannot reach a later domain, and a pool-domain region splits a data value and its counterpart into two block arguments that no longer name each other.

## What

- `PlaceholderOp::verify` gains `verifyConsumerTopology`, which checks both directions, and the ODS docs state the rule.
- `getShapeGraphCounterpart` becomes a free function next to the other hipsr operand helpers, so the verifier and `rewirePlaceholderInputs` resolve inputs the same way.
- `getHipsrInputOperands` returns the data operands of a hipsr op.
- ScatterND, the Gather host path, Shape, and the NonZero narrow barrier now list every operand their consumer reads.
- The NonZero narrow compute takes the host count its barrier reads and ignores it in the body, which sizes the slice from the destination the barrier resolved.
- New LIT cases cover both diagnostics.

## Notes for reviewers

Listing values one side ignores has a cost: it can push a pair one domain later than needed, and NonZero now yields one more value out of the earlier domain.

Developed with Cursor using Claude Opus 5, and validated with the LIT suite and the `-hipsr-partition-pool-domains` output.


