### PR TITLE
feat(hipsr): run materialize-init-tensors in the pipeline with shape links

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/HipsrOps.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrOps.h
@@ -49,12 +49,15 @@ bool isHipsrDestinationOperand(::mlir::OpOperand &use);
 
 // Returns the result that aliases this destination operand.
 // DPS pattern: outs()[i] and result[i] occupy the same buffer.
-// hipsr.compute is not DPS but holds its results in the same positions.
-// Returns null if the operand is not a destination.
+// hipsr.compute is not DPS but stores its results in the same positions.
+// Returns a null OpResult if the operand is not a destination.
 //
 // Example: %r0, %r1 = hipsr.foo outs(%init0, %init1)
 //          getResultForDestination(%init0) -> %r0
 //          getResultForDestination(%init1) -> %r1
+//
+// Example: %r = hipsr.compute outs(%d : tensor<?x256xf16>) : tensor<?xf16>
+//          getResultForDestination(%d) -> %r
 ::mlir::OpResult getResultForDestination(::mlir::OpOperand &use);
 
 } // namespace hipsr

--- a/include/hip/Dialect/Hipsr/IR/HipsrOps.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrOps.h
@@ -47,8 +47,15 @@ namespace hipsr {
 // dps: use is in Init
 bool isHipsrDestinationOperand(::mlir::OpOperand &use);
 
-// return the result held in the destination use names, or null if none.
-::mlir::OpResult getHipsrResultHeldIn(::mlir::OpOperand &use);
+// Returns the result that aliases this destination operand.
+// DPS pattern: outs()[i] and result[i] occupy the same buffer.
+// hipsr.compute is not DPS but holds its results in the same positions.
+// Returns null if the operand is not a destination.
+//
+// Example: %r0, %r1 = hipsr.foo outs(%init0, %init1)
+//          getResultForDestination(%init0) -> %r0
+//          getResultForDestination(%init1) -> %r1
+::mlir::OpResult getResultForDestination(::mlir::OpOperand &use);
 
 } // namespace hipsr
 } // namespace mlir

--- a/include/hip/Dialect/Hipsr/IR/HipsrOps.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrOps.h
@@ -47,6 +47,9 @@ namespace hipsr {
 // dps: use is in Init
 bool isHipsrDestinationOperand(::mlir::OpOperand &use);
 
+// return the result held in the destination use names, or null if none.
+::mlir::OpResult getHipsrResultHeldIn(::mlir::OpOperand &use);
+
 } // namespace hipsr
 } // namespace mlir
 

--- a/lib/Dialect/Hipsr/IR/HipsrOps.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrOps.cpp
@@ -61,7 +61,7 @@ bool mlir::hipsr::isHipsrDestinationOperand(OpOperand &use) {
   return index >= begin && index < begin + destinations.size();
 }
 
