### PR TITLE
feat(ep): negotiate the ORT API version at plugin load (cherry-pick of #875)

### DIFF
--- a/morphizen/ort-bridge/ort-bridge.cmake
+++ b/morphizen/ort-bridge/ort-bridge.cmake
@@ -4,6 +4,8 @@
 ##
 set(_ORT_BRIDGE_SOURCES
   src/ort-bridge.cpp
+  src/ort-api-version.hpp
+  src/ort-api-version.cpp
   src/api-ptrs.hpp
   src/api-ptrs.cpp
   src/ort-status-exception.hpp

--- a/morphizen/ort-bridge/src/morphizen-ep-factory.cpp
+++ b/morphizen/ort-bridge/src/morphizen-ep-factory.cpp
@@ -6,6 +6,7 @@
 
 #include "./morphizen-ep-factory.hpp"
 #include "./morphizen-ep.hpp"
+#include "./ort-api-version.hpp"
 #include "morphizen-utils/morphizen-utils.hpp"
 #include "morphizen-utils/morphizen_plugin.hpp"
 #include "morphizen/onnxruntime_morphizen_ep.hpp"
@@ -51,8 +52,7 @@ MorphiZenEpFactory::MorphiZenEpFactory(const char *ep_name, ApiPtrs apis,
       ApiPtrs(apis), default_logger_{default_logger}, ep_name_{ep_name},
       ep_metadata_{nullptr, apis.ort_api.ReleaseKeyValuePairs},
       ep_options_{nullptr, apis.ort_api.ReleaseKeyValuePairs} {
-  ort_version_supported =
-      ORT_API_VERSION; // set to the ORT version we were compiled with.
+  ort_version_supported = NegotiatedOrtApiVersion();
   GetName = GetNameImpl;
   GetVendor = GetVendorImpl;
   GetVendorId = GetVendorIdImpl;

--- a/morphizen/ort-bridge/src/morphizen-ep.cpp
+++ b/morphizen/ort-bridge/src/morphizen-ep.cpp
@@ -5,6 +5,7 @@
 #include "./morphizen-ep.hpp"
 #include "./ir-converter.hpp"
 #include "./morphizen-deps.hpp"
+#include "./ort-api-version.hpp"
 #include "./ort-graph-wrapper.hpp"
 #include "glog/logging.h"
 #include "morphizen-utils/morphizen-utils.hpp"
@@ -79,8 +80,7 @@ MorphiZenEP::MorphiZenEP(ApiPtrs apis, const std::string &name,
       session_options, "ep.context_enable", "0", ep_context_enable));
   enable_ep_context_ = ep_context_enable == "1";
 
-  OrtEp::ort_version_supported =
-      ORT_API_VERSION; // set to the ORT version we were compiled with.
+  OrtEp::ort_version_supported = NegotiatedOrtApiVersion();
   OrtEp::GetName = GetNameImpl;
   OrtEp::GetCapability = GetCapabilityImpl;
   OrtEp::Compile = CompileImpl;
@@ -377,7 +377,7 @@ MorphiZenEP::GetCapability(OrtGraphWrapper &graph_viewer,
   }
   // iterator over the execution providers and set the graph support info
   OrtNodeFusionOptions node_fusion_options = {};
-  node_fusion_options.ort_version_supported = ORT_API_VERSION;
+  node_fusion_options.ort_version_supported = NegotiatedOrtApiVersion();
   node_fusion_options.drop_constant_initializers = true;
   auto supported_node_groups = std::vector<std::vector<const OrtNode *>>();
   for (auto &ep : **execution_providers_) {
@@ -518,7 +518,8 @@ OrtStatus *MorphiZenEP::CompileSubgraph(const morphizen::ExecutionProvider &ep,
     }
     auto morphizen_node_compute_info = new MorphiZenEP_ComputeInfo();
     node_compute_info = morphizen_node_compute_info;
-    morphizen_node_compute_info->ort_version_supported = ORT_API_VERSION;
+    morphizen_node_compute_info->ort_version_supported =
+        NegotiatedOrtApiVersion();
     morphizen_node_compute_info->morphizen_ep =
         const_cast<morphizen::ExecutionProvider *>(&ep);
     morphizen_node_compute_info->CreateState =

--- a/morphizen/ort-bridge/src/morphizen-hip-gpu-allocator.cpp
+++ b/morphizen/ort-bridge/src/morphizen-hip-gpu-allocator.cpp
@@ -10,6 +10,7 @@
 
 #include "./morphizen-hip-gpu-allocator.hpp"
 
+#include "./ort-api-version.hpp"
 #include <glog/logging.h>
 #include <hip/hip_runtime.h>
 
@@ -98,7 +99,7 @@ int TryGetDeviceId(const OrtMemoryInfo *memory_info) noexcept {
 HipGpuAllocator::HipGpuAllocator(const OrtMemoryInfo *memory_info,
                                  const OrtApi & /*api*/)
     : memory_info_{memory_info}, device_id_{TryGetDeviceId(memory_info)} {
-  version = ORT_API_VERSION;
+  version = NegotiatedOrtApiVersion();
   Alloc = AllocImpl;
   Free = FreeImpl;
   Info = InfoImpl;
@@ -234,7 +235,7 @@ void *ORT_API_CALL HipGpuAllocator::ReserveImpl(OrtAllocator *this_,
 
 HipDataTransferImpl::HipDataTransferImpl(const OrtApi &ort_api_in)
     : ort_api{ort_api_in}, ep_api{*ort_api_in.GetEpApi()} {
-  ort_version_supported = ORT_API_VERSION;
+  ort_version_supported = NegotiatedOrtApiVersion();
   CanCopy = CanCopyImpl;
   CopyTensors = CopyTensorsImpl;
   Release = ReleaseImpl;

--- a/morphizen/ort-bridge/src/ort-api-version.cpp
+++ b/morphizen/ort-bridge/src/ort-api-version.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2023 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#include "./ort-api-version.hpp"
+
+#include <atomic>
+#include <onnxruntime_c_api.h>
+
+namespace morphizen {
+
+namespace {
+
+std::atomic<uint32_t> g_negotiated_ort_api_version{ORT_API_VERSION};
+
+uint32_t RuntimeApiVersionFromString(const char *version) noexcept {
+  if (version == nullptr) {
+    return 0;
+  }
+  const char *p = version;
+  while (*p != '\0' && *p != '.') {
+    ++p;
+  }
+  if (*p != '.') {
+    return 0;
+  }
+  ++p;
+  uint32_t minor = 0;
+  bool any_digit = false;
+  for (; *p >= '0' && *p <= '9'; ++p) {
+    minor = minor * 10 + static_cast<uint32_t>(*p - '0');
+    any_digit = true;
+  }
+  return any_digit ? minor : 0;
+}
+
+} // namespace
+
+uint32_t NegotiatedOrtApiVersion() noexcept {
+  return g_negotiated_ort_api_version.load(std::memory_order_relaxed);
+}
+
+const OrtApi *NegotiateOrtApi(const OrtApiBase &ort_api_base,
+                              uint32_t min_version) noexcept {
+  uint32_t ceiling = ORT_API_VERSION;
+  if (const uint32_t runtime_version =
+          RuntimeApiVersionFromString(ort_api_base.GetVersionString());
+      runtime_version != 0 && runtime_version < ceiling) {
+    ceiling = runtime_version;
+  }
+
+  for (uint32_t version = ceiling; version >= min_version; --version) {
+    if (const OrtApi *ort_api = ort_api_base.GetApi(version)) {
+      g_negotiated_ort_api_version.store(version, std::memory_order_relaxed);
+      return ort_api;
+    }
+  }
+
+  g_negotiated_ort_api_version.store(0, std::memory_order_relaxed);
+  return nullptr;
+}
+
+const OrtApi *FallbackOrtApiForStatus(const OrtApiBase &ort_api_base) noexcept {
+  uint32_t ceiling =
+      RuntimeApiVersionFromString(ort_api_base.GetVersionString());
+  if (ceiling == 0 || ceiling > ORT_API_VERSION) {
+    ceiling = ORT_API_VERSION;
+  }
+  for (uint32_t version = ceiling; version >= 1; --version) {
+    if (const OrtApi *ort_api = ort_api_base.GetApi(version)) {
+      return ort_api;
+    }
+  }
+  return nullptr;
+}
+
+} // namespace morphizen

--- a/morphizen/ort-bridge/src/ort-api-version.hpp
+++ b/morphizen/ort-bridge/src/ort-api-version.hpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2023 - 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+#pragma once
+#include <cstdint>
+
+struct OrtApi;
+struct OrtApiBase;
+
+namespace morphizen {
+
+inline constexpr uint32_t kMinOrtApiVersion{24};
+
+uint32_t NegotiatedOrtApiVersion() noexcept;
+
+const OrtApi *NegotiateOrtApi(const OrtApiBase &ort_api_base,
+                              uint32_t min_version) noexcept;
+
+const OrtApi *FallbackOrtApiForStatus(const OrtApiBase &ort_api_base) noexcept;
+
+} // namespace morphizen

--- a/morphizen/ort-bridge/src/ort-bridge.cpp
+++ b/morphizen/ort-bridge/src/ort-bridge.cpp
@@ -3,10 +3,12 @@
  * Licensed under the MIT License.
  */
 #include "./morphizen-ep-factory.hpp"
+#include "./ort-api-version.hpp"
 #include "morphizen-utils/morphizen-utils.hpp"
 #include "morphizen/onnxruntime_api.hpp"
 #include <glog/logging.h>
 #include <iostream>
+#include <string>
 DEF_ENV_PARAM(MORPHIZEN_DEBUG_ORT_EP_API, "0")
 #define MY_LOG(n) LOG_IF(INFO, ENV_PARAM(MORPHIZEN_DEBUG_ORT_EP_API) >= n)
 
@@ -17,11 +19,27 @@ OrtStatus *CreateEpFactories(const char *registration_name,
                              const OrtLogger *default_logger,
                              OrtEpFactory **factories, size_t max_factories,
                              size_t *num_factories) {
-  const OrtApi *ort_api = ort_api_base->GetApi(ORT_API_VERSION);
+  const OrtApi *ort_api =
+      morphizen::NegotiateOrtApi(*ort_api_base, morphizen::kMinOrtApiVersion);
+  if (ort_api == nullptr) {
+    const std::string message =
+        std::string{
+            "onnxruntime runtime too old: this EP requires ORT API >= "} +
+        std::to_string(morphizen::kMinOrtApiVersion) +
+        ", but the host reports " + ort_api_base->GetVersionString();
+    if (const OrtApi *fallback_api =
+            morphizen::FallbackOrtApiForStatus(*ort_api_base)) {
+      return fallback_api->CreateStatus(ORT_EP_FAIL, message.c_str());
+    }
+    LOG(FATAL) << message;
+  }
   // initialize the API in this dll.
   Ort::InitApi(ort_api);
   const OrtEpApi *ort_ep_api = ort_api->GetEpApi();
-  MY_LOG(1) << "ORT is initalized, ORT_API_VERSION=" << ORT_API_VERSION
+  MY_LOG(1) << "ORT is initalized, negotiated API version="
+            << morphizen::NegotiatedOrtApiVersion()
+            << " (built against ORT_API_VERSION=" << ORT_API_VERSION
+            << ", host reports " << ort_api_base->GetVersionString() << ")"
             << ", ptr=" << (void *)ort_ep_api << ", registration_name="
             << "\"" << registration_name << "\"";
 


### PR DESCRIPTION
## Summary

Cherry-pick of #875 onto `main`. `hipgpu.dll` is built against ORT 1.27 headers but asked the host for `GetApi(ORT_API_VERSION)` unconditionally, so loading the EP into an older runtime crashed with `0xC0000005`. It now negotiates the API version at load time: it runs on any runtime down to ORT 1.24, and reports a descriptive `OrtStatus` instead of crashing on anything older.

## Related issue or design

Cherry-pick of #875 (merged into `gpuep/releases/gpuep-rel-2610` as `ce4a8e5`). No code changes on top.

## Why

Same rationale as #875: `GetApi(v)` returns `nullptr` when `v` exceeds what the host supports, and `CreateEpFactories` dereferenced the result on the next line. Stamping the compile-time `ORT_API_VERSION` into each ABI struct's `ort_version_supported` had the same problem in a quieter form, telling ORT that fields absent from the running runtime's view of the struct are valid.

Landing it on `main` as well so the release branch and `main` do not diverge on the plugin entry path.

## What

Identical to #875, seven files:

- `morphizen/ort-bridge/src/ort-api-version.{hpp,cpp}`: `kMinOrtApiVersion` (24), `NegotiateOrtApi()`, `NegotiatedOrtApiVersion()`, `FallbackOrtApiForStatus()`.
- `CreateEpFactories` uses the negotiated `OrtApi` and returns `ORT_EP_FAIL` below `kMinOrtApiVersion`; its `MY_LOG(1)` line prints the negotiated version alongside the compile-time one.
- Six ABI structs stamp `NegotiatedOrtApiVersion()`: `OrtEpFactory`, `OrtEp`, `OrtAllocator`, `OrtDataTransferImpl`, `OrtNodeFusionOptions`, `OrtNodeComputeInfo`.

## Test plan

- [x] `git cherry-pick` applied without conflicts; the seven files are byte-identical to the merged `rel-2610` state (verified with `git diff origin/gpuep/releases/gpuep-rel-2610 -- <files>`, empty).
- [x] `pre-commit run --all-files` clean on first pass.
- [x] Windows build green on `main` (Ninja, Release, gfx1151).
- [ ] CI build-windows green.

Runtime behaviour was verified on the `rel-2610` branch against official ORT release runtimes (1.23.2 / 1.24.2 / 1.27.0); see #875 for that matrix. Since the code is byte-identical, it is not repeated here.

## Notes for reviewers

No changes relative to #875, so review can be limited to confirming the cherry-pick is faithful. `main` and `rel-2610` differed only by this patch under `morphizen/ort-bridge/` before this PR.
