### PR TITLE
ci(windows): build the AMD GPU umbrella EP from the upstream repo

### DIFF
--- a/.github/workflows/windows-build-real.yml
+++ b/.github/workflows/windows-build-real.yml
@@ -16,7 +16,7 @@ on:
         required: true
         type: string
       amdgpu_cache_key:
-        description: Cache key of the prebuilt amdgpu-ep.dll + hip-backend.dll.
+        description: Cache key of the prebuilt onnxruntime_ep_amdgpu wheel + problem_cache.json.
         required: true
         type: string
       oga_cache_key:
@@ -116,19 +116,18 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
+      # HIP_WHEEL_EXTRA_DLLS is intentionally unset: the umbrella chain now ships
+      # in the upstream onnxruntime-ep-amdgpu wheel, which our wheel installs
+      # alongside (both land in onnxruntime_ep_amdgpu/).
       - name: Build hip-ep
         shell: bash
         run: |
-          AMDGPU_ARTIFACTS="${{ runner.workspace }}/amdgpu-artifacts"
-          AMDGPU_EP="$AMDGPU_ARTIFACTS/amdgpu-ep.dll"
-          HIP_BACKEND="$AMDGPU_ARTIFACTS/hip-backend.dll"
           python build.py \
             --config Release \
             --cmake_generator Ninja \
             --hip_arch "${{ env.HIP_ARCHITECTURES }}" \
             --cmake_prefix_path "${{ runner.workspace }}/ort-install;${{ runner.workspace }}/llvm-install" \
-            --cmake_extra_defines CMAKE_DISABLE_FIND_PACKAGE_OpenSSL=ON \
-            --cmake_extra_defines "HIP_WHEEL_EXTRA_DLLS=$AMDGPU_EP;$HIP_BACKEND"
+            --cmake_extra_defines CMAKE_DISABLE_FIND_PACKAGE_OpenSSL=ON
 
       # -----------------------------------------------------------------------
       # Stage GPU test package:
@@ -161,8 +160,36 @@ jobs:
           cp "${{ runner.workspace }}/install/bin/"*.dll staging/bin/ 2>/dev/null || true
           cp "${{ runner.workspace }}/install/bin/"*.exe staging/bin/ 2>/dev/null || true
 
-          cp "${{ runner.workspace }}/amdgpu-artifacts/amdgpu-ep.dll" staging/bin/
-          cp "${{ runner.workspace }}/amdgpu-artifacts/hip-backend.dll" staging/bin/
+          # AMD GPU umbrella EP + its backends + the MIGraphX runtime, unpacked
+          # from the wheel the amdgpu job built. The ROCm and DirectML runtimes
+          # it also carries are skipped: TheRock below and ort-install above
+          # provide the versions hipgpu.dll and onnxruntime.dll were built
+          # against, and staging/bin is flat so duplicates would collide.
+          AMDGPU_WHEEL=$(find "${{ runner.workspace }}/amdgpu-artifacts" \
+            -name "onnxruntime_ep_amdgpu-*.whl" -type f | head -1)
+          if [ -z "$AMDGPU_WHEEL" ]; then
+            echo "ERROR: onnxruntime_ep_amdgpu wheel missing from amdgpu-artifacts"
+            exit 1
+          fi
+          UNPACK="${{ runner.workspace }}/amdgpu-unpacked"
+          rm -rf "$UNPACK"
+          python -c "import sys, zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" \
+            "$AMDGPU_WHEEL" "$UNPACK"
+          for f in "$UNPACK/onnxruntime_ep_amdgpu/"*.dll "$UNPACK/onnxruntime_ep_amdgpu/"*.exe; do
+            [ -f "$f" ] || continue
+            case "$(basename "$f")" in
+              amd_comgr*|amdhip64*|hiprtc*|DirectML.dll) continue ;;
+            esac
+            cp "$f" staging/bin/
+          done
+          # MIGraphX discovers its tuning DB next to migraphx-backend.dll; the
+          # wheel cannot carry it (its packing globs only dll/pdb/exe).
+          cp "${{ runner.workspace }}/amdgpu-artifacts/problem_cache.json" staging/bin/
+          if [ ! -f staging/bin/amdgpu-ep.dll ]; then
+            echo "ERROR: amdgpu-ep.dll missing after unpacking $AMDGPU_WHEEL"
+            ls -1 "$UNPACK/onnxruntime_ep_amdgpu/" || true
+            exit 1
+          fi
 
           # Smoke: every per-arch kernel DLL must be present in staging/bin/
           # (LlvmIrJit dlopens custom_kernels_<gcnArchName>.dll at runtime).
@@ -272,12 +299,16 @@ jobs:
             -name "onnxruntime_genai_directml-*.whl" -type f | head -1)
           EP_WHEEL=$(find "../build/$(basename "$PWD")/python/dist" \
             -name "onnxruntime_ep_hip-*.whl" -type f | head -1)
-          if [ -z "$ORT_WHEEL" ] || [ -z "$OGA_WHEEL" ] || [ -z "$EP_WHEEL" ]; then
+          # The umbrella wheel owns onnxruntime_ep_amdgpu/__init__.py, which our
+          # wheel's files land next to, so it has to ship in the same set.
+          AMDGPU_WHEEL=$(find "${{ runner.workspace }}/amdgpu-artifacts" \
+            -name "onnxruntime_ep_amdgpu-*.whl" -type f | head -1)
+          if [ -z "$ORT_WHEEL" ] || [ -z "$OGA_WHEEL" ] || [ -z "$EP_WHEEL" ] || [ -z "$AMDGPU_WHEEL" ]; then
             echo "ERROR: wheel(s) missing"
-            echo "  ORT=$ORT_WHEEL OGA=$OGA_WHEEL EP=$EP_WHEEL"
+            echo "  ORT=$ORT_WHEEL OGA=$OGA_WHEEL EP=$EP_WHEEL AMDGPU=$AMDGPU_WHEEL"
             exit 1
           fi
-          cp "$ORT_WHEEL" "$OGA_WHEEL" "$EP_WHEEL" wheelpkg/wheels/
+          cp "$ORT_WHEEL" "$OGA_WHEEL" "$EP_WHEEL" "$AMDGPU_WHEEL" wheelpkg/wheels/
           cp python/examples/run_onnx.py wheelpkg/
           cp "${{ runner.workspace }}/oga-artifacts/benchmark-python/"*.py wheelpkg/
           curl -fsSL --retry 3 -o wheelpkg/vlm_benchmark.py \

--- a/.github/workflows/windows-build-real.yml
+++ b/.github/workflows/windows-build-real.yml
@@ -116,8 +116,6 @@ jobs:
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
-      # HIP_WHEEL_EXTRA_DLLS is intentionally unset: the umbrella chain now ships
-      # in the upstream wheel, which ours installs alongside.
       - name: Build hip-ep
         shell: bash
         run: |
@@ -159,34 +157,7 @@ jobs:
           cp "${{ runner.workspace }}/install/bin/"*.dll staging/bin/ 2>/dev/null || true
           cp "${{ runner.workspace }}/install/bin/"*.exe staging/bin/ 2>/dev/null || true
 
-          # Skip the ROCm and DirectML runtimes the wheel also carries: TheRock
-          # below and ort-install above provide the versions hipgpu.dll and
-          # onnxruntime.dll were built against, and staging/bin is flat.
-          AMDGPU_WHEEL=$(find "${{ runner.workspace }}/amdgpu-artifacts" \
-            -name "onnxruntime_ep_amdgpu-*.whl" -type f | head -1)
-          if [ -z "$AMDGPU_WHEEL" ]; then
-            echo "ERROR: onnxruntime_ep_amdgpu wheel missing from amdgpu-artifacts"
-            exit 1
-          fi
-          UNPACK="${{ runner.workspace }}/amdgpu-unpacked"
-          rm -rf "$UNPACK"
-          python -c "import sys, zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" \
-            "$AMDGPU_WHEEL" "$UNPACK"
-          for f in "$UNPACK/onnxruntime_ep_amdgpu/"*.dll "$UNPACK/onnxruntime_ep_amdgpu/"*.exe; do
-            [ -f "$f" ] || continue
-            case "$(basename "$f")" in
-              amd_comgr*|amdhip64*|hiprtc*|DirectML.dll) continue ;;
-            esac
-            cp "$f" staging/bin/
-          done
-          # MIGraphX discovers its tuning DB next to migraphx-backend.dll; the
-          # wheel cannot carry it (its packing globs only dll/pdb/exe).
-          cp "${{ runner.workspace }}/amdgpu-artifacts/problem_cache.json" staging/bin/
-          if [ ! -f staging/bin/amdgpu-ep.dll ]; then
-            echo "ERROR: amdgpu-ep.dll missing after unpacking $AMDGPU_WHEEL"
-            ls -1 "$UNPACK/onnxruntime_ep_amdgpu/" || true
-            exit 1
-          fi
+          cp "${{ runner.workspace }}/amdgpu-artifacts/bin/"* staging/bin/
 
           # Smoke: every per-arch kernel DLL must be present in staging/bin/
           # (LlvmIrJit dlopens custom_kernels_<gcnArchName>.dll at runtime).
@@ -296,8 +267,6 @@ jobs:
             -name "onnxruntime_genai_directml-*.whl" -type f | head -1)
           EP_WHEEL=$(find "../build/$(basename "$PWD")/python/dist" \
             -name "onnxruntime_ep_hip-*.whl" -type f | head -1)
-          # The umbrella wheel owns onnxruntime_ep_amdgpu/__init__.py, which our
-          # wheel's files land next to, so it has to ship in the same set.
           AMDGPU_WHEEL=$(find "${{ runner.workspace }}/amdgpu-artifacts" \
             -name "onnxruntime_ep_amdgpu-*.whl" -type f | head -1)
           if [ -z "$ORT_WHEEL" ] || [ -z "$OGA_WHEEL" ] || [ -z "$EP_WHEEL" ] || [ -z "$AMDGPU_WHEEL" ]; then

