### PR TITLE
feat(ep): forward AMDGPU Hip provider options under the shared EP name

### DIFF
--- a/.github/workflows/windows-deps.yml
+++ b/.github/workflows/windows-deps.yml
@@ -34,6 +34,10 @@ env:
   OGA_PR_PATCHES: "2194"
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
   AMDGPU_EP_REF: "05eaa2a938f71e98b49bd1be3fb03720167be5cc"
+  # Space-separated onnxruntime/onnxruntime-ep-amdgpu PR numbers applied on top
+  # of AMDGPU_EP_REF. 105: forward unknown / Hip-owned provider options through
+  # the AMDGPU umbrella into the Hip backend under the shared ep.<amdgpu>.* prefix.
+  AMDGPU_PR_PATCHES: "105"
 
 jobs:
   llvm:
@@ -289,7 +293,7 @@ jobs:
         run: |
           DEPS_HASH=$(git rev-parse --short=12 HEAD:cmake/deps.txt)
           EP_REF="${{ env.AMDGPU_EP_REF }}"
-          echo "value=windows-amdgpu-${EP_REF:0:7}-deps${DEPS_HASH}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}" >> "$GITHUB_OUTPUT"
+          echo "value=windows-amdgpu-${EP_REF:0:7}-amdpr${{ env.AMDGPU_PR_PATCHES }}-deps${DEPS_HASH}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}" >> "$GITHUB_OUTPUT"
 
       - name: Probe amdgpu-artifacts
         id: cache-amdgpu
@@ -342,6 +346,31 @@ jobs:
           path: source-amdgpu
           fetch-depth: 1
           show-progress: false
+
+      - name: Apply amdgpu-ep PR patches
+        if: steps.cache-amdgpu.outputs.cache-hit != 'true'
+        shell: pwsh
+        working-directory: ${{ github.workspace }}\source-amdgpu
+        env:
+          AMDGPU_PRS: ${{ env.AMDGPU_PR_PATCHES }}
+        run: |
+          $prs = $env:AMDGPU_PRS.Trim()
+          if (-not $prs) {
+            Write-Host "AMDGPU_PR_PATCHES is empty; nothing to apply"
+            exit 0
+          }
+          foreach ($pr in $prs -split '\s+') {
+            if (-not $pr) { continue }
+            $url = "https://github.com/onnxruntime/onnxruntime-ep-amdgpu/pull/$pr.patch"
+            $tmp = Join-Path $env:RUNNER_TEMP "amdgpu-pr-$pr.patch"
+            Write-Host "Fetching $url"
+            Invoke-WebRequest -Uri $url -OutFile $tmp -UseBasicParsing
+            Write-Host "Applying PR #$pr"
+            git apply --whitespace=nowarn $tmp
+            if ($LASTEXITCODE -ne 0) {
+              throw "PR #$pr failed to apply (exit $LASTEXITCODE)"
+            }
+          }
 
       - name: Fetch MIGraphX + TheRock SDKs
         if: steps.cache-amdgpu.outputs.cache-hit != 'true'

--- a/.github/workflows/windows-deps.yml
+++ b/.github/workflows/windows-deps.yml
@@ -35,9 +35,9 @@ env:
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
   AMDGPU_EP_REF: "05eaa2a938f71e98b49bd1be3fb03720167be5cc"
   # Space-separated onnxruntime/onnxruntime-ep-amdgpu PR numbers applied on top
-  # of AMDGPU_EP_REF. 105: forward unknown / Hip-owned provider options through
-  # the AMDGPU umbrella into the Hip backend under the shared ep.<amdgpu>.* prefix.
-  AMDGPU_PR_PATCHES: "105"
+  # of AMDGPU_EP_REF. 102: forward Hip custom-op domains; 105: forward unknown /
+  # Hip-owned provider options under the shared ep.<amdgpu>.* prefix.
+  AMDGPU_PR_PATCHES: "102 105"
 
 jobs:
   llvm:
