### PR TITLE
fix(runtime): drop __cxa_atexit statics that fail JIT-linking on Linux

### DIFF
--- a/lib/Runtime/debug_log.h
+++ b/lib/Runtime/debug_log.h
@@ -48,9 +48,16 @@ inline bool hipdnn_ep_perf_enabled() {
 // A non-empty path writes a chrome://tracing JSON of the per-op timeline (one
 // fenceless marker per op, GPU time derived by differencing consecutive
 // markers) and also flips hipdnn_ep_perf_enabled() on.
+// Heap-allocated and never destroyed: a function-local static with a
+// non-trivial destructor emits `__cxa_atexit(dtor, &path, &__dso_handle)`, and
+// that `__dso_handle` reference cannot survive JIT-linking this bitcode into
+// the EP process (see the long-form explanation on WeakStore::storage() in
+// op_state.h). The `bool` flags above need no such treatment -- a trivial
+// destructor registers nothing.
 inline const std::string &hipdnn_ep_trace_path() {
-  static const std::string path = hipdnn_ep::env_string("HIPDNN_EP_TRACE_FILE");
-  return path;
+  static const std::string *path =
+      new std::string(hipdnn_ep::env_string("HIPDNN_EP_TRACE_FILE"));
+  return *path;
 }
 inline bool hipdnn_ep_trace_enabled() {
   return !hipdnn_ep_trace_path().empty();

--- a/lib/Runtime/op_state.h
+++ b/lib/Runtime/op_state.h
@@ -109,9 +109,21 @@ private:
     std::mutex mutex;
     std::map<Key, std::weak_ptr<Val>> entries;
   };
+  // Heap-allocated and never destroyed, rather than a plain `static Storage s`.
+  // A function-local static whose type has a non-trivial destructor makes the
+  // compiler emit `__cxa_atexit(dtor, &s, &__dso_handle)`. `__dso_handle` is
+  // hidden-visibility and per-DSO, so the compiler assumes it is in the same
+  // linked output and reaches it with a direct PC32 -- no GOT entry, no stub,
+  // nothing a linker can redirect. When this bitcode is JIT-linked into the EP
+  // process that symbol instead resolves to the host library's copy, at
+  // whatever distance ASLR chose; past the 2 GB a PC32 reaches, the fixup
+  // fails and the entire runtime module fails to materialize, taking every
+  // symbol in it down with it. Leaking the store is cheap: entries are
+  // weak_ptrs keyed by device id, and the values are owned by the sessions
+  // holding the shared_ptrs, so only the map and mutex shell outlive main.
   static Storage &storage() {
-    static Storage s;
-    return s;
+    static Storage *s = new Storage();
+    return *s;
   }
 };
 


### PR DESCRIPTION
## Summary

A GenAI perplexity run on Linux (`PPL`, `seq_len=512`) died before inference with every symbol in `runtime.bc` unresolved. The thousand-symbol `Failed to materialize symbols` dump is a cascade; the actual error is a single relocation:

```
JIT session error: In graph runtime.bc-jitted-objectbuffer, section
.text._ZN9WeakStoreIi13GemmAlgoTableE13get_or_create...: relocation target
0x7a923b6f7ffc (__dso_handle:0x7a923b6f8000 + 0xfffffffffffffffc) is out of
range of Delta32 fixup at address 0x7a923b6f8000
```

The JIT'd block sat **2.11 GB** from the host library's `__dso_handle`, past the **2.00 GB** a 32-bit PC-relative fixup reaches. One failed fixup stops the whole module from materializing, so every symbol in it goes missing — hence the misleading dump.

## Why the reference exists

A function-local static whose type has a non-trivial destructor makes the compiler emit `__cxa_atexit(dtor, &obj, &__dso_handle)`. `__dso_handle` is hidden-visibility and per-DSO, so the compiler assumes it lives in the same linked output and reaches it with a direct PC32 — no GOT entry, no stub, nothing a linker can redirect. JIT-linked into the EP process, that symbol instead resolves to the host library's copy at whatever distance the loader chose, and the distance is unbounded.

Two properties made this hard to attribute:

- **Linux only.** On the MSVC ABI clang emits a plain `atexit` call with no `__dso_handle` at all. The Windows-built `runtime.bc` has zero `__dso_handle` references, so no amount of Windows testing surfaces it.
- **Not a build failure.** It happens at JIT link time inside a running session, so a green build tells you nothing. It surfaced in a downstream accuracy test, not CI.

The margin was 5.7%, so any unrelated change to `runtime.bc`'s size is enough to cross the line in either direction. #862 tripped it by removing conv op-state code, but contains no error itself — this relocation is in `gemm.cpp` code that `main` already has.

## What

Both statics become heap-allocated and never destroyed, so nothing is registered:

- `WeakStore::storage()` in `op_state.h` — on the template, so it covers both the `GemmAlgoTable` and `MatmulAlgoTable` instantiations, including the one that failed.
- `hipdnn_ep_trace_path()` in `debug_log.h`.

Leaking them is cheap and changes no observable behaviour. The `WeakStore` entries are `weak_ptr`s keyed by device id whose values are owned by the sessions holding the `shared_ptr`s, so only the map and mutex shell outlive `main`; the trace path is a string read once from the environment. Thread-safety is unchanged — the runtime bitcode is already built with `-fno-threadsafe-statics`, so these magic statics were never guarded.

The four `static bool` env-var caches alongside them need no treatment: a trivial destructor registers nothing.

## Test plan

- [x] All ~90 runtime bitcode TUs recompile and link cleanly (`ninja lib/Runtime/runtime.bc`); only pre-existing warnings.
- [x] Disassembled the linked `runtime.bc`: destructor registrations drop **14 → 7**, dtor stubs **10 → 7**, and all three affected statics lose theirs.
- [x] A/B probe TU against unmodified vs. edited headers: 3 registrations → 0.
- [ ] Re-run the Linux `PPL seq_len=512` perplexity test, which is the only thing that exercises the failing path. Not reproducible on Windows by construction.

## Known limitation

This does not exhaust the pattern. `runtime.bc` still registers destructors for `g_gpu_buffer_pool` (`hipdnn_ep_runtime_tensor.cpp:93`) and `by_device`, `g_tables`, `g_table_ids`, `g_resolved` (`gqa_autotune.cpp`). Each is a `__dso_handle` site on Linux that could fail identically given a different layout, and each new non-trivially-destructible static in JIT-linked code re-arms the risk silently.

Fixing the class rather than the instances would mean defining `__dso_handle` in the JITDylib — `LlvmIrJit.cpp` already has the `absoluteSymbols`/`ExecutorSymbolDef` machinery for it, and upstream ORC's ELF platform does exactly this. Deliberately left out of scope here; worth considering as a follow-up.

## Related

- #869 fixed the same class of failure — a 32-bit relocation across independently-allocated slabs with no proximity guarantee — but is `#ifdef _WIN32`, so the Linux/JITLink path was never covered.
- #862 is the trigger for the observed failure, not its cause. Landing this first removes the trip hazard.
