### PR TITLE
Support packed INT4/UINT4 weights

### DIFF
--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -40,6 +40,16 @@ namespace {
 
 constexpr llvm::StringLiteral kOrtMemoryAddressLocation = "*/_ORT_MEM_ADDR_/*";
 
+/// Classification of an 8-bit constant's backing byte size against its element
+/// count, returned by markPackedInt4Consumers so the caller can diagnose a
+/// genuine mismatch.
+enum class PackedInt4Result {
+  NotApplicable, ///< Not an 8-bit static constant, or byte size unknown.
+  Unpacked,      ///< Full-width storage (bytes == numElements): plain int8.
+  Packed,        ///< Half-width storage (bytes == ceil(numElements/2)): int4.
+  SizeMismatch   ///< 8-bit storage that is neither full nor packed: malformed.
+};
+
 /// Mark the DequantizeLinear consumers of a 4-bit-packed constant.
 ///
 /// ONNX INT4/UINT4 is imported as i8/ui8 at the logical element count, but its
@@ -54,19 +64,30 @@ constexpr llvm::StringLiteral kOrtMemoryAddressLocation = "*/_ORT_MEM_ADDR_/*";
 /// generic "mark all users" would tag ops that never unpack). ONNX guarantees
 /// zero_point.dtype == x.dtype, so tagging the dequant covers both its packed
 /// operands.
-static void markPackedInt4Consumers(mlir::Operation *constOp,
-                                    mlir::RankedTensorType tensorType,
-                                    int64_t packedBytes) {
+///
+/// Returns how the backing size compared to the element count so the caller can
+/// reject a size that is neither full nor packed (a malformed source that would
+/// otherwise silently lower as int8 over a wrong-length buffer).
+static PackedInt4Result
+markPackedInt4Consumers(mlir::Operation *constOp,
+                        mlir::RankedTensorType tensorType,
+                        int64_t packedBytes) {
   auto elemIntTy =
       mlir::dyn_cast<mlir::IntegerType>(tensorType.getElementType());
-  if (!elemIntTy || elemIntTy.getWidth() != 8 || !tensorType.hasStaticShape())
-    return;
+  if (!elemIntTy || elemIntTy.getWidth() != 8 || !tensorType.hasStaticShape() ||
+      packedBytes < 0)
+    return PackedInt4Result::NotApplicable;
   int64_t numel = tensorType.getNumElements();
-  // Packed iff the backing buffer is exactly the ceil(numel/2) nibble count --
-  // the same relation hip.constant's verifier accepts (an odd numel packs its
-  // last nibble into a padded byte). Anything else is genuine 8-bit storage.
-  if (numel <= 0 || packedBytes != (numel + 1) / 2)
-    return;
+  if (numel <= 0)
+    return PackedInt4Result::NotApplicable;
+  // Full-width storage is plain int8; leave it untouched. ceil(numel/2) is the
+  // packed nibble count -- the same relation hip.constant's verifier accepts
+  // (an odd numel packs its last nibble into a padded byte). Any other size is
+  // a malformed source.
+  if (packedBytes == numel)
+    return PackedInt4Result::Unpacked;
+  if (packedBytes != (numel + 1) / 2)
+    return PackedInt4Result::SizeMismatch;
   mlir::OpBuilder builder(constOp->getContext());
   for (mlir::Operation *user : constOp->getResult(0).getUsers()) {
     llvm::StringRef opName = user->getName().getStringRef();
@@ -77,6 +98,7 @@ static void markPackedInt4Consumers(mlir::Operation *constOp,
     if (isDq)
       user->setAttr("packed_int4", builder.getUnitAttr());
   }
+  return PackedInt4Result::Packed;
 }
 
 /// Lower every onnx.Constant to a policy-neutral hip.constant carrier.
@@ -151,7 +173,12 @@ static mlir::LogicalResult lowerOnnxConstants(mlir::func::FuncOp funcOp,
     // Mark 4-bit-packed constants before rewiring: markPackedInt4Consumers
     // walks constOp's users (the DequantizeLinear ops), which still reference
     // it here.
-    markPackedInt4Consumers(constOp, tensorType, packedBytes);
+    if (markPackedInt4Consumers(constOp, tensorType, packedBytes) ==
+        PackedInt4Result::SizeMismatch)
+      return constOp->emitError("8-bit external source byte size ")
+             << packedBytes << " matches neither the full element count "
+             << tensorType.getNumElements() << " nor the packed nibble count "
+             << (tensorType.getNumElements() + 1) / 2;
     constOp->getResult(0).replaceAllUsesWith(carrier.getResult());
     constOp->erase();
   }

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -42,18 +42,12 @@ constexpr llvm::StringLiteral kOrtMemoryAddressLocation = "*/_ORT_MEM_ADDR_/*";
 
 /// Mark the DequantizeLinear consumers of a 4-bit-packed constant.
 ///
-/// ONNX INT4/UINT4 has no MLIR element type, so 4-bit initializers are imported
-/// as i8/ui8 carrying the LOGICAL element count while the backing buffer holds
-/// only ceil(numel/2) packed bytes (two nibbles per byte, low nibble first). A
-/// consumer that trusts the i8 element type would read two bytes per logical
-/// element and run off the end of the packed buffer. The byte size is the only
-/// surviving signal, and it is authoritative here (the true backing size: the
-/// inline dense-attr length, or the external `size` attribute), so mark it at
-/// import rather than leaving each consumer to re-derive it. Stamp
-/// `packed_int4` on the consuming DequantizeLinear ops so their downstream
-/// lowering nibble-unpacks instead of over-reading. `packedBytes` is the true
-/// backing byte count. Only 8-bit-typed storage can hide a 4-bit value this
-/// way; wider element types never halve, so the size relation is unambiguous.
+/// ONNX INT4/UINT4 is imported as i8/ui8 at the logical element count, but its
+/// buffer holds only ceil(numel/2) packed bytes; a consumer trusting the i8
+/// element type over-reads. The halved byte size is the only surviving signal,
+/// so stamp `packed_int4` on the consuming DequantizeLinear ops here (where the
+/// backing size is known) to make their lowering nibble-unpack. `packedBytes`
+/// is that true backing byte count; only 8-bit storage can halve this way.
 static void markPackedInt4Consumers(mlir::Operation *constOp,
                                     mlir::RankedTensorType tensorType,
                                     int64_t packedBytes) {

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -45,9 +45,15 @@ constexpr llvm::StringLiteral kOrtMemoryAddressLocation = "*/_ORT_MEM_ADDR_/*";
 /// ONNX INT4/UINT4 is imported as i8/ui8 at the logical element count, but its
 /// buffer holds only ceil(numel/2) packed bytes; a consumer trusting the i8
 /// element type over-reads. The halved byte size is the only surviving signal,
-/// so stamp `packed_int4` on the consuming DequantizeLinear ops here (where the
-/// backing size is known) to make their lowering nibble-unpack. `packedBytes`
-/// is that true backing byte count; only 8-bit storage can halve this way.
+/// so stamp `packed_int4` here (where the backing size is known) to make the
+/// lowering nibble-unpack. `packedBytes` is that true backing byte count.
+///
+/// The marker is scoped to DequantizeLinear rather than every user because the
+/// dequant is the one op whose lowering reinterprets the packed storage; the
+/// packed operand does not otherwise reach an op that reads it directly (a
+/// generic "mark all users" would tag ops that never unpack). ONNX guarantees
+/// zero_point.dtype == x.dtype, so tagging the dequant covers both its packed
+/// operands.
 static void markPackedInt4Consumers(mlir::Operation *constOp,
                                     mlir::RankedTensorType tensorType,
                                     int64_t packedBytes) {
@@ -56,7 +62,10 @@ static void markPackedInt4Consumers(mlir::Operation *constOp,
   if (!elemIntTy || elemIntTy.getWidth() != 8 || !tensorType.hasStaticShape())
     return;
   int64_t numel = tensorType.getNumElements();
-  if (numel <= 0 || packedBytes <= 0 || packedBytes * 2 != numel)
+  // Packed iff the backing buffer is exactly the ceil(numel/2) nibble count --
+  // the same relation hip.constant's verifier accepts (an odd numel packs its
+  // last nibble into a padded byte). Anything else is genuine 8-bit storage.
+  if (numel <= 0 || packedBytes != (numel + 1) / 2)
     return;
   mlir::OpBuilder builder(constOp->getContext());
   for (mlir::Operation *user : constOp->getResult(0).getUsers()) {

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -40,6 +40,42 @@ namespace {
 
 constexpr llvm::StringLiteral kOrtMemoryAddressLocation = "*/_ORT_MEM_ADDR_/*";
 
+/// Mark the DequantizeLinear consumers of a 4-bit-packed constant.
+///
+/// ONNX INT4/UINT4 has no MLIR element type, so 4-bit initializers are imported
+/// as i8/ui8 carrying the LOGICAL element count while the backing buffer holds
+/// only ceil(numel/2) packed bytes (two nibbles per byte, low nibble first). A
+/// consumer that trusts the i8 element type would read two bytes per logical
+/// element and run off the end of the packed buffer. The byte size is the only
+/// surviving signal, and it is authoritative here (the true backing size: the
+/// inline dense-attr length, or the external `size` attribute), so mark it at
+/// import rather than leaving each consumer to re-derive it. Stamp
+/// `packed_int4` on the consuming DequantizeLinear ops so their downstream
+/// lowering nibble-unpacks instead of over-reading. `packedBytes` is the true
+/// backing byte count. Only 8-bit-typed storage can hide a 4-bit value this
+/// way; wider element types never halve, so the size relation is unambiguous.
+static void markPackedInt4Consumers(mlir::Operation *constOp,
+                                    mlir::RankedTensorType tensorType,
+                                    int64_t packedBytes) {
+  auto elemIntTy =
+      mlir::dyn_cast<mlir::IntegerType>(tensorType.getElementType());
+  if (!elemIntTy || elemIntTy.getWidth() != 8 || !tensorType.hasStaticShape())
+    return;
+  int64_t numel = tensorType.getNumElements();
+  if (numel <= 0 || packedBytes <= 0 || packedBytes * 2 != numel)
+    return;
+  mlir::OpBuilder builder(constOp->getContext());
+  for (mlir::Operation *user : constOp->getResult(0).getUsers()) {
+    llvm::StringRef opName = user->getName().getStringRef();
+    bool isDq = opName == "onnx.DequantizeLinear";
+    if (!isDq && opName == "onnx.Custom")
+      if (auto fn = user->getAttrOfType<mlir::StringAttr>("function_name"))
+        isDq = fn.getValue() == "DequantizeLinear";
+    if (isDq)
+      user->setAttr("packed_int4", builder.getUnitAttr());
+  }
+}
+
 /// Lower every onnx.Constant to a policy-neutral hip.constant carrier.
 ///
 /// Both conversion sweeps call this helper: the first handles imported
@@ -66,8 +102,15 @@ static mlir::LogicalResult lowerOnnxConstants(mlir::func::FuncOp funcOp,
     mlir::OpBuilder builder(constOp);
     auto orderAttr = builder.getI64IntegerAttr(nextOrder);
     mlir::hip::ConstantOp carrier;
+    // True backing byte count of the constant's data, used to detect 4-bit
+    // packing (packedBytes == numel/2). -1 until a branch sets it.
+    int64_t packedBytes = -1;
     if (auto valueAttr = mlir::dyn_cast_or_null<mlir::DenseElementsAttr>(
             constOp->getAttrOfType<mlir::ElementsAttr>("value"))) {
+      // Splat raw data is a single element, not the full buffer, so its length
+      // is not comparable to the logical element count -- skip it.
+      if (!valueAttr.isSplat())
+        packedBytes = static_cast<int64_t>(valueAttr.getRawData().size());
       carrier = mlir::hip::ConstantOp::create(builder, constOp->getLoc(),
                                               tensorType, valueAttr);
     } else if (auto location =
@@ -77,6 +120,7 @@ static mlir::LogicalResult lowerOnnxConstants(mlir::func::FuncOp funcOp,
       if (!offset || !size)
         return constOp->emitError(
             "onnx.Constant external source requires location/offset/size");
+      packedBytes = size.getInt();
       carrier = location.getValue() == kOrtMemoryAddressLocation
                     ? mlir::hip::ConstantOp::create(builder, constOp->getLoc(),
                                                     tensorType, offset, size)
@@ -101,6 +145,10 @@ static mlir::LogicalResult lowerOnnxConstants(mlir::func::FuncOp funcOp,
         if (auto outputName = mlir::dyn_cast<mlir::StringAttr>(outputs[0]))
           carrier.setSourceNameAttr(outputName);
     }
+    // Mark 4-bit-packed constants before rewiring: markPackedInt4Consumers
+    // walks constOp's users (the DequantizeLinear ops), which still reference
+    // it here.
+    markPackedInt4Consumers(constOp, tensorType, packedBytes);
     constOp->getResult(0).replaceAllUsesWith(carrier.getResult());
     constOp->erase();
   }

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -200,12 +200,8 @@ LogicalResult ConstantOp::verify() {
   int64_t size = getSizeAttr().getInt();
   if (size <= 0)
     return emitOpError("external source `size` must be positive");
-  // ONNX INT4/UINT4 has no MLIR element type, so 4-bit initializers are
-  // imported as an i8/ui8 tensor of the LOGICAL element count while the backing
-  // buffer holds only ceil(numElements/2) packed bytes (two nibbles per byte).
-  // Accept that half-size external source for 8-bit integer results; the
-  // packing is recovered downstream (a `packed_int4` marker on the consuming
-  // ops). Any other size is a genuine mismatch.
+  // ONNX INT4/UINT4 imports as i8/ui8 at the logical element count, but its
+  // buffer is ceil(numElements/2) packed bytes; accept that half-size source.
   int64_t packedBytes = (numElements + 1) / 2;
   bool isPacked4Bit = elementBits == 8 && size == packedBytes;
   if (size != expectedBytes && !isPacked4Bit)

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -200,7 +200,15 @@ LogicalResult ConstantOp::verify() {
   int64_t size = getSizeAttr().getInt();
   if (size <= 0)
     return emitOpError("external source `size` must be positive");
-  if (size != expectedBytes)
+  // ONNX INT4/UINT4 has no MLIR element type, so 4-bit initializers are
+  // imported as an i8/ui8 tensor of the LOGICAL element count while the backing
+  // buffer holds only ceil(numElements/2) packed bytes (two nibbles per byte).
+  // Accept that half-size external source for 8-bit integer results; the
+  // packing is recovered downstream (a `packed_int4` marker on the consuming
+  // ops). Any other size is a genuine mismatch.
+  int64_t packedBytes = (numElements + 1) / 2;
+  bool isPacked4Bit = elementBits == 8 && size == packedBytes;
+  if (size != expectedBytes && !isPacked4Bit)
     return emitOpError("external source byte size ")
            << size << " does not match result byte size " << expectedBytes;
 

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -200,8 +200,9 @@ LogicalResult ConstantOp::verify() {
   int64_t size = getSizeAttr().getInt();
   if (size <= 0)
     return emitOpError("external source `size` must be positive");
-  // ONNX INT4/UINT4 imports as i8/ui8 at the logical element count, but its
-  // buffer is ceil(numElements/2) packed bytes; accept that half-size source.
+  // A 4-bit initializer with no MLIR element type is carried as an 8-bit result
+  // of the logical element count while its buffer holds only ceil(n/2) packed
+  // bytes (two values per byte); accept that half-size external source.
   int64_t packedBytes = (numElements + 1) / 2;
   bool isPacked4Bit = elementBits == 8 && size == packedBytes;
   if (size != expectedBytes && !isPacked4Bit)

--- a/lib/Dialect/Transforms/ExternalizeConstants.cpp
+++ b/lib/Dialect/Transforms/ExternalizeConstants.cpp
@@ -351,6 +351,21 @@ private:
       return failure();
     plan.size = *size;
 
+    // ONNX INT4/UINT4 has no MLIR element type, so 4-bit initializers are
+    // imported as an i8/ui8 tensor of the LOGICAL element count while the
+    // backing buffer holds only ceil(numElements/2) packed bytes. For such an
+    // external source the op's `size` attribute is that true (half) packed byte
+    // count -- honor it so the file read and storage layout use the real size
+    // rather than the logical `checkedByteSize`. The consuming ops carry a
+    // `packed_int4` marker so downstream lowering unpacks the nibbles.
+    if (plan.source != SourceKind::Inline)
+      if (auto sizeAttr = op.getSizeAttr()) {
+        int64_t declared = sizeAttr.getInt();
+        int64_t packedBytes = (plan.numElements + 1) / 2;
+        if (plan.type.getElementTypeBitWidth() == 8 && declared == packedBytes)
+          plan.size = declared;
+      }
+
     if (plan.source == SourceKind::Inline) {
       if (failed(planInlineSource(plan)))
         return failure();

--- a/lib/Dialect/Transforms/ExternalizeConstants.cpp
+++ b/lib/Dialect/Transforms/ExternalizeConstants.cpp
@@ -351,13 +351,9 @@ private:
       return failure();
     plan.size = *size;
 
-    // ONNX INT4/UINT4 has no MLIR element type, so 4-bit initializers are
-    // imported as an i8/ui8 tensor of the LOGICAL element count while the
-    // backing buffer holds only ceil(numElements/2) packed bytes. For such an
-    // external source the op's `size` attribute is that true (half) packed byte
-    // count -- honor it so the file read and storage layout use the real size
-    // rather than the logical `checkedByteSize`. The consuming ops carry a
-    // `packed_int4` marker so downstream lowering unpacks the nibbles.
+    // A packed INT4/UINT4 source is an i8 tensor whose buffer is only
+    // ceil(numElements/2) bytes; its `size` attr already holds that packed
+    // count, so honor it rather than the logical `checkedByteSize`.
     if (plan.source != SourceKind::Inline)
       if (auto sizeAttr = op.getSizeAttr()) {
         int64_t declared = sizeAttr.getInt();

--- a/test/lit/Conversion/onnx-to-hip/test_constant_packed_int4.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_constant_packed_int4.mlir
@@ -21,7 +21,7 @@
 // RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
 
 module {
-  func.func @main_graph() -> (tensor<8xf32>, tensor<8xf32>) {
+  func.func @main_graph() -> (tensor<8xf32>, tensor<8xf32>, tensor<7xf32>) {
     // Packed INT4 weight: i8 tensor of 8 LOGICAL elements backed by 4 bytes
     // (external size = 4 = ceil(8/2)) -> hip.constant accepts it; DQ is marked.
     %w4 = "onnx.Constant"() {location = "weights.bin", offset = 0 : i64,
@@ -45,7 +45,19 @@ module {
       onnx_node_name = "DQ_int8"
     } : (tensor<8xi8>, tensor<f32>, tensor<i8>) -> tensor<8xf32>
 
-    return %dq4, %dq8 : tensor<8xf32>, tensor<8xf32>
+    // Odd-count packed INT4 weight: 7 LOGICAL elements backed by 4 bytes
+    // (size = 4 = ceil(7/2); the last byte's high nibble is padding) -> still
+    // packed, so it must be accepted and marked.
+    %w4o = "onnx.Constant"() {location = "weights.bin", offset = 24 : i64,
+                              size = 4 : i64} : () -> tensor<7xi8>
+    %z4o = "onnx.Constant"() {location = "weights.bin", offset = 28 : i64,
+                              size = 1 : i64} : () -> tensor<1xi8>
+    %dq4o = "onnx.Custom"(%w4o, %s4, %z4o) {
+      function_name = "DequantizeLinear", domain_name = "com.microsoft",
+      onnx_node_name = "DQ_int4_odd"
+    } : (tensor<7xi8>, tensor<f32>, tensor<1xi8>) -> tensor<7xf32>
+
+    return %dq4, %dq8, %dq4o : tensor<8xf32>, tensor<8xf32>, tensor<7xf32>
   }
   "onnx.EntryPoint"() {func = @main_graph} : () -> ()
 }
@@ -65,3 +77,9 @@ module {
 // CHECK: onnx.Custom
 // CHECK-NOT: packed_int4
 // CHECK-SAME: onnx_node_name = "DQ_int8"
+
+// The odd-count (7-element, size 4 = ceil(7/2)) packed weight is also accepted
+// and marked -- odd logical counts pack their last nibble into a padded byte.
+// CHECK: onnx.Custom
+// CHECK-SAME: onnx_node_name = "DQ_int4_odd"
+// CHECK-SAME: packed_int4

--- a/test/lit/Conversion/onnx-to-hip/test_constant_packed_int4.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_constant_packed_int4.mlir
@@ -1,0 +1,67 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// Test: 4-bit-packed (INT4/UINT4) constant support + DequantizeLinear marking.
+//
+// ONNX INT4/UINT4 has no MLIR element type, so 4-bit initializers are imported
+// as an i8/ui8 tensor of the LOGICAL element count while the backing buffer is
+// only ceil(numel/2) packed bytes (two nibbles/byte). Two things must happen:
+//   1. The hip.constant carrier must ACCEPT the half-size external source
+//      (size == ceil(numel/2)) for an 8-bit result -- the verifier otherwise
+//      rejects "size does not match result byte size" and int4 models never
+//      compile.
+//   2. lowerOnnxConstants stamps `packed_int4` on the consuming DequantizeLinear
+//      so downstream lowering nibble-unpacks instead of over-reading the packed
+//      buffer as full-width i8.
+//
+// A real (size == numel) int8 weight is NOT packed and must NOT be marked.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+
+module {
+  func.func @main_graph() -> (tensor<8xf32>, tensor<8xf32>) {
+    // Packed INT4 weight: i8 tensor of 8 LOGICAL elements backed by 4 bytes
+    // (external size = 4 = ceil(8/2)) -> hip.constant accepts it; DQ is marked.
+    %w4 = "onnx.Constant"() {location = "weights.bin", offset = 0 : i64,
+                             size = 4 : i64} : () -> tensor<8xi8>
+    %s4 = "onnx.Constant"() {value = dense<0.02> : tensor<f32>} : () -> tensor<f32>
+    %z4 = "onnx.Constant"() {location = "weights.bin", offset = 4 : i64,
+                             size = 1 : i64} : () -> tensor<1xi8>
+    %dq4 = "onnx.Custom"(%w4, %s4, %z4) {
+      function_name = "DequantizeLinear", domain_name = "com.microsoft",
+      onnx_node_name = "DQ_int4"
+    } : (tensor<8xi8>, tensor<f32>, tensor<1xi8>) -> tensor<8xf32>
+
+    // Real INT8 weight: i8 tensor of 8 elements backed by 8 bytes
+    // (size == numel) -> not 4-bit; its DequantizeLinear must NOT be marked.
+    %w8 = "onnx.Constant"() {location = "weights.bin", offset = 16 : i64,
+                             size = 8 : i64} : () -> tensor<8xi8>
+    %s8 = "onnx.Constant"() {value = dense<0.02> : tensor<f32>} : () -> tensor<f32>
+    %z8 = "onnx.Constant"() {value = dense<0> : tensor<i8>} : () -> tensor<i8>
+    %dq8 = "onnx.Custom"(%w8, %s8, %z8) {
+      function_name = "DequantizeLinear", domain_name = "com.microsoft",
+      onnx_node_name = "DQ_int8"
+    } : (tensor<8xi8>, tensor<f32>, tensor<i8>) -> tensor<8xf32>
+
+    return %dq4, %dq8 : tensor<8xf32>, tensor<8xf32>
+  }
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}
+
+// The packed-int4 weight lowers to a hip.constant with the half-size external
+// source (size = 4 for 8 logical i8 elements) -- previously rejected.
+// CHECK: hip.constant
+// CHECK-SAME: size = 4 : i64
+
+// Its DequantizeLinear carries packed_int4; the real int8 one does not.
+// (DequantizeLinear is plugin-handled, so it survives convert-onnx-to-hip and
+// the marker rides on the surviving onnx.Custom op.)
+// CHECK: onnx.Custom
+// CHECK-SAME: onnx_node_name = "DQ_int4"
+// CHECK-SAME: packed_int4
+
+// CHECK: onnx.Custom
+// CHECK-NOT: packed_int4
+// CHECK-SAME: onnx_node_name = "DQ_int8"

--- a/test/lit/Conversion/onnx-to-hip/test_constant_packed_int4_invalid.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_constant_packed_int4_invalid.mlir
@@ -1,0 +1,30 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+//
+//===----------------------------------------------------------------------===//
+// An 8-bit external constant whose backing byte size is neither the full
+// element count nor the packed ceil(numel/2) nibble count is malformed: it
+// would otherwise lower silently as int8 over a wrong-length buffer. The
+// constant lowering rejects it at the marking site.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip \
+// RUN:   --split-input-file --verify-diagnostics %s
+
+module {
+  func.func @main_graph() -> tensor<8xf32> {
+    // 8 logical i8 elements, but size = 5 (neither 8 full nor 4 packed).
+    // expected-error @+1 {{8-bit external source byte size 5 matches neither the full element count 8 nor the packed nibble count 4}}
+    %w = "onnx.Constant"() {location = "weights.bin", offset = 0 : i64,
+                            size = 5 : i64} : () -> tensor<8xi8>
+    %s = "onnx.Constant"() {value = dense<0.02> : tensor<f32>} : () -> tensor<f32>
+    %z = "onnx.Constant"() {location = "weights.bin", offset = 5 : i64,
+                            size = 1 : i64} : () -> tensor<1xi8>
+    %dq = "onnx.Custom"(%w, %s, %z) {
+      function_name = "DequantizeLinear", domain_name = "com.microsoft",
+      onnx_node_name = "DQ_bad"
+    } : (tensor<8xi8>, tensor<f32>, tensor<1xi8>) -> tensor<8xf32>
+    return %dq : tensor<8xf32>
+  }
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}


### PR DESCRIPTION
## Summary
Models with **4-bit (INT4/UINT4) weights** currently fail to compile. ONNX INT4/UINT4 has no MLIR element type, so 4-bit initializers are imported as an **i8/ui8 tensor of the LOGICAL element count** while the backing buffer holds only `ceil(numel/2)` **packed bytes**. Verified on a real model: the qkv_proj weight arrives as `tensor<9216x3072x1x1xi8>` .

**Three changes across constant handling:**

1. **`hip.constant` verifier**: It also accepts `size == ceil(numElements/2)` for an 8-bit-integer result. Every other size is still a genuine mismatch.

2. **`hip-externalize-constants`** (`lib/Dialect/Transforms/ExternalizeConstants.cpp`) derived the storage/read size from the logical element count, so it would size the buffer and read the file at twice the packed length.

3. **`convert-onnx-to-hip`** (`lib/Conversion/OnnxToHip/OnnxToHip.cpp`) now stamps a `packed_int4` unit attribute on the `DequantizeLinear` ops that consume such a constant (detected by `size == ceil(numel/2)` on an 8-bit operand), so their downstream lowering nibble-unpacks instead of reading the packed buffer as full-width i8 (an out-of-bounds device read). Covers both inline and external constant paths; splat inline data is skipped.

## Test plan
- [x] LIT: `test/lit/Conversion/onnx-to-hip/test_constant_packed_int4.mlir`.
- [x] Mock build (`build.py --mock`) is clean.