### PR TITLE
feat(wheel): bundle the ROCm runtime into the EP wheel

### DIFF
--- a/.github/workflows/windows-gpu-test.yml
+++ b/.github/workflows/windows-gpu-test.yml
@@ -348,13 +348,6 @@ jobs:
           }
           exit $failed
 
-      # -----------------------------------------------------------------------
-      # OGA wheel smoke: install the project wheels from the morphizen-python-
-      # package artifact + ROCm wheels from repo.amd.com, then run OGA's
-      # benchmark_e2e.py against a real model.
-      # -----------------------------------------------------------------------
-      # The cp314 ORT/OGA wheels need Python 3.14 to create the smoke venv (the
-      # runner's default python may be a different version).
       - name: Setup Python 3.14 (wheel smoke)
         if: always()
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
@@ -382,21 +375,15 @@ jobs:
           python -m venv $venv
           $py = "$venv\Scripts\python.exe"
 
-          # Install project wheels from local dir + ROCm wheels from repo.amd.com.
           Push-Location "$pkg\wheels"
           & $py -m pip install --quiet `
             (Get-Item onnxruntime_directml-*.whl).Name `
             (Get-Item onnxruntime_ep_hip-*.whl).Name `
             (Get-Item onnxruntime_genai_directml-*.whl).Name `
-            --extra-index-url https://repo.amd.com/rocm/whl/gfx1151/ `
             psutil tqdm pandas
           Pop-Location
           if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] wheel install failed"; exit 1 }
-          & "$venv\Scripts\rocm-sdk.exe" init   # expand rocm[devel] import libs
-          if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] rocm-sdk init failed"; exit 1 }
 
-          # run_onnx.py --benchmark sets up env (THEROCK_DIST/LIB/PATH) from the
-          # installed wheels, then delegates to benchmark_e2e.py.
           New-Item -ItemType Directory -Force -Path oga-smoke-results | Out-Null
           & $py "$pkg\run_onnx.py" --benchmark "$pkg\benchmark_e2e.py" `
             -i $model -l 128 -g 128 -r 5 -w 1 -b 1 -m -1 -v `

--- a/build.py
+++ b/build.py
@@ -244,9 +244,7 @@ def generate_build_tree(args, build_dir, prefix_paths, hip_arch, mock):
         f"-DCMAKE_INSTALL_PREFIX={args.install_dir}",
         "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
     ]
-    # Build the Python wheel by default for real builds; mock has no ROCm libs
-    # to bundle, and --skip_wheel opts out.
-    if not mock and not args.skip_wheel:
+    if IS_WINDOWS and not mock and not args.skip_wheel:
         cmd.append("-DBUILD_PYTHON_WHEEL=ON")
     if prefix_paths:
         # CMAKE_PREFIX_PATH always uses ';' as the list separator.