@@ -293,7 +293,9 @@ jobs:
         run: |
           DEPS_HASH=$(git rev-parse --short=12 HEAD:cmake/deps.txt)
           EP_REF="${{ env.AMDGPU_EP_REF }}"
-          echo "value=windows-amdgpu-${EP_REF:0:7}-amdpr${{ env.AMDGPU_PR_PATCHES }}-deps${DEPS_HASH}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}" >> "$GITHUB_OUTPUT"
+          AMDPR_KEY="${{ env.AMDGPU_PR_PATCHES }}"
+          AMDPR_KEY="${AMDPR_KEY// /-}"
+          echo "value=windows-amdgpu-${EP_REF:0:7}-amdpr${AMDPR_KEY}-deps${DEPS_HASH}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}" >> "$GITHUB_OUTPUT"
 
       - name: Probe amdgpu-artifacts
         id: cache-amdgpu

--- a/.github/workflows/windows-gpu-test.yml
+++ b/.github/workflows/windows-gpu-test.yml
@@ -141,10 +141,9 @@ jobs:
       # ----------------------------------------------------------------------
       # AMD GPU umbrella NATIVE smoke test: same NATIVE compile/link/load path,
       # but driven through the amdgpu-ep umbrella instead of the hipgpu EP
-      # directly. profile=hip (an umbrella option, ep.amdgpuexecutionprovider.
-      # prefix) selects the hipgpu backend; the umbrella forwards non-umbrella
-      # session-config entries verbatim, so artifact_format is passed as a raw
-      # ep.hipgpu.* entry to reach the backend. Real gate (no exit /b 0).
+      # directly. profile=hip selects the hipgpu backend; artifact_format=NATIVE
+      # is a Hip-owned option forwarded under the shared ep.<amdgpu>.* prefix
+      # (requires amdgpu-ep PR 105 / AMDGPU_PR_PATCHES). Real gate (no exit /b 0).
       # ----------------------------------------------------------------------
       - name: Run AMD GPU umbrella native smoke test (GPU)
         if: always()
@@ -170,9 +169,8 @@ jobs:
           onnxruntime_perf_test.exe ^
             --plugin_ep_libs "AMDGPUExecutionProvider|amdgpu-ep.dll" ^
             --plugin_eps "AMDGPUExecutionProvider" ^
-            --plugin_ep_options "profile|hip" ^
+            --plugin_ep_options "profile|hip artifact_format|NATIVE" ^
             -C "session.disable_cpu_ep_fallback|1" ^
-            -C "ep.hipgpu.artifact_format|NATIVE" ^
             -r 1 -c 1 -s ^
             "%SMOKE_MODEL%" > "..\results-amdgpu-native\smoke.txt" 2>&1
           set RC=%ERRORLEVEL%

--- a/.github/workflows/windows-gpu-test.yml
+++ b/.github/workflows/windows-gpu-test.yml
@@ -143,7 +143,7 @@ jobs:
       # but driven through the amdgpu-ep umbrella instead of the hipgpu EP
       # directly. profile=hip selects the hipgpu backend; artifact_format=NATIVE
       # is a Hip-owned option forwarded under the shared ep.<amdgpu>.* prefix
-      # (requires amdgpu-ep PR 105 / AMDGPU_PR_PATCHES). Real gate (no exit /b 0).
+      # (amdgpu-ep PR 102/105 via AMDGPU_PR_PATCHES). Real gate (no exit /b 0).
       # ----------------------------------------------------------------------
       - name: Run AMD GPU umbrella native smoke test (GPU)
         if: always()

