### PR TITLE
fix(onnx): fold ConstantOfShape to scalar fill for Min consumers

### DIFF
--- a/lib/Conversion/OnnxToHip/ConstantOfShapeConversion.cpp
+++ b/lib/Conversion/OnnxToHip/ConstantOfShapeConversion.cpp
@@ -29,7 +29,8 @@ namespace {
 //
 //   1. ConstantOfShapeAsScalar (benefit=3): when the result is only consumed
 //      by ops that already broadcast a scalar input across the result shape
-//      (today: `onnx.Where`), replace the op with a rank-0 fill-value buffer.
+//      (today: `onnx.Where`, `onnx.Min`), replace the op with a rank-0
+//      fill-value buffer.
 //      The consumer broadcasts the scalar at no extra memory cost (stride==0
 //      along every output axis in the runtime kernel), avoiding the
 //      `tensor.splat` -> `linalg.map` -> `scf.for` bufferization chain that
@@ -222,16 +223,18 @@ struct ConstantOfShapeAsScalar : public mlir::RewritePattern {
       return rewriter.notifyMatchFailure(op, "expected 1 result");
     mlir::Value result = op->getResult(0);
 
-    // Only fold when every consumer is `onnx.Where`.  Future broadcasts
-    // (Mul / Add / ...) can be added incrementally as their lowerings are
-    // verified to handle a rank-0 operand.
+    // Only fold when every consumer broadcasts a scalar operand across the
+    // result shape.  Future broadcasts (Mul / Add / ...) can be added
+    // incrementally as their lowerings are verified to handle a rank-0
+    // operand.
     if (result.use_empty())
       return rewriter.notifyMatchFailure(op, "dead op, leave to DCE");
     for (auto &use : result.getUses()) {
-      if (use.getOwner()->getName().getStringRef() != "onnx.Where")
+      llvm::StringRef consumerName = use.getOwner()->getName().getStringRef();
+      if (consumerName != "onnx.Where" && consumerName != "onnx.Min")
         return rewriter.notifyMatchFailure(
-            op, "consumer is not onnx.Where; scalar broadcast not yet "
-                "supported for this consumer");
+            op, "consumer is not onnx.Where or onnx.Min; scalar broadcast "
+                "not yet supported for this consumer");
     }
 
     auto resultType = mlir::dyn_cast<mlir::RankedTensorType>(result.getType());

--- a/test/lit/Conversion/onnx-to-hip/test_constant_of_shape.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_constant_of_shape.mlir
@@ -4,7 +4,7 @@
 // Verify the three ONNX ConstantOfShape lowering paths:
 //
 //   1. ConstantOfShapeAsScalar (highest benefit): result is consumed only by
-//      ops that broadcast a scalar (today onnx.Where) -> a rank-0 fill-value
+//      ops that broadcast a scalar (today onnx.Where, onnx.Min) -> a rank-0 fill-value
 //      buffer (tensor.empty + linalg.fill), elide the full-size buffer.
 //   2. ConstantOfShapeFold: shape input is a compile-time constant AND result
 //      type is fully static -> single splat arith.constant; no runtime work.
@@ -126,6 +126,25 @@ module {
     // CHECK-NOT: onnx.ConstantOfShape
     // CHECK-NOT: tensor.splat
     // CHECK-DAG: %[[V:.*]] = arith.constant -100 : i64
+    // CHECK-DAG: %[[E:.*]] = tensor.empty() : tensor<i64>
+    // CHECK: linalg.fill ins(%[[V]] : i64) outs(%[[E]] : tensor<i64>) -> tensor<i64>
+
+    return %o : tensor<?x?xi64>
+  }
+
+  // Test 7: ConstantOfShapeAsScalar with onnx.Min -- same rank-0 fill path as
+  // Where; Min broadcasts the scalar across the other operand's shape.
+  func.func @test_constant_of_shape_as_scalar_min(
+      %a: tensor<?x?xi64>, %shape: tensor<2xi64>) -> tensor<?x?xi64> {
+    // CHECK-LABEL: func.func @test_constant_of_shape_as_scalar_min
+    %c = "onnx.ConstantOfShape"(%shape) {
+      value = dense<15> : tensor<1xi64>
+    } : (tensor<2xi64>) -> tensor<?x?xi64>
+    %o = "onnx.Min"(%a, %c) : (tensor<?x?xi64>, tensor<?x?xi64>) -> tensor<?x?xi64>
+
+    // CHECK-NOT: onnx.ConstantOfShape
+    // CHECK-NOT: tensor.splat
+    // CHECK-DAG: %[[V:.*]] = arith.constant 15 : i64
     // CHECK-DAG: %[[E:.*]] = tensor.empty() : tensor<i64>
     // CHECK: linalg.fill ins(%[[V]] : i64) outs(%[[E]] : tensor<i64>) -> tensor<i64>
 


### PR DESCRIPTION
When ConstantOfShape feeds onnx.Min with a dynamic result type, avoid tensor.splat bufferization that emits host memref.store loops into GPU pool memory. Reuse the rank-0 linalg.fill path already used for Where.

