### PR TITLE
mlir-imp: preserve unsigned identity for inline dense integer constants (fix QDQ sign-flip)

### DIFF
--- a/morphizen/mlir-imp/src/mlir-constants.cpp
+++ b/morphizen/mlir-imp/src/mlir-constants.cpp
@@ -75,16 +75,17 @@ mlir::Type onnxElementTypeToMlirDenseElementType(int element_type,
                                                  mlir::OpBuilder &builder) {
   mlir::Type elem = onnxElementTypeToMlirElementType(element_type, builder);
   if (auto intTy = mlir::dyn_cast<mlir::IntegerType>(elem)) {
-    // Preserve unsigned 16-bit (ONNX UINT16) on inline dense constants so they
+    // Preserve unsigned integers (ONNX UINTx) on inline dense constants so they
     // retain their unsigned identity through lowering, matching how EXTERNAL
-    // UINT16 initializers are already imported (ui16, via the offset/size path
-    // that bypasses DenseElementsAttr). A downstream QDQ dtype classifier must
-    // distinguish UINT16 from signed INT16: collapsing UINT16 to signless i16
-    // here makes the two indistinguishable, so inline unsigned constants with
-    // values >= 32768 get read as INT16 and sign-flip. LLVM 22 MLIR accepts
-    // unsigned DenseElementsAttr, and ui16 memrefs already flow end-to-end for
-    // external constants, so keeping ui16 here is consistent and safe.
-    if (intTy.getWidth() == 16 && intTy.isUnsigned())
+    // unsigned initializers are already imported (via the offset/size path that
+    // bypasses DenseElementsAttr). A downstream QDQ dtype classifier must
+    // distinguish an unsigned type from the signed type of the same width:
+    // collapsing e.g. UINT16 to signless i16 makes the two indistinguishable,
+    // so inline unsigned constants with values >= 2^(width-1) get read as
+    // signed and sign-flip. LLVM 22 MLIR accepts unsigned DenseElementsAttr,
+    // and unsigned memrefs already flow end-to-end for external constants, so
+    // keeping the unsigned type here is consistent and safe.
+    if (intTy.isUnsigned())
       return elem;
     if (!intTy.isSignless())
       return mlir::IntegerType::get(builder.getContext(), intTy.getWidth());

--- a/morphizen/mlir-imp/src/mlir-constants.cpp
+++ b/morphizen/mlir-imp/src/mlir-constants.cpp
@@ -75,6 +75,19 @@ mlir::Type onnxElementTypeToMlirDenseElementType(int element_type,
                                                  mlir::OpBuilder &builder) {
   mlir::Type elem = onnxElementTypeToMlirElementType(element_type, builder);
   if (auto intTy = mlir::dyn_cast<mlir::IntegerType>(elem)) {
+    // Preserve unsigned 16-bit (ONNX UINT16) on inline dense constants so they
+    // retain their unsigned identity through lowering, matching how EXTERNAL
+    // UINT16 initializers are already imported (ui16, via the offset/size path
+    // that bypasses DenseElementsAttr). The HipToLLVM QDQ dtype classifier must
+    // distinguish UINT16 (uint16) from signed INT16 (int16, added for the Quark
+    // ResNet50-INT8 bias): collapsing UINT16 to signless i16 here makes it
+    // indistinguishable from INT16, so small inline quantized constants (e.g.
+    // google_bert's per-layer attention sqrt(d_k) scaling scalar) get read as
+    // INT16 and sign-flip on values >= 32768. LLVM 22 MLIR accepts unsigned
+    // DenseElementsAttr, and ui16 memrefs already flow end-to-end for external
+    // constants, so keeping ui16 here is consistent and safe.
+    if (intTy.getWidth() == 16 && intTy.isUnsigned())
+      return elem;
     if (!intTy.isSignless())
       return mlir::IntegerType::get(builder.getContext(), intTy.getWidth());
   }

--- a/morphizen/mlir-imp/src/mlir-constants.cpp
+++ b/morphizen/mlir-imp/src/mlir-constants.cpp
@@ -78,14 +78,12 @@ mlir::Type onnxElementTypeToMlirDenseElementType(int element_type,
     // Preserve unsigned 16-bit (ONNX UINT16) on inline dense constants so they
     // retain their unsigned identity through lowering, matching how EXTERNAL
     // UINT16 initializers are already imported (ui16, via the offset/size path
-    // that bypasses DenseElementsAttr). The HipToLLVM QDQ dtype classifier must
-    // distinguish UINT16 (uint16) from signed INT16 (int16, added for the Quark
-    // ResNet50-INT8 bias): collapsing UINT16 to signless i16 here makes it
-    // indistinguishable from INT16, so small inline quantized constants (e.g.
-    // google_bert's per-layer attention sqrt(d_k) scaling scalar) get read as
-    // INT16 and sign-flip on values >= 32768. LLVM 22 MLIR accepts unsigned
-    // DenseElementsAttr, and ui16 memrefs already flow end-to-end for external
-    // constants, so keeping ui16 here is consistent and safe.
+    // that bypasses DenseElementsAttr). A downstream QDQ dtype classifier must
+    // distinguish UINT16 from signed INT16: collapsing UINT16 to signless i16
+    // here makes the two indistinguishable, so inline unsigned constants with
+    // values >= 32768 get read as INT16 and sign-flip. LLVM 22 MLIR accepts
+    // unsigned DenseElementsAttr, and ui16 memrefs already flow end-to-end for
+    // external constants, so keeping ui16 here is consistent and safe.
     if (intTy.getWidth() == 16 && intTy.isUnsigned())
       return elem;
     if (!intTy.isSignless())

--- a/morphizen/mlir-imp/src/mlir-constants.hpp
+++ b/morphizen/mlir-imp/src/mlir-constants.hpp
@@ -141,11 +141,10 @@ mlir::Type onnxElementTypeToMlirElementType(int element_type,
 
 // Element type for DenseElementsAttr / getFromRawBuffer. MLIR requires signless
 // integers (or index), so ONNX signed/unsigned integers map to signless storage
-// -- EXCEPT 16-bit unsigned (ONNX UINT16), which is kept as ui16. The
-// downstream HipToLLVM QDQ dtype classifier reads signless i16 as signed INT16
-// (the Quark ResNet50-INT8 bias path), so collapsing UINT16 to signless i16
-// here would sign-flip inline UINT16 constants >= 32768. See mlir-constants.cpp
-// for the full rationale.
+// -- EXCEPT 16-bit unsigned (ONNX UINT16), which is kept as ui16. A downstream
+// QDQ dtype classifier reads signless i16 as signed INT16, so folding UINT16
+// to signless i16 here would sign-flip inline UINT16 constants >= 32768. See
+// mlir-constants.cpp for the full rationale.
 mlir::Type onnxElementTypeToMlirDenseElementType(int element_type,
                                                  mlir::OpBuilder &builder);
 

--- a/morphizen/mlir-imp/src/mlir-constants.hpp
+++ b/morphizen/mlir-imp/src/mlir-constants.hpp
@@ -140,11 +140,11 @@ mlir::Type onnxElementTypeToMlirElementType(int element_type,
                                             mlir::OpBuilder &builder);
 
 // Element type for DenseElementsAttr / getFromRawBuffer. MLIR requires signless
-// integers (or index), so ONNX signed/unsigned integers map to signless storage
-// -- EXCEPT 16-bit unsigned (ONNX UINT16), which is kept as ui16. A downstream
-// QDQ dtype classifier reads signless i16 as signed INT16, so folding UINT16
-// to signless i16 here would sign-flip inline UINT16 constants >= 32768. See
-// mlir-constants.cpp for the full rationale.
+// integers (or index), so ONNX signed integers map to signless storage -- but
+// ONNX unsigned integers keep their unsigned type (e.g. ui8, ui16). A
+// downstream QDQ dtype classifier reads signless i16 as signed INT16, so
+// folding an unsigned type to signless here would sign-flip inline unsigned
+// constants >= 2^(width-1). See mlir-constants.cpp for the full rationale.
 mlir::Type onnxElementTypeToMlirDenseElementType(int element_type,
                                                  mlir::OpBuilder &builder);
 

--- a/morphizen/mlir-imp/src/mlir-constants.hpp
+++ b/morphizen/mlir-imp/src/mlir-constants.hpp
@@ -140,7 +140,12 @@ mlir::Type onnxElementTypeToMlirElementType(int element_type,
                                             mlir::OpBuilder &builder);
 
 // Element type for DenseElementsAttr / getFromRawBuffer. MLIR requires signless
-// integers (or index); map ONNX signed/unsigned integers to signless storage.
+// integers (or index), so ONNX signed/unsigned integers map to signless storage
+// -- EXCEPT 16-bit unsigned (ONNX UINT16), which is kept as ui16. The downstream
+// HipToLLVM QDQ dtype classifier reads signless i16 as signed INT16 (the Quark
+// ResNet50-INT8 bias path), so collapsing UINT16 to signless i16 here would
+// sign-flip inline UINT16 constants >= 32768. See mlir-constants.cpp for the
+// full rationale.
 mlir::Type onnxElementTypeToMlirDenseElementType(int element_type,
                                                  mlir::OpBuilder &builder);
 

--- a/morphizen/mlir-imp/src/mlir-constants.hpp
+++ b/morphizen/mlir-imp/src/mlir-constants.hpp
@@ -141,11 +141,11 @@ mlir::Type onnxElementTypeToMlirElementType(int element_type,
 
 // Element type for DenseElementsAttr / getFromRawBuffer. MLIR requires signless
 // integers (or index), so ONNX signed/unsigned integers map to signless storage
-// -- EXCEPT 16-bit unsigned (ONNX UINT16), which is kept as ui16. The downstream
-// HipToLLVM QDQ dtype classifier reads signless i16 as signed INT16 (the Quark
-// ResNet50-INT8 bias path), so collapsing UINT16 to signless i16 here would
-// sign-flip inline UINT16 constants >= 32768. See mlir-constants.cpp for the
-// full rationale.
+// -- EXCEPT 16-bit unsigned (ONNX UINT16), which is kept as ui16. The
+// downstream HipToLLVM QDQ dtype classifier reads signless i16 as signed INT16
+// (the Quark ResNet50-INT8 bias path), so collapsing UINT16 to signless i16
+// here would sign-flip inline UINT16 constants >= 32768. See mlir-constants.cpp
+// for the full rationale.
 mlir::Type onnxElementTypeToMlirDenseElementType(int element_type,
                                                  mlir::OpBuilder &builder);
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -41,3 +41,35 @@ add_test(NAME HipsrExternalizeConstantsUnit
 set_target_properties(test-hipsr-externalize-constants PROPERTIES
   FOLDER "mlir/Test/Dialect/Hipsr"
 )
+
+#=============================================================================
+# ONNX-dtype -> MLIR-type mapping unit test (GPU-free).
+#=============================================================================
+# Covers onnxElementTypeToMlirDenseElementType (morphizen/mlir-imp), which LIT
+# cannot reach: hip-mlir-opt has no ONNX front end and only consumes textual
+# MLIR. Regression guard for the QDQ UINT16 sign-flip (inline UINT16 dense
+# constants must stay ui16, not signless i16). Plain main() (no GTest).
+
+add_executable(test-dtype-mapping test_dtype_mapping.cpp)
+
+target_compile_features(test-dtype-mapping PRIVATE cxx_std_17)
+
+target_include_directories(test-dtype-mapping PRIVATE
+  ${MLIR_INCLUDE_DIRS}
+  ${LLVM_INCLUDE_DIRS}
+  ${CMAKE_SOURCE_DIR}/morphizen/mlir-imp/src  # mlir-constants.hpp
+)
+
+target_link_libraries(test-dtype-mapping PRIVATE
+  mlir-imp
+  MLIRIR
+  MLIRSupport
+)
+
+add_test(NAME MlirDtypeMappingUnit
+  COMMAND test-dtype-mapping
+)
+
+set_target_properties(test-dtype-mapping PROPERTIES
+  FOLDER "mlir/Test/Dialect/Hipsr"
+)

--- a/test/unit/test_dtype_mapping.cpp
+++ b/test/unit/test_dtype_mapping.cpp
@@ -6,11 +6,9 @@
 // Unit test for onnxElementTypeToMlirDenseElementType (morphizen/mlir-imp).
 //
 // Regression guard for the QDQ UINT16 sign-flip: inline ONNX UINT16 dense
-// constants must import as *unsigned* i16 (ui16), not signless i16. The
-// downstream HipToLLVM QDQ dtype classifier (added for the Quark ResNet50-INT8
-// signed-int16 bias) treats signless i16 as INT16, which sign-flips any UINT16
-// value >= 32768 (e.g. google_bert's per-layer attention sqrt(d_k) scaling
-// scalar) and corrupts DequantizeLinear output.
+// constants must import as *unsigned* i16 (ui16), not signless i16. A
+// downstream QDQ dtype classifier treats signless i16 as signed INT16, which
+// sign-flips any UINT16 value >= 32768 and corrupts DequantizeLinear output.
 //
 // This cannot be a LIT test: hip-mlir-opt has no ONNX-protobuf front end and
 // only consumes textual MLIR, so the ONNX-dtype -> MLIR-type mapping is only

--- a/test/unit/test_dtype_mapping.cpp
+++ b/test/unit/test_dtype_mapping.cpp
@@ -5,10 +5,12 @@
 
 // Unit test for onnxElementTypeToMlirDenseElementType (morphizen/mlir-imp).
 //
-// Regression guard for the QDQ UINT16 sign-flip: inline ONNX UINT16 dense
-// constants must import as *unsigned* i16 (ui16), not signless i16. A
-// downstream QDQ dtype classifier treats signless i16 as signed INT16, which
-// sign-flips any UINT16 value >= 32768 and corrupts DequantizeLinear output.
+// Regression guard for the QDQ unsigned-integer sign-flip: inline ONNX
+// unsigned dense constants (UINT8, UINT16, ...) must import as *unsigned*
+// integers (ui8, ui16, ...), not signless. A downstream QDQ dtype classifier
+// treats a signless integer as the signed type of the same width, which
+// sign-flips any unsigned value >= 2^(width-1) and corrupts DequantizeLinear
+// output.
 //
 // This cannot be a LIT test: hip-mlir-opt has no ONNX-protobuf front end and
 // only consumes textual MLIR, so the ONNX-dtype -> MLIR-type mapping is only
@@ -69,11 +71,11 @@ int main() {
   }
 
   // --- INT16 must remain SIGNLESS i16 so the QDQ classifier still reads it as
-  // INT16 (Quark ResNet50-INT8 bias path is unaffected by the fix) -----------
+  // signed INT16 (signed integers are unaffected by the fix) -----------------
   {
     auto t = asInt(onnxElementTypeToMlirDenseElementType(ONNX_INT16, builder));
     check(t && t.getWidth() == 16 && t.isSignless(),
-          "dense(INT16) -> signless i16 (ResNet50-INT8 bias path unchanged)");
+          "dense(INT16) -> signless i16 (signed path unchanged)");
   }
 
   // --- Unsigned 8-bit keeps its unsigned identity (ui8) too; signed INT8 still

--- a/test/unit/test_dtype_mapping.cpp
+++ b/test/unit/test_dtype_mapping.cpp
@@ -90,7 +90,8 @@ int main() {
 
   // --- Wider signless integers pass through untouched ------------------------
   {
-    auto i32 = asInt(onnxElementTypeToMlirDenseElementType(ONNX_INT32, builder));
+    auto i32 =
+        asInt(onnxElementTypeToMlirDenseElementType(ONNX_INT32, builder));
     check(i32 && i32.getWidth() == 32 && i32.isSignless(),
           "dense(INT32) -> signless i32 (unchanged)");
   }

--- a/test/unit/test_dtype_mapping.cpp
+++ b/test/unit/test_dtype_mapping.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// Unit test for onnxElementTypeToMlirDenseElementType (morphizen/mlir-imp).
+//
+// Regression guard for the QDQ UINT16 sign-flip: inline ONNX UINT16 dense
+// constants must import as *unsigned* i16 (ui16), not signless i16. The
+// downstream HipToLLVM QDQ dtype classifier (added for the Quark ResNet50-INT8
+// signed-int16 bias) treats signless i16 as INT16, which sign-flips any UINT16
+// value >= 32768 (e.g. google_bert's per-layer attention sqrt(d_k) scaling
+// scalar) and corrupts DequantizeLinear output.
+//
+// This cannot be a LIT test: hip-mlir-opt has no ONNX-protobuf front end and
+// only consumes textual MLIR, so the ONNX-dtype -> MLIR-type mapping is only
+// reachable at the C++ layer. Plain main() (no GTest): matches the other
+// MLIR-side unit tests and avoids a GTest dependency absent from the compiler
+// build.
+
+#include "mlir-constants.hpp"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
+
+#include "llvm/Support/raw_ostream.h"
+
+// ONNX TensorProto_DataType codes (subset under test).
+enum : int {
+  ONNX_FLOAT = 1,
+  ONNX_UINT8 = 2,
+  ONNX_INT8 = 3,
+  ONNX_UINT16 = 4,
+  ONNX_INT16 = 5,
+  ONNX_INT32 = 6,
+  ONNX_FLOAT16 = 10,
+};
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool cond, llvm::StringRef what) {
+  if (cond) {
+    llvm::outs() << "[ OK ] " << what << "\n";
+  } else {
+    llvm::errs() << "[FAIL] " << what << "\n";
+    ++g_failures;
+  }
+}
+
+// Returns the IntegerType for `elem` or nullptr if `elem` is not an integer.
+mlir::IntegerType asInt(mlir::Type elem) {
+  return mlir::dyn_cast<mlir::IntegerType>(elem);
+}
+
+} // namespace
+
+int main() {
+  mlir::MLIRContext ctx;
+  mlir::OpBuilder builder(&ctx);
+  using morphizen::mlir_impl::onnxElementTypeToMlirDenseElementType;
+  using morphizen::mlir_impl::onnxElementTypeToMlirElementType;
+
+  // --- The fix: inline UINT16 dense constant must stay UNSIGNED i16 ---------
+  {
+    auto t = asInt(onnxElementTypeToMlirDenseElementType(ONNX_UINT16, builder));
+    check(t && t.getWidth() == 16 && t.isUnsigned(),
+          "dense(UINT16) -> unsigned i16 (ui16), not signless i16");
+  }
+
+  // --- INT16 must remain SIGNLESS i16 so the QDQ classifier still reads it as
+  // INT16 (Quark ResNet50-INT8 bias path is unaffected by the fix) -----------
+  {
+    auto t = asInt(onnxElementTypeToMlirDenseElementType(ONNX_INT16, builder));
+    check(t && t.getWidth() == 16 && t.isSignless(),
+          "dense(INT16) -> signless i16 (ResNet50-INT8 bias path unchanged)");
+  }
+
+  // --- 8-bit integers keep the pre-existing signless-flatten behavior -------
+  {
+    auto u8 = asInt(onnxElementTypeToMlirDenseElementType(ONNX_UINT8, builder));
+    check(u8 && u8.getWidth() == 8 && u8.isSignless(),
+          "dense(UINT8) -> signless i8 (unchanged)");
+    auto i8 = asInt(onnxElementTypeToMlirDenseElementType(ONNX_INT8, builder));
+    check(i8 && i8.getWidth() == 8 && i8.isSignless(),
+          "dense(INT8) -> signless i8 (unchanged)");
+  }
+
+  // --- Wider signless integers pass through untouched ------------------------
+  {
+    auto i32 = asInt(onnxElementTypeToMlirDenseElementType(ONNX_INT32, builder));
+    check(i32 && i32.getWidth() == 32 && i32.isSignless(),
+          "dense(INT32) -> signless i32 (unchanged)");
+  }
+
+  // --- Non-integer element types are returned untouched ----------------------
+  {
+    auto f16 = onnxElementTypeToMlirDenseElementType(ONNX_FLOAT16, builder);
+    check(f16.isF16() && !asInt(f16), "dense(FLOAT16) -> f16 (unchanged)");
+    auto f32 = onnxElementTypeToMlirDenseElementType(ONNX_FLOAT, builder);
+    check(f32.isF32() && !asInt(f32), "dense(FLOAT) -> f32 (unchanged)");
+  }
+
+  // --- Dense mapping for UINT16 now matches the bare element-type mapping,
+  // which already preserved ui16; confirm they agree (inline vs external
+  // UINT16 consistency the fix establishes) ----------------------------------
+  {
+    auto dense = onnxElementTypeToMlirDenseElementType(ONNX_UINT16, builder);
+    auto elem = onnxElementTypeToMlirElementType(ONNX_UINT16, builder);
+    check(dense == elem, "dense(UINT16) == elem(UINT16) (both ui16)");
+  }
+
+  if (g_failures == 0) {
+    llvm::outs() << "All dtype-mapping checks passed.\n";
+    return 0;
+  }
+  llvm::errs() << g_failures << " dtype-mapping check(s) FAILED.\n";
+  return 1;
+}

--- a/test/unit/test_dtype_mapping.cpp
+++ b/test/unit/test_dtype_mapping.cpp
@@ -76,11 +76,12 @@ int main() {
           "dense(INT16) -> signless i16 (ResNet50-INT8 bias path unchanged)");
   }
 
-  // --- 8-bit integers keep the pre-existing signless-flatten behavior -------
+  // --- Unsigned 8-bit keeps its unsigned identity (ui8) too; signed INT8 still
+  // flattens to signless i8 ---------------------------------------------------
   {
     auto u8 = asInt(onnxElementTypeToMlirDenseElementType(ONNX_UINT8, builder));
-    check(u8 && u8.getWidth() == 8 && u8.isSignless(),
-          "dense(UINT8) -> signless i8 (unchanged)");
+    check(u8 && u8.getWidth() == 8 && u8.isUnsigned(),
+          "dense(UINT8) -> unsigned i8 (ui8)");
     auto i8 = asInt(onnxElementTypeToMlirDenseElementType(ONNX_INT8, builder));
     check(i8 && i8.getWidth() == 8 && i8.isSignless(),
           "dense(INT8) -> signless i8 (unchanged)");


### PR DESCRIPTION
## Problem
onnxElementTypeToMlirDenseElementType flattened every signed/unsigned integer to signless, so inline ONNX unsigned constants (UINT8, UINT16, ...) were imported as signless integers of the same width. The HipToLLVM QDQ dtype classifier needs to distinguish an unsigned type from the signed type of the same width; collapsing them makes the two indistinguishable, corrupting DequantizeLinear output.

## Fix
Preserve the unsigned identity of all inline dense unsigned integers (ui8, ui16, ...) so they keep their unsigned type through lowering, matching how external unsigned initializers are already imported (via the offset/size path that bypasses DenseElementsAttr).

## Test plan
- Added unit tests, test/unit/test_dtype_mapping.cpp.
- Re-validated the enabled models, all passing.