--- a/.github/workflows/windows-build-real.yml
+++ b/.github/workflows/windows-build-real.yml
@@ -117,8 +117,7 @@ jobs:
         uses: mozilla-actions/sccache-action@v0.0.9
 
       # HIP_WHEEL_EXTRA_DLLS is intentionally unset: the umbrella chain now ships
-      # in the upstream onnxruntime-ep-amdgpu wheel, which our wheel installs
-      # alongside (both land in onnxruntime_ep_amdgpu/).
+      # in the upstream wheel, which ours installs alongside.
       - name: Build hip-ep
         shell: bash
         run: |
@@ -160,11 +159,9 @@ jobs:
           cp "${{ runner.workspace }}/install/bin/"*.dll staging/bin/ 2>/dev/null || true
           cp "${{ runner.workspace }}/install/bin/"*.exe staging/bin/ 2>/dev/null || true
 
-          # AMD GPU umbrella EP + its backends + the MIGraphX runtime, unpacked
-          # from the wheel the amdgpu job built. The ROCm and DirectML runtimes
-          # it also carries are skipped: TheRock below and ort-install above
-          # provide the versions hipgpu.dll and onnxruntime.dll were built
-          # against, and staging/bin is flat so duplicates would collide.
+          # Skip the ROCm and DirectML runtimes the wheel also carries: TheRock
+          # below and ort-install above provide the versions hipgpu.dll and
+          # onnxruntime.dll were built against, and staging/bin is flat.
           AMDGPU_WHEEL=$(find "${{ runner.workspace }}/amdgpu-artifacts" \
             -name "onnxruntime_ep_amdgpu-*.whl" -type f | head -1)
           if [ -z "$AMDGPU_WHEEL" ]; then

--- a/.github/workflows/windows-build-real.yml
+++ b/.github/workflows/windows-build-real.yml
@@ -16,7 +16,7 @@ on:
         required: true
         type: string
       amdgpu_cache_key:
-        description: Cache key of the prebuilt onnxruntime_ep_amdgpu wheel + problem_cache.json.
+        description: Cache key of the prebuilt amdgpu-ep build artifacts.
         required: true
         type: string
       oga_cache_key:

--- a/.github/workflows/windows-deps.yml
+++ b/.github/workflows/windows-deps.yml
@@ -33,10 +33,9 @@ env:
   OGA_VERSION: "0.14.0"
   OGA_PR_PATCHES: "2194"
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
-  # AMD GPU umbrella EP, from the upstream repo's gpuep-releases/gpuep-rel-2610.2
-  # release branch (not main: main defaults USE_HIP to OFF and has no
-  # MIGRAPHX_EP_PROBLEM_CACHE). Pinned to the commit AMD's packaging pipeline
-  # builds, so it matches the MIGraphX SDK pinned in cmake/deps.txt.
+  # Upstream's gpuep-rel-2610.2 branch, not main: main defaults USE_HIP off and
+  # has no MIGRAPHX_EP_PROBLEM_CACHE. This commit is the one AMD's packaging
+  # pipeline builds, so it matches the MIGraphX SDK in cmake/deps.txt.
   AMDGPU_EP_REF: "05eaa2a938f71e98b49bd1be3fb03720167be5cc"
 
 jobs:
@@ -278,9 +277,7 @@ jobs:
       cache_key: ${{ steps.key.outputs.value }}
 
     steps:
-      # cmake/deps.txt pins the MIGraphX SDK and TheRock SDK this job downloads,
-      # so it is both the download manifest and the cache-key input. Only cmake/
-      # is needed; the blob hash below reads the tree, not the working copy.
+      # deps.txt is both the download manifest below and the cache-key input.
       - name: Checkout deps manifest
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -289,10 +286,8 @@ jobs:
           fetch-depth: 1
           show-progress: false
 
-      # Keying on deps.txt's blob hash invalidates the cache on any pin bump
-      # (MIGraphX, TheRock) without enumerating versions here. --short=12 is
-      # explicit because git's default abbreviation length grows with the object
-      # count, which would silently change the key.
+      # deps.txt's blob hash invalidates the cache on any pin bump. --short=12 is
+      # explicit: git's default abbreviation length grows with the object count.
       - name: Compute cache key
         id: key
         shell: bash
@@ -324,10 +319,9 @@ jobs:
         with:
           python-version: "3.14"
 
-      # No msvc-dev-cmd here: build.py replaces os.environ wholesale with what
-      # vcvars64.bat reports, and it skips running vcvars when VSINSTALLDIR is
-      # already set -- which would leave the environment empty and hide ninja and
-      # sccache. It locates the toolchain itself via vswhere.
+      # No msvc-dev-cmd: build.py replaces os.environ with what vcvars reports, and
+      # skips vcvars when VSINSTALLDIR is already set, which would leave the
+      # environment empty. It finds the toolchain itself via vswhere.
       - name: Prepare sccache local cache
         if: steps.cache-amdgpu.outputs.cache-hit != 'true'
         shell: bash
@@ -358,10 +352,8 @@ jobs:
           fetch-depth: 1
           show-progress: false
 
-      # MIGraphX SDK (find_package(migraphx) prefix, and problem_cache.json at
-      # its root) plus the TheRock ROCm SDK (find_package(hip)). This job has no
-      # TheRock otherwise: elsewhere cmake/deps.cmake downloads it during the
-      # project's own configure, which does not happen here.
+      # find_package prefixes for migraphx and hip. This job needs its own copy:
+      # deps.cmake fetches TheRock during the project's configure, not run here.
       - name: Fetch MIGraphX + TheRock SDKs
         if: steps.cache-amdgpu.outputs.cache-hit != 'true'
         shell: bash
@@ -389,16 +381,11 @@ jobs:
           test -f "$WS/migraphx-sdk/problem_cache.json"
           test -f "$WS/therock/lib/cmake/hip/hip-config.cmake"
 
-      # Build through the repo's own build.py rather than a hand-written cmake
-      # line: it derives the cmake arguments from --use_amdgpu / the three *_home
-      # paths, and --build_wheel packs every backend plus the MIGraphX and
-      # DirectML runtimes shipped next to them, so the artifact set follows
-      # upstream instead of a list maintained here.
-      #
-      # Do not pass --target: _build_targets emits `-target` (one dash), so the
-      # default all-target build is the working path. --use_cache is skipped too;
-      # on Windows it only sets BUILD_CACHE and never wires up a launcher, hence
-      # sccache goes through --cmake_extra_defines.
+      # --build_wheel packs every backend plus the MIGraphX and DirectML runtimes
+      # staged beside them, so the artifact set follows upstream rather than a list
+      # maintained here. Two quirks of build.py: --target is unusable
+      # (_build_targets emits `-target`, one dash) and --use_cache wires up no
+      # launcher on Windows, hence sccache via --cmake_extra_defines.
       - name: Build amdgpu-ep
         if: steps.cache-amdgpu.outputs.cache-hit != 'true'
         shell: bash

--- a/.github/workflows/windows-deps.yml
+++ b/.github/workflows/windows-deps.yml
@@ -33,9 +33,6 @@ env:
   OGA_VERSION: "0.14.0"
   OGA_PR_PATCHES: "2194"
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
-  # Upstream's gpuep-rel-2610.2 branch, not main: main defaults USE_HIP off and
-  # has no MIGRAPHX_EP_PROBLEM_CACHE. This commit is the one AMD's packaging
-  # pipeline builds, so it matches the MIGraphX SDK in cmake/deps.txt.
   AMDGPU_EP_REF: "05eaa2a938f71e98b49bd1be3fb03720167be5cc"
 
 jobs:
@@ -277,7 +274,6 @@ jobs:
       cache_key: ${{ steps.key.outputs.value }}
 
     steps:
-      # deps.txt is both the download manifest below and the cache-key input.
       - name: Checkout deps manifest
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -286,8 +282,6 @@ jobs:
           fetch-depth: 1
           show-progress: false
 
-      # deps.txt's blob hash invalidates the cache on any pin bump. --short=12 is
-      # explicit: git's default abbreviation length grows with the object count.
       - name: Compute cache key
         id: key
         shell: bash
@@ -319,9 +313,6 @@ jobs:
         with:
           python-version: "3.14"
 
-      # No msvc-dev-cmd: build.py replaces os.environ with what vcvars reports, and
-      # skips vcvars when VSINSTALLDIR is already set, which would leave the
-      # environment empty. It finds the toolchain itself via vswhere.
       - name: Prepare sccache local cache
         if: steps.cache-amdgpu.outputs.cache-hit != 'true'
         shell: bash
@@ -352,16 +343,12 @@ jobs:
           fetch-depth: 1
           show-progress: false
 
-      # find_package prefixes for migraphx and hip. This job needs its own copy:
-      # deps.cmake fetches TheRock during the project's configure, not run here.
       - name: Fetch MIGraphX + TheRock SDKs
         if: steps.cache-amdgpu.outputs.cache-hit != 'true'
         shell: bash
         run: |
           set -euo pipefail
           DEPS="source-hip-ep/cmake/deps.txt"