--- a/morphizen/morphizen-core/src/pass_context_imp.cpp
+++ b/morphizen/morphizen-core/src/pass_context_imp.cpp
@@ -1054,7 +1054,7 @@ void PassContextImp::print_version_info(const char *prefix) {
     }
   }
   for (auto &kv : session_configs_) {
-    LOG_VERBOSE(3) << "session_config: " << kv.first << " = " << kv.second;
+    LOG_VERBOSE(1) << "session_config: " << kv.first << " = " << kv.second;
   }
   auto all_po = get_all_provider_options();
   for (auto &kv : all_po) {

--- a/morphizen/ort-bridge/src/morphizen-ep.cpp
+++ b/morphizen/ort-bridge/src/morphizen-ep.cpp
@@ -12,6 +12,8 @@
 #include "morphizen/morphizen-ort-api-ext.hpp"
 #include "morphizen/morphizen.hpp"
 #include "morphizen/onnxruntime_morphizen_ep.hpp"
+#include <algorithm>
+#include <cctype>
 #include <google/protobuf/util/json_util.h>
 #include <set>
 
@@ -110,8 +112,10 @@ void MorphiZenEP::update_provider_options_from_session_config(
 
     MY_LOG(2) << "Processing " << num_keys << " config entries";
 
-    const std::string morphizen_ep_prefix =
-        "ep." MORPHIZEN_EP_REGISTRATION_NAME_LOWER ".";
+    std::string name_lower = name_;
+    std::transform(name_lower.begin(), name_lower.end(), name_lower.begin(),
+                   ::tolower);
+    const std::string morphizen_ep_prefix = "ep." + name_lower + ".";
     for (size_t i = 0; i < num_keys; ++i) {
       if (keys[i] != nullptr && values[i] != nullptr) {
         std::string key_str(keys[i]);


### PR DESCRIPTION
## Summary
- Strip `ep.<runtime_ep_name>.*` session-config entries into provider options using the EP instance name (not only `MORPHIZEN_EP_REGISTRATION_NAME_LOWER`), so Hip receives keys forwarded by the AMDGPU umbrella.
- Keep Windows CI on release pin `AMDGPU_EP_REF=05eaa2a` and apply `AMDGPU_PR_PATCHES: "102 105"` on top (same patch-on-pin pattern as #889). Cache key normalizes spaces to `-` (`-amdpr102-105-`).
- Drive the AMDGPU NATIVE smoke test with `--plugin_ep_options "profile|hip artifact_format|NATIVE"` instead of a separate `ep.hipgpu.*` session-config entry.
- Raise session-config dump verbosity to `LOG_VERBOSE(1)` to make passthrough easier to verify.

## Why
Users set Hip options via one `AppendExecutionProvider_V2` map on AMDGPU (`profile=hip`, `artifact_format=...`, etc.). Upstream patches:

- [onnxruntime-ep-amdgpu#102](https://github.com/onnxruntime/onnxruntime-ep-amdgpu/pull/102): forward Hip custom-op domains so `com.amd` schemas register at `Model::Load`
- [onnxruntime-ep-amdgpu#105](https://github.com/onnxruntime/onnxruntime-ep-amdgpu/pull/105): ignore unknown umbrella keys and forward `ep.<amdgpu>.*` (except `profile`) into Hip

Hip-ep must strip that shared instance-name prefix into provider options. Pinning stays on `gpuep-rel-2610.2` (`05eaa2a`) so `USE_HIP` / `MIGRAPHX_EP_PROBLEM_CACHE` behavior from the release branch is preserved; moving the pin to main would require `USE_HIP=ON` and loses problem-cache install (see #889 notes).

## Related
- Mechanism: #889
- Upstream: onnxruntime/onnxruntime-ep-amdgpu#102, #105
- Pin: `05eaa2a938f71e98b49bd1be3fb03720167be5cc`

## Test plan
- [ ] CI `prebuild / amdgpu` applies `102` then `105` on `05eaa2a` (cold cache via `-amdpr102-105-`)
- [ ] Downstream `build_real` / `gpu_test` green
- [ ] AMDGPU NATIVE smoke (`profile|hip artifact_format|NATIVE`) creates without `Unknown provider option`
- [ ] Hip logs / provider options show forwarded keys under the shared `ep.<amdgpu>.*` prefix

## Checklist
- [x] Change is focused (EP session-config prefix + CI patches / smoke options)
- [ ] Downstream CI green
- [x] AI assistance disclosed

AI assistance: workflow updates and PR description drafted with Cursor; diffs reviewed by the author.
