### PR TITLE
fix(hipsr): give hipsr.equal the i1 result onnx.Equal declares

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/HipsrEqualOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrEqualOp.td
@@ -10,8 +10,9 @@ def Hipsr_EqualOp : Hipsr_DpsOp<"equal",
     Elementwise equality with ONNX broadcasting: `init = lhs == rhs`.
 
     Shapes are right-aligned, and each aligned pair must be equal or contain a
-    one. `init` holds `ui8` rather than the operand element type, because the
-    runtime writes one byte per result element.
+    one. `init` holds `i1` rather than the operand element type, because a
+    comparison yields a bool whatever it compared. The runtime stores that bool
+    one byte per element.
   }];
 
   let arguments = (ins

--- a/include/hip/datatype_abi.h
+++ b/include/hip/datatype_abi.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#ifndef HIP_DATATYPE_ABI_H
+#define HIP_DATATYPE_ABI_H
+
+//===----------------------------------------------------------------------===//
+// Backend-Independent Data Type Identifiers
+//===----------------------------------------------------------------------===//
+//
+// Single source of truth for the element-type identifiers the compiler writes
+// into generated runtime calls and the runtime reads back out. They are our own
+// values -- do NOT assume they match cuDNN or any other library's enum. Each
+// backend provides an explicit mapping function to convert these to
+// library-specific types.
+//
+// Both sides include this header, so a value cannot be changed on one side
+// alone. They stay plain #defines because the runtime's C ABI header uses them.
+//
+// To add a new type:
+//   1. Add the #define here
+//   2. Update hipdnn_ep_datatype_size() and hipdnn_ep_datatype_name() in
+//      lib/Runtime/hipdnn_ep_runtime.h
+//   3. Update the compiler mappings from an MLIR element type:
+//   getHipdnnDataType()
+//      in lib/Conversion/HipToLLVM/HipToLLVMUtils.h and in
+//      lib/Dialect/Hipsr/IR/HipsrLLVMLoweringUtils.cpp, and
+//      getHipdnnInputDataType() in lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+//   4. Update each backend mapping function
+//===----------------------------------------------------------------------===//
+
+#define HIPDNN_EP_DATATYPE_FLOAT 0    // f32, 4 bytes
+#define HIPDNN_EP_DATATYPE_HALF 1     // f16, 2 bytes
+#define HIPDNN_EP_DATATYPE_BFLOAT16 2 // bf16, 2 bytes
+#define HIPDNN_EP_DATATYPE_INT32 3    // i32, 4 bytes
+#define HIPDNN_EP_DATATYPE_INT64 4    // i64, 8 bytes
+#define HIPDNN_EP_DATATYPE_INT8 5     // i8, 1 byte
+#define HIPDNN_EP_DATATYPE_DOUBLE 6   // f64, 8 bytes
+#define HIPDNN_EP_DATATYPE_UINT8 7    // ui8, 1 byte
+#define HIPDNN_EP_DATATYPE_INT16 8    // i16, 2 byte
+
+// Returned by the compiler-side mappings for an element type with no runtime
+// identifier, so a caller fails conversion explicitly instead of passing a
+// wrong type.
+#define HIPDNN_EP_DATATYPE_UNSUPPORTED (-1)
+
+#endif // HIP_DATATYPE_ABI_H

--- a/lib/Conversion/HipToLLVM/GatherBlockQuantizedLowering.cpp
+++ b/lib/Conversion/HipToLLVM/GatherBlockQuantizedLowering.cpp
@@ -64,7 +64,7 @@ struct GatherBlockQuantizedOpLowering
     int64_t dataDtype = getHipdnnDataType(dataType.getElementType());
     if (dataType.getElementType().isUnsignedInteger(8) || op.getBits() == 8 ||
         op->hasAttr("unsigned_quant_storage"))
-      dataDtype = 7; // HIPDNN_EP_DATATYPE_UINT8
+      dataDtype = HIPDNN_EP_DATATYPE_UINT8;
     int64_t indicesDtype = getHipdnnDataType(indicesType.getElementType());
     int64_t scalesDtype = getHipdnnDataType(scalesType.getElementType());
     if (dataDtype < 0 || indicesDtype < 0 || scalesDtype < 0)

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -8,6 +8,7 @@
 
 #include "hip/Dialect/IR/HipDialect.h"
 #include "hip/Dialect/Transforms/Passes.h"
+#include "hip/datatype_abi.h"
 #include "hip/debug_log.h"
 #include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
 #include "mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h"
@@ -165,29 +166,29 @@ inline constexpr int64_t kGlobalPoolAverage = 0;
 inline constexpr int64_t kGlobalPoolMax = 1;
 inline constexpr int64_t kGlobalPoolLp = 2;
 
-// Maps MLIR element type to runtime data type enum (HIPDNN_EP_DATATYPE_*).
-// Values must match the #defines in hipdnn_ep_runtime.h.
-// Returns -1 for unsupported types.
+// Maps MLIR element type to the runtime data type identifier shared through
+// hip/datatype_abi.h. Returns HIPDNN_EP_DATATYPE_UNSUPPORTED for types the
+// runtime cannot name.
 inline int64_t getHipdnnDataType(Type elemType) {
   if (elemType.isF32())
-    return 0; // HIPDNN_EP_DATATYPE_FLOAT
+    return HIPDNN_EP_DATATYPE_FLOAT;
   if (elemType.isF16())
-    return 1; // HIPDNN_EP_DATATYPE_HALF
+    return HIPDNN_EP_DATATYPE_HALF;
   if (elemType.isBF16())
-    return 2; // HIPDNN_EP_DATATYPE_BFLOAT16
+    return HIPDNN_EP_DATATYPE_BFLOAT16;
   if (elemType.isInteger(32))
-    return 3; // HIPDNN_EP_DATATYPE_INT32
+    return HIPDNN_EP_DATATYPE_INT32;
   if (elemType.isInteger(64))
-    return 4; // HIPDNN_EP_DATATYPE_INT64
+    return HIPDNN_EP_DATATYPE_INT64;
   if (elemType.isUnsignedInteger(8))
-    return 7; // HIPDNN_EP_DATATYPE_UINT8
+    return HIPDNN_EP_DATATYPE_UINT8;
   if (elemType.isSignedInteger(8) || elemType.isSignlessInteger(8))
-    return 5; // HIPDNN_EP_DATATYPE_INT8
+    return HIPDNN_EP_DATATYPE_INT8;
   if (elemType.isF64())
-    return 6; // HIPDNN_EP_DATATYPE_DOUBLE
+    return HIPDNN_EP_DATATYPE_DOUBLE;
   if (elemType.isInteger(16))
-    return 8; // HIPDNN_EP_DATATYPE_INT16
-  return -1;
+    return HIPDNN_EP_DATATYPE_INT16;
+  return HIPDNN_EP_DATATYPE_UNSUPPORTED;
 }
 
 // Tensor operation types (must match runtime enum).

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -17,6 +17,7 @@
 #include "hip/Conversion/OnnxToHip/Passes.h"
 #include "hip/Dialect/IR/HipDialect.h"
 #include "hip/Dialect/Transforms/Passes.h"
+#include "hip/datatype_abi.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Utils/Utils.h"
@@ -190,23 +191,23 @@ getContextArg(mlir::Operation *op, mlir::PatternRewriter &rewriter) {
 /// wrappers take as an `input_data_type` argument. Only the subset needed by
 /// the converters that scan a raw buffer (hip.nonzero, and the Compress
 /// selected-count scan built on top of it) is enumerated; any other element
-/// type returns -1 so the caller fails conversion explicitly instead of
-/// silently mis-classifying the buffer.
+/// type returns HIPDNN_EP_DATATYPE_UNSUPPORTED so the caller fails conversion
+/// explicitly instead of silently mis-classifying the buffer.
 inline int64_t getHipdnnInputDataType(mlir::Type elemType) {
   if (elemType.isF32())
-    return 0; // HIPDNN_EP_DATATYPE_FLOAT
+    return HIPDNN_EP_DATATYPE_FLOAT;
   if (elemType.isF16())
-    return 1; // HIPDNN_EP_DATATYPE_HALF
+    return HIPDNN_EP_DATATYPE_HALF;
   if (elemType.isInteger(32))
-    return 3; // HIPDNN_EP_DATATYPE_INT32
+    return HIPDNN_EP_DATATYPE_INT32;
   if (elemType.isInteger(64))
-    return 4; // HIPDNN_EP_DATATYPE_INT64
+    return HIPDNN_EP_DATATYPE_INT64;
   if (elemType.isUnsignedInteger(8))
-    return 7; // HIPDNN_EP_DATATYPE_UINT8 (ORT bool, ui8)
+    return HIPDNN_EP_DATATYPE_UINT8; // ORT bool, ui8
   if (elemType.isInteger(1) || elemType.isSignedInteger(8) ||
       elemType.isSignlessInteger(8))
-    return 5; // HIPDNN_EP_DATATYPE_INT8 (bool/i1, signed/signless i8)
-  return -1;
+    return HIPDNN_EP_DATATYPE_INT8; // bool/i1, signed/signless i8
+  return HIPDNN_EP_DATATYPE_UNSUPPORTED;
 }
 
 /// Build a hip.gqa op for the Whisper-MHA / Whisper-encoder-Attention paths.

--- a/lib/Conversion/OnnxToHipsr/EqualConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/EqualConversion.cpp
@@ -4,9 +4,10 @@
  */
 //===- EqualConversion.cpp - Convert onnx.Equal to hipsr.equal ------------===//
 //
-// The mask becomes ui8, the byte the runtime writes per element. The runtime
-// reads both operands from device memory, so a host constant operand gets a
-// device constant of its own.
+// The mask becomes i1, the element type onnx.Equal declares. It still occupies
+// one byte per element in memory, which is what the runtime writes and reads.
+// The runtime reads both operands from device memory, so a host constant
+// operand gets a device constant of its own.
 //
 // The placeholder's shape region is left empty: hipsr.equal is DPS, so
 // hipsr-populate-shape-region fills it in later, as for every DPS op.
@@ -22,10 +23,10 @@
 //       : tensor<i64, #hipsr.mem<device>>
 //   %init = hipsr.placeholder(%ctx) ins(%ids, %token)
 //       {placeholder_type = #hipsr.placeholder_type<normal>}
-//       : tensor<?x?xui8, #hipsr.mem<device>>
+//       : tensor<?x?xi1, #hipsr.mem<device>>
 //   %m = hipsr.equal(%ctx) ins(%ids, %token)
-//       outs(%init : tensor<?x?xui8, #hipsr.mem<device>>)
-//       : tensor<?x?xui8, #hipsr.mem<device>>
+//       outs(%init : tensor<?x?xi1, #hipsr.mem<device>>)
+//       : tensor<?x?xi1, #hipsr.mem<device>>
 //
 //===----------------------------------------------------------------------===//
 
@@ -112,10 +113,10 @@ struct EqualToHipsr : public OpConversionPattern<onnx::EqualOp> {
       operand = *deviceOperand;
     }
 
-    // ONNX declares a bool mask; hipsr uses the byte the runtime writes.
+    // The mask keeps the bool ONNX declares. The runtime stores it one byte per
+    // element, which the pool sizing and the lowering's data type carry.
     RankedTensorType maskType = tensorTypeInSpace(
-        RankedTensorType::get(resultType.getShape(),
-                              rewriter.getIntegerType(8, /*isSigned=*/false)),
+        RankedTensorType::get(resultType.getShape(), rewriter.getI1Type()),
         MemorySpace::Device);
     Value init = PlaceholderOp::create(rewriter, loc, TypeRange{maskType}, *ctx,
                                        operands, PlaceholderType::Normal)

--- a/lib/Dialect/Hipsr/IR/HipsrEqualOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrEqualOp.cpp
@@ -35,10 +35,10 @@ LogicalResult EqualOp::verify() {
   auto rhsType = cast<ShapedType>(getRhs().getType());
   auto outputType = cast<ShapedType>(getInit().getType());
 
-  // The runtime writes one byte per element, so the mask is that byte rather
-  // than the bit ONNX declares.
-  if (!outputType.getElementType().isUnsignedInteger(8)) {
-    return emitOpError("output element type must be ui8");
+  // A comparison yields a bool whatever it compared, so the mask never takes
+  // the operand element type.
+  if (!outputType.getElementType().isInteger(1)) {
+    return emitOpError("output element type must be i1");
   }
 
   SmallVector<int64_t> broadcastShape;

--- a/lib/Dialect/Hipsr/IR/HipsrLLVMLoweringUtils.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrLLVMLoweringUtils.cpp
@@ -5,6 +5,8 @@
 
 #include "hip/Dialect/Hipsr/IR/HipsrLLVMLoweringUtils.h"
 
+#include "hip/datatype_abi.h"
+
 #include "mlir/Conversion/LLVMCommon/MemRefBuilder.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
@@ -19,33 +21,36 @@ using namespace mlir;
 
 int64_t mlir::hipsr::getHipdnnDataType(Type elemType) {
   if (elemType.isF32()) {
-    return 0;
+    return HIPDNN_EP_DATATYPE_FLOAT;
   }
   if (elemType.isF16()) {
-    return 1;
+    return HIPDNN_EP_DATATYPE_HALF;
   }
   if (elemType.isBF16()) {
-    return 2;
+    return HIPDNN_EP_DATATYPE_BFLOAT16;
   }
   if (elemType.isInteger(32)) {
-    return 3;
+    return HIPDNN_EP_DATATYPE_INT32;
   }
   if (elemType.isInteger(64)) {
-    return 4;
+    return HIPDNN_EP_DATATYPE_INT64;
   }
-  if (elemType.isUnsignedInteger(8)) {
-    return 7;
+  // A bool shares the unsigned-byte slot. The runtime gives every element its
+  // own byte and reads a mask as 0 or 1, so an i1 tensor and a ui8 one have the
+  // same representation.
+  if (elemType.isUnsignedInteger(8) || elemType.isInteger(1)) {
+    return HIPDNN_EP_DATATYPE_UINT8;
   }
   if (elemType.isSignedInteger(8) || elemType.isSignlessInteger(8)) {
-    return 5;
+    return HIPDNN_EP_DATATYPE_INT8;
   }
   if (elemType.isF64()) {
-    return 6;
+    return HIPDNN_EP_DATATYPE_DOUBLE;
   }
   if (elemType.isInteger(16)) {
-    return 8;
+    return HIPDNN_EP_DATATYPE_INT16;
   }
-  return -1;
+  return HIPDNN_EP_DATATYPE_UNSUPPORTED;
 }
 
 Value mlir::hipsr::extractContiguousMemRefPtr(

--- a/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
@@ -20,6 +20,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/MathExtras.h"
 
 #include <algorithm>
 #include <cstddef>
@@ -57,7 +58,9 @@ struct AllocationSize {
 constexpr int64_t kPoolAlignment = 256;
 
 int64_t staticByteFactor(MemRefType memTy) {
-  int64_t factor = memTy.getElementTypeBitWidth() / 8;
+  // The runtime gives every element its own byte, so a sub-byte element such as
+  // an i1 mask rounds up to one rather than down to zero.
+  int64_t factor = llvm::divideCeil(memTy.getElementTypeBitWidth(), 8);
   for (int64_t dim : memTy.getShape()) {
     if (!ShapedType::isDynamic(dim)) {
       factor *= dim;

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -272,6 +272,7 @@ macro(compile_to_bitcode SOURCE_FILE OUTPUT_BC)
                 -o ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_BC}
         DEPENDS ${SOURCE_FILE}
                 ${CMAKE_CURRENT_SOURCE_DIR}/hipdnn_ep_runtime.h
+                ${CMAKE_SOURCE_DIR}/include/hip/datatype_abi.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/runtime_state_internal.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/op_state.h
                 ${CMAKE_CURRENT_SOURCE_DIR}/op_profile.h

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -5,6 +5,7 @@
 #ifndef HIP_EP_RUNTIME_H
 #define HIP_EP_RUNTIME_H
 
+#include "hip/datatype_abi.h"
 #include "hipdnn_ep_errors.h"
 #include <stdbool.h>
 #include <stddef.h>
@@ -14,30 +15,8 @@
 extern "C" {
 #endif
 
-//===----------------------------------------------------------------------===//
-// Backend-Independent Data Type Identifiers
-//===----------------------------------------------------------------------===//
-//
-// These are our own values -- do NOT assume they match cuDNN or any other
-// library's enum. Each backend provides an explicit mapping function to
-// convert these to library-specific types.
-//
-// To add a new type:
-//   1. Add #define here
-//   2. Update hipdnn_ep_datatype_size() and hipdnn_ep_datatype_name()
-//   3. Update compiler mapping getHipdnnDataType() in HipToLLVM.cpp
-//   4. Update each backend mapping function
-//===----------------------------------------------------------------------===//
-
-#define HIPDNN_EP_DATATYPE_FLOAT 0    // f32, 4 bytes
-#define HIPDNN_EP_DATATYPE_HALF 1     // f16, 2 bytes
-#define HIPDNN_EP_DATATYPE_BFLOAT16 2 // bf16, 2 bytes
-#define HIPDNN_EP_DATATYPE_INT32 3    // i32, 4 bytes
-#define HIPDNN_EP_DATATYPE_INT64 4    // i64, 8 bytes
-#define HIPDNN_EP_DATATYPE_INT8 5     // i8, 1 byte
-#define HIPDNN_EP_DATATYPE_DOUBLE 6   // f64, 8 bytes
-#define HIPDNN_EP_DATATYPE_UINT8 7    // ui8, 1 byte
-#define HIPDNN_EP_DATATYPE_INT16 8    // i16, 2 byte
+// The HIPDNN_EP_DATATYPE_* identifiers come from hip/datatype_abi.h, which the
+// compiler includes as well so neither side can redefine a value on its own.
 
 //===----------------------------------------------------------------------===//
 // Backend-Independent Tensor Operation Identifiers

--- a/test/lit/Conversion/hipsr-to-llvm/equal.mlir
+++ b/test/lit/Conversion/hipsr-to-llvm/equal.mlir
@@ -3,33 +3,85 @@
 
 // RUN: hip-mlir-opt %s --convert-to-llvm | FileCheck %s
 
+// The whole function is checked. Seventeen operands reach the runtime call, and
+// which value lands in which position is the whole contract, so a check that
+// skipped the descriptor and extent lines would let two of them swap unnoticed.
+
+// The lowering declares the runtime entry point before calling it.
+// CHECK-LABEL:   llvm.func @wrap_equal(!llvm.ptr, !llvm.ptr<1>, !llvm.ptr<1>, !llvm.ptr<1>, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
+
 // The call's data type is 4 (i64), the operand type being compared. The mask
 // needs none of its own: the runtime always writes one byte per element.
-// CHECK-LABEL: llvm.func @equal
-// CHECK-SAME:  (%[[CTX:.*]]: !llvm.ptr,
-// CHECK:       %[[LHS_N:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:  %[[LHS_C:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:  %[[LHS_H:.*]] = llvm.mlir.constant(4 : i64) : i64
-// CHECK-NEXT:  %[[LHS_W:.*]] = llvm.mlir.constant(1024 : i64) : i64
-// CHECK-NEXT:  %[[RHS_N:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:  %[[RHS_C:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:  %[[RHS_H:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:  %[[RHS_W:.*]] = llvm.mlir.constant(1024 : i64) : i64
-// CHECK-NEXT:  %[[OUT_N:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:  %[[OUT_C:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:  %[[OUT_H:.*]] = llvm.mlir.constant(4 : i64) : i64
-// CHECK-NEXT:  %[[OUT_W:.*]] = llvm.mlir.constant(1024 : i64) : i64
-// CHECK-NEXT:  %[[LHS_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
-// CHECK-NEXT:  %[[RHS_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
-// CHECK-NEXT:  %[[OUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
-// CHECK-NEXT:  %[[DATA_TYPE:.*]] = llvm.mlir.constant(4 : i64) : i64
-// CHECK-NEXT:  llvm.call @wrap_equal(%[[CTX]], %[[LHS_PTR]], %[[RHS_PTR]], %[[OUT_PTR]], %[[LHS_N]], %[[LHS_C]], %[[LHS_H]], %[[LHS_W]], %[[RHS_N]], %[[RHS_C]], %[[RHS_H]], %[[RHS_W]], %[[OUT_N]], %[[OUT_C]], %[[OUT_H]], %[[OUT_W]], %[[DATA_TYPE]]) : (!llvm.ptr, !llvm.ptr<1>, !llvm.ptr<1>, !llvm.ptr<1>, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
-// CHECK-NEXT:  llvm.return
+// CHECK-LABEL:   llvm.func @equal(
+// CHECK-SAME:                     %[[CTX:[^,]*]]: !llvm.ptr,
+// CHECK-SAME:                     %[[ARG1:[^,]*]]: !llvm.ptr<1>,
+// CHECK-SAME:                     %[[ARG2:[^,]*]]: !llvm.ptr<1>,
+// CHECK-SAME:                     %[[ARG3:[^,]*]]: i64,
+// CHECK-SAME:                     %[[ARG4:[^,]*]]: i64,
+// CHECK-SAME:                     %[[ARG5:[^,]*]]: i64,
+// CHECK-SAME:                     %[[ARG6:[^,]*]]: i64,
+// CHECK-SAME:                     %[[ARG7:[^,]*]]: i64,
+// CHECK-SAME:                     %[[ARG8:[^,]*]]: !llvm.ptr<1>,
+// CHECK-SAME:                     %[[ARG9:[^,]*]]: !llvm.ptr<1>,
+// CHECK-SAME:                     %[[ARG10:[^,]*]]: i64,
+// CHECK-SAME:                     %[[ARG11:[^,]*]]: i64,
+// CHECK-SAME:                     %[[ARG12:[^,]*]]: i64,
+// CHECK-SAME:                     %[[ARG13:[^,]*]]: !llvm.ptr<1>,
+// CHECK-SAME:                     %[[ARG14:[^,]*]]: !llvm.ptr<1>,
+// CHECK-SAME:                     %[[ARG15:[^,]*]]: i64,
+// CHECK-SAME:                     %[[ARG16:[^,]*]]: i64,
+// CHECK-SAME:                     %[[ARG17:[^,]*]]: i64,
+// CHECK-SAME:                     %[[ARG18:[^,]*]]: i64,
+// CHECK-SAME:                     %[[ARG19:[^,]*]]: i64) {
+// Each memref arrives as unpacked fields, so the lowering rebuilds a descriptor
+// per operand, in the order init, rhs, lhs. Only the aligned pointer each one
+// holds at index 1 reaches the call.
+// CHECK-NEXT:           %[[MLIR_0:.*]] = llvm.mlir.poison : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_0:.*]] = llvm.insertvalue %[[ARG13]], %[[MLIR_0]][0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_1:.*]] = llvm.insertvalue %[[ARG14]], %[[INSERTVALUE_0]][1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_2:.*]] = llvm.insertvalue %[[ARG15]], %[[INSERTVALUE_1]][2] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_3:.*]] = llvm.insertvalue %[[ARG16]], %[[INSERTVALUE_2]][3, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_4:.*]] = llvm.insertvalue %[[ARG18]], %[[INSERTVALUE_3]][4, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_5:.*]] = llvm.insertvalue %[[ARG17]], %[[INSERTVALUE_4]][3, 1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_6:.*]] = llvm.insertvalue %[[ARG19]], %[[INSERTVALUE_5]][4, 1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[MLIR_1:.*]] = llvm.mlir.poison : !llvm.struct<(ptr<1>, ptr<1>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_7:.*]] = llvm.insertvalue %[[ARG8]], %[[MLIR_1]][0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_8:.*]] = llvm.insertvalue %[[ARG9]], %[[INSERTVALUE_7]][1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_9:.*]] = llvm.insertvalue %[[ARG10]], %[[INSERTVALUE_8]][2] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_10:.*]] = llvm.insertvalue %[[ARG11]], %[[INSERTVALUE_9]][3, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_11:.*]] = llvm.insertvalue %[[ARG12]], %[[INSERTVALUE_10]][4, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-NEXT:           %[[MLIR_2:.*]] = llvm.mlir.poison : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_12:.*]] = llvm.insertvalue %[[ARG1]], %[[MLIR_2]][0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_13:.*]] = llvm.insertvalue %[[ARG2]], %[[INSERTVALUE_12]][1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_14:.*]] = llvm.insertvalue %[[ARG3]], %[[INSERTVALUE_13]][2] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_15:.*]] = llvm.insertvalue %[[ARG4]], %[[INSERTVALUE_14]][3, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_16:.*]] = llvm.insertvalue %[[ARG6]], %[[INSERTVALUE_15]][4, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_17:.*]] = llvm.insertvalue %[[ARG5]], %[[INSERTVALUE_16]][3, 1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_18:.*]] = llvm.insertvalue %[[ARG7]], %[[INSERTVALUE_17]][4, 1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[LHS_N:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:           %[[LHS_C:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:           %[[LHS_H:.*]] = llvm.mlir.constant(4 : i64) : i64
+// CHECK-NEXT:           %[[LHS_W:.*]] = llvm.mlir.constant(1024 : i64) : i64
+// CHECK-NEXT:           %[[RHS_N:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:           %[[RHS_C:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:           %[[RHS_H:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:           %[[RHS_W:.*]] = llvm.mlir.constant(1024 : i64) : i64
+// CHECK-NEXT:           %[[OUT_N:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:           %[[OUT_C:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:           %[[OUT_H:.*]] = llvm.mlir.constant(4 : i64) : i64
+// CHECK-NEXT:           %[[OUT_W:.*]] = llvm.mlir.constant(1024 : i64) : i64
+// CHECK-NEXT:           %[[LHS_PTR:.*]] = llvm.extractvalue %[[INSERTVALUE_18]][1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[RHS_PTR:.*]] = llvm.extractvalue %[[INSERTVALUE_11]][1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-NEXT:           %[[OUT_PTR:.*]] = llvm.extractvalue %[[INSERTVALUE_6]][1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[DATA_TYPE:.*]] = llvm.mlir.constant(4 : i64) : i64
+// CHECK-NEXT:           %[[CALL_0:.*]] = llvm.call @wrap_equal(%[[CTX]], %[[LHS_PTR]], %[[RHS_PTR]], %[[OUT_PTR]], %[[LHS_N]], %[[LHS_C]], %[[LHS_H]], %[[LHS_W]], %[[RHS_N]], %[[RHS_C]], %[[RHS_H]], %[[RHS_W]], %[[OUT_N]], %[[OUT_C]], %[[OUT_H]], %[[OUT_W]], %[[DATA_TYPE]]) : (!llvm.ptr, !llvm.ptr<1>, !llvm.ptr<1>, !llvm.ptr<1>, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i32
+// CHECK-NEXT:           llvm.return
+// CHECK-NEXT:         }
 func.func @equal(%ctx: !hipsr.context,
                  %lhs: memref<4x1024xi64, #hipsr.mem<device>>,
                  %rhs: memref<1024xi64, #hipsr.mem<device>>,
-                 %init: memref<4x1024xui8, #hipsr.mem<device>>) {
+                 %init: memref<4x1024xi1, #hipsr.mem<device>>) {
   hipsr.equal(%ctx) ins(%lhs, %rhs : memref<4x1024xi64, #hipsr.mem<device>>, memref<1024xi64, #hipsr.mem<device>>)
-               outs(%init : memref<4x1024xui8, #hipsr.mem<device>>)
+               outs(%init : memref<4x1024xi1, #hipsr.mem<device>>)
   return
 }

--- a/test/lit/Conversion/hipsr-to-llvm/expand.mlir
+++ b/test/lit/Conversion/hipsr-to-llvm/expand.mlir
@@ -3,17 +3,94 @@
 
 // RUN: hip-mlir-opt %s --convert-to-llvm | FileCheck %s
 
-// CHECK-LABEL: llvm.func @expand_host_shape
-// CHECK-SAME:  (%[[CTX:[^,]+]]: !llvm.ptr,
-// CHECK:       %[[SHAPE_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr,
-// CHECK:       %[[INPUT_SHAPE:.*]] = llvm.alloca {{.*}} x !llvm.array<2 x i64>
-// CHECK:       %[[OUTPUT_SHAPE:.*]] = llvm.alloca {{.*}} x !llvm.array<3 x i64>
-// CHECK:       %[[INPUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
-// CHECK-NEXT:  %[[OUTPUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
-// CHECK-NEXT:  %[[INPUT_RANK:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-NEXT:  %[[OUTPUT_RANK:.*]] = llvm.mlir.constant(3 : i64) : i64
-// CHECK-NEXT:  %[[DATA_TYPE:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:  llvm.call @wrap_expand(%[[CTX]], %[[INPUT_PTR]], %[[SHAPE_PTR]], %[[OUTPUT_PTR]], %[[INPUT_SHAPE]], %[[INPUT_RANK]], %[[OUTPUT_SHAPE]], %[[OUTPUT_RANK]], %[[DATA_TYPE]]) : (!llvm.ptr, !llvm.ptr<1>, !llvm.ptr, !llvm.ptr<1>, !llvm.ptr, i64, !llvm.ptr, i64, i64) -> i32
+// Each case checks its whole function. The lowering writes the input and output
+// extents into two stack arrays one element at a time, and the call is only
+// correct if every store lands at the index it was meant for, so the stores are
+// checked in order rather than skipped over.
+
+// The lowering declares the runtime entry point before calling it.
+// CHECK-LABEL:   llvm.func @wrap_expand(!llvm.ptr, !llvm.ptr<1>, !llvm.ptr, !llvm.ptr<1>, !llvm.ptr, i64, !llvm.ptr, i64, i64) -> i32
+
+// A shape operand in host memory reaches the call as its own pointer.
+// CHECK-LABEL:   llvm.func @expand_host_shape(
+// CHECK-SAME:      %[[CTX:[^,]*]]: !llvm.ptr,
+// CHECK-SAME:      %[[ARG1:[^,]*]]: !llvm.ptr<1>,
+// CHECK-SAME:      %[[ARG2:[^,]*]]: !llvm.ptr<1>,
+// CHECK-SAME:      %[[ARG3:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG4:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG5:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG6:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG7:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG8:[^,]*]]: !llvm.ptr,
+// CHECK-SAME:      %[[ARG9:[^,]*]]: !llvm.ptr,
+// CHECK-SAME:      %[[ARG10:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG11:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG12:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG13:[^,]*]]: !llvm.ptr<1>,
+// CHECK-SAME:      %[[ARG14:[^,]*]]: !llvm.ptr<1>,
+// CHECK-SAME:      %[[ARG15:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG16:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG17:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG18:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG19:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG20:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG21:[^,]*]]: i64) {
+// CHECK-NEXT:           %[[MLIR_0:.*]] = llvm.mlir.poison : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_0:.*]] = llvm.insertvalue %[[ARG13]], %[[MLIR_0]][0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_1:.*]] = llvm.insertvalue %[[ARG14]], %[[INSERTVALUE_0]][1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_2:.*]] = llvm.insertvalue %[[ARG15]], %[[INSERTVALUE_1]][2] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_3:.*]] = llvm.insertvalue %[[ARG16]], %[[INSERTVALUE_2]][3, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_4:.*]] = llvm.insertvalue %[[ARG19]], %[[INSERTVALUE_3]][4, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_5:.*]] = llvm.insertvalue %[[ARG17]], %[[INSERTVALUE_4]][3, 1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_6:.*]] = llvm.insertvalue %[[ARG20]], %[[INSERTVALUE_5]][4, 1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_7:.*]] = llvm.insertvalue %[[ARG18]], %[[INSERTVALUE_6]][3, 2] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_8:.*]] = llvm.insertvalue %[[ARG21]], %[[INSERTVALUE_7]][4, 2] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[MLIR_1:.*]] = llvm.mlir.poison : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_9:.*]] = llvm.insertvalue %[[ARG8]], %[[MLIR_1]][0] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_10:.*]] = llvm.insertvalue %[[ARG9]], %[[INSERTVALUE_9]][1] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_11:.*]] = llvm.insertvalue %[[ARG10]], %[[INSERTVALUE_10]][2] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_12:.*]] = llvm.insertvalue %[[ARG11]], %[[INSERTVALUE_11]][3, 0] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_13:.*]] = llvm.insertvalue %[[ARG12]], %[[INSERTVALUE_12]][4, 0] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-NEXT:           %[[MLIR_2:.*]] = llvm.mlir.poison : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_14:.*]] = llvm.insertvalue %[[ARG1]], %[[MLIR_2]][0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_15:.*]] = llvm.insertvalue %[[ARG2]], %[[INSERTVALUE_14]][1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_16:.*]] = llvm.insertvalue %[[ARG3]], %[[INSERTVALUE_15]][2] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_17:.*]] = llvm.insertvalue %[[ARG4]], %[[INSERTVALUE_16]][3, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_18:.*]] = llvm.insertvalue %[[ARG6]], %[[INSERTVALUE_17]][4, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_19:.*]] = llvm.insertvalue %[[ARG5]], %[[INSERTVALUE_18]][3, 1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_20:.*]] = llvm.insertvalue %[[ARG7]], %[[INSERTVALUE_19]][4, 1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[MLIR_3:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:           %[[SHAPE_PTR:.*]] = llvm.extractvalue %[[INSERTVALUE_13]][1] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-NEXT:           %[[INPUT_SHAPE:.*]] = llvm.alloca %[[MLIR_3]] x !llvm.array<2 x i64> {alignment = 8 : i64} : (i64) -> !llvm.ptr
+// CHECK-NEXT:           %[[MLIR_4:.*]] = llvm.mlir.constant(3 : i64) : i64
+// CHECK-NEXT:           %[[MLIR_5:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:           %[[GETELEMENTPTR_0:.*]] = llvm.getelementptr %[[INPUT_SHAPE]]{{\[}}%[[MLIR_5]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK-NEXT:           llvm.store %[[MLIR_4]], %[[GETELEMENTPTR_0]] : i64, !llvm.ptr
+// CHECK-NEXT:           %[[MLIR_6:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:           %[[MLIR_7:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:           %[[GETELEMENTPTR_1:.*]] = llvm.getelementptr %[[INPUT_SHAPE]]{{\[}}%[[MLIR_7]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK-NEXT:           llvm.store %[[MLIR_6]], %[[GETELEMENTPTR_1]] : i64, !llvm.ptr
+// CHECK-NEXT:           %[[OUTPUT_SHAPE:.*]] = llvm.alloca %[[MLIR_3]] x !llvm.array<3 x i64> {alignment = 8 : i64} : (i64) -> !llvm.ptr
+// CHECK-NEXT:           %[[MLIR_8:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK-NEXT:           %[[MLIR_9:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:           %[[GETELEMENTPTR_2:.*]] = llvm.getelementptr %[[OUTPUT_SHAPE]]{{\[}}%[[MLIR_9]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK-NEXT:           llvm.store %[[MLIR_8]], %[[GETELEMENTPTR_2]] : i64, !llvm.ptr
+// CHECK-NEXT:           %[[MLIR_10:.*]] = llvm.mlir.constant(3 : i64) : i64
+// CHECK-NEXT:           %[[MLIR_11:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:           %[[GETELEMENTPTR_3:.*]] = llvm.getelementptr %[[OUTPUT_SHAPE]]{{\[}}%[[MLIR_11]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK-NEXT:           llvm.store %[[MLIR_10]], %[[GETELEMENTPTR_3]] : i64, !llvm.ptr
+// CHECK-NEXT:           %[[MLIR_12:.*]] = llvm.mlir.constant(6 : i64) : i64
+// CHECK-NEXT:           %[[MLIR_13:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK-NEXT:           %[[GETELEMENTPTR_4:.*]] = llvm.getelementptr %[[OUTPUT_SHAPE]]{{\[}}%[[MLIR_13]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK-NEXT:           llvm.store %[[MLIR_12]], %[[GETELEMENTPTR_4]] : i64, !llvm.ptr
+// CHECK-NEXT:           %[[INPUT_PTR:.*]] = llvm.extractvalue %[[INSERTVALUE_20]][1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[OUTPUT_PTR:.*]] = llvm.extractvalue %[[INSERTVALUE_8]][1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INPUT_RANK:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK-NEXT:           %[[OUTPUT_RANK:.*]] = llvm.mlir.constant(3 : i64) : i64
+// CHECK-NEXT:           %[[DATA_TYPE:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:           %[[CALL_0:.*]] = llvm.call @wrap_expand(%[[CTX]], %[[INPUT_PTR]], %[[SHAPE_PTR]], %[[OUTPUT_PTR]], %[[INPUT_SHAPE]], %[[INPUT_RANK]], %[[OUTPUT_SHAPE]], %[[OUTPUT_RANK]], %[[DATA_TYPE]]) : (!llvm.ptr, !llvm.ptr<1>, !llvm.ptr, !llvm.ptr<1>, !llvm.ptr, i64, !llvm.ptr, i64, i64) -> i32
+// CHECK-NEXT:           llvm.return
+// CHECK-NEXT:         }
 func.func @expand_host_shape(
     %ctx: !hipsr.context,
     %input: memref<3x1xf32, #hipsr.mem<device>>,
@@ -26,18 +103,76 @@ func.func @expand_host_shape(
   return
 }
 
-// CHECK-LABEL: llvm.func @expand_shape_attr
-// CHECK-SAME:  (%[[ATTR_CTX:[^,]+]]: !llvm.ptr,
-// CHECK:       %[[NULL_SHAPE:.*]] = llvm.mlir.zero : !llvm.ptr
-// CHECK:       %[[ATTR_INPUT_SHAPE:.*]] = llvm.alloca {{.*}} x !llvm.array<2 x i64>
-// CHECK:       %[[ATTR_OUTPUT_SHAPE:.*]] = llvm.alloca {{.*}} x !llvm.array<3 x i64>
-// CHECK:       llvm.extractvalue {{.*}}[3, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>,
-// CHECK:       %[[ATTR_INPUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
-// CHECK-NEXT:  %[[ATTR_OUTPUT_PTR:.*]] = llvm.extractvalue {{.*}}[1] : !llvm.struct<(ptr<1>,
-// CHECK-NEXT:  %[[ATTR_INPUT_RANK:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-NEXT:  %[[ATTR_OUTPUT_RANK:.*]] = llvm.mlir.constant(3 : i64) : i64
-// CHECK-NEXT:  %[[ATTR_DATA_TYPE:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:  llvm.call @wrap_expand(%[[ATTR_CTX]], %[[ATTR_INPUT_PTR]], %[[NULL_SHAPE]], %[[ATTR_OUTPUT_PTR]], %[[ATTR_INPUT_SHAPE]], %[[ATTR_INPUT_RANK]], %[[ATTR_OUTPUT_SHAPE]], %[[ATTR_OUTPUT_RANK]], %[[ATTR_DATA_TYPE]]) : (!llvm.ptr, !llvm.ptr<1>, !llvm.ptr, !llvm.ptr<1>, !llvm.ptr, i64, !llvm.ptr, i64, i64) -> i32
+// A shape carried in an attribute leaves nothing to pass, so the shape operand
+// is null and the extents are read from the descriptors instead.
+// CHECK-LABEL:   llvm.func @expand_shape_attr(
+// CHECK-SAME:      %[[CTX:[^,]*]]: !llvm.ptr,
+// CHECK-SAME:      %[[ARG1:[^,]*]]: !llvm.ptr<1>,
+// CHECK-SAME:      %[[ARG2:[^,]*]]: !llvm.ptr<1>,
+// CHECK-SAME:      %[[ARG3:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG4:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG5:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG6:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG7:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG8:[^,]*]]: !llvm.ptr<1>,
+// CHECK-SAME:      %[[ARG9:[^,]*]]: !llvm.ptr<1>,
+// CHECK-SAME:      %[[ARG10:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG11:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG12:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG13:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG14:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG15:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG16:[^,]*]]: i64) {
+// CHECK-NEXT:           %[[MLIR_0:.*]] = llvm.mlir.poison : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_0:.*]] = llvm.insertvalue %[[ARG8]], %[[MLIR_0]][0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_1:.*]] = llvm.insertvalue %[[ARG9]], %[[INSERTVALUE_0]][1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_2:.*]] = llvm.insertvalue %[[ARG10]], %[[INSERTVALUE_1]][2] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_3:.*]] = llvm.insertvalue %[[ARG11]], %[[INSERTVALUE_2]][3, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_4:.*]] = llvm.insertvalue %[[ARG14]], %[[INSERTVALUE_3]][4, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_5:.*]] = llvm.insertvalue %[[ARG12]], %[[INSERTVALUE_4]][3, 1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_6:.*]] = llvm.insertvalue %[[ARG15]], %[[INSERTVALUE_5]][4, 1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_7:.*]] = llvm.insertvalue %[[ARG13]], %[[INSERTVALUE_6]][3, 2] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_8:.*]] = llvm.insertvalue %[[ARG16]], %[[INSERTVALUE_7]][4, 2] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[MLIR_1:.*]] = llvm.mlir.poison : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_9:.*]] = llvm.insertvalue %[[ARG1]], %[[MLIR_1]][0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_10:.*]] = llvm.insertvalue %[[ARG2]], %[[INSERTVALUE_9]][1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_11:.*]] = llvm.insertvalue %[[ARG3]], %[[INSERTVALUE_10]][2] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_12:.*]] = llvm.insertvalue %[[ARG4]], %[[INSERTVALUE_11]][3, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_13:.*]] = llvm.insertvalue %[[ARG6]], %[[INSERTVALUE_12]][4, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_14:.*]] = llvm.insertvalue %[[ARG5]], %[[INSERTVALUE_13]][3, 1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_15:.*]] = llvm.insertvalue %[[ARG7]], %[[INSERTVALUE_14]][4, 1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[MLIR_2:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:           %[[NULL_SHAPE:.*]] = llvm.mlir.zero : !llvm.ptr
+// CHECK-NEXT:           %[[INPUT_SHAPE:.*]] = llvm.alloca %[[MLIR_2]] x !llvm.array<2 x i64> {alignment = 8 : i64} : (i64) -> !llvm.ptr
+// CHECK-NEXT:           %[[EXTRACTVALUE_0:.*]] = llvm.extractvalue %[[INSERTVALUE_15]][3, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[MLIR_4:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:           %[[GETELEMENTPTR_0:.*]] = llvm.getelementptr %[[INPUT_SHAPE]]{{\[}}%[[MLIR_4]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK-NEXT:           llvm.store %[[EXTRACTVALUE_0]], %[[GETELEMENTPTR_0]] : i64, !llvm.ptr
+// CHECK-NEXT:           %[[MLIR_5:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:           %[[MLIR_6:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:           %[[GETELEMENTPTR_1:.*]] = llvm.getelementptr %[[INPUT_SHAPE]]{{\[}}%[[MLIR_6]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK-NEXT:           llvm.store %[[MLIR_5]], %[[GETELEMENTPTR_1]] : i64, !llvm.ptr
+// CHECK-NEXT:           %[[OUTPUT_SHAPE:.*]] = llvm.alloca %[[MLIR_2]] x !llvm.array<3 x i64> {alignment = 8 : i64} : (i64) -> !llvm.ptr
+// CHECK-NEXT:           %[[EXTRACTVALUE_1:.*]] = llvm.extractvalue %[[INSERTVALUE_8]][3, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[MLIR_7:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:           %[[GETELEMENTPTR_2:.*]] = llvm.getelementptr %[[OUTPUT_SHAPE]]{{\[}}%[[MLIR_7]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK-NEXT:           llvm.store %[[EXTRACTVALUE_1]], %[[GETELEMENTPTR_2]] : i64, !llvm.ptr
+// CHECK-NEXT:           %[[MLIR_8:.*]] = llvm.mlir.constant(3 : i64) : i64
+// CHECK-NEXT:           %[[MLIR_9:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:           %[[GETELEMENTPTR_3:.*]] = llvm.getelementptr %[[OUTPUT_SHAPE]]{{\[}}%[[MLIR_9]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK-NEXT:           llvm.store %[[MLIR_8]], %[[GETELEMENTPTR_3]] : i64, !llvm.ptr
+// CHECK-NEXT:           %[[EXTRACTVALUE_2:.*]] = llvm.extractvalue %[[INSERTVALUE_8]][3, 2] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[MLIR_10:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK-NEXT:           %[[GETELEMENTPTR_4:.*]] = llvm.getelementptr %[[OUTPUT_SHAPE]]{{\[}}%[[MLIR_10]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK-NEXT:           llvm.store %[[EXTRACTVALUE_2]], %[[GETELEMENTPTR_4]] : i64, !llvm.ptr
+// CHECK-NEXT:           %[[INPUT_PTR:.*]] = llvm.extractvalue %[[INSERTVALUE_15]][1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[OUTPUT_PTR:.*]] = llvm.extractvalue %[[INSERTVALUE_8]][1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INPUT_RANK:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK-NEXT:           %[[OUTPUT_RANK:.*]] = llvm.mlir.constant(3 : i64) : i64
+// CHECK-NEXT:           %[[DATA_TYPE:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:           %[[CALL_0:.*]] = llvm.call @wrap_expand(%[[CTX]], %[[INPUT_PTR]], %[[NULL_SHAPE]], %[[OUTPUT_PTR]], %[[INPUT_SHAPE]], %[[INPUT_RANK]], %[[OUTPUT_SHAPE]], %[[OUTPUT_RANK]], %[[DATA_TYPE]]) : (!llvm.ptr, !llvm.ptr<1>, !llvm.ptr, !llvm.ptr<1>, !llvm.ptr, i64, !llvm.ptr, i64, i64) -> i32
+// CHECK-NEXT:           llvm.return
+// CHECK-NEXT:         }
 func.func @expand_shape_attr(
     %ctx: !hipsr.context,
     %input: memref<?x1xf16, #hipsr.mem<device>>,
@@ -45,6 +180,87 @@ func.func @expand_shape_attr(
   hipsr.expand(%ctx)
       ins(%input : memref<?x1xf16, #hipsr.mem<device>>)
       outs(%init : memref<?x3x?xf16, #hipsr.mem<device>>)
+      {shape_attr = array<i64: 2, 3, 6>}
+  return
+}
+
+// A mask arrives as i1 and takes data type 7, the unsigned-byte slot, because
+// the runtime gives every mask element a whole byte.
+// CHECK-LABEL:   llvm.func @expand_bool_mask(
+// CHECK-SAME:      %[[CTX:[^,]*]]: !llvm.ptr,
+// CHECK-SAME:      %[[ARG1:[^,]*]]: !llvm.ptr<1>,
+// CHECK-SAME:      %[[ARG2:[^,]*]]: !llvm.ptr<1>,
+// CHECK-SAME:      %[[ARG3:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG4:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG5:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG6:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG7:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG8:[^,]*]]: !llvm.ptr<1>,
+// CHECK-SAME:      %[[ARG9:[^,]*]]: !llvm.ptr<1>,
+// CHECK-SAME:      %[[ARG10:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG11:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG12:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG13:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG14:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG15:[^,]*]]: i64,
+// CHECK-SAME:      %[[ARG16:[^,]*]]: i64) {
+// CHECK-NEXT:           %[[MLIR_0:.*]] = llvm.mlir.poison : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_0:.*]] = llvm.insertvalue %[[ARG8]], %[[MLIR_0]][0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_1:.*]] = llvm.insertvalue %[[ARG9]], %[[INSERTVALUE_0]][1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_2:.*]] = llvm.insertvalue %[[ARG10]], %[[INSERTVALUE_1]][2] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_3:.*]] = llvm.insertvalue %[[ARG11]], %[[INSERTVALUE_2]][3, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_4:.*]] = llvm.insertvalue %[[ARG14]], %[[INSERTVALUE_3]][4, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_5:.*]] = llvm.insertvalue %[[ARG12]], %[[INSERTVALUE_4]][3, 1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_6:.*]] = llvm.insertvalue %[[ARG15]], %[[INSERTVALUE_5]][4, 1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_7:.*]] = llvm.insertvalue %[[ARG13]], %[[INSERTVALUE_6]][3, 2] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_8:.*]] = llvm.insertvalue %[[ARG16]], %[[INSERTVALUE_7]][4, 2] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[MLIR_1:.*]] = llvm.mlir.poison : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_9:.*]] = llvm.insertvalue %[[ARG1]], %[[MLIR_1]][0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_10:.*]] = llvm.insertvalue %[[ARG2]], %[[INSERTVALUE_9]][1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_11:.*]] = llvm.insertvalue %[[ARG3]], %[[INSERTVALUE_10]][2] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_12:.*]] = llvm.insertvalue %[[ARG4]], %[[INSERTVALUE_11]][3, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_13:.*]] = llvm.insertvalue %[[ARG6]], %[[INSERTVALUE_12]][4, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_14:.*]] = llvm.insertvalue %[[ARG5]], %[[INSERTVALUE_13]][3, 1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[INSERTVALUE_15:.*]] = llvm.insertvalue %[[ARG7]], %[[INSERTVALUE_14]][4, 1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[MLIR_2:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:           %[[NULL_SHAPE:.*]] = llvm.mlir.zero : !llvm.ptr
+// CHECK-NEXT:           %[[INPUT_SHAPE:.*]] = llvm.alloca %[[MLIR_2]] x !llvm.array<2 x i64> {alignment = 8 : i64} : (i64) -> !llvm.ptr
+// CHECK-NEXT:           %[[EXTRACTVALUE_0:.*]] = llvm.extractvalue %[[INSERTVALUE_15]][3, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[MLIR_4:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:           %[[GETELEMENTPTR_0:.*]] = llvm.getelementptr %[[INPUT_SHAPE]]{{\[}}%[[MLIR_4]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK-NEXT:           llvm.store %[[EXTRACTVALUE_0]], %[[GETELEMENTPTR_0]] : i64, !llvm.ptr
+// CHECK-NEXT:           %[[MLIR_5:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:           %[[MLIR_6:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:           %[[GETELEMENTPTR_1:.*]] = llvm.getelementptr %[[INPUT_SHAPE]]{{\[}}%[[MLIR_6]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK-NEXT:           llvm.store %[[MLIR_5]], %[[GETELEMENTPTR_1]] : i64, !llvm.ptr
+// CHECK-NEXT:           %[[OUTPUT_SHAPE:.*]] = llvm.alloca %[[MLIR_2]] x !llvm.array<3 x i64> {alignment = 8 : i64} : (i64) -> !llvm.ptr
+// CHECK-NEXT:           %[[EXTRACTVALUE_1:.*]] = llvm.extractvalue %[[INSERTVALUE_8]][3, 0] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[MLIR_7:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:           %[[GETELEMENTPTR_2:.*]] = llvm.getelementptr %[[OUTPUT_SHAPE]]{{\[}}%[[MLIR_7]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK-NEXT:           llvm.store %[[EXTRACTVALUE_1]], %[[GETELEMENTPTR_2]] : i64, !llvm.ptr
+// CHECK-NEXT:           %[[MLIR_8:.*]] = llvm.mlir.constant(3 : i64) : i64
+// CHECK-NEXT:           %[[MLIR_9:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:           %[[GETELEMENTPTR_3:.*]] = llvm.getelementptr %[[OUTPUT_SHAPE]]{{\[}}%[[MLIR_9]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK-NEXT:           llvm.store %[[MLIR_8]], %[[GETELEMENTPTR_3]] : i64, !llvm.ptr
+// CHECK-NEXT:           %[[EXTRACTVALUE_2:.*]] = llvm.extractvalue %[[INSERTVALUE_8]][3, 2] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[MLIR_10:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK-NEXT:           %[[GETELEMENTPTR_4:.*]] = llvm.getelementptr %[[OUTPUT_SHAPE]]{{\[}}%[[MLIR_10]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK-NEXT:           llvm.store %[[EXTRACTVALUE_2]], %[[GETELEMENTPTR_4]] : i64, !llvm.ptr
+// CHECK-NEXT:           %[[INPUT_PTR:.*]] = llvm.extractvalue %[[INSERTVALUE_15]][1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+// CHECK-NEXT:           %[[OUTPUT_PTR:.*]] = llvm.extractvalue %[[INSERTVALUE_8]][1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<3 x i64>, array<3 x i64>)>
+// CHECK-NEXT:           %[[INPUT_RANK:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK-NEXT:           %[[OUTPUT_RANK:.*]] = llvm.mlir.constant(3 : i64) : i64
+// CHECK-NEXT:           %[[MASK_DATA_TYPE:.*]] = llvm.mlir.constant(7 : i64) : i64
+// CHECK-NEXT:           %[[CALL_0:.*]] = llvm.call @wrap_expand(%[[CTX]], %[[INPUT_PTR]], %[[NULL_SHAPE]], %[[OUTPUT_PTR]], %[[INPUT_SHAPE]], %[[INPUT_RANK]], %[[OUTPUT_SHAPE]], %[[OUTPUT_RANK]], %[[MASK_DATA_TYPE]]) : (!llvm.ptr, !llvm.ptr<1>, !llvm.ptr, !llvm.ptr<1>, !llvm.ptr, i64, !llvm.ptr, i64, i64) -> i32
+// CHECK-NEXT:           llvm.return
+// CHECK-NEXT:         }
+func.func @expand_bool_mask(
+    %ctx: !hipsr.context,
+    %input: memref<?x1xi1, #hipsr.mem<device>>,
+    %init: memref<?x3x?xi1, #hipsr.mem<device>>) {
+  hipsr.expand(%ctx)
+      ins(%input : memref<?x1xi1, #hipsr.mem<device>>)
+      outs(%init : memref<?x3x?xi1, #hipsr.mem<device>>)
       {shape_attr = array<i64: 2, 3, 6>}
   return
 }

--- a/test/lit/Conversion/onnx-to-hipsr/equal.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/equal.mlir
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 //===----------------------------------------------------------------------===//
-// onnx.Equal becomes hipsr.equal with a ui8 mask, the byte the runtime writes.
+// onnx.Equal becomes hipsr.equal with the i1 mask a comparison yields.
 // Both operands must be on the device, so a host constant gets a device copy.
 // Rejected forms are in equal-invalid.mlir.
 //===----------------------------------------------------------------------===//
@@ -16,13 +16,13 @@
 // hipsr-populate-shape-region fills it in later.
 // CHECK-LABEL: func.func @host_scalar_on_device(
 // CHECK-SAME:    %[[CTX:.+]]: !hipsr.context,
-// CHECK-SAME:    %[[IDS:.+]]: tensor<?x?xi64, #hipsr.mem<device>>) -> tensor<?x?xui8, #hipsr.mem<device>> {
+// CHECK-SAME:    %[[IDS:.+]]: tensor<?x?xi64, #hipsr.mem<device>>) -> tensor<?x?xi1, #hipsr.mem<device>> {
 // The host constant has no use left and waits for canonicalization.
 // CHECK-NEXT:    arith.constant dense<248056> : tensor<i64>
 // CHECK-NEXT:    %[[TOKEN:.+]] = hipsr.constant {value = dense<248056> : tensor<i64>} : tensor<i64, #hipsr.mem<device>>
-// CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[IDS]], %[[TOKEN]] : tensor<?x?xi64, #hipsr.mem<device>>, tensor<i64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x?xui8, #hipsr.mem<device>>
-// CHECK-NEXT:    %[[RESULT:.+]] = hipsr.equal(%[[CTX]]) ins(%[[IDS]], %[[TOKEN]] : tensor<?x?xi64, #hipsr.mem<device>>, tensor<i64, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x?xui8, #hipsr.mem<device>>) : tensor<?x?xui8, #hipsr.mem<device>>
-// CHECK-NEXT:    return %[[RESULT]] : tensor<?x?xui8, #hipsr.mem<device>>
+// CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[IDS]], %[[TOKEN]] : tensor<?x?xi64, #hipsr.mem<device>>, tensor<i64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:    %[[RESULT:.+]] = hipsr.equal(%[[CTX]]) ins(%[[IDS]], %[[TOKEN]] : tensor<?x?xi64, #hipsr.mem<device>>, tensor<i64, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x?xi1, #hipsr.mem<device>>) : tensor<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:    return %[[RESULT]] : tensor<?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:  }
 func.func @host_scalar_on_device(%ctx: !hipsr.context, %ids: tensor<?x?xi64>)
     -> tensor<?x?xi1> {

--- a/test/lit/Dialect/Hipsr/IR/equal.mlir
+++ b/test/lit/Dialect/Hipsr/IR/equal.mlir
@@ -7,33 +7,33 @@
 func.func @equal_operand_element_mismatch(
     %ctx: !hipsr.context, %lhs: tensor<2x3xf16, #hipsr.mem<device>>,
     %rhs: tensor<2x3xf32, #hipsr.mem<device>>,
-    %init: tensor<2x3xui8, #hipsr.mem<device>>)
-    -> tensor<2x3xui8, #hipsr.mem<device>> {
+    %init: tensor<2x3xi1, #hipsr.mem<device>>)
+    -> tensor<2x3xi1, #hipsr.mem<device>> {
   // expected-error@+1 {{failed to verify that all of {lhs, rhs} have same element type}}
   %result = hipsr.equal(%ctx)
       ins(%lhs, %rhs : tensor<2x3xf16, #hipsr.mem<device>>,
                        tensor<2x3xf32, #hipsr.mem<device>>)
-      outs(%init : tensor<2x3xui8, #hipsr.mem<device>>)
-      : tensor<2x3xui8, #hipsr.mem<device>>
-  return %result : tensor<2x3xui8, #hipsr.mem<device>>
+      outs(%init : tensor<2x3xi1, #hipsr.mem<device>>)
+      : tensor<2x3xi1, #hipsr.mem<device>>
+  return %result : tensor<2x3xi1, #hipsr.mem<device>>
 }
 
 // -----
 
-// The mask is the byte the runtime writes. The conversion turns the bit ONNX
-// declares into ui8 before building the op.
-func.func @equal_bit_mask(
+// The mask is a bool. The byte the runtime stores it in is not the type the op
+// carries, so the storage spelling is rejected here.
+func.func @equal_byte_mask(
     %ctx: !hipsr.context, %lhs: tensor<2x3xf16, #hipsr.mem<device>>,
     %rhs: tensor<2x3xf16, #hipsr.mem<device>>,
-    %init: tensor<2x3xi1, #hipsr.mem<device>>)
-    -> tensor<2x3xi1, #hipsr.mem<device>> {
-  // expected-error@+1 {{output element type must be ui8}}
+    %init: tensor<2x3xui8, #hipsr.mem<device>>)
+    -> tensor<2x3xui8, #hipsr.mem<device>> {
+  // expected-error@+1 {{output element type must be i1}}
   %result = hipsr.equal(%ctx)
       ins(%lhs, %rhs : tensor<2x3xf16, #hipsr.mem<device>>,
                        tensor<2x3xf16, #hipsr.mem<device>>)
-      outs(%init : tensor<2x3xi1, #hipsr.mem<device>>)
-      : tensor<2x3xi1, #hipsr.mem<device>>
-  return %result : tensor<2x3xi1, #hipsr.mem<device>>
+      outs(%init : tensor<2x3xui8, #hipsr.mem<device>>)
+      : tensor<2x3xui8, #hipsr.mem<device>>
+  return %result : tensor<2x3xui8, #hipsr.mem<device>>
 }
 
 // -----
@@ -42,15 +42,15 @@ func.func @equal_bit_mask(
 func.func @equal_incompatible_operands(
     %ctx: !hipsr.context, %lhs: tensor<2x3xf16, #hipsr.mem<device>>,
     %rhs: tensor<2x4xf16, #hipsr.mem<device>>,
-    %init: tensor<2x3xui8, #hipsr.mem<device>>)
-    -> tensor<2x3xui8, #hipsr.mem<device>> {
+    %init: tensor<2x3xi1, #hipsr.mem<device>>)
+    -> tensor<2x3xi1, #hipsr.mem<device>> {
   // expected-error@+1 {{lhs and rhs shapes are not broadcast compatible}}
   %result = hipsr.equal(%ctx)
       ins(%lhs, %rhs : tensor<2x3xf16, #hipsr.mem<device>>,
                        tensor<2x4xf16, #hipsr.mem<device>>)
-      outs(%init : tensor<2x3xui8, #hipsr.mem<device>>)
-      : tensor<2x3xui8, #hipsr.mem<device>>
-  return %result : tensor<2x3xui8, #hipsr.mem<device>>
+      outs(%init : tensor<2x3xi1, #hipsr.mem<device>>)
+      : tensor<2x3xi1, #hipsr.mem<device>>
+  return %result : tensor<2x3xi1, #hipsr.mem<device>>
 }
 
 // -----
@@ -59,13 +59,13 @@ func.func @equal_incompatible_operands(
 func.func @equal_output_shape(
     %ctx: !hipsr.context, %lhs: tensor<4x1xf16, #hipsr.mem<device>>,
     %rhs: tensor<3xf16, #hipsr.mem<device>>,
-    %init: tensor<4x1xui8, #hipsr.mem<device>>)
-    -> tensor<4x1xui8, #hipsr.mem<device>> {
+    %init: tensor<4x1xi1, #hipsr.mem<device>>)
+    -> tensor<4x1xi1, #hipsr.mem<device>> {
   // expected-error@+1 {{output shape must be the broadcast of lhs and rhs}}
   %result = hipsr.equal(%ctx)
       ins(%lhs, %rhs : tensor<4x1xf16, #hipsr.mem<device>>,
                        tensor<3xf16, #hipsr.mem<device>>)
-      outs(%init : tensor<4x1xui8, #hipsr.mem<device>>)
-      : tensor<4x1xui8, #hipsr.mem<device>>
-  return %result : tensor<4x1xui8, #hipsr.mem<device>>
+      outs(%init : tensor<4x1xi1, #hipsr.mem<device>>)
+      : tensor<4x1xi1, #hipsr.mem<device>>
+  return %result : tensor<4x1xi1, #hipsr.mem<device>>
 }

--- a/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
@@ -7,49 +7,342 @@
 // The input is the ONNX-MLIR form of a text-embedding graph that scatters image
 // features into token embeddings. Every batch and sequence extent stays
 // symbolic, and NonZero makes the scatter index count data-dependent, so the
-// pipeline must never freeze an extent to a constant. The embedding table is a
-// two-gigabyte external constant carried as an offset/size reference rather
-// than inline data.
+// pipeline must never freeze an extent to a constant.
 //
-// The graph is importer output conformed to the modeled dialect in two places:
-// the omitted `steps` operand of onnx.Slice is present as onnx.NoValue, and the
-// bool mask is `i1` rather than the `ui8` the importer writes today.
+// The graph is importer output with one edit: the omitted `steps` operand of
+// onnx.Slice is spelled onnx.NoValue. The embedding table stays as imported, an
+// external byte range naming the model's two-gigabyte weight file, so the RUN
+// line creates a file of exactly that size for the conversion to map. Only its
+// length matters: the compiler records the path and offset and never reads the
+// weights, so the contents are left undefined.
 //
-// Skipped for now: this graph uses operations the pipeline does not support
-// yet.
+// The whole output is checked. The pipeline decides how many pool domains to
+// cut, where each barrier sits, and what every shape region computes, so a
+// partial check would let those move unnoticed.
+//
+// Pool domains and what cuts them
+// -------------------------------
+//
+// A domain is one pool allocation, so every buffer inside it must be sized
+// before it runs. The pipeline therefore starts a new domain wherever a shape
+// depends on a value the host cannot know until the previous domain has
+// finished. Each cut below is a barrier placeholder whose shape region reads
+// the host tensor named on the arrow.
+//
+//   domain 0   collapse(image_features)              -> flat
+//              equal(input_ids, 248056) -> unsqueeze -> mask
+//              gather(table, input_ids)              -> embeds
+//              shape(embeds)                         -> extents  host 3xi64
+//                   |
+//                   |  extents: the broadcast destination is not in any type
+//                   v
+//   domain 1   expand(mask, extents)                 -> mask3d
+//                   |
+//                   |  extents: the second broadcast reads them again
+//                   v
+//   domain 2   expand(mask3d, extents)               -> mask3d'
+//              nonzero(mask3d')                      -> coords 3x?, count
+//              copy_d2h(count)                       -> count    host 1xi64
+//                   |
+//                   |  count: how many coordinates the search actually found
+//                   v
+//   domain 3   extract_slice(coords, count)          -> coords 3x?
+//              transpose(coords)                     -> coords ?x3
+//              shape -> gather -> unsqueeze          -> window   host 1xi64
+//                   |
+//                   |  window: where the update slice ends
+//                   v
+//   domain 4   slice(flat, window)                   -> updates
+//              scatter_nd(embeds, coords, updates)   -> inputs_embeds
+//
+// Only domain 0 opens with an ordinary placeholder, because everything in it is
+// shaped by the argument types alone. Domains 1 through 4 each open with a
+// barrier placeholder, which is what a cut looks like in the IR below.
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: true
-
-// RUN: hip-mlir-opt --onnx-dialect=modeled --hipsr-pipeline %s | FileCheck %s
-
-// CHECK-LABEL: func.func @main_graph(
-// CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
-// CHECK-SAME:      %[[IDS:.*]]: tensor<?x?xi64> {onnx.name = "input_ids"},
-// CHECK-SAME:      %[[FEATURES:.*]]: tensor<?x4096xf16> {onnx.name = "image_features"})
-// CHECK-SAME:      -> (tensor<?x?x4096xf16> {onnx.name = "inputs_embeds"})
-
-// The embedding table stays a reference to external data.
-// CHECK: %[[TABLE:.*]] = "onnx.Constant"() <{location = "embedding.onnx.data"
-// CHECK-SAME: offset = 0 : i64, size = 2034237440 : i64}> {{.*}} -> tensor<248320x4096xf16>
-
-// CHECK: %[[FLAT:.*]] = "onnx.Reshape"(%[[FEATURES]], %{{.*}}) {{.*}} -> tensor<?xf16>
-// CHECK: %[[MASK:.*]] = "onnx.Equal"(%[[IDS]], %{{.*}}) {{.*}} -> tensor<?x?xi1>
-// CHECK: %[[EMBEDS:.*]] = "onnx.Gather"(%[[TABLE]], %[[IDS]]) {{.*}} -> tensor<?x?x4096xf16>
-// CHECK: %[[SHAPE:.*]] = "onnx.Shape"(%[[EMBEDS]]) {{.*}} -> tensor<3xi64>
-
-// NonZero yields a data-dependent trailing extent that feeds the scatter.
-// CHECK: %[[NONZERO:.*]] = "onnx.NonZero"(%{{.*}}) {{.*}} -> tensor<3x?xi64>
-// CHECK: %[[INDICES:.*]] = "onnx.Transpose"(%[[NONZERO]]) {{.*}} -> tensor<?x3xi64>
-// CHECK: %[[UPDATES:.*]] = "onnx.Slice"(%[[FLAT]], {{.*}}) {{.*}} -> tensor<?xf16>
-// CHECK: %[[OUT:.*]] = "onnx.ScatterND"(%[[EMBEDS]], %[[INDICES]], %[[UPDATES]])
-// CHECK-SAME: -> tensor<?x?x4096xf16>
-// CHECK: "onnx.Return"(%[[OUT]])
+// RUN: %python %S/../../../Inputs/make_external_data.py %t/embedding.onnx.data 2034237440 && cd %t && hip-mlir-opt --onnx-dialect=modeled --hipsr-pipeline --mlir-elide-resource-strings-if-larger=32 %s | FileCheck %s
 
 module {
+
+// The context becomes argument 0 and every symbolic extent survives.
+// CHECK-LABEL:   func.func @main_graph(
+// CHECK-SAME:      %[[ARG0:[^,]*]]: !hipsr.context,
+// CHECK-SAME:      %[[ARG1:[^,]*]]: tensor<?x?xi64, #hipsr.mem<device>> {onnx.name = "input_ids"},
+// CHECK-SAME:      %[[ARG2:[^,]*]]: tensor<?x4096xf16, #hipsr.mem<device>> {onnx.name = "image_features"}) -> (tensor<?x?x4096xf16, #hipsr.mem<device>> {onnx.name = "inputs_embeds"}) attributes {onnx.graph.name = "main_graph"} {
+
+// Domain 0 takes everything whose shape follows from the graph inputs alone:
+// the embedding lookup, the bool mask, and the shape vector the broadcasts
+// downstream will read.
+// CHECK-NEXT:           %[[POOL_DOMAIN_0:.*]]:8 = hipsr.pool_domain(%[[ARG0]], %[[ARG2]], %[[ARG1]] : !hipsr.context, tensor<?x4096xf16, #hipsr.mem<device>>, tensor<?x?xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:           ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: tensor<?x4096xf16, #hipsr.mem<device>>, %[[VAL_2:.*]]: tensor<?x?xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:             %[[CONSTANT_0:.*]] = hipsr.constant {value = dense_resource<"file|embedding.onnx.data|0"> : tensor<248320x4096xf16, #hipsr.mem<device>>} : tensor<248320x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[CONSTANT_1:.*]] = arith.constant dense<248056> : tensor<i64>
+// CHECK-NEXT:             %[[CONSTANT_2:.*]] = hipsr.constant {value = dense<-1> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[CONSTANT_3:.*]] = arith.constant dense<0> : tensor<i64>
+// CHECK-NEXT:             %[[CONSTANT_4:.*]] = hipsr.constant {value = dense<0> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[PLACEHOLDER_0:.*]] = hipsr.placeholder(%[[VAL_0]]) ins(%[[VAL_1]] : tensor<?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?xf16, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:             ^bb0(%[[VAL_3:.*]]: !shape.shape):
+// CHECK-NEXT:               %[[NUM_ELEMENTS_0:.*]] = shape.num_elements %[[VAL_3]] : !shape.shape -> !shape.size
+// CHECK-NEXT:               %[[SIZE_TO_INDEX_0:.*]] = shape.size_to_index %[[NUM_ELEMENTS_0]] : !shape.size
+// CHECK-NEXT:               %[[CONSTANT_5:.*]] = arith.constant 1 : index
+// CHECK-NEXT:               %[[DIVUI_0:.*]] = arith.divui %[[SIZE_TO_INDEX_0]], %[[CONSTANT_5]] : index
+// CHECK-NEXT:               %[[FROM_EXTENTS_0:.*]] = shape.from_extents %[[DIVUI_0]] : index
+// CHECK-NEXT:               hipsr.shape_yield %[[FROM_EXTENTS_0]] : !shape.shape
+// CHECK-NEXT:             }
+// CHECK-NEXT:             %[[COMPUTE_0:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[VAL_1]] : tensor<?x4096xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_0]] : tensor<?xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:             ^bb0(%[[VAL_4:.*]]: !hipsr.context, %[[VAL_5:.*]]: tensor<?x4096xf16, #hipsr.mem<device>>, %[[VAL_6:.*]]: tensor<?xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:               %[[COLLAPSE_SHAPE_0:.*]] = tensor.collapse_shape %[[VAL_5]] {{\[\[}}0, 1]] : tensor<?x4096xf16, #hipsr.mem<device>> into tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:               hipsr.compute_yield %[[COLLAPSE_SHAPE_0]] : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             } : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[CONSTANT_6:.*]] = hipsr.constant {value = dense<248056> : tensor<i64>} : tensor<i64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[PLACEHOLDER_1:.*]] = hipsr.placeholder(%[[VAL_0]]) ins(%[[VAL_2]], %[[CONSTANT_6]] : tensor<?x?xi64, #hipsr.mem<device>>, tensor<i64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x?xi1, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:             ^bb0(%[[VAL_7:.*]]: !shape.shape, %[[VAL_8:.*]]: !shape.shape):
+// CHECK-NEXT:               %[[BROADCAST_0:.*]] = shape.broadcast %[[VAL_7]], %[[VAL_8]] : !shape.shape, !shape.shape -> !shape.shape
+// CHECK-NEXT:               hipsr.shape_yield %[[BROADCAST_0]] : !shape.shape
+// CHECK-NEXT:             }
+// CHECK-NEXT:             %[[EQUAL_0:.*]] = hipsr.equal(%[[VAL_0]]) ins(%[[VAL_2]], %[[CONSTANT_6]] : tensor<?x?xi64, #hipsr.mem<device>>, tensor<i64, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_1]] : tensor<?x?xi1, #hipsr.mem<device>>) : tensor<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[PLACEHOLDER_2:.*]] = hipsr.placeholder(%[[VAL_0]]) ins(%[[PLACEHOLDER_1]] : tensor<?x?xi1, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x?x1xi1, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:             ^bb0(%[[VAL_9:.*]]: !shape.shape):
+// CHECK-NEXT:               %[[CONST_SIZE_0:.*]] = shape.const_size 0
+// CHECK-NEXT:               %[[GET_EXTENT_0:.*]] = shape.get_extent %[[VAL_9]], %[[CONST_SIZE_0]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:               %[[SIZE_TO_INDEX_1:.*]] = shape.size_to_index %[[GET_EXTENT_0]] : !shape.size
+// CHECK-NEXT:               %[[CONST_SIZE_1:.*]] = shape.const_size 1
+// CHECK-NEXT:               %[[GET_EXTENT_1:.*]] = shape.get_extent %[[VAL_9]], %[[CONST_SIZE_1]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:               %[[SIZE_TO_INDEX_2:.*]] = shape.size_to_index %[[GET_EXTENT_1]] : !shape.size
+// CHECK-NEXT:               %[[CONSTANT_7:.*]] = arith.constant 1 : index
+// CHECK-NEXT:               %[[CONSTANT_8:.*]] = arith.constant 1 : index
+// CHECK-NEXT:               %[[CONSTANT_9:.*]] = arith.constant 1 : index
+// CHECK-NEXT:               %[[FROM_EXTENTS_1:.*]] = shape.from_extents %[[SIZE_TO_INDEX_1]], %[[SIZE_TO_INDEX_2]], %[[CONSTANT_9]] : index, index, index
+// CHECK-NEXT:               hipsr.shape_yield %[[FROM_EXTENTS_1]] : !shape.shape
+// CHECK-NEXT:             }
+// CHECK-NEXT:             %[[COMPUTE_1:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[EQUAL_0]] : tensor<?x?xi1, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_2]] : tensor<?x?x1xi1, #hipsr.mem<device>>) {
+// CHECK-NEXT:             ^bb0(%[[VAL_10:.*]]: !hipsr.context, %[[VAL_11:.*]]: tensor<?x?xi1, #hipsr.mem<device>>, %[[VAL_12:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>):
+// CHECK-NEXT:               %[[CONSTANT_10:.*]] = arith.constant 0 : index
+// CHECK-NEXT:               %[[DIM_0:.*]] = tensor.dim %[[VAL_12]], %[[CONSTANT_10]] : tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[CONSTANT_11:.*]] = arith.constant 1 : index
+// CHECK-NEXT:               %[[DIM_1:.*]] = tensor.dim %[[VAL_12]], %[[CONSTANT_11]] : tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[EXPAND_SHAPE_0:.*]] = tensor.expand_shape %[[VAL_11]] {{\[\[}}0], [1, 2]] output_shape {{\[}}%[[DIM_0]], %[[DIM_1]], 1] : tensor<?x?xi1, #hipsr.mem<device>> into tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:               hipsr.compute_yield %[[EXPAND_SHAPE_0]] : tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             } : tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[PLACEHOLDER_3:.*]] = hipsr.placeholder(%[[VAL_0]]) ins(%[[CONSTANT_0]], %[[VAL_2]] : tensor<248320x4096xf16, #hipsr.mem<device>>, tensor<?x?xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x?x4096xf16, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:             ^bb0(%[[VAL_13:.*]]: !shape.shape, %[[VAL_14:.*]]: !shape.shape):
+// CHECK-NEXT:               %[[CONST_SIZE_2:.*]] = shape.const_size 0
+// CHECK-NEXT:               %[[VAL_15:.*]], %[[VAL_16:.*]] = "shape.split_at"(%[[VAL_13]], %[[CONST_SIZE_2]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
+// CHECK-NEXT:               %[[CONST_SIZE_3:.*]] = shape.const_size 1
+// CHECK-NEXT:               %[[VAL_17:.*]], %[[VAL_18:.*]] = "shape.split_at"(%[[VAL_13]], %[[CONST_SIZE_3]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
+// CHECK-NEXT:               %[[CONCAT_0:.*]] = shape.concat %[[VAL_15]], %[[VAL_14]] : !shape.shape, !shape.shape -> !shape.shape
+// CHECK-NEXT:               %[[CONCAT_1:.*]] = shape.concat %[[CONCAT_0]], %[[VAL_18]] : !shape.shape, !shape.shape -> !shape.shape
+// CHECK-NEXT:               hipsr.shape_yield %[[CONCAT_1]] : !shape.shape
+// CHECK-NEXT:             }
+// CHECK-NEXT:             %[[GATHER_0:.*]] = hipsr.gather(%[[VAL_0]]) ins(%[[CONSTANT_0]], %[[VAL_2]] : tensor<248320x4096xf16, #hipsr.mem<device>>, tensor<?x?xi64, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_3]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {axis = 0 : i64} : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[PLACEHOLDER_4:.*]] = hipsr.placeholder(%[[VAL_0]]) ins(%[[PLACEHOLDER_3]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<3xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:             ^bb0(%[[VAL_19:.*]]: !shape.shape):
+// CHECK-NEXT:               %[[CONSTANT_12:.*]] = arith.constant 3 : index
+// CHECK-NEXT:               %[[FROM_EXTENTS_2:.*]] = shape.from_extents %[[CONSTANT_12]] : index
+// CHECK-NEXT:               hipsr.shape_yield %[[FROM_EXTENTS_2]] : !shape.shape
+// CHECK-NEXT:             }
+// CHECK-NEXT:             %[[COMPUTE_2:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[GATHER_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_4]] : tensor<3xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:             ^bb0(%[[VAL_20:.*]]: !hipsr.context, %[[VAL_21:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_22:.*]]: tensor<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:               %[[CONSTANT_13:.*]] = arith.constant 0 : index
+// CHECK-NEXT:               %[[DIM_2:.*]] = tensor.dim %[[VAL_21]], %[[CONSTANT_13]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[INDEX_CAST_0:.*]] = arith.index_cast %[[DIM_2]] : index to i64
+// CHECK-NEXT:               %[[CONSTANT_14:.*]] = arith.constant 1 : index
+// CHECK-NEXT:               %[[DIM_3:.*]] = tensor.dim %[[VAL_21]], %[[CONSTANT_14]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[INDEX_CAST_1:.*]] = arith.index_cast %[[DIM_3]] : index to i64
+// CHECK-NEXT:               %[[CONSTANT_15:.*]] = arith.constant 4096 : i64
+// CHECK-NEXT:               %[[FROM_ELEMENTS_0:.*]] = tensor.from_elements %[[INDEX_CAST_0]], %[[INDEX_CAST_1]], %[[CONSTANT_15]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               hipsr.compute_yield %[[FROM_ELEMENTS_0]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             } : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             hipsr.pool_domain_yield %[[PLACEHOLDER_0]], %[[COMPUTE_0]], %[[PLACEHOLDER_2]], %[[COMPUTE_1]], %[[PLACEHOLDER_3]], %[[GATHER_0]], %[[PLACEHOLDER_4]], %[[COMPUTE_2]] : tensor<?xf16, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:           } -> tensor<?xf16, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<3xi64, #hipsr.mem<host>> {domain_id = 0 : i64}
+
+// Each broadcast reads its extents from a host shape vector rather than from
+// the type, so each one opens a domain behind a barrier placeholder.
+// CHECK-NEXT:           %[[POOL_DOMAIN_1:.*]]:2 = hipsr.pool_domain(%[[ARG0]], %[[VAL_23:.*]]#2, %[[VAL_23]]#6, %[[VAL_23]]#3, %[[VAL_23]]#7 : !hipsr.context, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:           ^bb0(%[[VAL_24:.*]]: !hipsr.context, %[[VAL_25:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_26:.*]]: tensor<3xi64, #hipsr.mem<host>>, %[[VAL_27:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_28:.*]]: tensor<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:             %[[PLACEHOLDER_5:.*]] = hipsr.placeholder(%[[VAL_24]]) ins(%[[VAL_25]], %[[VAL_26]] : tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x?x?xi1, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:             ^bb0(%[[VAL_29:.*]]: !hipsr.context, %[[VAL_30:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_31:.*]]: tensor<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:               %[[SHAPE_OF_0:.*]] = shape.shape_of %[[VAL_30]] : tensor<?x?x1xi1, #hipsr.mem<device>> -> tensor<3xindex>
+// CHECK-NEXT:               %[[CONSTANT_16:.*]] = arith.constant 0 : index
+// CHECK-NEXT:               %[[EXTRACT_0:.*]] = tensor.extract %[[VAL_31]]{{\[}}%[[CONSTANT_16]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               %[[INDEX_CAST_2:.*]] = arith.index_cast %[[EXTRACT_0]] : i64 to index
+// CHECK-NEXT:               %[[CONSTANT_17:.*]] = arith.constant 1 : index
+// CHECK-NEXT:               %[[EXTRACT_1:.*]] = tensor.extract %[[VAL_31]]{{\[}}%[[CONSTANT_17]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               %[[INDEX_CAST_3:.*]] = arith.index_cast %[[EXTRACT_1]] : i64 to index
+// CHECK-NEXT:               %[[CONSTANT_18:.*]] = arith.constant 2 : index
+// CHECK-NEXT:               %[[EXTRACT_2:.*]] = tensor.extract %[[VAL_31]]{{\[}}%[[CONSTANT_18]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               %[[INDEX_CAST_4:.*]] = arith.index_cast %[[EXTRACT_2]] : i64 to index
+// CHECK-NEXT:               %[[FROM_EXTENTS_3:.*]] = shape.from_extents %[[INDEX_CAST_2]], %[[INDEX_CAST_3]], %[[INDEX_CAST_4]] : index, index, index
+// CHECK-NEXT:               %[[CSTR_BROADCASTABLE_0:.*]] = shape.cstr_broadcastable %[[SHAPE_OF_0]], %[[FROM_EXTENTS_3]] : tensor<3xindex>, !shape.shape
+// CHECK-NEXT:               %[[ASSUMING_0:.*]] = shape.assuming %[[CSTR_BROADCASTABLE_0]] -> (!shape.shape) {
+// CHECK-NEXT:                 %[[BROADCAST_1:.*]] = shape.broadcast %[[SHAPE_OF_0]], %[[FROM_EXTENTS_3]] : tensor<3xindex>, !shape.shape -> !shape.shape
+// CHECK-NEXT:                 shape.assuming_yield %[[BROADCAST_1]] : !shape.shape
+// CHECK-NEXT:               }
+// CHECK-NEXT:               hipsr.shape_yield %[[ASSUMING_0]] : !shape.shape
+// CHECK-NEXT:             }
+// CHECK-NEXT:             %[[EXPAND_0:.*]] = hipsr.expand(%[[VAL_24]]) ins(%[[VAL_27]], %[[VAL_28]] : tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) outs(%[[PLACEHOLDER_5]] : tensor<?x?x?xi1, #hipsr.mem<device>>) : tensor<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.pool_domain_yield %[[PLACEHOLDER_5]], %[[EXPAND_0]] : tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:           } -> tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<?x?x?xi1, #hipsr.mem<device>> {domain_id = 1 : i64}
+
+// The second broadcast feeds the search. Its destination holds one row per
+// input axis and, in the worst case, a column per input element; the count of
+// the columns it filled sits beside it and is read back to the host.
+// CHECK-NEXT:           %[[POOL_DOMAIN_2:.*]]:4 = hipsr.pool_domain(%[[ARG0]], %[[VAL_32:.*]]#0, %[[VAL_33:.*]]#6, %[[VAL_32]]#1, %[[VAL_33]]#7 : !hipsr.context, tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:           ^bb0(%[[VAL_34:.*]]: !hipsr.context, %[[VAL_35:.*]]: tensor<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_36:.*]]: tensor<3xi64, #hipsr.mem<host>>, %[[VAL_37:.*]]: tensor<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_38:.*]]: tensor<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:             %[[PLACEHOLDER_6:.*]] = hipsr.placeholder(%[[VAL_34]]) ins(%[[VAL_35]], %[[VAL_36]] : tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x?x?xi1, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:             ^bb0(%[[VAL_39:.*]]: !hipsr.context, %[[VAL_40:.*]]: tensor<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_41:.*]]: tensor<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:               %[[SHAPE_OF_1:.*]] = shape.shape_of %[[VAL_40]] : tensor<?x?x?xi1, #hipsr.mem<device>> -> tensor<3xindex>
+// CHECK-NEXT:               %[[CONSTANT_19:.*]] = arith.constant 0 : index
+// CHECK-NEXT:               %[[EXTRACT_3:.*]] = tensor.extract %[[VAL_41]]{{\[}}%[[CONSTANT_19]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               %[[INDEX_CAST_5:.*]] = arith.index_cast %[[EXTRACT_3]] : i64 to index
+// CHECK-NEXT:               %[[CONSTANT_20:.*]] = arith.constant 1 : index
+// CHECK-NEXT:               %[[EXTRACT_4:.*]] = tensor.extract %[[VAL_41]]{{\[}}%[[CONSTANT_20]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               %[[INDEX_CAST_6:.*]] = arith.index_cast %[[EXTRACT_4]] : i64 to index
+// CHECK-NEXT:               %[[CONSTANT_21:.*]] = arith.constant 2 : index
+// CHECK-NEXT:               %[[EXTRACT_5:.*]] = tensor.extract %[[VAL_41]]{{\[}}%[[CONSTANT_21]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               %[[INDEX_CAST_7:.*]] = arith.index_cast %[[EXTRACT_5]] : i64 to index
+// CHECK-NEXT:               %[[FROM_EXTENTS_4:.*]] = shape.from_extents %[[INDEX_CAST_5]], %[[INDEX_CAST_6]], %[[INDEX_CAST_7]] : index, index, index
+// CHECK-NEXT:               %[[CSTR_BROADCASTABLE_1:.*]] = shape.cstr_broadcastable %[[SHAPE_OF_1]], %[[FROM_EXTENTS_4]] : tensor<3xindex>, !shape.shape
+// CHECK-NEXT:               %[[ASSUMING_1:.*]] = shape.assuming %[[CSTR_BROADCASTABLE_1]] -> (!shape.shape) {
+// CHECK-NEXT:                 %[[BROADCAST_2:.*]] = shape.broadcast %[[SHAPE_OF_1]], %[[FROM_EXTENTS_4]] : tensor<3xindex>, !shape.shape -> !shape.shape
+// CHECK-NEXT:                 shape.assuming_yield %[[BROADCAST_2]] : !shape.shape
+// CHECK-NEXT:               }
+// CHECK-NEXT:               hipsr.shape_yield %[[ASSUMING_1]] : !shape.shape
+// CHECK-NEXT:             }
+// CHECK-NEXT:             %[[EXPAND_1:.*]] = hipsr.expand(%[[VAL_34]]) ins(%[[VAL_37]], %[[VAL_38]] : tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) outs(%[[PLACEHOLDER_6]] : tensor<?x?x?xi1, #hipsr.mem<device>>) : tensor<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[PLACEHOLDER_7:.*]]:2 = hipsr.placeholder(%[[VAL_34]]) ins(%[[PLACEHOLDER_6]] : tensor<?x?x?xi1, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:             ^bb0(%[[VAL_42:.*]]: !shape.shape):
+// CHECK-NEXT:               %[[CONST_SIZE_4:.*]] = shape.const_size 3
+// CHECK-NEXT:               %[[NUM_ELEMENTS_1:.*]] = shape.num_elements %[[VAL_42]] : !shape.shape -> !shape.size
+// CHECK-NEXT:               %[[FROM_EXTENTS_5:.*]] = shape.from_extents %[[CONST_SIZE_4]], %[[NUM_ELEMENTS_1]] : !shape.size, !shape.size
+// CHECK-NEXT:               %[[CONST_SHAPE_0:.*]] = shape.const_shape [1] : !shape.shape
+// CHECK-NEXT:               hipsr.shape_yield %[[FROM_EXTENTS_5]], %[[CONST_SHAPE_0]] : !shape.shape, !shape.shape
+// CHECK-NEXT:             }
+// CHECK-NEXT:             %[[NONZERO_0:.*]]:2 = hipsr.nonzero(%[[VAL_34]]) ins(%[[EXPAND_1]] : tensor<?x?x?xi1, #hipsr.mem<device>>) outs(%[[VAL_43:.*]]#0, %[[VAL_43]]#1 : tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>) : tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[PLACEHOLDER_8:.*]] = hipsr.placeholder(%[[VAL_34]]) ins(%[[VAL_43]]#1 : tensor<1xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<1xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:             ^bb0(%[[VAL_44:.*]]: !shape.shape):
+// CHECK-NEXT:               hipsr.shape_yield %[[VAL_44]] : !shape.shape
+// CHECK-NEXT:             }
+// CHECK-NEXT:             %[[VAL_45:.*]] = hipsr.copy_d2h(%[[VAL_34]]) ins(%[[NONZERO_0]]#1 : tensor<1xi64, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_8]] : tensor<1xi64, #hipsr.mem<host>>) : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             hipsr.pool_domain_yield %[[VAL_43]]#0, %[[NONZERO_0]]#0, %[[PLACEHOLDER_8]], %[[VAL_45]] : tensor<3x?xi64, #hipsr.mem<device>>, tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:           } -> tensor<3x?xi64, #hipsr.mem<device>>, tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>> {domain_id = 2 : i64}
+
+// That host count opens the next domain. A barrier turns it into the trailing
+// extent so the search destination narrows to the columns that hold a position.
+// The barrier and the compute list the same two values, so they share a domain
+// and each reads only the one it needs.
+// CHECK-NEXT:           %[[POOL_DOMAIN_3:.*]]:4 = hipsr.pool_domain(%[[ARG0]], %[[VAL_46:.*]]#2, %[[VAL_46]]#0, %[[VAL_46]]#3, %[[VAL_46]]#1 : !hipsr.context, tensor<1xi64, #hipsr.mem<host>>, tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<3x?xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:           ^bb0(%[[VAL_47:.*]]: !hipsr.context, %[[VAL_48:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_49:.*]]: tensor<3x?xi64, #hipsr.mem<device>>, %[[VAL_50:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_51:.*]]: tensor<3x?xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:             %[[PLACEHOLDER_9:.*]] = hipsr.placeholder(%[[VAL_47]]) ins(%[[VAL_48]], %[[VAL_49]] : tensor<1xi64, #hipsr.mem<host>>, tensor<3x?xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<3x?xi64, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:             ^bb0(%[[VAL_52:.*]]: !hipsr.context, %[[VAL_53:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_54:.*]]: tensor<3x?xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:               %[[CONSTANT_22:.*]] = arith.constant 0 : index
+// CHECK-NEXT:               %[[EXTRACT_6:.*]] = tensor.extract %[[VAL_53]]{{\[}}%[[CONSTANT_22]]] : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               %[[INDEX_CAST_8:.*]] = arith.index_cast %[[EXTRACT_6]] : i64 to index
+// CHECK-NEXT:               %[[CONSTANT_23:.*]] = arith.constant 3 : index
+// CHECK-NEXT:               %[[FROM_EXTENTS_6:.*]] = shape.from_extents %[[CONSTANT_23]], %[[INDEX_CAST_8]] : index, index
+// CHECK-NEXT:               hipsr.shape_yield %[[FROM_EXTENTS_6]] : !shape.shape
+// CHECK-NEXT:             }
+// CHECK-NEXT:             %[[COMPUTE_3:.*]] = hipsr.compute(%[[VAL_47]]) ins(%[[VAL_50]], %[[VAL_51]] : tensor<1xi64, #hipsr.mem<host>>, tensor<3x?xi64, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_9]] : tensor<3x?xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:             ^bb0(%[[VAL_55:.*]]: !hipsr.context, %[[VAL_56:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_57:.*]]: tensor<3x?xi64, #hipsr.mem<device>>, %[[VAL_58:.*]]: tensor<3x?xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:               %[[CONSTANT_24:.*]] = arith.constant 1 : index
+// CHECK-NEXT:               %[[DIM_4:.*]] = tensor.dim %[[VAL_58]], %[[CONSTANT_24]] : tensor<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[EXTRACT_SLICE_0:.*]] = tensor.extract_slice %[[VAL_57]][0, 0] [3, %[[DIM_4]]] [1, 1] : tensor<3x?xi64, #hipsr.mem<device>> to tensor<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:               hipsr.compute_yield %[[EXTRACT_SLICE_0]] : tensor<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             } : tensor<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[PLACEHOLDER_10:.*]] = hipsr.placeholder(%[[VAL_47]]) ins(%[[PLACEHOLDER_9]] : tensor<3x?xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x3xi64, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:             ^bb0(%[[VAL_59:.*]]: !shape.shape):
+// CHECK-NEXT:               %[[CONST_SIZE_5:.*]] = shape.const_size 1
+// CHECK-NEXT:               %[[GET_EXTENT_2:.*]] = shape.get_extent %[[VAL_59]], %[[CONST_SIZE_5]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:               %[[CONST_SIZE_6:.*]] = shape.const_size 0
+// CHECK-NEXT:               %[[GET_EXTENT_3:.*]] = shape.get_extent %[[VAL_59]], %[[CONST_SIZE_6]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:               %[[FROM_EXTENTS_7:.*]] = shape.from_extents %[[GET_EXTENT_2]], %[[GET_EXTENT_3]] : !shape.size, !shape.size
+// CHECK-NEXT:               hipsr.shape_yield %[[FROM_EXTENTS_7]] : !shape.shape
+// CHECK-NEXT:             }
+// CHECK-NEXT:             %[[TRANSPOSE_0:.*]] = hipsr.transpose(%[[VAL_47]]) ins(%[[COMPUTE_3]] : tensor<3x?xi64, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_10]] : tensor<?x3xi64, #hipsr.mem<device>>) {perm = array<i64: 1, 0>} : tensor<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[PLACEHOLDER_11:.*]] = hipsr.placeholder(%[[VAL_47]]) ins(%[[PLACEHOLDER_10]] : tensor<?x3xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:             ^bb0(%[[VAL_60:.*]]: !shape.shape):
+// CHECK-NEXT:               %[[CONSTANT_25:.*]] = arith.constant 2 : index
+// CHECK-NEXT:               %[[FROM_EXTENTS_8:.*]] = shape.from_extents %[[CONSTANT_25]] : index
+// CHECK-NEXT:               hipsr.shape_yield %[[FROM_EXTENTS_8]] : !shape.shape
+// CHECK-NEXT:             }
+// CHECK-NEXT:             %[[COMPUTE_4:.*]] = hipsr.compute(%[[VAL_47]]) ins(%[[TRANSPOSE_0]] : tensor<?x3xi64, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_11]] : tensor<2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:             ^bb0(%[[VAL_61:.*]]: !hipsr.context, %[[VAL_62:.*]]: tensor<?x3xi64, #hipsr.mem<device>>, %[[VAL_63:.*]]: tensor<2xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:               %[[CONSTANT_26:.*]] = arith.constant 0 : index
+// CHECK-NEXT:               %[[DIM_5:.*]] = tensor.dim %[[VAL_62]], %[[CONSTANT_26]] : tensor<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[INDEX_CAST_9:.*]] = arith.index_cast %[[DIM_5]] : index to i64
+// CHECK-NEXT:               %[[CONSTANT_27:.*]] = arith.constant 3 : i64
+// CHECK-NEXT:               %[[FROM_ELEMENTS_1:.*]] = tensor.from_elements %[[INDEX_CAST_9]], %[[CONSTANT_27]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               hipsr.compute_yield %[[FROM_ELEMENTS_1]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             } : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[PLACEHOLDER_12:.*]] = hipsr.placeholder(%[[VAL_47]]) ins(%[[PLACEHOLDER_11]] : tensor<2xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<i64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:             ^bb0(%[[VAL_64:.*]]: !shape.shape):
+// CHECK-NEXT:               %[[CONST_SHAPE_1:.*]] = shape.const_shape [] : !shape.shape
+// CHECK-NEXT:               hipsr.shape_yield %[[CONST_SHAPE_1]] : !shape.shape
+// CHECK-NEXT:             }
+// CHECK-NEXT:             %[[COMPUTE_5:.*]] = hipsr.compute(%[[VAL_47]]) ins(%[[COMPUTE_4]] : tensor<2xi64, #hipsr.mem<host>>) outs(%[[PLACEHOLDER_12]] : tensor<i64, #hipsr.mem<host>>) {
+// CHECK-NEXT:             ^bb0(%[[VAL_65:.*]]: !hipsr.context, %[[VAL_66:.*]]: tensor<2xi64, #hipsr.mem<host>>, %[[VAL_67:.*]]: tensor<i64, #hipsr.mem<host>>):
+// CHECK-NEXT:               %[[CONSTANT_28:.*]] = arith.constant 0 : index
+// CHECK-NEXT:               %[[EXTRACT_7:.*]] = tensor.extract %[[VAL_66]]{{\[}}%[[CONSTANT_28]]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               %[[FROM_ELEMENTS_2:.*]] = tensor.from_elements %[[EXTRACT_7]] : tensor<i64, #hipsr.mem<host>>
+// CHECK-NEXT:               hipsr.compute_yield %[[FROM_ELEMENTS_2]] : tensor<i64, #hipsr.mem<host>>
+// CHECK-NEXT:             } : tensor<i64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[PLACEHOLDER_13:.*]] = hipsr.placeholder(%[[VAL_47]]) ins(%[[PLACEHOLDER_12]] : tensor<i64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<1xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT:             ^bb0(%[[VAL_68:.*]]: !shape.shape):
+// CHECK-NEXT:               %[[CONSTANT_29:.*]] = arith.constant 1 : index
+// CHECK-NEXT:               %[[FROM_EXTENTS_9:.*]] = shape.from_extents %[[CONSTANT_29]] : index
+// CHECK-NEXT:               hipsr.shape_yield %[[FROM_EXTENTS_9]] : !shape.shape
+// CHECK-NEXT:             }
+// CHECK-NEXT:             %[[COMPUTE_6:.*]] = hipsr.compute(%[[VAL_47]]) ins(%[[COMPUTE_5]] : tensor<i64, #hipsr.mem<host>>) outs(%[[PLACEHOLDER_13]] : tensor<1xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:             ^bb0(%[[VAL_69:.*]]: !hipsr.context, %[[VAL_70:.*]]: tensor<i64, #hipsr.mem<host>>, %[[VAL_71:.*]]: tensor<1xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:               %[[EXPAND_SHAPE_1:.*]] = tensor.expand_shape %[[VAL_70]] [] output_shape [1] : tensor<i64, #hipsr.mem<host>> into tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               hipsr.compute_yield %[[EXPAND_SHAPE_1]] : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             } : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             hipsr.pool_domain_yield %[[PLACEHOLDER_10]], %[[TRANSPOSE_0]], %[[PLACEHOLDER_13]], %[[COMPUTE_6]] : tensor<?x3xi64, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:           } -> tensor<?x3xi64, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>> {domain_id = 3 : i64}
+
+// The update window ends at that same count, and the scatter writes it into
+// the embeddings.
+// CHECK-NEXT:           %[[POOL_DOMAIN_4:.*]] = hipsr.pool_domain(%[[ARG0]], %[[VAL_72:.*]]#0, %[[VAL_73:.*]]#2, %[[VAL_72]]#1, %[[VAL_73]]#3, %[[VAL_72]]#4, %[[VAL_73]]#0, %[[VAL_72]]#5, %[[VAL_73]]#1 : !hipsr.context, tensor<?xf16, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<?xf16, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:           ^bb0(%[[VAL_74:.*]]: !hipsr.context, %[[VAL_75:.*]]: tensor<?xf16, #hipsr.mem<device>>, %[[VAL_76:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_77:.*]]: tensor<?xf16, #hipsr.mem<device>>, %[[VAL_78:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_79:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_80:.*]]: tensor<?x3xi64, #hipsr.mem<device>>, %[[VAL_81:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_82:.*]]: tensor<?x3xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:             %[[PLACEHOLDER_14:.*]] = hipsr.placeholder(%[[VAL_74]]) ins(%[[VAL_75]], %[[VAL_76]] : tensor<?xf16, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?xf16, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:             ^bb0(%[[VAL_83:.*]]: !hipsr.context, %[[VAL_84:.*]]: tensor<?xf16, #hipsr.mem<device>>, %[[VAL_85:.*]]: tensor<1xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:               %[[CONSTANT_30:.*]] = arith.constant 0 : index
+// CHECK-NEXT:               %[[DIM_6:.*]] = tensor.dim %[[VAL_84]], %[[CONSTANT_30]] : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[CONSTANT_31:.*]] = arith.constant 0 : index
+// CHECK-NEXT:               %[[EXTRACT_8:.*]] = tensor.extract %[[VAL_85]]{{\[}}%[[CONSTANT_31]]] : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               %[[INDEX_CAST_10:.*]] = arith.index_cast %[[EXTRACT_8]] : i64 to index
+// CHECK-NEXT:               %[[CONSTANT_32:.*]] = arith.constant 0 : index
+// CHECK-NEXT:               %[[CMPI_0:.*]] = arith.cmpi slt, %[[INDEX_CAST_10]], %[[CONSTANT_32]] : index
+// CHECK-NEXT:               %[[ADDI_0:.*]] = arith.addi %[[INDEX_CAST_10]], %[[DIM_6]] : index
+// CHECK-NEXT:               %[[SELECT_0:.*]] = arith.select %[[CMPI_0]], %[[ADDI_0]], %[[INDEX_CAST_10]] : index
+// CHECK-NEXT:               %[[CONSTANT_33:.*]] = arith.constant 0 : index
+// CHECK-NEXT:               %[[MINSI_0:.*]] = arith.minsi %[[DIM_6]], %[[CONSTANT_33]] : index
+// CHECK-NEXT:               %[[MAXSI_0:.*]] = arith.maxsi %[[SELECT_0]], %[[CONSTANT_32]] : index
+// CHECK-NEXT:               %[[MINSI_1:.*]] = arith.minsi %[[MAXSI_0]], %[[DIM_6]] : index
+// CHECK-NEXT:               %[[SUBI_0:.*]] = arith.subi %[[MINSI_1]], %[[MINSI_0]] : index
+// CHECK-NEXT:               %[[MAXSI_1:.*]] = arith.maxsi %[[SUBI_0]], %[[CONSTANT_32]] : index
+// CHECK-NEXT:               %[[FROM_EXTENTS_10:.*]] = shape.from_extents %[[MAXSI_1]] : index
+// CHECK-NEXT:               hipsr.shape_yield %[[FROM_EXTENTS_10]] : !shape.shape
+// CHECK-NEXT:             }
+// CHECK-NEXT:             %[[SLICE_0:.*]] = hipsr.slice(%[[VAL_74]]) ins(%[[VAL_77]] : tensor<?xf16, #hipsr.mem<device>>) ends(%[[VAL_78]] : tensor<1xi64, #hipsr.mem<host>>) outs(%[[PLACEHOLDER_14]] : tensor<?xf16, #hipsr.mem<device>>) {axes_attr = array<i64: 0>, starts_attr = array<i64: 0>, steps_attr = array<i64: 1>} : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[PLACEHOLDER_15:.*]] = hipsr.placeholder(%[[VAL_74]]) ins(%[[VAL_79]], %[[VAL_80]], %[[PLACEHOLDER_14]] : tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x?x4096xf16, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:             ^bb0(%[[VAL_86:.*]]: !shape.shape, %[[VAL_87:.*]]: !shape.shape, %[[VAL_88:.*]]: !shape.shape):
+// CHECK-NEXT:               hipsr.shape_yield %[[VAL_86]] : !shape.shape
+// CHECK-NEXT:             }
+// CHECK-NEXT:             %[[SCATTER_ND_0:.*]] = hipsr.scatter_nd(%[[VAL_74]]) ins(%[[VAL_81]], %[[VAL_82]], %[[SLICE_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_15]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.pool_domain_yield %[[SCATTER_ND_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:           } -> tensor<?x?x4096xf16, #hipsr.mem<device>> {domain_id = 4 : i64}
+// CHECK-NEXT:           return %[[POOL_DOMAIN_4]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:         }
+
+// The table's bytes stay outside the IR, so the resource section prints empty
+// once the RUN line's elision drops the blob string.
+// CHECK:              {-#
+// CHECK-EMPTY:
+// CHECK-NEXT:         #-}
   func.func @main_graph(%arg0: tensor<?x?xi64> {onnx.name = "input_ids"}, %arg1: tensor<?x4096xf16> {onnx.name = "image_features"}) -> (tensor<?x?x4096xf16> {onnx.name = "inputs_embeds"}) attributes {onnx.graph.name = "main_graph"} {
     %0 = "onnx.NoValue"() {value} : () -> none
-    %1 = "onnx.Constant"() {location = "embedding.onnx.data", node.outputs = ["embed_tokens.weight"], offset = 0 : i64, size = 2034237440 : i64} : () -> tensor<248320x4096xf16>
+    %1 = "onnx.Constant"() {node.outputs = ["embed_tokens.weight"], location = "embedding.onnx.data", offset = 0 : i64, size = 2034237440 : i64} : () -> tensor<248320x4096xf16>
     %2 = "onnx.Constant"() {node.outputs = ["/Constant_output_0"], value = dense<248056> : tensor<i64>} : () -> tensor<i64>
     %3 = "onnx.Constant"() {node.outputs = ["/Constant_1_output_0"], value = dense<-1> : tensor<1xi64>} : () -> tensor<1xi64>
     %4 = "onnx.Constant"() {node.outputs = ["/Constant_3_output_0"], value = dense<0> : tensor<i64>} : () -> tensor<i64>

--- a/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/equal.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/equal.mlir
@@ -3,22 +3,22 @@
 
 // RUN: hip-mlir-opt --one-shot-bufferize="bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map use-encoding-for-memory-space" %s | FileCheck %s
 
-// The mask buffer takes ui8 from the destination, not from the operands.
+// The mask buffer takes i1 from the destination, not from the operands.
 // CHECK-LABEL: func.func @equal(
 // CHECK-SAME:    %[[CTX:.+]]: !hipsr.context,
 // CHECK-SAME:    %[[LHS:.+]]: memref<4x1024xi64, #hipsr.mem<device>>,
-// CHECK-SAME:    %[[RHS:.+]]: memref<1024xi64, #hipsr.mem<device>>) -> memref<4x1024xui8, #hipsr.mem<device>> {
-// CHECK-NEXT:    %[[OUT:.+]] = memref.alloc() {{.*}}: memref<4x1024xui8, #hipsr.mem<device>>
-// CHECK-NEXT:    hipsr.equal(%[[CTX]]) ins(%[[LHS]], %[[RHS]] : memref<4x1024xi64, #hipsr.mem<device>>, memref<1024xi64, #hipsr.mem<device>>) outs(%[[OUT]] : memref<4x1024xui8, #hipsr.mem<device>>)
-// CHECK-NEXT:    return %[[OUT]] : memref<4x1024xui8, #hipsr.mem<device>>
+// CHECK-SAME:    %[[RHS:.+]]: memref<1024xi64, #hipsr.mem<device>>) -> memref<4x1024xi1, #hipsr.mem<device>> {
+// CHECK-NEXT:    %[[OUT:.+]] = memref.alloc() {{.*}}: memref<4x1024xi1, #hipsr.mem<device>>
+// CHECK-NEXT:    hipsr.equal(%[[CTX]]) ins(%[[LHS]], %[[RHS]] : memref<4x1024xi64, #hipsr.mem<device>>, memref<1024xi64, #hipsr.mem<device>>) outs(%[[OUT]] : memref<4x1024xi1, #hipsr.mem<device>>)
+// CHECK-NEXT:    return %[[OUT]] : memref<4x1024xi1, #hipsr.mem<device>>
 // CHECK-NEXT:  }
 func.func @equal(%ctx: !hipsr.context,
                  %lhs: tensor<4x1024xi64, #hipsr.mem<device>>,
                  %rhs: tensor<1024xi64, #hipsr.mem<device>>)
-    -> tensor<4x1024xui8, #hipsr.mem<device>> {
-  %init = tensor.empty() : tensor<4x1024xui8, #hipsr.mem<device>>
+    -> tensor<4x1024xi1, #hipsr.mem<device>> {
+  %init = tensor.empty() : tensor<4x1024xi1, #hipsr.mem<device>>
   %0 = hipsr.equal(%ctx) ins(%lhs, %rhs : tensor<4x1024xi64, #hipsr.mem<device>>, tensor<1024xi64, #hipsr.mem<device>>)
-      outs(%init : tensor<4x1024xui8, #hipsr.mem<device>>)
-      : tensor<4x1024xui8, #hipsr.mem<device>>
-  return %0 : tensor<4x1024xui8, #hipsr.mem<device>>
+      outs(%init : tensor<4x1024xi1, #hipsr.mem<device>>)
+      : tensor<4x1024xi1, #hipsr.mem<device>>
+  return %0 : tensor<4x1024xi1, #hipsr.mem<device>>
 }

--- a/test/lit/Dialect/Hipsr/Transforms/PoolAlloc/basic.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PoolAlloc/basic.mlir
@@ -3,19 +3,29 @@
 
 // RUN: hip-mlir-opt %s -split-input-file -hipsr-pool-alloc | FileCheck %s
 
-// CHECK-LABEL: func.func @align_up_rounding
-// CHECK: %[[C6:.+]] = arith.constant 6 : index
-// CHECK-NEXT: %[[C256:.+]] = arith.constant 256 : index
-// CHECK-NEXT: %[[C255:.+]] = arith.constant 255 : index
-// CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[C6]], %[[C255]] : index
-// CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
-// CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
-// CHECK-NEXT: %[[OFF:.+]] = arith.constant 0 : index
-// CHECK-NEXT: %[[POOL:.+]] = hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
-// CHECK-NEXT: %[[V0:.+]] = memref.view %[[POOL]][%[[OFF]]][] : memref<?xi8, #hipsr.mem<device>> to memref<3xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} :{{.*}}) outs(%[[V0]] :{{.*}})
-// CHECK-NOT: arith.maxui
-// CHECK-NOT: memref.alloc
+// Each case checks its whole function. The pass decides a pool size, an offset
+// per buffer and which allocations survive, and those only mean anything as one
+// sequence, so a partial check would let any of them drift.
+
+// Three f16 elements are six bytes, which round up to the pool alignment.
+// CHECK-LABEL:   func.func @align_up_rounding(
+// CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[ARG1:.*]]: memref<3xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:           hipsr.pool_domain(%[[ARG0]], %[[ARG1]] : !hipsr.context, memref<3xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:           ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: memref<3xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:             %[[CONSTANT_0:.*]] = arith.constant 6 : index
+// CHECK-NEXT:             %[[CONSTANT_1:.*]] = arith.constant 256 : index
+// CHECK-NEXT:             %[[CONSTANT_2:.*]] = arith.constant 255 : index
+// CHECK-NEXT:             %[[ADDI_0:.*]] = arith.addi %[[CONSTANT_0]], %[[CONSTANT_2]] : index
+// CHECK-NEXT:             %[[DIVUI_0:.*]] = arith.divui %[[ADDI_0]], %[[CONSTANT_1]] : index
+// CHECK-NEXT:             %[[MULI_0:.*]] = arith.muli %[[DIVUI_0]], %[[CONSTANT_1]] : index
+// CHECK-NEXT:             %[[CONSTANT_3:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[GET_POOL_0:.*]] = hipsr.get_pool(%[[VAL_0]], %[[MULI_0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[VIEW_0:.*]] = memref.view %[[GET_POOL_0]]{{\[}}%[[CONSTANT_3]]][] : memref<?xi8, #hipsr.mem<device>> to memref<3xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.add(%[[VAL_0]]) ins(%[[VAL_1]], %[[VAL_1]] : memref<3xf16, #hipsr.mem<device>>, memref<3xf16, #hipsr.mem<device>>) outs(%[[VIEW_0]] : memref<3xf16, #hipsr.mem<device>>)
+// CHECK-NEXT:           } {domain_id = 0 : i64}
+// CHECK-NEXT:           return
+// CHECK-NEXT:         }
 func.func @align_up_rounding(%ctx: !hipsr.context,
                              %in: memref<3xf16, #hipsr.mem<device>>) {
   hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<3xf16, #hipsr.mem<device>>) {
@@ -30,19 +40,61 @@ func.func @align_up_rounding(%ctx: !hipsr.context,
 
 // -----
 
-// CHECK-LABEL: func.func @dead_alloc_skipped
-// CHECK: memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[C8192:.+]] = arith.constant 8192 : index
-// CHECK-NEXT: %[[C256:.+]] = arith.constant 256 : index
-// CHECK-NEXT: %[[C255:.+]] = arith.constant 255 : index
-// CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[C8192]], %[[C255]] : index
-// CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
-// CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
-// CHECK-NEXT: %[[OFF:.+]] = arith.constant 0 : index
-// CHECK-NEXT: %[[POOL:.+]] = hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
-// CHECK-NEXT: %[[V0:.+]] = memref.view %[[POOL]][%[[OFF]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} :{{.*}}) outs(%[[V0]] :{{.*}})
-// CHECK-NOT: arith.maxui
+// A mask element gets a whole byte, so 4x256 reserves 1024 rather than the 0 a
+// truncating bit-width-over-eight would give it.
+// CHECK-LABEL:   func.func @sub_byte_element(
+// CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[ARG1:.*]]: memref<4x256xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:           hipsr.pool_domain(%[[ARG0]], %[[ARG1]] : !hipsr.context, memref<4x256xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:           ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: memref<4x256xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:             %[[CONSTANT_0:.*]] = arith.constant 1024 : index
+// CHECK-NEXT:             %[[CONSTANT_1:.*]] = arith.constant 256 : index
+// CHECK-NEXT:             %[[CONSTANT_2:.*]] = arith.constant 255 : index
+// CHECK-NEXT:             %[[ADDI_0:.*]] = arith.addi %[[CONSTANT_0]], %[[CONSTANT_2]] : index
+// CHECK-NEXT:             %[[DIVUI_0:.*]] = arith.divui %[[ADDI_0]], %[[CONSTANT_1]] : index
+// CHECK-NEXT:             %[[MULI_0:.*]] = arith.muli %[[DIVUI_0]], %[[CONSTANT_1]] : index
+// CHECK-NEXT:             %[[CONSTANT_3:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[GET_POOL_0:.*]] = hipsr.get_pool(%[[VAL_0]], %[[MULI_0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[VIEW_0:.*]] = memref.view %[[GET_POOL_0]]{{\[}}%[[CONSTANT_3]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x256xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.equal(%[[VAL_0]]) ins(%[[VAL_1]], %[[VAL_1]] : memref<4x256xf16, #hipsr.mem<device>>, memref<4x256xf16, #hipsr.mem<device>>) outs(%[[VIEW_0]] : memref<4x256xi1, #hipsr.mem<device>>)
+// CHECK-NEXT:           } {domain_id = 0 : i64}
+// CHECK-NEXT:           return
+// CHECK-NEXT:         }
+func.func @sub_byte_element(%ctx: !hipsr.context,
+                            %in: memref<4x256xf16, #hipsr.mem<device>>) {
+  hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x256xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context, %din: memref<4x256xf16, #hipsr.mem<device>>):
+    %a1 = memref.alloc() : memref<4x256xi1, #hipsr.mem<device>>
+    hipsr.equal(%dctx) ins(%din, %din : memref<4x256xf16, #hipsr.mem<device>>, memref<4x256xf16, #hipsr.mem<device>>)
+                 outs(%a1 : memref<4x256xi1, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  } {domain_id = 0 : i64}
+  return
+}
+
+// -----
+
+// An allocation nothing reads keeps its memref.alloc. Only the live one is
+// sized into the pool, so the reserved bytes cover one buffer rather than two.
+// CHECK-LABEL:   func.func @dead_alloc_skipped(
+// CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[ARG1:.*]]: memref<4x1024xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:           hipsr.pool_domain(%[[ARG0]], %[[ARG1]] : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:           ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: memref<4x1024xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:             %[[ALLOC_0:.*]] = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[CONSTANT_0:.*]] = arith.constant 8192 : index
+// CHECK-NEXT:             %[[CONSTANT_1:.*]] = arith.constant 256 : index
+// CHECK-NEXT:             %[[CONSTANT_2:.*]] = arith.constant 255 : index
+// CHECK-NEXT:             %[[ADDI_0:.*]] = arith.addi %[[CONSTANT_0]], %[[CONSTANT_2]] : index
+// CHECK-NEXT:             %[[DIVUI_0:.*]] = arith.divui %[[ADDI_0]], %[[CONSTANT_1]] : index
+// CHECK-NEXT:             %[[MULI_0:.*]] = arith.muli %[[DIVUI_0]], %[[CONSTANT_1]] : index
+// CHECK-NEXT:             %[[CONSTANT_3:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[GET_POOL_0:.*]] = hipsr.get_pool(%[[VAL_0]], %[[MULI_0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[VIEW_0:.*]] = memref.view %[[GET_POOL_0]]{{\[}}%[[CONSTANT_3]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.add(%[[VAL_0]]) ins(%[[VAL_1]], %[[VAL_1]] : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%[[VIEW_0]] : memref<4x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT:           } {domain_id = 0 : i64}
+// CHECK-NEXT:           return
+// CHECK-NEXT:         }
 func.func @dead_alloc_skipped(%ctx: !hipsr.context,
                               %in: memref<4x1024xf16, #hipsr.mem<device>>) {
   hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
@@ -58,24 +110,34 @@ func.func @dead_alloc_skipped(%ctx: !hipsr.context,
 
 // -----
 
-// CHECK-LABEL: func.func @mixed_dtypes
-// CHECK: %[[DIM:.+]] = memref.dim %{{.+}}, %{{.+}} : memref<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[C4096:.+]] = arith.constant 4096 : index
-// CHECK-NEXT: %[[C1024:.+]] = arith.constant 1024 : index
-// CHECK-NEXT: %[[BYTES:.+]] = arith.muli %[[C1024]], %[[DIM]] : index
-// CHECK-NEXT: %[[MAX:.+]] = arith.maxui %[[C4096]], %[[BYTES]] : index
-// CHECK-NEXT: %[[C256:.+]] = arith.constant 256 : index
-// CHECK-NEXT: %[[C255:.+]] = arith.constant 255 : index
-// CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[MAX]], %[[C255]] : index
-// CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
-// CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
-// CHECK-NEXT: %[[OFF:.+]] = arith.constant 0 : index
-// CHECK-NEXT: %[[POOL:.+]] = hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
-// CHECK-NEXT: %[[V0:.+]] = memref.view %[[POOL]][%[[OFF]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x256xf32, #hipsr.mem<device>>
-// CHECK-NEXT: %[[V1:.+]] = memref.view %[[POOL]][%[[OFF]]][%[[DIM]]] : memref<?xi8, #hipsr.mem<device>> to memref<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} :{{.*}}) outs(%[[V0]] :{{.*}})
-// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} :{{.*}}) outs(%[[V1]] :{{.*}})
-// CHECK-NOT: memref.alloc
+// Buffers of different element types share one pool, so its size is the larger
+// of a static f32 buffer and a dynamic f16 one.
+// CHECK-LABEL:   func.func @mixed_dtypes(
+// CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[ARG1:.*]]: memref<4x256xf32, #hipsr.mem<device>>,
+// CHECK-SAME:      %[[ARG2:.*]]: memref<?x512xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:           hipsr.pool_domain(%[[ARG0]], %[[ARG1]], %[[ARG2]] : !hipsr.context, memref<4x256xf32, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:           ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: memref<4x256xf32, #hipsr.mem<device>>, %[[VAL_2:.*]]: memref<?x512xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:             %[[CONSTANT_0:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[DIM_0:.*]] = memref.dim %[[VAL_2]], %[[CONSTANT_0]] : memref<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[CONSTANT_1:.*]] = arith.constant 4096 : index
+// CHECK-NEXT:             %[[CONSTANT_2:.*]] = arith.constant 1024 : index
+// CHECK-NEXT:             %[[MULI_0:.*]] = arith.muli %[[CONSTANT_2]], %[[DIM_0]] : index
+// CHECK-NEXT:             %[[MAXUI_0:.*]] = arith.maxui %[[CONSTANT_1]], %[[MULI_0]] : index
+// CHECK-NEXT:             %[[CONSTANT_3:.*]] = arith.constant 256 : index
+// CHECK-NEXT:             %[[CONSTANT_4:.*]] = arith.constant 255 : index
+// CHECK-NEXT:             %[[ADDI_0:.*]] = arith.addi %[[MAXUI_0]], %[[CONSTANT_4]] : index
+// CHECK-NEXT:             %[[DIVUI_0:.*]] = arith.divui %[[ADDI_0]], %[[CONSTANT_3]] : index
+// CHECK-NEXT:             %[[MULI_1:.*]] = arith.muli %[[DIVUI_0]], %[[CONSTANT_3]] : index
+// CHECK-NEXT:             %[[CONSTANT_5:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[GET_POOL_0:.*]] = hipsr.get_pool(%[[VAL_0]], %[[MULI_1]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[VIEW_0:.*]] = memref.view %[[GET_POOL_0]]{{\[}}%[[CONSTANT_5]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x256xf32, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[VIEW_1:.*]] = memref.view %[[GET_POOL_0]]{{\[}}%[[CONSTANT_5]]]{{\[}}%[[DIM_0]]] : memref<?xi8, #hipsr.mem<device>> to memref<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.add(%[[VAL_0]]) ins(%[[VAL_1]], %[[VAL_1]] : memref<4x256xf32, #hipsr.mem<device>>, memref<4x256xf32, #hipsr.mem<device>>) outs(%[[VIEW_0]] : memref<4x256xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:             hipsr.add(%[[VAL_0]]) ins(%[[VAL_2]], %[[VAL_2]] : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>) outs(%[[VIEW_1]] : memref<?x512xf16, #hipsr.mem<device>>)
+// CHECK-NEXT:           } {domain_id = 0 : i64}
+// CHECK-NEXT:           return
+// CHECK-NEXT:         }
 func.func @mixed_dtypes(%ctx: !hipsr.context,
                         %inf32: memref<4x256xf32, #hipsr.mem<device>>,
                         %inf16: memref<?x512xf16, #hipsr.mem<device>>) {
@@ -101,25 +163,38 @@ func.func @mixed_dtypes(%ctx: !hipsr.context,
 
 // -----
 
-// CHECK-LABEL: func.func @mixed_dynamic_dims
-// CHECK: %[[DIM0:.+]] = memref.dim %{{.+}}, %{{.+}} : memref<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[DIM1:.+]] = memref.dim %{{.+}}, %{{.+}} : memref<?x256xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[C1024:.+]] = arith.constant 1024 : index
-// CHECK-NEXT: %[[S0:.+]] = arith.muli %[[C1024]], %[[DIM0]] : index
-// CHECK-NEXT: %[[C512:.+]] = arith.constant 512 : index
-// CHECK-NEXT: %[[S1:.+]] = arith.muli %[[C512]], %[[DIM1]] : index
-// CHECK-NEXT: %[[MAX:.+]] = arith.maxui %[[S0]], %[[S1]] : index
-// CHECK-NEXT: %[[C256:.+]] = arith.constant 256 : index
-// CHECK-NEXT: %[[C255:.+]] = arith.constant 255 : index
-// CHECK-NEXT: %[[NUM:.+]] = arith.addi %[[MAX]], %[[C255]] : index
-// CHECK-NEXT: %[[DIV:.+]] = arith.divui %[[NUM]], %[[C256]] : index
-// CHECK-NEXT: %[[G0:.+]] = arith.muli %[[DIV]], %[[C256]] : index
-// CHECK-NEXT: %[[OFF:.+]] = arith.constant 0 : index
-// CHECK-NEXT: %[[POOL:.+]] = hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
-// CHECK-NEXT: %[[V0:.+]] = memref.view %[[POOL]][%[[OFF]]][%[[DIM0]]] : memref<?xi8, #hipsr.mem<device>> to memref<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[V1:.+]] = memref.view %[[POOL]][%[[OFF]]][%[[DIM1]]] : memref<?xi8, #hipsr.mem<device>> to memref<?x256xf16, #hipsr.mem<device>>
-// CHECK-NOT: arith.maxui
-// CHECK-NOT: memref.alloc
+// Neither size is known at compile time, so the pool takes a runtime max of
+// the two products rather than folding to a constant.
+// CHECK-LABEL:   func.func @mixed_dynamic_dims(
+// CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[ARG1:.*]]: memref<?x512xf16, #hipsr.mem<device>>,
+// CHECK-SAME:      %[[ARG2:.*]]: memref<?x256xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:           hipsr.pool_domain(%[[ARG0]], %[[ARG1]], %[[ARG2]] : !hipsr.context, memref<?x512xf16, #hipsr.mem<device>>, memref<?x256xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:           ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: memref<?x512xf16, #hipsr.mem<device>>, %[[VAL_2:.*]]: memref<?x256xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:             %[[CONSTANT_0:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[DIM_0:.*]] = memref.dim %[[VAL_1]], %[[CONSTANT_0]] : memref<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[DIM_1:.*]] = memref.dim %[[VAL_2]], %[[CONSTANT_0]] : memref<?x256xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[CONSTANT_1:.*]] = arith.constant 1024 : index
+// CHECK-NEXT:             %[[MULI_0:.*]] = arith.muli %[[CONSTANT_1]], %[[DIM_0]] : index
+// CHECK-NEXT:             %[[CONSTANT_2:.*]] = arith.constant 512 : index
+// CHECK-NEXT:             %[[MULI_1:.*]] = arith.muli %[[CONSTANT_2]], %[[DIM_1]] : index
+// CHECK-NEXT:             %[[MAXUI_0:.*]] = arith.maxui %[[MULI_0]], %[[MULI_1]] : index
+// CHECK-NEXT:             %[[CONSTANT_3:.*]] = arith.constant 256 : index
+// CHECK-NEXT:             %[[CONSTANT_4:.*]] = arith.constant 255 : index
+// CHECK-NEXT:             %[[ADDI_0:.*]] = arith.addi %[[MAXUI_0]], %[[CONSTANT_4]] : index
+// CHECK-NEXT:             %[[DIVUI_0:.*]] = arith.divui %[[ADDI_0]], %[[CONSTANT_3]] : index
+// CHECK-NEXT:             %[[MULI_2:.*]] = arith.muli %[[DIVUI_0]], %[[CONSTANT_3]] : index
+// CHECK-NEXT:             %[[CONSTANT_5:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[GET_POOL_0:.*]] = hipsr.get_pool(%[[VAL_0]], %[[MULI_2]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[VIEW_0:.*]] = memref.view %[[GET_POOL_0]]{{\[}}%[[CONSTANT_5]]]{{\[}}%[[DIM_0]]] : memref<?xi8, #hipsr.mem<device>> to memref<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[VIEW_1:.*]] = memref.view %[[GET_POOL_0]]{{\[}}%[[CONSTANT_5]]]{{\[}}%[[DIM_1]]] : memref<?xi8, #hipsr.mem<device>> to memref<?x256xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.add(%[[VAL_0]]) ins(%[[VAL_1]], %[[VAL_1]] : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>) outs(%[[VIEW_0]] : memref<?x512xf16, #hipsr.mem<device>>)
+// CHECK-NEXT:             hipsr.add(%[[VAL_0]]) ins(%[[VIEW_0]], %[[VIEW_0]] : memref<?x512xf16, #hipsr.mem<device>>, memref<?x512xf16, #hipsr.mem<device>>) outs(%[[VAL_1]] : memref<?x512xf16, #hipsr.mem<device>>)
+// CHECK-NEXT:             hipsr.add(%[[VAL_0]]) ins(%[[VAL_2]], %[[VAL_2]] : memref<?x256xf16, #hipsr.mem<device>>, memref<?x256xf16, #hipsr.mem<device>>) outs(%[[VIEW_1]] : memref<?x256xf16, #hipsr.mem<device>>)
+// CHECK-NEXT:             hipsr.add(%[[VAL_0]]) ins(%[[VIEW_1]], %[[VIEW_1]] : memref<?x256xf16, #hipsr.mem<device>>, memref<?x256xf16, #hipsr.mem<device>>) outs(%[[VAL_2]] : memref<?x256xf16, #hipsr.mem<device>>)
+// CHECK-NEXT:           } {domain_id = 0 : i64}
+// CHECK-NEXT:           return
+// CHECK-NEXT:         }
 func.func @mixed_dynamic_dims(%ctx: !hipsr.context,
                               %ina: memref<?x512xf16, #hipsr.mem<device>>,
                               %inb: memref<?x256xf16, #hipsr.mem<device>>) {
@@ -146,18 +221,39 @@ func.func @mixed_dynamic_dims(%ctx: !hipsr.context,
 
 // -----
 
-// CHECK-LABEL: func.func @two_domains
-// CHECK: %[[G0:.+]] = arith.muli %{{.+}}, %{{.+}} : index
-// CHECK-NEXT: %[[OFF0:.+]] = arith.constant 0 : index
-// CHECK-NEXT: %[[POOL0:.+]] = hipsr.get_pool(%{{.+}}, %[[G0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
-// CHECK-NEXT: %[[V0:.+]] = memref.view %[[POOL0]][%[[OFF0]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} :{{.*}}) outs(%[[V0]] :{{.*}})
-// CHECK: %[[G1:.+]] = arith.muli %{{.+}}, %{{.+}} : index
-// CHECK-NEXT: %[[OFF1:.+]] = arith.constant 0 : index
-// CHECK-NEXT: %[[POOL1:.+]] = hipsr.get_pool(%{{.+}}, %[[G1]]) {domain_id = 7 : i64} : memref<?xi8, #hipsr.mem<device>>
-// CHECK-NEXT: %[[V1:.+]] = memref.view %[[POOL1]][%[[OFF1]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.add(%{{.+}}) ins(%{{.+}}, %{{.+}} :{{.*}}) outs(%[[V1]] :{{.*}})
-// CHECK-NOT: memref.alloc
+// Two domains size and fetch their pools separately, each keyed by its own
+// domain_id, so neither reuses the other's bytes.
+// CHECK-LABEL:   func.func @two_domains(
+// CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[ARG1:.*]]: memref<4x1024xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:           hipsr.pool_domain(%[[ARG0]], %[[ARG1]] : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:           ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: memref<4x1024xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:             %[[CONSTANT_0:.*]] = arith.constant 8192 : index
+// CHECK-NEXT:             %[[CONSTANT_1:.*]] = arith.constant 256 : index
+// CHECK-NEXT:             %[[CONSTANT_2:.*]] = arith.constant 255 : index
+// CHECK-NEXT:             %[[ADDI_0:.*]] = arith.addi %[[CONSTANT_0]], %[[CONSTANT_2]] : index
+// CHECK-NEXT:             %[[DIVUI_0:.*]] = arith.divui %[[ADDI_0]], %[[CONSTANT_1]] : index
+// CHECK-NEXT:             %[[MULI_0:.*]] = arith.muli %[[DIVUI_0]], %[[CONSTANT_1]] : index
+// CHECK-NEXT:             %[[CONSTANT_3:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[GET_POOL_0:.*]] = hipsr.get_pool(%[[VAL_0]], %[[MULI_0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[VIEW_0:.*]] = memref.view %[[GET_POOL_0]]{{\[}}%[[CONSTANT_3]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.add(%[[VAL_0]]) ins(%[[VAL_1]], %[[VAL_1]] : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%[[VIEW_0]] : memref<4x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT:           } {domain_id = 0 : i64}
+// CHECK-NEXT:           hipsr.pool_domain(%[[ARG0]], %[[ARG1]] : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:           ^bb0(%[[VAL_2:.*]]: !hipsr.context, %[[VAL_3:.*]]: memref<4x1024xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:             %[[CONSTANT_4:.*]] = arith.constant 8192 : index
+// CHECK-NEXT:             %[[CONSTANT_5:.*]] = arith.constant 256 : index
+// CHECK-NEXT:             %[[CONSTANT_6:.*]] = arith.constant 255 : index
+// CHECK-NEXT:             %[[ADDI_1:.*]] = arith.addi %[[CONSTANT_4]], %[[CONSTANT_6]] : index
+// CHECK-NEXT:             %[[DIVUI_1:.*]] = arith.divui %[[ADDI_1]], %[[CONSTANT_5]] : index
+// CHECK-NEXT:             %[[MULI_1:.*]] = arith.muli %[[DIVUI_1]], %[[CONSTANT_5]] : index
+// CHECK-NEXT:             %[[CONSTANT_7:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[GET_POOL_1:.*]] = hipsr.get_pool(%[[VAL_2]], %[[MULI_1]]) {domain_id = 7 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[VIEW_1:.*]] = memref.view %[[GET_POOL_1]]{{\[}}%[[CONSTANT_7]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.add(%[[VAL_2]]) ins(%[[VAL_3]], %[[VAL_3]] : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%[[VIEW_1]] : memref<4x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT:           } {domain_id = 7 : i64}
+// CHECK-NEXT:           return
+// CHECK-NEXT:         }
 func.func @two_domains(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr.mem<device>>) {
   hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
   ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):

--- a/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/equal.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/equal.mlir
@@ -9,12 +9,12 @@
 // CHECK-SAME: %[[CTX:.+]]: !hipsr.context,
 // CHECK-SAME: %[[LHS:.+]]: tensor<?x1024xi64, #hipsr.mem<device>>,
 // CHECK-SAME: %[[RHS:.+]]: tensor<1024xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[LHS]], %[[RHS]] : tensor<?x1024xi64, #hipsr.mem<device>>, tensor<1024xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x1024xui8, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[LHS]], %[[RHS]] : tensor<?x1024xi64, #hipsr.mem<device>>, tensor<1024xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x1024xi1, #hipsr.mem<device>> shape_region {
 // CHECK-NEXT: ^bb0(%[[LHS_SHAPE:.+]]: !shape.shape, %[[RHS_SHAPE:.+]]: !shape.shape):
 // CHECK-NEXT: %[[BROADCAST:.+]] = shape.broadcast %[[LHS_SHAPE]], %[[RHS_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
 // CHECK-NEXT: hipsr.shape_yield %[[BROADCAST]] : !shape.shape
 // CHECK-NEXT: }
-// CHECK-NEXT: %[[RESULT:.+]] = hipsr.equal(%[[CTX]]) ins(%[[LHS]], %[[RHS]] : tensor<?x1024xi64, #hipsr.mem<device>>, tensor<1024xi64, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x1024xui8, #hipsr.mem<device>>) : tensor<?x1024xui8, #hipsr.mem<device>>
+// CHECK-NEXT: %[[RESULT:.+]] = hipsr.equal(%[[CTX]]) ins(%[[LHS]], %[[RHS]] : tensor<?x1024xi64, #hipsr.mem<device>>, tensor<1024xi64, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x1024xi1, #hipsr.mem<device>>) : tensor<?x1024xi1, #hipsr.mem<device>>
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 func.func @equal_normal(
@@ -23,9 +23,9 @@ func.func @equal_normal(
   %init = hipsr.placeholder(%ctx)
       ins(%lhs, %rhs : tensor<?x1024xi64, #hipsr.mem<device>>, tensor<1024xi64, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<normal>}
-      : tensor<?x1024xui8, #hipsr.mem<device>>
+      : tensor<?x1024xi1, #hipsr.mem<device>>
   %result = hipsr.equal(%ctx)
       ins(%lhs, %rhs : tensor<?x1024xi64, #hipsr.mem<device>>, tensor<1024xi64, #hipsr.mem<device>>)
-      outs(%init : tensor<?x1024xui8, #hipsr.mem<device>>) : tensor<?x1024xui8, #hipsr.mem<device>>
+      outs(%init : tensor<?x1024xi1, #hipsr.mem<device>>) : tensor<?x1024xi1, #hipsr.mem<device>>
   return
 }

--- a/test/lit/Inputs/make_external_data.py
+++ b/test/lit/Inputs/make_external_data.py
@@ -1,0 +1,38 @@
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+"""Create a placeholder weight file of an exact byte size.
+
+A test naming an external byte range needs a file the conversion can memory
+map, but not the weights themselves: the compiler records the path and offset
+and never reads the bytes. So the file is only given a length, and its contents
+are left undefined. Systems that support sparse files back it with no blocks at
+all; the rest allocate without writing, which is still near-instant.
+
+Creating the directory and skipping an already-correct file keeps the caller to
+one command, with no shell utilities to be portable about.
+
+Usage: make_external_data.py <path> <size-in-bytes>
+"""
+
+import os
+import sys
+
+
+def main(argv):
+    if len(argv) != 3:
+        sys.exit(f"usage: {argv[0]} <path> <size-in-bytes>")
+    path, size = argv[1], int(argv[2])
+
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    if os.path.exists(path) and os.path.getsize(path) == size:
+        return
+
+    with open(path, "wb") as f:
+        f.truncate(size)
+
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
## Summary

`hipsr.equal` produced a `ui8` mask while `onnx.Equal` declares an `i1` one. It
now yields `i1`, which removes the type divergence rather than working around
it.

Stacked on #866; the diff is a single commit once that merges.

## Why

`Onnx_EqualOp` declares its result `TensorOf<[I1]>`, yet `EqualConversion`
discarded that and built the mask as `ui8`, and `EqualOp::verify` required it.

Nothing downstream needed the byte: `hipsr.nonzero` accepts any integer,
`hipsr.expand` only requires input and output to agree, `hipsr.cast` has no
verifier, and the equal lowering passes the **operand** type as its `data_type`.

The divergence had one real cost, and it is why the previous revision of this PR
existed: `ExpandConversion` compared its operand against the declared ONNX
result, saw `ui8` against `i1`, and rejected a mask it could otherwise
broadcast. Retyping the producer removes the mismatch at its source, so the
tolerance previously added to Expand is reverted.

## What

`EqualConversion` builds an `i1` mask, `EqualOp::verify` requires `i1`, and the
ODS description says so. The mask stays `i1` from conversion through NonZero.

Two latent assumptions that a mask occupies a whole byte had to be fixed first:

| Site | Was | Now |
|---|---|---|
| `HipsrPoolAllocPass::staticByteFactor` | `bitWidth / 8`, so `i1` reserved **0 bytes** | rounds up, matching `MemoryLowering` |
| `getHipdnnDataType` | no `i1` case, returned `-1` | `i1` shares the unsigned-byte slot with `ui8` |

Three things ride along:

- Every LIT test this touches now checks its full output.
- The pipeline test loses a hand-edit, so the embedding table keeps the
  external-data form the importer actually emits rather than a form it never
  produces. `test/lit/Inputs/make_external_data.py` materializes the sidecar the
  constant names; only its length matters, since the conversion records the path
  and offset and never reads the weights.
- From review, the runtime data type identifiers move to
  `include/hip/datatype_abi.h`, included by both the runtime header and the
  compiler mappings, instead of being repeated as bare integers. No value
  changed.

## Notes for reviewers

`staticByteFactor` deserves the closest look. It is one line, but it is the
difference between a correctly sized mask buffer and a zero-sized one, and the
failure mode is memory corruption at run time rather than a test failure.
`i4`/`u4` also previously sized to 0 here and now size to one byte per element,
which over-allocates against true bit packing; no hipsr pass or test uses those
types today, and 0 was unusable either way.

The `hipsr-to-llvm` tests now pin upstream's memref-descriptor prologue, so a
change to how upstream builds descriptors means regenerating them.

AI assistance: the dialect and pass changes, the LIT assertions and their test
helper, and this description were drafted with Cursor and Claude Opus 5, then
validated by the full LIT suite (454 passed, 12 unsupported, 0 failed) and by
`pre-commit run --files <changed files>`.