-OpResult mlir::hipsr::getHipsrResultHeldIn(OpOperand &use) {
+OpResult mlir::hipsr::getResultForDestination(OpOperand &use) {
   if (!isHipsrDestinationOperand(use)) {
     return {};
   }

--- a/lib/Dialect/Hipsr/IR/HipsrOps.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrOps.cpp
@@ -60,3 +60,18 @@ bool mlir::hipsr::isHipsrDestinationOperand(OpOperand &use) {
   unsigned begin = destinations.getBeginOperandIndex();
   return index >= begin && index < begin + destinations.size();
 }
+
+// A hipsr op holds the result in the destination slot at the same position.
+OpResult mlir::hipsr::getHipsrResultHeldIn(OpOperand &use) {
+  if (!isHipsrDestinationOperand(use)) {
+    return {};
+  }
+  Operation *op = use.getOwner();
+  unsigned slot = use.getOperandNumber() -
+                  getHipsrDestinationOperands(op).getBeginOperandIndex();
+  // Bufferization keeps the destinations and drops the results they held.
+  if (slot >= op->getNumResults()) {
+    return {};
+  }
+  return op->getResult(slot);
+}

--- a/lib/Dialect/Hipsr/IR/HipsrOps.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrOps.cpp
@@ -61,7 +61,6 @@ bool mlir::hipsr::isHipsrDestinationOperand(OpOperand &use) {
   return index >= begin && index < begin + destinations.size();
 }
 
-// A hipsr op holds the result in the destination slot at the same position.
 OpResult mlir::hipsr::getHipsrResultHeldIn(OpOperand &use) {
   if (!isHipsrDestinationOperand(use)) {
     return {};
@@ -69,7 +68,6 @@ OpResult mlir::hipsr::getHipsrResultHeldIn(OpOperand &use) {
   Operation *op = use.getOwner();
   unsigned slot = use.getOperandNumber() -
                   getHipsrDestinationOperands(op).getBeginOperandIndex();
-  // Bufferization keeps the destinations and drops the results they held.
   if (slot >= op->getNumResults()) {
     return {};
   }

--- a/lib/Dialect/Hipsr/Pipelines/Pipelines.cpp
+++ b/lib/Dialect/Hipsr/Pipelines/Pipelines.cpp
@@ -16,12 +16,14 @@
 //   --convert-onnx-to-hipsr
 //   --hipsr-populate-shape-region
 //   --hipsr-partition-pool-domains
+//   --hipsr-materialize-init-tensors
 void mlir::hipsr::buildHipsrPipeline(OpPassManager &pm,
                                      const HipsrPipelineOptions & /*options*/) {
   pm.addPass(createAddContextArgPass());
   pm.addPass(createConvertOnnxToHipsrPass());
   pm.addNestedPass<func::FuncOp>(createPopulateShapeRegionPass());
   pm.addNestedPass<func::FuncOp>(createPartitionPoolDomainsPass());
+  pm.addPass(createMaterializeInitTensorsPass());
 }
 
 void mlir::hipsr::registerHipsrPipelines() {

--- a/lib/Dialect/Hipsr/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/lib/Dialect/Hipsr/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -90,19 +90,6 @@ ComputeYieldOp getYieldOp(ComputeOp computeOp) {
   return cast<ComputeYieldOp>(computeOp.getBody().front().getTerminator());
 }
 
-// get result by output operand
-OpResult getResultHeldIn(ComputeOp computeOp, OpOperand &opOperand) {
-  OperandRange outputs = computeOp.getOutputs();
-  if (outputs.empty())
-    return {};
-
-  unsigned begin = outputs.getBeginOperandIndex();
-  unsigned number = opOperand.getOperandNumber();
-  if (number < begin || number - begin >= computeOp->getNumResults())
-    return {};
-  return computeOp->getResult(number - begin);
-}
-
 // get output operand by result index
 OpOperand *getDestinationOf(ComputeOp computeOp, unsigned resultIndex) {
   OperandRange outputs = computeOp.getOutputs();
@@ -177,7 +164,7 @@ struct ComputeOpBufferization
     aliases.addAlias({getEntryArgument(computeOp, opOperand.getOperandNumber()),
                       BufferRelation::Equivalent});
 
-    if (OpResult result = getResultHeldIn(computeOp, opOperand)) {
+    if (OpResult result = getHipsrResultHeldIn(opOperand)) {
       aliases.addAlias({result, BufferRelation::Equivalent});
     }
     return aliases;

--- a/lib/Dialect/Hipsr/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/lib/Dialect/Hipsr/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -164,7 +164,7 @@ struct ComputeOpBufferization
     aliases.addAlias({getEntryArgument(computeOp, opOperand.getOperandNumber()),
                       BufferRelation::Equivalent});
 
-    if (OpResult result = getHipsrResultHeldIn(opOperand)) {
+    if (OpResult result = getResultForDestination(opOperand)) {
       aliases.addAlias({result, BufferRelation::Equivalent});
     }
     return aliases;

--- a/lib/Dialect/Hipsr/Transforms/MaterializeInitTensorsPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/MaterializeInitTensorsPass.cpp
@@ -4,23 +4,30 @@
  */
 //===- MaterializeInitTensorsPass.cpp - Materialize placeholder inits -----===//
 //
-// Rewrites each pool domain into the virtual 3-region form: every
-// hipsr.placeholder shape region becomes an scf.execute_region yielding
-// !shape.shape, every placeholder result becomes a tensor.empty built from
-// that shape, and the data ops keep their order.
+// Replaces every hipsr.placeholder in a pool domain with a shape computation
+// and a tensor.empty. Runs last in --hipsr-pipeline, so domains are cut and
+// shape regions are filled.
 //
 // Before:
-//   %init = hipsr.placeholder(%ctx) ins(%a, %b) : tensor<?x512xf16>
-//       shape_region { ^bb0(%a_shape: !shape.shape, %b_shape: !shape.shape):
-//         hipsr.shape_yield %result_shape : !shape.shape }
-//   %0 = hipsr.matmul(%ctx) ins(%a, %b) outs(%init) : tensor<?x512xf16>
-// After:
-//   %shape = scf.execute_region -> !shape.shape { ... }
-//   %init = tensor.empty(%d0) : tensor<?x512xf16>
-//   %0 = hipsr.matmul(%ctx) ins(%a, %b) outs(%init) : tensor<?x512xf16>
+//   %init = hipsr.placeholder(%ctx) ins(%a) : tensor<?x4xf32> shape_region {
+//   ^bb0(%a_shape: !shape.shape):
+//     hipsr.shape_yield %a_shape : !shape.shape
+//   }
+//   %0 = hipsr.cast(%ctx) ins(%a) outs(%init) : tensor<?x4xf32>
 //
-// The phases run per domain: collect and group the placeholders, build the
-// shape regions, build the init tensors, then replace and erase.
+// After:
+//   %s = scf.execute_region -> !shape.shape {
+//     %a_shape = shape.shape_of %a : tensor<?x4xf16> -> !shape.shape
+//     scf.yield %a_shape : !shape.shape
+//   }
+//   %d0 = shape.size_to_index (shape.get_extent %s, 0)
+//   %empty = tensor.empty(%d0) : tensor<?x4xf32>
+//   %0 = hipsr.cast(%ctx) ins(%a) outs(%empty) : tensor<?x4xf32>
+//
+// The domain is rebuilt in a fresh block in four steps: constants, shape
+// computations, allocations, then every other op. hipsr-pool-alloc replaces the
+// allocations in a domain with views of one pool it emits after the last of
+// them, so every allocation has to come before the first op that reads one.
 //
 //===----------------------------------------------------------------------===//
 
@@ -35,12 +42,15 @@
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Visitors.h"
 
-#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/SmallVectorExtras.h"
 
 namespace mlir {
 namespace hipsr {
@@ -50,248 +60,196 @@ namespace hipsr {
 
 namespace {
 
-// Collects a domain's placeholders and moves them to the front of the domain
-// block. SSA form already orders them topologically, so grouping only has to
-// keep their relative order.
-FailureOr<SmallVector<PlaceholderOp>>
-collectAndGroupPlaceholders(PoolDomainOp poolDomain) {
-  Block &domainBlock = poolDomain.getBody().front();
-
-  SmallVector<PlaceholderOp> placeholders;
-  for (Operation &operation : domainBlock) {
-    auto placeholder = dyn_cast<PlaceholderOp>(&operation);
-    if (!placeholder) {
-      continue;
-    }
-    if (placeholder.getShapeRegion().empty()) {
-      placeholder.emitOpError(
-          "shape region must be populated by -hipsr-populate-shape-region");
-      return failure();
-    }
-    placeholders.push_back(placeholder);
+// What each shape region argument becomes, in the placeholder's operand order.
+//
+// Barrier, ctx then the inputs, read as data:
+//   a. ctx                -> the new ctx argument
+//   b. arith.constant     -> the value itself
+//   c. hipsr.constant     -> the value itself
+//   d. block argument     -> the new block argument
+//   e. placeholder result -> rejected by verifyMaterializable
+//
+// Normal, one !shape.shape per input:
+//   a. arith.constant     -> shape.shape_of it
+//   b. hipsr.constant     -> shape.shape_of it
+//   c. block argument     -> shape.shape_of it
+//   d. placeholder result -> the shape its region yielded
+SmallVector<Value> getArgumentReplacements(PlaceholderOp placeholder,
+                                           const IRMapping &shapes,
+                                           const IRMapping &cloned,
+                                           OpBuilder &builder) {
+  if (placeholder.getPlaceholderType() == PlaceholderType::Barrier) {
+    return llvm::map_to_vector(placeholder->getOperands(), [&](Value operand) {
+      return cloned.lookup(operand);
+    });
   }
 
-  // Placeholders already sitting at the front are skipped rather than moved:
-  // splicing an operation before itself corrupts the block's operation list.
-  Block::iterator insertionPoint = domainBlock.begin();
-  for (PlaceholderOp placeholder : placeholders) {
-    if (&*insertionPoint == placeholder.getOperation()) {
-      ++insertionPoint;
-      continue;
-    }
-    placeholder->moveBefore(&domainBlock, insertionPoint);
-  }
-
-  return placeholders;
-}
-
-// Returns the shape a placeholder input contributes to the shape graph. An
-// input produced by another placeholder reads that placeholder's shape from its
-// scf.execute_region, because the placeholder itself is erased later; any other
-// input is a value that outlives the pass, so its shape is taken directly.
-Value getShapeForInput(Value input, Location loc,
-                       const DenseMap<PlaceholderOp, scf::ExecuteRegionOp>
-                           &placeholderToExecuteRegion,
-                       OpBuilder &builder) {
-  if (auto producer = input.getDefiningOp<PlaceholderOp>()) {
-    scf::ExecuteRegionOp executeRegion =
-        placeholderToExecuteRegion.lookup(producer);
-    if (!executeRegion) {
-      return nullptr;
-    }
-    return executeRegion.getResult(cast<OpResult>(input).getResultNumber());
-  }
-  return builder.create<shape::ShapeOfOp>(
-      loc, shape::ShapeType::get(builder.getContext()), input);
-}
-
-// Moves a placeholder's shape region body into a new scf.execute_region placed
-// just before it. hipsr.shape_yield is bound to hipsr.placeholder by HasParent
-// and cannot come along, so the transferred body gets the scf terminator.
-scf::ExecuteRegionOp
-createExecuteRegionAndTransferBody(PlaceholderOp placeholder,
-                                   OpBuilder &builder) {
   Location loc = placeholder.getLoc();
-  SmallVector<Type> shapeTypes(placeholder.getNumResults(),
-                               shape::ShapeType::get(builder.getContext()));
-
-  builder.setInsertionPoint(placeholder);
-  auto executeRegion = builder.create<scf::ExecuteRegionOp>(loc, shapeTypes);
-  executeRegion.getRegion().takeBody(placeholder.getShapeRegion());
-
-  auto shapeYield =
-      cast<ShapeYieldOp>(executeRegion.getRegion().front().getTerminator());
-  builder.setInsertionPoint(shapeYield);
-  builder.create<scf::YieldOp>(shapeYield.getLoc(), shapeYield.getShapes());
-  shapeYield.erase();
-
-  return executeRegion;
+  auto shapeType = shape::ShapeType::get(builder.getContext());
+  return llvm::map_to_vector(
+      placeholder.getInputs(), [&](Value input) -> Value {
+        if (Value recorded = shapes.lookupOrNull(input)) {
+          return recorded;
+        }
+        return shape::ShapeOfOp::create(builder, loc, shapeType,
+                                        cloned.lookup(input));
+      });
 }
 
-// Rewrites a transferred body to read from the enclosing domain instead of the
-// shape region's own block arguments, then drops those arguments: an
-// scf.execute_region region takes none.
-LogicalResult
-replaceShapeRegionArguments(PlaceholderOp placeholder, Block &shapeBlock,
-                            const DenseMap<PlaceholderOp, scf::ExecuteRegionOp>
-                                &placeholderToExecuteRegion,
-                            OpBuilder &builder) {
-  ValueRange inputs = placeholder.getInputs();
-  if (shapeBlock.getNumArguments() != inputs.size()) {
-    return placeholder.emitOpError("shape region takes ")
-           << shapeBlock.getNumArguments()
-           << " arguments but the placeholder has " << inputs.size()
-           << " inputs";
-  }
+// One placeholder's shape region, rebuilt as an scf.execute_region.
+ResultRange materializeShapeRegion(PlaceholderOp placeholder,
+                                   const IRMapping &shapes, IRMapping &cloned,
+                                   RewriterBase &rewriter) {
+  OpBuilder::InsertionGuard guard(rewriter);
+  SmallVector<Type> shapeTypes(placeholder.getNumResults(),
+                               shape::ShapeType::get(rewriter.getContext()));
+  auto executeRegion =
+      scf::ExecuteRegionOp::create(rewriter, placeholder.getLoc(), shapeTypes);
 
-  // The shapes go at the top of the body so they dominate every use of the
-  // argument they replace.
-  builder.setInsertionPointToStart(&shapeBlock);
+  // The block comes first, so a replacement that builds IR lands in the body.
+  Block &shapeBody = placeholder.getShapeRegion().front();
+  rewriter.createBlock(&executeRegion.getRegion());
+  SmallVector<Value> replacements =
+      getArgumentReplacements(placeholder, shapes, cloned, rewriter);
+  assert(shapeBody.getNumArguments() == replacements.size() &&
+         "expected one replacement per shape region argument");
+  cloned.map(shapeBody.getArguments(), replacements);
+  llvm::for_each(shapeBody.without_terminator(),
+                 [&](Operation &op) { rewriter.clone(op, cloned); });
 
-  for (auto [argument, input] :
-       llvm::zip_equal(shapeBlock.getArguments(), inputs)) {
-    Value shape = getShapeForInput(input, placeholder.getLoc(),
-                                   placeholderToExecuteRegion, builder);
-    if (!shape) {
+  // HasParent binds hipsr.shape_yield to placeholder, so scf.yield replaces it.
+  auto shapeYield = cast<ShapeYieldOp>(shapeBody.getTerminator());
+  scf::YieldOp::create(
+      rewriter, shapeYield.getLoc(),
+      llvm::map_to_vector(shapeYield.getShapes(),
+                          [&](Value shape) { return cloned.lookup(shape); }));
+
+  return executeRegion.getResults();
+}
+
+// Only dynamic dimensions come from the shape; a static extent is in the type.
+Value createInitTensor(Value result, Value resultShape, OpBuilder &builder) {
+  Location loc = result.getLoc();
+  auto tensorType = cast<RankedTensorType>(result.getType());
+  auto isDynamic = [tensorType](int64_t dimension) {
+    return tensorType.isDynamicDim(dimension);
+  };
+  auto readExtent = [&](int64_t dimension) -> Value {
+    Value extent =
+        shape::GetExtentOp::create(builder, loc, resultShape, dimension);
+    return shape::SizeToIndexOp::create(builder, loc, extent);
+  };
+
+  SmallVector<Value> dynamicSizes = llvm::map_to_vector(
+      llvm::make_filter_range(llvm::seq<int64_t>(tensorType.getRank()),
+                              isDynamic),
+      readExtent);
+  return tensor::EmptyOp::create(builder, loc, tensorType, dynamicSizes);
+}
+
+LogicalResult verifyMaterializable(ArrayRef<PlaceholderOp> placeholders) {
+  for (PlaceholderOp placeholder : placeholders) {
+    if (placeholder.getShapeRegion().empty()) {
       return placeholder.emitOpError(
-          "input has no shape computation; the producing placeholder was not "
-          "materialized first");
+          "shape region must be populated by -hipsr-populate-shape-region");
     }
-    argument.replaceAllUsesWith(shape);
+    if (placeholder.getPlaceholderType() == PlaceholderType::Barrier &&
+        llvm::any_of(placeholder.getInputs(), [](Value input) {
+          return isa_and_nonnull<PlaceholderOp>(input.getDefiningOp());
+        })) {
+      return placeholder.emitOpError(
+          "barrier input must be allocated outside this pool domain");
+    }
   }
-
-  shapeBlock.eraseArguments(0, shapeBlock.getNumArguments());
   return success();
 }
 
-// Turns every placeholder shape region into an scf.execute_region yielding one
-// !shape.shape per placeholder result, and maps each placeholder to it so later
-// placeholders can consume the shapes.
-FailureOr<DenseMap<PlaceholderOp, scf::ExecuteRegionOp>>
-createShapeComputations(ArrayRef<PlaceholderOp> placeholders,
-                        OpBuilder &builder) {
+// Taking no operands, a constant can lead the block and dominate its readers.
+void cloneConstants(Block &oldBlock, IRMapping &cloned,
+                    RewriterBase &rewriter) {
+  for (Operation &op : oldBlock) {
+    if (matchPattern(&op, m_Constant())) {
+      rewriter.clone(op, cloned);
+    }
+  }
+}
+
+// Block order is SSA order, so a shape from an earlier placeholder is mapped.
+IRMapping createShapeComputations(ArrayRef<PlaceholderOp> placeholders,
+                                  IRMapping &cloned, RewriterBase &rewriter) {
+  IRMapping shapes;
   for (PlaceholderOp placeholder : placeholders) {
-    if (placeholder.getPlaceholderType() != PlaceholderType::Normal) {
-      placeholder.emitOpError("barrier placeholders are not materialized yet");
-      return failure();
-    }
+    shapes.map(placeholder.getResults(),
+               materializeShapeRegion(placeholder, shapes, cloned, rewriter));
   }
+  return shapes;
+}
 
-  DenseMap<PlaceholderOp, scf::ExecuteRegionOp> placeholderToExecuteRegion;
+// Each result maps to its tensor.empty, so ops cloned later use that buffer.
+void createAllocations(ArrayRef<PlaceholderOp> placeholders,
+                       const IRMapping &shapes, IRMapping &cloned,
+                       OpBuilder &builder) {
   for (PlaceholderOp placeholder : placeholders) {
-    scf::ExecuteRegionOp executeRegion =
-        createExecuteRegionAndTransferBody(placeholder, builder);
-    if (failed(replaceShapeRegionArguments(
-            placeholder, executeRegion.getRegion().front(),
-            placeholderToExecuteRegion, builder))) {
-      return failure();
-    }
-    placeholderToExecuteRegion[placeholder] = executeRegion;
-  }
-
-  return placeholderToExecuteRegion;
-}
-
-// Reads the dynamic extents of a result out of its computed shape. Static
-// dimensions are already carried by the result type, so only the dynamic ones
-// need an SSA value, converted to index for tensor.empty.
-SmallVector<Value> extractDynamicDimensions(Value shapeValue,
-                                            RankedTensorType tensorType,
-                                            Location loc, OpBuilder &builder) {
-  SmallVector<Value> dynamicDimensions;
-  for (int64_t dimension : llvm::seq<int64_t>(0, tensorType.getRank())) {
-    if (!tensorType.isDynamicDim(dimension)) {
-      continue;
-    }
-    Value extent =
-        builder.create<shape::GetExtentOp>(loc, shapeValue, dimension);
-    dynamicDimensions.push_back(
-        builder.create<shape::SizeToIndexOp>(loc, extent));
-  }
-  return dynamicDimensions;
-}
-
-Value createInitTensorFromShape(Value placeholderResult, Value shapeValue,
-                                Location loc, OpBuilder &builder) {
-  auto tensorType = cast<RankedTensorType>(placeholderResult.getType());
-  SmallVector<Value> dynamicDimensions =
-      extractDynamicDimensions(shapeValue, tensorType, loc, builder);
-  return builder.create<tensor::EmptyOp>(loc, tensorType, dynamicDimensions);
-}
-
-// Materializes one tensor.empty per placeholder result. They all go after the
-// last shape computation, so once the placeholders are erased the domain reads
-// as shape computations, then allocations, then data operations.
-DenseMap<Value, Value>
-createInitTensors(ArrayRef<PlaceholderOp> placeholders,
-                  const DenseMap<PlaceholderOp, scf::ExecuteRegionOp>
-                      &placeholderToExecuteRegion,
-                  OpBuilder &builder) {
-  builder.setInsertionPointAfter(
-      placeholderToExecuteRegion.lookup(placeholders.back()));
-
-  DenseMap<Value, Value> placeholderResultToInitTensor;
-  for (PlaceholderOp placeholder : placeholders) {
-    scf::ExecuteRegionOp executeRegion =
-        placeholderToExecuteRegion.lookup(placeholder);
-    for (auto [result, shapeValue] : llvm::zip_equal(
-             placeholder.getResults(), executeRegion.getResults())) {
-      placeholderResultToInitTensor[result] = createInitTensorFromShape(
-          result, shapeValue, placeholder.getLoc(), builder);
+    for (OpResult result : placeholder.getResults()) {
+      cloned.map(result,
+                 createInitTensor(result, shapes.lookup(result), builder));
     }
   }
-  return placeholderResultToInitTensor;
 }
 
-// Hands every placeholder result over to the tensor.empty that stands in for
-// it and drops the placeholder. A placeholder result can feed a later
-// placeholder's inputs, which is why the erase cannot come before the
-// replacement, and why every placeholder in the domain has to go in the same
-// run: an input that now reads a tensor.empty is not a legal shape-graph input.
-void replaceAndCleanup(
-    ArrayRef<PlaceholderOp> placeholders,
-    const DenseMap<Value, Value> &placeholderResultToInitTensor) {
-  for (PlaceholderOp placeholder : placeholders) {
-    for (Value result : placeholder.getResults()) {
-      result.replaceAllUsesWith(placeholderResultToInitTensor.lookup(result));
+// The terminator comes along, so it closes the new block.
+void cloneRemainingOps(Block &oldBlock, IRMapping &cloned,
+                       RewriterBase &rewriter) {
+  for (Operation &op : oldBlock) {
+    if (!isa<PlaceholderOp>(op) && !cloned.contains(&op)) {
+      rewriter.clone(op, cloned);
     }
-    placeholder.erase();
   }
 }
 
-LogicalResult materializePoolDomain(PoolDomainOp poolDomain) {
-  FailureOr<SmallVector<PlaceholderOp>> placeholders =
-      collectAndGroupPlaceholders(poolDomain);
-  if (failed(placeholders)) {
-    return failure();
-  }
-  if (placeholders->empty()) {
+// Rebuilds one domain body with every placeholder materialized.
+LogicalResult materializePoolDomain(Region &body, RewriterBase &rewriter) {
+  Block &oldBlock = body.front();
+  SmallVector<PlaceholderOp> placeholders =
+      llvm::to_vector(oldBlock.getOps<PlaceholderOp>());
+  if (placeholders.empty()) {
     return success();
   }
-
-  OpBuilder builder(poolDomain.getContext());
-  FailureOr<DenseMap<PlaceholderOp, scf::ExecuteRegionOp>>
-      placeholderToExecuteRegion =
-          createShapeComputations(*placeholders, builder);
-  if (failed(placeholderToExecuteRegion)) {
+  if (failed(verifyMaterializable(placeholders))) {
     return failure();
   }
 
-  DenseMap<Value, Value> placeholderResultToInitTensor =
-      createInitTensors(*placeholders, *placeholderToExecuteRegion, builder);
-  replaceAndCleanup(*placeholders, placeholderResultToInitTensor);
+  // Every step appends to the new block, so emission order is final order.
+  Block *newBlock = rewriter.createBlock(
+      &body, body.end(), oldBlock.getArgumentTypes(),
+      llvm::map_to_vector(oldBlock.getArguments(), [](BlockArgument argument) {
+        return argument.getLoc();
+      }));
+
+  // Maps every old value to what stands in for it in the new block.
+  IRMapping cloned;
+  cloned.map(oldBlock.getArguments(), newBlock->getArguments());
+
+  cloneConstants(oldBlock, cloned, rewriter);
+  IRMapping shapes = createShapeComputations(placeholders, cloned, rewriter);
+  createAllocations(placeholders, shapes, cloned, rewriter);
+  cloneRemainingOps(oldBlock, cloned, rewriter);
+
+  rewriter.eraseBlock(&oldBlock);
   return success();
 }
 
 struct MaterializeInitTensorsPass
     : impl::MaterializeInitTensorsPassBase<MaterializeInitTensorsPass> {
   void runOnOperation() override {
-    WalkResult walkResult = getOperation().walk([](PoolDomainOp poolDomain) {
-      if (failed(materializePoolDomain(poolDomain))) {
-        return WalkResult::interrupt();
-      }
-      return WalkResult::advance();
-    });
+    IRRewriter rewriter(&getContext());
+    WalkResult walkResult =
+        getOperation().walk([&rewriter](PoolDomainOp poolDomain) {
+          if (failed(materializePoolDomain(poolDomain.getBody(), rewriter))) {
+            return WalkResult::interrupt();
+          }
+          return WalkResult::advance();
+        });
     if (walkResult.wasInterrupted()) {
       signalPassFailure();
     }

--- a/lib/Dialect/Hipsr/Transforms/MaterializeInitTensorsPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/MaterializeInitTensorsPass.cpp
@@ -213,7 +213,7 @@ void cloneRemainingOps(Block &oldBlock, IRMapping &cloned,
 // Linking the allocation would miss a hipsr.compute result that is only a view.
 Value getTiedConsumerResult(OpResult init) {
   for (OpOperand &use : init.getUses()) {
-    if (OpResult held = getHipsrResultHeldIn(use)) {
+    if (OpResult held = getResultForDestination(use)) {
       return held;
     }
   }

--- a/lib/Dialect/Hipsr/Transforms/MaterializeInitTensorsPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/MaterializeInitTensorsPass.cpp
@@ -23,11 +23,14 @@
 //   %d0 = shape.size_to_index (shape.get_extent %s, 0)
 //   %empty = tensor.empty(%d0) : tensor<?x4xf32>
 //   %0 = hipsr.cast(%ctx) ins(%a) outs(%empty) : tensor<?x4xf32>
+//   hipsr.preserve_shape %s, %0 : tensor<?x4xf32>
 //
-// The domain is rebuilt in a fresh block in four steps: constants, shape
-// computations, allocations, then every other op. hipsr-pool-alloc replaces the
-// allocations in a domain with views of one pool it emits after the last of
-// them, so every allocation has to come before the first op that reads one.
+// The domain is rebuilt in a fresh block in five steps: constants, shape
+// computations, allocations, every other op, then one shape link per
+// allocation. hipsr-pool-alloc replaces the allocations in a domain with views
+// of one pool it emits after the last of them, so every allocation has to come
+// before the first op that reads one. A link names the result of the op that
+// fills the buffer, so it can only come after the data ops.
 //
 //===----------------------------------------------------------------------===//
 
@@ -197,12 +200,34 @@ void createAllocations(ArrayRef<PlaceholderOp> placeholders,
   }
 }
 
-// The terminator comes along, so it closes the new block.
+// Whatever an earlier step did not emit, still in its original order.
 void cloneRemainingOps(Block &oldBlock, IRMapping &cloned,
                        RewriterBase &rewriter) {
-  for (Operation &op : oldBlock) {
+  for (Operation &op : oldBlock.without_terminator()) {
     if (!isa<PlaceholderOp>(op) && !cloned.contains(&op)) {
       rewriter.clone(op, cloned);
+    }
+  }
+}
+
+// Linking the allocation would miss a hipsr.compute result that is only a view.
+Value getTiedConsumerResult(OpResult init) {
+  for (OpOperand &use : init.getUses()) {
+    if (OpResult held = getHipsrResultHeldIn(use)) {
+      return held;
+    }
+  }
+  return init;
+}
+
+// -hip-use-output-allocator reads these links to size a graph output.
+void preserveShapes(ArrayRef<PlaceholderOp> placeholders,
+                    const IRMapping &shapes, const IRMapping &cloned,
+                    OpBuilder &builder) {
+  for (PlaceholderOp placeholder : placeholders) {
+    for (OpResult result : placeholder.getResults()) {
+      PreserveShapeOp::create(builder, result.getLoc(), shapes.lookup(result),
+                              cloned.lookup(getTiedConsumerResult(result)));
     }
   }
 }
@@ -234,6 +259,8 @@ LogicalResult materializePoolDomain(Region &body, RewriterBase &rewriter) {
   IRMapping shapes = createShapeComputations(placeholders, cloned, rewriter);
   createAllocations(placeholders, shapes, cloned, rewriter);
   cloneRemainingOps(oldBlock, cloned, rewriter);
+  preserveShapes(placeholders, shapes, cloned, rewriter);
+  rewriter.clone(*oldBlock.getTerminator(), cloned);
 
   rewriter.eraseBlock(&oldBlock);
   return success();

--- a/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
@@ -17,8 +17,8 @@
 // weights, so the contents are left undefined.
 //
 // The whole output is checked. The pipeline decides how many pool domains to
-// cut, where each barrier sits, and what every shape region computes, so a
-// partial check would let those move unnoticed.
+// cut, where each cut sits, and what every shape computation does, so a partial
+// check would let those move unnoticed.
 //
 // Pool domains and what cuts them
 // -------------------------------
@@ -26,8 +26,7 @@
 // A domain is one pool allocation, so every buffer inside it must be sized
 // before it runs. The pipeline therefore starts a new domain wherever a shape
 // depends on a value the host cannot know until the previous domain has
-// finished. Each cut below is a barrier placeholder whose shape region reads
-// the host tensor named on the arrow.
+// finished. Each cut below reads the host tensor named on the arrow.
 //
 //   domain 0   collapse(image_features)              -> flat
 //              equal(input_ids, 248056) -> unsqueeze -> mask
@@ -55,9 +54,18 @@
 //   domain 4   slice(flat, window)                   -> updates
 //              scatter_nd(embeds, coords, updates)   -> inputs_embeds
 //
-// Only domain 0 opens with an ordinary placeholder, because everything in it is
-// shaped by the argument types alone. Domains 1 through 4 each open with a
-// barrier placeholder, which is what a cut looks like in the IR below.
+// Everything in domain 0 is shaped by the argument types alone. Domains 1
+// through 4 each open with a shape computation that extracts extents from a
+// host buffer an earlier domain filled, which is what a cut looks like below.
+//
+// The three zones of a domain
+// ---------------------------
+//
+// hipsr-materialize-init-tensors leaves each domain body in order: the
+// scf.execute_region shape computations, then the tensor.empty allocations that
+// read their dynamic extents back out of those shapes, then the data ops. A
+// constant a shape computation reads moves up with it; the rest stay where
+// conversion left them.
 //===----------------------------------------------------------------------===//
 
 // RUN: %python %S/../../../Inputs/make_external_data.py %t/embedding.onnx.data 2034237440 && cd %t && hip-mlir-opt --onnx-dialect=modeled --hipsr-pipeline --mlir-elide-resource-strings-if-larger=32 %s | FileCheck %s
@@ -72,244 +80,309 @@ module {
 
 // Domain 0 takes everything whose shape follows from the graph inputs alone:
 // the embedding lookup, the bool mask, and the shape vector the broadcasts
-// downstream will read.
+// downstream will read. Its six constants come first, in conversion order, so
+// each stays ahead of the two shape computations that read one, then the five
+// computations follow.
 // CHECK-NEXT:           %[[POOL_DOMAIN_0:.*]]:8 = hipsr.pool_domain(%[[ARG0]], %[[ARG2]], %[[ARG1]] : !hipsr.context, tensor<?x4096xf16, #hipsr.mem<device>>, tensor<?x?xi64, #hipsr.mem<device>>) {
 // CHECK-NEXT:           ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: tensor<?x4096xf16, #hipsr.mem<device>>, %[[VAL_2:.*]]: tensor<?x?xi64, #hipsr.mem<device>>):
-// CHECK-NEXT:             %[[CONSTANT_0:.*]] = hipsr.constant {value = dense_resource<"file|embedding.onnx.data|0"> : tensor<248320x4096xf16, #hipsr.mem<device>>} : tensor<248320x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[CONSTANT_1:.*]] = arith.constant dense<248056> : tensor<i64>
-// CHECK-NEXT:             %[[CONSTANT_2:.*]] = hipsr.constant {value = dense<-1> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[CONSTANT_3:.*]] = arith.constant dense<0> : tensor<i64>
-// CHECK-NEXT:             %[[CONSTANT_4:.*]] = hipsr.constant {value = dense<0> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[PLACEHOLDER_0:.*]] = hipsr.placeholder(%[[VAL_0]]) ins(%[[VAL_1]] : tensor<?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?xf16, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:             ^bb0(%[[VAL_3:.*]]: !shape.shape):
-// CHECK-NEXT:               %[[NUM_ELEMENTS_0:.*]] = shape.num_elements %[[VAL_3]] : !shape.shape -> !shape.size
+// CHECK-NEXT:             %[[CONSTANT_5:.*]] = hipsr.constant {value = dense_resource<"file|embedding.onnx.data|0"> : tensor<248320x4096xf16, #hipsr.mem<device>>} : tensor<248320x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[CONSTANT_7:.*]] = arith.constant dense<248056> : tensor<i64>
+// CHECK-NEXT:             %[[CONSTANT_8:.*]] = hipsr.constant {value = dense<-1> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[CONSTANT_9:.*]] = arith.constant dense<0> : tensor<i64>
+// CHECK-NEXT:             %[[CONSTANT_10:.*]] = hipsr.constant {value = dense<0> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[CONSTANT_1:.*]] = hipsr.constant {value = dense<248056> : tensor<i64>} : tensor<i64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[EXECUTE_REGION_0:.*]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:               %[[SHAPE_OF_0:.*]] = shape.shape_of %[[VAL_1]] : tensor<?x4096xf16, #hipsr.mem<device>> -> !shape.shape
+// CHECK-NEXT:               %[[NUM_ELEMENTS_0:.*]] = shape.num_elements %[[SHAPE_OF_0]] : !shape.shape -> !shape.size
 // CHECK-NEXT:               %[[SIZE_TO_INDEX_0:.*]] = shape.size_to_index %[[NUM_ELEMENTS_0]] : !shape.size
-// CHECK-NEXT:               %[[CONSTANT_5:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[DIVUI_0:.*]] = arith.divui %[[SIZE_TO_INDEX_0]], %[[CONSTANT_5]] : index
+// CHECK-NEXT:               %[[CONSTANT_0:.*]] = arith.constant 1 : index
+// CHECK-NEXT:               %[[DIVUI_0:.*]] = arith.divui %[[SIZE_TO_INDEX_0]], %[[CONSTANT_0]] : index
 // CHECK-NEXT:               %[[FROM_EXTENTS_0:.*]] = shape.from_extents %[[DIVUI_0]] : index
-// CHECK-NEXT:               hipsr.shape_yield %[[FROM_EXTENTS_0]] : !shape.shape
+// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_0]] : !shape.shape
 // CHECK-NEXT:             }
-// CHECK-NEXT:             %[[COMPUTE_0:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[VAL_1]] : tensor<?x4096xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_0]] : tensor<?xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_4:.*]]: !hipsr.context, %[[VAL_5:.*]]: tensor<?x4096xf16, #hipsr.mem<device>>, %[[VAL_6:.*]]: tensor<?xf16, #hipsr.mem<device>>):
-// CHECK-NEXT:               %[[COLLAPSE_SHAPE_0:.*]] = tensor.collapse_shape %[[VAL_5]] {{\[\[}}0, 1]] : tensor<?x4096xf16, #hipsr.mem<device>> into tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:               hipsr.compute_yield %[[COLLAPSE_SHAPE_0]] : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             } : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[CONSTANT_6:.*]] = hipsr.constant {value = dense<248056> : tensor<i64>} : tensor<i64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[PLACEHOLDER_1:.*]] = hipsr.placeholder(%[[VAL_0]]) ins(%[[VAL_2]], %[[CONSTANT_6]] : tensor<?x?xi64, #hipsr.mem<device>>, tensor<i64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x?xi1, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:             ^bb0(%[[VAL_7:.*]]: !shape.shape, %[[VAL_8:.*]]: !shape.shape):
-// CHECK-NEXT:               %[[BROADCAST_0:.*]] = shape.broadcast %[[VAL_7]], %[[VAL_8]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:               hipsr.shape_yield %[[BROADCAST_0]] : !shape.shape
+// CHECK-NEXT:             %[[EXECUTE_REGION_1:.*]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:               %[[SHAPE_OF_1:.*]] = shape.shape_of %[[VAL_2]] : tensor<?x?xi64, #hipsr.mem<device>> -> !shape.shape
+// CHECK-NEXT:               %[[SHAPE_OF_2:.*]] = shape.shape_of %[[CONSTANT_1]] : tensor<i64, #hipsr.mem<device>> -> !shape.shape
+// CHECK-NEXT:               %[[BROADCAST_0:.*]] = shape.broadcast %[[SHAPE_OF_1]], %[[SHAPE_OF_2]] : !shape.shape, !shape.shape -> !shape.shape
+// CHECK-NEXT:               scf.yield %[[BROADCAST_0]] : !shape.shape
 // CHECK-NEXT:             }
-// CHECK-NEXT:             %[[EQUAL_0:.*]] = hipsr.equal(%[[VAL_0]]) ins(%[[VAL_2]], %[[CONSTANT_6]] : tensor<?x?xi64, #hipsr.mem<device>>, tensor<i64, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_1]] : tensor<?x?xi1, #hipsr.mem<device>>) : tensor<?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[PLACEHOLDER_2:.*]] = hipsr.placeholder(%[[VAL_0]]) ins(%[[PLACEHOLDER_1]] : tensor<?x?xi1, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x?x1xi1, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:             ^bb0(%[[VAL_9:.*]]: !shape.shape):
+// CHECK-NEXT:             %[[EXECUTE_REGION_2:.*]] = scf.execute_region -> !shape.shape {
 // CHECK-NEXT:               %[[CONST_SIZE_0:.*]] = shape.const_size 0
-// CHECK-NEXT:               %[[GET_EXTENT_0:.*]] = shape.get_extent %[[VAL_9]], %[[CONST_SIZE_0]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:               %[[GET_EXTENT_0:.*]] = shape.get_extent %[[EXECUTE_REGION_1]], %[[CONST_SIZE_0]] : !shape.shape, !shape.size -> !shape.size
 // CHECK-NEXT:               %[[SIZE_TO_INDEX_1:.*]] = shape.size_to_index %[[GET_EXTENT_0]] : !shape.size
 // CHECK-NEXT:               %[[CONST_SIZE_1:.*]] = shape.const_size 1
-// CHECK-NEXT:               %[[GET_EXTENT_1:.*]] = shape.get_extent %[[VAL_9]], %[[CONST_SIZE_1]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:               %[[GET_EXTENT_1:.*]] = shape.get_extent %[[EXECUTE_REGION_1]], %[[CONST_SIZE_1]] : !shape.shape, !shape.size -> !shape.size
 // CHECK-NEXT:               %[[SIZE_TO_INDEX_2:.*]] = shape.size_to_index %[[GET_EXTENT_1]] : !shape.size
-// CHECK-NEXT:               %[[CONSTANT_7:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[CONSTANT_8:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[CONSTANT_9:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[FROM_EXTENTS_1:.*]] = shape.from_extents %[[SIZE_TO_INDEX_1]], %[[SIZE_TO_INDEX_2]], %[[CONSTANT_9]] : index, index, index
-// CHECK-NEXT:               hipsr.shape_yield %[[FROM_EXTENTS_1]] : !shape.shape
+// CHECK-NEXT:               %[[CONSTANT_2:.*]] = arith.constant 1 : index
+// CHECK-NEXT:               %[[CONSTANT_3:.*]] = arith.constant 1 : index
+// CHECK-NEXT:               %[[CONSTANT_4:.*]] = arith.constant 1 : index
+// CHECK-NEXT:               %[[FROM_EXTENTS_1:.*]] = shape.from_extents %[[SIZE_TO_INDEX_1]], %[[SIZE_TO_INDEX_2]], %[[CONSTANT_4]] : index, index, index
+// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_1]] : !shape.shape
 // CHECK-NEXT:             }
-// CHECK-NEXT:             %[[COMPUTE_1:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[EQUAL_0]] : tensor<?x?xi1, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_2]] : tensor<?x?x1xi1, #hipsr.mem<device>>) {
+// CHECK-NEXT:             %[[EXECUTE_REGION_3:.*]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:               %[[SHAPE_OF_3:.*]] = shape.shape_of %[[CONSTANT_5]] : tensor<248320x4096xf16, #hipsr.mem<device>> -> !shape.shape
+// CHECK-NEXT:               %[[SHAPE_OF_4:.*]] = shape.shape_of %[[VAL_2]] : tensor<?x?xi64, #hipsr.mem<device>> -> !shape.shape
+// CHECK-NEXT:               %[[CONST_SIZE_2:.*]] = shape.const_size 0
+// CHECK-NEXT:               %[[VAL_3:.*]], %[[VAL_4:.*]] = "shape.split_at"(%[[SHAPE_OF_3]], %[[CONST_SIZE_2]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
+// CHECK-NEXT:               %[[CONST_SIZE_3:.*]] = shape.const_size 1
+// CHECK-NEXT:               %[[VAL_5:.*]], %[[VAL_6:.*]] = "shape.split_at"(%[[SHAPE_OF_3]], %[[CONST_SIZE_3]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
+// CHECK-NEXT:               %[[CONCAT_0:.*]] = shape.concat %[[VAL_3]], %[[SHAPE_OF_4]] : !shape.shape, !shape.shape -> !shape.shape
+// CHECK-NEXT:               %[[CONCAT_1:.*]] = shape.concat %[[CONCAT_0]], %[[VAL_6]] : !shape.shape, !shape.shape -> !shape.shape
+// CHECK-NEXT:               scf.yield %[[CONCAT_1]] : !shape.shape
+// CHECK-NEXT:             }
+// CHECK-NEXT:             %[[EXECUTE_REGION_4:.*]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:               %[[CONSTANT_6:.*]] = arith.constant 3 : index
+// CHECK-NEXT:               %[[FROM_EXTENTS_2:.*]] = shape.from_extents %[[CONSTANT_6]] : index
+// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_2]] : !shape.shape
+// CHECK-NEXT:             }
+
+// The allocation zone. Each tensor.empty takes its dynamic extents from the
+// shape yielded above; a fully static result type needs none.
+// CHECK-NEXT:             %[[CONST_SIZE_4:.*]] = shape.const_size 0
+// CHECK-NEXT:             %[[GET_EXTENT_2:.*]] = shape.get_extent %[[EXECUTE_REGION_0]], %[[CONST_SIZE_4]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:             %[[SIZE_TO_INDEX_3:.*]] = shape.size_to_index %[[GET_EXTENT_2]] : !shape.size
+// CHECK-NEXT:             %[[EMPTY_0:.*]] = tensor.empty(%[[SIZE_TO_INDEX_3]]) : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[CONST_SIZE_5:.*]] = shape.const_size 0
+// CHECK-NEXT:             %[[GET_EXTENT_3:.*]] = shape.get_extent %[[EXECUTE_REGION_1]], %[[CONST_SIZE_5]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:             %[[SIZE_TO_INDEX_4:.*]] = shape.size_to_index %[[GET_EXTENT_3]] : !shape.size
+// CHECK-NEXT:             %[[CONST_SIZE_6:.*]] = shape.const_size 1
+// CHECK-NEXT:             %[[GET_EXTENT_4:.*]] = shape.get_extent %[[EXECUTE_REGION_1]], %[[CONST_SIZE_6]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:             %[[SIZE_TO_INDEX_5:.*]] = shape.size_to_index %[[GET_EXTENT_4]] : !shape.size
+// CHECK-NEXT:             %[[EMPTY_1:.*]] = tensor.empty(%[[SIZE_TO_INDEX_4]], %[[SIZE_TO_INDEX_5]]) : tensor<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[CONST_SIZE_7:.*]] = shape.const_size 0
+// CHECK-NEXT:             %[[GET_EXTENT_5:.*]] = shape.get_extent %[[EXECUTE_REGION_2]], %[[CONST_SIZE_7]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:             %[[SIZE_TO_INDEX_6:.*]] = shape.size_to_index %[[GET_EXTENT_5]] : !shape.size
+// CHECK-NEXT:             %[[CONST_SIZE_8:.*]] = shape.const_size 1
+// CHECK-NEXT:             %[[GET_EXTENT_6:.*]] = shape.get_extent %[[EXECUTE_REGION_2]], %[[CONST_SIZE_8]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:             %[[SIZE_TO_INDEX_7:.*]] = shape.size_to_index %[[GET_EXTENT_6]] : !shape.size
+// CHECK-NEXT:             %[[EMPTY_2:.*]] = tensor.empty(%[[SIZE_TO_INDEX_6]], %[[SIZE_TO_INDEX_7]]) : tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[CONST_SIZE_9:.*]] = shape.const_size 0
+// CHECK-NEXT:             %[[GET_EXTENT_7:.*]] = shape.get_extent %[[EXECUTE_REGION_3]], %[[CONST_SIZE_9]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:             %[[SIZE_TO_INDEX_8:.*]] = shape.size_to_index %[[GET_EXTENT_7]] : !shape.size
+// CHECK-NEXT:             %[[CONST_SIZE_10:.*]] = shape.const_size 1
+// CHECK-NEXT:             %[[GET_EXTENT_8:.*]] = shape.get_extent %[[EXECUTE_REGION_3]], %[[CONST_SIZE_10]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:             %[[SIZE_TO_INDEX_9:.*]] = shape.size_to_index %[[GET_EXTENT_8]] : !shape.size
+// CHECK-NEXT:             %[[EMPTY_3:.*]] = tensor.empty(%[[SIZE_TO_INDEX_8]], %[[SIZE_TO_INDEX_9]]) : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[EMPTY_4:.*]] = tensor.empty() : tensor<3xi64, #hipsr.mem<host>>
+
+// The data zone, in conversion order, each op now initialized by a tensor.empty.
+// CHECK-NEXT:             %[[COMPUTE_0:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[VAL_1]] : tensor<?x4096xf16, #hipsr.mem<device>>) outs(%[[EMPTY_0]] : tensor<?xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:             ^bb0(%[[VAL_7:.*]]: !hipsr.context, %[[VAL_8:.*]]: tensor<?x4096xf16, #hipsr.mem<device>>, %[[VAL_9:.*]]: tensor<?xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:               %[[COLLAPSE_SHAPE_0:.*]] = tensor.collapse_shape %[[VAL_8]] {{\[\[}}0, 1]] : tensor<?x4096xf16, #hipsr.mem<device>> into tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:               hipsr.compute_yield %[[COLLAPSE_SHAPE_0]] : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             } : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[EQUAL_0:.*]] = hipsr.equal(%[[VAL_0]]) ins(%[[VAL_2]], %[[CONSTANT_1]] : tensor<?x?xi64, #hipsr.mem<device>>, tensor<i64, #hipsr.mem<device>>) outs(%[[EMPTY_1]] : tensor<?x?xi1, #hipsr.mem<device>>) : tensor<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[COMPUTE_1:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[EQUAL_0]] : tensor<?x?xi1, #hipsr.mem<device>>) outs(%[[EMPTY_2]] : tensor<?x?x1xi1, #hipsr.mem<device>>) {
 // CHECK-NEXT:             ^bb0(%[[VAL_10:.*]]: !hipsr.context, %[[VAL_11:.*]]: tensor<?x?xi1, #hipsr.mem<device>>, %[[VAL_12:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>):
-// CHECK-NEXT:               %[[CONSTANT_10:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[DIM_0:.*]] = tensor.dim %[[VAL_12]], %[[CONSTANT_10]] : tensor<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:               %[[CONSTANT_11:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[DIM_1:.*]] = tensor.dim %[[VAL_12]], %[[CONSTANT_11]] : tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[CONSTANT_11:.*]] = arith.constant 0 : index
+// CHECK-NEXT:               %[[DIM_0:.*]] = tensor.dim %[[VAL_12]], %[[CONSTANT_11]] : tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[CONSTANT_12:.*]] = arith.constant 1 : index
+// CHECK-NEXT:               %[[DIM_1:.*]] = tensor.dim %[[VAL_12]], %[[CONSTANT_12]] : tensor<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT:               %[[EXPAND_SHAPE_0:.*]] = tensor.expand_shape %[[VAL_11]] {{\[\[}}0], [1, 2]] output_shape {{\[}}%[[DIM_0]], %[[DIM_1]], 1] : tensor<?x?xi1, #hipsr.mem<device>> into tensor<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT:               hipsr.compute_yield %[[EXPAND_SHAPE_0]] : tensor<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT:             } : tensor<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[PLACEHOLDER_3:.*]] = hipsr.placeholder(%[[VAL_0]]) ins(%[[CONSTANT_0]], %[[VAL_2]] : tensor<248320x4096xf16, #hipsr.mem<device>>, tensor<?x?xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x?x4096xf16, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:             ^bb0(%[[VAL_13:.*]]: !shape.shape, %[[VAL_14:.*]]: !shape.shape):
-// CHECK-NEXT:               %[[CONST_SIZE_2:.*]] = shape.const_size 0
-// CHECK-NEXT:               %[[VAL_15:.*]], %[[VAL_16:.*]] = "shape.split_at"(%[[VAL_13]], %[[CONST_SIZE_2]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT:               %[[CONST_SIZE_3:.*]] = shape.const_size 1
-// CHECK-NEXT:               %[[VAL_17:.*]], %[[VAL_18:.*]] = "shape.split_at"(%[[VAL_13]], %[[CONST_SIZE_3]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT:               %[[CONCAT_0:.*]] = shape.concat %[[VAL_15]], %[[VAL_14]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:               %[[CONCAT_1:.*]] = shape.concat %[[CONCAT_0]], %[[VAL_18]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:               hipsr.shape_yield %[[CONCAT_1]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[GATHER_0:.*]] = hipsr.gather(%[[VAL_0]]) ins(%[[CONSTANT_0]], %[[VAL_2]] : tensor<248320x4096xf16, #hipsr.mem<device>>, tensor<?x?xi64, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_3]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {axis = 0 : i64} : tensor<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[PLACEHOLDER_4:.*]] = hipsr.placeholder(%[[VAL_0]]) ins(%[[PLACEHOLDER_3]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<3xi64, #hipsr.mem<host>> shape_region {
-// CHECK-NEXT:             ^bb0(%[[VAL_19:.*]]: !shape.shape):
-// CHECK-NEXT:               %[[CONSTANT_12:.*]] = arith.constant 3 : index
-// CHECK-NEXT:               %[[FROM_EXTENTS_2:.*]] = shape.from_extents %[[CONSTANT_12]] : index
-// CHECK-NEXT:               hipsr.shape_yield %[[FROM_EXTENTS_2]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[COMPUTE_2:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[GATHER_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_4]] : tensor<3xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_20:.*]]: !hipsr.context, %[[VAL_21:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_22:.*]]: tensor<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:             %[[GATHER_0:.*]] = hipsr.gather(%[[VAL_0]]) ins(%[[CONSTANT_5]], %[[VAL_2]] : tensor<248320x4096xf16, #hipsr.mem<device>>, tensor<?x?xi64, #hipsr.mem<device>>) outs(%[[EMPTY_3]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {axis = 0 : i64} : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[COMPUTE_2:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[GATHER_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[EMPTY_4]] : tensor<3xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:             ^bb0(%[[VAL_13:.*]]: !hipsr.context, %[[VAL_14:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_15:.*]]: tensor<3xi64, #hipsr.mem<host>>):
 // CHECK-NEXT:               %[[CONSTANT_13:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[DIM_2:.*]] = tensor.dim %[[VAL_21]], %[[CONSTANT_13]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[DIM_2:.*]] = tensor.dim %[[VAL_14]], %[[CONSTANT_13]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:               %[[INDEX_CAST_0:.*]] = arith.index_cast %[[DIM_2]] : index to i64
 // CHECK-NEXT:               %[[CONSTANT_14:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[DIM_3:.*]] = tensor.dim %[[VAL_21]], %[[CONSTANT_14]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[DIM_3:.*]] = tensor.dim %[[VAL_14]], %[[CONSTANT_14]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:               %[[INDEX_CAST_1:.*]] = arith.index_cast %[[DIM_3]] : index to i64
 // CHECK-NEXT:               %[[CONSTANT_15:.*]] = arith.constant 4096 : i64
 // CHECK-NEXT:               %[[FROM_ELEMENTS_0:.*]] = tensor.from_elements %[[INDEX_CAST_0]], %[[INDEX_CAST_1]], %[[CONSTANT_15]] : tensor<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:               hipsr.compute_yield %[[FROM_ELEMENTS_0]] : tensor<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:             } : tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             hipsr.pool_domain_yield %[[PLACEHOLDER_0]], %[[COMPUTE_0]], %[[PLACEHOLDER_2]], %[[COMPUTE_1]], %[[PLACEHOLDER_3]], %[[GATHER_0]], %[[PLACEHOLDER_4]], %[[COMPUTE_2]] : tensor<?xf16, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             hipsr.pool_domain_yield %[[EMPTY_0]], %[[COMPUTE_0]], %[[EMPTY_2]], %[[COMPUTE_1]], %[[EMPTY_3]], %[[GATHER_0]], %[[EMPTY_4]], %[[COMPUTE_2]] : tensor<?xf16, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:           } -> tensor<?xf16, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<3xi64, #hipsr.mem<host>> {domain_id = 0 : i64}
 
 // Each broadcast reads its extents from a host shape vector rather than from
-// the type, so each one opens a domain behind a barrier placeholder.
-// CHECK-NEXT:           %[[POOL_DOMAIN_1:.*]]:2 = hipsr.pool_domain(%[[ARG0]], %[[VAL_23:.*]]#2, %[[VAL_23]]#6, %[[VAL_23]]#3, %[[VAL_23]]#7 : !hipsr.context, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:           ^bb0(%[[VAL_24:.*]]: !hipsr.context, %[[VAL_25:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_26:.*]]: tensor<3xi64, #hipsr.mem<host>>, %[[VAL_27:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_28:.*]]: tensor<3xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:             %[[PLACEHOLDER_5:.*]] = hipsr.placeholder(%[[VAL_24]]) ins(%[[VAL_25]], %[[VAL_26]] : tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x?x?xi1, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:             ^bb0(%[[VAL_29:.*]]: !hipsr.context, %[[VAL_30:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_31:.*]]: tensor<3xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:               %[[SHAPE_OF_0:.*]] = shape.shape_of %[[VAL_30]] : tensor<?x?x1xi1, #hipsr.mem<device>> -> tensor<3xindex>
+// the type, so each one opens a domain whose shape computation extracts them
+// with tensor.extract and rebuilds the destination shape.
+// CHECK-NEXT:           %[[POOL_DOMAIN_1:.*]]:2 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#2, %[[POOL_DOMAIN_0]]#6, %[[POOL_DOMAIN_0]]#3, %[[POOL_DOMAIN_0]]#7 : !hipsr.context, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:           ^bb0(%[[VAL_17:.*]]: !hipsr.context, %[[VAL_18:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_19:.*]]: tensor<3xi64, #hipsr.mem<host>>, %[[VAL_20:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_21:.*]]: tensor<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:             %[[EXECUTE_REGION_5:.*]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:               %[[SHAPE_OF_5:.*]] = shape.shape_of %[[VAL_18]] : tensor<?x?x1xi1, #hipsr.mem<device>> -> tensor<3xindex>
 // CHECK-NEXT:               %[[CONSTANT_16:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[EXTRACT_0:.*]] = tensor.extract %[[VAL_31]]{{\[}}%[[CONSTANT_16]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               %[[EXTRACT_0:.*]] = tensor.extract %[[VAL_19]]{{\[}}%[[CONSTANT_16]]] : tensor<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:               %[[INDEX_CAST_2:.*]] = arith.index_cast %[[EXTRACT_0]] : i64 to index
 // CHECK-NEXT:               %[[CONSTANT_17:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[EXTRACT_1:.*]] = tensor.extract %[[VAL_31]]{{\[}}%[[CONSTANT_17]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               %[[EXTRACT_1:.*]] = tensor.extract %[[VAL_19]]{{\[}}%[[CONSTANT_17]]] : tensor<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:               %[[INDEX_CAST_3:.*]] = arith.index_cast %[[EXTRACT_1]] : i64 to index
 // CHECK-NEXT:               %[[CONSTANT_18:.*]] = arith.constant 2 : index
-// CHECK-NEXT:               %[[EXTRACT_2:.*]] = tensor.extract %[[VAL_31]]{{\[}}%[[CONSTANT_18]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               %[[EXTRACT_2:.*]] = tensor.extract %[[VAL_19]]{{\[}}%[[CONSTANT_18]]] : tensor<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:               %[[INDEX_CAST_4:.*]] = arith.index_cast %[[EXTRACT_2]] : i64 to index
 // CHECK-NEXT:               %[[FROM_EXTENTS_3:.*]] = shape.from_extents %[[INDEX_CAST_2]], %[[INDEX_CAST_3]], %[[INDEX_CAST_4]] : index, index, index
-// CHECK-NEXT:               %[[CSTR_BROADCASTABLE_0:.*]] = shape.cstr_broadcastable %[[SHAPE_OF_0]], %[[FROM_EXTENTS_3]] : tensor<3xindex>, !shape.shape
+// CHECK-NEXT:               %[[CSTR_BROADCASTABLE_0:.*]] = shape.cstr_broadcastable %[[SHAPE_OF_5]], %[[FROM_EXTENTS_3]] : tensor<3xindex>, !shape.shape
 // CHECK-NEXT:               %[[ASSUMING_0:.*]] = shape.assuming %[[CSTR_BROADCASTABLE_0]] -> (!shape.shape) {
-// CHECK-NEXT:                 %[[BROADCAST_1:.*]] = shape.broadcast %[[SHAPE_OF_0]], %[[FROM_EXTENTS_3]] : tensor<3xindex>, !shape.shape -> !shape.shape
+// CHECK-NEXT:                 %[[BROADCAST_1:.*]] = shape.broadcast %[[SHAPE_OF_5]], %[[FROM_EXTENTS_3]] : tensor<3xindex>, !shape.shape -> !shape.shape
 // CHECK-NEXT:                 shape.assuming_yield %[[BROADCAST_1]] : !shape.shape
 // CHECK-NEXT:               }
-// CHECK-NEXT:               hipsr.shape_yield %[[ASSUMING_0]] : !shape.shape
+// CHECK-NEXT:               scf.yield %[[ASSUMING_0]] : !shape.shape
 // CHECK-NEXT:             }
-// CHECK-NEXT:             %[[EXPAND_0:.*]] = hipsr.expand(%[[VAL_24]]) ins(%[[VAL_27]], %[[VAL_28]] : tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) outs(%[[PLACEHOLDER_5]] : tensor<?x?x?xi1, #hipsr.mem<device>>) : tensor<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.pool_domain_yield %[[PLACEHOLDER_5]], %[[EXPAND_0]] : tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[CONST_SIZE_11:.*]] = shape.const_size 0
+// CHECK-NEXT:             %[[GET_EXTENT_9:.*]] = shape.get_extent %[[EXECUTE_REGION_5]], %[[CONST_SIZE_11]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:             %[[SIZE_TO_INDEX_10:.*]] = shape.size_to_index %[[GET_EXTENT_9]] : !shape.size
+// CHECK-NEXT:             %[[CONST_SIZE_12:.*]] = shape.const_size 1
+// CHECK-NEXT:             %[[GET_EXTENT_10:.*]] = shape.get_extent %[[EXECUTE_REGION_5]], %[[CONST_SIZE_12]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:             %[[SIZE_TO_INDEX_11:.*]] = shape.size_to_index %[[GET_EXTENT_10]] : !shape.size
+// CHECK-NEXT:             %[[CONST_SIZE_13:.*]] = shape.const_size 2
+// CHECK-NEXT:             %[[GET_EXTENT_11:.*]] = shape.get_extent %[[EXECUTE_REGION_5]], %[[CONST_SIZE_13]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:             %[[SIZE_TO_INDEX_12:.*]] = shape.size_to_index %[[GET_EXTENT_11]] : !shape.size
+// CHECK-NEXT:             %[[EMPTY_5:.*]] = tensor.empty(%[[SIZE_TO_INDEX_10]], %[[SIZE_TO_INDEX_11]], %[[SIZE_TO_INDEX_12]]) : tensor<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[EXPAND_0:.*]] = hipsr.expand(%[[VAL_17]]) ins(%[[VAL_20]], %[[VAL_21]] : tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) outs(%[[EMPTY_5]] : tensor<?x?x?xi1, #hipsr.mem<device>>) : tensor<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.pool_domain_yield %[[EMPTY_5]], %[[EXPAND_0]] : tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<?x?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:           } -> tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<?x?x?xi1, #hipsr.mem<device>> {domain_id = 1 : i64}
 
 // The second broadcast feeds the search. Its destination holds one row per
 // input axis and, in the worst case, a column per input element; the count of
 // the columns it filled sits beside it and is read back to the host.
-// CHECK-NEXT:           %[[POOL_DOMAIN_2:.*]]:4 = hipsr.pool_domain(%[[ARG0]], %[[VAL_32:.*]]#0, %[[VAL_33:.*]]#6, %[[VAL_32]]#1, %[[VAL_33]]#7 : !hipsr.context, tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:           ^bb0(%[[VAL_34:.*]]: !hipsr.context, %[[VAL_35:.*]]: tensor<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_36:.*]]: tensor<3xi64, #hipsr.mem<host>>, %[[VAL_37:.*]]: tensor<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_38:.*]]: tensor<3xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:             %[[PLACEHOLDER_6:.*]] = hipsr.placeholder(%[[VAL_34]]) ins(%[[VAL_35]], %[[VAL_36]] : tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x?x?xi1, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:             ^bb0(%[[VAL_39:.*]]: !hipsr.context, %[[VAL_40:.*]]: tensor<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_41:.*]]: tensor<3xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:               %[[SHAPE_OF_1:.*]] = shape.shape_of %[[VAL_40]] : tensor<?x?x?xi1, #hipsr.mem<device>> -> tensor<3xindex>
+// CHECK-NEXT:           %[[POOL_DOMAIN_2:.*]]:4 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_1]]#0, %[[POOL_DOMAIN_0]]#6, %[[POOL_DOMAIN_1]]#1, %[[POOL_DOMAIN_0]]#7 : !hipsr.context, tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:           ^bb0(%[[VAL_24:.*]]: !hipsr.context, %[[VAL_25:.*]]: tensor<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_26:.*]]: tensor<3xi64, #hipsr.mem<host>>, %[[VAL_27:.*]]: tensor<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_28:.*]]: tensor<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:             %[[EXECUTE_REGION_6:.*]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:               %[[SHAPE_OF_6:.*]] = shape.shape_of %[[VAL_25]] : tensor<?x?x?xi1, #hipsr.mem<device>> -> tensor<3xindex>
 // CHECK-NEXT:               %[[CONSTANT_19:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[EXTRACT_3:.*]] = tensor.extract %[[VAL_41]]{{\[}}%[[CONSTANT_19]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               %[[EXTRACT_3:.*]] = tensor.extract %[[VAL_26]]{{\[}}%[[CONSTANT_19]]] : tensor<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:               %[[INDEX_CAST_5:.*]] = arith.index_cast %[[EXTRACT_3]] : i64 to index
 // CHECK-NEXT:               %[[CONSTANT_20:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[EXTRACT_4:.*]] = tensor.extract %[[VAL_41]]{{\[}}%[[CONSTANT_20]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               %[[EXTRACT_4:.*]] = tensor.extract %[[VAL_26]]{{\[}}%[[CONSTANT_20]]] : tensor<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:               %[[INDEX_CAST_6:.*]] = arith.index_cast %[[EXTRACT_4]] : i64 to index
 // CHECK-NEXT:               %[[CONSTANT_21:.*]] = arith.constant 2 : index
-// CHECK-NEXT:               %[[EXTRACT_5:.*]] = tensor.extract %[[VAL_41]]{{\[}}%[[CONSTANT_21]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               %[[EXTRACT_5:.*]] = tensor.extract %[[VAL_26]]{{\[}}%[[CONSTANT_21]]] : tensor<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:               %[[INDEX_CAST_7:.*]] = arith.index_cast %[[EXTRACT_5]] : i64 to index
 // CHECK-NEXT:               %[[FROM_EXTENTS_4:.*]] = shape.from_extents %[[INDEX_CAST_5]], %[[INDEX_CAST_6]], %[[INDEX_CAST_7]] : index, index, index
-// CHECK-NEXT:               %[[CSTR_BROADCASTABLE_1:.*]] = shape.cstr_broadcastable %[[SHAPE_OF_1]], %[[FROM_EXTENTS_4]] : tensor<3xindex>, !shape.shape
+// CHECK-NEXT:               %[[CSTR_BROADCASTABLE_1:.*]] = shape.cstr_broadcastable %[[SHAPE_OF_6]], %[[FROM_EXTENTS_4]] : tensor<3xindex>, !shape.shape
 // CHECK-NEXT:               %[[ASSUMING_1:.*]] = shape.assuming %[[CSTR_BROADCASTABLE_1]] -> (!shape.shape) {
-// CHECK-NEXT:                 %[[BROADCAST_2:.*]] = shape.broadcast %[[SHAPE_OF_1]], %[[FROM_EXTENTS_4]] : tensor<3xindex>, !shape.shape -> !shape.shape
+// CHECK-NEXT:                 %[[BROADCAST_2:.*]] = shape.broadcast %[[SHAPE_OF_6]], %[[FROM_EXTENTS_4]] : tensor<3xindex>, !shape.shape -> !shape.shape
 // CHECK-NEXT:                 shape.assuming_yield %[[BROADCAST_2]] : !shape.shape
 // CHECK-NEXT:               }
-// CHECK-NEXT:               hipsr.shape_yield %[[ASSUMING_1]] : !shape.shape
+// CHECK-NEXT:               scf.yield %[[ASSUMING_1]] : !shape.shape
 // CHECK-NEXT:             }
-// CHECK-NEXT:             %[[EXPAND_1:.*]] = hipsr.expand(%[[VAL_34]]) ins(%[[VAL_37]], %[[VAL_38]] : tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) outs(%[[PLACEHOLDER_6]] : tensor<?x?x?xi1, #hipsr.mem<device>>) : tensor<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[PLACEHOLDER_7:.*]]:2 = hipsr.placeholder(%[[VAL_34]]) ins(%[[PLACEHOLDER_6]] : tensor<?x?x?xi1, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:             ^bb0(%[[VAL_42:.*]]: !shape.shape):
-// CHECK-NEXT:               %[[CONST_SIZE_4:.*]] = shape.const_size 3
-// CHECK-NEXT:               %[[NUM_ELEMENTS_1:.*]] = shape.num_elements %[[VAL_42]] : !shape.shape -> !shape.size
-// CHECK-NEXT:               %[[FROM_EXTENTS_5:.*]] = shape.from_extents %[[CONST_SIZE_4]], %[[NUM_ELEMENTS_1]] : !shape.size, !shape.size
+// CHECK-NEXT:             %[[EXECUTE_REGION_7:.*]]:2 = scf.execute_region -> (!shape.shape, !shape.shape) {
+// CHECK-NEXT:               %[[CONST_SIZE_14:.*]] = shape.const_size 3
+// CHECK-NEXT:               %[[NUM_ELEMENTS_1:.*]] = shape.num_elements %[[EXECUTE_REGION_6]] : !shape.shape -> !shape.size
+// CHECK-NEXT:               %[[FROM_EXTENTS_5:.*]] = shape.from_extents %[[CONST_SIZE_14]], %[[NUM_ELEMENTS_1]] : !shape.size, !shape.size
 // CHECK-NEXT:               %[[CONST_SHAPE_0:.*]] = shape.const_shape [1] : !shape.shape
-// CHECK-NEXT:               hipsr.shape_yield %[[FROM_EXTENTS_5]], %[[CONST_SHAPE_0]] : !shape.shape, !shape.shape
+// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_5]], %[[CONST_SHAPE_0]] : !shape.shape, !shape.shape
 // CHECK-NEXT:             }
-// CHECK-NEXT:             %[[NONZERO_0:.*]]:2 = hipsr.nonzero(%[[VAL_34]]) ins(%[[EXPAND_1]] : tensor<?x?x?xi1, #hipsr.mem<device>>) outs(%[[VAL_43:.*]]#0, %[[VAL_43]]#1 : tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>) : tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[PLACEHOLDER_8:.*]] = hipsr.placeholder(%[[VAL_34]]) ins(%[[VAL_43]]#1 : tensor<1xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<1xi64, #hipsr.mem<host>> shape_region {
-// CHECK-NEXT:             ^bb0(%[[VAL_44:.*]]: !shape.shape):
-// CHECK-NEXT:               hipsr.shape_yield %[[VAL_44]] : !shape.shape
+
+// The host count is a 1xi64 buffer, so its allocation needs no extent and this
+// shape goes unread.
+// CHECK-NEXT:             %[[EXECUTE_REGION_8:.*]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:               scf.yield %[[EXECUTE_REGION_7]]#1 : !shape.shape
 // CHECK-NEXT:             }
-// CHECK-NEXT:             %[[VAL_45:.*]] = hipsr.copy_d2h(%[[VAL_34]]) ins(%[[NONZERO_0]]#1 : tensor<1xi64, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_8]] : tensor<1xi64, #hipsr.mem<host>>) : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             hipsr.pool_domain_yield %[[VAL_43]]#0, %[[NONZERO_0]]#0, %[[PLACEHOLDER_8]], %[[VAL_45]] : tensor<3x?xi64, #hipsr.mem<device>>, tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[CONST_SIZE_15:.*]] = shape.const_size 0
+// CHECK-NEXT:             %[[GET_EXTENT_12:.*]] = shape.get_extent %[[EXECUTE_REGION_6]], %[[CONST_SIZE_15]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:             %[[SIZE_TO_INDEX_13:.*]] = shape.size_to_index %[[GET_EXTENT_12]] : !shape.size
+// CHECK-NEXT:             %[[CONST_SIZE_16:.*]] = shape.const_size 1
+// CHECK-NEXT:             %[[GET_EXTENT_13:.*]] = shape.get_extent %[[EXECUTE_REGION_6]], %[[CONST_SIZE_16]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:             %[[SIZE_TO_INDEX_14:.*]] = shape.size_to_index %[[GET_EXTENT_13]] : !shape.size
+// CHECK-NEXT:             %[[CONST_SIZE_17:.*]] = shape.const_size 2
+// CHECK-NEXT:             %[[GET_EXTENT_14:.*]] = shape.get_extent %[[EXECUTE_REGION_6]], %[[CONST_SIZE_17]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:             %[[SIZE_TO_INDEX_15:.*]] = shape.size_to_index %[[GET_EXTENT_14]] : !shape.size
+// CHECK-NEXT:             %[[EMPTY_6:.*]] = tensor.empty(%[[SIZE_TO_INDEX_13]], %[[SIZE_TO_INDEX_14]], %[[SIZE_TO_INDEX_15]]) : tensor<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[CONST_SIZE_18:.*]] = shape.const_size 1
+// CHECK-NEXT:             %[[GET_EXTENT_15:.*]] = shape.get_extent %[[EXECUTE_REGION_7]]#0, %[[CONST_SIZE_18]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:             %[[SIZE_TO_INDEX_16:.*]] = shape.size_to_index %[[GET_EXTENT_15]] : !shape.size
+// CHECK-NEXT:             %[[EMPTY_7:.*]] = tensor.empty(%[[SIZE_TO_INDEX_16]]) : tensor<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[EMPTY_8:.*]] = tensor.empty() : tensor<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[EMPTY_9:.*]] = tensor.empty() : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[EXPAND_1:.*]] = hipsr.expand(%[[VAL_24]]) ins(%[[VAL_27]], %[[VAL_28]] : tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) outs(%[[EMPTY_6]] : tensor<?x?x?xi1, #hipsr.mem<device>>) : tensor<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[NONZERO_0:.*]]:2 = hipsr.nonzero(%[[VAL_24]]) ins(%[[EXPAND_1]] : tensor<?x?x?xi1, #hipsr.mem<device>>) outs(%[[EMPTY_7]], %[[EMPTY_8]] : tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>) : tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[VAL_31:.*]] = hipsr.copy_d2h(%[[VAL_24]]) ins(%[[NONZERO_0]]#1 : tensor<1xi64, #hipsr.mem<device>>) outs(%[[EMPTY_9]] : tensor<1xi64, #hipsr.mem<host>>) : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             hipsr.pool_domain_yield %[[EMPTY_7]], %[[NONZERO_0]]#0, %[[EMPTY_9]], %[[VAL_31]] : tensor<3x?xi64, #hipsr.mem<device>>, tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:           } -> tensor<3x?xi64, #hipsr.mem<device>>, tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>> {domain_id = 2 : i64}
 
-// That host count opens the next domain. A barrier turns it into the trailing
-// extent so the search destination narrows to the columns that hold a position.
-// The barrier and the compute list the same two values, so they share a domain
-// and each reads only the one it needs.
-// CHECK-NEXT:           %[[POOL_DOMAIN_3:.*]]:4 = hipsr.pool_domain(%[[ARG0]], %[[VAL_46:.*]]#2, %[[VAL_46]]#0, %[[VAL_46]]#3, %[[VAL_46]]#1 : !hipsr.context, tensor<1xi64, #hipsr.mem<host>>, tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<3x?xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:           ^bb0(%[[VAL_47:.*]]: !hipsr.context, %[[VAL_48:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_49:.*]]: tensor<3x?xi64, #hipsr.mem<device>>, %[[VAL_50:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_51:.*]]: tensor<3x?xi64, #hipsr.mem<device>>):
-// CHECK-NEXT:             %[[PLACEHOLDER_9:.*]] = hipsr.placeholder(%[[VAL_47]]) ins(%[[VAL_48]], %[[VAL_49]] : tensor<1xi64, #hipsr.mem<host>>, tensor<3x?xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<3x?xi64, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:             ^bb0(%[[VAL_52:.*]]: !hipsr.context, %[[VAL_53:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_54:.*]]: tensor<3x?xi64, #hipsr.mem<device>>):
+// That host count opens the next domain, where the first shape computation
+// turns it into the trailing extent so the search destination narrows to the
+// columns that hold a position. The domain takes both buffers twice, and the
+// shape computation reads only the count while the data op reads only the
+// coordinates.
+// CHECK-NEXT:           %[[POOL_DOMAIN_3:.*]]:4 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_2]]#2, %[[POOL_DOMAIN_2]]#0, %[[POOL_DOMAIN_2]]#3, %[[POOL_DOMAIN_2]]#1 : !hipsr.context, tensor<1xi64, #hipsr.mem<host>>, tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<3x?xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:           ^bb0(%[[VAL_33:.*]]: !hipsr.context, %[[VAL_34:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_35:.*]]: tensor<3x?xi64, #hipsr.mem<device>>, %[[VAL_36:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_37:.*]]: tensor<3x?xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:             %[[EXECUTE_REGION_9:.*]] = scf.execute_region -> !shape.shape {
 // CHECK-NEXT:               %[[CONSTANT_22:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[EXTRACT_6:.*]] = tensor.extract %[[VAL_53]]{{\[}}%[[CONSTANT_22]]] : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               %[[EXTRACT_6:.*]] = tensor.extract %[[VAL_34]]{{\[}}%[[CONSTANT_22]]] : tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:               %[[INDEX_CAST_8:.*]] = arith.index_cast %[[EXTRACT_6]] : i64 to index
 // CHECK-NEXT:               %[[CONSTANT_23:.*]] = arith.constant 3 : index
 // CHECK-NEXT:               %[[FROM_EXTENTS_6:.*]] = shape.from_extents %[[CONSTANT_23]], %[[INDEX_CAST_8]] : index, index
-// CHECK-NEXT:               hipsr.shape_yield %[[FROM_EXTENTS_6]] : !shape.shape
+// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_6]] : !shape.shape
 // CHECK-NEXT:             }
-// CHECK-NEXT:             %[[COMPUTE_3:.*]] = hipsr.compute(%[[VAL_47]]) ins(%[[VAL_50]], %[[VAL_51]] : tensor<1xi64, #hipsr.mem<host>>, tensor<3x?xi64, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_9]] : tensor<3x?xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_55:.*]]: !hipsr.context, %[[VAL_56:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_57:.*]]: tensor<3x?xi64, #hipsr.mem<device>>, %[[VAL_58:.*]]: tensor<3x?xi64, #hipsr.mem<device>>):
-// CHECK-NEXT:               %[[CONSTANT_24:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[DIM_4:.*]] = tensor.dim %[[VAL_58]], %[[CONSTANT_24]] : tensor<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:               %[[EXTRACT_SLICE_0:.*]] = tensor.extract_slice %[[VAL_57]][0, 0] [3, %[[DIM_4]]] [1, 1] : tensor<3x?xi64, #hipsr.mem<device>> to tensor<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[EXECUTE_REGION_10:.*]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:               %[[CONST_SIZE_19:.*]] = shape.const_size 1
+// CHECK-NEXT:               %[[GET_EXTENT_16:.*]] = shape.get_extent %[[EXECUTE_REGION_9]], %[[CONST_SIZE_19]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:               %[[CONST_SIZE_20:.*]] = shape.const_size 0
+// CHECK-NEXT:               %[[GET_EXTENT_17:.*]] = shape.get_extent %[[EXECUTE_REGION_9]], %[[CONST_SIZE_20]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:               %[[FROM_EXTENTS_7:.*]] = shape.from_extents %[[GET_EXTENT_16]], %[[GET_EXTENT_17]] : !shape.size, !shape.size
+// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_7]] : !shape.shape
+// CHECK-NEXT:             }
+// CHECK-NEXT:             %[[EXECUTE_REGION_11:.*]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:               %[[CONSTANT_24:.*]] = arith.constant 2 : index
+// CHECK-NEXT:               %[[FROM_EXTENTS_8:.*]] = shape.from_extents %[[CONSTANT_24]] : index
+// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_8]] : !shape.shape
+// CHECK-NEXT:             }
+// CHECK-NEXT:             %[[EXECUTE_REGION_12:.*]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:               %[[CONST_SHAPE_1:.*]] = shape.const_shape [] : !shape.shape
+// CHECK-NEXT:               scf.yield %[[CONST_SHAPE_1]] : !shape.shape
+// CHECK-NEXT:             }
+// CHECK-NEXT:             %[[EXECUTE_REGION_13:.*]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:               %[[CONSTANT_25:.*]] = arith.constant 1 : index
+// CHECK-NEXT:               %[[FROM_EXTENTS_9:.*]] = shape.from_extents %[[CONSTANT_25]] : index
+// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_9]] : !shape.shape
+// CHECK-NEXT:             }
+// CHECK-NEXT:             %[[CONST_SIZE_21:.*]] = shape.const_size 1
+// CHECK-NEXT:             %[[GET_EXTENT_18:.*]] = shape.get_extent %[[EXECUTE_REGION_9]], %[[CONST_SIZE_21]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:             %[[SIZE_TO_INDEX_17:.*]] = shape.size_to_index %[[GET_EXTENT_18]] : !shape.size
+// CHECK-NEXT:             %[[EMPTY_10:.*]] = tensor.empty(%[[SIZE_TO_INDEX_17]]) : tensor<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[CONST_SIZE_22:.*]] = shape.const_size 0
+// CHECK-NEXT:             %[[GET_EXTENT_19:.*]] = shape.get_extent %[[EXECUTE_REGION_10]], %[[CONST_SIZE_22]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:             %[[SIZE_TO_INDEX_18:.*]] = shape.size_to_index %[[GET_EXTENT_19]] : !shape.size
+// CHECK-NEXT:             %[[EMPTY_11:.*]] = tensor.empty(%[[SIZE_TO_INDEX_18]]) : tensor<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[EMPTY_12:.*]] = tensor.empty() : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[EMPTY_13:.*]] = tensor.empty() : tensor<i64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[EMPTY_14:.*]] = tensor.empty() : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[COMPUTE_3:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[VAL_36]], %[[VAL_37]] : tensor<1xi64, #hipsr.mem<host>>, tensor<3x?xi64, #hipsr.mem<device>>) outs(%[[EMPTY_10]] : tensor<3x?xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:             ^bb0(%[[VAL_38:.*]]: !hipsr.context, %[[VAL_39:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_40:.*]]: tensor<3x?xi64, #hipsr.mem<device>>, %[[VAL_41:.*]]: tensor<3x?xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:               %[[CONSTANT_26:.*]] = arith.constant 1 : index
+// CHECK-NEXT:               %[[DIM_4:.*]] = tensor.dim %[[VAL_41]], %[[CONSTANT_26]] : tensor<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[EXTRACT_SLICE_0:.*]] = tensor.extract_slice %[[VAL_40]][0, 0] [3, %[[DIM_4]]] [1, 1] : tensor<3x?xi64, #hipsr.mem<device>> to tensor<3x?xi64, #hipsr.mem<device>>
 // CHECK-NEXT:               hipsr.compute_yield %[[EXTRACT_SLICE_0]] : tensor<3x?xi64, #hipsr.mem<device>>
 // CHECK-NEXT:             } : tensor<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[PLACEHOLDER_10:.*]] = hipsr.placeholder(%[[VAL_47]]) ins(%[[PLACEHOLDER_9]] : tensor<3x?xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x3xi64, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:             ^bb0(%[[VAL_59:.*]]: !shape.shape):
-// CHECK-NEXT:               %[[CONST_SIZE_5:.*]] = shape.const_size 1
-// CHECK-NEXT:               %[[GET_EXTENT_2:.*]] = shape.get_extent %[[VAL_59]], %[[CONST_SIZE_5]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:               %[[CONST_SIZE_6:.*]] = shape.const_size 0
-// CHECK-NEXT:               %[[GET_EXTENT_3:.*]] = shape.get_extent %[[VAL_59]], %[[CONST_SIZE_6]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:               %[[FROM_EXTENTS_7:.*]] = shape.from_extents %[[GET_EXTENT_2]], %[[GET_EXTENT_3]] : !shape.size, !shape.size
-// CHECK-NEXT:               hipsr.shape_yield %[[FROM_EXTENTS_7]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[TRANSPOSE_0:.*]] = hipsr.transpose(%[[VAL_47]]) ins(%[[COMPUTE_3]] : tensor<3x?xi64, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_10]] : tensor<?x3xi64, #hipsr.mem<device>>) {perm = array<i64: 1, 0>} : tensor<?x3xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[PLACEHOLDER_11:.*]] = hipsr.placeholder(%[[VAL_47]]) ins(%[[PLACEHOLDER_10]] : tensor<?x3xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
-// CHECK-NEXT:             ^bb0(%[[VAL_60:.*]]: !shape.shape):
-// CHECK-NEXT:               %[[CONSTANT_25:.*]] = arith.constant 2 : index
-// CHECK-NEXT:               %[[FROM_EXTENTS_8:.*]] = shape.from_extents %[[CONSTANT_25]] : index
-// CHECK-NEXT:               hipsr.shape_yield %[[FROM_EXTENTS_8]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[COMPUTE_4:.*]] = hipsr.compute(%[[VAL_47]]) ins(%[[TRANSPOSE_0]] : tensor<?x3xi64, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_11]] : tensor<2xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_61:.*]]: !hipsr.context, %[[VAL_62:.*]]: tensor<?x3xi64, #hipsr.mem<device>>, %[[VAL_63:.*]]: tensor<2xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:               %[[CONSTANT_26:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[DIM_5:.*]] = tensor.dim %[[VAL_62]], %[[CONSTANT_26]] : tensor<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[TRANSPOSE_0:.*]] = hipsr.transpose(%[[VAL_33]]) ins(%[[COMPUTE_3]] : tensor<3x?xi64, #hipsr.mem<device>>) outs(%[[EMPTY_11]] : tensor<?x3xi64, #hipsr.mem<device>>) {perm = array<i64: 1, 0>} : tensor<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[COMPUTE_4:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[TRANSPOSE_0]] : tensor<?x3xi64, #hipsr.mem<device>>) outs(%[[EMPTY_12]] : tensor<2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:             ^bb0(%[[VAL_42:.*]]: !hipsr.context, %[[VAL_43:.*]]: tensor<?x3xi64, #hipsr.mem<device>>, %[[VAL_44:.*]]: tensor<2xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:               %[[CONSTANT_27:.*]] = arith.constant 0 : index
+// CHECK-NEXT:               %[[DIM_5:.*]] = tensor.dim %[[VAL_43]], %[[CONSTANT_27]] : tensor<?x3xi64, #hipsr.mem<device>>
 // CHECK-NEXT:               %[[INDEX_CAST_9:.*]] = arith.index_cast %[[DIM_5]] : index to i64
-// CHECK-NEXT:               %[[CONSTANT_27:.*]] = arith.constant 3 : i64
-// CHECK-NEXT:               %[[FROM_ELEMENTS_1:.*]] = tensor.from_elements %[[INDEX_CAST_9]], %[[CONSTANT_27]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               %[[CONSTANT_28:.*]] = arith.constant 3 : i64
+// CHECK-NEXT:               %[[FROM_ELEMENTS_1:.*]] = tensor.from_elements %[[INDEX_CAST_9]], %[[CONSTANT_28]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:               hipsr.compute_yield %[[FROM_ELEMENTS_1]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:             } : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             %[[PLACEHOLDER_12:.*]] = hipsr.placeholder(%[[VAL_47]]) ins(%[[PLACEHOLDER_11]] : tensor<2xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<i64, #hipsr.mem<host>> shape_region {
-// CHECK-NEXT:             ^bb0(%[[VAL_64:.*]]: !shape.shape):
-// CHECK-NEXT:               %[[CONST_SHAPE_1:.*]] = shape.const_shape [] : !shape.shape
-// CHECK-NEXT:               hipsr.shape_yield %[[CONST_SHAPE_1]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[COMPUTE_5:.*]] = hipsr.compute(%[[VAL_47]]) ins(%[[COMPUTE_4]] : tensor<2xi64, #hipsr.mem<host>>) outs(%[[PLACEHOLDER_12]] : tensor<i64, #hipsr.mem<host>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_65:.*]]: !hipsr.context, %[[VAL_66:.*]]: tensor<2xi64, #hipsr.mem<host>>, %[[VAL_67:.*]]: tensor<i64, #hipsr.mem<host>>):
-// CHECK-NEXT:               %[[CONSTANT_28:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[EXTRACT_7:.*]] = tensor.extract %[[VAL_66]]{{\[}}%[[CONSTANT_28]]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[COMPUTE_5:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[COMPUTE_4]] : tensor<2xi64, #hipsr.mem<host>>) outs(%[[EMPTY_13]] : tensor<i64, #hipsr.mem<host>>) {
+// CHECK-NEXT:             ^bb0(%[[VAL_45:.*]]: !hipsr.context, %[[VAL_46:.*]]: tensor<2xi64, #hipsr.mem<host>>, %[[VAL_47:.*]]: tensor<i64, #hipsr.mem<host>>):
+// CHECK-NEXT:               %[[CONSTANT_29:.*]] = arith.constant 0 : index
+// CHECK-NEXT:               %[[EXTRACT_7:.*]] = tensor.extract %[[VAL_46]]{{\[}}%[[CONSTANT_29]]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:               %[[FROM_ELEMENTS_2:.*]] = tensor.from_elements %[[EXTRACT_7]] : tensor<i64, #hipsr.mem<host>>
 // CHECK-NEXT:               hipsr.compute_yield %[[FROM_ELEMENTS_2]] : tensor<i64, #hipsr.mem<host>>
 // CHECK-NEXT:             } : tensor<i64, #hipsr.mem<host>>
-// CHECK-NEXT:             %[[PLACEHOLDER_13:.*]] = hipsr.placeholder(%[[VAL_47]]) ins(%[[PLACEHOLDER_12]] : tensor<i64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<1xi64, #hipsr.mem<host>> shape_region {
-// CHECK-NEXT:             ^bb0(%[[VAL_68:.*]]: !shape.shape):
-// CHECK-NEXT:               %[[CONSTANT_29:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[FROM_EXTENTS_9:.*]] = shape.from_extents %[[CONSTANT_29]] : index
-// CHECK-NEXT:               hipsr.shape_yield %[[FROM_EXTENTS_9]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[COMPUTE_6:.*]] = hipsr.compute(%[[VAL_47]]) ins(%[[COMPUTE_5]] : tensor<i64, #hipsr.mem<host>>) outs(%[[PLACEHOLDER_13]] : tensor<1xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_69:.*]]: !hipsr.context, %[[VAL_70:.*]]: tensor<i64, #hipsr.mem<host>>, %[[VAL_71:.*]]: tensor<1xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:               %[[EXPAND_SHAPE_1:.*]] = tensor.expand_shape %[[VAL_70]] [] output_shape [1] : tensor<i64, #hipsr.mem<host>> into tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[COMPUTE_6:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[COMPUTE_5]] : tensor<i64, #hipsr.mem<host>>) outs(%[[EMPTY_14]] : tensor<1xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:             ^bb0(%[[VAL_48:.*]]: !hipsr.context, %[[VAL_49:.*]]: tensor<i64, #hipsr.mem<host>>, %[[VAL_50:.*]]: tensor<1xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:               %[[EXPAND_SHAPE_1:.*]] = tensor.expand_shape %[[VAL_49]] [] output_shape [1] : tensor<i64, #hipsr.mem<host>> into tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:               hipsr.compute_yield %[[EXPAND_SHAPE_1]] : tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:             } : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             hipsr.pool_domain_yield %[[PLACEHOLDER_10]], %[[TRANSPOSE_0]], %[[PLACEHOLDER_13]], %[[COMPUTE_6]] : tensor<?x3xi64, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             hipsr.pool_domain_yield %[[EMPTY_11]], %[[TRANSPOSE_0]], %[[EMPTY_14]], %[[COMPUTE_6]] : tensor<?x3xi64, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:           } -> tensor<?x3xi64, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>> {domain_id = 3 : i64}
 
 // The update window ends at that same count, and the scatter writes it into
 // the embeddings.
-// CHECK-NEXT:           %[[POOL_DOMAIN_4:.*]] = hipsr.pool_domain(%[[ARG0]], %[[VAL_72:.*]]#0, %[[VAL_73:.*]]#2, %[[VAL_72]]#1, %[[VAL_73]]#3, %[[VAL_72]]#4, %[[VAL_73]]#0, %[[VAL_72]]#5, %[[VAL_73]]#1 : !hipsr.context, tensor<?xf16, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<?xf16, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:           ^bb0(%[[VAL_74:.*]]: !hipsr.context, %[[VAL_75:.*]]: tensor<?xf16, #hipsr.mem<device>>, %[[VAL_76:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_77:.*]]: tensor<?xf16, #hipsr.mem<device>>, %[[VAL_78:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_79:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_80:.*]]: tensor<?x3xi64, #hipsr.mem<device>>, %[[VAL_81:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_82:.*]]: tensor<?x3xi64, #hipsr.mem<device>>):
-// CHECK-NEXT:             %[[PLACEHOLDER_14:.*]] = hipsr.placeholder(%[[VAL_74]]) ins(%[[VAL_75]], %[[VAL_76]] : tensor<?xf16, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?xf16, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:             ^bb0(%[[VAL_83:.*]]: !hipsr.context, %[[VAL_84:.*]]: tensor<?xf16, #hipsr.mem<device>>, %[[VAL_85:.*]]: tensor<1xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:           %[[POOL_DOMAIN_4:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#0, %[[POOL_DOMAIN_3]]#2, %[[POOL_DOMAIN_0]]#1, %[[POOL_DOMAIN_3]]#3, %[[POOL_DOMAIN_0]]#4, %[[POOL_DOMAIN_3]]#0, %[[POOL_DOMAIN_0]]#5, %[[POOL_DOMAIN_3]]#1 : !hipsr.context, tensor<?xf16, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<?xf16, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:           ^bb0(%[[VAL_53:.*]]: !hipsr.context, %[[VAL_54:.*]]: tensor<?xf16, #hipsr.mem<device>>, %[[VAL_55:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_56:.*]]: tensor<?xf16, #hipsr.mem<device>>, %[[VAL_57:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_58:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_59:.*]]: tensor<?x3xi64, #hipsr.mem<device>>, %[[VAL_60:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_61:.*]]: tensor<?x3xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:             %[[EXECUTE_REGION_14:.*]] = scf.execute_region -> !shape.shape {
 // CHECK-NEXT:               %[[CONSTANT_30:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[DIM_6:.*]] = tensor.dim %[[VAL_84]], %[[CONSTANT_30]] : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[DIM_6:.*]] = tensor.dim %[[VAL_54]], %[[CONSTANT_30]] : tensor<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT:               %[[CONSTANT_31:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[EXTRACT_8:.*]] = tensor.extract %[[VAL_85]]{{\[}}%[[CONSTANT_31]]] : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               %[[EXTRACT_8:.*]] = tensor.extract %[[VAL_55]]{{\[}}%[[CONSTANT_31]]] : tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:               %[[INDEX_CAST_10:.*]] = arith.index_cast %[[EXTRACT_8]] : i64 to index
 // CHECK-NEXT:               %[[CONSTANT_32:.*]] = arith.constant 0 : index
 // CHECK-NEXT:               %[[CMPI_0:.*]] = arith.cmpi slt, %[[INDEX_CAST_10]], %[[CONSTANT_32]] : index
@@ -322,14 +395,26 @@ module {
 // CHECK-NEXT:               %[[SUBI_0:.*]] = arith.subi %[[MINSI_1]], %[[MINSI_0]] : index
 // CHECK-NEXT:               %[[MAXSI_1:.*]] = arith.maxsi %[[SUBI_0]], %[[CONSTANT_32]] : index
 // CHECK-NEXT:               %[[FROM_EXTENTS_10:.*]] = shape.from_extents %[[MAXSI_1]] : index
-// CHECK-NEXT:               hipsr.shape_yield %[[FROM_EXTENTS_10]] : !shape.shape
+// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_10]] : !shape.shape
 // CHECK-NEXT:             }
-// CHECK-NEXT:             %[[SLICE_0:.*]] = hipsr.slice(%[[VAL_74]]) ins(%[[VAL_77]] : tensor<?xf16, #hipsr.mem<device>>) ends(%[[VAL_78]] : tensor<1xi64, #hipsr.mem<host>>) outs(%[[PLACEHOLDER_14]] : tensor<?xf16, #hipsr.mem<device>>) {axes_attr = array<i64: 0>, starts_attr = array<i64: 0>, steps_attr = array<i64: 1>} : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[PLACEHOLDER_15:.*]] = hipsr.placeholder(%[[VAL_74]]) ins(%[[VAL_79]], %[[VAL_80]], %[[PLACEHOLDER_14]] : tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x?x4096xf16, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:             ^bb0(%[[VAL_86:.*]]: !shape.shape, %[[VAL_87:.*]]: !shape.shape, %[[VAL_88:.*]]: !shape.shape):
-// CHECK-NEXT:               hipsr.shape_yield %[[VAL_86]] : !shape.shape
+// CHECK-NEXT:             %[[EXECUTE_REGION_15:.*]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:               %[[SHAPE_OF_7:.*]] = shape.shape_of %[[VAL_58]] : tensor<?x?x4096xf16, #hipsr.mem<device>> -> !shape.shape
+// CHECK-NEXT:               %[[SHAPE_OF_8:.*]] = shape.shape_of %[[VAL_59]] : tensor<?x3xi64, #hipsr.mem<device>> -> !shape.shape
+// CHECK-NEXT:               scf.yield %[[SHAPE_OF_7]] : !shape.shape
 // CHECK-NEXT:             }
-// CHECK-NEXT:             %[[SCATTER_ND_0:.*]] = hipsr.scatter_nd(%[[VAL_74]]) ins(%[[VAL_81]], %[[VAL_82]], %[[SLICE_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_15]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[CONST_SIZE_23:.*]] = shape.const_size 0
+// CHECK-NEXT:             %[[GET_EXTENT_20:.*]] = shape.get_extent %[[EXECUTE_REGION_14]], %[[CONST_SIZE_23]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:             %[[SIZE_TO_INDEX_19:.*]] = shape.size_to_index %[[GET_EXTENT_20]] : !shape.size
+// CHECK-NEXT:             %[[EMPTY_15:.*]] = tensor.empty(%[[SIZE_TO_INDEX_19]]) : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[CONST_SIZE_24:.*]] = shape.const_size 0
+// CHECK-NEXT:             %[[GET_EXTENT_21:.*]] = shape.get_extent %[[EXECUTE_REGION_15]], %[[CONST_SIZE_24]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:             %[[SIZE_TO_INDEX_20:.*]] = shape.size_to_index %[[GET_EXTENT_21]] : !shape.size
+// CHECK-NEXT:             %[[CONST_SIZE_25:.*]] = shape.const_size 1
+// CHECK-NEXT:             %[[GET_EXTENT_22:.*]] = shape.get_extent %[[EXECUTE_REGION_15]], %[[CONST_SIZE_25]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:             %[[SIZE_TO_INDEX_21:.*]] = shape.size_to_index %[[GET_EXTENT_22]] : !shape.size
+// CHECK-NEXT:             %[[EMPTY_16:.*]] = tensor.empty(%[[SIZE_TO_INDEX_20]], %[[SIZE_TO_INDEX_21]]) : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[SLICE_0:.*]] = hipsr.slice(%[[VAL_53]]) ins(%[[VAL_56]] : tensor<?xf16, #hipsr.mem<device>>) ends(%[[VAL_57]] : tensor<1xi64, #hipsr.mem<host>>) outs(%[[EMPTY_15]] : tensor<?xf16, #hipsr.mem<device>>) {axes_attr = array<i64: 0>, starts_attr = array<i64: 0>, steps_attr = array<i64: 1>} : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[SCATTER_ND_0:.*]] = hipsr.scatter_nd(%[[VAL_53]]) ins(%[[VAL_60]], %[[VAL_61]], %[[SLICE_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>) outs(%[[EMPTY_16]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) : tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:             hipsr.pool_domain_yield %[[SCATTER_ND_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:           } -> tensor<?x?x4096xf16, #hipsr.mem<device>> {domain_id = 4 : i64}
 // CHECK-NEXT:           return %[[POOL_DOMAIN_4]] : tensor<?x?x4096xf16, #hipsr.mem<device>>

--- a/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
@@ -58,14 +58,15 @@
 // through 4 each open with a shape computation that extracts extents from a
 // host buffer an earlier domain filled, which is what a cut looks like below.
 //
-// The three zones of a domain
-// ---------------------------
+// The four zones of a domain
+// --------------------------
 //
 // hipsr-materialize-init-tensors leaves each domain body in order: the
 // scf.execute_region shape computations, then the tensor.empty allocations that
-// read their dynamic extents back out of those shapes, then the data ops. A
-// constant a shape computation reads moves up with it; the rest stay where
-// conversion left them.
+// read their dynamic extents back out of those shapes, then the data ops, then
+// a hipsr.preserve_shape per allocation tying the shape that sized it to the
+// result that fills it. A constant a shape computation reads moves up with it;
+// the rest stay where conversion left them.
 //===----------------------------------------------------------------------===//
 
 // RUN: %python %S/../../../Inputs/make_external_data.py %t/embedding.onnx.data 2034237440 && cd %t && hip-mlir-opt --onnx-dialect=modeled --hipsr-pipeline --mlir-elide-resource-strings-if-larger=32 %s | FileCheck %s
@@ -194,6 +195,16 @@ module {
 // CHECK-NEXT:               %[[FROM_ELEMENTS_0:.*]] = tensor.from_elements %[[INDEX_CAST_0]], %[[INDEX_CAST_1]], %[[CONSTANT_15]] : tensor<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:               hipsr.compute_yield %[[FROM_ELEMENTS_0]] : tensor<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:             } : tensor<3xi64, #hipsr.mem<host>>
+
+// The link zone. One hipsr.preserve_shape per allocation, in allocation order,
+// each naming the result of the op that fills that buffer, so a later pass can
+// still read the shape once bufferization has replaced the tensor values with
+// the buffers behind them.
+// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_0]], %[[COMPUTE_0]] : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_1]], %[[EQUAL_0]] : tensor<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_2]], %[[COMPUTE_1]] : tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_3]], %[[GATHER_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_4]], %[[COMPUTE_2]] : tensor<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:             hipsr.pool_domain_yield %[[EMPTY_0]], %[[COMPUTE_0]], %[[EMPTY_2]], %[[COMPUTE_1]], %[[EMPTY_3]], %[[GATHER_0]], %[[EMPTY_4]], %[[COMPUTE_2]] : tensor<?xf16, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:           } -> tensor<?xf16, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<3xi64, #hipsr.mem<host>> {domain_id = 0 : i64}
 
@@ -232,6 +243,7 @@ module {
 // CHECK-NEXT:             %[[SIZE_TO_INDEX_12:.*]] = shape.size_to_index %[[GET_EXTENT_11]] : !shape.size
 // CHECK-NEXT:             %[[EMPTY_5:.*]] = tensor.empty(%[[SIZE_TO_INDEX_10]], %[[SIZE_TO_INDEX_11]], %[[SIZE_TO_INDEX_12]]) : tensor<?x?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:             %[[EXPAND_0:.*]] = hipsr.expand(%[[VAL_17]]) ins(%[[VAL_20]], %[[VAL_21]] : tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) outs(%[[EMPTY_5]] : tensor<?x?x?xi1, #hipsr.mem<device>>) : tensor<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_5]], %[[EXPAND_0]] : tensor<?x?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:             hipsr.pool_domain_yield %[[EMPTY_5]], %[[EXPAND_0]] : tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<?x?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:           } -> tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<?x?x?xi1, #hipsr.mem<device>> {domain_id = 1 : i64}
 
@@ -291,6 +303,13 @@ module {
 // CHECK-NEXT:             %[[EXPAND_1:.*]] = hipsr.expand(%[[VAL_24]]) ins(%[[VAL_27]], %[[VAL_28]] : tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) outs(%[[EMPTY_6]] : tensor<?x?x?xi1, #hipsr.mem<device>>) : tensor<?x?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:             %[[NONZERO_0:.*]]:2 = hipsr.nonzero(%[[VAL_24]]) ins(%[[EXPAND_1]] : tensor<?x?x?xi1, #hipsr.mem<device>>) outs(%[[EMPTY_7]], %[[EMPTY_8]] : tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>) : tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>
 // CHECK-NEXT:             %[[VAL_31:.*]] = hipsr.copy_d2h(%[[VAL_24]]) ins(%[[NONZERO_0]]#1 : tensor<1xi64, #hipsr.mem<device>>) outs(%[[EMPTY_9]] : tensor<1xi64, #hipsr.mem<host>>) : tensor<1xi64, #hipsr.mem<host>>
+
+// The search sizes two buffers, so its one shape computation yields two shapes
+// and each links to the matching result.
+// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_6]], %[[EXPAND_1]] : tensor<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_7]]#0, %[[NONZERO_0]]#0 : tensor<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_7]]#1, %[[NONZERO_0]]#1 : tensor<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_8]], %[[VAL_31]] : tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:             hipsr.pool_domain_yield %[[EMPTY_7]], %[[NONZERO_0]]#0, %[[EMPTY_9]], %[[VAL_31]] : tensor<3x?xi64, #hipsr.mem<device>>, tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:           } -> tensor<3x?xi64, #hipsr.mem<device>>, tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>> {domain_id = 2 : i64}
 
@@ -371,6 +390,11 @@ module {
 // CHECK-NEXT:               %[[EXPAND_SHAPE_1:.*]] = tensor.expand_shape %[[VAL_49]] [] output_shape [1] : tensor<i64, #hipsr.mem<host>> into tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:               hipsr.compute_yield %[[EXPAND_SHAPE_1]] : tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:             } : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_9]], %[[COMPUTE_3]] : tensor<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_10]], %[[TRANSPOSE_0]] : tensor<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_11]], %[[COMPUTE_4]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_12]], %[[COMPUTE_5]] : tensor<i64, #hipsr.mem<host>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_13]], %[[COMPUTE_6]] : tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:             hipsr.pool_domain_yield %[[EMPTY_11]], %[[TRANSPOSE_0]], %[[EMPTY_14]], %[[COMPUTE_6]] : tensor<?x3xi64, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:           } -> tensor<?x3xi64, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>> {domain_id = 3 : i64}
 
@@ -415,6 +439,8 @@ module {
 // CHECK-NEXT:             %[[EMPTY_16:.*]] = tensor.empty(%[[SIZE_TO_INDEX_20]], %[[SIZE_TO_INDEX_21]]) : tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:             %[[SLICE_0:.*]] = hipsr.slice(%[[VAL_53]]) ins(%[[VAL_56]] : tensor<?xf16, #hipsr.mem<device>>) ends(%[[VAL_57]] : tensor<1xi64, #hipsr.mem<host>>) outs(%[[EMPTY_15]] : tensor<?xf16, #hipsr.mem<device>>) {axes_attr = array<i64: 0>, starts_attr = array<i64: 0>, steps_attr = array<i64: 1>} : tensor<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT:             %[[SCATTER_ND_0:.*]] = hipsr.scatter_nd(%[[VAL_53]]) ins(%[[VAL_60]], %[[VAL_61]], %[[SLICE_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>) outs(%[[EMPTY_16]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_14]], %[[SLICE_0]] : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_15]], %[[SCATTER_ND_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:             hipsr.pool_domain_yield %[[SCATTER_ND_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:           } -> tensor<?x?x4096xf16, #hipsr.mem<device>> {domain_id = 4 : i64}
 // CHECK-NEXT:           return %[[POOL_DOMAIN_4]] : tensor<?x?x4096xf16, #hipsr.mem<device>>

--- a/test/lit/Dialect/Hipsr/Pipelines/sample_dynamic.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/sample_dynamic.mlir
@@ -14,14 +14,17 @@
 // CHECK-SAME:      -> (tensor<?x2xf32, #hipsr.mem<device>> {onnx.name = "y"})
 // CHECK-SAME:      attributes {onnx.graph.name = "main_graph"} {
 
-// The domains split exactly where they do in sample_static.mlir: the barrier
-// placeholder's position does not depend on whether the extents are known.
+// The domains split exactly where they do in sample_static.mlir, and so do the
+// four zones inside each one: neither the barrier's position nor the shape
+// graph depends on whether the extents are known.
 // CHECK-NEXT:    %[[D0:.+]]:5 = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]] : !hipsr.context, tensor<?x3xf16, #hipsr.mem<device>>, tensor<?x4xf32, #hipsr.mem<device>>) {
 // CHECK-NEXT:    ^bb0(%[[D0_CTX:.+]]: !hipsr.context, %[[D0_A:.+]]: tensor<?x3xf16, #hipsr.mem<device>>, %[[D0_B:.+]]: tensor<?x4xf32, #hipsr.mem<device>>):
 
 // CHECK-NEXT:      %[[W1:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<3x1xf16>} : tensor<3x1xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[MM1_INIT:.+]] = hipsr.placeholder(%[[D0_CTX]]) ins(%[[D0_A]], %[[W1]] : tensor<?x3xf16, #hipsr.mem<device>>, tensor<3x1xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x1xf16, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:      ^bb0(%[[A_SHAPE:.+]]: !shape.shape, %[[W1_SHAPE:.+]]: !shape.shape):
+// CHECK-NEXT:      %[[W2:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<4x2xf32>} : tensor<4x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[MM1_SHAPE:.+]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[D0_A]] : tensor<?x3xf16, #hipsr.mem<device>> -> !shape.shape
+// CHECK-NEXT:        %[[W1_SHAPE:.+]] = shape.shape_of %[[W1]] : tensor<3x1xf16, #hipsr.mem<device>> -> !shape.shape
 // CHECK-NEXT:        %[[A_K_IDX:.+]] = shape.const_size 1
 // CHECK-NEXT:        %[[A_K:.+]] = shape.get_extent %[[A_SHAPE]], %[[A_K_IDX]] : !shape.shape, !shape.size -> !shape.size
 // CHECK-NEXT:        %[[A_K_SHAPE:.+]] = shape.from_extents %[[A_K]] : !shape.size
@@ -45,71 +48,81 @@
 // CHECK-NEXT:          %[[RESULT:.+]] = shape.concat %[[BATCH]], %[[MATRIX]] : !shape.shape, !shape.shape -> !shape.shape
 // CHECK-NEXT:          shape.assuming_yield %[[RESULT]] : !shape.shape
 // CHECK-NEXT:        }
-// CHECK-NEXT:        hipsr.shape_yield %[[MM1_SHAPE_VAL]] : !shape.shape
+// CHECK-NEXT:        scf.yield %[[MM1_SHAPE_VAL]] : !shape.shape
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %[[MM1:.+]] = hipsr.matmul(%[[D0_CTX]]) ins(%[[D0_A]], %[[W1]] : tensor<?x3xf16, #hipsr.mem<device>>, tensor<3x1xf16, #hipsr.mem<device>>) outs(%[[MM1_INIT]] : tensor<?x1xf16, #hipsr.mem<device>>) : tensor<?x1xf16, #hipsr.mem<device>>
 
-// CHECK-NEXT:      %[[CAST_INIT:.+]] = hipsr.placeholder(%[[D0_CTX]]) ins(%[[MM1_INIT]] : tensor<?x1xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x1xf32, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:      ^bb0(%[[MM1_SHAPE:.+]]: !shape.shape):
-// CHECK-NEXT:        hipsr.shape_yield %[[MM1_SHAPE]] : !shape.shape
+// CHECK-NEXT:      %[[CAST_SHAPE:.+]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:        scf.yield %[[MM1_SHAPE]] : !shape.shape
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %[[CAST:.+]] = hipsr.cast(%[[D0_CTX]]) ins(%[[MM1]] : tensor<?x1xf16, #hipsr.mem<device>>) outs(%[[CAST_INIT]] : tensor<?x1xf32, #hipsr.mem<device>>) : tensor<?x1xf32, #hipsr.mem<device>>
 
-// The extent vector's length is still a constant -- the operand's rank fixes it.
-// The dynamic extent appears one level down, as a tensor.dim in the body.
-// CHECK-NEXT:      %[[SHAPE_INIT:.+]] = hipsr.placeholder(%[[D0_CTX]]) ins(%[[D0_B]] : tensor<?x4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
-// CHECK-NEXT:      ^bb0(%{{.+}}: !shape.shape):
+// The extent vector's length is still a constant -- the operand's rank fixes it
+// -- so the operand's shape goes unread here and the vector needs no extent of
+// its own below.
+// CHECK-NEXT:      %[[EXTENTS_SHAPE:.+]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:        %[[B_SHAPE:.+]] = shape.shape_of %[[D0_B]] : tensor<?x4xf32, #hipsr.mem<device>> -> !shape.shape
 // CHECK-NEXT:        %[[RANK:.+]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[RANK_SHAPE:.+]] = shape.from_extents %[[RANK]] : index
-// CHECK-NEXT:        hipsr.shape_yield %[[RANK_SHAPE]] : !shape.shape
+// CHECK-NEXT:        scf.yield %[[RANK_SHAPE]] : !shape.shape
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %[[SHAPE:.+]] = hipsr.compute(%[[D0_CTX]]) ins(%[[D0_B]] : tensor<?x4xf32, #hipsr.mem<device>>) outs(%[[SHAPE_INIT]] : tensor<2xi64, #hipsr.mem<host>>) {
+
+// This is where the dynamic extent shows up: each allocation whose type leaves
+// a dimension open reads it back out of the shape computed above.
+// CHECK-NEXT:      %[[MM1_M_IDX:.+]] = shape.const_size 0
+// CHECK-NEXT:      %[[MM1_M_EXTENT:.+]] = shape.get_extent %[[MM1_SHAPE]], %[[MM1_M_IDX]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:      %[[MM1_M:.+]] = shape.size_to_index %[[MM1_M_EXTENT]] : !shape.size
+// CHECK-NEXT:      %[[MM1_INIT:.+]] = tensor.empty(%[[MM1_M]]) : tensor<?x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[CAST_M_IDX:.+]] = shape.const_size 0
+// CHECK-NEXT:      %[[CAST_M_EXTENT:.+]] = shape.get_extent %[[CAST_SHAPE]], %[[CAST_M_IDX]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:      %[[CAST_M:.+]] = shape.size_to_index %[[CAST_M_EXTENT]] : !shape.size
+// CHECK-NEXT:      %[[CAST_INIT:.+]] = tensor.empty(%[[CAST_M]]) : tensor<?x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[EXTENTS_INIT:.+]] = tensor.empty() : tensor<2xi64, #hipsr.mem<host>>
+
+// CHECK-NEXT:      %[[MM1:.+]] = hipsr.matmul(%[[D0_CTX]]) ins(%[[D0_A]], %[[W1]] : tensor<?x3xf16, #hipsr.mem<device>>, tensor<3x1xf16, #hipsr.mem<device>>) outs(%[[MM1_INIT]] : tensor<?x1xf16, #hipsr.mem<device>>) : tensor<?x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[CAST:.+]] = hipsr.cast(%[[D0_CTX]]) ins(%[[MM1]] : tensor<?x1xf16, #hipsr.mem<device>>) outs(%[[CAST_INIT]] : tensor<?x1xf32, #hipsr.mem<device>>) : tensor<?x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[EXTENTS:.+]] = hipsr.compute(%[[D0_CTX]]) ins(%[[D0_B]] : tensor<?x4xf32, #hipsr.mem<device>>) outs(%[[EXTENTS_INIT]] : tensor<2xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:      ^bb0(%{{.+}}: !hipsr.context, %[[BODY_B:.+]]: tensor<?x4xf32, #hipsr.mem<device>>, %{{.+}}: tensor<2xi64, #hipsr.mem<host>>):
 // CHECK-NEXT:        %[[DIM_IDX:.+]] = arith.constant 0 : index
 // CHECK-NEXT:        %[[DIM:.+]] = tensor.dim %[[BODY_B]], %[[DIM_IDX]] : tensor<?x4xf32, #hipsr.mem<device>>
 // CHECK-NEXT:        %[[D0_EXT:.+]] = arith.index_cast %[[DIM]] : index to i64
 // CHECK-NEXT:        %[[D1_EXT:.+]] = arith.constant 4 : i64
-// CHECK-NEXT:        %[[EXTENTS:.+]] = tensor.from_elements %[[D0_EXT]], %[[D1_EXT]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.compute_yield %[[EXTENTS]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[EXTENT_VECTOR:.+]] = tensor.from_elements %[[D0_EXT]], %[[D1_EXT]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.compute_yield %[[EXTENT_VECTOR]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:      } : tensor<2xi64, #hipsr.mem<host>>
 
-// CHECK-NEXT:      %[[W2:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<4x2xf32>} : tensor<4x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.pool_domain_yield %[[CAST_INIT]], %[[CAST]], %[[SHAPE_INIT]], %[[SHAPE]], %[[W2]] : tensor<?x1xf32, #hipsr.mem<device>>, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.pool_domain_yield %[[CAST_INIT]], %[[CAST]], %[[EXTENTS_INIT]], %[[EXTENTS]], %[[W2]] : tensor<?x1xf32, #hipsr.mem<device>>, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    } -> tensor<?x1xf32, #hipsr.mem<device>>, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
 
 // CHECK-NEXT:    %[[D1:.+]] = hipsr.pool_domain(%[[CTX]], %[[D0]]#0, %[[D0]]#2, %[[D0]]#1, %[[D0]]#3, %[[D0]]#4 : !hipsr.context, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>>) {
-// CHECK-NEXT:    ^bb0(%[[D1_CTX:.+]]: !hipsr.context, %[[D1_CAST_INIT:.+]]: tensor<?x1xf32, #hipsr.mem<device>>, %[[D1_SHAPE_INIT:.+]]: tensor<2xi64, #hipsr.mem<host>>, %[[D1_CAST:.+]]: tensor<?x1xf32, #hipsr.mem<device>>, %[[D1_SHAPE:.+]]: tensor<2xi64, #hipsr.mem<host>>, %[[D1_W2:.+]]: tensor<4x2xf32, #hipsr.mem<device>>):
+// CHECK-NEXT:    ^bb0(%[[D1_CTX:.+]]: !hipsr.context, %[[D1_CAST_INIT:.+]]: tensor<?x1xf32, #hipsr.mem<device>>, %[[D1_EXTENTS_INIT:.+]]: tensor<2xi64, #hipsr.mem<host>>, %[[D1_CAST:.+]]: tensor<?x1xf32, #hipsr.mem<device>>, %[[D1_EXTENTS:.+]]: tensor<2xi64, #hipsr.mem<host>>, %[[D1_W2:.+]]: tensor<4x2xf32, #hipsr.mem<device>>):
 
-// CHECK-NEXT:      %[[EXPAND_INIT:.+]] = hipsr.placeholder(%[[D1_CTX]]) ins(%[[D1_CAST_INIT]], %[[D1_SHAPE_INIT]] : tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x4xf32, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:      ^bb0(%{{.+}}: !hipsr.context, %[[IN:.+]]: tensor<?x1xf32, #hipsr.mem<device>>, %[[EXT:.+]]: tensor<2xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:        %[[IN_SHAPE:.+]] = shape.shape_of %[[IN]] : tensor<?x1xf32, #hipsr.mem<device>> -> tensor<2xindex>
+// CHECK-NEXT:      %[[EXPAND_SHAPE:.+]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:        %[[IN_SHAPE:.+]] = shape.shape_of %[[D1_CAST_INIT]] : tensor<?x1xf32, #hipsr.mem<device>> -> tensor<2xindex>
 // CHECK-NEXT:        %[[I0:.+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[E0:.+]] = tensor.extract %[[EXT]][%[[I0]]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[E0:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[I0]]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[X0:.+]] = arith.index_cast %[[E0]] : i64 to index
 // CHECK-NEXT:        %[[I1:.+]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[E1:.+]] = tensor.extract %[[EXT]][%[[I1]]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[E1:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[I1]]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[X1:.+]] = arith.index_cast %[[E1]] : i64 to index
 // CHECK-NEXT:        %[[REQ:.+]] = shape.from_extents %[[X0]], %[[X1]] : index, index
 // CHECK-NEXT:        %[[EXPAND_WITNESS:.+]] = shape.cstr_broadcastable %[[IN_SHAPE]], %[[REQ]] : tensor<2xindex>, !shape.shape
-// CHECK-NEXT:        %[[EXPAND_SHAPE:.+]] = shape.assuming %[[EXPAND_WITNESS]] -> (!shape.shape) {
+// CHECK-NEXT:        %[[EXPAND_SHAPE_VAL:.+]] = shape.assuming %[[EXPAND_WITNESS]] -> (!shape.shape) {
 // CHECK-NEXT:          %[[BROADCAST:.+]] = shape.broadcast %[[IN_SHAPE]], %[[REQ]] : tensor<2xindex>, !shape.shape -> !shape.shape
 // CHECK-NEXT:          shape.assuming_yield %[[BROADCAST]] : !shape.shape
 // CHECK-NEXT:        }
-// CHECK-NEXT:        hipsr.shape_yield %[[EXPAND_SHAPE]] : !shape.shape
+// CHECK-NEXT:        scf.yield %[[EXPAND_SHAPE_VAL]] : !shape.shape
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %[[EXPAND:.+]] = hipsr.expand(%[[D1_CTX]]) ins(%[[D1_CAST]], %[[D1_SHAPE]] : tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) outs(%[[EXPAND_INIT]] : tensor<?x4xf32, #hipsr.mem<device>>) : tensor<?x4xf32, #hipsr.mem<device>>
 
-// CHECK-NEXT:      %[[MM2_INIT:.+]] = hipsr.placeholder(%[[D1_CTX]]) ins(%[[EXPAND_INIT]], %[[D1_W2]] : tensor<?x4xf32, #hipsr.mem<device>>, tensor<4x2xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x2xf32, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:      ^bb0(%[[E_SHAPE:.+]]: !shape.shape, %[[W2_SHAPE:.+]]: !shape.shape):
+// CHECK-NEXT:      %[[MM2_SHAPE:.+]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:        %[[W2_SHAPE:.+]] = shape.shape_of %[[D1_W2]] : tensor<4x2xf32, #hipsr.mem<device>> -> !shape.shape
 // CHECK-NEXT:        %[[E_K_IDX:.+]] = shape.const_size 1
-// CHECK-NEXT:        %[[E_K:.+]] = shape.get_extent %[[E_SHAPE]], %[[E_K_IDX]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:        %[[E_K:.+]] = shape.get_extent %[[EXPAND_SHAPE]], %[[E_K_IDX]] : !shape.shape, !shape.size -> !shape.size
 // CHECK-NEXT:        %[[E_K_SHAPE:.+]] = shape.from_extents %[[E_K]] : !shape.size
 // CHECK-NEXT:        %[[W2_K_IDX:.+]] = shape.const_size 0
 // CHECK-NEXT:        %[[W2_K:.+]] = shape.get_extent %[[W2_SHAPE]], %[[W2_K_IDX]] : !shape.shape, !shape.size -> !shape.size
 // CHECK-NEXT:        %[[W2_K_SHAPE:.+]] = shape.from_extents %[[W2_K]] : !shape.size
 // CHECK-NEXT:        %[[K2_WITNESS:.+]] = shape.cstr_eq %[[E_K_SHAPE]], %[[W2_K_SHAPE]] : !shape.shape, !shape.shape
 // CHECK-NEXT:        %[[E_SPLIT_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[E_BATCH:.+]], %[[E_TAIL:.+]] = "shape.split_at"(%[[E_SHAPE]], %[[E_SPLIT_IDX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
+// CHECK-NEXT:        %[[E_BATCH:.+]], %[[E_TAIL:.+]] = "shape.split_at"(%[[EXPAND_SHAPE]], %[[E_SPLIT_IDX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
 // CHECK-NEXT:        %[[W2_SPLIT_IDX:.+]] = shape.const_size 0
 // CHECK-NEXT:        %[[W2_BATCH:.+]], %[[W2_TAIL:.+]] = "shape.split_at"(%[[W2_SHAPE]], %[[W2_SPLIT_IDX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
 // CHECK-NEXT:        %[[BATCH2_WITNESS:.+]] = shape.cstr_broadcastable %[[E_BATCH]], %[[W2_BATCH]] : !shape.shape, !shape.shape
@@ -117,15 +130,25 @@
 // CHECK-NEXT:        %[[MM2_SHAPE_VAL:.+]] = shape.assuming %[[WITNESS2]] -> (!shape.shape) {
 // CHECK-NEXT:          %[[BATCH2:.+]] = shape.broadcast %[[E_BATCH]], %[[W2_BATCH]] : !shape.shape, !shape.shape -> !shape.shape
 // CHECK-NEXT:          %[[M2_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:          %[[M2:.+]] = shape.get_extent %[[E_SHAPE]], %[[M2_IDX]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:          %[[M2:.+]] = shape.get_extent %[[EXPAND_SHAPE]], %[[M2_IDX]] : !shape.shape, !shape.size -> !shape.size
 // CHECK-NEXT:          %[[N2_IDX:.+]] = shape.const_size 1
 // CHECK-NEXT:          %[[N2:.+]] = shape.get_extent %[[W2_SHAPE]], %[[N2_IDX]] : !shape.shape, !shape.size -> !shape.size
 // CHECK-NEXT:          %[[MATRIX2:.+]] = shape.from_extents %[[M2]], %[[N2]] : !shape.size, !shape.size
 // CHECK-NEXT:          %[[RESULT2:.+]] = shape.concat %[[BATCH2]], %[[MATRIX2]] : !shape.shape, !shape.shape -> !shape.shape
 // CHECK-NEXT:          shape.assuming_yield %[[RESULT2]] : !shape.shape
 // CHECK-NEXT:        }
-// CHECK-NEXT:        hipsr.shape_yield %[[MM2_SHAPE_VAL]] : !shape.shape
+// CHECK-NEXT:        scf.yield %[[MM2_SHAPE_VAL]] : !shape.shape
 // CHECK-NEXT:      }
+
+// CHECK-NEXT:      %[[EXPAND_M_IDX:.+]] = shape.const_size 0
+// CHECK-NEXT:      %[[EXPAND_M_EXTENT:.+]] = shape.get_extent %[[EXPAND_SHAPE]], %[[EXPAND_M_IDX]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:      %[[EXPAND_M:.+]] = shape.size_to_index %[[EXPAND_M_EXTENT]] : !shape.size
+// CHECK-NEXT:      %[[EXPAND_INIT:.+]] = tensor.empty(%[[EXPAND_M]]) : tensor<?x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[MM2_M_IDX:.+]] = shape.const_size 0
+// CHECK-NEXT:      %[[MM2_M_EXTENT:.+]] = shape.get_extent %[[MM2_SHAPE]], %[[MM2_M_IDX]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:      %[[MM2_M:.+]] = shape.size_to_index %[[MM2_M_EXTENT]] : !shape.size
+// CHECK-NEXT:      %[[MM2_INIT:.+]] = tensor.empty(%[[MM2_M]]) : tensor<?x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[EXPAND:.+]] = hipsr.expand(%[[D1_CTX]]) ins(%[[D1_CAST]], %[[D1_EXTENTS]] : tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) outs(%[[EXPAND_INIT]] : tensor<?x4xf32, #hipsr.mem<device>>) : tensor<?x4xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[MM2:.+]] = hipsr.matmul(%[[D1_CTX]]) ins(%[[EXPAND]], %[[D1_W2]] : tensor<?x4xf32, #hipsr.mem<device>>, tensor<4x2xf32, #hipsr.mem<device>>) outs(%[[MM2_INIT]] : tensor<?x2xf32, #hipsr.mem<device>>) : tensor<?x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[MM2]] : tensor<?x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    } -> tensor<?x2xf32, #hipsr.mem<device>> {domain_id = 1 : i64}

--- a/test/lit/Dialect/Hipsr/Pipelines/sample_dynamic.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/sample_dynamic.mlir
@@ -15,7 +15,7 @@
 // CHECK-SAME:      attributes {onnx.graph.name = "main_graph"} {
 
 // The domains split exactly where they do in sample_static.mlir, and so do the
-// four zones inside each one: neither the barrier's position nor the shape
+// five zones inside each one: neither the barrier's position nor the shape
 // graph depends on whether the extents are known.
 // CHECK-NEXT:    %[[D0:.+]]:5 = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]] : !hipsr.context, tensor<?x3xf16, #hipsr.mem<device>>, tensor<?x4xf32, #hipsr.mem<device>>) {
 // CHECK-NEXT:    ^bb0(%[[D0_CTX:.+]]: !hipsr.context, %[[D0_A:.+]]: tensor<?x3xf16, #hipsr.mem<device>>, %[[D0_B:.+]]: tensor<?x4xf32, #hipsr.mem<device>>):
@@ -89,6 +89,10 @@
 // CHECK-NEXT:        hipsr.compute_yield %[[EXTENT_VECTOR]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:      } : tensor<2xi64, #hipsr.mem<host>>
 
+// CHECK-NEXT:      hipsr.preserve_shape %[[MM1_SHAPE]], %[[MM1]] : tensor<?x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[CAST_SHAPE]], %[[CAST]] : tensor<?x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[EXTENTS_SHAPE]], %[[EXTENTS]] : tensor<2xi64, #hipsr.mem<host>>
+
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[CAST_INIT]], %[[CAST]], %[[EXTENTS_INIT]], %[[EXTENTS]], %[[W2]] : tensor<?x1xf32, #hipsr.mem<device>>, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    } -> tensor<?x1xf32, #hipsr.mem<device>>, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
 
@@ -150,6 +154,8 @@
 // CHECK-NEXT:      %[[MM2_INIT:.+]] = tensor.empty(%[[MM2_M]]) : tensor<?x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[EXPAND:.+]] = hipsr.expand(%[[D1_CTX]]) ins(%[[D1_CAST]], %[[D1_EXTENTS]] : tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) outs(%[[EXPAND_INIT]] : tensor<?x4xf32, #hipsr.mem<device>>) : tensor<?x4xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[MM2:.+]] = hipsr.matmul(%[[D1_CTX]]) ins(%[[EXPAND]], %[[D1_W2]] : tensor<?x4xf32, #hipsr.mem<device>>, tensor<4x2xf32, #hipsr.mem<device>>) outs(%[[MM2_INIT]] : tensor<?x2xf32, #hipsr.mem<device>>) : tensor<?x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[EXPAND_SHAPE]], %[[EXPAND]] : tensor<?x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[MM2_SHAPE]], %[[MM2]] : tensor<?x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[MM2]] : tensor<?x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    } -> tensor<?x2xf32, #hipsr.mem<device>> {domain_id = 1 : i64}
 

--- a/test/lit/Dialect/Hipsr/Pipelines/sample_static.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/sample_static.mlir
@@ -14,15 +14,21 @@
 // CHECK-SAME:      -> (tensor<2x2xf32, #hipsr.mem<device>> {onnx.name = "y"})
 // CHECK-SAME:      attributes {onnx.graph.name = "main_graph"} {
 
-// The barrier placeholder the expand needs splits the graph in two. Everything
-// up to it lands in domain 0, which yields both halves of the shape and data
-// graphs for domain 1 to pick up.
+// The barrier the expand needs splits the graph in two. Everything up to it
+// lands in domain 0, which yields both halves of the shape and data graphs for
+// domain 1 to pick up. Inside a domain the constants come first, then the shape
+// computations, then the allocations they size, then the data ops.
 // CHECK-NEXT:    %[[D0:.+]]:5 = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]] : !hipsr.context, tensor<2x3xf16, #hipsr.mem<device>>, tensor<2x4xf32, #hipsr.mem<device>>) {
 // CHECK-NEXT:    ^bb0(%[[D0_CTX:.+]]: !hipsr.context, %[[D0_A:.+]]: tensor<2x3xf16, #hipsr.mem<device>>, %[[D0_B:.+]]: tensor<2x4xf32, #hipsr.mem<device>>):
 
+// Both weights lead the domain. Only the first one has a shape a computation
+// reads; the second is here because a constant takes no operands, so the pass
+// brings every one of them over ahead of the computations.
 // CHECK-NEXT:      %[[W1:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<3x1xf16>} : tensor<3x1xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[MM1_INIT:.+]] = hipsr.placeholder(%[[D0_CTX]]) ins(%[[D0_A]], %[[W1]] : tensor<2x3xf16, #hipsr.mem<device>>, tensor<3x1xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2x1xf16, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:      ^bb0(%[[A_SHAPE:.+]]: !shape.shape, %[[W1_SHAPE:.+]]: !shape.shape):
+// CHECK-NEXT:      %[[W2:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<4x2xf32>} : tensor<4x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[MM1_SHAPE:.+]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[D0_A]] : tensor<2x3xf16, #hipsr.mem<device>> -> !shape.shape
+// CHECK-NEXT:        %[[W1_SHAPE:.+]] = shape.shape_of %[[W1]] : tensor<3x1xf16, #hipsr.mem<device>> -> !shape.shape
 // CHECK-NEXT:        %[[A_K_IDX:.+]] = shape.const_size 1
 // CHECK-NEXT:        %[[A_K:.+]] = shape.get_extent %[[A_SHAPE]], %[[A_K_IDX]] : !shape.shape, !shape.size -> !shape.size
 // CHECK-NEXT:        %[[A_K_SHAPE:.+]] = shape.from_extents %[[A_K]] : !shape.size
@@ -46,71 +52,81 @@
 // CHECK-NEXT:          %[[RESULT:.+]] = shape.concat %[[BATCH]], %[[MATRIX]] : !shape.shape, !shape.shape -> !shape.shape
 // CHECK-NEXT:          shape.assuming_yield %[[RESULT]] : !shape.shape
 // CHECK-NEXT:        }
-// CHECK-NEXT:        hipsr.shape_yield %[[MM1_SHAPE_VAL]] : !shape.shape
+// CHECK-NEXT:        scf.yield %[[MM1_SHAPE_VAL]] : !shape.shape
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %[[MM1:.+]] = hipsr.matmul(%[[D0_CTX]]) ins(%[[D0_A]], %[[W1]] : tensor<2x3xf16, #hipsr.mem<device>>, tensor<3x1xf16, #hipsr.mem<device>>) outs(%[[MM1_INIT]] : tensor<2x1xf16, #hipsr.mem<device>>) : tensor<2x1xf16, #hipsr.mem<device>>
 
-// CHECK-NEXT:      %[[CAST_INIT:.+]] = hipsr.placeholder(%[[D0_CTX]]) ins(%[[MM1_INIT]] : tensor<2x1xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2x1xf32, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:      ^bb0(%[[MM1_SHAPE:.+]]: !shape.shape):
-// CHECK-NEXT:        hipsr.shape_yield %[[MM1_SHAPE]] : !shape.shape
+// The cast keeps its operand's shape, so its shape computation forwards the one
+// next to it.
+// CHECK-NEXT:      %[[CAST_SHAPE:.+]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:        scf.yield %[[MM1_SHAPE]] : !shape.shape
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %[[CAST:.+]] = hipsr.cast(%[[D0_CTX]]) ins(%[[MM1]] : tensor<2x1xf16, #hipsr.mem<device>>) outs(%[[CAST_INIT]] : tensor<2x1xf32, #hipsr.mem<device>>) : tensor<2x1xf32, #hipsr.mem<device>>
 
-// CHECK-NEXT:      %[[SHAPE_INIT:.+]] = hipsr.placeholder(%[[D0_CTX]]) ins(%[[D0_B]] : tensor<2x4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
-// CHECK-NEXT:      ^bb0(%{{.+}}: !shape.shape):
+// The extent vector's length follows the rank of the operand, not its extents,
+// so the operand's shape goes unread here.
+// CHECK-NEXT:      %[[EXTENTS_SHAPE:.+]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:        %[[B_SHAPE:.+]] = shape.shape_of %[[D0_B]] : tensor<2x4xf32, #hipsr.mem<device>> -> !shape.shape
 // CHECK-NEXT:        %[[RANK:.+]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[RANK_SHAPE:.+]] = shape.from_extents %[[RANK]] : index
-// CHECK-NEXT:        hipsr.shape_yield %[[RANK_SHAPE]] : !shape.shape
+// CHECK-NEXT:        scf.yield %[[RANK_SHAPE]] : !shape.shape
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %[[SHAPE:.+]] = hipsr.compute(%[[D0_CTX]]) ins(%[[D0_B]] : tensor<2x4xf32, #hipsr.mem<device>>) outs(%[[SHAPE_INIT]] : tensor<2xi64, #hipsr.mem<host>>) {
+
+// Every extent is in the types, so no allocation reads a shape back.
+// CHECK-NEXT:      %[[MM1_INIT:.+]] = tensor.empty() : tensor<2x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[CAST_INIT:.+]] = tensor.empty() : tensor<2x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[EXTENTS_INIT:.+]] = tensor.empty() : tensor<2xi64, #hipsr.mem<host>>
+
+// CHECK-NEXT:      %[[MM1:.+]] = hipsr.matmul(%[[D0_CTX]]) ins(%[[D0_A]], %[[W1]] : tensor<2x3xf16, #hipsr.mem<device>>, tensor<3x1xf16, #hipsr.mem<device>>) outs(%[[MM1_INIT]] : tensor<2x1xf16, #hipsr.mem<device>>) : tensor<2x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[CAST:.+]] = hipsr.cast(%[[D0_CTX]]) ins(%[[MM1]] : tensor<2x1xf16, #hipsr.mem<device>>) outs(%[[CAST_INIT]] : tensor<2x1xf32, #hipsr.mem<device>>) : tensor<2x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[EXTENTS:.+]] = hipsr.compute(%[[D0_CTX]]) ins(%[[D0_B]] : tensor<2x4xf32, #hipsr.mem<device>>) outs(%[[EXTENTS_INIT]] : tensor<2xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:      ^bb0(%{{.+}}: !hipsr.context, %{{.+}}: tensor<2x4xf32, #hipsr.mem<device>>, %{{.+}}: tensor<2xi64, #hipsr.mem<host>>):
 // CHECK-NEXT:        %[[D0_EXT:.+]] = arith.constant 2 : i64
 // CHECK-NEXT:        %[[D1_EXT:.+]] = arith.constant 4 : i64
-// CHECK-NEXT:        %[[EXTENTS:.+]] = tensor.from_elements %[[D0_EXT]], %[[D1_EXT]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.compute_yield %[[EXTENTS]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[EXTENT_VECTOR:.+]] = tensor.from_elements %[[D0_EXT]], %[[D1_EXT]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.compute_yield %[[EXTENT_VECTOR]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:      } : tensor<2xi64, #hipsr.mem<host>>
 
-// The second weight has no inputs, so it stays in domain 0 and is yielded out.
-// CHECK-NEXT:      %[[W2:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<4x2xf32>} : tensor<4x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.pool_domain_yield %[[CAST_INIT]], %[[CAST]], %[[SHAPE_INIT]], %[[SHAPE]], %[[W2]] : tensor<2x1xf32, #hipsr.mem<device>>, tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>>
+// The second weight has no inputs, which keeps it in domain 0, and only the
+// yield uses it there.
+// CHECK-NEXT:      hipsr.pool_domain_yield %[[CAST_INIT]], %[[CAST]], %[[EXTENTS_INIT]], %[[EXTENTS]], %[[W2]] : tensor<2x1xf32, #hipsr.mem<device>>, tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    } -> tensor<2x1xf32, #hipsr.mem<device>>, tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
 
-// Domain 1 takes the shape-graph results first and the data results after, so a
-// placeholder keeps following placeholders across the boundary while the
+// Domain 1 takes the shape-graph results first and the data results after, so
+// the barrier keeps reading the buffers the shape graph names while the
 // operations keep following results.
 // CHECK-NEXT:    %[[D1:.+]] = hipsr.pool_domain(%[[CTX]], %[[D0]]#0, %[[D0]]#2, %[[D0]]#1, %[[D0]]#3, %[[D0]]#4 : !hipsr.context, tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>>) {
-// CHECK-NEXT:    ^bb0(%[[D1_CTX:.+]]: !hipsr.context, %[[D1_CAST_INIT:.+]]: tensor<2x1xf32, #hipsr.mem<device>>, %[[D1_SHAPE_INIT:.+]]: tensor<2xi64, #hipsr.mem<host>>, %[[D1_CAST:.+]]: tensor<2x1xf32, #hipsr.mem<device>>, %[[D1_SHAPE:.+]]: tensor<2xi64, #hipsr.mem<host>>, %[[D1_W2:.+]]: tensor<4x2xf32, #hipsr.mem<device>>):
+// CHECK-NEXT:    ^bb0(%[[D1_CTX:.+]]: !hipsr.context, %[[D1_CAST_INIT:.+]]: tensor<2x1xf32, #hipsr.mem<device>>, %[[D1_EXTENTS_INIT:.+]]: tensor<2xi64, #hipsr.mem<host>>, %[[D1_CAST:.+]]: tensor<2x1xf32, #hipsr.mem<device>>, %[[D1_EXTENTS:.+]]: tensor<2xi64, #hipsr.mem<host>>, %[[D1_W2:.+]]: tensor<4x2xf32, #hipsr.mem<device>>):
 
-// CHECK-NEXT:      %[[EXPAND_INIT:.+]] = hipsr.placeholder(%[[D1_CTX]]) ins(%[[D1_CAST_INIT]], %[[D1_SHAPE_INIT]] : tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<2x4xf32, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:      ^bb0(%{{.+}}: !hipsr.context, %[[IN:.+]]: tensor<2x1xf32, #hipsr.mem<device>>, %[[EXT:.+]]: tensor<2xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:        %[[IN_SHAPE:.+]] = shape.shape_of %[[IN]] : tensor<2x1xf32, #hipsr.mem<device>> -> tensor<2xindex>
+// The expand's destination is the reason for the cut: its extents come out of
+// the host vector domain 0 wrote, so the barrier's shape computation reads that
+// buffer instead of a shape.
+// CHECK-NEXT:      %[[EXPAND_SHAPE:.+]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:        %[[IN_SHAPE:.+]] = shape.shape_of %[[D1_CAST_INIT]] : tensor<2x1xf32, #hipsr.mem<device>> -> tensor<2xindex>
 // CHECK-NEXT:        %[[I0:.+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[E0:.+]] = tensor.extract %[[EXT]][%[[I0]]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[E0:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[I0]]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[X0:.+]] = arith.index_cast %[[E0]] : i64 to index
 // CHECK-NEXT:        %[[I1:.+]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[E1:.+]] = tensor.extract %[[EXT]][%[[I1]]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[E1:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[I1]]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[X1:.+]] = arith.index_cast %[[E1]] : i64 to index
 // CHECK-NEXT:        %[[REQ:.+]] = shape.from_extents %[[X0]], %[[X1]] : index, index
 // CHECK-NEXT:        %[[EXPAND_WITNESS:.+]] = shape.cstr_broadcastable %[[IN_SHAPE]], %[[REQ]] : tensor<2xindex>, !shape.shape
-// CHECK-NEXT:        %[[EXPAND_SHAPE:.+]] = shape.assuming %[[EXPAND_WITNESS]] -> (!shape.shape) {
+// CHECK-NEXT:        %[[EXPAND_SHAPE_VAL:.+]] = shape.assuming %[[EXPAND_WITNESS]] -> (!shape.shape) {
 // CHECK-NEXT:          %[[BROADCAST:.+]] = shape.broadcast %[[IN_SHAPE]], %[[REQ]] : tensor<2xindex>, !shape.shape -> !shape.shape
 // CHECK-NEXT:          shape.assuming_yield %[[BROADCAST]] : !shape.shape
 // CHECK-NEXT:        }
-// CHECK-NEXT:        hipsr.shape_yield %[[EXPAND_SHAPE]] : !shape.shape
+// CHECK-NEXT:        scf.yield %[[EXPAND_SHAPE_VAL]] : !shape.shape
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %[[EXPAND:.+]] = hipsr.expand(%[[D1_CTX]]) ins(%[[D1_CAST]], %[[D1_SHAPE]] : tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) outs(%[[EXPAND_INIT]] : tensor<2x4xf32, #hipsr.mem<device>>) : tensor<2x4xf32, #hipsr.mem<device>>
 
-// CHECK-NEXT:      %[[MM2_INIT:.+]] = hipsr.placeholder(%[[D1_CTX]]) ins(%[[EXPAND_INIT]], %[[D1_W2]] : tensor<2x4xf32, #hipsr.mem<device>>, tensor<4x2xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2x2xf32, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:      ^bb0(%[[E_SHAPE:.+]]: !shape.shape, %[[W2_SHAPE:.+]]: !shape.shape):
+// CHECK-NEXT:      %[[MM2_SHAPE:.+]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:        %[[W2_SHAPE:.+]] = shape.shape_of %[[D1_W2]] : tensor<4x2xf32, #hipsr.mem<device>> -> !shape.shape
 // CHECK-NEXT:        %[[E_K_IDX:.+]] = shape.const_size 1
-// CHECK-NEXT:        %[[E_K:.+]] = shape.get_extent %[[E_SHAPE]], %[[E_K_IDX]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:        %[[E_K:.+]] = shape.get_extent %[[EXPAND_SHAPE]], %[[E_K_IDX]] : !shape.shape, !shape.size -> !shape.size
 // CHECK-NEXT:        %[[E_K_SHAPE:.+]] = shape.from_extents %[[E_K]] : !shape.size
 // CHECK-NEXT:        %[[W2_K_IDX:.+]] = shape.const_size 0
 // CHECK-NEXT:        %[[W2_K:.+]] = shape.get_extent %[[W2_SHAPE]], %[[W2_K_IDX]] : !shape.shape, !shape.size -> !shape.size
 // CHECK-NEXT:        %[[W2_K_SHAPE:.+]] = shape.from_extents %[[W2_K]] : !shape.size
 // CHECK-NEXT:        %[[K2_WITNESS:.+]] = shape.cstr_eq %[[E_K_SHAPE]], %[[W2_K_SHAPE]] : !shape.shape, !shape.shape
 // CHECK-NEXT:        %[[E_SPLIT_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[E_BATCH:.+]], %[[E_TAIL:.+]] = "shape.split_at"(%[[E_SHAPE]], %[[E_SPLIT_IDX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
+// CHECK-NEXT:        %[[E_BATCH:.+]], %[[E_TAIL:.+]] = "shape.split_at"(%[[EXPAND_SHAPE]], %[[E_SPLIT_IDX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
 // CHECK-NEXT:        %[[W2_SPLIT_IDX:.+]] = shape.const_size 0
 // CHECK-NEXT:        %[[W2_BATCH:.+]], %[[W2_TAIL:.+]] = "shape.split_at"(%[[W2_SHAPE]], %[[W2_SPLIT_IDX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
 // CHECK-NEXT:        %[[BATCH2_WITNESS:.+]] = shape.cstr_broadcastable %[[E_BATCH]], %[[W2_BATCH]] : !shape.shape, !shape.shape
@@ -118,15 +134,19 @@
 // CHECK-NEXT:        %[[MM2_SHAPE_VAL:.+]] = shape.assuming %[[WITNESS2]] -> (!shape.shape) {
 // CHECK-NEXT:          %[[BATCH2:.+]] = shape.broadcast %[[E_BATCH]], %[[W2_BATCH]] : !shape.shape, !shape.shape -> !shape.shape
 // CHECK-NEXT:          %[[M2_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:          %[[M2:.+]] = shape.get_extent %[[E_SHAPE]], %[[M2_IDX]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:          %[[M2:.+]] = shape.get_extent %[[EXPAND_SHAPE]], %[[M2_IDX]] : !shape.shape, !shape.size -> !shape.size
 // CHECK-NEXT:          %[[N2_IDX:.+]] = shape.const_size 1
 // CHECK-NEXT:          %[[N2:.+]] = shape.get_extent %[[W2_SHAPE]], %[[N2_IDX]] : !shape.shape, !shape.size -> !shape.size
 // CHECK-NEXT:          %[[MATRIX2:.+]] = shape.from_extents %[[M2]], %[[N2]] : !shape.size, !shape.size
 // CHECK-NEXT:          %[[RESULT2:.+]] = shape.concat %[[BATCH2]], %[[MATRIX2]] : !shape.shape, !shape.shape -> !shape.shape
 // CHECK-NEXT:          shape.assuming_yield %[[RESULT2]] : !shape.shape
 // CHECK-NEXT:        }
-// CHECK-NEXT:        hipsr.shape_yield %[[MM2_SHAPE_VAL]] : !shape.shape
+// CHECK-NEXT:        scf.yield %[[MM2_SHAPE_VAL]] : !shape.shape
 // CHECK-NEXT:      }
+
+// CHECK-NEXT:      %[[EXPAND_INIT:.+]] = tensor.empty() : tensor<2x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[MM2_INIT:.+]] = tensor.empty() : tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[EXPAND:.+]] = hipsr.expand(%[[D1_CTX]]) ins(%[[D1_CAST]], %[[D1_EXTENTS]] : tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) outs(%[[EXPAND_INIT]] : tensor<2x4xf32, #hipsr.mem<device>>) : tensor<2x4xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[MM2:.+]] = hipsr.matmul(%[[D1_CTX]]) ins(%[[EXPAND]], %[[D1_W2]] : tensor<2x4xf32, #hipsr.mem<device>>, tensor<4x2xf32, #hipsr.mem<device>>) outs(%[[MM2_INIT]] : tensor<2x2xf32, #hipsr.mem<device>>) : tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[MM2]] : tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    } -> tensor<2x2xf32, #hipsr.mem<device>> {domain_id = 1 : i64}

--- a/test/lit/Dialect/Hipsr/Pipelines/sample_static.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/sample_static.mlir
@@ -17,7 +17,9 @@
 // The barrier the expand needs splits the graph in two. Everything up to it
 // lands in domain 0, which yields both halves of the shape and data graphs for
 // domain 1 to pick up. Inside a domain the constants come first, then the shape
-// computations, then the allocations they size, then the data ops.
+// computations, then the allocations they size, then the data ops, and last a
+// hipsr.preserve_shape tying each shape to the value filling the buffer it
+// sized.
 // CHECK-NEXT:    %[[D0:.+]]:5 = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]] : !hipsr.context, tensor<2x3xf16, #hipsr.mem<device>>, tensor<2x4xf32, #hipsr.mem<device>>) {
 // CHECK-NEXT:    ^bb0(%[[D0_CTX:.+]]: !hipsr.context, %[[D0_A:.+]]: tensor<2x3xf16, #hipsr.mem<device>>, %[[D0_B:.+]]: tensor<2x4xf32, #hipsr.mem<device>>):
 
@@ -85,6 +87,10 @@
 // CHECK-NEXT:        hipsr.compute_yield %[[EXTENT_VECTOR]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:      } : tensor<2xi64, #hipsr.mem<host>>
 
+// CHECK-NEXT:      hipsr.preserve_shape %[[MM1_SHAPE]], %[[MM1]] : tensor<2x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[CAST_SHAPE]], %[[CAST]] : tensor<2x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[EXTENTS_SHAPE]], %[[EXTENTS]] : tensor<2xi64, #hipsr.mem<host>>
+
 // The second weight has no inputs, which keeps it in domain 0, and only the
 // yield uses it there.
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[CAST_INIT]], %[[CAST]], %[[EXTENTS_INIT]], %[[EXTENTS]], %[[W2]] : tensor<2x1xf32, #hipsr.mem<device>>, tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>>
@@ -148,6 +154,8 @@
 // CHECK-NEXT:      %[[MM2_INIT:.+]] = tensor.empty() : tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[EXPAND:.+]] = hipsr.expand(%[[D1_CTX]]) ins(%[[D1_CAST]], %[[D1_EXTENTS]] : tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) outs(%[[EXPAND_INIT]] : tensor<2x4xf32, #hipsr.mem<device>>) : tensor<2x4xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[MM2:.+]] = hipsr.matmul(%[[D1_CTX]]) ins(%[[EXPAND]], %[[D1_W2]] : tensor<2x4xf32, #hipsr.mem<device>>, tensor<4x2xf32, #hipsr.mem<device>>) outs(%[[MM2_INIT]] : tensor<2x2xf32, #hipsr.mem<device>>) : tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[EXPAND_SHAPE]], %[[EXPAND]] : tensor<2x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[MM2_SHAPE]], %[[MM2]] : tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[MM2]] : tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    } -> tensor<2x2xf32, #hipsr.mem<device>> {domain_id = 1 : i64}
 

--- a/test/lit/Dialect/Hipsr/Transforms/MaterializeInitTensors/invalid.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/MaterializeInitTensors/invalid.mlir
@@ -2,14 +2,15 @@
 // Licensed under the MIT License.
 
 //===----------------------------------------------------------------------===//
-// Error paths of -hipsr-materialize-init-tensors. Later phases add cases here
-// rather than a new file; positive coverage lives in
-// materialize-init-tensors.mlir. Cases that only record a gap in the current
-// implementation move over to the positive file once that gap is closed.
+// Error paths of -hipsr-materialize-init-tensors. New cases go here rather than
+// into a new file; positive coverage lives in materialize-init-tensors.mlir.
 //===----------------------------------------------------------------------===//
 
 // RUN: hip-mlir-opt %s -split-input-file -verify-diagnostics -hipsr-materialize-init-tensors
 
+// The allocation is sized from the shape region, so an empty one leaves nothing
+// to compute it from. The op verifier allows the region to be empty because
+// -hipsr-populate-shape-region fills it later.
 func.func @unpopulated_shape_region(%ctx: !hipsr.context, %a: tensor<?x256xf16, #hipsr.mem<device>>,
                                     %b: tensor<256x512xf16, #hipsr.mem<device>>)
     -> tensor<?x512xf16, #hipsr.mem<device>> {
@@ -32,37 +33,41 @@ func.func @unpopulated_shape_region(%ctx: !hipsr.context, %a: tensor<?x256xf16, 
 
 // -----
 
-// A barrier shape region reads data values rather than shapes, so its arguments
-// cannot be replaced with shape.shape_of. Until that path is implemented the
-// pass rejects the placeholder instead of building a wrong shape graph.
-func.func @barrier_placeholder(%ctx: !hipsr.context, %a: tensor<?x256xf16, #hipsr.mem<device>>,
-                               %b: tensor<256x512xf16, #hipsr.mem<device>>) -> tensor<?x512xf16, #hipsr.mem<device>> {
-  %0 = hipsr.pool_domain(%ctx, %a, %b
-      : !hipsr.context, tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>) {
-  ^bb0(%domain_ctx: !hipsr.context, %domain_a: tensor<?x256xf16, #hipsr.mem<device>>,
-       %domain_b: tensor<256x512xf16, #hipsr.mem<device>>):
-    // expected-error@+1 {{barrier placeholders are not materialized yet}}
-    %init = hipsr.placeholder(%domain_ctx)
-        ins(%domain_a, %domain_b : tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>)
-        {placeholder_type = #hipsr.placeholder_type<barrier>}
-        : tensor<?x512xf16, #hipsr.mem<device>> shape_region {
-    ^bb0(%region_ctx: !hipsr.context, %region_a: tensor<?x256xf16, #hipsr.mem<device>>,
-         %region_b: tensor<256x512xf16, #hipsr.mem<device>>):
-      %a_shape = shape.shape_of %region_a : tensor<?x256xf16, #hipsr.mem<device>> -> !shape.shape
-      %b_shape = shape.shape_of %region_b : tensor<256x512xf16, #hipsr.mem<device>> -> !shape.shape
-      %m_index = shape.const_size 0
-      %m = shape.get_extent %a_shape, %m_index
-          : !shape.shape, !shape.size -> !shape.size
-      %n_index = shape.const_size 1
-      %n = shape.get_extent %b_shape, %n_index
-          : !shape.shape, !shape.size -> !shape.size
-      %result_shape = shape.from_extents %m, %n : !shape.size, !shape.size
-      hipsr.shape_yield %result_shape : !shape.shape
+// A barrier reads its inputs as buffers, and the pool hands a buffer out only
+// after the last allocation in the domain, so an input allocated here has no
+// value to name yet. The placeholder verifier allows the edge, because a
+// placeholder result is a legal shape-graph input, and
+// -hipsr-partition-pool-domains never builds it, because it starts a barrier one
+// domain past every input. That leaves the pass to reject it.
+func.func @barrier_over_placeholder(%ctx: !hipsr.context, %in: tensor<?x1xf16, #hipsr.mem<device>>)
+    -> tensor<?x1xf16, #hipsr.mem<device>> {
+  %0 = hipsr.pool_domain(%ctx, %in
+      : !hipsr.context, tensor<?x1xf16, #hipsr.mem<device>>) {
+  ^bb0(%domain_ctx: !hipsr.context, %domain_in: tensor<?x1xf16, #hipsr.mem<device>>):
+    %cast_init = hipsr.placeholder(%domain_ctx)
+        ins(%domain_in : tensor<?x1xf16, #hipsr.mem<device>>)
+        {placeholder_type = #hipsr.placeholder_type<normal>}
+        : tensor<?x1xf32, #hipsr.mem<device>> shape_region {
+    ^bb0(%in_shape: !shape.shape):
+      hipsr.shape_yield %in_shape : !shape.shape
     }
-    %matmul = hipsr.matmul(%domain_ctx)
-        ins(%domain_a, %domain_b : tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>)
-        outs(%init : tensor<?x512xf16, #hipsr.mem<device>>) : tensor<?x512xf16, #hipsr.mem<device>>
-    hipsr.pool_domain_yield %matmul : tensor<?x512xf16, #hipsr.mem<device>>
-  } -> tensor<?x512xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
-  return %0 : tensor<?x512xf16, #hipsr.mem<device>>
+    %cast = hipsr.cast(%domain_ctx)
+        ins(%domain_in : tensor<?x1xf16, #hipsr.mem<device>>)
+        outs(%cast_init : tensor<?x1xf32, #hipsr.mem<device>>) : tensor<?x1xf32, #hipsr.mem<device>>
+    // expected-error@+1 {{barrier input must be allocated outside this pool domain}}
+    %barrier_init = hipsr.placeholder(%domain_ctx)
+        ins(%cast_init : tensor<?x1xf32, #hipsr.mem<device>>)
+        {placeholder_type = #hipsr.placeholder_type<barrier>}
+        : tensor<?x1xf16, #hipsr.mem<device>> shape_region {
+    ^bb0(%region_ctx: !hipsr.context, %region_cast: tensor<?x1xf32, #hipsr.mem<device>>):
+      %cast_shape = shape.shape_of %region_cast
+          : tensor<?x1xf32, #hipsr.mem<device>> -> !shape.shape
+      hipsr.shape_yield %cast_shape : !shape.shape
+    }
+    %out = hipsr.cast(%domain_ctx)
+        ins(%cast : tensor<?x1xf32, #hipsr.mem<device>>)
+        outs(%barrier_init : tensor<?x1xf16, #hipsr.mem<device>>) : tensor<?x1xf16, #hipsr.mem<device>>
+    hipsr.pool_domain_yield %out : tensor<?x1xf16, #hipsr.mem<device>>
+  } -> tensor<?x1xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+  return %0 : tensor<?x1xf16, #hipsr.mem<device>>
 }

--- a/test/lit/Dialect/Hipsr/Transforms/MaterializeInitTensors/materialize-init-tensors.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/MaterializeInitTensors/materialize-init-tensors.mlir
@@ -4,28 +4,9 @@
 //===----------------------------------------------------------------------===//
 // Positive coverage for -hipsr-materialize-init-tensors.
 //
-// This file grows with the pass instead of gaining a sibling per phase: each
-// case keeps its input IR and only its CHECK lines are extended as later phases
-// land. The transformation is end to end as of phase 4, and runs as:
-//
-//   phase 1, grouping -- every hipsr.placeholder in a domain moves to the front
-//   of the domain block, keeping the relative order SSA form already gives it;
-//   phase 2, shape computation -- each shape region body moves into an
-//   scf.execute_region yielding !shape.shape, with the region's block arguments
-//   replaced by the shapes of the placeholder inputs;
-//   phase 3, allocation -- one tensor.empty per placeholder result, its dynamic
-//   extents read out of the computed shape, all of them grouped after the last
-//   scf.execute_region;
-//   phase 4, cleanup -- every placeholder result use is rewired to its
-//   tensor.empty and the placeholders are erased.
-//
-// So each domain ends up in the virtual 3-region form: shape computations, then
-// allocations, then the data ops in their original order, with no
-// hipsr.placeholder left behind.
-//
 // Every case spells out its whole function with CHECK-NEXT, so the CHECK block
 // reads as the expected output rather than as a set of spot checks. That also
-// makes the absences load bearing without a single CHECK-NOT: an erased
+// makes the absences load bearing without a single CHECK-NOT: a leftover
 // placeholder, or an extent read for a static dimension, shows up as an extra
 // line that breaks the chain.
 //
@@ -34,135 +15,30 @@
 
 // RUN: hip-mlir-opt %s -split-input-file -hipsr-materialize-init-tensors | FileCheck %s
 
-// The canonical single-placeholder domain. Its placeholder already leads the
-// block, so grouping leaves the domain as it is. The two shape region arguments
-// become shape.shape_of on the matmul inputs, and hipsr.shape_yield becomes
-// scf.yield because it is bound to hipsr.placeholder by HasParent. Only dim 0
-// of the result is dynamic, so the allocation reads a single extent back out of
-// the shape and 512 stays in the tensor.empty type. The matmul ends up taking
-// that tensor.empty as its outs operand, with the placeholder gone.
-// CHECK-LABEL: func.func @matmul_domain(
-// CHECK-SAME:      %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<?x256xf16, #hipsr.mem<device>>, %[[B:.+]]: tensor<256x512xf16, #hipsr.mem<device>>) -> tensor<?x512xf16, #hipsr.mem<device>> {
-// CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]] : !hipsr.context, tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT:    ^bb0(%[[DCTX:.+]]: !hipsr.context, %[[DA:.+]]: tensor<?x256xf16, #hipsr.mem<device>>, %[[DB:.+]]: tensor<256x512xf16, #hipsr.mem<device>>):
-// CHECK-NEXT:      %[[MATMUL_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[DA]] : tensor<?x256xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[B_SHAPE:.+]] = shape.shape_of %[[DB]] : tensor<256x512xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[M_INDEX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[M_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[N_INDEX:.+]] = shape.const_size 1
-// CHECK-NEXT:        %[[N:.+]] = shape.get_extent %[[B_SHAPE]], %[[N_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[RESULT_SHAPE:.+]] = shape.from_extents %[[M]], %[[N]] : !shape.size, !shape.size
-// CHECK-NEXT:        scf.yield %[[RESULT_SHAPE]] : !shape.shape
-// CHECK-NEXT:      }
-// CHECK-NEXT:      %[[DIM0_INDEX:.+]] = shape.const_size 0
-// CHECK-NEXT:      %[[DIM0_EXTENT:.+]] = shape.get_extent %[[MATMUL_SHAPE]], %[[DIM0_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:      %[[DIM0:.+]] = shape.size_to_index %[[DIM0_EXTENT]] : !shape.size
-// CHECK-NEXT:      %[[INIT:.+]] = tensor.empty(%[[DIM0]]) : tensor<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[MATMUL:.+]] = hipsr.matmul(%[[DCTX]]) ins(%[[DA]], %[[DB]] : tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x512xf16, #hipsr.mem<device>>) : tensor<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.pool_domain_yield %[[MATMUL]] : tensor<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:    } -> tensor<?x512xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:  }
-func.func @matmul_domain(%ctx: !hipsr.context, %a: tensor<?x256xf16, #hipsr.mem<device>>,
-                         %b: tensor<256x512xf16, #hipsr.mem<device>>) -> tensor<?x512xf16, #hipsr.mem<device>> {
-  %0 = hipsr.pool_domain(%ctx, %a, %b
-      : !hipsr.context, tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>) {
-  ^bb0(%domain_ctx: !hipsr.context, %domain_a: tensor<?x256xf16, #hipsr.mem<device>>,
-       %domain_b: tensor<256x512xf16, #hipsr.mem<device>>):
-    %init = hipsr.placeholder(%domain_ctx)
-        ins(%domain_a, %domain_b : tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>)
-        {placeholder_type = #hipsr.placeholder_type<normal>}
-        : tensor<?x512xf16, #hipsr.mem<device>> shape_region {
-    ^bb0(%a_shape: !shape.shape, %b_shape: !shape.shape):
-      %m_index = shape.const_size 0
-      %m = shape.get_extent %a_shape, %m_index
-          : !shape.shape, !shape.size -> !shape.size
-      %n_index = shape.const_size 1
-      %n = shape.get_extent %b_shape, %n_index
-          : !shape.shape, !shape.size -> !shape.size
-      %result_shape = shape.from_extents %m, %n : !shape.size, !shape.size
-      hipsr.shape_yield %result_shape : !shape.shape
-    }
-    %matmul = hipsr.matmul(%domain_ctx)
-        ins(%domain_a, %domain_b : tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>)
-        outs(%init : tensor<?x512xf16, #hipsr.mem<device>>) : tensor<?x512xf16, #hipsr.mem<device>>
-    hipsr.pool_domain_yield %matmul : tensor<?x512xf16, #hipsr.mem<device>>
-  } -> tensor<?x512xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
-  return %0 : tensor<?x512xf16, #hipsr.mem<device>>
-}
-
-// -----
-
-// The same domain shape as @matmul_domain but with a fully static result. The
-// shape computation is still built -- the pass does not try to prove it dead,
-// it is left for canonicalization -- yet nothing is read back out of it,
-// because the tensor.empty type already carries both extents. %[[SHAPE]] having
-// no reader below is the point of the case.
-// CHECK-LABEL: func.func @static_shape(
-// CHECK-SAME:      %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<128x256xf16, #hipsr.mem<device>>, %[[B:.+]]: tensor<256x512xf16, #hipsr.mem<device>>) -> tensor<128x512xf16, #hipsr.mem<device>> {
-// CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]] : !hipsr.context, tensor<128x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT:    ^bb0(%[[DCTX:.+]]: !hipsr.context, %[[DA:.+]]: tensor<128x256xf16, #hipsr.mem<device>>, %[[DB:.+]]: tensor<256x512xf16, #hipsr.mem<device>>):
+// A barrier reads the data of its inputs rather than their shapes, so its
+// region arguments become ctx and the input tensors themselves, and the pass
+// builds no shape.shape_of at region entry. Both tensor arguments are used as
+// tensors here, which is what pins that: %[[DIN]] feeds a shape.shape_of inside
+// the region yielding tensor<2xindex>, %[[DEXTENTS]] feeds a tensor.extract,
+// and a !shape.shape in either spot would not verify. Neither extent of the
+// result is in the result type: the shape comes from data the region reads,
+// which is why a barrier lands one domain past its inputs. Both
+// inputs enter the domain as block arguments, so an earlier domain filled those
+// buffers and the region reads them as they are. That is the only form the pass
+// accepts; an input this domain allocates is the error case in invalid.mlir.
+// CHECK-LABEL: func.func @barrier_domain(
+// CHECK-SAME:      %[[CTX:.+]]: !hipsr.context, %[[IN:.+]]: tensor<?x1xf32, #hipsr.mem<device>>, %[[EXTENTS:.+]]: tensor<2xi64, #hipsr.mem<host>>) -> tensor<?x?xf32, #hipsr.mem<device>> {
+// CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[IN]], %[[EXTENTS]] : !hipsr.context, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:    ^bb0(%[[DCTX:.+]]: !hipsr.context, %[[DIN:.+]]: tensor<?x1xf32, #hipsr.mem<device>>, %[[DEXTENTS:.+]]: tensor<2xi64, #hipsr.mem<host>>):
 // CHECK-NEXT:      %[[SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[DA]] : tensor<128x256xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[B_SHAPE:.+]] = shape.shape_of %[[DB]] : tensor<256x512xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[M_INDEX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[M_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[N_INDEX:.+]] = shape.const_size 1
-// CHECK-NEXT:        %[[N:.+]] = shape.get_extent %[[B_SHAPE]], %[[N_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[RESULT_SHAPE:.+]] = shape.from_extents %[[M]], %[[N]] : !shape.size, !shape.size
+// CHECK-NEXT:        %[[IN_SHAPE:.+]] = shape.shape_of %[[DIN]] : tensor<?x1xf32, #hipsr.mem<device>> -> tensor<2xindex>
+// CHECK-NEXT:        %[[ROW_INDEX:.+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[ROWS:.+]] = tensor.extract %[[IN_SHAPE]]{{\[}}%[[ROW_INDEX]]] : tensor<2xindex>
+// CHECK-NEXT:        %[[COLUMN_INDEX:.+]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[COLUMN:.+]] = tensor.extract %[[DEXTENTS]]{{\[}}%[[COLUMN_INDEX]]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[COLUMNS:.+]] = arith.index_cast %[[COLUMN]] : i64 to index
+// CHECK-NEXT:        %[[RESULT_SHAPE:.+]] = shape.from_extents %[[ROWS]], %[[COLUMNS]] : index, index
 // CHECK-NEXT:        scf.yield %[[RESULT_SHAPE]] : !shape.shape
-// CHECK-NEXT:      }
-// CHECK-NEXT:      %[[INIT:.+]] = tensor.empty() : tensor<128x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[MATMUL:.+]] = hipsr.matmul(%[[DCTX]]) ins(%[[DA]], %[[DB]] : tensor<128x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<128x512xf16, #hipsr.mem<device>>) : tensor<128x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.pool_domain_yield %[[MATMUL]] : tensor<128x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:    } -> tensor<128x512xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT:    return %[[DOMAIN]] : tensor<128x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:  }
-func.func @static_shape(%ctx: !hipsr.context, %a: tensor<128x256xf16, #hipsr.mem<device>>,
-                        %b: tensor<256x512xf16, #hipsr.mem<device>>) -> tensor<128x512xf16, #hipsr.mem<device>> {
-  %0 = hipsr.pool_domain(%ctx, %a, %b
-      : !hipsr.context, tensor<128x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>) {
-  ^bb0(%domain_ctx: !hipsr.context, %domain_a: tensor<128x256xf16, #hipsr.mem<device>>,
-       %domain_b: tensor<256x512xf16, #hipsr.mem<device>>):
-    %init = hipsr.placeholder(%domain_ctx)
-        ins(%domain_a, %domain_b : tensor<128x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>)
-        {placeholder_type = #hipsr.placeholder_type<normal>}
-        : tensor<128x512xf16, #hipsr.mem<device>> shape_region {
-    ^bb0(%a_shape: !shape.shape, %b_shape: !shape.shape):
-      %m_index = shape.const_size 0
-      %m = shape.get_extent %a_shape, %m_index
-          : !shape.shape, !shape.size -> !shape.size
-      %n_index = shape.const_size 1
-      %n = shape.get_extent %b_shape, %n_index
-          : !shape.shape, !shape.size -> !shape.size
-      %result_shape = shape.from_extents %m, %n : !shape.size, !shape.size
-      hipsr.shape_yield %result_shape : !shape.shape
-    }
-    %matmul = hipsr.matmul(%domain_ctx)
-        ins(%domain_a, %domain_b : tensor<128x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>)
-        outs(%init : tensor<128x512xf16, #hipsr.mem<device>>) : tensor<128x512xf16, #hipsr.mem<device>>
-    hipsr.pool_domain_yield %matmul : tensor<128x512xf16, #hipsr.mem<device>>
-  } -> tensor<128x512xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
-  return %0 : tensor<128x512xf16, #hipsr.mem<device>>
-}
-
-// -----
-
-// A result with two dynamic dims and one static dim: dim 0 and dim 1 are read
-// back out of the computed shape, dim 2 is not, because 64 is already in the
-// type. The shape region here has a single op, so it also shows that an input
-// coming from a domain block argument is the only thing that gets a
-// shape.shape_of.
-// CHECK-LABEL: func.func @multi_dynamic(
-// CHECK-SAME:      %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<?x?x64xf16, #hipsr.mem<device>>, %[[B:.+]]: tensor<?x?x64xf16, #hipsr.mem<device>>) -> tensor<?x?x64xf16, #hipsr.mem<device>> {
-// CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]] : !hipsr.context, tensor<?x?x64xf16, #hipsr.mem<device>>, tensor<?x?x64xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT:    ^bb0(%[[DCTX:.+]]: !hipsr.context, %[[DA:.+]]: tensor<?x?x64xf16, #hipsr.mem<device>>, %[[DB:.+]]: tensor<?x?x64xf16, #hipsr.mem<device>>):
-// CHECK-NEXT:      %[[SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[DA]] : tensor<?x?x64xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[B_SHAPE:.+]] = shape.shape_of %[[DB]] : tensor<?x?x64xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[BROADCAST:.+]] = shape.broadcast %[[A_SHAPE]], %[[B_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:        scf.yield %[[BROADCAST]] : !shape.shape
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %[[D0_INDEX:.+]] = shape.const_size 0
 // CHECK-NEXT:      %[[D0_EXTENT:.+]] = shape.get_extent %[[SHAPE]], %[[D0_INDEX]] : !shape.shape, !shape.size -> !shape.size
@@ -170,45 +46,58 @@ func.func @static_shape(%ctx: !hipsr.context, %a: tensor<128x256xf16, #hipsr.mem
 // CHECK-NEXT:      %[[D1_INDEX:.+]] = shape.const_size 1
 // CHECK-NEXT:      %[[D1_EXTENT:.+]] = shape.get_extent %[[SHAPE]], %[[D1_INDEX]] : !shape.shape, !shape.size -> !shape.size
 // CHECK-NEXT:      %[[D1:.+]] = shape.size_to_index %[[D1_EXTENT]] : !shape.size
-// CHECK-NEXT:      %[[INIT:.+]] = tensor.empty(%[[D0]], %[[D1]]) : tensor<?x?x64xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[ADD:.+]] = hipsr.add(%[[DCTX]]) ins(%[[DA]], %[[DB]] : tensor<?x?x64xf16, #hipsr.mem<device>>, tensor<?x?x64xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x?x64xf16, #hipsr.mem<device>>) : tensor<?x?x64xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.pool_domain_yield %[[ADD]] : tensor<?x?x64xf16, #hipsr.mem<device>>
-// CHECK-NEXT:    } -> tensor<?x?x64xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x?x64xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[INIT:.+]] = tensor.empty(%[[D0]], %[[D1]]) : tensor<?x?xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[EXPAND:.+]] = hipsr.expand(%[[DCTX]]) ins(%[[DIN]], %[[DEXTENTS]] : tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) outs(%[[INIT]] : tensor<?x?xf32, #hipsr.mem<device>>) : tensor<?x?xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.pool_domain_yield %[[EXPAND]] : tensor<?x?xf32, #hipsr.mem<device>>
+// CHECK-NEXT:    } -> tensor<?x?xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x?xf32, #hipsr.mem<device>>
 // CHECK-NEXT:  }
-func.func @multi_dynamic(%ctx: !hipsr.context, %a: tensor<?x?x64xf16, #hipsr.mem<device>>,
-                         %b: tensor<?x?x64xf16, #hipsr.mem<device>>) -> tensor<?x?x64xf16, #hipsr.mem<device>> {
-  %0 = hipsr.pool_domain(%ctx, %a, %b
-      : !hipsr.context, tensor<?x?x64xf16, #hipsr.mem<device>>, tensor<?x?x64xf16, #hipsr.mem<device>>) {
-  ^bb0(%domain_ctx: !hipsr.context, %domain_a: tensor<?x?x64xf16, #hipsr.mem<device>>,
-       %domain_b: tensor<?x?x64xf16, #hipsr.mem<device>>):
+func.func @barrier_domain(%ctx: !hipsr.context, %in: tensor<?x1xf32, #hipsr.mem<device>>,
+                          %extents: tensor<2xi64, #hipsr.mem<host>>) -> tensor<?x?xf32, #hipsr.mem<device>> {
+  %0 = hipsr.pool_domain(%ctx, %in, %extents
+      : !hipsr.context, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) {
+  ^bb0(%domain_ctx: !hipsr.context, %domain_in: tensor<?x1xf32, #hipsr.mem<device>>,
+       %domain_extents: tensor<2xi64, #hipsr.mem<host>>):
     %init = hipsr.placeholder(%domain_ctx)
-        ins(%domain_a, %domain_b : tensor<?x?x64xf16, #hipsr.mem<device>>, tensor<?x?x64xf16, #hipsr.mem<device>>)
-        {placeholder_type = #hipsr.placeholder_type<normal>}
-        : tensor<?x?x64xf16, #hipsr.mem<device>> shape_region {
-    ^bb0(%lhs_shape: !shape.shape, %rhs_shape: !shape.shape):
-      %result_shape = shape.broadcast %lhs_shape, %rhs_shape
-          : !shape.shape, !shape.shape -> !shape.shape
+        ins(%domain_in, %domain_extents : tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>)
+        {placeholder_type = #hipsr.placeholder_type<barrier>}
+        : tensor<?x?xf32, #hipsr.mem<device>> shape_region {
+    ^bb0(%region_ctx: !hipsr.context, %region_in: tensor<?x1xf32, #hipsr.mem<device>>,
+         %region_extents: tensor<2xi64, #hipsr.mem<host>>):
+      %in_shape = shape.shape_of %region_in : tensor<?x1xf32, #hipsr.mem<device>> -> tensor<2xindex>
+      %row_index = arith.constant 0 : index
+      %rows = tensor.extract %in_shape[%row_index] : tensor<2xindex>
+      %column_index = arith.constant 1 : index
+      %column = tensor.extract %region_extents[%column_index] : tensor<2xi64, #hipsr.mem<host>>
+      %columns = arith.index_cast %column : i64 to index
+      %result_shape = shape.from_extents %rows, %columns : index, index
       hipsr.shape_yield %result_shape : !shape.shape
     }
-    %add = hipsr.add(%domain_ctx)
-        ins(%domain_a, %domain_b : tensor<?x?x64xf16, #hipsr.mem<device>>, tensor<?x?x64xf16, #hipsr.mem<device>>)
-        outs(%init : tensor<?x?x64xf16, #hipsr.mem<device>>) : tensor<?x?x64xf16, #hipsr.mem<device>>
-    hipsr.pool_domain_yield %add : tensor<?x?x64xf16, #hipsr.mem<device>>
-  } -> tensor<?x?x64xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
-  return %0 : tensor<?x?x64xf16, #hipsr.mem<device>>
+    %expand = hipsr.expand(%domain_ctx)
+        ins(%domain_in, %domain_extents : tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>)
+        outs(%init : tensor<?x?xf32, #hipsr.mem<device>>) : tensor<?x?xf32, #hipsr.mem<device>>
+    hipsr.pool_domain_yield %expand : tensor<?x?xf32, #hipsr.mem<device>>
+  } -> tensor<?x?xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
+  return %0 : tensor<?x?xf32, #hipsr.mem<device>>
 }
 
 // -----
 
-// The add placeholder is defined after the matmul in the input; grouping pulls
-// it in front of both data ops without overtaking the matmul placeholder it
-// depends on. That dependency then shows up in the shape graph: the add shape
-// region took the matmul placeholder result as its first input, so its first
-// argument becomes %[[MATMUL_SHAPE]] and only its second one gets a
-// shape.shape_of. Both allocations are grouped after the second
-// execute_region, so the domain reads as two shape computations, two
-// allocations, then the two data ops.
+// The canonical form: a shape region argument standing for a domain input
+// becomes shape.shape_of on it, hipsr.shape_yield becomes scf.yield because
+// HasParent binds it to hipsr.placeholder, and only dim 0 of tensor<?x512xf16>
+// is read back out of a computed shape -- 512 stays in the tensor.empty type.
+// Each data op takes the tensor.empty as its outs operand, with the
+// placeholders gone.
+//
+// The add placeholder comes after the matmul in the input, so its shape
+// computation has to move ahead of both data ops without overtaking the matmul
+// computation it reads. That dependency shows up in the shape graph: the add
+// shape region took the matmul placeholder result as its first input, so its
+// first argument becomes %[[MATMUL_SHAPE]] and only its second one gets a
+// shape.shape_of. Both allocations land after the second execute_region, so the
+// domain reads as two shape computations, two allocations, then the two data
+// ops.
 // CHECK-LABEL: func.func @interleaved(
 // CHECK-SAME:      %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<?x256xf16, #hipsr.mem<device>>, %[[B:.+]]: tensor<256x512xf16, #hipsr.mem<device>>, %[[C:.+]]: tensor<?x512xf16, #hipsr.mem<device>>) -> tensor<?x512xf16, #hipsr.mem<device>> {
 // CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]], %[[C]] : !hipsr.context, tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>, tensor<?x512xf16, #hipsr.mem<device>>) {
@@ -286,84 +175,67 @@ func.func @interleaved(%ctx: !hipsr.context, %a: tensor<?x256xf16, #hipsr.mem<de
 
 // -----
 
-// Same domain as @interleaved but already grouped, so grouping is a no-op and
-// the output is identical -- the CHECK block below is a copy of the previous
-// one, which is the assertion. Two leading placeholders in a row pin the skip
-// that keeps a placeholder from being moved before itself, which would
-// otherwise reverse their order.
-// CHECK-LABEL: func.func @already_grouped(
-// CHECK-SAME:      %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<?x256xf16, #hipsr.mem<device>>, %[[B:.+]]: tensor<256x512xf16, #hipsr.mem<device>>, %[[C:.+]]: tensor<?x512xf16, #hipsr.mem<device>>) -> tensor<?x512xf16, #hipsr.mem<device>> {
-// CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]], %[[C]] : !hipsr.context, tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>, tensor<?x512xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT:    ^bb0(%[[DCTX:.+]]: !hipsr.context, %[[DA:.+]]: tensor<?x256xf16, #hipsr.mem<device>>, %[[DB:.+]]: tensor<256x512xf16, #hipsr.mem<device>>, %[[DC:.+]]: tensor<?x512xf16, #hipsr.mem<device>>):
-// CHECK-NEXT:      %[[MATMUL_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[DA]] : tensor<?x256xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[B_SHAPE:.+]] = shape.shape_of %[[DB]] : tensor<256x512xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[M_INDEX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[M_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[N_INDEX:.+]] = shape.const_size 1
-// CHECK-NEXT:        %[[N:.+]] = shape.get_extent %[[B_SHAPE]], %[[N_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[FROM_EXTENTS:.+]] = shape.from_extents %[[M]], %[[N]] : !shape.size, !shape.size
-// CHECK-NEXT:        scf.yield %[[FROM_EXTENTS]] : !shape.shape
+// The weight the add placeholder reads is defined between the two placeholders,
+// so it has to come over ahead of the shape computation that reads it. The
+// constant landing at the front of the domain is the assertion -- left where it
+// was, it would no longer dominate the read. Both results are fully static, so
+// neither allocation reads an extent; the only reader of a computed shape here
+// is the add region, which broadcasts the cast's.
+// CHECK-LABEL: func.func @constant_between_placeholders(
+// CHECK-SAME:      %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<2x2xf16, #hipsr.mem<device>>) -> tensor<2x2xf32, #hipsr.mem<device>> {
+// CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[A]] : !hipsr.context, tensor<2x2xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:    ^bb0(%[[DCTX:.+]]: !hipsr.context, %[[DA:.+]]: tensor<2x2xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:      %[[WEIGHT:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<2x2xf32>} : tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[CAST_SHAPE:.+]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[DA]] : tensor<2x2xf16, #hipsr.mem<device>> -> !shape.shape
+// CHECK-NEXT:        scf.yield %[[A_SHAPE]] : !shape.shape
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %[[ADD_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[C_SHAPE:.+]] = shape.shape_of %[[DC]] : tensor<?x512xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[BROADCAST:.+]] = shape.broadcast %[[MATMUL_SHAPE]], %[[C_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
+// CHECK-NEXT:        %[[WEIGHT_SHAPE:.+]] = shape.shape_of %[[WEIGHT]] : tensor<2x2xf32, #hipsr.mem<device>> -> !shape.shape
+// CHECK-NEXT:        %[[BROADCAST:.+]] = shape.broadcast %[[CAST_SHAPE]], %[[WEIGHT_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
 // CHECK-NEXT:        scf.yield %[[BROADCAST]] : !shape.shape
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %[[MATMUL_D0_INDEX:.+]] = shape.const_size 0
-// CHECK-NEXT:      %[[MATMUL_D0_EXTENT:.+]] = shape.get_extent %[[MATMUL_SHAPE]], %[[MATMUL_D0_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:      %[[MATMUL_D0:.+]] = shape.size_to_index %[[MATMUL_D0_EXTENT]] : !shape.size
-// CHECK-NEXT:      %[[MATMUL_INIT:.+]] = tensor.empty(%[[MATMUL_D0]]) : tensor<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[ADD_D0_INDEX:.+]] = shape.const_size 0
-// CHECK-NEXT:      %[[ADD_D0_EXTENT:.+]] = shape.get_extent %[[ADD_SHAPE]], %[[ADD_D0_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:      %[[ADD_D0:.+]] = shape.size_to_index %[[ADD_D0_EXTENT]] : !shape.size
-// CHECK-NEXT:      %[[ADD_INIT:.+]] = tensor.empty(%[[ADD_D0]]) : tensor<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[MATMUL:.+]] = hipsr.matmul(%[[DCTX]]) ins(%[[DA]], %[[DB]] : tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>) outs(%[[MATMUL_INIT]] : tensor<?x512xf16, #hipsr.mem<device>>) : tensor<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[ADD:.+]] = hipsr.add(%[[DCTX]]) ins(%[[MATMUL]], %[[DC]] : tensor<?x512xf16, #hipsr.mem<device>>, tensor<?x512xf16, #hipsr.mem<device>>) outs(%[[ADD_INIT]] : tensor<?x512xf16, #hipsr.mem<device>>) : tensor<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.pool_domain_yield %[[ADD]] : tensor<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:    } -> tensor<?x512xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[CAST_INIT:.+]] = tensor.empty() : tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[ADD_INIT:.+]] = tensor.empty() : tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[CAST:.+]] = hipsr.cast(%[[DCTX]]) ins(%[[DA]] : tensor<2x2xf16, #hipsr.mem<device>>) outs(%[[CAST_INIT]] : tensor<2x2xf32, #hipsr.mem<device>>) : tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[ADD:.+]] = hipsr.add(%[[DCTX]]) ins(%[[CAST]], %[[WEIGHT]] : tensor<2x2xf32, #hipsr.mem<device>>, tensor<2x2xf32, #hipsr.mem<device>>) outs(%[[ADD_INIT]] : tensor<2x2xf32, #hipsr.mem<device>>) : tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.pool_domain_yield %[[ADD]] : tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:    } -> tensor<2x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT:    return %[[DOMAIN]] : tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:  }
-func.func @already_grouped(%ctx: !hipsr.context, %a: tensor<?x256xf16, #hipsr.mem<device>>,
-                           %b: tensor<256x512xf16, #hipsr.mem<device>>, %c: tensor<?x512xf16, #hipsr.mem<device>>)
-    -> tensor<?x512xf16, #hipsr.mem<device>> {
-  %0 = hipsr.pool_domain(%ctx, %a, %b, %c
-      : !hipsr.context, tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>,
-        tensor<?x512xf16, #hipsr.mem<device>>) {
-  ^bb0(%domain_ctx: !hipsr.context, %domain_a: tensor<?x256xf16, #hipsr.mem<device>>,
-       %domain_b: tensor<256x512xf16, #hipsr.mem<device>>, %domain_c: tensor<?x512xf16, #hipsr.mem<device>>):
-    %matmul_init = hipsr.placeholder(%domain_ctx)
-        ins(%domain_a, %domain_b : tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>)
+func.func @constant_between_placeholders(%ctx: !hipsr.context,
+                                         %a: tensor<2x2xf16, #hipsr.mem<device>>)
+    -> tensor<2x2xf32, #hipsr.mem<device>> {
+  %0 = hipsr.pool_domain(%ctx, %a
+      : !hipsr.context, tensor<2x2xf16, #hipsr.mem<device>>) {
+  ^bb0(%domain_ctx: !hipsr.context, %domain_a: tensor<2x2xf16, #hipsr.mem<device>>):
+    %cast_init = hipsr.placeholder(%domain_ctx)
+        ins(%domain_a : tensor<2x2xf16, #hipsr.mem<device>>)
         {placeholder_type = #hipsr.placeholder_type<normal>}
-        : tensor<?x512xf16, #hipsr.mem<device>> shape_region {
-    ^bb0(%a_shape: !shape.shape, %b_shape: !shape.shape):
-      %m_index = shape.const_size 0
-      %m = shape.get_extent %a_shape, %m_index
-          : !shape.shape, !shape.size -> !shape.size
-      %n_index = shape.const_size 1
-      %n = shape.get_extent %b_shape, %n_index
-          : !shape.shape, !shape.size -> !shape.size
-      %matmul_shape = shape.from_extents %m, %n : !shape.size, !shape.size
-      hipsr.shape_yield %matmul_shape : !shape.shape
+        : tensor<2x2xf32, #hipsr.mem<device>> shape_region {
+    ^bb0(%a_shape: !shape.shape):
+      hipsr.shape_yield %a_shape : !shape.shape
     }
+    %cast = hipsr.cast(%domain_ctx)
+        ins(%domain_a : tensor<2x2xf16, #hipsr.mem<device>>)
+        outs(%cast_init : tensor<2x2xf32, #hipsr.mem<device>>) : tensor<2x2xf32, #hipsr.mem<device>>
+    %weight = hipsr.constant {value = dense<[[1.0, 2.0], [3.0, 4.0]]> : tensor<2x2xf32>}
+        : tensor<2x2xf32, #hipsr.mem<device>>
     %add_init = hipsr.placeholder(%domain_ctx)
-        ins(%matmul_init, %domain_c : tensor<?x512xf16, #hipsr.mem<device>>, tensor<?x512xf16, #hipsr.mem<device>>)
+        ins(%cast_init, %weight : tensor<2x2xf32, #hipsr.mem<device>>, tensor<2x2xf32, #hipsr.mem<device>>)
         {placeholder_type = #hipsr.placeholder_type<normal>}
-        : tensor<?x512xf16, #hipsr.mem<device>> shape_region {
+        : tensor<2x2xf32, #hipsr.mem<device>> shape_region {
     ^bb0(%lhs_shape: !shape.shape, %rhs_shape: !shape.shape):
       %add_shape = shape.broadcast %lhs_shape, %rhs_shape
           : !shape.shape, !shape.shape -> !shape.shape
       hipsr.shape_yield %add_shape : !shape.shape
     }
-    %matmul = hipsr.matmul(%domain_ctx)
-        ins(%domain_a, %domain_b : tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>)
-        outs(%matmul_init : tensor<?x512xf16, #hipsr.mem<device>>) : tensor<?x512xf16, #hipsr.mem<device>>
     %add = hipsr.add(%domain_ctx)
-        ins(%matmul, %domain_c : tensor<?x512xf16, #hipsr.mem<device>>, tensor<?x512xf16, #hipsr.mem<device>>)
-        outs(%add_init : tensor<?x512xf16, #hipsr.mem<device>>) : tensor<?x512xf16, #hipsr.mem<device>>
-    hipsr.pool_domain_yield %add : tensor<?x512xf16, #hipsr.mem<device>>
-  } -> tensor<?x512xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
-  return %0 : tensor<?x512xf16, #hipsr.mem<device>>
+        ins(%cast, %weight : tensor<2x2xf32, #hipsr.mem<device>>, tensor<2x2xf32, #hipsr.mem<device>>)
+        outs(%add_init : tensor<2x2xf32, #hipsr.mem<device>>) : tensor<2x2xf32, #hipsr.mem<device>>
+    hipsr.pool_domain_yield %add : tensor<2x2xf32, #hipsr.mem<device>>
+  } -> tensor<2x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
+  return %0 : tensor<2x2xf32, #hipsr.mem<device>>
 }
 
 // -----

--- a/test/lit/Dialect/Hipsr/Transforms/MaterializeInitTensors/materialize-init-tensors.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/MaterializeInitTensors/materialize-init-tensors.mlir
@@ -48,6 +48,7 @@
 // CHECK-NEXT:      %[[D1:.+]] = shape.size_to_index %[[D1_EXTENT]] : !shape.size
 // CHECK-NEXT:      %[[INIT:.+]] = tensor.empty(%[[D0]], %[[D1]]) : tensor<?x?xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[EXPAND:.+]] = hipsr.expand(%[[DCTX]]) ins(%[[DIN]], %[[DEXTENTS]] : tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) outs(%[[INIT]] : tensor<?x?xf32, #hipsr.mem<device>>) : tensor<?x?xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[SHAPE]], %[[EXPAND]] : tensor<?x?xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[EXPAND]] : tensor<?x?xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    } -> tensor<?x?xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
 // CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x?xf32, #hipsr.mem<device>>
@@ -96,8 +97,14 @@ func.func @barrier_domain(%ctx: !hipsr.context, %in: tensor<?x1xf32, #hipsr.mem<
 // shape region took the matmul placeholder result as its first input, so its
 // first argument becomes %[[MATMUL_SHAPE]] and only its second one gets a
 // shape.shape_of. Both allocations land after the second execute_region, so the
-// domain reads as two shape computations, two allocations, then the two data
-// ops.
+// domain reads as two shape computations, two allocations, the two data ops,
+// then the two shape links.
+//
+// A link names the result of the op that filled the buffer rather than the
+// tensor.empty it was handed. The two are one buffer after bufferization, which
+// is what leaves the shape on the memref.alloc for -hip-use-output-allocator,
+// and naming the tensor.empty instead would keep it alive as an allocation of
+// its own for an op whose result is only a view of another buffer.
 // CHECK-LABEL: func.func @interleaved(
 // CHECK-SAME:      %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<?x256xf16, #hipsr.mem<device>>, %[[B:.+]]: tensor<256x512xf16, #hipsr.mem<device>>, %[[C:.+]]: tensor<?x512xf16, #hipsr.mem<device>>) -> tensor<?x512xf16, #hipsr.mem<device>> {
 // CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]], %[[C]] : !hipsr.context, tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>, tensor<?x512xf16, #hipsr.mem<device>>) {
@@ -127,6 +134,8 @@ func.func @barrier_domain(%ctx: !hipsr.context, %in: tensor<?x1xf32, #hipsr.mem<
 // CHECK-NEXT:      %[[ADD_INIT:.+]] = tensor.empty(%[[ADD_D0]]) : tensor<?x512xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[MATMUL:.+]] = hipsr.matmul(%[[DCTX]]) ins(%[[DA]], %[[DB]] : tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>) outs(%[[MATMUL_INIT]] : tensor<?x512xf16, #hipsr.mem<device>>) : tensor<?x512xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[ADD:.+]] = hipsr.add(%[[DCTX]]) ins(%[[MATMUL]], %[[DC]] : tensor<?x512xf16, #hipsr.mem<device>>, tensor<?x512xf16, #hipsr.mem<device>>) outs(%[[ADD_INIT]] : tensor<?x512xf16, #hipsr.mem<device>>) : tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[MATMUL_SHAPE]], %[[MATMUL]] : tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[ADD_SHAPE]], %[[ADD]] : tensor<?x512xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[ADD]] : tensor<?x512xf16, #hipsr.mem<device>>
 // CHECK-NEXT:    } -> tensor<?x512xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
 // CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x512xf16, #hipsr.mem<device>>
@@ -199,6 +208,8 @@ func.func @interleaved(%ctx: !hipsr.context, %a: tensor<?x256xf16, #hipsr.mem<de
 // CHECK-NEXT:      %[[ADD_INIT:.+]] = tensor.empty() : tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[CAST:.+]] = hipsr.cast(%[[DCTX]]) ins(%[[DA]] : tensor<2x2xf16, #hipsr.mem<device>>) outs(%[[CAST_INIT]] : tensor<2x2xf32, #hipsr.mem<device>>) : tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[ADD:.+]] = hipsr.add(%[[DCTX]]) ins(%[[CAST]], %[[WEIGHT]] : tensor<2x2xf32, #hipsr.mem<device>>, tensor<2x2xf32, #hipsr.mem<device>>) outs(%[[ADD_INIT]] : tensor<2x2xf32, #hipsr.mem<device>>) : tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[CAST_SHAPE]], %[[CAST]] : tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[ADD_SHAPE]], %[[ADD]] : tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[ADD]] : tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    } -> tensor<2x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
 // CHECK-NEXT:    return %[[DOMAIN]] : tensor<2x2xf32, #hipsr.mem<device>>


### PR DESCRIPTION
﻿## Summary

`buildHipsrPipeline` now runs `hipsr-materialize-init-tensors`. A pool domain leaves the pipeline as constants, shape computations, `tensor.empty` allocations, data ops, then one `hipsr.preserve_shape` per allocation.

The pass emits that order into a fresh domain block instead of moving ops into place, so emission order is final order and nothing is repositioned afterwards. Enabling it in the pipeline turned up two cases it could not yet handle.

## Related issue or design

None. #790 touches this pass too, and it needs a rebase rather than just ordering: it patches `replaceAndCleanup` and the `@already_grouped`, `@static_shape`, and `@multi_dynamic` tests, none of which survive this PR.

## Compiler IR

Trimmed: `#hipsr.mem<device>` and operand type lists omitted.

```mlir
// Before
%init = hipsr.placeholder(%ctx) ins(%a, %b) : tensor<?x512xf16> shape_region {
^bb0(%a_shape: !shape.shape, %b_shape: !shape.shape):
  ...
  hipsr.shape_yield %shape : !shape.shape
}
%0 = hipsr.matmul(%ctx) ins(%a, %b) outs(%init) : tensor<?x512xf16>

// After
%s = scf.execute_region -> !shape.shape {
  %a_shape = shape.shape_of %a : tensor<?x256xf16> -> !shape.shape
  %b_shape = shape.shape_of %b : tensor<256x512xf16> -> !shape.shape
  ...
  scf.yield %shape : !shape.shape
}
%c0 = shape.const_size 0
%extent = shape.get_extent %s, %c0        // only dim 0; 512 is in the type
%d0 = shape.size_to_index %extent
%init = tensor.empty(%d0) : tensor<?x512xf16>
%0 = hipsr.matmul(%ctx) ins(%a, %b) outs(%init) : tensor<?x512xf16>
hipsr.preserve_shape %s, %0 : tensor<?x512xf16>
```

**Fix 1, barrier regions.** Their arguments are `ctx` and the input tensors, which is the placeholder's own operand list, so they map straight through.

```mlir
// Before
^bb0(%rctx: !hipsr.context, %rin: tensor<?x1xf32>, %rextents: tensor<2xi64>):
  %in_shape = shape.shape_of %rin : tensor<?x1xf32> -> tensor<2xindex>
  %column = tensor.extract %rextents[%c1] : tensor<2xi64>

// After, nothing built at region entry
%s = scf.execute_region -> !shape.shape {
  %in_shape = shape.shape_of %in : tensor<?x1xf32> -> tensor<2xindex>
  %column = tensor.extract %extents[%c1] : tensor<2xi64>
  ...
}

// New error: the pool hands buffers out only after the last allocation, and
// -hipsr-partition-pool-domains keeps a barrier one domain past its inputs.
%cast_init = hipsr.placeholder(%ctx) ins(%in) <normal> ...
// expected-error {{barrier input must be allocated outside this pool domain}}
%barrier_init = hipsr.placeholder(%ctx) ins(%cast_init) <barrier> ...
```

**Fix 2, constant dominance.** Conversion emits a constant next to the op that consumes it, so a shape region can read one defined below where its computation has to land. Emitting the constants late fails all three `Dialect/Hipsr/Pipelines/` tests with `operand #0 does not dominate this use`.

```mlir
// Before, %weight sits below the front of the block, where computations go
%cast = hipsr.cast(%ctx) ins(%a) outs(%cast_init)
%weight = hipsr.constant {value = dense<...>} : tensor<2x2xf32>
%add_init = hipsr.placeholder(%ctx) ins(%cast_init, %weight) ...

// After. A constant takes no operands, so every constant in the domain comes
// over first, where it dominates every computation. The data op below reads
// that same clone.
%weight = hipsr.constant {value = dense<...>} : tensor<2x2xf32>
%cast_shape = scf.execute_region -> !shape.shape { ... }
%add_shape = scf.execute_region -> !shape.shape {
  %weight_shape = shape.shape_of %weight : tensor<2x2xf32> -> !shape.shape
  ...
}
%cast_init = tensor.empty() : tensor<2x2xf32>
%add_init = tensor.empty() : tensor<2x2xf32>
%cast = hipsr.cast(%ctx) ins(%a) outs(%cast_init)
%add = hipsr.add(%ctx) ins(%cast, %weight) outs(%add_init)
```

The step hoists every constant rather than the ones a shape region reads: a constant has no operands, so the front of the domain dominates every reader either way, and one walk reaches each constant once. A placeholder input can only be a block argument, another placeholder, or a constant, so nothing else needs to come over early.

## Shape links

The pass built a shape per placeholder result, sized an allocation with it, then dropped it, so nothing downstream could tell which shape belonged to which buffer. `-hip-use-output-allocator` is the only reader of these links, and no pass produced one.

A link names the result of the op that fills the buffer rather than the allocation feeding its `outs`, which is why it comes after the data ops. For a destination-passing op the two become one buffer and the choice looks free, but:

- `hipsr.compute` is not destination-passing. Its result may be a view carrying a shape the destination does not: in `OneShotBufferize/compute.mlir`, a `memref<?xf16>` collapse of a `memref<?x256xf16>` destination.
- Naming the allocation puts a use on the empty tensor after its writer consumed it, so One-Shot Bufferize gives the writer a buffer of its own. Linking the inits in that same graph turns two allocations into four and strands both links on buffers nothing fills (measured by bufferizing the test both ways).

`BufferizableOpInterfaceImpl` already had a `ComputeOp`-only `getResultHeldIn` for this mapping. It becomes `getResultForDestination` beside the other destination helpers, takes any hipsr op, and serves both callers.

## Tests

LIT: 458 passed, 12 unsupported (pre-existing). Most of the diff is regenerated expectations for `Dialect/Hipsr/Pipelines/` and the rewritten pass test, both now carrying the `hipsr.preserve_shape` lines; `embedding.mlir` covers a placeholder whose two results each get one.

Four positive cases remain, each owning a boundary of its own:

| Case | Boundary |
|---|---|
| `@interleaved` | one dynamic extent, plus the shape one placeholder reads from another |
| `@barrier_domain` | two dynamic extents, plus the barrier argument layout |
| `@constant_between_placeholders` | no dynamic extent, plus constant dominance |
| `@no_placeholder` | domain left alone |

Every case spells its whole function out with `CHECK-NEXT`, so a leftover placeholder or an extent read for a static dimension breaks the chain. The single-placeholder, `@static_shape`, and `@multi_dynamic` cases hand their boundaries to the four above; `@already_grouped` goes because it pinned the skip that kept a placeholder from being moved ahead of itself, and a rebuild moves nothing. `invalid.mlir` covers both diagnostics the pass emits.

## AI assistance

AI-assisted (Claude Opus 5 via Cursor): the pass rewrite, the shape-link step and its shared helper, the LIT expectations, and this description, validated by the LIT suite and `pre-commit`. I reviewed the result and own the design decisions.