@@ -417,7 +415,7 @@ def parse_arguments():
     p.add_argument(
         "--skip_wheel",
         action="store_true",
-        help="do not build the Python wheel (built by default for real builds)",
+        help="do not build the Python wheel (built by default on real Windows builds)",
     )
     p.add_argument(
         "--skip_tests",

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -312,43 +312,36 @@ below. `onnxruntime_perf_test.exe` is staged separately in
 
 If you also want to drive ORT / OGA from Python (e.g. to write your own
 generation script instead of using `model_benchmark.exe`), install the wheels.
-The hipgpu EP wheel is built by default by `build.py` (pass `--skip_wheel` to
-opt out, or build just it with `cmake --build <build> --target wheel`) at
-`../build/hip-ep/python/dist/`.
+The hipgpu EP wheel is built by default by `build.py` on Windows (pass
+`--skip_wheel` to opt out, or build just it with
+`cmake --build <build> --target wheel`) at `../build/hip-ep/python/dist/`.
 
-**Install** -- give ORT / EP / OGA as local `.whl` files (so pip uses your custom
-builds, not the stock PyPI ones), and let `--extra-index-url` resolve ROCm:
+**Install** -- give ORT / EP / OGA as local `.whl` files so pip uses your custom
+builds, not the stock PyPI ones:
 
 ```bash
 cd ../hip-ep  # Back to the project root
 pip install \
   ../build/onnxruntime/Release/dist/onnxruntime_directml-*.whl \
   ../build/hip-ep/python/dist/onnxruntime_ep_hip-*.whl \
-  ../build/onnxruntime-genai/Release/wheel/onnxruntime_genai_directml-*.whl \
-  --extra-index-url https://repo.amd.com/rocm/whl/gfx1151/
+  ../build/onnxruntime-genai/Release/wheel/onnxruntime_genai_directml-*.whl
 ```
 > **Note**: the ORT whl may be under `../build/onnxruntime/Release/Release/dist/`.
-> Replace `gfx1151` with your GPU arch. Install the EP wheel AFTER onnxruntime:
-> it ships its own native files (EP plugin `hipgpu.dll`, which carries the
-> JIT compiler, plus the custom kernels) straight into `onnxruntime/capi/`
-> next to `onnxruntime.dll`. The ROCm
-> runtime DLLs (amdhip64/hipBLASLt) come from the `rocm[devel]` wheel
-> (expanded next). The wheel does NOT bundle the AMD GPU umbrella
-> (`amdgpu-ep.dll` + `hip-backend.dll`); driving OGA through the umbrella needs
-> those supplied separately (CI injects them via `HIP_WHEEL_EXTRA_DLLS`).
+> Install the EP wheel AFTER onnxruntime: it ships its own native files straight
+> into `onnxruntime/capi/`, next to `onnxruntime.dll` -- the EP plugin
+> `hipgpu.dll` (which carries the JIT compiler), the custom kernels, and the
+> ROCm runtime it was built against (amdhip64 + hipBLASLt and their
+> dependencies), so no separate ROCm install is needed. The wheel does NOT
+> bundle the AMD GPU umbrella (`amdgpu-ep.dll` + `hip-backend.dll`); driving OGA
+> through the umbrella needs those supplied separately (CI injects them via
+> `HIP_WHEEL_EXTRA_DLLS`).
 
-**Expand ROCm devel** -- the EP's JIT linker needs the ROCm import libs, which
-`rocm[devel]` ships compressed. Expand them once:
-
-```bash
-rocm-sdk init   # populates site-packages/_rocm_sdk_devel/lib
-```
-
-**Runtime env** -- depends on the artifact mode:
-
-- Default (bitcode): the ROCm runtime DLLs on `PATH`.
-- NATIVE artifact (opt-in): the above plus `THEROCK_DIST` and `LIB`, used by the
-  lld-link step that builds the per-model `.dll`.
+**Runtime env** -- the bundled ROCm DLLs sit next to `hipgpu.dll`, but Windows
+does not search a DLL's own directory for its dependencies, so
+`onnxruntime/capi` has to be on the DLL search path before ORT loads the EP.
+`python/examples/run_onnx.py` does that (and forwards it to the `--benchmark`
+child process). NATIVE artifacts are not supported from a wheel: their lld-link
+step needs the ROCm import libs, which only a `THEROCK_DIST` install has.
 
 **Use** -- there is no Python API to import; the native files are found by
 location. Run a model whose `genai_config.json` selects the EP via
@@ -357,17 +350,13 @@ the CI wheel smoke does (`Run OGA wheel smoke (Python)` in
 `.github/workflows/windows-gpu-test.yml`):
 
 ```bash
-# site-packages root + the colocated capi dir
-SP=$(python -c "import onnxruntime, os; print(os.path.dirname(os.path.dirname(onnxruntime.__file__)))")
-CAPI="$SP/onnxruntime/capi"
-
-# Default (bitcode): the ROCm runtime DLLs + colocated capi on PATH.
-# Replace gfx1151 with your GPU arch.
-export PATH="$CAPI:$SP/_rocm_sdk_core/bin:$SP/_rocm_sdk_libraries_gfx1151/bin:$PATH"
-
-# Run OGA's own end-to-end benchmark from the OGA source cloned in step 3
-python onnxruntime-genai/benchmark/python/benchmark_e2e.py \
+# OGA's own end-to-end benchmark, from the OGA source cloned in step 3
+python python/examples/run_onnx.py \
+  --benchmark onnxruntime-genai/benchmark/python/benchmark_e2e.py \
   -i /path/to/model_dir -l 128 -g 128 -r 5 -w 1 -b 1 -m -1 -v
+
+# Or a plain ONNX model with random inputs
+python python/examples/run_onnx.py /path/to/model.onnx
 ```
 
 `benchmark_e2e.py` runs with the default `-e follow_config`, so the model's
@@ -376,8 +365,8 @@ python onnxruntime-genai/benchmark/python/benchmark_e2e.py \
 (`provider_options [{ "AMDGPU": {"profile": "hip"} }]`), which loads
 `amdgpu-ep.dll` and needs the umbrella DLLs colocated (see
 `.github/workflows/windows-build-real.yml`); the default wheel ships only the hipgpu
-chain. For plain ORT (direct hipgpu, no OGA), register the colocated plugin via
-`ort.register_execution_provider_library("hipgpu", "$CAPI/hipgpu.dll")`.
+chain. For plain ORT (direct hipgpu, no OGA), the model form above registers the
+colocated plugin itself via `ort.register_execution_provider_library`.
 
 ## Testing & Benchmarking
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -3,6 +3,11 @@
 # ** Licensed under the MIT License.
 ##
 
+if(NOT WIN32)
+  message(FATAL_ERROR
+    "BUILD_PYTHON_WHEEL is Windows-only; re-configure without it.")
+endif()
+
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 # Build out-of-source: never write into the source python/ tree. The package is
@@ -15,9 +20,6 @@ set(_stage "${CMAKE_CURRENT_BINARY_DIR}/pkg")
 set(_libs_dir "${_stage}/onnxruntime/capi")
 set(_dist_dir "${CMAKE_CURRENT_BINARY_DIR}/dist")
 
-# GPU arch this wheel targets, for the rocm --extra-index-url hint in
-# pyproject.toml. Take the first if HIP_ARCHITECTURES is a list; fall back to
-# gfx1151 when unset (e.g. mock builds).
 set(MORPHIZEN_HIP_ARCH "${HIP_ARCHITECTURES}")
 if(MORPHIZEN_HIP_ARCH MATCHES ";")
   list(GET MORPHIZEN_HIP_ARCH 0 MORPHIZEN_HIP_ARCH)
@@ -26,7 +28,6 @@ if(NOT MORPHIZEN_HIP_ARCH)
   set(MORPHIZEN_HIP_ARCH "gfx1151")
 endif()
 
-# Inject the project version + target arch into the staged pyproject.toml.
 configure_file(
   "${_pkg_src}/pyproject.toml.in"
   "${_stage}/pyproject.toml"
@@ -46,16 +47,11 @@ endif()
 set(_dll_args "--dll" "$<TARGET_FILE:${_ep_target}>")
 set(_wheel_deps ${_ep_target})
 
-if(WIN32)
-  set(_with_crt "--with-crt")
-else()
-  set(_with_crt "")
+if(NOT THEROCK_DIST)
+  message(FATAL_ERROR
+    "THEROCK_DIST is empty; the wheel cannot bundle the ROCm runtime.")
 endif()
 
-# Bundle the per-arch custom-kernels runtime libraries. The EP dlopens
-# custom_kernels_<arch>.{dll,so} from its own directory at JIT init, so each
-# must ship in onnxruntime/capi next to the EP DLL. ROCm import libs
-# (amdhip64/hipBLASLt) come from the pip rocm[devel] package at runtime.
 foreach(_arch IN LISTS HIP_ARCHITECTURES)
   set(_ck_target custom_kernels_${_arch})
   if(TARGET ${_ck_target})
@@ -97,7 +93,9 @@ add_custom_target(wheel ALL
   COMMAND ${Python3_EXECUTABLE} "${_pkg_src}/_pack_libs.py"
           ${_dll_args}
           --dest "${_libs_dir}"
-          ${_with_crt}
+          --rocm-dist "${THEROCK_DIST}"
+          --rocm-arch "${MORPHIZEN_HIP_ARCH}"
+          --with-crt
   # 3. Build the wheel (PEP 517). Drop setuptools' build cache + egg-info first:
   #    they linger across runs and would re-pack stale (e.g. removed) artifacts.
   #    --no-deps: do not pull deps here.

--- a/python/_pack_libs.py
+++ b/python/_pack_libs.py
@@ -2,14 +2,6 @@
 # Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # Licensed under the MIT License.
 #
-"""Build helper: stage native artifacts into the wheel's onnxruntime/capi.
-
-Invoked by python/CMakeLists.txt's `wheel` target (NOT shipped at runtime).
-Copies the prebuilt native libraries and, on Windows, the MSVC/WinSDK CRT import
-libraries the JIT linker (lld-link) resolves against. The CRT libs are located
-by scanning the `LIB` environment variable, which the VS dev environment / MSVC
-toolset populates with the MSVC and WinSDK lib directories.
-"""
 
 import argparse
 import os
@@ -29,6 +21,15 @@ CRT_LIBS = [
     "kernel32.lib",
     "user32.lib",
 ]
+
+ROCM_DLL_GROUPS = [
+    ["amdhip64*.dll"],
+    ["amd_comgr*.dll"],
+    ["hipblaslt.dll", "libhipblaslt.dll"],
+    ["hiprtc*.dll"],
+]
+
+HIPBLASLT_DATA = ("hipblaslt", "library")
 
 
 def _find_in_lib_env(name: str):
@@ -60,6 +61,42 @@ def _copy_crt_libs(dest: Path) -> int:
     return len(missing)
 
 
+def _copy_rocm_runtime(dist: Path, arch: str, dest: Path) -> int:
+    bin_dir = dist / "bin"
+    if not bin_dir.is_dir():
+        print(f"ERROR: --rocm-dist has no bin/: {dist}", file=sys.stderr)
+        return 1
+
+    for group in ROCM_DLL_GROUPS:
+        hits = sorted({p for pat in group for p in bin_dir.glob(pat) if p.is_file()})
+        if not hits:
+            print(
+                f"ERROR: no ROCm runtime library matching {' / '.join(group)} "
+                f"in {bin_dir}",
+                file=sys.stderr,
+            )
+            return 1
+        for src in hits:
+            shutil.copy2(src, dest / src.name)
+            print(f"  packaged ROCm dll: {src.name} <- {src}")
+
+    src_data = bin_dir.joinpath(*HIPBLASLT_DATA, arch)
+    if not src_data.is_dir():
+        print(
+            f"ERROR: hipBLASLt Tensile data for {arch} not found: {src_data}",
+            file=sys.stderr,
+        )
+        return 1
+    dst_data = dest.joinpath(*HIPBLASLT_DATA, arch)
+    shutil.copytree(src_data, dst_data)
+    count = sum(1 for p in dst_data.rglob("*") if p.is_file())
+    print(
+        f"  packaged hipBLASLt Tensile data: {'/'.join(HIPBLASLT_DATA)}/{arch} "
+        f"({count} files) <- {src_data}"
+    )
+    return 0
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument(
@@ -72,6 +109,20 @@ def main():
     )
     ap.add_argument(
         "--dest", required=True, help="Destination dir (the wheel's onnxruntime/capi)."
+    )
+    ap.add_argument(
+        "--rocm-dist",
+        required=True,
+        metavar="PATH",
+        help="TheRock ROCm SDK the EP was built against (THEROCK_DIST). Its "
+        "runtime libraries are bundled so the wheel needs no ROCm install.",
+    )
+    ap.add_argument(
+        "--rocm-arch",
+        required=True,
+        metavar="GFX",
+        help="GPU arch whose hipBLASLt Tensile data to bundle, e.g. gfx1151. A "
+        "multi-arch distribution carries every arch; the wheel ships one.",
     )
     ap.add_argument(
         "--extra-lib",
@@ -123,6 +174,10 @@ def main():
             print(f"  packaged optional dll: {lib.name} <- {lib}")
         else:
             print(f"  WARNING: optional dll not found (skipping): {lib}")
+
+    rc = _copy_rocm_runtime(Path(args.rocm_dist), args.rocm_arch, dest)
+    if rc:
+        return rc
 
     if args.with_crt:
         _copy_crt_libs(dest)

--- a/python/examples/run_onnx.py
+++ b/python/examples/run_onnx.py
@@ -4,21 +4,19 @@
 #
 """Run an ONNX model or OGA benchmark on the MorphiZen EP.
 
-Sets up the JIT-link / runtime-DLL environment (THEROCK_DIST / LIB / DLL dirs)
-from the installed wheels, then either:
+Sets up the DLL search path and the JIT linker's LIB from the installed wheels,
+then either:
   - Runs a plain ONNX model with random inputs (default), or
   - Delegates to benchmark_e2e.py for OGA benchmarks (--benchmark).
 
-Prerequisites (see docs/python_package_guide.md):
+Prerequisites (see docs/quick_start.md):
   - pip install the onnxruntime + onnxruntime_ep_hip wheels
-  - rocm-sdk init        (expands rocm[devel] import libs)
 
 Usage:
   python run_onnx.py path/to/model.onnx
   python run_onnx.py --benchmark benchmark_e2e.py -i model_dir [args...]
 """
 
-import glob
 import os
 import subprocess
 import sys
@@ -44,17 +42,9 @@ def _setup_env():
     sp = os.path.dirname(os.path.dirname(ort.__file__))
     capi = os.path.join(sp, "onnxruntime", "capi")
 
-    os.environ["THEROCK_DIST"] = os.path.join(sp, "_rocm_sdk_devel")
     os.environ["LIB"] = os.pathsep.join(filter(None, [capi, os.environ.get("LIB", "")]))
-
-    dll_dirs = [
-        d
-        for d in [capi, *glob.glob(os.path.join(sp, "_rocm_sdk_*", "bin"))]
-        if os.path.isdir(d)
-    ]
-    os.environ["PATH"] = os.pathsep.join([*dll_dirs, os.environ.get("PATH", "")])
-    for d in dll_dirs:
-        os.add_dll_directory(d)
+    os.environ["PATH"] = os.pathsep.join([capi, os.environ.get("PATH", "")])
+    os.add_dll_directory(capi)
     return capi
 
 

--- a/python/onnxruntime_ep_hip/__init__.py
+++ b/python/onnxruntime_ep_hip/__init__.py
@@ -2,22 +2,3 @@
 # Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # Licensed under the MIT License.
 #
-"""hipgpu Execution Provider for ONNX Runtime -- packaging marker.
-
-This distribution carries no Python API and no payload in this package. Its
-native artifacts (the EP plugin ``hipgpu.dll``, which carries the hip-compiler
-JIT inside it, the per-arch custom-kernels, and the AMD GPU umbrella chain
-``amdgpu-ep.dll`` + ``hip-backend.dll``) are installed directly into
-``onnxruntime/capi/`` -- next to ``onnxruntime.dll`` -- by the wheel. The ROCm
-import libraries come from ``rocm[devel]``.
-
-Install this wheel AFTER ``onnxruntime`` so ``onnxruntime/capi/`` exists. Then:
-
-- ONNX Runtime GenAI (OGA) discovers and registers the EP automatically (it
-  searches next to ``onnxruntime.dll``).
-- ONNX Runtime: register the colocated plugin, e.g.
-  ``ort.register_execution_provider_library("hipgpu",
-  <onnxruntime capi>/hipgpu.dll)``.
-
-ROCm runtime DLLs must be on ``PATH`` (e.g. from ``rocm[libraries]``).
-"""

--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -15,19 +15,7 @@ description = "hipgpu Execution Provider for ONNX Runtime (AMD GPU via HIP/ROCm)
 requires-python = ">=3.8"
 license = { text = "MIT" }
 authors = [{ name = "Advanced Micro Devices, Inc." }]
-dependencies = [
-    # ROCm runtime (TheRock). Not on PyPI -- supply at install time via
-    # `--extra-index-url https://repo.amd.com/rocm/whl/@MORPHIZEN_HIP_ARCH@/`
-    # (@MORPHIZEN_HIP_ARCH@ = the GPU arch this wheel was built for). Pinned to
-    # the exact TheRock version the EP is built against to avoid runtime/JIT
-    # import ABI skew.
-    "rocm[libraries,devel]==7.11.0",
-]
-# NOTE: a custom ONNX Runtime build (the plugin-EP-patched onnxruntime-directml)
-# is required at runtime, but it is NOT declared as a dependency: this wheel
-# ships its native files into onnxruntime/capi (platlib), so onnxruntime must
-# already be installed (install this wheel AFTER it). Declaring it would also
-# risk pip pulling the stock PyPI build over the custom one.
+dependencies = []
 
 [tool.setuptools]
 # The EP's native artifacts ship directly under onnxruntime/capi/ (platlib),
@@ -42,4 +30,4 @@ include = ["onnxruntime_ep_hip", "onnxruntime.capi"]
 namespaces = true
 
 [tool.setuptools.package-data]
-"onnxruntime.capi" = ["*.dll", "*.lib", "*.dll.a", "*.so"]
+"onnxruntime.capi" = ["*.dll", "*.lib", "*.dll.a", "*.so", "hipblaslt/library/*/*"]


### PR DESCRIPTION
## Summary

The EP wheel now ships the ROCm runtime it was built against, so installing it is a single `pip install` with no extra index, no `rocm[libraries,devel]` package, and no `rocm-sdk init` step. Measured 97.6 MB compressed / 260 MB unpacked on gfx1151.

Before: `pip install ... --extra-index-url https://repo.amd.com/rocm/whl/gfx1151/` then `rocm-sdk init` then run. After: `pip install onnxruntime_ep_hip-*.whl` then run.

## Related issue or design

None.

## Why

The pinned `rocm[libraries,devel]==7.11.0` dependency had to be kept in sync by hand with `cmake/deps.txt`'s `therock-dist-windows-gfx1151-7.14.0`, and the two were already out of step. Bundling from `THEROCK_DIST` makes the wheel carry the exact ROCm build the EP was compiled against, so that skew cannot happen. It also removes two setup steps that only exist because the runtime came from elsewhere.

Bundling fits in the size budget now that the EP no longer loads MIOpen or rocBLAS (#861): shipping those two plus their kernel data would have added ~107 MB of payload the EP never touches, which is what previously put this over the PyPI limit.

## What

`_pack_libs.py` gains `--rocm-dist` / `--rocm-arch` and copies `amdhip64*`, `amd_comgr*`, `hipblaslt`, `hiprtc*`, plus the target arch's `hipblaslt/library/<arch>/` Tensile data from `<dist>/bin` into `onnxruntime/capi`. The whitelist is a list of glob groups because TheRock version-suffixes some libraries (`amd_comgr0714.dll`) and names hipBLASLt differently across distributions. A missing library aborts the build rather than warning, unlike the GPU-test staging step: a wheel shipped without `amdhip64` only fails once it reaches a user.

`python/CMakeLists.txt` passes `THEROCK_DIST` and the target arch through, and fails the configure if `THEROCK_DIST` is empty.

`pyproject.toml.in` drops the `rocm[libraries,devel]` dependency and adds the Tensile data to `package-data` (hipBLASLt resolves that tree relative to its own DLL, so it has to stay a subdirectory of `capi`).

`run_onnx.py`'s `_setup_env()` drops the `_rocm_sdk_*` globbing and the `THEROCK_DIST` export and just puts `onnxruntime/capi` on `PATH` and `add_dll_directory`.

The ROCm whitelist is Windows-only, so the wheel is now gated on Windows: `build.py` stops enabling `BUILD_PYTHON_WHEEL` elsewhere and `python/CMakeLists.txt` rejects a forced non-Windows configure. No Linux EP wheel has ever been published, and Linux CI does not consume one (it stages only the ORT and OGA wheels), so no workflow change is needed.

## Test plan

Built on gfx1151 against the pinned `therock-dist-windows-gfx1151-7.14.0`.

- [x] Wheel contents: `amd_comgr0714.dll`, `amdhip64_7.dll`, `hipblaslt.dll`, `hiprtc0714.dll`, `hiprtc-builtins0714.dll`, and 100 Tensile files under `onnxruntime/capi/hipblaslt/library/gfx1151/`. No `MIOpen*`, no `rocblas*`, no ROCm `.lib`.
- [x] Size: 97.6 MB compressed (102,316,572 B), under the 100 MiB PyPI single-file limit.
- [x] Clean venv, ORT 1.27.0 + this wheel, no extra index: `pip show onnxruntime-ep-hip` reports an empty `Requires`, and site-packages has no `_rocm_sdk_*` directory.
- [x] `run_onnx.py --benchmark benchmark_e2e.py -i Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml`: green through the AMDGPU umbrella, TTFT 221 ms, 36.8 tps.
- [x] `run_onnx.py <model.onnx>` on MatMul and two Conv models: green, confirming Conv still reaches the custom-kernel path without MIOpen.
- [x] `memory_maps` confirms `hipgpu.dll`, `custom_kernels_gfx1151.dll`, `hipblaslt.dll` and the Tensile data all load out of `onnxruntime/capi` (see the note below on `amdhip64`).
- [x] `_pack_libs.py` aborts with a clear message and exit 1 when the dist has no `bin/`, when a whitelist group matches nothing, and when the requested arch has no Tensile data.
- [x] `pre-commit run --all-files`: passed, no files modified.

## Notes for reviewers

`amdhip64` and `amd_comgr` are bundled but do not win the load on a machine with an AMD driver installed. Windows searches System32 before `PATH` and `add_dll_directory`, and the driver installs `amdhip64_7.dll` into System32 and `amd_comgr_3.dll` into DriverStore, so those are what actually map into the process. `hipblaslt` (which the driver does not ship) does load from the wheel. Removing the two from the installed `capi` and re-running leaves every test above green, so on a driver-equipped machine they are ~129 MB of unpacked fallback that only matters where System32 has no HIP runtime.

Trimming them would shrink the wheel substantially and take the pressure off the PyPI limit, but that is a separate question about which machines we intend to support, so this PR keeps the bundle complete. Worth a follow-up probe.

The 8 MSVC/WinSDK CRT import libs are unchanged. They serve only the opt-in NATIVE artifact path, same as the ROCm import libs this PR deliberately does not bundle, so they are arguably removable too -- but that is pre-existing behaviour and out of scope here.