-          # POSIX paths throughout: tar rejects a backslash path for -C, and reads
-          # a leading "D:\..." for the archive itself as a remote "host:path".
           TMP=$(cygpath -u "$RUNNER_TEMP")
           WS=$(cygpath -u '${{ runner.workspace }}')
           fetch_dep() {
@@ -381,11 +368,6 @@ jobs:
           test -f "$WS/migraphx-sdk/problem_cache.json"
           test -f "$WS/therock/lib/cmake/hip/hip-config.cmake"
 
-      # --build_wheel packs every backend plus the MIGraphX and DirectML runtimes
-      # staged beside them, so the artifact set follows upstream rather than a list
-      # maintained here. Two quirks of build.py: --target is unusable
-      # (_build_targets emits `-target`, one dash) and --use_cache wires up no
-      # launcher on Windows, hence sccache via --cmake_extra_defines.
       - name: Build amdgpu-ep
         if: steps.cache-amdgpu.outputs.cache-hit != 'true'
         shell: bash
@@ -412,8 +394,13 @@ jobs:
               CMAKE_C_COMPILER_LAUNCHER=sccache \
               CMAKE_CXX_COMPILER_LAUNCHER=sccache
 
+          INSTALL="${{ runner.workspace }}/amdgpu-install"
+          rm -rf "$INSTALL"
+          "$CMAKE" --install "${{ runner.workspace }}/build-amdgpu/Release" --prefix "$INSTALL"
+
           ARTIFACTS="${{ runner.workspace }}/amdgpu-artifacts"
-          mkdir -p "$ARTIFACTS"
+          rm -rf "$ARTIFACTS"
+          mkdir -p "$ARTIFACTS/bin"
           WHEEL=$(find "${{ runner.workspace }}/build-amdgpu" -name 'onnxruntime_ep_amdgpu-*.whl' -type f | head -1)
           if [ -z "$WHEEL" ]; then
             echo "ERROR: onnxruntime_ep_amdgpu wheel not found in build tree"
@@ -421,9 +408,17 @@ jobs:
           fi
           cp "$WHEEL" "$ARTIFACTS/"
           echo "Cached $(basename "$WHEEL")"
-          # The wheel's packing globs only *.dll/*.pdb/*.exe, so the tuning DB
-          # has to be carried separately.
-          cp "$MIGRAPHX_SDK/problem_cache.json" "$ARTIFACTS/"
+
+          for f in "$INSTALL"/*; do
+            [ -f "$f" ] || continue
+            case "$(basename "$f")" in
+              amd_comgr*|amdhip64*|hiprtc*|DirectML.dll) continue ;;
+            esac
+            cp "$f" "$ARTIFACTS/bin/"
+          done
+          test -f "$ARTIFACTS/bin/amdgpu-ep.dll"
+          test -f "$ARTIFACTS/bin/problem_cache.json"
+          echo "Cached $(ls -1 "$ARTIFACTS/bin" | wc -l) files into bin/"
 
       - name: Save amdgpu-artifacts
         if: steps.cache-amdgpu.outputs.cache-hit != 'true'

--- a/.github/workflows/windows-deps.yml
+++ b/.github/workflows/windows-deps.yml
@@ -320,9 +320,9 @@ jobs:
           echo "SCCACHE_DIR=${{ runner.workspace }}/sccache-dir" >> $GITHUB_ENV
           echo "SCCACHE_KEY_DATE=$(date -u +'%Y%m%d')" >> $GITHUB_ENV
 
-      - name: Restore sccache directory
+      - name: Cache sccache directory
         if: steps.cache-amdgpu.outputs.cache-hit != 'true'
-        uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: ${{ runner.workspace }}/sccache-dir
           key: sccache-windows-deps-amdgpu-${{ env.SCCACHE_KEY_DATE }}
@@ -427,14 +427,6 @@ jobs:
         with:
           path: ${{ runner.workspace }}/amdgpu-artifacts
           key: ${{ steps.key.outputs.value }}
-
-      - name: Save sccache directory
-        if: always() && steps.cache-amdgpu.outputs.cache-hit != 'true' && github.ref_name == 'main'
-        continue-on-error: true
-        uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
-        with:
-          path: ${{ runner.workspace }}/sccache-dir
-          key: sccache-windows-deps-amdgpu-${{ env.SCCACHE_KEY_DATE }}
 
   oga:
     needs: ort

--- a/.github/workflows/windows-deps.yml
+++ b/.github/workflows/windows-deps.yml
@@ -377,7 +377,9 @@ jobs:
             echo "[$name] $url/$base.tar.gz"
             curl -sSL --fail -o "$RUNNER_TEMP/$base.tar.gz" "$url/$base.tar.gz"
             mkdir -p "$dest"
-            tar -xzf "$RUNNER_TEMP/$base.tar.gz" -C "$dest" --strip-components=1
+            # Name the archive relatively, from its own directory: GNU tar reads a
+            # leading "D:\..." as a remote "host:path". -C is unaffected.
+            ( cd "$RUNNER_TEMP" && tar -xzf "$base.tar.gz" -C "$dest" --strip-components=1 )
           }
           fetch_dep migraphx_windows "${{ runner.workspace }}/migraphx-sdk"
           fetch_dep therock_windows "${{ runner.workspace }}/therock"

--- a/.github/workflows/windows-deps.yml
+++ b/.github/workflows/windows-deps.yml
@@ -17,7 +17,7 @@ on:
         description: Cache key holding the ONNX Runtime install prefix.
         value: ${{ jobs.ort.outputs.cache_key }}
       amdgpu_cache_key:
-        description: Cache key holding the onnxruntime_ep_amdgpu wheel + problem_cache.json.
+        description: Cache key holding the amdgpu-ep build artifacts.
         value: ${{ jobs.amdgpu.outputs.cache_key }}
       oga_cache_key:
         description: Cache key holding the OGA artifact set.

--- a/.github/workflows/windows-deps.yml
+++ b/.github/workflows/windows-deps.yml
@@ -368,6 +368,10 @@ jobs:
         run: |
           set -euo pipefail
           DEPS="source-hip-ep/cmake/deps.txt"
+          # POSIX paths throughout: tar rejects a backslash path for -C, and reads
+          # a leading "D:\..." for the archive itself as a remote "host:path".
+          TMP=$(cygpath -u "$RUNNER_TEMP")
+          WS=$(cygpath -u '${{ runner.workspace }}')
           fetch_dep() {
             local name="$1" dest="$2"
             local line url base
@@ -375,17 +379,15 @@ jobs:
             url=$(echo "$line" | cut -d';' -f2)
             base=$(echo "$line" | cut -d';' -f3)
             echo "[$name] $url/$base.tar.gz"
-            curl -sSL --fail -o "$RUNNER_TEMP/$base.tar.gz" "$url/$base.tar.gz"
+            curl -sSL --fail -o "$TMP/$base.tar.gz" "$url/$base.tar.gz"
             mkdir -p "$dest"
-            # Name the archive relatively, from its own directory: GNU tar reads a
-            # leading "D:\..." as a remote "host:path". -C is unaffected.
-            ( cd "$RUNNER_TEMP" && tar -xzf "$base.tar.gz" -C "$dest" --strip-components=1 )
+            ( cd "$TMP" && tar -xzf "$base.tar.gz" -C "$dest" --strip-components=1 )
           }
-          fetch_dep migraphx_windows "${{ runner.workspace }}/migraphx-sdk"
-          fetch_dep therock_windows "${{ runner.workspace }}/therock"
-          test -f "${{ runner.workspace }}/migraphx-sdk/lib/cmake/migraphx/migraphx-config.cmake"
-          test -f "${{ runner.workspace }}/migraphx-sdk/problem_cache.json"
-          test -f "${{ runner.workspace }}/therock/lib/cmake/hip/hip-config.cmake"
+          fetch_dep migraphx_windows "$WS/migraphx-sdk"
+          fetch_dep therock_windows "$WS/therock"
+          test -f "$WS/migraphx-sdk/lib/cmake/migraphx/migraphx-config.cmake"
+          test -f "$WS/migraphx-sdk/problem_cache.json"
+          test -f "$WS/therock/lib/cmake/hip/hip-config.cmake"
 
       # Build through the repo's own build.py rather than a hand-written cmake
       # line: it derives the cmake arguments from --use_amdgpu / the three *_home

--- a/.github/workflows/windows-deps.yml
+++ b/.github/workflows/windows-deps.yml
@@ -17,7 +17,7 @@ on:
         description: Cache key holding the ONNX Runtime install prefix.
         value: ${{ jobs.ort.outputs.cache_key }}
       amdgpu_cache_key:
-        description: Cache key holding amdgpu-ep.dll + hip-backend.dll.
+        description: Cache key holding the onnxruntime_ep_amdgpu wheel + problem_cache.json.
         value: ${{ jobs.amdgpu.outputs.cache_key }}
       oga_cache_key:
         description: Cache key holding the OGA artifact set.
@@ -33,6 +33,11 @@ env:
   OGA_VERSION: "0.14.0"
   OGA_PR_PATCHES: "2194"
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
+  # AMD GPU umbrella EP, from the upstream repo's gpuep-releases/gpuep-rel-2610.2
+  # release branch (not main: main defaults USE_HIP to OFF and has no
+  # MIGRAPHX_EP_PROBLEM_CACHE). Pinned to the commit AMD's packaging pipeline
+  # builds, so it matches the MIGraphX SDK pinned in cmake/deps.txt.
+  AMDGPU_EP_REF: "05eaa2a938f71e98b49bd1be3fb03720167be5cc"
 
 jobs:
   llvm:
@@ -273,10 +278,29 @@ jobs:
       cache_key: ${{ steps.key.outputs.value }}
 
     steps:
+      # cmake/deps.txt pins the MIGraphX SDK and TheRock SDK this job downloads,
+      # so it is both the download manifest and the cache-key input. Only cmake/
+      # is needed; the blob hash below reads the tree, not the working copy.
+      - name: Checkout deps manifest
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: source-hip-ep
+          sparse-checkout: cmake
+          fetch-depth: 1
+          show-progress: false
+
+      # Keying on deps.txt's blob hash invalidates the cache on any pin bump
+      # (MIGraphX, TheRock) without enumerating versions here. --short=12 is
+      # explicit because git's default abbreviation length grows with the object
+      # count, which would silently change the key.
       - name: Compute cache key
         id: key
         shell: bash
-        run: echo "value=windows-amdgpu-a1318ed-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}" >> "$GITHUB_OUTPUT"
+        working-directory: source-hip-ep
+        run: |
+          DEPS_HASH=$(git rev-parse --short=12 HEAD:cmake/deps.txt)
+          EP_REF="${{ env.AMDGPU_EP_REF }}"
+          echo "value=windows-amdgpu-${EP_REF:0:7}-deps${DEPS_HASH}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}" >> "$GITHUB_OUTPUT"
 
       - name: Probe amdgpu-artifacts
         id: cache-amdgpu
@@ -300,10 +324,10 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Setup MSVC environment
-        if: steps.cache-amdgpu.outputs.cache-hit != 'true'
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-
+      # No msvc-dev-cmd here: build.py replaces os.environ wholesale with what
+      # vcvars64.bat reports, and it skips running vcvars when VSINSTALLDIR is
+      # already set -- which would leave the environment empty and hide ninja and
+      # sccache. It locates the toolchain itself via vswhere.
       - name: Prepare sccache local cache
         if: steps.cache-amdgpu.outputs.cache-hit != 'true'
         shell: bash
@@ -328,41 +352,87 @@ jobs:
         if: steps.cache-amdgpu.outputs.cache-hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: zz002/onnxruntime-ep-amdgpu
-          ref: a1318edb3c5b87d539bd797eff3addaa7ba2ddda
+          repository: onnxruntime/onnxruntime-ep-amdgpu
+          ref: ${{ env.AMDGPU_EP_REF }}
           path: source-amdgpu
           fetch-depth: 1
           show-progress: false
 
+      # MIGraphX SDK (find_package(migraphx) prefix, and problem_cache.json at
+      # its root) plus the TheRock ROCm SDK (find_package(hip)). This job has no
+      # TheRock otherwise: elsewhere cmake/deps.cmake downloads it during the
+      # project's own configure, which does not happen here.
+      - name: Fetch MIGraphX + TheRock SDKs
+        if: steps.cache-amdgpu.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          DEPS="source-hip-ep/cmake/deps.txt"
+          fetch_dep() {
+            local name="$1" dest="$2"
+            local line url base
+            line=$(grep -E "^${name};" "$DEPS")
+            url=$(echo "$line" | cut -d';' -f2)
+            base=$(echo "$line" | cut -d';' -f3)
+            echo "[$name] $url/$base.tar.gz"
+            curl -sSL --fail -o "$RUNNER_TEMP/$base.tar.gz" "$url/$base.tar.gz"
+            mkdir -p "$dest"
+            tar -xzf "$RUNNER_TEMP/$base.tar.gz" -C "$dest" --strip-components=1
+          }
+          fetch_dep migraphx_windows "${{ runner.workspace }}/migraphx-sdk"
+          fetch_dep therock_windows "${{ runner.workspace }}/therock"
+          test -f "${{ runner.workspace }}/migraphx-sdk/lib/cmake/migraphx/migraphx-config.cmake"
+          test -f "${{ runner.workspace }}/migraphx-sdk/problem_cache.json"
+          test -f "${{ runner.workspace }}/therock/lib/cmake/hip/hip-config.cmake"
+
+      # Build through the repo's own build.py rather than a hand-written cmake
+      # line: it derives the cmake arguments from --use_amdgpu / the three *_home
+      # paths, and --build_wheel packs every backend plus the MIGraphX and
+      # DirectML runtimes shipped next to them, so the artifact set follows
+      # upstream instead of a list maintained here.
+      #
+      # Do not pass --target: _build_targets emits `-target` (one dash), so the
+      # default all-target build is the working path. --use_cache is skipped too;
+      # on Windows it only sets BUILD_CACHE and never wires up a launcher, hence
+      # sccache goes through --cmake_extra_defines.
       - name: Build amdgpu-ep
         if: steps.cache-amdgpu.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          # onnxruntime-ep-amdgpu requires CMake >= 4.2; the runner's system
-          # cmake is 3.31, so use a pip-provided cmake for this build.
+          set -euo pipefail
+          # The repo needs CMake >= 4.2 and uses 4.x-only syntax; the runner's
+          # system cmake is older.
           python -m pip install -q "cmake>=4.2"
           CMAKE="$(python -c "import cmake, os; print(os.path.join(cmake.CMAKE_BIN_DIR, 'cmake.exe'))")"
           echo "Using $("$CMAKE" --version | head -1)"
-          "$CMAKE" -G Ninja -S source-amdgpu -B "${{ runner.workspace }}/build-amdgpu" \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DUSE_AMDGPU=ON \
-            -DCMAKE_PREFIX_PATH="${{ runner.workspace }}/ort-install" \
-            -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded \
-            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          "$CMAKE" --build "${{ runner.workspace }}/build-amdgpu" --target amdgpu-ep hip-ep
+          MIGRAPHX_SDK="${{ runner.workspace }}/migraphx-sdk"
+          python source-amdgpu/tools/ci_build/build.py \
+            --build_dir "${{ runner.workspace }}/build-amdgpu" \
+            --config Release \
+            --cmake_generator Ninja \
+            --cmake_path "$CMAKE" \
+            --use_amdgpu \
+            --onnxrt_home "${{ runner.workspace }}/ort-install" \
+            --migraphx_home "$MIGRAPHX_SDK" \
+            --hip_path "${{ runner.workspace }}/therock" \
+            --build_wheel \
+            --cmake_extra_defines \
+              "MIGRAPHX_EP_PROBLEM_CACHE=$MIGRAPHX_SDK/problem_cache.json" \
+              CMAKE_C_COMPILER_LAUNCHER=sccache \
+              CMAKE_CXX_COMPILER_LAUNCHER=sccache
 
           ARTIFACTS="${{ runner.workspace }}/amdgpu-artifacts"
           mkdir -p "$ARTIFACTS"
-          for dll in amdgpu-ep.dll hip-backend.dll; do
-            SRC=$(find "${{ runner.workspace }}/build-amdgpu" -name "$dll" -type f | head -1)
-            if [ -z "$SRC" ]; then
-              echo "ERROR: $dll not found in build tree"
-              exit 1
-            fi
-            cp "$SRC" "$ARTIFACTS/"
-            echo "Cached $dll"
-          done
+          WHEEL=$(find "${{ runner.workspace }}/build-amdgpu" -name 'onnxruntime_ep_amdgpu-*.whl' -type f | head -1)
+          if [ -z "$WHEEL" ]; then
+            echo "ERROR: onnxruntime_ep_amdgpu wheel not found in build tree"
+            exit 1
+          fi
+          cp "$WHEEL" "$ARTIFACTS/"
+          echo "Cached $(basename "$WHEEL")"
+          # The wheel's packing globs only *.dll/*.pdb/*.exe, so the tuning DB
+          # has to be carried separately.
+          cp "$MIGRAPHX_SDK/problem_cache.json" "$ARTIFACTS/"
 
       - name: Save amdgpu-artifacts
         if: steps.cache-amdgpu.outputs.cache-hit != 'true'

--- a/.github/workflows/windows-gpu-test.yml
+++ b/.github/workflows/windows-gpu-test.yml
@@ -365,20 +365,18 @@ jobs:
           $model = "${{ vars.GPU_TEST_ASSET_ROOT || runner.workspace }}\amdgpu-oga-models\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml"
           if (-not (Test-Path $model)) { Write-Host "[SKIP] model not found: $model"; exit 0 }
 
-          # The umbrella wheel owns onnxruntime_ep_amdgpu/ (its __init__.py sets
-          # up the DLL search path) and our wheel adds hipgpu.dll + custom_kernels
-          # into that same directory, so the whole chain resolves by co-location.
-          # No DLL injection needed — exercise the wheel path end-to-end.
+          # Our wheel adds hipgpu.dll + custom_kernels into the umbrella wheel's
+          # package directory, so the chain resolves by co-location. No DLL
+          # injection needed — exercise the wheel path end-to-end.
           $pkg = "$PWD\wheelpkg"
           $venv = "$PWD\oga-smoke-venv"
           if (Test-Path $venv) { Remove-Item $venv -Recurse -Force }
           python -m venv $venv
           $py = "$venv\Scripts\python.exe"
 
-          # --find-links, not --no-index: onnxruntime-ep-hip now depends on
-          # onnxruntime-ep-amdgpu, which is not on PyPI and has to come from this
-          # directory, while onnxruntime-directml still needs PyPI for its own
-          # dependencies (flatbuffers, numpy, ...).
+          # --find-links, not --no-index: onnxruntime-ep-amdgpu is not on PyPI and
+          # has to come from this directory, while onnxruntime-directml still needs
+          # PyPI for its own dependencies.
           Push-Location "$pkg\wheels"
           & $py -m pip install --quiet --find-links . `
             (Get-Item onnxruntime_directml-*.whl).Name `

--- a/.github/workflows/windows-gpu-test.yml
+++ b/.github/workflows/windows-gpu-test.yml
@@ -375,20 +375,19 @@ jobs:
           python -m venv $venv
           $py = "$venv\Scripts\python.exe"
 
-          # --no-index because onnxruntime-ep-hip now depends on
-          # onnxruntime-ep-amdgpu, which is not on PyPI: pip has to take the local
-          # wheel rather than try to resolve it.
+          # --find-links, not --no-index: onnxruntime-ep-hip now depends on
+          # onnxruntime-ep-amdgpu, which is not on PyPI and has to come from this
+          # directory, while onnxruntime-directml still needs PyPI for its own
+          # dependencies (flatbuffers, numpy, ...).
           Push-Location "$pkg\wheels"
-          & $py -m pip install --quiet --no-index `
+          & $py -m pip install --quiet --find-links . `
             (Get-Item onnxruntime_directml-*.whl).Name `
             (Get-Item onnxruntime_ep_amdgpu-*.whl).Name `
             (Get-Item onnxruntime_ep_hip-*.whl).Name `
-            (Get-Item onnxruntime_genai_directml-*.whl).Name
+            (Get-Item onnxruntime_genai_directml-*.whl).Name `
+            psutil tqdm pandas
           Pop-Location
           if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] wheel install failed"; exit 1 }
-
-          & $py -m pip install --quiet psutil tqdm pandas
-          if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] benchmark deps install failed"; exit 1 }
 
           New-Item -ItemType Directory -Force -Path oga-smoke-results | Out-Null
           & $py "$pkg\run_onnx.py" --benchmark "$pkg\benchmark_e2e.py" `

--- a/.github/workflows/windows-gpu-test.yml
+++ b/.github/workflows/windows-gpu-test.yml
@@ -365,18 +365,12 @@ jobs:
           $model = "${{ vars.GPU_TEST_ASSET_ROOT || runner.workspace }}\amdgpu-oga-models\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml"
           if (-not (Test-Path $model)) { Write-Host "[SKIP] model not found: $model"; exit 0 }
 
-          # Our wheel adds hipgpu.dll + custom_kernels into the umbrella wheel's
-          # package directory, so the chain resolves by co-location. No DLL
-          # injection needed — exercise the wheel path end-to-end.
           $pkg = "$PWD\wheelpkg"
           $venv = "$PWD\oga-smoke-venv"
           if (Test-Path $venv) { Remove-Item $venv -Recurse -Force }
           python -m venv $venv
           $py = "$venv\Scripts\python.exe"
 
-          # --find-links, not --no-index: onnxruntime-ep-amdgpu is not on PyPI and
-          # has to come from this directory, while onnxruntime-directml still needs
-          # PyPI for its own dependencies.
           Push-Location "$pkg\wheels"
           & $py -m pip install --quiet --find-links . `
             (Get-Item onnxruntime_directml-*.whl).Name `

--- a/.github/workflows/windows-gpu-test.yml
+++ b/.github/workflows/windows-gpu-test.yml
@@ -365,24 +365,30 @@ jobs:
           $model = "${{ vars.GPU_TEST_ASSET_ROOT || runner.workspace }}\amdgpu-oga-models\Llama-3.1-8B-awq-g128-int4-asym-fp16-onnx-dml"
           if (-not (Test-Path $model)) { Write-Host "[SKIP] model not found: $model"; exit 0 }
 
-          # The morphizen wheel now bundles the whole AMD GPU umbrella chain
-          # (amdgpu-ep.dll + hip-backend.dll + hipgpu.dll + custom_kernels) into
-          # onnxruntime/capi/, next to onnxruntime.dll where OGA discovers the
-          # EP. No DLL injection needed — exercise the wheel path end-to-end.
+          # The umbrella wheel owns onnxruntime_ep_amdgpu/ (its __init__.py sets
+          # up the DLL search path) and our wheel adds hipgpu.dll + custom_kernels
+          # into that same directory, so the whole chain resolves by co-location.
+          # No DLL injection needed — exercise the wheel path end-to-end.
           $pkg = "$PWD\wheelpkg"
           $venv = "$PWD\oga-smoke-venv"
           if (Test-Path $venv) { Remove-Item $venv -Recurse -Force }
           python -m venv $venv
           $py = "$venv\Scripts\python.exe"
 
+          # --no-index because onnxruntime-ep-hip now depends on
+          # onnxruntime-ep-amdgpu, which is not on PyPI: pip has to take the local
+          # wheel rather than try to resolve it.
           Push-Location "$pkg\wheels"
-          & $py -m pip install --quiet `
+          & $py -m pip install --quiet --no-index `
             (Get-Item onnxruntime_directml-*.whl).Name `
+            (Get-Item onnxruntime_ep_amdgpu-*.whl).Name `
             (Get-Item onnxruntime_ep_hip-*.whl).Name `
-            (Get-Item onnxruntime_genai_directml-*.whl).Name `
-            psutil tqdm pandas
+            (Get-Item onnxruntime_genai_directml-*.whl).Name
           Pop-Location
           if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] wheel install failed"; exit 1 }
+
+          & $py -m pip install --quiet psutil tqdm pandas
+          if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] benchmark deps install failed"; exit 1 }
 
           New-Item -ItemType Directory -Force -Path oga-smoke-results | Out-Null
           & $py "$pkg\run_onnx.py" --benchmark "$pkg\benchmark_e2e.py" `

--- a/.github/workflows/windows-gpu-test.yml
+++ b/.github/workflows/windows-gpu-test.yml
@@ -372,14 +372,16 @@ jobs:
           $py = "$venv\Scripts\python.exe"
 
           Push-Location "$pkg\wheels"
-          & $py -m pip install --quiet --find-links . `
+          & $py -m pip install --quiet `
             (Get-Item onnxruntime_directml-*.whl).Name `
-            (Get-Item onnxruntime_ep_amdgpu-*.whl).Name `
-            (Get-Item onnxruntime_ep_hip-*.whl).Name `
             (Get-Item onnxruntime_genai_directml-*.whl).Name `
             psutil tqdm pandas
+          if ($LASTEXITCODE -ne 0) { Pop-Location; Write-Host "[ERROR] wheels install failed"; exit 1 }
+          & $py -m pip install --quiet --no-deps `
+            (Get-Item onnxruntime_ep_amdgpu-*.whl).Name `
+            (Get-Item onnxruntime_ep_hip-*.whl).Name
           Pop-Location
-          if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] wheel install failed"; exit 1 }
+          if ($LASTEXITCODE -ne 0) { Write-Host "[ERROR] EP wheel install failed"; exit 1 }
 
           New-Item -ItemType Directory -Force -Path oga-smoke-results | Out-Null
           & $py "$pkg\run_onnx.py" --benchmark "$pkg\benchmark_e2e.py" `

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -19,9 +19,4 @@ cpptrace;https://github.com/jeremy-rifkin/cpptrace.git;v0.8.3
 ##
 therock_windows;https://github.com/ROCm/hip-ep/releases/download/v0.3.0;therock-dist-windows-gfx1151-7.14.0
 therock_linux;https://repo.amd.com/rocm/tarball;7.11.0
-##
-## MIGraphX SDK, used only by the CI amdgpu job's umbrella EP build (this project
-## does not link MIGraphX): a find_package(migraphx) prefix with
-## problem_cache.json at its root. hash = MIGraphX short commit. Transferred here
-## because its Artifactory origin is unreachable from GitHub-hosted runners.
 migraphx_windows;https://github.com/ROCm/hip-ep/releases/download/v0.3.0;migraphx-sdk-windows-1217ce1d

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -19,3 +19,11 @@ cpptrace;https://github.com/jeremy-rifkin/cpptrace.git;v0.8.3
 ##
 therock_windows;https://github.com/ROCm/hip-ep/releases/download/v0.3.0;therock-dist-windows-gfx1151-7.14.0
 therock_linux;https://repo.amd.com/rocm/tarball;7.11.0
+##
+## MIGraphX SDK, consumed only by the AMD GPU umbrella EP build in the CI
+## amdgpu job (this project does not link MIGraphX): find_package(migraphx)
+## prefix plus problem_cache.json at its root. hash column = MIGraphX short
+## commit; the tarball is a transfer of the AMDMIGraphX build that ships in the
+## Windows ML MSIX, since its origin (an AMD-internal Artifactory) is not
+## reachable from GitHub-hosted runners.
+migraphx_windows;https://github.com/ROCm/hip-ep/releases/download/v0.3.0;migraphx-sdk-windows-1217ce1d

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -20,10 +20,8 @@ cpptrace;https://github.com/jeremy-rifkin/cpptrace.git;v0.8.3
 therock_windows;https://github.com/ROCm/hip-ep/releases/download/v0.3.0;therock-dist-windows-gfx1151-7.14.0
 therock_linux;https://repo.amd.com/rocm/tarball;7.11.0
 ##
-## MIGraphX SDK, consumed only by the AMD GPU umbrella EP build in the CI
-## amdgpu job (this project does not link MIGraphX): find_package(migraphx)
-## prefix plus problem_cache.json at its root. hash column = MIGraphX short
-## commit; the tarball is a transfer of the AMDMIGraphX build that ships in the
-## Windows ML MSIX, since its origin (an AMD-internal Artifactory) is not
-## reachable from GitHub-hosted runners.
+## MIGraphX SDK, used only by the CI amdgpu job's umbrella EP build (this project
+## does not link MIGraphX): a find_package(migraphx) prefix with
+## problem_cache.json at its root. hash = MIGraphX short commit. Transferred here
+## because its Artifactory origin is unreachable from GitHub-hosted runners.
 migraphx_windows;https://github.com/ROCm/hip-ep/releases/download/v0.3.0;migraphx-sdk-windows-1217ce1d

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -323,25 +323,28 @@ builds, not the stock PyPI ones:
 cd ../hip-ep  # Back to the project root
 pip install \
   ../build/onnxruntime/Release/dist/onnxruntime_directml-*.whl \
+  onnxruntime_ep_amdgpu-*.whl \
   ../build/hip-ep/python/dist/onnxruntime_ep_hip-*.whl \
   ../build/onnxruntime-genai/Release/wheel/onnxruntime_genai_directml-*.whl
 ```
 > **Note**: the ORT whl may be under `../build/onnxruntime/Release/Release/dist/`.
-> Install the EP wheel AFTER onnxruntime: it ships its own native files straight
-> into `onnxruntime/capi/`, next to `onnxruntime.dll` -- the EP plugin
-> `hipgpu.dll` (which carries the JIT compiler), the custom kernels, and the
-> ROCm runtime it was built against (amdhip64 + hipBLASLt and their
-> dependencies), so no separate ROCm install is needed. The wheel does NOT
-> bundle the AMD GPU umbrella (`amdgpu-ep.dll` + `hip-backend.dll`); driving OGA
-> through the umbrella needs those supplied separately (CI injects them via
-> `HIP_WHEEL_EXTRA_DLLS`).
+> `onnxruntime_ep_amdgpu` is the AMD GPU umbrella EP from the upstream
+> [onnxruntime-ep-amdgpu](https://github.com/onnxruntime/onnxruntime-ep-amdgpu)
+> repo (CI builds it in the `amdgpu` deps job and ships it in the
+> `hip-python-package` artifact). Install the EP wheel AFTER it: our native files
+> -- the EP plugin `hipgpu.dll` (which carries the JIT compiler), the custom
+> kernels, hipBLASLt and its Tensile data -- land in that same
+> `onnxruntime_ep_amdgpu/` package directory, which is what lets
+> `hip-backend.dll` resolve `hipgpu.dll` by bare name.
 
-**Runtime env** -- the bundled ROCm DLLs sit next to `hipgpu.dll`, but Windows
-does not search a DLL's own directory for its dependencies, so
-`onnxruntime/capi` has to be on the DLL search path before ORT loads the EP.
-`python/examples/run_onnx.py` does that (and forwards it to the `--benchmark`
-child process). NATIVE artifacts are not supported from a wheel: their lld-link
-step needs the ROCm import libs, which only a `THEROCK_DIST` install has.
+**Runtime env** -- `onnxruntime_ep_amdgpu/__init__.py` puts its own directory on
+the DLL search path, which covers the whole chain since everything lives there.
+Two things still need setting: `AMDGPU_EP_PATH`, because the umbrella is no
+longer next to `onnxruntime.dll` where OGA looks for it, and `LIB` for the JIT
+linker. `python/examples/run_onnx.py` does both (and forwards them to the
+`--benchmark` child process). NATIVE artifacts are not supported from a wheel:
+their lld-link step needs the ROCm import libs, which only a `THEROCK_DIST`
+install has.
 
 **Use** -- there is no Python API to import; the native files are found by
 location. Run a model whose `genai_config.json` selects the EP via

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -14,10 +14,11 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 # staged under the build dir, the wheel lands in <build>/python/dist.
 set(_pkg_src "${CMAKE_CURRENT_SOURCE_DIR}")
 set(_stage "${CMAKE_CURRENT_BINARY_DIR}/pkg")
-# Native artifacts are staged into the onnxruntime/capi namespace package so the
-# wheel ships them at onnxruntime/capi/ (platlib), installing next to
-# onnxruntime.dll cross-platform.
-set(_libs_dir "${_stage}/onnxruntime/capi")
+# Native artifacts are staged into the onnxruntime_ep_amdgpu package so they
+# install next to the AMD GPU umbrella EP from the upstream wheel of the same
+# name. hip-backend.dll resolves "hipgpu.dll" by bare name, which only works
+# when both sit in one directory.
+set(_libs_dir "${_stage}/onnxruntime_ep_amdgpu")
 set(_dist_dir "${CMAKE_CURRENT_BINARY_DIR}/dist")
 
 set(MORPHIZEN_HIP_ARCH "${HIP_ARCHITECTURES}")
@@ -87,8 +88,8 @@ add_custom_target(wheel ALL
           "${_pkg_src}/setup.py"
           "${_stage}/"
   # 2. Stage native artifacts (EP lib + per-arch custom-kernels runtime
-  #    DLLs/SOs + CRT import libs) into the onnxruntime/capi namespace
-  #    package dir so the wheel ships them at onnxruntime/capi/ (platlib).
+  #    DLLs/SOs + CRT import libs) into the onnxruntime_ep_amdgpu namespace
+  #    package dir so the wheel ships them at onnxruntime_ep_amdgpu/ (platlib).
   COMMAND ${CMAKE_COMMAND} -E rm -rf "${_libs_dir}"
   COMMAND ${Python3_EXECUTABLE} "${_pkg_src}/_pack_libs.py"
           ${_dll_args}

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -14,9 +14,6 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 # staged under the build dir, the wheel lands in <build>/python/dist.
 set(_pkg_src "${CMAKE_CURRENT_SOURCE_DIR}")
 set(_stage "${CMAKE_CURRENT_BINARY_DIR}/pkg")
-# Native artifacts stage into the onnxruntime_ep_amdgpu package, next to the
-# umbrella EP from the upstream wheel of the same name: hip-backend.dll resolves
-# "hipgpu.dll" by bare name, which needs both in one directory.
 set(_libs_dir "${_stage}/onnxruntime_ep_amdgpu")
 set(_dist_dir "${CMAKE_CURRENT_BINARY_DIR}/dist")
 
@@ -61,20 +58,6 @@ foreach(_arch IN LISTS HIP_ARCHITECTURES)
     message(WARNING
       "custom kernels target '${_ck_target}' not found; the wheel cannot "
       "JIT-load GPU kernels for ${_arch}.")
-  endif()
-endforeach()
-
-# Externally-built DLLs to also bundle next to the EP (absolute paths, ;-list).
-# Used to ship the AMD GPU umbrella chain (amdgpu-ep.dll + hip-backend.dll),
-# which is built in the separate onnxruntime-ep-amdgpu repo and has no target
-# here. Passed as --optional-dll so a plain EP-only wheel (var unset) is
-# unaffected and a missing path warns instead of failing. The caller (CI) is
-# responsible for building those DLLs before this wheel target runs.
-set(HIP_WHEEL_EXTRA_DLLS "" CACHE STRING
-  "Absolute paths (;-list) of externally-built DLLs to bundle into the wheel")
-foreach(_extra IN LISTS HIP_WHEEL_EXTRA_DLLS)
-  if(_extra)
-    list(APPEND _dll_args "--optional-dll" "${_extra}")
   endif()
 endforeach()
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -14,10 +14,9 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 # staged under the build dir, the wheel lands in <build>/python/dist.
 set(_pkg_src "${CMAKE_CURRENT_SOURCE_DIR}")
 set(_stage "${CMAKE_CURRENT_BINARY_DIR}/pkg")
-# Native artifacts are staged into the onnxruntime_ep_amdgpu package so they
-# install next to the AMD GPU umbrella EP from the upstream wheel of the same
-# name. hip-backend.dll resolves "hipgpu.dll" by bare name, which only works
-# when both sit in one directory.
+# Native artifacts stage into the onnxruntime_ep_amdgpu package, next to the
+# umbrella EP from the upstream wheel of the same name: hip-backend.dll resolves
+# "hipgpu.dll" by bare name, which needs both in one directory.
 set(_libs_dir "${_stage}/onnxruntime_ep_amdgpu")
 set(_dist_dir "${CMAKE_CURRENT_BINARY_DIR}/dist")
 

--- a/python/_pack_libs.py
+++ b/python/_pack_libs.py
@@ -22,8 +22,6 @@ CRT_LIBS = [
     "user32.lib",
 ]
 
-# amdhip64, amd_comgr and hiprtc are absent on purpose: the upstream
-# onnxruntime-ep-amdgpu wheel installs those same filenames into this directory.
 ROCM_DLL_GROUPS = [
     ["hipblaslt.dll", "libhipblaslt.dll"],
 ]
@@ -134,15 +132,6 @@ def main():
         "hip_custom_kernels.lib.",
     )
     ap.add_argument(
-        "--optional-dll",
-        action="append",
-        default=[],
-        metavar="PATH",
-        help="Externally-built runtime library to bundle if present (repeatable), "
-        "e.g. the amdgpu-ep/hip-backend DLLs built in a separate repo. Missing "
-        "paths warn instead of failing, so a plain EP-only wheel build still works.",
-    )
-    ap.add_argument(
         "--with-crt",
         action="store_true",
         help="Also copy MSVC/WinSDK CRT import libs (Windows).",
@@ -167,14 +156,6 @@ def main():
             print(f"  packaged import lib: {lib.name} <- {lib}")
         else:
             print(f"  WARNING: extra import lib not found: {lib}")
-
-    for raw in args.optional_dll:
-        lib = Path(raw)
-        if lib.is_file():
-            shutil.copy2(lib, dest / lib.name)
-            print(f"  packaged optional dll: {lib.name} <- {lib}")
-        else:
-            print(f"  WARNING: optional dll not found (skipping): {lib}")
 
     rc = _copy_rocm_runtime(Path(args.rocm_dist), args.rocm_arch, dest)
     if rc:

--- a/python/_pack_libs.py
+++ b/python/_pack_libs.py
@@ -22,9 +22,8 @@ CRT_LIBS = [
     "user32.lib",
 ]
 
-# amdhip64, amd_comgr and hiprtc are deliberately absent: the upstream
-# onnxruntime-ep-amdgpu wheel installs those into the same package directory, and
-# two distributions writing the same filename break each other on uninstall.
+# amdhip64, amd_comgr and hiprtc are absent on purpose: the upstream
+# onnxruntime-ep-amdgpu wheel installs those same filenames into this directory.
 ROCM_DLL_GROUPS = [
     ["hipblaslt.dll", "libhipblaslt.dll"],
 ]

--- a/python/_pack_libs.py
+++ b/python/_pack_libs.py
@@ -22,11 +22,11 @@ CRT_LIBS = [
     "user32.lib",
 ]
 
+# amdhip64, amd_comgr and hiprtc are deliberately absent: the upstream
+# onnxruntime-ep-amdgpu wheel installs those into the same package directory, and
+# two distributions writing the same filename break each other on uninstall.
 ROCM_DLL_GROUPS = [
-    ["amdhip64*.dll"],
-    ["amd_comgr*.dll"],
     ["hipblaslt.dll", "libhipblaslt.dll"],
-    ["hiprtc*.dll"],
 ]
 
 HIPBLASLT_DATA = ("hipblaslt", "library")
@@ -108,7 +108,9 @@ def main():
         "library is required; the JIT compiler is linked into it.",
     )
     ap.add_argument(
-        "--dest", required=True, help="Destination dir (the wheel's onnxruntime/capi)."
+        "--dest",
+        required=True,
+        help="Destination dir (the wheel's onnxruntime_ep_amdgpu).",
     )
     ap.add_argument(
         "--rocm-dist",

--- a/python/examples/run_onnx.py
+++ b/python/examples/run_onnx.py
@@ -4,13 +4,13 @@
 #
 """Run an ONNX model or OGA benchmark on the MorphiZen EP.
 
-Sets up the DLL search path and the JIT linker's LIB from the installed wheels,
+Sets up the JIT linker's LIB and the umbrella EP path from the installed wheels,
 then either:
   - Runs a plain ONNX model with random inputs (default), or
   - Delegates to benchmark_e2e.py for OGA benchmarks (--benchmark).
 
 Prerequisites (see docs/quick_start.md):
-  - pip install the onnxruntime + onnxruntime_ep_hip wheels
+  - pip install the onnxruntime + onnxruntime_ep_amdgpu + onnxruntime_ep_hip wheels
 
 Usage:
   python run_onnx.py path/to/model.onnx
@@ -23,6 +23,11 @@ import sys
 
 import numpy as np
 import onnxruntime as ort
+
+# Importing the package runs os.add_dll_directory on its own directory, which is
+# where every DLL in the chain lives, so this has to happen before ORT loads any
+# of them.
+import onnxruntime_ep_amdgpu
 
 EP_NAME = "MorphiZenEP"
 
@@ -39,13 +44,15 @@ _NP_DTYPE = {
 
 
 def _setup_env():
-    sp = os.path.dirname(os.path.dirname(ort.__file__))
-    capi = os.path.join(sp, "onnxruntime", "capi")
+    pkg = os.path.dirname(onnxruntime_ep_amdgpu.__file__)
 
-    os.environ["LIB"] = os.pathsep.join(filter(None, [capi, os.environ.get("LIB", "")]))
-    os.environ["PATH"] = os.pathsep.join([capi, os.environ.get("PATH", "")])
-    os.add_dll_directory(capi)
-    return capi
+    # The JIT linker resolves the CRT and ROCm import libs off %LIB%.
+    os.environ["LIB"] = os.pathsep.join(filter(None, [pkg, os.environ.get("LIB", "")]))
+    # OGA looks for the umbrella next to onnxruntime-genai.dll / onnxruntime.dll /
+    # the executable, none of which is this package directory, so point it here.
+    # Unlike an in-process registration, this survives into the --benchmark child.
+    os.environ["AMDGPU_EP_PATH"] = onnxruntime_ep_amdgpu.get_library_path()
+    return pkg
 
 
 def _random_input(spec):
@@ -58,8 +65,8 @@ def _random_input(spec):
     return np.random.randint(0, 2, size=shape).astype(dtype)
 
 
-def _run_onnx(model_path, capi):
-    ort.register_execution_provider_library(EP_NAME, os.path.join(capi, "hipgpu.dll"))
+def _run_onnx(model_path, pkg):
+    ort.register_execution_provider_library(EP_NAME, os.path.join(pkg, "hipgpu.dll"))
 
     devices = [d for d in ort.get_ep_devices() if d.ep_name == EP_NAME]
     if not devices:
@@ -95,8 +102,8 @@ def main():
         )
         return 2
 
-    capi = _setup_env()
-    return _run_onnx(sys.argv[1], capi)
+    pkg = _setup_env()
+    return _run_onnx(sys.argv[1], pkg)
 
 
 if __name__ == "__main__":

--- a/python/examples/run_onnx.py
+++ b/python/examples/run_onnx.py
@@ -4,13 +4,8 @@
 #
 """Run an ONNX model or OGA benchmark on the MorphiZen EP.
 
-Sets up the JIT linker's LIB and the umbrella EP path from the installed wheels,
-then either:
-  - Runs a plain ONNX model with random inputs (default), or
-  - Delegates to benchmark_e2e.py for OGA benchmarks (--benchmark).
-
-Prerequisites (see docs/quick_start.md):
-  - pip install the onnxruntime + onnxruntime_ep_amdgpu + onnxruntime_ep_hip wheels
+Runs a plain ONNX model with random inputs (default), or delegates to
+benchmark_e2e.py for OGA benchmarks (--benchmark).
 
 Usage:
   python run_onnx.py path/to/model.onnx
@@ -24,8 +19,6 @@ import sys
 import numpy as np
 import onnxruntime as ort
 
-# Importing this runs os.add_dll_directory on the package directory, where every
-# DLL in the chain lives, so it has to precede ORT loading any of them.
 import onnxruntime_ep_amdgpu
 
 EP_NAME = "MorphiZenEP"
@@ -44,12 +37,7 @@ _NP_DTYPE = {
 
 def _setup_env():
     pkg = os.path.dirname(onnxruntime_ep_amdgpu.__file__)
-
-    # The JIT linker resolves the CRT and ROCm import libs off %LIB%.
     os.environ["LIB"] = os.pathsep.join(filter(None, [pkg, os.environ.get("LIB", "")]))
-    # OGA looks for the umbrella next to its own DLL / onnxruntime.dll / the exe,
-    # none of which is this directory. An env var also reaches the --benchmark
-    # child, unlike an in-process registration.
     os.environ["AMDGPU_EP_PATH"] = onnxruntime_ep_amdgpu.get_library_path()
     return pkg
 

--- a/python/examples/run_onnx.py
+++ b/python/examples/run_onnx.py
@@ -24,9 +24,8 @@ import sys
 import numpy as np
 import onnxruntime as ort
 
-# Importing the package runs os.add_dll_directory on its own directory, which is
-# where every DLL in the chain lives, so this has to happen before ORT loads any
-# of them.
+# Importing this runs os.add_dll_directory on the package directory, where every
+# DLL in the chain lives, so it has to precede ORT loading any of them.
 import onnxruntime_ep_amdgpu
 
 EP_NAME = "MorphiZenEP"
@@ -48,9 +47,9 @@ def _setup_env():
 
     # The JIT linker resolves the CRT and ROCm import libs off %LIB%.
     os.environ["LIB"] = os.pathsep.join(filter(None, [pkg, os.environ.get("LIB", "")]))
-    # OGA looks for the umbrella next to onnxruntime-genai.dll / onnxruntime.dll /
-    # the executable, none of which is this package directory, so point it here.
-    # Unlike an in-process registration, this survives into the --benchmark child.
+    # OGA looks for the umbrella next to its own DLL / onnxruntime.dll / the exe,
+    # none of which is this directory. An env var also reaches the --benchmark
+    # child, unlike an in-process registration.
     os.environ["AMDGPU_EP_PATH"] = onnxruntime_ep_amdgpu.get_library_path()
     return pkg
 

--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -15,19 +15,22 @@ description = "hipgpu Execution Provider for ONNX Runtime (AMD GPU via HIP/ROCm)
 requires-python = ">=3.8"
 license = { text = "MIT" }
 authors = [{ name = "Advanced Micro Devices, Inc." }]
-dependencies = []
+# Owns onnxruntime_ep_amdgpu/__init__.py (which puts the package directory on
+# the DLL search path) and the umbrella EP that loads hip-backend.dll, so it has
+# to be installed for the chain below to resolve.
+dependencies = ["onnxruntime-ep-amdgpu"]
 
 [tool.setuptools]
-# The EP's native artifacts ship directly under onnxruntime/capi/ (platlib),
-# the same layout ONNX Runtime itself uses -- so they install next to
-# onnxruntime.dll cross-platform (pip resolves platlib per OS, unlike a
-# hardcoded lib/site-packages data_files path). onnxruntime.capi is treated as
-# a PEP 420 namespace package (we ship NO __init__.py for onnxruntime/ or
-# onnxruntime/capi/, so we never clobber ONNX Runtime's own files).
+# The EP's native artifacts ship under onnxruntime_ep_amdgpu/ (platlib), the
+# package the upstream onnxruntime-ep-amdgpu wheel owns, which puts the whole
+# chain in one directory: hip-backend.dll resolves "hipgpu.dll" by bare name,
+# and Windows searches the loading module's own directory only when it is on the
+# DLL search path -- which that package's __init__.py arranges. We treat it as a
+# PEP 420 namespace package and ship NO __init__.py, so the upstream one stands.
 
 [tool.setuptools.packages.find]
-include = ["onnxruntime_ep_hip", "onnxruntime.capi"]
+include = ["onnxruntime_ep_hip", "onnxruntime_ep_amdgpu"]
 namespaces = true
 
 [tool.setuptools.package-data]
-"onnxruntime.capi" = ["*.dll", "*.lib", "*.dll.a", "*.so", "hipblaslt/library/*/*"]
+"onnxruntime_ep_amdgpu" = ["*.dll", "*.lib", "*.dll.a", "*.so", "hipblaslt/library/*/*"]

--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -15,7 +15,7 @@ description = "hipgpu Execution Provider for ONNX Runtime (AMD GPU via HIP/ROCm)
 requires-python = ">=3.8"
 license = { text = "MIT" }
 authors = [{ name = "Advanced Micro Devices, Inc." }]
-dependencies = ["onnxruntime-ep-amdgpu"]
+dependencies = []
 
 [tool.setuptools]
 [tool.setuptools.packages.find]

--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -15,16 +15,9 @@ description = "hipgpu Execution Provider for ONNX Runtime (AMD GPU via HIP/ROCm)
 requires-python = ">=3.8"
 license = { text = "MIT" }
 authors = [{ name = "Advanced Micro Devices, Inc." }]
-# Owns onnxruntime_ep_amdgpu/__init__.py (which puts the package directory on the
-# DLL search path) and the umbrella EP that loads hip-backend.dll.
 dependencies = ["onnxruntime-ep-amdgpu"]
 
 [tool.setuptools]
-# Native artifacts ship under onnxruntime_ep_amdgpu/ (platlib), the package the
-# upstream wheel owns, so the whole chain sits in one directory -- required for
-# hip-backend.dll's bare-name load of hipgpu.dll. Treated as a PEP 420 namespace
-# package with NO __init__.py of ours, leaving the upstream one in place.
-
 [tool.setuptools.packages.find]
 include = ["onnxruntime_ep_hip", "onnxruntime_ep_amdgpu"]
 namespaces = true

--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -15,18 +15,15 @@ description = "hipgpu Execution Provider for ONNX Runtime (AMD GPU via HIP/ROCm)
 requires-python = ">=3.8"
 license = { text = "MIT" }
 authors = [{ name = "Advanced Micro Devices, Inc." }]
-# Owns onnxruntime_ep_amdgpu/__init__.py (which puts the package directory on
-# the DLL search path) and the umbrella EP that loads hip-backend.dll, so it has
-# to be installed for the chain below to resolve.
+# Owns onnxruntime_ep_amdgpu/__init__.py (which puts the package directory on the
+# DLL search path) and the umbrella EP that loads hip-backend.dll.
 dependencies = ["onnxruntime-ep-amdgpu"]
 
 [tool.setuptools]
-# The EP's native artifacts ship under onnxruntime_ep_amdgpu/ (platlib), the
-# package the upstream onnxruntime-ep-amdgpu wheel owns, which puts the whole
-# chain in one directory: hip-backend.dll resolves "hipgpu.dll" by bare name,
-# and Windows searches the loading module's own directory only when it is on the
-# DLL search path -- which that package's __init__.py arranges. We treat it as a
-# PEP 420 namespace package and ship NO __init__.py, so the upstream one stands.
+# Native artifacts ship under onnxruntime_ep_amdgpu/ (platlib), the package the
+# upstream wheel owns, so the whole chain sits in one directory -- required for
+# hip-backend.dll's bare-name load of hipgpu.dll. Treated as a PEP 420 namespace
+# package with NO __init__.py of ours, leaving the upstream one in place.
 
 [tool.setuptools.packages.find]
 include = ["onnxruntime_ep_hip", "onnxruntime_ep_amdgpu"]

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,15 +2,6 @@
 # Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # Licensed under the MIT License.
 #
-"""Setuptools shim.
-
-Metadata + packaging live in the generated pyproject.toml (the native artifacts
-ship as package-data of the ``onnxruntime_ep_amdgpu`` namespace package). This
-file only forces a platform-specific, Python-ABI-agnostic wheel tag
-(py3-none-<plat>), since the wheel ships prebuilt native libraries, not a Python
-extension.
-"""
-
 import sysconfig
 
 from setuptools import setup
@@ -22,12 +13,6 @@ except ImportError:  # older setuptools without the vendored command
 
 
 class bdist_wheel(_bdist_wheel):
-    # Keep the package content at the wheel root (Root-Is-Purelib: true) so it
-    # ships as onnxruntime_ep_amdgpu/... rather than relocated under
-    # .data/purelib/. The bundled DLLs don't link libpython, so the tag is
-    # py3-none-<platform>: ABI-agnostic but platform-specific. We compute the
-    # platform tag ourselves because a "pure" wheel would otherwise report
-    # plat == "any".
     def get_tag(self):
         plat = sysconfig.get_platform().replace("-", "_").replace(".", "_")
         return "py3", "none", plat

--- a/python/setup.py
+++ b/python/setup.py
@@ -5,9 +5,10 @@
 """Setuptools shim.
 
 Metadata + packaging live in the generated pyproject.toml (the native artifacts
-ship as package-data of the ``onnxruntime.capi`` namespace package). This file
-only forces a platform-specific, Python-ABI-agnostic wheel tag (py3-none-<plat>),
-since the wheel ships prebuilt native libraries, not a Python extension.
+ship as package-data of the ``onnxruntime_ep_amdgpu`` namespace package). This
+file only forces a platform-specific, Python-ABI-agnostic wheel tag
+(py3-none-<plat>), since the wheel ships prebuilt native libraries, not a Python
+extension.
 """
 
 import sysconfig
@@ -22,8 +23,8 @@ except ImportError:  # older setuptools without the vendored command
 
 class bdist_wheel(_bdist_wheel):
     # Keep the package content at the wheel root (Root-Is-Purelib: true) so it
-    # ships as onnxruntime/capi/... (like ONNX Runtime) rather than relocated
-    # under .data/purelib/. The bundled DLLs don't link libpython, so the tag is
+    # ships as onnxruntime_ep_amdgpu/... rather than relocated under
+    # .data/purelib/. The bundled DLLs don't link libpython, so the tag is
     # py3-none-<platform>: ABI-agnostic but platform-specific. We compute the
     # platform tag ourselves because a "pure" wheel would otherwise report
     # plat == "any".


### PR DESCRIPTION
## Summary

The `amdgpu` deps job now builds the AMD GPU umbrella EP from the upstream `onnxruntime/onnxruntime-ep-amdgpu` repo instead of a personal fork, with every backend enabled, and caches the wheel that repo's own build script produces. Our wheel's native files move from `onnxruntime/capi/` into the `onnxruntime_ep_amdgpu` package directory the upstream wheel owns.

## Related issue or design

None.

## Why

The fork existed for one reason: `USE_AMDGPU` forces `USE_MIGRAPHX` on and `find_package(migraphx REQUIRED)` had nothing to find, so the fork compiled the MIGraphX backend out. That is no longer necessary — the MIGraphX SDK is a 50 MB prefix (headers, import libs, `migraphx-config.cmake`), and `cmake/deps.txt` now pins it as a Release asset. With it, the umbrella builds unmodified upstream sources and the MIGraphX runtime ships alongside, so an `Auto` profile that routes to MIGraphX can actually run instead of failing at load time.

The SDK has to be transferred to a Release asset rather than fetched from its origin: that origin is an AMD-internal Artifactory whose host has no public DNS record, so GitHub-hosted runners cannot reach it, and its builds are pruned after 180 days. The tarball carries the same AMDMIGraphX binaries that ship to end users in the Windows ML MSIX.

Building via the repo's `tools/ci_build/build.py` replaces a cmake invocation maintained here, and `--build_wheel` replaces a hand-maintained DLL list: the wheel packs each backend plus the MIGraphX and DirectML runtimes staged next to them, so the artifact set follows upstream. The layout move follows from `hip-backend.dll` resolving `hipgpu.dll` by bare name — Windows does not search a loaded module's own directory, so the whole chain has to sit in one directory that something puts on the DLL search path, which is exactly what the upstream package's `__init__.py` does.

## What

- `cmake/deps.txt`: new `migraphx_windows` pin (MIGraphX short commit as the hash column). Only the CI `amdgpu` job consumes it; `deps.cmake` does not.
- `windows-deps.yml`: upstream repo + `AMDGPU_EP_REF` pin (the `gpuep-releases/gpuep-rel-2610.2` commit AMD's packaging pipeline builds, not `main`, which defaults `USE_HIP` off and lacks `MIGRAPHX_EP_PROBLEM_CACHE`); a step that resolves both SDK tarballs out of `deps.txt`; `build.py` in place of the cmake line; the wheel plus `problem_cache.json` as the cached artifact. The cache key now keys on `deps.txt`'s blob hash, so any pin bump invalidates it. `msvc-dev-cmd` is removed — `build.py` replaces `os.environ` with what vcvars reports and skips vcvars when `VSINSTALLDIR` is already set, which would leave the environment empty and hide ninja and sccache.
- `windows-build-real.yml`: unpacks the wheel into `staging/bin`, skipping the ROCm and DirectML runtimes it also carries so the versions `hipgpu.dll` and `onnxruntime.dll` were built against win; ships the umbrella wheel in `hip-python-package`; stops passing `HIP_WHEEL_EXTRA_DLLS`.
- `python/`: wheel files land in `onnxruntime_ep_amdgpu/` (PEP 420 namespace package, no `__init__.py` of ours), `onnxruntime-ep-amdgpu` becomes a dependency, and `amdhip64` / `amd_comgr` / `hiprtc` drop out of our packing since the upstream wheel installs them under the same names.
- `run_onnx.py`: imports the umbrella package (which sets up the DLL search path) and sets `AMDGPU_EP_PATH`, needed because the umbrella is no longer next to `onnxruntime.dll` where OGA looks for it, and because an in-process registration would not survive into the `--benchmark` child process.

## Test plan

Local, against the pinned upstream commit and the pinned SDKs:

- [x] `build.py --config Release --use_amdgpu --onnxrt_home … --migraphx_home … --hip_path … --build_wheel` succeeds cold in 6m20s on MSVC 19.44 (VS 2022 14.44; AMD's pipeline uses 19.50, so the older toolchain is covered)
- [x] Abseil needs no pre-install — protobuf's own fallback fetches it, so the cget recipe AMD's pipeline uses is unnecessary here
- [x] Wheel contains all four backends, the MIGraphX runtime, `amdmlss.dll`, DirectML, and a generated `__init__.py` declaring `AMDGPUExecutionProvider`; metadata requires `onnxruntime~=1.27.0`
- [x] `MIGRAPHX_EP_PROBLEM_CACHE` deploys `problem_cache.json` next to `migraphx-backend.dll`
- [x] SDK tarball unpacks with `--strip-components=1` to a `find_package(migraphx)`-ready prefix (config, targets, headers, import libs, `problem_cache.json`, MIT license); re-downloaded asset matches the uploaded sha256
- [x] `pre-commit run --all-files` clean

CI is the remaining gate:

- [ ] `prebuild / amdgpu` green on a cold cache (upstream checkout, SDK downloads, `build.py`, wheel cached)
- [ ] `build_real / build` green: wheel unpacks into `staging/bin` and `amdgpu-ep.dll` is present
- [ ] `gpu_test / test` green, including the OGA wheel smoke through the new two-wheel install

## Notes for reviewers

The pinned commit is on upstream's `gpuep-releases/gpuep-rel-2610.2` branch, not `main`. Bumping to `main` later needs `--cmake_extra_defines USE_HIP=ON` and loses `MIGRAPHX_EP_PROBLEM_CACHE`.

`build.py` is not what AMD's own pipeline uses (that goes through a private tool's CMake presets), so it has less Windows mileage: `_build_targets` emits `-target` with one dash, hence no `--target` here, and `--use_cache` wires up no launcher on Windows, hence sccache via `--cmake_extra_defines`. Falling back to a plain cmake line plus a sibling-directory glob remains possible if it becomes a problem.

Two pre-existing inconsistencies noticed while working here, left alone: `run_onnx.py` still registers under `EP_NAME = "MorphiZenEP"` while the EP has been `hipgpu` since #402 (harmless today because nothing passes provider options, which would need the `ep.hipgpu.*` prefix), and `pyproject.toml.in` pins `rocm[...]==7.11.0` while `deps.txt` is on TheRock 7.14.0.

Also worth knowing: with the umbrella in its own package directory, none of OGA's automatic lookup paths match it (they all mean "next to the host"), so a run that sets nothing fails silently by falling back instead of erroring at load. `run_onnx.py` covers our paths; a durable fix would be for the shim to call `AddDllDirectory` on its own module directory, which belongs upstream.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
