### PR TITLE
refactor(onnx-to-hip): define DEBUG_TYPE per file, not in the shared header

### DIFF
--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -38,8 +38,6 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 
-#define DEBUG_TYPE "convert-onnx-to-hip"
-
 namespace mlir {
 namespace hip {
 

--- a/lib/Conversion/OnnxToHip/SliceConversion.cpp
+++ b/lib/Conversion/OnnxToHip/SliceConversion.cpp
@@ -10,6 +10,8 @@
 
 #include "llvm/ADT/APInt.h"
 
+#define DEBUG_TYPE "slice-conversion"
+
 namespace mlir {
 namespace hip {
 namespace {


### PR DESCRIPTION
## Summary

`lib/Conversion/OnnxToHip/OnnxToHipUtils.h` defined `DEBUG_TYPE` and never used it, so its only effect was to leak a value into every file that includes it. Each pattern file that declares its own debug name then redefines the macro, which is 11 C4005 macro-redefinition warnings on MSVC. Drop it from the header and give `SliceConversion.cpp` -- the one file that was relying on the leak -- its own name.

## Related issue or design

None. Split out of #795, which needs a per-file `DEBUG_TYPE` in a new pattern file and would otherwise carry this unrelated cleanup.

## Why

The define is carry-over from #98, which split the `OnnxToHip.cpp` monolith into per-operator files. In the monolith a single `DEBUG_TYPE` at the top was correct; the split moved it into the shared header along with the rest of the common boilerplate, which kept the scattered `LLVM_DEBUG` calls compiling without visiting each file.

That it was mechanical rather than intended is visible two ways: the same commit split `HipToLLVM.cpp` the same way and its `HipToLLVMUtils.h` does not define `DEBUG_TYPE`, and `OnnxToHip.cpp` carries its own token-identical define, so the header copy was redundant for the one file it would have served. `OnnxToHipUtils.h` was the only header under `lib/` defining `DEBUG_TYPE`.

Dropping it is also what LLVM's convention asks: the macro belongs in a `.cpp` after the includes.

## What

- Remove `#define DEBUG_TYPE "convert-onnx-to-hip"` from `OnnxToHipUtils.h`.
- Add `#define DEBUG_TYPE "slice-conversion"` to `SliceConversion.cpp`, which references `DEBUG_TYPE` directly in a log string and was relying on the leak.

Found by scanning all of `lib/` for files that use `LLVM_DEBUG` / `DEBUG_WITH_TYPE` / `STATISTIC` / `DEBUG_TYPE` without defining one; `SliceConversion.cpp` was the only such file. All 13 files under `lib/Conversion/OnnxToHip` that use the machinery now define their own name.

No behaviour change. `OnnxToHip.cpp` keeps `convert-onnx-to-hip`, every other file keeps the name it already had, and `SliceConversion.cpp` gains one it never had a way to be selected by before.

## Test plan

- `cmake --build build/hip-ep --target check-hip-mlir-lit` -- results recorded in the PR thread once the local run finishes.
- Verified by inspection that no file under `lib/Conversion/OnnxToHip` uses the debug machinery without defining its own `DEBUG_TYPE`.

## Notes for reviewers

#795 is stacked on this branch, because its new `AttentionWindowFold.cpp` defines its own `DEBUG_TYPE` and would be the 12th redefinition warning while the header still defines one. Merging this first lets #795 rebase onto `main` and drop the dependency.

Prepared with AI assistance (Cursor): the header/file scan and this description were AI-assisted and reviewed by me. The change itself is two lines and was verified by the scan described above.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
