### PR TITLE
feat(hipsr): lower shape regions with upstream shape passes

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/HipsrOps.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrOps.h
@@ -60,6 +60,22 @@ bool isHipsrDestinationOperand(::mlir::OpOperand &use);
 //          getResultForDestination(%d) -> %r
 ::mlir::OpResult getResultForDestination(::mlir::OpOperand &use);
 
+// Example: getExtentTensorTypeForRank(ctx, 2) -> tensor<2xindex>
+::mlir::RankedTensorType getExtentTensorTypeForRank(::mlir::MLIRContext *ctx,
+                                                    int64_t rank);
+
+// Takes a ranked data tensor, not a shape or a buffer.
+//
+// Example: %d : tensor<?x4xf16> -> tensor<2xindex>
+::mlir::RankedTensorType getExtentTensorTypeOf(::mlir::Value data);
+
+// Broadcasting left-pads, so the result is as long as the longest input. Every
+// input must state its extent count.
+//
+// Example: {tensor<3xindex>, tensor<1xindex>} -> tensor<3xindex>
+::mlir::RankedTensorType
+getBroadcastExtentTensorType(::mlir::ValueRange shapes);
+
 } // namespace hipsr
 } // namespace mlir
 

--- a/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
@@ -36,8 +36,9 @@ def Hipsr_PlaceholderOp : Hipsr_Op<
     constants, are outside the rule.
 
     The optional `shape_region` computes the result shapes and ends with
-    `hipsr.shape_yield`. A `normal` region takes one `!shape.shape` per input
-    and omits `ctx`; a `barrier` region takes `ctx` followed by its inputs.
+    `hipsr.shape_yield`. A `normal` region omits `ctx` and takes one extent
+    tensor per input, with one extent per input dimension; a `barrier` region
+    takes `ctx` followed by its inputs.
 
     All results must fill `outs` slots of one op, one slot each, and may also
     feed other placeholders or leave a pool domain through

--- a/include/hip/Dialect/Hipsr/IR/HipsrPreserveShapeOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrPreserveShapeOp.td
@@ -21,22 +21,26 @@ def Hipsr_PreserveShapeOp : Hipsr_Op<"preserve_shape",
     memory, produce results, or generate code.
 
     ```mlir
-    %shape = scf.execute_region -> !shape.shape { ... }
+    %shape = scf.execute_region -> tensor<2xindex> { ... }
     %d0 = ...
     %init = tensor.empty(%d0) : tensor<?x2048xf16>
-    hipsr.preserve_shape %shape, %init : tensor<?x2048xf16>
+    hipsr.preserve_shape %shape, %init : tensor<2xindex>, tensor<?x2048xf16>
     ```
 
     ```mlir
     %alloc = memref.alloc(%d0) : memref<?x2048xf16>
-    hipsr.preserve_shape %shape, %alloc : memref<?x2048xf16>
+    hipsr.preserve_shape %shape, %alloc : tensor<2xindex>, memref<?x2048xf16>
     ```
 
-    `$shape` has the same rank as `$data`.
+    `$shape` holds one extent per dimension of `$data`.
   }];
 
-  let arguments = (ins Shape_ShapeType:$shape, Hipsr_TensorOrMemRef:$data);
+  let arguments = (ins Shape_ExtentTensorType:$shape,
+                       Hipsr_TensorOrMemRef:$data);
   let results = (outs);
 
-  let assemblyFormat = "$shape `,` $data attr-dict `:` type($data)";
+  let assemblyFormat =
+      "$shape `,` $data attr-dict `:` type($shape) `,` type($data)";
+
+  let hasVerifier = 1;
 }

--- a/include/hip/Dialect/Hipsr/IR/HipsrShapeRegionPopulationUtils.h
+++ b/include/hip/Dialect/Hipsr/IR/HipsrShapeRegionPopulationUtils.h
@@ -8,8 +8,11 @@
 
 #include "hip/Dialect/Hipsr/IR/HipsrOps.h"
 
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Block.h"
 #include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Value.h"
 
 #include "llvm/ADT/StringRef.h"
@@ -35,6 +38,25 @@ inline Block &createPlaceholderShapeBlock(OpBuilder &builder,
   return block;
 }
 
+/// Example:
+///   createExtentTensor(b, loc, {%d0, %d1}) -> tensor<2xindex>
+///   createExtentTensor(b, loc, {})         -> tensor<0xindex>
+inline Value createExtentTensor(OpBuilder &builder, Location loc,
+                                ValueRange extents) {
+  RankedTensorType extentTensorType = getExtentTensorTypeForRank(
+      builder.getContext(), static_cast<int64_t>(extents.size()));
+
+  // tensor.from_elements needs at least one element, so a rank-0 shape comes
+  // from a constant instead.
+  if (extents.empty()) {
+    return arith::ConstantOp::create(
+        builder, loc,
+        DenseElementsAttr::get(extentTensorType, ArrayRef<Attribute>{}));
+  }
+  return tensor::FromElementsOp::create(builder, loc, extentTensorType,
+                                        extents);
+}
+
 /// Accesses block arguments of a placeholder-owned shape region.
 /// Missing arguments are fatal because createPlaceholderShapeBlock adds one per
 /// entry in `getShapeRegionArgumentTypes`.
@@ -53,6 +75,13 @@ struct PlaceholderShapeRegionArgs {
   }
 
   Value in(unsigned i) const { return arg(numCtxArgs() + i); }
+
+  /// Returns true when `in` yields data values rather than their shapes. A
+  /// recipe asks before reading an extent, since a data extent tensor looks
+  /// like a shape.
+  bool holdsDataValues() const {
+    return getPlaceholderType() == PlaceholderType::Barrier;
+  }
 
 private:
   Block &block;

--- a/include/hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrShapeYieldOp.td
@@ -15,20 +15,26 @@ def Hipsr_ShapeYieldOp : Hipsr_Op<
     "shape_yield", [Pure, Terminator, HasParent<"PlaceholderOp">]> {
   let summary = "Yield result shapes from a placeholder shape region";
   let description = [{
-    Ends a `hipsr.placeholder` shape region and yields one `!shape.shape`
-    value for each placeholder result. Element types and ranked tensor types
-    remain on the placeholder results.
+    Ends a `hipsr.placeholder` shape region and yields one extent tensor for
+    each placeholder result. Element types and ranked tensor types remain on
+    the placeholder results.
 
-    A scalar result still has one shape operand whose extent list is empty.
+    Each extent tensor holds one extent per dimension of the result it
+    describes, so a static length must equal that result's rank. A scalar
+    result still has one shape operand: an extent tensor of length zero.
     For example:
     ```mlir
-    hipsr.shape_yield %shape : !shape.shape
+    // result rank 2
+    hipsr.shape_yield %shape : tensor<2xindex>
+    // result ranks 2 and 1
     hipsr.shape_yield %values_shape, %indices_shape
-        : !shape.shape, !shape.shape
+        : tensor<2xindex>, tensor<1xindex>
+    // scalar result
+    hipsr.shape_yield %scalar_shape : tensor<0xindex>
     ```
   }];
 
-  let arguments = (ins Variadic<Shape_ShapeType>:$shapes);
+  let arguments = (ins Variadic<Shape_ExtentTensorType>:$shapes);
   let assemblyFormat = "$shapes attr-dict `:` type($shapes)";
   let hasVerifier = 1;
 

--- a/include/hip/Dialect/Hipsr/Transforms/Passes.td
+++ b/include/hip/Dialect/Hipsr/Transforms/Passes.td
@@ -143,8 +143,8 @@ def MaterializeInitTensorsPass
     `hipsr.pool_domain`, leaving the domain body in three ordered groups:
 
     1. shape computation: one `scf.execute_region` per placeholder, yielding
-       `!shape.shape` and holding the body moved out of the placeholder's
-       `shape_region`;
+       one extent tensor per result and holding the body moved out of the
+       placeholder's `shape_region`;
     2. tensor allocation: `shape.get_extent` plus `tensor.empty` per
        placeholder result, taking rank and element type from that result type;
     3. data: the hipsr DPS ops, now initialized by the `tensor.empty` values.

--- a/include/hip/InitAllPasses.h
+++ b/include/hip/InitAllPasses.h
@@ -34,6 +34,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/MemRef/Transforms/AllocationOpInterfaceImpl.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
+#include "mlir/Dialect/Shape/Transforms/Passes.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/IR/TensorInferTypeOpInterfaceImpl.h"
 #include "mlir/Dialect/Tensor/Transforms/BufferizableOpInterfaceImpl.h"
@@ -185,6 +186,10 @@ inline void registerAllPasses() {
     mlir::registerSCFToControlFlowPass();
     mlir::registerReconcileUnrealizedCastsPass();
     mlir::memref::registerResolveShapedTypeResultDimsPass();
+    // registerShapePasses covers remove-shape-constraints and
+    // shape-to-shape-lowering, which --hipsr-pipeline runs.
+    mlir::registerShapePasses();
+    mlir::registerConvertShapeToStandardPass();
   });
 }
 

--- a/lib/Conversion/OnnxToHipsr/GatherConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/GatherConversion.cpp
@@ -133,9 +133,11 @@ void populateHostShapeRegion(OpBuilder &builder, PlaceholderOp placeholder,
   builder.setInsertionPointToStart(&block);
 
   Location loc = placeholder.getLoc();
-  Value shape = shape::ConstShapeOp::create(
-      builder, loc, shape::ShapeType::get(builder.getContext()),
-      builder.getIndexTensorAttr(resultShape));
+  Value shape = createExtentTensor(
+      builder, loc,
+      llvm::map_to_vector(resultShape, [&](int64_t extent) -> Value {
+        return arith::ConstantIndexOp::create(builder, loc, extent);
+      }));
   ShapeYieldOp::create(builder, loc, ValueRange{shape});
 }
 

--- a/lib/Conversion/OnnxToHipsr/NonZeroConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/NonZeroConversion.cpp
@@ -136,9 +136,7 @@ void populateNarrowShapeRegion(OpBuilder &builder, PlaceholderOp placeholder,
   Value columns =
       arith::IndexCastOp::create(builder, loc, builder.getIndexType(), found);
   Value rowCount = arith::ConstantIndexOp::create(builder, loc, rows);
-  Value shape = shape::FromExtentsOp::create(
-      builder, loc, shape::ShapeType::get(builder.getContext()),
-      ValueRange{rowCount, columns});
+  Value shape = createExtentTensor(builder, loc, ValueRange{rowCount, columns});
   ShapeYieldOp::create(builder, loc, ValueRange{shape});
 }
 

--- a/lib/Conversion/OnnxToHipsr/ReshapeConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/ReshapeConversion.cpp
@@ -129,9 +129,7 @@ Value buildInferredDim(OpBuilder &builder, Location loc, Value inputShape,
   assert(resultStaticCount > 0 &&
          "a 0 result dimension is rejected before this point");
 
-  Value count = shape::NumElementsOp::create(builder, loc, inputShape);
-  Value dividend =
-      shape::SizeToIndexOp::create(builder, loc, builder.getIndexType(), count);
+  Value dividend = shape::NumElementsOp::create(builder, loc, inputShape);
   Value divisor =
       arith::ConstantIndexOp::create(builder, loc, resultStaticCount);
   return arith::DivUIOp::create(builder, loc, dividend, divisor);
@@ -158,8 +156,7 @@ void populateShapeRegion(OpBuilder &builder, PlaceholderOp placeholder,
         }
         return arith::ConstantIndexOp::create(builder, loc, dim);
       });
-  Value shape = shape::FromExtentsOp::create(
-      builder, loc, shape::ShapeType::get(builder.getContext()), dims);
+  Value shape = createExtentTensor(builder, loc, dims);
   ShapeYieldOp::create(builder, loc, ValueRange{shape});
 }
 

--- a/lib/Conversion/OnnxToHipsr/ShapeConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/ShapeConversion.cpp
@@ -101,9 +101,7 @@ void populateShapeRegion(OpBuilder &builder, PlaceholderOp placeholder,
 
   Location loc = placeholder.getLoc();
   Value extent = arith::ConstantIndexOp::create(builder, loc, numExtents);
-  Value shape = shape::FromExtentsOp::create(
-      builder, loc, shape::ShapeType::get(builder.getContext()),
-      ValueRange{extent});
+  Value shape = createExtentTensor(builder, loc, ValueRange{extent});
   ShapeYieldOp::create(builder, loc, ValueRange{shape});
 }
 

--- a/lib/Conversion/OnnxToHipsr/UnsqueezeConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/UnsqueezeConversion.cpp
@@ -131,12 +131,8 @@ SmallVector<OpFoldResult> buildInputDims(OpBuilder &builder, Location loc,
         if (!inputType.isDynamicDim(axis)) {
           return builder.getIndexAttr(inputType.getDimSize(axis));
         }
-        // shape.get_extent returns a `!shape.size`, which converts to index
-        // because it can hold an error.
-        Value size = shape::GetExtentOp::create(builder, loc, inputShape, axis);
-        Value dim = shape::SizeToIndexOp::create(builder, loc,
-                                                 builder.getIndexType(), size);
-        return dim;
+        return Value{
+            shape::GetExtentOp::create(builder, loc, inputShape, axis)};
       });
 }
 
@@ -161,9 +157,8 @@ void populateShapeRegion(OpBuilder &builder, PlaceholderOp placeholder,
                                               reassociation, inputDims);
   assert(succeeded(resultDims) &&
          "a group holds one input dimension, so only it can be dynamic");
-  Value shape = shape::FromExtentsOp::create(
-      builder, loc, shape::ShapeType::get(builder.getContext()),
-      getValueOrCreateConstantIndexOp(builder, loc, *resultDims));
+  Value shape = createExtentTensor(
+      builder, loc, getValueOrCreateConstantIndexOp(builder, loc, *resultDims));
   ShapeYieldOp::create(builder, loc, ValueRange{shape});
 }
 

--- a/lib/Dialect/Hipsr/IR/HipsrAddOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrAddOp.cpp
@@ -35,9 +35,10 @@ LogicalResult populateAddShapeRegion(OpBuilder &builder, Block &shapeBlock,
   builder.setInsertionPointToStart(&shapeBlock);
 
   AddPlaceholderShapeArgs args{shapeBlock};
-  Value broadcast = builder.create<shape::BroadcastOp>(
-      op.getLoc(), shape::ShapeType::get(builder.getContext()),
-      ValueRange{args.getLhs(), args.getRhs()}, /*error=*/nullptr);
+  SmallVector<Value> operandShapes{args.getLhs(), args.getRhs()};
+  Value broadcast = shape::BroadcastOp::create(
+      builder, op.getLoc(), getBroadcastExtentTensorType(operandShapes),
+      operandShapes, /*error=*/nullptr);
   ShapeYieldOp::create(builder, op.getLoc(), ValueRange{broadcast});
   return success();
 }

--- a/lib/Dialect/Hipsr/IR/HipsrEqualOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrEqualOp.cpp
@@ -61,9 +61,10 @@ LogicalResult populateEqualShapeRegion(OpBuilder &builder, Block &shapeBlock,
   builder.setInsertionPointToStart(&shapeBlock);
 
   EqualPlaceholderShapeArgs args{shapeBlock};
+  SmallVector<Value> operandShapes{args.getLhs(), args.getRhs()};
   Value broadcast = shape::BroadcastOp::create(
-      builder, op.getLoc(), shape::ShapeType::get(builder.getContext()),
-      ValueRange{args.getLhs(), args.getRhs()}, /*error=*/nullptr);
+      builder, op.getLoc(), getBroadcastExtentTensorType(operandShapes),
+      operandShapes, /*error=*/nullptr);
   ShapeYieldOp::create(builder, op.getLoc(), ValueRange{broadcast});
   return success();
 }

--- a/lib/Dialect/Hipsr/IR/HipsrExpandOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrExpandOp.cpp
@@ -141,7 +141,8 @@ LogicalResult populateExpandShapeRegion(OpBuilder &builder, Block &shapeBlock,
           arith::ConstantIndexOp::create(builder, loc, extent));
     }
   } else {
-    inputShape = shape::ShapeOfOp::create(builder, loc, args.getInput());
+    inputShape = shape::ShapeOfOp::create(
+        builder, loc, getExtentTensorTypeOf(args.getInput()), args.getInput());
     Value requestedShapeArg = args.getRequestedShape();
     auto requestedShapeType = cast<ShapedType>(requestedShapeArg.getType());
     int64_t requestedRank = requestedShapeType.getDimSize(0);
@@ -161,9 +162,7 @@ LogicalResult populateExpandShapeRegion(OpBuilder &builder, Block &shapeBlock,
     }
   }
 
-  auto shapeType = shape::ShapeType::get(builder.getContext());
-  Value requestedShape = shape::FromExtentsOp::create(
-      builder, loc, shapeType, ValueRange{requestedExtents});
+  Value requestedShape = createExtentTensor(builder, loc, requestedExtents);
 
   // ONNX Expand uses right-aligned multidirectional broadcasting.
   Value witness = shape::CstrBroadcastableOp::create(builder, loc, inputShape,
@@ -172,7 +171,8 @@ LogicalResult populateExpandShapeRegion(OpBuilder &builder, Block &shapeBlock,
       builder, loc, witness,
       [&](OpBuilder &b, Location) -> SmallVector<Value, 2> {
         Value broadcastShape = shape::BroadcastOp::create(
-            b, loc, shapeType, inputShape, requestedShape, StringAttr{});
+            b, loc, getBroadcastExtentTensorType({inputShape, requestedShape}),
+            inputShape, requestedShape, StringAttr{});
         return SmallVector<Value, 2>{broadcastShape};
       });
 

--- a/lib/Dialect/Hipsr/IR/HipsrGatherOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrGatherOp.cpp
@@ -42,30 +42,35 @@ SmallVector<int64_t> inferGatherResultShape(ArrayRef<int64_t> dataShape,
                                   dataShape.drop_front(axis + 1)));
 }
 
-// The same rule on symbolic shapes: splitting the data shape around the axis
-// leaves the two pieces the indices shape goes between, whatever the ranks are.
+// The same rule on symbolic shapes, one extent per output dimension.
 LogicalResult populateGatherShapeRegion(OpBuilder &builder, Block &shapeBlock,
                                         GatherOp op) {
   OpBuilder::InsertionGuard guard(builder);
   builder.setInsertionPointToStart(&shapeBlock);
 
   Location loc = op.getLoc();
-  Type shapeType = shape::ShapeType::get(builder.getContext());
   GatherPlaceholderShapeArgs args{shapeBlock};
-
-  auto splitDataAt = [&](int64_t position) {
-    Value index = shape::ConstSizeOp::create(builder, loc, position);
-    return shape::SplitAtOp::create(
-        builder, loc, TypeRange{shapeType, shapeType}, args.getData(), index);
-  };
+  int64_t dataRank = cast<ShapedType>(op.getData().getType()).getRank();
+  int64_t indicesRank = cast<ShapedType>(op.getIndices().getType()).getRank();
   int64_t axis = op.getAxis();
-  Value leading = splitDataAt(axis).getHead();
-  Value trailing = splitDataAt(axis + 1).getTail();
 
-  Value gathered = shape::ConcatOp::create(builder, loc, shapeType, leading,
-                                           args.getIndices());
-  Value outputShape =
-      shape::ConcatOp::create(builder, loc, shapeType, gathered, trailing);
+  auto extent = [&](Value shape, int64_t index) -> Value {
+    return shape::GetExtentOp::create(builder, loc, shape, index);
+  };
+  auto appendExtents = [&](SmallVectorImpl<Value> &extents, Value shape,
+                           int64_t begin, int64_t end) {
+    for (int64_t index : llvm::seq(begin, end)) {
+      extents.push_back(extent(shape, index));
+    }
+  };
+
+  SmallVector<Value> outputExtents;
+  outputExtents.reserve(dataRank - 1 + indicesRank);
+  appendExtents(outputExtents, args.getData(), 0, axis);
+  appendExtents(outputExtents, args.getIndices(), 0, indicesRank);
+  appendExtents(outputExtents, args.getData(), axis + 1, dataRank);
+
+  Value outputShape = createExtentTensor(builder, loc, outputExtents);
   ShapeYieldOp::create(builder, loc, ValueRange{outputShape});
   return success();
 }

--- a/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrMatMulOp.cpp
@@ -68,49 +68,60 @@ LogicalResult populateMatMulShapeRegion(OpBuilder &builder, Block &shapeBlock,
   // K is A's last dim; B's last dim when B is 1-D, else its second-to-last.
   int64_t kAIndex = aRank - 1;
   int64_t kBIndex = bIs1D ? bRank - 1 : bRank - 2;
-  Type shapeType = shape::ShapeType::get(ctx);
   Type witnessType = shape::WitnessType::get(ctx);
-  Value aKShape = shape::FromExtentsOp::create(
-      builder, loc, shapeType, ValueRange{extent(builder, aShape, kAIndex)});
-  Value bKShape = shape::FromExtentsOp::create(
-      builder, loc, shapeType, ValueRange{extent(builder, bShape, kBIndex)});
+  Value aKShape = createExtentTensor(
+      builder, loc, ValueRange{extent(builder, aShape, kAIndex)});
+  Value bKShape = createExtentTensor(
+      builder, loc, ValueRange{extent(builder, bShape, kBIndex)});
   Value kWitness = shape::CstrEqOp::create(builder, loc, witnessType,
                                            ValueRange{aKShape, bKShape});
 
-  // Only leading dimensions participate in MatMul batch broadcasting.
-  auto getBatchShape = [&](Value inputShape, int64_t rank) -> Value {
-    int64_t batchRank = std::max<int64_t>(rank - 2, 0);
-    Value splitIndex = shape::ConstSizeOp::create(builder, loc, batchRank);
-    return shape::SplitAtOp::create(builder, loc,
-                                    TypeRange{shapeType, shapeType}, inputShape,
-                                    splitIndex)
-        .getHead();
-  };
-  Value aBatchShape = getBatchShape(aShape, aRank);
-  Value bBatchShape = getBatchShape(bShape, bRank);
-  Value batchWitness = shape::CstrBroadcastableOp::create(
-      builder, loc, aBatchShape, bBatchShape);
-  Value witness = shape::AssumingAllOp::create(
-      builder, loc, witnessType, ValueRange{kWitness, batchWitness});
+  // Only leading dimensions take part in batch broadcasting, so a 1-D or 2-D
+  // operand adds no constraint and no extent.
+  int64_t aBatchRank = std::max<int64_t>(aRank - 2, 0);
+  int64_t bBatchRank = std::max<int64_t>(bRank - 2, 0);
+  int64_t batchRank = std::max(aBatchRank, bBatchRank);
+  Value aBatchShape;
+  Value bBatchShape;
+  SmallVector<Value, 2> witnesses{kWitness};
+  if (batchRank > 0) {
+    auto getBatchShape = [&](Value inputShape, int64_t rank) -> Value {
+      SmallVector<Value> batchExtents =
+          llvm::map_to_vector(llvm::seq<int64_t>(rank), [&](int64_t index) {
+            return extent(builder, inputShape, index);
+          });
+      return createExtentTensor(builder, loc, batchExtents);
+    };
+    aBatchShape = getBatchShape(aShape, aBatchRank);
+    bBatchShape = getBatchShape(bShape, bBatchRank);
+    witnesses.push_back(shape::CstrBroadcastableOp::create(
+        builder, loc, aBatchShape, bBatchShape));
+  }
+  Value witness =
+      witnesses.size() == 1
+          ? witnesses.front()
+          : shape::AssumingAllOp::create(builder, loc, witnessType, witnesses)
+                .getResult();
 
   auto assuming = shape::AssumingOp::create(
       builder, loc, witness,
       [&](OpBuilder &b, Location) -> SmallVector<Value, 2> {
-        Value batchShape = shape::BroadcastOp::create(
-            b, loc, shapeType, aBatchShape, bBatchShape, StringAttr{});
-
-        SmallVector<Value, 2> matrixExtents;
+        SmallVector<Value> resultExtents;
+        if (batchRank > 0) {
+          Value batchShape = shape::BroadcastOp::create(
+              b, loc, getBroadcastExtentTensorType({aBatchShape, bBatchShape}),
+              aBatchShape, bBatchShape, StringAttr{});
+          for (int64_t index : llvm::seq<int64_t>(batchRank)) {
+            resultExtents.push_back(extent(b, batchShape, index));
+          }
+        }
         if (!aIs1D) {
-          matrixExtents.push_back(extent(b, aShape, aRank - 2));
+          resultExtents.push_back(extent(b, aShape, aRank - 2));
         }
         if (!bIs1D) {
-          matrixExtents.push_back(extent(b, bShape, bRank - 1));
+          resultExtents.push_back(extent(b, bShape, bRank - 1));
         }
-        Value matrixShape = shape::FromExtentsOp::create(
-            b, loc, shapeType, ValueRange{matrixExtents});
-        Value resultShape =
-            shape::ConcatOp::create(b, loc, shapeType, batchShape, matrixShape);
-        return {resultShape};
+        return {createExtentTensor(b, loc, resultExtents)};
       });
 
   ShapeYieldOp::create(builder, loc, ValueRange{assuming.getResult(0)});

--- a/lib/Dialect/Hipsr/IR/HipsrMinOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrMinOp.cpp
@@ -35,9 +35,10 @@ LogicalResult populateMinShapeRegion(OpBuilder &builder, Block &shapeBlock,
   builder.setInsertionPointToStart(&shapeBlock);
 
   MinPlaceholderShapeArgs args{shapeBlock};
-  Value broadcast = builder.create<shape::BroadcastOp>(
-      op.getLoc(), shape::ShapeType::get(builder.getContext()),
-      ValueRange{args.getLhs(), args.getRhs()}, /*error=*/nullptr);
+  SmallVector<Value> operandShapes{args.getLhs(), args.getRhs()};
+  Value broadcast = shape::BroadcastOp::create(
+      builder, op.getLoc(), getBroadcastExtentTensorType(operandShapes),
+      operandShapes, /*error=*/nullptr);
   ShapeYieldOp::create(builder, op.getLoc(), ValueRange{broadcast});
   return success();
 }

--- a/lib/Dialect/Hipsr/IR/HipsrMulOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrMulOp.cpp
@@ -35,9 +35,10 @@ LogicalResult populateMulShapeRegion(OpBuilder &builder, Block &shapeBlock,
   builder.setInsertionPointToStart(&shapeBlock);
 
   MulPlaceholderShapeArgs args{shapeBlock};
-  Value broadcast = builder.create<shape::BroadcastOp>(
-      op.getLoc(), shape::ShapeType::get(builder.getContext()),
-      ValueRange{args.getLhs(), args.getRhs()}, /*error=*/nullptr);
+  SmallVector<Value> operandShapes{args.getLhs(), args.getRhs()};
+  Value broadcast = shape::BroadcastOp::create(
+      builder, op.getLoc(), getBroadcastExtentTensorType(operandShapes),
+      operandShapes, /*error=*/nullptr);
   ShapeYieldOp::create(builder, op.getLoc(), ValueRange{broadcast});
   return success();
 }

--- a/lib/Dialect/Hipsr/IR/HipsrNonZeroOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrNonZeroOp.cpp
@@ -30,17 +30,16 @@ LogicalResult populateNonZeroShapeRegion(OpBuilder &builder, Block &shapeBlock,
   builder.setInsertionPointToStart(&shapeBlock);
 
   Location loc = op.getLoc();
-  Type shapeType = shape::ShapeType::get(builder.getContext());
   NonZeroPlaceholderShapeArgs args{shapeBlock};
   Value inputShape = args.getInput();
 
   int64_t rank = cast<ShapedType>(op.getInput().getType()).getRank();
-  Value rows = shape::ConstSizeOp::create(builder, loc, rank);
+  Value rows = arith::ConstantIndexOp::create(builder, loc, rank);
   Value capacity = shape::NumElementsOp::create(builder, loc, inputShape);
-  Value indicesShape = shape::FromExtentsOp::create(builder, loc, shapeType,
-                                                    ValueRange{rows, capacity});
-  Value countShape = shape::ConstShapeOp::create(
-      builder, loc, shapeType, builder.getIndexTensorAttr({1}));
+  Value indicesShape =
+      createExtentTensor(builder, loc, ValueRange{rows, capacity});
+  Value one = arith::ConstantIndexOp::create(builder, loc, 1);
+  Value countShape = createExtentTensor(builder, loc, ValueRange{one});
   ShapeYieldOp::create(builder, loc, ValueRange{indicesShape, countShape});
   return success();
 }

--- a/lib/Dialect/Hipsr/IR/HipsrOps.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrOps.cpp
@@ -7,6 +7,8 @@
 
 #include "mlir/Interfaces/DestinationStyleOpInterface.h"
 
+#include "llvm/ADT/STLExtras.h"
+
 using namespace mlir;
 using namespace mlir::hipsr;
 
@@ -59,6 +61,30 @@ bool mlir::hipsr::isHipsrDestinationOperand(OpOperand &use) {
   unsigned index = use.getOperandNumber();
   unsigned begin = destinations.getBeginOperandIndex();
   return index >= begin && index < begin + destinations.size();
+}
+
+RankedTensorType mlir::hipsr::getExtentTensorTypeForRank(MLIRContext *ctx,
+                                                         int64_t rank) {
+  return RankedTensorType::get({rank}, IndexType::get(ctx));
+}
+
+RankedTensorType mlir::hipsr::getExtentTensorTypeOf(Value data) {
+  auto tensorType = cast<RankedTensorType>(data.getType());
+  return getExtentTensorTypeForRank(data.getContext(), tensorType.getRank());
+}
+
+RankedTensorType mlir::hipsr::getBroadcastExtentTensorType(ValueRange shapes) {
+  assert(!shapes.empty() && "broadcast needs at least one shape");
+  auto extentCount = [](Value shape) {
+    int64_t count = cast<RankedTensorType>(shape.getType()).getDimSize(0);
+    // kDynamic is the smallest int64, so an unknown count would lose the
+    // comparison below and silently understate the broadcast rank.
+    assert(!ShapedType::isDynamic(count) &&
+           "broadcast operand must state its extent count");
+    return count;
+  };
+  int64_t rank = *llvm::max_element(llvm::map_range(shapes, extentCount));
+  return getExtentTensorTypeForRank(shapes.front().getContext(), rank);
 }
 
 OpResult mlir::hipsr::getResultForDestination(OpOperand &use) {

--- a/lib/Dialect/Hipsr/IR/HipsrPlaceholderOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrPlaceholderOp.cpp
@@ -145,12 +145,13 @@ Operation *PlaceholderOp::getConsumer() {
 }
 
 SmallVector<Type> PlaceholderOp::getShapeRegionArgumentTypes() {
-  SmallVector<Type> types;
   if (getPlaceholderType() == PlaceholderType::Normal) {
-    types.assign(getInputs().size(), shape::ShapeType::get(getContext()));
-    return types;
+    return llvm::map_to_vector(getInputs(), [](Value input) -> Type {
+      return getExtentTensorTypeOf(input);
+    });
   }
 
+  SmallVector<Type> types;
   types.reserve(getNumOperands());
   types.push_back(getCtx().getType());
   llvm::append_range(types, getInputs().getTypes());

--- a/lib/Dialect/Hipsr/IR/HipsrPreserveShapeOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrPreserveShapeOp.cpp
@@ -11,6 +11,18 @@
 using namespace mlir;
 using namespace mlir::hipsr;
 
+// A shape built outside a recipe may still be dynamic, so the check skips a
+// dynamic extent count.
+LogicalResult PreserveShapeOp::verify() {
+  int64_t extents = cast<RankedTensorType>(getShape().getType()).getDimSize(0);
+  int64_t rank = cast<ShapedType>(getData().getType()).getRank();
+  if (!ShapedType::isDynamic(extents) && extents != rank) {
+    return emitOpError("shape holds ")
+           << extents << " extents but data has rank " << rank;
+  }
+  return success();
+}
+
 // PreserveShapeOp does not modify memory, but it must report a side effect
 // to avoid being eliminated as a trivially dead operation.
 void PreserveShapeOp::getEffects(

--- a/lib/Dialect/Hipsr/IR/HipsrShapeYieldOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrShapeYieldOp.cpp
@@ -5,6 +5,8 @@
 
 #include "hip/Dialect/Hipsr/IR/HipsrOps.h"
 
+#include "llvm/ADT/STLExtras.h"
+
 using namespace mlir;
 using namespace mlir::hipsr;
 
@@ -12,9 +14,27 @@ LogicalResult ShapeYieldOp::verify() {
   auto placeholder = cast<PlaceholderOp>(getOperation()->getParentOp());
   if (getShapes().size() != placeholder.getNumResults()) {
     return emitOpError(
-               "must yield one !shape.shape per enclosing placeholder result; "
+               "must yield one extent tensor per enclosing placeholder result; "
                "expected ")
            << placeholder.getNumResults() << ", got " << getShapes().size();
+  }
+
+  // Materialize reads only the dynamic dimensions of a result type, so a shape
+  // that is too short would otherwise surface as an out-of-range extent read
+  // much later.
+  for (auto [index, shape] : llvm::enumerate(getShapes())) {
+    int64_t extents = cast<RankedTensorType>(shape.getType()).getDimSize(0);
+    if (ShapedType::isDynamic(extents)) {
+      continue;
+    }
+    int64_t rank =
+        cast<RankedTensorType>(placeholder->getResult(index).getType())
+            .getRank();
+    if (extents != rank) {
+      return emitOpError("shape #")
+             << index << " holds " << extents << " extents but result #"
+             << index << " has rank " << rank;
+    }
   }
   return success();
 }

--- a/lib/Dialect/Hipsr/IR/HipsrSliceOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrSliceOp.cpp
@@ -227,11 +227,10 @@ LogicalResult populateSliceShapeRegion(OpBuilder &builder, Block &shapeBlock,
                                             dataType.getDimSize(axis));
     }
     Value data = args.getData();
-    if (isa<ShapedType>(data.getType())) {
+    if (args.holdsDataValues()) {
       return tensor::DimOp::create(builder, loc, data, axis);
     }
-    return shape::SizeToIndexOp::create(
-        builder, loc, shape::GetExtentOp::create(builder, loc, data, axis));
+    return shape::GetExtentOp::create(builder, loc, data, axis);
   };
 
   SmallVector<Value> sizes =
@@ -243,8 +242,7 @@ LogicalResult populateSliceShapeRegion(OpBuilder &builder, Block &shapeBlock,
         return windowSize(builder, loc, boundOf(starts, *entry),
                           boundOf(ends, *entry), steps[*entry], sizeOf(axis));
       });
-  Value outputShape = shape::FromExtentsOp::create(
-      builder, loc, shape::ShapeType::get(builder.getContext()), sizes);
+  Value outputShape = createExtentTensor(builder, loc, sizes);
   ShapeYieldOp::create(builder, loc, ValueRange{outputShape});
 
   // Folding on creation leaves dead constants behind.

--- a/lib/Dialect/Hipsr/IR/HipsrTransposeOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrTransposeOp.cpp
@@ -68,8 +68,7 @@ LogicalResult populateTransposeShapeRegion(OpBuilder &builder,
       llvm::map_to_vector(op.getPerm(), [&](int64_t axis) -> Value {
         return shape::GetExtentOp::create(builder, loc, inputShape, axis);
       });
-  Value outputShape = shape::FromExtentsOp::create(
-      builder, loc, shape::ShapeType::get(builder.getContext()), extents);
+  Value outputShape = createExtentTensor(builder, loc, extents);
   ShapeYieldOp::create(builder, loc, ValueRange{outputShape});
   return success();
 }

--- a/lib/Dialect/Hipsr/Pipelines/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/Pipelines/CMakeLists.txt
@@ -13,4 +13,8 @@ target_link_libraries(HipsrDialectPipelines PUBLIC
   MLIRPass
   MLIRIR
   MLIRSupport
+  # Upstream passes that lower shape regions.
+  MLIRShapeOpsTransforms
+  MLIRShapeToStandard
+  MLIRTransforms
 )

--- a/lib/Dialect/Hipsr/Pipelines/Pipelines.cpp
+++ b/lib/Dialect/Hipsr/Pipelines/Pipelines.cpp
@@ -8,8 +8,11 @@
 #include "hip/Conversion/OnnxToHipsr/OnnxToHipsr.h"
 #include "hip/Dialect/Hipsr/Transforms/Passes.h"
 
+#include "mlir/Conversion/ShapeToStandard/ShapeToStandard.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Shape/Transforms/Passes.h"
 #include "mlir/Pass/PassRegistry.h"
+#include "mlir/Transforms/Passes.h"
 
 // --hipsr-pipeline is equivalent to running these in order:
 //   --hipsr-add-context-arg
@@ -17,6 +20,10 @@
 //   --hipsr-populate-shape-region
 //   --hipsr-partition-pool-domains
 //   --hipsr-materialize-init-tensors
+//   --remove-shape-constraints
+//   --shape-to-shape-lowering
+//   --convert-shape-to-std
+//   --canonicalize
 void mlir::hipsr::buildHipsrPipeline(OpPassManager &pm,
                                      const HipsrPipelineOptions & /*options*/) {
   pm.addPass(createAddContextArgPass());
@@ -24,6 +31,17 @@ void mlir::hipsr::buildHipsrPipeline(OpPassManager &pm,
   pm.addNestedPass<func::FuncOp>(createPopulateShapeRegionPass());
   pm.addNestedPass<func::FuncOp>(createPartitionPoolDomainsPass());
   pm.addPass(createMaterializeInitTensorsPass());
+
+  // A shape region yields extent tensors, which the upstream shape passes
+  // lower. The constraints a recipe records need the other three passes:
+  //
+  //   - nothing downstream reads them, so remove-shape-constraints drops them;
+  //   - the leftover witness always passes and guards a shape.assuming;
+  //   - convert-shape-to-std cannot lower that op, so canonicalize inlines it.
+  pm.addNestedPass<func::FuncOp>(createRemoveShapeConstraintsPass());
+  pm.addNestedPass<func::FuncOp>(createShapeToShapeLoweringPass());
+  pm.addPass(createConvertShapeToStandardPass());
+  pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
 }
 
 void mlir::hipsr::registerHipsrPipelines() {

--- a/lib/Dialect/Hipsr/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/lib/Dialect/Hipsr/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -67,6 +67,12 @@ struct PreserveShapeBufferizableModel
     return {};
   }
 
+  // `$shape` stays an extent tensor after bufferize, so the default
+  // hasTensorSemantics would still call the rewritten op tensor-like.
+  bool hasTensorSemantics(Operation *op) const {
+    return isa<TensorType>(cast<PreserveShapeOp>(op).getData().getType());
+  }
+
   LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
                           const BufferizationOptions &options,
                           BufferizationState &state) const {

--- a/lib/Dialect/Hipsr/Transforms/HipsrUseOutputAllocator.cpp
+++ b/lib/Dialect/Hipsr/Transforms/HipsrUseOutputAllocator.cpp
@@ -128,9 +128,8 @@ static SmallVector<Value> materializeDimensions(Value preservedShape,
     Value size;
     if (type.isDynamicDim(dimension)) {
       assert(preservedShape && "dynamic dims require a preserved shape");
-      Value extent =
-          builder.create<shape::GetExtentOp>(loc, preservedShape, dimension);
-      size = builder.create<shape::SizeToIndexOp>(loc, extent);
+      size =
+          shape::GetExtentOp::create(builder, loc, preservedShape, dimension);
     } else {
       size = arith::ConstantIndexOp::create(builder, loc,
                                             type.getDimSize(dimension));

--- a/lib/Dialect/Hipsr/Transforms/MaterializeInitTensorsPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/MaterializeInitTensorsPass.cpp
@@ -10,20 +10,21 @@
 //
 // Before:
 //   %init = hipsr.placeholder(%ctx) ins(%a) : tensor<?x4xf32> shape_region {
-//   ^bb0(%a_shape: !shape.shape):
-//     hipsr.shape_yield %a_shape : !shape.shape
+//   ^bb0(%a_shape: tensor<2xindex>):
+//     hipsr.shape_yield %a_shape : tensor<2xindex>
 //   }
 //   %0 = hipsr.cast(%ctx) ins(%a) outs(%init) : tensor<?x4xf32>
 //
 // After:
-//   %s = scf.execute_region -> !shape.shape {
-//     %a_shape = shape.shape_of %a : tensor<?x4xf16> -> !shape.shape
-//     scf.yield %a_shape : !shape.shape
+//   %s = scf.execute_region -> tensor<2xindex> {
+//     %a_shape = shape.shape_of %a : tensor<?x4xf32> -> tensor<2xindex>
+//     scf.yield %a_shape : tensor<2xindex>
 //   }
-//   %d0 = shape.size_to_index (shape.get_extent %s, 0)
+//   %c0 = arith.constant 0 : index
+//   %d0 = shape.get_extent %s, %c0 : tensor<2xindex>, index -> index
 //   %empty = tensor.empty(%d0) : tensor<?x4xf32>
 //   %0 = hipsr.cast(%ctx) ins(%a) outs(%empty) : tensor<?x4xf32>
-//   hipsr.preserve_shape %s, %0 : tensor<?x4xf32>
+//   hipsr.preserve_shape %s, %0 : tensor<2xindex>, tensor<?x4xf32>
 //
 // The domain is rebuilt in a fresh block in five steps: constants, shape
 // computations, allocations, every other op, then one shape link per
@@ -72,7 +73,7 @@ namespace {
 //   d. block argument     -> the new block argument
 //   e. placeholder result -> rejected by verifyMaterializable
 //
-// Normal, one !shape.shape per input:
+// Normal, one extent tensor per input:
 //   a. arith.constant     -> shape.shape_of it
 //   b. hipsr.constant     -> shape.shape_of it
 //   c. block argument     -> shape.shape_of it
@@ -88,14 +89,14 @@ SmallVector<Value> getArgumentReplacements(PlaceholderOp placeholder,
   }
 
   Location loc = placeholder.getLoc();
-  auto shapeType = shape::ShapeType::get(builder.getContext());
   return llvm::map_to_vector(
       placeholder.getInputs(), [&](Value input) -> Value {
         if (Value recorded = shapes.lookupOrNull(input)) {
           return recorded;
         }
-        return shape::ShapeOfOp::create(builder, loc, shapeType,
-                                        cloned.lookup(input));
+        Value data = cloned.lookup(input);
+        return shape::ShapeOfOp::create(builder, loc,
+                                        getExtentTensorTypeOf(data), data);
       });
 }
 
@@ -104,8 +105,10 @@ ResultRange materializeShapeRegion(PlaceholderOp placeholder,
                                    const IRMapping &shapes, IRMapping &cloned,
                                    RewriterBase &rewriter) {
   OpBuilder::InsertionGuard guard(rewriter);
-  SmallVector<Type> shapeTypes(placeholder.getNumResults(),
-                               shape::ShapeType::get(rewriter.getContext()));
+  SmallVector<Type> shapeTypes =
+      llvm::map_to_vector(placeholder.getResults(), [](Value result) -> Type {
+        return getExtentTensorTypeOf(result);
+      });
   auto executeRegion =
       scf::ExecuteRegionOp::create(rewriter, placeholder.getLoc(), shapeTypes);
 
@@ -138,9 +141,7 @@ Value createInitTensor(Value result, Value resultShape, OpBuilder &builder) {
     return tensorType.isDynamicDim(dimension);
   };
   auto readExtent = [&](int64_t dimension) -> Value {
-    Value extent =
-        shape::GetExtentOp::create(builder, loc, resultShape, dimension);
-    return shape::SizeToIndexOp::create(builder, loc, extent);
+    return shape::GetExtentOp::create(builder, loc, resultShape, dimension);
   };
 
   SmallVector<Value> dynamicSizes = llvm::map_to_vector(

--- a/lib/Dialect/Hipsr/Transforms/PopulateShapeRegionPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/PopulateShapeRegionPass.cpp
@@ -13,8 +13,8 @@
 // After:
 //   %init = hipsr.placeholder(%ctx) ins(%input) : tensor<?x8xf16>
 //       shape_region {
-//   ^bb0(%input_shape: !shape.shape):
-//     hipsr.shape_yield %input_shape : !shape.shape
+//   ^bb0(%input_shape: tensor<2xindex>):
+//     hipsr.shape_yield %input_shape : tensor<2xindex>
 //   }
 //   %0 = hipsr.cast(%ctx) ins(%input) outs(%init) : tensor<?x8xf16>
 //

--- a/test/lit/Conversion/onnx-to-hipsr/gather.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/gather.mlir
@@ -57,10 +57,10 @@ func.func @negative_axis(%ctx: !hipsr.context, %data: tensor<2x3x4xf16>,
 // CHECK-SAME:    %[[CTX:.+]]: !hipsr.context,
 // CHECK-SAME:    %[[INPUT:.+]]: tensor<?x4096xf16, #hipsr.mem<device>>) {
 // CHECK-NEXT:    %[[EXTENTS_INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
-// CHECK-NEXT:    ^bb0(%{{.+}}: !shape.shape):
+// CHECK-NEXT:    ^bb0(%{{.+}}: tensor<2xindex>):
 // CHECK-NEXT:      %[[LEN:.+]] = arith.constant 2 : index
-// CHECK-NEXT:      %[[EXTENTS_SHAPE:.+]] = shape.from_extents %[[LEN]] : index
-// CHECK-NEXT:      hipsr.shape_yield %[[EXTENTS_SHAPE]] : !shape.shape
+// CHECK-NEXT:      %[[SHAPE_EXTENTS:.+]] = tensor.from_elements %[[LEN]] : tensor<1xindex>
+// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE_EXTENTS]] : tensor<1xindex>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %[[SHAPE:.+]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x4096xf16, #hipsr.mem<device>>) outs(%[[EXTENTS_INIT]] : tensor<2xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:    ^bb0(%{{.+}}: !hipsr.context, %[[DATA:.+]]: tensor<?x4096xf16, #hipsr.mem<device>>, %{{.+}}: tensor<2xi64, #hipsr.mem<host>>):
@@ -73,9 +73,9 @@ func.func @negative_axis(%ctx: !hipsr.context, %data: tensor<2x3x4xf16>,
 // CHECK-NEXT:    } : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:    %{{.+}} = arith.constant dense<0> : tensor<i64>
 // CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[EXTENTS_INIT]] : tensor<2xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<i64, #hipsr.mem<host>> shape_region {
-// CHECK-NEXT:    ^bb0(%{{.+}}: !shape.shape):
-// CHECK-NEXT:      %[[RESULT_SHAPE:.+]] = shape.const_shape [] : !shape.shape
-// CHECK-NEXT:      hipsr.shape_yield %[[RESULT_SHAPE]] : !shape.shape
+// CHECK-NEXT:    ^bb0(%{{.+}}: tensor<1xindex>):
+// CHECK-NEXT:      %[[NO_EXTENTS:.+]] = arith.constant dense<> : tensor<0xindex>
+// CHECK-NEXT:      hipsr.shape_yield %[[NO_EXTENTS]] : tensor<0xindex>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %{{.+}} = hipsr.compute(%[[CTX]]) ins(%[[SHAPE]] : tensor<2xi64, #hipsr.mem<host>>) outs(%[[INIT]] : tensor<i64, #hipsr.mem<host>>) {
 // CHECK-NEXT:    ^bb0(%{{.+}}: !hipsr.context, %[[IN:.+]]: tensor<2xi64, #hipsr.mem<host>>, %{{.+}}: tensor<i64, #hipsr.mem<host>>):
@@ -106,10 +106,10 @@ func.func @host_leading_dim(%ctx: !hipsr.context,
 // CHECK-SAME:    %[[CTX:.+]]: !hipsr.context,
 // CHECK-SAME:    %[[INPUT:.+]]: tensor<?x?x4096xf16, #hipsr.mem<device>>) {
 // CHECK-NEXT:    %[[EXTENTS_INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<3xi64, #hipsr.mem<host>> shape_region {
-// CHECK-NEXT:    ^bb0(%{{.+}}: !shape.shape):
+// CHECK-NEXT:    ^bb0(%{{.+}}: tensor<3xindex>):
 // CHECK-NEXT:      %[[LEN:.+]] = arith.constant 3 : index
-// CHECK-NEXT:      %[[EXTENTS_SHAPE:.+]] = shape.from_extents %[[LEN]] : index
-// CHECK-NEXT:      hipsr.shape_yield %[[EXTENTS_SHAPE]] : !shape.shape
+// CHECK-NEXT:      %[[SHAPE_EXTENTS:.+]] = tensor.from_elements %[[LEN]] : tensor<1xindex>
+// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE_EXTENTS]] : tensor<1xindex>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %[[SHAPE:.+]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[EXTENTS_INIT]] : tensor<3xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:    ^bb0(%{{.+}}: !hipsr.context, %[[DATA:.+]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %{{.+}}: tensor<3xi64, #hipsr.mem<host>>):
@@ -125,9 +125,10 @@ func.func @host_leading_dim(%ctx: !hipsr.context,
 // CHECK-NEXT:    } : tensor<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:    %{{.+}} = hipsr.constant {value = dense<[-1, 0]> : tensor<2xi64>} : tensor<2xi64, #hipsr.mem<device>>
 // CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[EXTENTS_INIT]] : tensor<3xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
-// CHECK-NEXT:    ^bb0(%{{.+}}: !shape.shape):
-// CHECK-NEXT:      %[[RESULT_SHAPE:.+]] = shape.const_shape [2] : !shape.shape
-// CHECK-NEXT:      hipsr.shape_yield %[[RESULT_SHAPE]] : !shape.shape
+// CHECK-NEXT:    ^bb0(%{{.+}}: tensor<1xindex>):
+// CHECK-NEXT:      %[[RESULT_LEN:.+]] = arith.constant 2 : index
+// CHECK-NEXT:      %[[RESULT_EXTENTS:.+]] = tensor.from_elements %[[RESULT_LEN]] : tensor<1xindex>
+// CHECK-NEXT:      hipsr.shape_yield %[[RESULT_EXTENTS]] : tensor<1xindex>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %{{.+}} = hipsr.compute(%[[CTX]]) ins(%[[SHAPE]] : tensor<3xi64, #hipsr.mem<host>>) outs(%[[INIT]] : tensor<2xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:    ^bb0(%{{.+}}: !hipsr.context, %[[IN:.+]]: tensor<3xi64, #hipsr.mem<host>>, %{{.+}}: tensor<2xi64, #hipsr.mem<host>>):

--- a/test/lit/Conversion/onnx-to-hipsr/nonzero.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/nonzero.mlir
@@ -20,8 +20,8 @@
 // A copy keeps the source shape, so the host destination forwards the shape of
 // the search's count destination.
 // CHECK-NEXT:    %[[HOST_INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[INITS]]#1 : tensor<1xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<1xi64, #hipsr.mem<host>> shape_region {
-// CHECK-NEXT:    ^bb0(%[[COUNT_SHAPE:.+]]: !shape.shape):
-// CHECK-NEXT:      hipsr.shape_yield %[[COUNT_SHAPE]] : !shape.shape
+// CHECK-NEXT:    ^bb0(%[[COUNT_SHAPE:.+]]: tensor<1xindex>):
+// CHECK-NEXT:      hipsr.shape_yield %[[COUNT_SHAPE]] : tensor<1xindex>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %[[HOST_COUNT:.+]] = hipsr.copy_d2h(%[[CTX]]) ins(%[[SEARCH]]#1 : tensor<1xi64, #hipsr.mem<device>>) outs(%[[HOST_INIT]] : tensor<1xi64, #hipsr.mem<host>>) : tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[HOST_INIT]], %[[INITS]]#0 : tensor<1xi64, #hipsr.mem<host>>, tensor<2x?xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<2x?xi64, #hipsr.mem<device>> shape_region {
@@ -30,8 +30,8 @@
 // CHECK-NEXT:      %[[FOUND:.+]] = tensor.extract %[[COUNT]]{{\[}}%[[ZERO]]] : tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:      %[[COLUMNS:.+]] = arith.index_cast %[[FOUND]] : i64 to index
 // CHECK-NEXT:      %[[ROWS:.+]] = arith.constant 2 : index
-// CHECK-NEXT:      %[[SHAPE:.+]] = shape.from_extents %[[ROWS]], %[[COLUMNS]] : index, index
-// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:      %[[EXTENTS:.+]] = tensor.from_elements %[[ROWS]], %[[COLUMNS]] : tensor<2xindex>
+// CHECK-NEXT:      hipsr.shape_yield %[[EXTENTS]] : tensor<2xindex>
 // CHECK-NEXT:    }
 // The compute lists the count the barrier reads, so the two share a pool
 // domain, and ignores it in the body.
@@ -61,8 +61,8 @@ func.func @nonzero_mask(%ctx: !hipsr.context,
 // CHECK-NEXT:    %[[INITS:.+]]:2 = hipsr.placeholder(%[[CTX]]) ins(%[[MASK]] : tensor<12xi1, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<1x12xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>
 // CHECK-NEXT:    %[[SEARCH:.+]]:2 = hipsr.nonzero(%[[CTX]]) ins(%[[MASK]] : tensor<12xi1, #hipsr.mem<device>>) outs(%[[INITS]]#0, %[[INITS]]#1 : tensor<1x12xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>) : tensor<1x12xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>
 // CHECK-NEXT:    %[[HOST_INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[INITS]]#1 : tensor<1xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<1xi64, #hipsr.mem<host>> shape_region {
-// CHECK-NEXT:    ^bb0(%[[COUNT_SHAPE:.+]]: !shape.shape):
-// CHECK-NEXT:      hipsr.shape_yield %[[COUNT_SHAPE]] : !shape.shape
+// CHECK-NEXT:    ^bb0(%[[COUNT_SHAPE:.+]]: tensor<1xindex>):
+// CHECK-NEXT:      hipsr.shape_yield %[[COUNT_SHAPE]] : tensor<1xindex>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %[[HOST_COUNT:.+]] = hipsr.copy_d2h(%[[CTX]]) ins(%[[SEARCH]]#1 : tensor<1xi64, #hipsr.mem<device>>) outs(%[[HOST_INIT]] : tensor<1xi64, #hipsr.mem<host>>) : tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[HOST_INIT]], %[[INITS]]#0 : tensor<1xi64, #hipsr.mem<host>>, tensor<1x12xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<1x?xi64, #hipsr.mem<device>> shape_region {
@@ -71,8 +71,8 @@ func.func @nonzero_mask(%ctx: !hipsr.context,
 // CHECK-NEXT:      %[[FOUND:.+]] = tensor.extract %[[COUNT]]{{\[}}%[[ZERO]]] : tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:      %[[COLUMNS:.+]] = arith.index_cast %[[FOUND]] : i64 to index
 // CHECK-NEXT:      %[[ROWS:.+]] = arith.constant 1 : index
-// CHECK-NEXT:      %[[SHAPE:.+]] = shape.from_extents %[[ROWS]], %[[COLUMNS]] : index, index
-// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:      %[[EXTENTS:.+]] = tensor.from_elements %[[ROWS]], %[[COLUMNS]] : tensor<2xindex>
+// CHECK-NEXT:      hipsr.shape_yield %[[EXTENTS]] : tensor<2xindex>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %[[NARROWED:.+]] = hipsr.compute(%[[CTX]]) ins(%[[HOST_COUNT]], %[[SEARCH]]#0 : tensor<1xi64, #hipsr.mem<host>>, tensor<1x12xi64, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<1x?xi64, #hipsr.mem<device>>) {
 // CHECK-NEXT:    ^bb0(%{{.+}}: !hipsr.context, %{{.+}}: tensor<1xi64, #hipsr.mem<host>>, %[[POSITIONS:.+]]: tensor<1x12xi64, #hipsr.mem<device>>, %[[DEST:.+]]: tensor<1x?xi64, #hipsr.mem<device>>):

--- a/test/lit/Conversion/onnx-to-hipsr/reshape.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/reshape.mlir
@@ -18,13 +18,12 @@
 // CHECK-SAME:    %[[INPUT:.*]]: tensor<?x4096xf16, #hipsr.mem<device>>) -> tensor<?xf16, #hipsr.mem<device>> {
 // CHECK-NEXT:    %{{.*}} = hipsr.constant {value = dense<-1> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
 // CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?xf16, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:    ^bb0(%[[IN_SHAPE:.*]]: !shape.shape):
-// CHECK-NEXT:      %[[COUNT:.*]] = shape.num_elements %[[IN_SHAPE]] : !shape.shape -> !shape.size
-// CHECK-NEXT:      %[[DIVIDEND:.*]] = shape.size_to_index %[[COUNT]] : !shape.size
+// CHECK-NEXT:    ^bb0(%[[IN_SHAPE:.*]]: tensor<2xindex>):
+// CHECK-NEXT:      %[[COUNT:.*]] = shape.num_elements %[[IN_SHAPE]] : tensor<2xindex> -> index
 // CHECK-NEXT:      %[[DIVISOR:.*]] = arith.constant 1 : index
-// CHECK-NEXT:      %[[DIM:.*]] = arith.divui %[[DIVIDEND]], %[[DIVISOR]] : index
-// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[DIM]] : index
-// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:      %[[DIM:.*]] = arith.divui %[[COUNT]], %[[DIVISOR]] : index
+// CHECK-NEXT:      %[[EXTENTS:.*]] = tensor.from_elements %[[DIM]] : tensor<1xindex>
+// CHECK-NEXT:      hipsr.shape_yield %[[EXTENTS]] : tensor<1xindex>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x4096xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?xf16, #hipsr.mem<device>>) {
 // CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x4096xf16, #hipsr.mem<device>>, %{{.*}}: tensor<?xf16, #hipsr.mem<device>>):
@@ -50,14 +49,13 @@ func.func @flatten_dynamic(%ctx: !hipsr.context,
 // CHECK-SAME:    %[[INPUT:.*]]: tensor<?xf16, #hipsr.mem<device>>) -> tensor<?x4096xf16, #hipsr.mem<device>> {
 // CHECK-NEXT:    %{{.*}} = hipsr.constant {value = dense<[-1, 4096]> : tensor<2xi64>} : tensor<2xi64, #hipsr.mem<device>>
 // CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x4096xf16, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:    ^bb0(%[[IN_SHAPE:.*]]: !shape.shape):
-// CHECK-NEXT:      %[[COUNT:.*]] = shape.num_elements %[[IN_SHAPE]] : !shape.shape -> !shape.size
-// CHECK-NEXT:      %[[DIVIDEND:.*]] = shape.size_to_index %[[COUNT]] : !shape.size
+// CHECK-NEXT:    ^bb0(%[[IN_SHAPE:.*]]: tensor<1xindex>):
+// CHECK-NEXT:      %[[COUNT:.*]] = shape.num_elements %[[IN_SHAPE]] : tensor<1xindex> -> index
 // CHECK-NEXT:      %[[DIVISOR:.*]] = arith.constant 4096 : index
-// CHECK-NEXT:      %[[ROWS:.*]] = arith.divui %[[DIVIDEND]], %[[DIVISOR]] : index
+// CHECK-NEXT:      %[[ROWS:.*]] = arith.divui %[[COUNT]], %[[DIVISOR]] : index
 // CHECK-NEXT:      %[[COLS:.*]] = arith.constant 4096 : index
-// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[ROWS]], %[[COLS]] : index, index
-// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:      %[[EXTENTS:.*]] = tensor.from_elements %[[ROWS]], %[[COLS]] : tensor<2xindex>
+// CHECK-NEXT:      hipsr.shape_yield %[[EXTENTS]] : tensor<2xindex>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x4096xf16, #hipsr.mem<device>>) {
 // CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?xf16, #hipsr.mem<device>>, %[[DEST:.*]]: tensor<?x4096xf16, #hipsr.mem<device>>):
@@ -86,11 +84,11 @@ func.func @expand_dynamic(%ctx: !hipsr.context,
 // CHECK-SAME:    %[[INPUT:.*]]: tensor<?x4xi64, #hipsr.mem<device>>) -> tensor<6x4xi64, #hipsr.mem<device>> {
 // CHECK-NEXT:    %{{.*}} = hipsr.constant {value = dense<[6, 4]> : tensor<2xi64>} : tensor<2xi64, #hipsr.mem<device>>
 // CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x4xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<6x4xi64, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:    ^bb0(%{{.*}}: !shape.shape):
+// CHECK-NEXT:    ^bb0(%{{.*}}: tensor<2xindex>):
 // CHECK-NEXT:      %[[ROWS:.*]] = arith.constant 6 : index
 // CHECK-NEXT:      %[[COLS:.*]] = arith.constant 4 : index
-// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[ROWS]], %[[COLS]] : index, index
-// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:      %[[EXTENTS:.*]] = tensor.from_elements %[[ROWS]], %[[COLS]] : tensor<2xindex>
+// CHECK-NEXT:      hipsr.shape_yield %[[EXTENTS]] : tensor<2xindex>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x4xi64, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<6x4xi64, #hipsr.mem<device>>) {
 // CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x4xi64, #hipsr.mem<device>>, %{{.*}}: tensor<6x4xi64, #hipsr.mem<device>>):
@@ -136,11 +134,11 @@ func.func @refines_to_input(%ctx: !hipsr.context,
 // CHECK-SAME:    %[[INPUT:.*]]: tensor<2x3x4xf16, #hipsr.mem<device>>) -> tensor<6x4xf16, #hipsr.mem<device>> {
 // CHECK-NEXT:    %{{.*}} = hipsr.constant {value = dense<[-1, 4]> : tensor<2xi64>} : tensor<2xi64, #hipsr.mem<device>>
 // CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<2x3x4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<6x4xf16, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:    ^bb0(%{{.*}}: !shape.shape):
+// CHECK-NEXT:    ^bb0(%{{.*}}: tensor<3xindex>):
 // CHECK-NEXT:      %[[ROWS:.*]] = arith.constant 6 : index
 // CHECK-NEXT:      %[[COLS:.*]] = arith.constant 4 : index
-// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[ROWS]], %[[COLS]] : index, index
-// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:      %[[EXTENTS:.*]] = tensor.from_elements %[[ROWS]], %[[COLS]] : tensor<2xindex>
+// CHECK-NEXT:      hipsr.shape_yield %[[EXTENTS]] : tensor<2xindex>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<2x3x4xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<6x4xf16, #hipsr.mem<device>>) {
 // CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<2x3x4xf16, #hipsr.mem<device>>, %{{.*}}: tensor<6x4xf16, #hipsr.mem<device>>):

--- a/test/lit/Conversion/onnx-to-hipsr/shape.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/shape.mlir
@@ -12,8 +12,9 @@
 // no space.
 //
 // The input's rank fixes the result length, so every shape region below is
-// constant. The placeholder still reads the input, because it mirrors the
-// compute's operands to share a pool domain with it.
+// constant. It yields a one-element extent tensor with that length. The
+// placeholder still reads the input, because it mirrors the compute's operands
+// to share a pool domain with it.
 //===----------------------------------------------------------------------===//
 
 // RUN: hip-mlir-opt %s --onnx-dialect=modeled --split-input-file -allow-unregistered-dialect -convert-onnx-to-hipsr | FileCheck %s
@@ -23,10 +24,10 @@
 // CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:      %[[INPUT:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>) -> tensor<3xi64, #hipsr.mem<host>> {
 // CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<3xi64, #hipsr.mem<host>> shape_region {
-// CHECK-NEXT:      ^bb0(%{{.*}}: !shape.shape):
+// CHECK-NEXT:      ^bb0(%{{.*}}: tensor<3xindex>):
 // CHECK-NEXT:        %[[LEN:.*]] = arith.constant 3 : index
-// CHECK-NEXT:        %[[SHAPE:.*]] = shape.from_extents %[[LEN]] : index
-// CHECK-NEXT:        hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:        %[[SHAPE_EXTENTS:.*]] = tensor.from_elements %[[LEN]] : tensor<1xindex>
+// CHECK-NEXT:        hipsr.shape_yield %[[SHAPE_EXTENTS]] : tensor<1xindex>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<3xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:      ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %{{.*}}: tensor<3xi64, #hipsr.mem<host>>):
@@ -55,10 +56,10 @@ func.func @shape_full(%ctx: !hipsr.context, %input: tensor<?x?x4096xf16>)
 // CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:      %[[INPUT:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>) -> tensor<2xi64, #hipsr.mem<host>> {
 // CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
-// CHECK-NEXT:      ^bb0(%{{.*}}: !shape.shape):
+// CHECK-NEXT:      ^bb0(%{{.*}}: tensor<3xindex>):
 // CHECK-NEXT:        %[[LEN:.*]] = arith.constant 2 : index
-// CHECK-NEXT:        %[[SHAPE:.*]] = shape.from_extents %[[LEN]] : index
-// CHECK-NEXT:        hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:        %[[SHAPE_EXTENTS:.*]] = tensor.from_elements %[[LEN]] : tensor<1xindex>
+// CHECK-NEXT:        hipsr.shape_yield %[[SHAPE_EXTENTS]] : tensor<1xindex>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<2xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:      ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %{{.*}}: tensor<2xi64, #hipsr.mem<host>>):
@@ -85,10 +86,10 @@ func.func @shape_start(%ctx: !hipsr.context, %input: tensor<?x?x4096xf16>)
 // CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:      %[[INPUT:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>) -> tensor<1xi64, #hipsr.mem<host>> {
 // CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<1xi64, #hipsr.mem<host>> shape_region {
-// CHECK-NEXT:      ^bb0(%{{.*}}: !shape.shape):
+// CHECK-NEXT:      ^bb0(%{{.*}}: tensor<3xindex>):
 // CHECK-NEXT:        %[[LEN:.*]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[SHAPE:.*]] = shape.from_extents %[[LEN]] : index
-// CHECK-NEXT:        hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:        %[[SHAPE_EXTENTS:.*]] = tensor.from_elements %[[LEN]] : tensor<1xindex>
+// CHECK-NEXT:        hipsr.shape_yield %[[SHAPE_EXTENTS]] : tensor<1xindex>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<1xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:      ^bb0(%{{.*}}: !hipsr.context, %{{.*}}: tensor<?x?x4096xf16, #hipsr.mem<device>>, %{{.*}}: tensor<1xi64, #hipsr.mem<host>>):
@@ -112,10 +113,10 @@ func.func @shape_negative_start(%ctx: !hipsr.context,
 // CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:      %[[INPUT:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>) -> tensor<2xi64, #hipsr.mem<host>> {
 // CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
-// CHECK-NEXT:      ^bb0(%{{.*}}: !shape.shape):
+// CHECK-NEXT:      ^bb0(%{{.*}}: tensor<3xindex>):
 // CHECK-NEXT:        %[[LEN:.*]] = arith.constant 2 : index
-// CHECK-NEXT:        %[[SHAPE:.*]] = shape.from_extents %[[LEN]] : index
-// CHECK-NEXT:        hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:        %[[SHAPE_EXTENTS:.*]] = tensor.from_elements %[[LEN]] : tensor<1xindex>
+// CHECK-NEXT:        hipsr.shape_yield %[[SHAPE_EXTENTS]] : tensor<1xindex>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<2xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:      ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %{{.*}}: tensor<2xi64, #hipsr.mem<host>>):
@@ -144,10 +145,10 @@ func.func @shape_end(%ctx: !hipsr.context, %input: tensor<?x?x4096xf16>)
 // CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:      %[[INPUT:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>) -> tensor<3xi64, #hipsr.mem<host>> {
 // CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<3xi64, #hipsr.mem<host>> shape_region {
-// CHECK-NEXT:      ^bb0(%{{.*}}: !shape.shape):
+// CHECK-NEXT:      ^bb0(%{{.*}}: tensor<3xindex>):
 // CHECK-NEXT:        %[[LEN:.*]] = arith.constant 3 : index
-// CHECK-NEXT:        %[[SHAPE:.*]] = shape.from_extents %[[LEN]] : index
-// CHECK-NEXT:        hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:        %[[SHAPE_EXTENTS:.*]] = tensor.from_elements %[[LEN]] : tensor<1xindex>
+// CHECK-NEXT:        hipsr.shape_yield %[[SHAPE_EXTENTS]] : tensor<1xindex>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<3xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:      ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %{{.*}}: tensor<3xi64, #hipsr.mem<host>>):
@@ -178,10 +179,10 @@ func.func @shape_bounds_past_the_ends(%ctx: !hipsr.context,
 // CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:      %[[INPUT:.*]]: tensor<2x3xf16, #hipsr.mem<device>>) {
 // CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<2x3xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
-// CHECK-NEXT:      ^bb0(%{{.*}}: !shape.shape):
+// CHECK-NEXT:      ^bb0(%{{.*}}: tensor<2xindex>):
 // CHECK-NEXT:        %[[LEN:.*]] = arith.constant 2 : index
-// CHECK-NEXT:        %[[SHAPE:.*]] = shape.from_extents %[[LEN]] : index
-// CHECK-NEXT:        hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:        %[[SHAPE_EXTENTS:.*]] = tensor.from_elements %[[LEN]] : tensor<1xindex>
+// CHECK-NEXT:        hipsr.shape_yield %[[SHAPE_EXTENTS]] : tensor<1xindex>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<2x3xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<2xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:      ^bb0(%{{.*}}: !hipsr.context, %{{.*}}: tensor<2x3xf16, #hipsr.mem<device>>, %{{.*}}: tensor<2xi64, #hipsr.mem<host>>):
@@ -213,10 +214,10 @@ func.func @result_names_no_space(%ctx: !hipsr.context,
 // CHECK-SAME:      %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:      %[[INPUT:.*]]: tensor<?x3xf16, #hipsr.mem<device>>) -> tensor<?x?xf16, #hipsr.mem<device>> {
 // CHECK-NEXT:      %[[EXTENTS_INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x3xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2xi64, #hipsr.mem<host>> shape_region {
-// CHECK-NEXT:      ^bb0(%{{.*}}: !shape.shape):
+// CHECK-NEXT:      ^bb0(%{{.*}}: tensor<2xindex>):
 // CHECK-NEXT:        %[[LEN:.*]] = arith.constant 2 : index
-// CHECK-NEXT:        %[[SHAPE:.*]] = shape.from_extents %[[LEN]] : index
-// CHECK-NEXT:        hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:        %[[SHAPE_EXTENTS:.*]] = tensor.from_elements %[[LEN]] : tensor<1xindex>
+// CHECK-NEXT:        hipsr.shape_yield %[[SHAPE_EXTENTS]] : tensor<1xindex>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x3xf16, #hipsr.mem<device>>) outs(%[[EXTENTS_INIT]] : tensor<2xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:      ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x3xf16, #hipsr.mem<device>>, %{{.*}}: tensor<2xi64, #hipsr.mem<host>>):

--- a/test/lit/Conversion/onnx-to-hipsr/slice.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/slice.mlir
@@ -49,10 +49,10 @@ func.func @strided_window(%ctx: !hipsr.context,
 // CHECK-SAME:    %[[DATA:.+]]: tensor<8xf16, #hipsr.mem<device>>,
 // CHECK-SAME:    %[[OTHER:.+]]: tensor<?x4096xf16, #hipsr.mem<device>>) -> tensor<?xf16, #hipsr.mem<device>> {
 // CHECK-NEXT:    %[[ENDS_INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[OTHER]] : tensor<?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<1xi64, #hipsr.mem<host>> shape_region {
-// CHECK-NEXT:    ^bb0(%{{.+}}: !shape.shape):
+// CHECK-NEXT:    ^bb0(%{{.+}}: tensor<2xindex>):
 // CHECK-NEXT:      %[[LEN:.+]] = arith.constant 1 : index
-// CHECK-NEXT:      %[[ENDS_SHAPE:.+]] = shape.from_extents %[[LEN]] : index
-// CHECK-NEXT:      hipsr.shape_yield %[[ENDS_SHAPE]] : !shape.shape
+// CHECK-NEXT:      %[[ENDS_EXTENTS:.+]] = tensor.from_elements %[[LEN]] : tensor<1xindex>
+// CHECK-NEXT:      hipsr.shape_yield %[[ENDS_EXTENTS]] : tensor<1xindex>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %[[ENDS:.+]] = hipsr.compute(%[[CTX]]) ins(%[[OTHER]] : tensor<?x4096xf16, #hipsr.mem<device>>) outs(%[[ENDS_INIT]] : tensor<1xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:    ^bb0(%{{.+}}: !hipsr.context, %[[BODY_OTHER:.+]]: tensor<?x4096xf16, #hipsr.mem<device>>, %{{.+}}: tensor<1xi64, #hipsr.mem<host>>):

--- a/test/lit/Conversion/onnx-to-hipsr/unsqueeze.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/unsqueeze.mlir
@@ -21,19 +21,17 @@
 // CHECK-SAME:    %[[INPUT:.*]]: tensor<?x?xi1, #hipsr.mem<device>>) -> tensor<?x?x1xi1, #hipsr.mem<device>> {
 // CHECK-NEXT:    %{{.*}} = hipsr.constant {value = dense<-1> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
 // CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?xi1, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x?x1xi1, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:    ^bb0(%[[IN_SHAPE:.*]]: !shape.shape):
-// CHECK-NEXT:      %[[AXIS0:.*]] = shape.const_size 0
-// CHECK-NEXT:      %[[SIZE0:.*]] = shape.get_extent %[[IN_SHAPE]], %[[AXIS0]]
-// CHECK-NEXT:      %[[ROWS:.*]] = shape.size_to_index %[[SIZE0]] : !shape.size
-// CHECK-NEXT:      %[[AXIS1:.*]] = shape.const_size 1
-// CHECK-NEXT:      %[[SIZE1:.*]] = shape.get_extent %[[IN_SHAPE]], %[[AXIS1]]
-// CHECK-NEXT:      %[[COLS:.*]] = shape.size_to_index %[[SIZE1]] : !shape.size
+// CHECK-NEXT:    ^bb0(%[[IN_SHAPE:.*]]: tensor<2xindex>):
+// CHECK-NEXT:      %[[AXIS0:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[ROWS:.*]] = shape.get_extent %[[IN_SHAPE]], %[[AXIS0]] : tensor<2xindex>, index -> index
+// CHECK-NEXT:      %[[AXIS1:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[COLS:.*]] = shape.get_extent %[[IN_SHAPE]], %[[AXIS1]] : tensor<2xindex>, index -> index
 // One unused divisor per dynamic group, left by the expand's shape inference.
 // CHECK-NEXT:      arith.constant 1 : index
 // CHECK-NEXT:      arith.constant 1 : index
 // CHECK-NEXT:      %[[ONE:.*]] = arith.constant 1 : index
-// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[ROWS]], %[[COLS]], %[[ONE]] : index, index, index
-// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:      %[[EXTENTS:.*]] = tensor.from_elements %[[ROWS]], %[[COLS]], %[[ONE]] : tensor<3xindex>
+// CHECK-NEXT:      hipsr.shape_yield %[[EXTENTS]] : tensor<3xindex>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?xi1, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x?x1xi1, #hipsr.mem<device>>) {
 // CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x?xi1, #hipsr.mem<device>>, %[[DEST:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>):
@@ -64,19 +62,17 @@ func.func @trailing_axis(%ctx: !hipsr.context,
 // CHECK-SAME:    %[[INPUT:.*]]: tensor<?x?xi1, #hipsr.mem<device>>) -> tensor<?x1x?xi1, #hipsr.mem<device>> {
 // CHECK-NEXT:    %{{.*}} = hipsr.constant {value = dense<1> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
 // CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?xi1, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x1x?xi1, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:    ^bb0(%[[IN_SHAPE:.*]]: !shape.shape):
-// CHECK-NEXT:      %[[AXIS0:.*]] = shape.const_size 0
-// CHECK-NEXT:      %[[SIZE0:.*]] = shape.get_extent %[[IN_SHAPE]], %[[AXIS0]]
-// CHECK-NEXT:      %[[ROWS:.*]] = shape.size_to_index %[[SIZE0]] : !shape.size
-// CHECK-NEXT:      %[[AXIS1:.*]] = shape.const_size 1
-// CHECK-NEXT:      %[[SIZE1:.*]] = shape.get_extent %[[IN_SHAPE]], %[[AXIS1]]
-// CHECK-NEXT:      %[[COLS:.*]] = shape.size_to_index %[[SIZE1]] : !shape.size
+// CHECK-NEXT:    ^bb0(%[[IN_SHAPE:.*]]: tensor<2xindex>):
+// CHECK-NEXT:      %[[AXIS0:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[ROWS:.*]] = shape.get_extent %[[IN_SHAPE]], %[[AXIS0]] : tensor<2xindex>, index -> index
+// CHECK-NEXT:      %[[AXIS1:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[COLS:.*]] = shape.get_extent %[[IN_SHAPE]], %[[AXIS1]] : tensor<2xindex>, index -> index
 // One unused divisor per dynamic group, then the inserted unit.
 // CHECK-NEXT:      arith.constant 1 : index
 // CHECK-NEXT:      arith.constant 1 : index
 // CHECK-NEXT:      %[[ONE:.*]] = arith.constant 1 : index
-// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[ROWS]], %[[ONE]], %[[COLS]] : index, index, index
-// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:      %[[EXTENTS:.*]] = tensor.from_elements %[[ROWS]], %[[ONE]], %[[COLS]] : tensor<3xindex>
+// CHECK-NEXT:      hipsr.shape_yield %[[EXTENTS]] : tensor<3xindex>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?xi1, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x1x?xi1, #hipsr.mem<device>>) {
 // CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x?xi1, #hipsr.mem<device>>, %[[DEST:.*]]: tensor<?x1x?xi1, #hipsr.mem<device>>):
@@ -107,11 +103,11 @@ func.func @interior_axis(%ctx: !hipsr.context,
 // CHECK-SAME:    %[[INPUT:.*]]: tensor<2xi64, #hipsr.mem<host>>) -> tensor<1x2xi64, #hipsr.mem<host>> {
 // CHECK-NEXT:    %{{.*}} = hipsr.constant {value = dense<0> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
 // CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<2xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<1x2xi64, #hipsr.mem<host>> shape_region {
-// CHECK-NEXT:    ^bb0(%{{.*}}: !shape.shape):
+// CHECK-NEXT:    ^bb0(%{{.*}}: tensor<1xindex>):
 // CHECK-NEXT:      %[[D0:.*]] = arith.constant 1 : index
 // CHECK-NEXT:      %[[D1:.*]] = arith.constant 2 : index
-// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[D0]], %[[D1]] : index, index
-// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:      %[[EXTENTS:.*]] = tensor.from_elements %[[D0]], %[[D1]] : tensor<2xindex>
+// CHECK-NEXT:      hipsr.shape_yield %[[EXTENTS]] : tensor<2xindex>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<2xi64, #hipsr.mem<host>>) outs(%[[INIT]] : tensor<1x2xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<2xi64, #hipsr.mem<host>>, %{{.*}}: tensor<1x2xi64, #hipsr.mem<host>>):
@@ -138,13 +134,13 @@ func.func @host_input(%ctx: !hipsr.context,
 // CHECK-SAME:    %[[INPUT:.*]]: tensor<3x4xf16, #hipsr.mem<device>>) -> tensor<1x3x4x1xf16, #hipsr.mem<device>> {
 // CHECK-NEXT:    %{{.*}} = hipsr.constant {value = dense<[3, 0]> : tensor<2xi64>} : tensor<2xi64, #hipsr.mem<device>>
 // CHECK-NEXT:    %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<3x4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<1x3x4x1xf16, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:    ^bb0(%{{.*}}: !shape.shape):
+// CHECK-NEXT:    ^bb0(%{{.*}}: tensor<2xindex>):
 // CHECK-NEXT:      %[[D0:.*]] = arith.constant 1 : index
 // CHECK-NEXT:      %[[D1:.*]] = arith.constant 3 : index
 // CHECK-NEXT:      %[[D2:.*]] = arith.constant 4 : index
 // CHECK-NEXT:      %[[D3:.*]] = arith.constant 1 : index
-// CHECK-NEXT:      %[[SHAPE:.*]] = shape.from_extents %[[D0]], %[[D1]], %[[D2]], %[[D3]] : index, index, index, index
-// CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT:      %[[EXTENTS:.*]] = tensor.from_elements %[[D0]], %[[D1]], %[[D2]], %[[D3]] : tensor<4xindex>
+// CHECK-NEXT:      hipsr.shape_yield %[[EXTENTS]] : tensor<4xindex>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<3x4xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<1x3x4x1xf16, #hipsr.mem<device>>) {
 // CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<3x4xf16, #hipsr.mem<device>>, %{{.*}}: tensor<1x3x4x1xf16, #hipsr.mem<device>>):

--- a/test/lit/Dialect/Hipsr/IR/placeholder.mlir
+++ b/test/lit/Dialect/Hipsr/IR/placeholder.mlir
@@ -98,7 +98,7 @@ func.func @non_hipsr_outs(%ctx: !hipsr.context, %input: tensor<4x8xf32, #hipsr.m
 }
 
 // -----
-// A normal shape region takes one !shape.shape per input.
+// A normal shape region takes one extent tensor per input.
 func.func @shape_region_argument_count(
     %ctx: !hipsr.context, %input: tensor<4x8xf32, #hipsr.mem<device>>) -> tensor<4x8xf16, #hipsr.mem<device>> {
   // expected-error @+1 {{shape region block argument count does not match the placeholder type layout; expected 1, got 0}}
@@ -106,8 +106,8 @@ func.func @shape_region_argument_count(
       ins(%input : tensor<4x8xf32, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16, #hipsr.mem<device>>
       shape_region {
-    %shape = shape.const_shape [4, 8] : !shape.shape
-    hipsr.shape_yield %shape : !shape.shape
+    %shape = shape.const_shape [4, 8] : tensor<2xindex>
+    hipsr.shape_yield %shape : tensor<2xindex>
   }
   %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32, #hipsr.mem<device>>)
       outs(%init : tensor<4x8xf16, #hipsr.mem<device>>) : tensor<4x8xf16, #hipsr.mem<device>>
@@ -119,14 +119,14 @@ func.func @shape_region_argument_count(
 // takes the tensor types, led by ctx.
 func.func @shape_region_argument_type(
     %ctx: !hipsr.context, %input: tensor<4x8xf32, #hipsr.mem<device>>) -> tensor<4x8xf16, #hipsr.mem<device>> {
-  // expected-error @+1 {{shape region block argument 0 type 'tensor<4x8xf32, #hipsr.mem<device>>' does not match expected type '!shape.shape'}}
+  // expected-error @+1 {{shape region block argument 0 type 'tensor<4x8xf32, #hipsr.mem<device>>' does not match expected type 'tensor<2xindex>'}}
   %init = hipsr.placeholder(%ctx)
       ins(%input : tensor<4x8xf32, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16, #hipsr.mem<device>>
       shape_region {
   ^bb0(%input_shape: tensor<4x8xf32, #hipsr.mem<device>>):
-    %shape = shape.const_shape [4, 8] : !shape.shape
-    hipsr.shape_yield %shape : !shape.shape
+    %shape = shape.const_shape [4, 8] : tensor<2xindex>
+    hipsr.shape_yield %shape : tensor<2xindex>
   }
   %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32, #hipsr.mem<device>>)
       outs(%init : tensor<4x8xf16, #hipsr.mem<device>>) : tensor<4x8xf16, #hipsr.mem<device>>
@@ -138,14 +138,14 @@ func.func @shape_region_argument_type(
 // shapes of a normal region do not fit.
 func.func @barrier_shape_region_layout(
     %ctx: !hipsr.context, %input: tensor<4x8xf32, #hipsr.mem<device>>) -> tensor<4x8xf16, #hipsr.mem<device>> {
-  // expected-error @+1 {{shape region block argument 0 type '!shape.shape' does not match expected type '!hipsr.context'}}
+  // expected-error @+1 {{shape region block argument 0 type 'tensor<2xindex>' does not match expected type '!hipsr.context'}}
   %init = hipsr.placeholder(%ctx)
       ins(%input : tensor<4x8xf32, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4x8xf16, #hipsr.mem<device>>
       shape_region {
-  ^bb0(%input_shape: !shape.shape, %data: tensor<4x8xf32, #hipsr.mem<device>>):
-    %shape = shape.const_shape [4, 8] : !shape.shape
-    hipsr.shape_yield %shape : !shape.shape
+  ^bb0(%input_shape: tensor<2xindex>, %data: tensor<4x8xf32, #hipsr.mem<device>>):
+    %shape = shape.const_shape [4, 8] : tensor<2xindex>
+    hipsr.shape_yield %shape : tensor<2xindex>
   }
   %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32, #hipsr.mem<device>>)
       outs(%init : tensor<4x8xf16, #hipsr.mem<device>>) : tensor<4x8xf16, #hipsr.mem<device>>
@@ -162,10 +162,10 @@ func.func @shape_region_capture(
       ins(%input : tensor<?x8xf32, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16, #hipsr.mem<device>>
       shape_region {
-  ^bb0(%input_shape: !shape.shape):
+  ^bb0(%input_shape: tensor<2xindex>):
     // expected-error @+1 {{using value defined outside the region}}
-    %captured = shape.shape_of %input : tensor<?x8xf32, #hipsr.mem<device>> -> !shape.shape
-    hipsr.shape_yield %captured : !shape.shape
+    %captured = shape.shape_of %input : tensor<?x8xf32, #hipsr.mem<device>> -> tensor<2xindex>
+    hipsr.shape_yield %captured : tensor<2xindex>
   }
   %result = hipsr.cast(%ctx) ins(%input : tensor<?x8xf32, #hipsr.mem<device>>)
       outs(%init : tensor<?x8xf16, #hipsr.mem<device>>) : tensor<?x8xf16, #hipsr.mem<device>>
@@ -181,11 +181,11 @@ func.func @two_shape_region_blocks(
       ins(%input : tensor<4x8xf32, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16, #hipsr.mem<device>>
       shape_region {
-  ^bb0(%input_shape: !shape.shape):
-    hipsr.shape_yield %input_shape : !shape.shape
+  ^bb0(%input_shape: tensor<2xindex>):
+    hipsr.shape_yield %input_shape : tensor<2xindex>
   ^bb1:
-    %shape = shape.const_shape [4, 8] : !shape.shape
-    hipsr.shape_yield %shape : !shape.shape
+    %shape = shape.const_shape [4, 8] : tensor<2xindex>
+    hipsr.shape_yield %shape : tensor<2xindex>
   }
   %result = hipsr.cast(%ctx) ins(%input : tensor<4x8xf32, #hipsr.mem<device>>)
       outs(%init : tensor<4x8xf16, #hipsr.mem<device>>) : tensor<4x8xf16, #hipsr.mem<device>>
@@ -199,7 +199,7 @@ func.func @wrong_shape_region_terminator(
   // expected-error @+2 {{expects regions to end with 'hipsr.shape_yield', found 'llvm.unreachable'}}
   // expected-note @+1 {{in custom textual format, the absence of terminator implies 'hipsr.shape_yield'}}
   %init = "hipsr.placeholder"(%ctx, %input) ({
-  ^bb0(%input_shape: !shape.shape):
+  ^bb0(%input_shape: tensor<2xindex>):
     llvm.unreachable
   }) {placeholder_type = #hipsr.placeholder_type<normal>}
       : (!hipsr.context, tensor<4x8xf32, #hipsr.mem<device>>) -> tensor<4x8xf16, #hipsr.mem<device>>

--- a/test/lit/Dialect/Hipsr/IR/preserve_shape.mlir
+++ b/test/lit/Dialect/Hipsr/IR/preserve_shape.mlir
@@ -4,19 +4,21 @@
 
 // RUN: hip-mlir-opt --split-input-file --verify-diagnostics %s | FileCheck %s
 
+// The assembly format prints both types, so the shape operand carries its
+// length and the verifier can compare it with the data's rank.
 // CHECK-LABEL: func.func @tensor_form(
 // CHECK-SAME: %[[D0:.+]]: index) {
 // CHECK-NEXT: %[[C2048:.+]] = arith.constant 2048 : index
-// CHECK-NEXT: %[[SHAPE:.+]] = shape.from_extents %[[D0]], %[[C2048]] : index, index
+// CHECK-NEXT: %[[SHAPE:.+]] = tensor.from_elements %[[D0]], %[[C2048]] : tensor<2xindex>
 // CHECK-NEXT: %[[INIT:.+]] = tensor.empty(%[[D0]]) : tensor<?x2048xf16>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[INIT]] : tensor<?x2048xf16>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[INIT]] : tensor<2xindex>, tensor<?x2048xf16>
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 func.func @tensor_form(%d0: index) {
   %c2048 = arith.constant 2048 : index
-  %shape = shape.from_extents %d0, %c2048 : index, index
+  %shape = tensor.from_elements %d0, %c2048 : tensor<2xindex>
   %init = tensor.empty(%d0) : tensor<?x2048xf16>
-  hipsr.preserve_shape %shape, %init : tensor<?x2048xf16>
+  hipsr.preserve_shape %shape, %init : tensor<2xindex>, tensor<?x2048xf16>
   return
 }
 
@@ -28,36 +30,36 @@ func.func @tensor_form(%d0: index) {
 // CHECK-LABEL: func.func @tensor_form_device(
 // CHECK-SAME: %[[D0:.+]]: index) {
 // CHECK-NEXT: %[[C2048:.+]] = arith.constant 2048 : index
-// CHECK-NEXT: %[[SHAPE:.+]] = shape.from_extents %[[D0]], %[[C2048]] : index, index
+// CHECK-NEXT: %[[SHAPE:.+]] = tensor.from_elements %[[D0]], %[[C2048]] : tensor<2xindex>
 // CHECK-NEXT: %[[INIT:.+]] = tensor.empty(%[[D0]]) : tensor<?x2048xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[INIT]] : tensor<?x2048xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[INIT]] : tensor<2xindex>, tensor<?x2048xf16, #hipsr.mem<device>>
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 func.func @tensor_form_device(%d0: index) {
   %c2048 = arith.constant 2048 : index
-  %shape = shape.from_extents %d0, %c2048 : index, index
+  %shape = tensor.from_elements %d0, %c2048 : tensor<2xindex>
   %init = tensor.empty(%d0) : tensor<?x2048xf16, #hipsr.mem<device>>
-  hipsr.preserve_shape %shape, %init : tensor<?x2048xf16, #hipsr.mem<device>>
+  hipsr.preserve_shape %shape, %init : tensor<2xindex>, tensor<?x2048xf16, #hipsr.mem<device>>
   return
 }
 
 // -----
 
-// The memref form: same shape operand, data operand now the kind of space-less
-// memref one-shot-bufferize emits.
+// The memref form, as one-shot-bufferize leaves it: the data operand is a bare
+// memref and the shape reaches the op through bufferization.to_tensor. An
+// extent tensor stays a tensor, because preserve_shape names it without
+// reading through it.
 // CHECK-LABEL: func.func @memref_form(
-// CHECK-SAME: %[[D0:.+]]: index) {
-// CHECK-NEXT: %[[C2048:.+]] = arith.constant 2048 : index
-// CHECK-NEXT: %[[SHAPE:.+]] = shape.from_extents %[[D0]], %[[C2048]] : index, index
+// CHECK-SAME: %[[D0:.+]]: index, %[[EXTENTS:.+]]: memref<2xindex>) {
+// CHECK-NEXT: %[[SHAPE:.+]] = bufferization.to_tensor %[[EXTENTS]] : memref<2xindex> to tensor<2xindex>
 // CHECK-NEXT: %[[ALLOC:.+]] = memref.alloc(%[[D0]]) : memref<?x2048xf16>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[ALLOC]] : memref<?x2048xf16>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[ALLOC]] : tensor<2xindex>, memref<?x2048xf16>
 // CHECK-NEXT: return
 // CHECK-NEXT: }
-func.func @memref_form(%d0: index) {
-  %c2048 = arith.constant 2048 : index
-  %shape = shape.from_extents %d0, %c2048 : index, index
+func.func @memref_form(%d0: index, %extents: memref<2xindex>) {
+  %shape = bufferization.to_tensor %extents : memref<2xindex> to tensor<2xindex>
   %alloc = memref.alloc(%d0) : memref<?x2048xf16>
-  hipsr.preserve_shape %shape, %alloc : memref<?x2048xf16>
+  hipsr.preserve_shape %shape, %alloc : tensor<2xindex>, memref<?x2048xf16>
   return
 }
 
@@ -65,35 +67,41 @@ func.func @memref_form(%d0: index) {
 
 // A memref that does name its space is equally acceptable.
 // CHECK-LABEL: func.func @device_memref_form(
+// CHECK-SAME: %[[EXTENTS:.+]]: memref<2xindex>,
 // CHECK-SAME: %[[DATA:.+]]: memref<4x8xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: %[[C4:.+]] = arith.constant 4 : index
-// CHECK-NEXT: %[[C8:.+]] = arith.constant 8 : index
-// CHECK-NEXT: %[[SHAPE:.+]] = shape.from_extents %[[C4]], %[[C8]] : index, index
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[DATA]] : memref<4x8xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[SHAPE:.+]] = bufferization.to_tensor %[[EXTENTS]] : memref<2xindex> to tensor<2xindex>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[DATA]] : tensor<2xindex>, memref<4x8xf16, #hipsr.mem<device>>
 // CHECK-NEXT: return
 // CHECK-NEXT: }
-func.func @device_memref_form(%data: memref<4x8xf16, #hipsr.mem<device>>) {
-  %c4 = arith.constant 4 : index
-  %c8 = arith.constant 8 : index
-  %shape = shape.from_extents %c4, %c8 : index, index
-  hipsr.preserve_shape %shape, %data : memref<4x8xf16, #hipsr.mem<device>>
+func.func @device_memref_form(%extents: memref<2xindex>,
+                              %data: memref<4x8xf16, #hipsr.mem<device>>) {
+  %shape = bufferization.to_tensor %extents : memref<2xindex> to tensor<2xindex>
+  hipsr.preserve_shape %shape, %data : tensor<2xindex>, memref<4x8xf16, #hipsr.mem<device>>
   return
 }
 
 // -----
 
-// A shape that does not come from shape.from_extents carries no rank, so the
-// verifier has nothing to compare and accepts it. This is the case the intended
-// producer builds, where the shape comes out of an scf.execute_region.
+// A tensor<?xindex> shape states no length, so the verifier has nothing to
+// compare and accepts it. No pass builds one, but the type is still legal.
 // CHECK-LABEL: func.func @opaque_shape(
-// CHECK-SAME: %[[D0:.+]]: index, %[[SHAPE:.+]]: !shape.shape) {
+// CHECK-SAME: %[[D0:.+]]: index, %[[SHAPE:.+]]: tensor<?xindex>) {
 // CHECK-NEXT: %[[INIT:.+]] = tensor.empty(%[[D0]]) : tensor<?x2048xf16>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[INIT]] : tensor<?x2048xf16>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[INIT]] : tensor<?xindex>, tensor<?x2048xf16>
 // CHECK-NEXT: return
 // CHECK-NEXT: }
-func.func @opaque_shape(%d0: index, %shape: !shape.shape) {
+func.func @opaque_shape(%d0: index, %shape: tensor<?xindex>) {
   %init = tensor.empty(%d0) : tensor<?x2048xf16>
-  hipsr.preserve_shape %shape, %init : tensor<?x2048xf16>
+  hipsr.preserve_shape %shape, %init : tensor<?xindex>, tensor<?x2048xf16>
+  return
+}
+
+// -----
+
+func.func @rank_mismatch(%d0: index, %shape: tensor<3xindex>) {
+  %init = tensor.empty(%d0) : tensor<?x2048xf16>
+  // expected-error @+1 {{shape holds 3 extents but data has rank 2}}
+  hipsr.preserve_shape %shape, %init : tensor<3xindex>, tensor<?x2048xf16>
   return
 }
 
@@ -101,8 +109,8 @@ func.func @opaque_shape(%d0: index, %shape: !shape.shape) {
 
 // The data operand must be ranked: an unranked tensor has no dimensions for a
 // shape to describe.
-func.func @unranked_data(%shape: !shape.shape, %data: tensor<*xf16>) {
+func.func @unranked_data(%shape: tensor<?xindex>, %data: tensor<*xf16>) {
   // expected-error @+1 {{operand #1 must be ranked tensor or memref}}
-  hipsr.preserve_shape %shape, %data : tensor<*xf16>
+  hipsr.preserve_shape %shape, %data : tensor<?xindex>, tensor<*xf16>
   return
 }

--- a/test/lit/Dialect/Hipsr/IR/shape_yield.mlir
+++ b/test/lit/Dialect/Hipsr/IR/shape_yield.mlir
@@ -6,15 +6,21 @@
 // Multi-result placeholders yield one shape per result. A scalar still has one
 // shape value, produced from an empty extent list.
 // CHECK-LABEL: func.func @multiple_results_and_scalar(
-// CHECK: %[[INITS:.+]]:2 = hipsr.placeholder
-// CHECK-SAME: shape_region {
+// CHECK-SAME: %[[CTX:.+]]: !hipsr.context) -> (tensor<2x3xf16, #hipsr.mem<device>>, tensor<f16, #hipsr.mem<device>>) {
+// CHECK-NEXT: %[[INITS:.+]]:2 = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<2x3xf16, #hipsr.mem<device>>, tensor<f16, #hipsr.mem<device>> shape_region {
 // CHECK-NEXT: ^bb0(%{{.+}}: !hipsr.context):
 // CHECK-NEXT: %[[C2:.+]] = arith.constant 2 : index
 // CHECK-NEXT: %[[C3:.+]] = arith.constant 3 : index
-// CHECK-NEXT: %[[VALUES_SHAPE:.+]] = shape.from_extents %[[C2]], %[[C3]]
-// CHECK-NEXT: %[[SCALAR_SHAPE:.+]] = shape.from_extents
+// CHECK-NEXT: %[[VALUES_SHAPE:.+]] = tensor.from_elements %[[C2]], %[[C3]] : tensor<2xindex>
+// CHECK-NEXT: %[[SCALAR_SHAPE:.+]] = arith.constant dense<> : tensor<0xindex>
 // CHECK-NEXT: hipsr.shape_yield %[[VALUES_SHAPE]], %[[SCALAR_SHAPE]]
-// CHECK-SAME: : !shape.shape, !shape.shape
+// CHECK-SAME: : tensor<2xindex>, tensor<0xindex>
+// CHECK-NEXT: }
+// CHECK-NEXT: %[[RESULTS:.+]]:2 = hipsr.compute(%[[CTX]]) ins() outs(%[[INITS]]#0, %[[INITS]]#1 : tensor<2x3xf16, #hipsr.mem<device>>, tensor<f16, #hipsr.mem<device>>) {
+// CHECK-NEXT: ^bb0(%{{.+}}: !hipsr.context, %[[VALUES_DEST:.+]]: tensor<2x3xf16, #hipsr.mem<device>>, %[[SCALAR_DEST:.+]]: tensor<f16, #hipsr.mem<device>>):
+// CHECK-NEXT: hipsr.compute_yield %[[VALUES_DEST]], %[[SCALAR_DEST]] : tensor<2x3xf16, #hipsr.mem<device>>, tensor<f16, #hipsr.mem<device>>
+// CHECK-NEXT: } : tensor<2x3xf16, #hipsr.mem<device>>, tensor<f16, #hipsr.mem<device>>
+// CHECK-NEXT: return %[[RESULTS]]#0, %[[RESULTS]]#1 : tensor<2x3xf16, #hipsr.mem<device>>, tensor<f16, #hipsr.mem<device>>
 // CHECK-NEXT: }
 func.func @multiple_results_and_scalar(%ctx: !hipsr.context)
     -> (tensor<2x3xf16, #hipsr.mem<device>>, tensor<f16, #hipsr.mem<device>>) {
@@ -24,11 +30,10 @@ func.func @multiple_results_and_scalar(%ctx: !hipsr.context)
   ^bb0(%shape_ctx: !hipsr.context):
     %c2 = arith.constant 2 : index
     %c3 = arith.constant 3 : index
-    %values_shape = "shape.from_extents"(%c2, %c3)
-        : (index, index) -> !shape.shape
-    %scalar_shape = "shape.from_extents"() : () -> !shape.shape
+    %values_shape = tensor.from_elements %c2, %c3 : tensor<2xindex>
+    %scalar_shape = arith.constant dense<> : tensor<0xindex>
     hipsr.shape_yield %values_shape, %scalar_shape
-        : !shape.shape, !shape.shape
+        : tensor<2xindex>, tensor<0xindex>
   }
   %results:2 = hipsr.compute(%ctx) ins()
       outs(%inits#0, %inits#1 : tensor<2x3xf16, #hipsr.mem<device>>, tensor<f16, #hipsr.mem<device>>) {
@@ -42,14 +47,13 @@ func.func @multiple_results_and_scalar(%ctx: !hipsr.context)
 
 // -----
 
-// Shape-yield operands must use the Shape dialect's value shape type.
 func.func @non_shape_operand(%ctx: !hipsr.context) -> tensor<f16, #hipsr.mem<device>> {
   %init = hipsr.placeholder(%ctx)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<f16, #hipsr.mem<device>>
       shape_region {
   ^bb0(%shape_ctx: !hipsr.context):
     %extent = arith.constant 1 : index
-    // expected-error @+1 {{operand #0 must be variadic of , but got 'index'}}
+    // expected-error @+1 {{operand #0 must be variadic of 1D tensor of index values, but got 'index'}}
     hipsr.shape_yield %extent : index
   }
   %result = hipsr.compute(%ctx) ins() outs(%init : tensor<f16, #hipsr.mem<device>>) {
@@ -64,7 +68,7 @@ func.func @non_shape_operand(%ctx: !hipsr.context) -> tensor<f16, #hipsr.mem<dev
 // An empty block gets an implicit zero-operand yield, which cannot describe
 // the placeholder's result.
 func.func @implicit_empty_yield(%ctx: !hipsr.context) -> tensor<f16, #hipsr.mem<device>> {
-  // expected-error @+1 {{must yield one !shape.shape per enclosing placeholder result; expected 1, got 0}}
+  // expected-error @+1 {{must yield one extent tensor per enclosing placeholder result; expected 1, got 0}}
   %init = hipsr.placeholder(%ctx)
       {placeholder_type = #hipsr.placeholder_type<barrier>}
       : tensor<f16, #hipsr.mem<device>> shape_region {
@@ -79,9 +83,69 @@ func.func @implicit_empty_yield(%ctx: !hipsr.context) -> tensor<f16, #hipsr.mem<
 
 // -----
 
+// A yielded shape must describe its result, so a length that disagrees with
+// the result rank is rejected here rather than at a later extent read.
+func.func @extent_count_mismatch(%ctx: !hipsr.context)
+    -> tensor<2x3xf16, #hipsr.mem<device>> {
+  %init = hipsr.placeholder(%ctx)
+      {placeholder_type = #hipsr.placeholder_type<barrier>}
+      : tensor<2x3xf16, #hipsr.mem<device>> shape_region {
+  ^bb0(%shape_ctx: !hipsr.context):
+    %c2 = arith.constant 2 : index
+    %shape = tensor.from_elements %c2 : tensor<1xindex>
+    // expected-error @+1 {{shape #0 holds 1 extents but result #0 has rank 2}}
+    hipsr.shape_yield %shape : tensor<1xindex>
+  }
+  %result = hipsr.compute(%ctx) ins() outs(%init : tensor<2x3xf16, #hipsr.mem<device>>) {
+  ^bb0(%body_ctx: !hipsr.context, %dest: tensor<2x3xf16, #hipsr.mem<device>>):
+    hipsr.compute_yield %dest : tensor<2x3xf16, #hipsr.mem<device>>
+  } : tensor<2x3xf16, #hipsr.mem<device>>
+  return %result : tensor<2x3xf16, #hipsr.mem<device>>
+}
+
+// -----
+
+// A dynamic length states nothing, so the verifier has nothing to compare.
+// CHECK-LABEL: func.func @dynamic_extent_count(
+// CHECK-SAME: %[[CTX:.+]]: !hipsr.context) -> tensor<2x3xf16, #hipsr.mem<device>> {
+// CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<2x3xf16, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT: ^bb0(%{{.+}}: !hipsr.context):
+// CHECK-NEXT: %[[C2:.+]] = arith.constant 2 : index
+// CHECK-NEXT: %[[C3:.+]] = arith.constant 3 : index
+// CHECK-NEXT: %[[STATIC_SHAPE:.+]] = tensor.from_elements %[[C2]], %[[C3]] : tensor<2xindex>
+// CHECK-NEXT: %[[SHAPE:.+]] = tensor.cast %[[STATIC_SHAPE]] : tensor<2xindex> to tensor<?xindex>
+// CHECK-NEXT: hipsr.shape_yield %[[SHAPE]] : tensor<?xindex>
+// CHECK-NEXT: }
+// CHECK-NEXT: %[[RESULT:.+]] = hipsr.compute(%[[CTX]]) ins() outs(%[[INIT]] : tensor<2x3xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT: ^bb0(%{{.+}}: !hipsr.context, %[[DEST:.+]]: tensor<2x3xf16, #hipsr.mem<device>>):
+// CHECK-NEXT: hipsr.compute_yield %[[DEST]] : tensor<2x3xf16, #hipsr.mem<device>>
+// CHECK-NEXT: } : tensor<2x3xf16, #hipsr.mem<device>>
+// CHECK-NEXT: return %[[RESULT]] : tensor<2x3xf16, #hipsr.mem<device>>
+// CHECK-NEXT: }
+func.func @dynamic_extent_count(%ctx: !hipsr.context)
+    -> tensor<2x3xf16, #hipsr.mem<device>> {
+  %init = hipsr.placeholder(%ctx)
+      {placeholder_type = #hipsr.placeholder_type<barrier>}
+      : tensor<2x3xf16, #hipsr.mem<device>> shape_region {
+  ^bb0(%shape_ctx: !hipsr.context):
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %static_shape = tensor.from_elements %c2, %c3 : tensor<2xindex>
+    %shape = tensor.cast %static_shape : tensor<2xindex> to tensor<?xindex>
+    hipsr.shape_yield %shape : tensor<?xindex>
+  }
+  %result = hipsr.compute(%ctx) ins() outs(%init : tensor<2x3xf16, #hipsr.mem<device>>) {
+  ^bb0(%body_ctx: !hipsr.context, %dest: tensor<2x3xf16, #hipsr.mem<device>>):
+    hipsr.compute_yield %dest : tensor<2x3xf16, #hipsr.mem<device>>
+  } : tensor<2x3xf16, #hipsr.mem<device>>
+  return %result : tensor<2x3xf16, #hipsr.mem<device>>
+}
+
+// -----
+
 // ShapeYield terminates placeholder shape regions only.
 func.func @wrong_parent() {
-  %shape = "shape.from_extents"() : () -> !shape.shape
+  %shape = arith.constant dense<> : tensor<0xindex>
   // expected-error @+1 {{expects parent op 'hipsr.placeholder'}}
-  hipsr.shape_yield %shape : !shape.shape
+  hipsr.shape_yield %shape : tensor<0xindex>
 }

--- a/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
@@ -58,399 +58,374 @@
 // through 4 each open with a shape computation that extracts extents from a
 // host buffer an earlier domain filled, which is what a cut looks like below.
 //
-// The four zones of a domain
-// --------------------------
+// The zones of a domain
+// ---------------------
 //
-// hipsr-materialize-init-tensors leaves each domain body in order: the
-// scf.execute_region shape computations, then the tensor.empty allocations that
-// read their dynamic extents back out of those shapes, then the data ops, then
-// a hipsr.preserve_shape per allocation tying the shape that sized it to the
-// result that fills it. A constant a shape computation reads moves up with it;
-// the rest stay where conversion left them.
+// hipsr-materialize-init-tensors leaves each domain body in this order:
+//
+//   1. the constants;
+//   2. the shape computations;
+//   3. the tensor.empty allocations that read their dynamic extents from those
+//      shapes;
+//   4. the data ops;
+//   5. one hipsr.preserve_shape per result, tying its shape to the value that
+//      filled the buffer it sized.
+//
+// A shape computation starts as an scf.execute_region yielding one extent
+// tensor per result. What reaches the checks below:
+//
+//   - upstream lowers the region to arith, scf and tensor arithmetic;
+//   - canonicalization inlines it, leaving straight-line code;
+//   - everything constant-like is hoisted to the top of the domain;
+//   - preserve_shape names every result shape, so a shape stays alive even
+//     when no allocation reads its extents;
+//   - nothing of the shape dialect survives, which checking every line of the
+//     output shows: such an op would have to appear on a line of its own.
 //===----------------------------------------------------------------------===//
 
 // RUN: %python %S/../../../Inputs/make_external_data.py %t/embedding.onnx.data 2034237440 && cd %t && hip-mlir-opt --onnx-dialect=modeled --hipsr-pipeline --mlir-elide-resource-strings-if-larger=32 %s | FileCheck %s
 
 module {
 
+
 // The context becomes argument 0 and every symbolic extent survives.
 // CHECK-LABEL:   func.func @main_graph(
-// CHECK-SAME:      %[[ARG0:[^,]*]]: !hipsr.context,
-// CHECK-SAME:      %[[ARG1:[^,]*]]: tensor<?x?xi64, #hipsr.mem<device>> {onnx.name = "input_ids"},
-// CHECK-SAME:      %[[ARG2:[^,]*]]: tensor<?x4096xf16, #hipsr.mem<device>> {onnx.name = "image_features"}) -> (tensor<?x?x4096xf16, #hipsr.mem<device>> {onnx.name = "inputs_embeds"}) attributes {onnx.graph.name = "main_graph"} {
+// CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[ARG1:.*]]: tensor<?x?xi64, #hipsr.mem<device>> {onnx.name = "input_ids"},
+// CHECK-SAME:      %[[ARG2:.*]]: tensor<?x4096xf16, #hipsr.mem<device>> {onnx.name = "image_features"}) -> (tensor<?x?x4096xf16, #hipsr.mem<device>> {onnx.name = "inputs_embeds"}) attributes {onnx.graph.name = "main_graph"} {
 
-// Domain 0 takes everything whose shape follows from the graph inputs alone:
-// the embedding lookup, the bool mask, and the shape vector the broadcasts
-// downstream will read. Its six constants come first, in conversion order, so
-// each stays ahead of the two shape computations that read one, then the five
-// computations follow.
+// Domain 0 takes everything shaped by the graph inputs alone: the embedding
+// lookup, the bool mask, and the shape vector the broadcasts read.
+//
+//   - Constant-like values lead: index constants, static shapes, weights.
+//   - The flat reshape's extent is a product over the input shape, so an
+//     scf.for opens the shape graph.
 // CHECK-NEXT:           %[[POOL_DOMAIN_0:.*]]:8 = hipsr.pool_domain(%[[ARG0]], %[[ARG2]], %[[ARG1]] : !hipsr.context, tensor<?x4096xf16, #hipsr.mem<device>>, tensor<?x?xi64, #hipsr.mem<device>>) {
 // CHECK-NEXT:           ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: tensor<?x4096xf16, #hipsr.mem<device>>, %[[VAL_2:.*]]: tensor<?x?xi64, #hipsr.mem<device>>):
-// CHECK-NEXT:             %[[CONSTANT_5:.*]] = hipsr.constant {value = dense_resource<"file|embedding.onnx.data|0"> : tensor<248320x4096xf16, #hipsr.mem<device>>} : tensor<248320x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[CONSTANT_7:.*]] = arith.constant dense<248056> : tensor<i64>
-// CHECK-NEXT:             %[[CONSTANT_8:.*]] = hipsr.constant {value = dense<-1> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[CONSTANT_9:.*]] = arith.constant dense<0> : tensor<i64>
-// CHECK-NEXT:             %[[CONSTANT_10:.*]] = hipsr.constant {value = dense<0> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[CONSTANT_1:.*]] = hipsr.constant {value = dense<248056> : tensor<i64>} : tensor<i64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[EXECUTE_REGION_0:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[SHAPE_OF_0:.*]] = shape.shape_of %[[VAL_1]] : tensor<?x4096xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:               %[[NUM_ELEMENTS_0:.*]] = shape.num_elements %[[SHAPE_OF_0]] : !shape.shape -> !shape.size
-// CHECK-NEXT:               %[[SIZE_TO_INDEX_0:.*]] = shape.size_to_index %[[NUM_ELEMENTS_0]] : !shape.size
-// CHECK-NEXT:               %[[CONSTANT_0:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[DIVUI_0:.*]] = arith.divui %[[SIZE_TO_INDEX_0]], %[[CONSTANT_0]] : index
-// CHECK-NEXT:               %[[FROM_EXTENTS_0:.*]] = shape.from_extents %[[DIVUI_0]] : index
-// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_0]] : !shape.shape
+// CHECK-NEXT:             %[[CONSTANT_0:.*]] = arith.constant dense<> : tensor<0xindex>
+// CHECK-NEXT:             %[[CONSTANT_1:.*]] = arith.constant 2 : index
+// CHECK-NEXT:             %[[CONSTANT_2:.*]] = arith.constant 4096 : index
+// CHECK-NEXT:             %[[CONSTANT_3:.*]] = arith.constant dense<3> : tensor<1xindex>
+// CHECK-NEXT:             %[[CONSTANT_4:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[CONSTANT_5:.*]] = arith.constant 1 : index
+// CHECK-NEXT:             %[[CONSTANT_6:.*]] = hipsr.constant {value = dense_resource<"file|embedding.onnx.data|0"> : tensor<248320x4096xf16, #hipsr.mem<device>>} : tensor<248320x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[CONSTANT_7:.*]] = hipsr.constant {value = dense<248056> : tensor<i64>} : tensor<i64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[DIM_0:.*]] = tensor.dim %[[VAL_1]], %[[CONSTANT_4]] : tensor<?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[FROM_ELEMENTS_0:.*]] = tensor.from_elements %[[DIM_0]], %[[CONSTANT_2]] : tensor<2xindex>
+// CHECK-NEXT:             %[[FOR_0:.*]] = scf.for %[[VAL_3:.*]] = %[[CONSTANT_4]] to %[[CONSTANT_1]] step %[[CONSTANT_5]] iter_args(%[[VAL_4:.*]] = %[[CONSTANT_5]]) -> (index) {
+// CHECK-NEXT:               %[[EXTRACT_0:.*]] = tensor.extract %[[FROM_ELEMENTS_0]]{{\[}}%[[VAL_3]]] : tensor<2xindex>
+// CHECK-NEXT:               %[[MULI_0:.*]] = arith.muli %[[EXTRACT_0]], %[[VAL_4]] : index
+// CHECK-NEXT:               scf.yield %[[MULI_0]] : index
 // CHECK-NEXT:             }
-// CHECK-NEXT:             %[[EXECUTE_REGION_1:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[SHAPE_OF_1:.*]] = shape.shape_of %[[VAL_2]] : tensor<?x?xi64, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:               %[[SHAPE_OF_2:.*]] = shape.shape_of %[[CONSTANT_1]] : tensor<i64, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:               %[[BROADCAST_0:.*]] = shape.broadcast %[[SHAPE_OF_1]], %[[SHAPE_OF_2]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:               scf.yield %[[BROADCAST_0]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[EXECUTE_REGION_2:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[CONST_SIZE_0:.*]] = shape.const_size 0
-// CHECK-NEXT:               %[[GET_EXTENT_0:.*]] = shape.get_extent %[[EXECUTE_REGION_1]], %[[CONST_SIZE_0]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:               %[[SIZE_TO_INDEX_1:.*]] = shape.size_to_index %[[GET_EXTENT_0]] : !shape.size
-// CHECK-NEXT:               %[[CONST_SIZE_1:.*]] = shape.const_size 1
-// CHECK-NEXT:               %[[GET_EXTENT_1:.*]] = shape.get_extent %[[EXECUTE_REGION_1]], %[[CONST_SIZE_1]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:               %[[SIZE_TO_INDEX_2:.*]] = shape.size_to_index %[[GET_EXTENT_1]] : !shape.size
-// CHECK-NEXT:               %[[CONSTANT_2:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[CONSTANT_3:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[CONSTANT_4:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[FROM_EXTENTS_1:.*]] = shape.from_extents %[[SIZE_TO_INDEX_1]], %[[SIZE_TO_INDEX_2]], %[[CONSTANT_4]] : index, index, index
-// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_1]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[EXECUTE_REGION_3:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[SHAPE_OF_3:.*]] = shape.shape_of %[[CONSTANT_5]] : tensor<248320x4096xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:               %[[SHAPE_OF_4:.*]] = shape.shape_of %[[VAL_2]] : tensor<?x?xi64, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:               %[[CONST_SIZE_2:.*]] = shape.const_size 0
-// CHECK-NEXT:               %[[VAL_3:.*]], %[[VAL_4:.*]] = "shape.split_at"(%[[SHAPE_OF_3]], %[[CONST_SIZE_2]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT:               %[[CONST_SIZE_3:.*]] = shape.const_size 1
-// CHECK-NEXT:               %[[VAL_5:.*]], %[[VAL_6:.*]] = "shape.split_at"(%[[SHAPE_OF_3]], %[[CONST_SIZE_3]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT:               %[[CONCAT_0:.*]] = shape.concat %[[VAL_3]], %[[SHAPE_OF_4]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:               %[[CONCAT_1:.*]] = shape.concat %[[CONCAT_0]], %[[VAL_6]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:               scf.yield %[[CONCAT_1]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[EXECUTE_REGION_4:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[CONSTANT_6:.*]] = arith.constant 3 : index
-// CHECK-NEXT:               %[[FROM_EXTENTS_2:.*]] = shape.from_extents %[[CONSTANT_6]] : index
-// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_2]] : !shape.shape
-// CHECK-NEXT:             }
+// CHECK-NEXT:             %[[FROM_ELEMENTS_1:.*]] = tensor.from_elements %[[FOR_0]] : tensor<1xindex>
+// CHECK-NEXT:             %[[DIM_1:.*]] = tensor.dim %[[VAL_2]], %[[CONSTANT_4]] : tensor<?x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[DIM_2:.*]] = tensor.dim %[[VAL_2]], %[[CONSTANT_5]] : tensor<?x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[FROM_ELEMENTS_2:.*]] = tensor.from_elements %[[DIM_1]], %[[DIM_2]] : tensor<2xindex>
+// CHECK-NEXT:             %[[GENERATE_0:.*]] = tensor.generate  {
+// CHECK-NEXT:             ^bb0(%[[VAL_5:.*]]: index):
+// CHECK-NEXT:               %[[CMPI_0:.*]] = arith.cmpi ult, %[[VAL_5]], %[[CONSTANT_4]] : index
+// CHECK-NEXT:               %[[IF_0:.*]] = scf.if %[[CMPI_0]] -> (index) {
+// CHECK-NEXT:                 scf.yield %[[CONSTANT_5]] : index
+// CHECK-NEXT:               } else {
+// CHECK-NEXT:                 %[[EXTRACT_1:.*]] = tensor.extract %[[FROM_ELEMENTS_2]]{{\[}}%[[VAL_5]]] : tensor<2xindex>
+// CHECK-NEXT:                 scf.yield %[[EXTRACT_1]] : index
+// CHECK-NEXT:               }
+// CHECK-NEXT:               %[[CMPI_1:.*]] = arith.cmpi ult, %[[VAL_5]], %[[CONSTANT_1]] : index
+// CHECK-NEXT:               %[[IF_1:.*]] = scf.if %[[CMPI_1]] -> (index) {
+// CHECK-NEXT:                 scf.yield %[[IF_0]] : index
+// CHECK-NEXT:               } else {
+// CHECK-NEXT:                 %[[SUBI_0:.*]] = arith.subi %[[VAL_5]], %[[CONSTANT_1]] : index
+// CHECK-NEXT:                 %[[EXTRACT_2:.*]] = tensor.extract %[[CONSTANT_0]]{{\[}}%[[SUBI_0]]] : tensor<0xindex>
+// CHECK-NEXT:                 %[[CMPI_2:.*]] = arith.cmpi eq, %[[EXTRACT_2]], %[[CONSTANT_5]] : index
+// CHECK-NEXT:                 %[[SELECT_0:.*]] = arith.select %[[CMPI_2]], %[[IF_0]], %[[EXTRACT_2]] : index
+// CHECK-NEXT:                 scf.yield %[[SELECT_0]] : index
+// CHECK-NEXT:               }
+// CHECK-NEXT:               tensor.yield %[[IF_1]] : index
+// CHECK-NEXT:             } : tensor<2xindex>
+// CHECK-NEXT:             %[[FROM_ELEMENTS_3:.*]] = tensor.from_elements %[[DIM_1]], %[[DIM_2]], %[[CONSTANT_5]] : tensor<3xindex>
+// CHECK-NEXT:             %[[DIM_3:.*]] = tensor.dim %[[VAL_2]], %[[CONSTANT_4]] : tensor<?x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[DIM_4:.*]] = tensor.dim %[[VAL_2]], %[[CONSTANT_5]] : tensor<?x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[FROM_ELEMENTS_4:.*]] = tensor.from_elements %[[DIM_3]], %[[DIM_4]], %[[CONSTANT_2]] : tensor<3xindex>
 
 // The allocation zone. Each tensor.empty takes its dynamic extents from the
-// shape yielded above; a fully static result type needs none.
-// CHECK-NEXT:             %[[CONST_SIZE_4:.*]] = shape.const_size 0
-// CHECK-NEXT:             %[[GET_EXTENT_2:.*]] = shape.get_extent %[[EXECUTE_REGION_0]], %[[CONST_SIZE_4]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_3:.*]] = shape.size_to_index %[[GET_EXTENT_2]] : !shape.size
-// CHECK-NEXT:             %[[EMPTY_0:.*]] = tensor.empty(%[[SIZE_TO_INDEX_3]]) : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[CONST_SIZE_5:.*]] = shape.const_size 0
-// CHECK-NEXT:             %[[GET_EXTENT_3:.*]] = shape.get_extent %[[EXECUTE_REGION_1]], %[[CONST_SIZE_5]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_4:.*]] = shape.size_to_index %[[GET_EXTENT_3]] : !shape.size
-// CHECK-NEXT:             %[[CONST_SIZE_6:.*]] = shape.const_size 1
-// CHECK-NEXT:             %[[GET_EXTENT_4:.*]] = shape.get_extent %[[EXECUTE_REGION_1]], %[[CONST_SIZE_6]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_5:.*]] = shape.size_to_index %[[GET_EXTENT_4]] : !shape.size
-// CHECK-NEXT:             %[[EMPTY_1:.*]] = tensor.empty(%[[SIZE_TO_INDEX_4]], %[[SIZE_TO_INDEX_5]]) : tensor<?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[CONST_SIZE_7:.*]] = shape.const_size 0
-// CHECK-NEXT:             %[[GET_EXTENT_5:.*]] = shape.get_extent %[[EXECUTE_REGION_2]], %[[CONST_SIZE_7]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_6:.*]] = shape.size_to_index %[[GET_EXTENT_5]] : !shape.size
-// CHECK-NEXT:             %[[CONST_SIZE_8:.*]] = shape.const_size 1
-// CHECK-NEXT:             %[[GET_EXTENT_6:.*]] = shape.get_extent %[[EXECUTE_REGION_2]], %[[CONST_SIZE_8]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_7:.*]] = shape.size_to_index %[[GET_EXTENT_6]] : !shape.size
-// CHECK-NEXT:             %[[EMPTY_2:.*]] = tensor.empty(%[[SIZE_TO_INDEX_6]], %[[SIZE_TO_INDEX_7]]) : tensor<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[CONST_SIZE_9:.*]] = shape.const_size 0
-// CHECK-NEXT:             %[[GET_EXTENT_7:.*]] = shape.get_extent %[[EXECUTE_REGION_3]], %[[CONST_SIZE_9]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_8:.*]] = shape.size_to_index %[[GET_EXTENT_7]] : !shape.size
-// CHECK-NEXT:             %[[CONST_SIZE_10:.*]] = shape.const_size 1
-// CHECK-NEXT:             %[[GET_EXTENT_8:.*]] = shape.get_extent %[[EXECUTE_REGION_3]], %[[CONST_SIZE_10]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_9:.*]] = shape.size_to_index %[[GET_EXTENT_8]] : !shape.size
-// CHECK-NEXT:             %[[EMPTY_3:.*]] = tensor.empty(%[[SIZE_TO_INDEX_8]], %[[SIZE_TO_INDEX_9]]) : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// shape graph above; a fully static result type needs none. Assembling an
+// extent tensor and reading one back out fold, so each allocation names it.
+// CHECK-NEXT:             %[[EMPTY_0:.*]] = tensor.empty(%[[FOR_0]]) : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[EMPTY_1:.*]] = tensor.empty(%[[DIM_1]], %[[DIM_2]]) : tensor<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[EMPTY_2:.*]] = tensor.empty(%[[DIM_1]], %[[DIM_2]]) : tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[EMPTY_3:.*]] = tensor.empty(%[[DIM_3]], %[[DIM_4]]) : tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:             %[[EMPTY_4:.*]] = tensor.empty() : tensor<3xi64, #hipsr.mem<host>>
 
 // The data zone, in conversion order, each op now initialized by a tensor.empty.
 // CHECK-NEXT:             %[[COMPUTE_0:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[VAL_1]] : tensor<?x4096xf16, #hipsr.mem<device>>) outs(%[[EMPTY_0]] : tensor<?xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_7:.*]]: !hipsr.context, %[[VAL_8:.*]]: tensor<?x4096xf16, #hipsr.mem<device>>, %[[VAL_9:.*]]: tensor<?xf16, #hipsr.mem<device>>):
-// CHECK-NEXT:               %[[COLLAPSE_SHAPE_0:.*]] = tensor.collapse_shape %[[VAL_8]] {{\[\[}}0, 1]] : tensor<?x4096xf16, #hipsr.mem<device>> into tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             ^bb0(%[[VAL_6:.*]]: !hipsr.context, %[[VAL_7:.*]]: tensor<?x4096xf16, #hipsr.mem<device>>, %[[VAL_8:.*]]: tensor<?xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:               %[[COLLAPSE_SHAPE_0:.*]] = tensor.collapse_shape %[[VAL_7]] {{\[\[}}0, 1]] : tensor<?x4096xf16, #hipsr.mem<device>> into tensor<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT:               hipsr.compute_yield %[[COLLAPSE_SHAPE_0]] : tensor<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT:             } : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[EQUAL_0:.*]] = hipsr.equal(%[[VAL_0]]) ins(%[[VAL_2]], %[[CONSTANT_1]] : tensor<?x?xi64, #hipsr.mem<device>>, tensor<i64, #hipsr.mem<device>>) outs(%[[EMPTY_1]] : tensor<?x?xi1, #hipsr.mem<device>>) : tensor<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[EQUAL_0:.*]] = hipsr.equal(%[[VAL_0]]) ins(%[[VAL_2]], %[[CONSTANT_7]] : tensor<?x?xi64, #hipsr.mem<device>>, tensor<i64, #hipsr.mem<device>>) outs(%[[EMPTY_1]] : tensor<?x?xi1, #hipsr.mem<device>>) : tensor<?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:             %[[COMPUTE_1:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[EQUAL_0]] : tensor<?x?xi1, #hipsr.mem<device>>) outs(%[[EMPTY_2]] : tensor<?x?x1xi1, #hipsr.mem<device>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_10:.*]]: !hipsr.context, %[[VAL_11:.*]]: tensor<?x?xi1, #hipsr.mem<device>>, %[[VAL_12:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>):
-// CHECK-NEXT:               %[[CONSTANT_11:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[DIM_0:.*]] = tensor.dim %[[VAL_12]], %[[CONSTANT_11]] : tensor<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:               %[[CONSTANT_12:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[DIM_1:.*]] = tensor.dim %[[VAL_12]], %[[CONSTANT_12]] : tensor<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:               %[[EXPAND_SHAPE_0:.*]] = tensor.expand_shape %[[VAL_11]] {{\[\[}}0], [1, 2]] output_shape {{\[}}%[[DIM_0]], %[[DIM_1]], 1] : tensor<?x?xi1, #hipsr.mem<device>> into tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             ^bb0(%[[VAL_9:.*]]: !hipsr.context, %[[VAL_10:.*]]: tensor<?x?xi1, #hipsr.mem<device>>, %[[VAL_11:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>):
+// CHECK-NEXT:               %[[CONSTANT_8:.*]] = arith.constant 1 : index
+// CHECK-NEXT:               %[[CONSTANT_9:.*]] = arith.constant 0 : index
+// CHECK-NEXT:               %[[DIM_5:.*]] = tensor.dim %[[VAL_11]], %[[CONSTANT_9]] : tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[DIM_6:.*]] = tensor.dim %[[VAL_11]], %[[CONSTANT_8]] : tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[EXPAND_SHAPE_0:.*]] = tensor.expand_shape %[[VAL_10]] {{\[\[}}0], [1, 2]] output_shape [%[[DIM_5]], %[[DIM_6]], 1] : tensor<?x?xi1, #hipsr.mem<device>> into tensor<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT:               hipsr.compute_yield %[[EXPAND_SHAPE_0]] : tensor<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT:             } : tensor<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[GATHER_0:.*]] = hipsr.gather(%[[VAL_0]]) ins(%[[CONSTANT_5]], %[[VAL_2]] : tensor<248320x4096xf16, #hipsr.mem<device>>, tensor<?x?xi64, #hipsr.mem<device>>) outs(%[[EMPTY_3]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {axis = 0 : i64} : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[GATHER_0:.*]] = hipsr.gather(%[[VAL_0]]) ins(%[[CONSTANT_6]], %[[VAL_2]] : tensor<248320x4096xf16, #hipsr.mem<device>>, tensor<?x?xi64, #hipsr.mem<device>>) outs(%[[EMPTY_3]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {axis = 0 : i64} : tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:             %[[COMPUTE_2:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[GATHER_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[EMPTY_4]] : tensor<3xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_13:.*]]: !hipsr.context, %[[VAL_14:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_15:.*]]: tensor<3xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:               %[[CONSTANT_13:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[DIM_2:.*]] = tensor.dim %[[VAL_14]], %[[CONSTANT_13]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:               %[[INDEX_CAST_0:.*]] = arith.index_cast %[[DIM_2]] : index to i64
-// CHECK-NEXT:               %[[CONSTANT_14:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[DIM_3:.*]] = tensor.dim %[[VAL_14]], %[[CONSTANT_14]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:               %[[INDEX_CAST_1:.*]] = arith.index_cast %[[DIM_3]] : index to i64
-// CHECK-NEXT:               %[[CONSTANT_15:.*]] = arith.constant 4096 : i64
-// CHECK-NEXT:               %[[FROM_ELEMENTS_0:.*]] = tensor.from_elements %[[INDEX_CAST_0]], %[[INDEX_CAST_1]], %[[CONSTANT_15]] : tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               hipsr.compute_yield %[[FROM_ELEMENTS_0]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             ^bb0(%[[VAL_12:.*]]: !hipsr.context, %[[VAL_13:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_14:.*]]: tensor<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:               %[[CONSTANT_10:.*]] = arith.constant 4096 : i64
+// CHECK-NEXT:               %[[CONSTANT_11:.*]] = arith.constant 1 : index
+// CHECK-NEXT:               %[[CONSTANT_12:.*]] = arith.constant 0 : index
+// CHECK-NEXT:               %[[DIM_7:.*]] = tensor.dim %[[VAL_13]], %[[CONSTANT_12]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[INDEX_CAST_0:.*]] = arith.index_cast %[[DIM_7]] : index to i64
+// CHECK-NEXT:               %[[DIM_8:.*]] = tensor.dim %[[VAL_13]], %[[CONSTANT_11]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[INDEX_CAST_1:.*]] = arith.index_cast %[[DIM_8]] : index to i64
+// CHECK-NEXT:               %[[FROM_ELEMENTS_5:.*]] = tensor.from_elements %[[INDEX_CAST_0]], %[[INDEX_CAST_1]], %[[CONSTANT_10]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               hipsr.compute_yield %[[FROM_ELEMENTS_5]] : tensor<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:             } : tensor<3xi64, #hipsr.mem<host>>
 
-// The link zone. One hipsr.preserve_shape per allocation, in allocation order,
-// each naming the result of the op that fills that buffer, so a later pass can
-// still read the shape once bufferization has replaced the tensor values with
-// the buffers behind them.
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_0]], %[[COMPUTE_0]] : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_1]], %[[EQUAL_0]] : tensor<?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_2]], %[[COMPUTE_1]] : tensor<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_3]], %[[GATHER_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_4]], %[[COMPUTE_2]] : tensor<3xi64, #hipsr.mem<host>>
+// The preserve_shape zone closes the domain. Each one names the shape that
+// sized the buffer its value filled. For a shape no allocation reads, this is
+// the only use left, and it is what keeps the shape alive.
+// CHECK-NEXT:             hipsr.preserve_shape %[[FROM_ELEMENTS_1]], %[[COMPUTE_0]] : tensor<1xindex>, tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[GENERATE_0]], %[[EQUAL_0]] : tensor<2xindex>, tensor<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[FROM_ELEMENTS_3]], %[[COMPUTE_1]] : tensor<3xindex>, tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[FROM_ELEMENTS_4]], %[[GATHER_0]] : tensor<3xindex>, tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[CONSTANT_3]], %[[COMPUTE_2]] : tensor<1xindex>, tensor<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:             hipsr.pool_domain_yield %[[EMPTY_0]], %[[COMPUTE_0]], %[[EMPTY_2]], %[[COMPUTE_1]], %[[EMPTY_3]], %[[GATHER_0]], %[[EMPTY_4]], %[[COMPUTE_2]] : tensor<?xf16, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:           } -> tensor<?xf16, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<3xi64, #hipsr.mem<host>> {domain_id = 0 : i64}
 
-// Each broadcast reads its extents from a host shape vector rather than from
-// the type, so each one opens a domain whose shape computation extracts them
-// with tensor.extract and rebuilds the destination shape.
+// Each broadcast reads its extents from a host shape vector, not from the type,
+// so each one opens a domain. Its shape graph extracts them with tensor.extract
+// and rebuilds the destination shape, which folds to one select per axis.
 // CHECK-NEXT:           %[[POOL_DOMAIN_1:.*]]:2 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#2, %[[POOL_DOMAIN_0]]#6, %[[POOL_DOMAIN_0]]#3, %[[POOL_DOMAIN_0]]#7 : !hipsr.context, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:           ^bb0(%[[VAL_17:.*]]: !hipsr.context, %[[VAL_18:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_19:.*]]: tensor<3xi64, #hipsr.mem<host>>, %[[VAL_20:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_21:.*]]: tensor<3xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:             %[[EXECUTE_REGION_5:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[SHAPE_OF_5:.*]] = shape.shape_of %[[VAL_18]] : tensor<?x?x1xi1, #hipsr.mem<device>> -> tensor<3xindex>
-// CHECK-NEXT:               %[[CONSTANT_16:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[EXTRACT_0:.*]] = tensor.extract %[[VAL_19]]{{\[}}%[[CONSTANT_16]]] : tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               %[[INDEX_CAST_2:.*]] = arith.index_cast %[[EXTRACT_0]] : i64 to index
-// CHECK-NEXT:               %[[CONSTANT_17:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[EXTRACT_1:.*]] = tensor.extract %[[VAL_19]]{{\[}}%[[CONSTANT_17]]] : tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               %[[INDEX_CAST_3:.*]] = arith.index_cast %[[EXTRACT_1]] : i64 to index
-// CHECK-NEXT:               %[[CONSTANT_18:.*]] = arith.constant 2 : index
-// CHECK-NEXT:               %[[EXTRACT_2:.*]] = tensor.extract %[[VAL_19]]{{\[}}%[[CONSTANT_18]]] : tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               %[[INDEX_CAST_4:.*]] = arith.index_cast %[[EXTRACT_2]] : i64 to index
-// CHECK-NEXT:               %[[FROM_EXTENTS_3:.*]] = shape.from_extents %[[INDEX_CAST_2]], %[[INDEX_CAST_3]], %[[INDEX_CAST_4]] : index, index, index
-// CHECK-NEXT:               %[[CSTR_BROADCASTABLE_0:.*]] = shape.cstr_broadcastable %[[SHAPE_OF_5]], %[[FROM_EXTENTS_3]] : tensor<3xindex>, !shape.shape
-// CHECK-NEXT:               %[[ASSUMING_0:.*]] = shape.assuming %[[CSTR_BROADCASTABLE_0]] -> (!shape.shape) {
-// CHECK-NEXT:                 %[[BROADCAST_1:.*]] = shape.broadcast %[[SHAPE_OF_5]], %[[FROM_EXTENTS_3]] : tensor<3xindex>, !shape.shape -> !shape.shape
-// CHECK-NEXT:                 shape.assuming_yield %[[BROADCAST_1]] : !shape.shape
+// CHECK-NEXT:           ^bb0(%[[VAL_15:.*]]: !hipsr.context, %[[VAL_16:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_17:.*]]: tensor<3xi64, #hipsr.mem<host>>, %[[VAL_18:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_19:.*]]: tensor<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:             %[[CONSTANT_13:.*]] = arith.constant 2 : index
+// CHECK-NEXT:             %[[CONSTANT_14:.*]] = arith.constant 1 : index
+// CHECK-NEXT:             %[[CONSTANT_15:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[DIM_9:.*]] = tensor.dim %[[VAL_16]], %[[CONSTANT_15]] : tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[DIM_10:.*]] = tensor.dim %[[VAL_16]], %[[CONSTANT_14]] : tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[FROM_ELEMENTS_6:.*]] = tensor.from_elements %[[DIM_9]], %[[DIM_10]], %[[CONSTANT_14]] : tensor<3xindex>
+// CHECK-NEXT:             %[[EXTRACT_3:.*]] = tensor.extract %[[VAL_17]]{{\[}}%[[CONSTANT_15]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[INDEX_CAST_2:.*]] = arith.index_cast %[[EXTRACT_3]] : i64 to index
+// CHECK-NEXT:             %[[EXTRACT_4:.*]] = tensor.extract %[[VAL_17]]{{\[}}%[[CONSTANT_14]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[INDEX_CAST_3:.*]] = arith.index_cast %[[EXTRACT_4]] : i64 to index
+// CHECK-NEXT:             %[[EXTRACT_5:.*]] = tensor.extract %[[VAL_17]]{{\[}}%[[CONSTANT_13]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[INDEX_CAST_4:.*]] = arith.index_cast %[[EXTRACT_5]] : i64 to index
+// CHECK-NEXT:             %[[FROM_ELEMENTS_7:.*]] = tensor.from_elements %[[INDEX_CAST_2]], %[[INDEX_CAST_3]], %[[INDEX_CAST_4]] : tensor<3xindex>
+// CHECK-NEXT:             %[[GENERATE_1:.*]] = tensor.generate  {
+// CHECK-NEXT:             ^bb0(%[[VAL_20:.*]]: index):
+// CHECK-NEXT:               %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_20]], %[[CONSTANT_15]] : index
+// CHECK-NEXT:               %[[IF_2:.*]] = scf.if %[[CMPI_3]] -> (index) {
+// CHECK-NEXT:                 scf.yield %[[CONSTANT_14]] : index
+// CHECK-NEXT:               } else {
+// CHECK-NEXT:                 %[[EXTRACT_6:.*]] = tensor.extract %[[FROM_ELEMENTS_6]]{{\[}}%[[VAL_20]]] : tensor<3xindex>
+// CHECK-NEXT:                 scf.yield %[[EXTRACT_6]] : index
 // CHECK-NEXT:               }
-// CHECK-NEXT:               scf.yield %[[ASSUMING_0]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[CONST_SIZE_11:.*]] = shape.const_size 0
-// CHECK-NEXT:             %[[GET_EXTENT_9:.*]] = shape.get_extent %[[EXECUTE_REGION_5]], %[[CONST_SIZE_11]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_10:.*]] = shape.size_to_index %[[GET_EXTENT_9]] : !shape.size
-// CHECK-NEXT:             %[[CONST_SIZE_12:.*]] = shape.const_size 1
-// CHECK-NEXT:             %[[GET_EXTENT_10:.*]] = shape.get_extent %[[EXECUTE_REGION_5]], %[[CONST_SIZE_12]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_11:.*]] = shape.size_to_index %[[GET_EXTENT_10]] : !shape.size
-// CHECK-NEXT:             %[[CONST_SIZE_13:.*]] = shape.const_size 2
-// CHECK-NEXT:             %[[GET_EXTENT_11:.*]] = shape.get_extent %[[EXECUTE_REGION_5]], %[[CONST_SIZE_13]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_12:.*]] = shape.size_to_index %[[GET_EXTENT_11]] : !shape.size
-// CHECK-NEXT:             %[[EMPTY_5:.*]] = tensor.empty(%[[SIZE_TO_INDEX_10]], %[[SIZE_TO_INDEX_11]], %[[SIZE_TO_INDEX_12]]) : tensor<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[EXPAND_0:.*]] = hipsr.expand(%[[VAL_17]]) ins(%[[VAL_20]], %[[VAL_21]] : tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) outs(%[[EMPTY_5]] : tensor<?x?x?xi1, #hipsr.mem<device>>) : tensor<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_5]], %[[EXPAND_0]] : tensor<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_20]], %[[CONSTANT_15]] : index
+// CHECK-NEXT:               %[[IF_3:.*]] = scf.if %[[CMPI_4]] -> (index) {
+// CHECK-NEXT:                 scf.yield %[[IF_2]] : index
+// CHECK-NEXT:               } else {
+// CHECK-NEXT:                 %[[EXTRACT_7:.*]] = tensor.extract %[[FROM_ELEMENTS_7]]{{\[}}%[[VAL_20]]] : tensor<3xindex>
+// CHECK-NEXT:                 %[[CMPI_5:.*]] = arith.cmpi eq, %[[EXTRACT_7]], %[[CONSTANT_14]] : index
+// CHECK-NEXT:                 %[[SELECT_1:.*]] = arith.select %[[CMPI_5]], %[[IF_2]], %[[EXTRACT_7]] : index
+// CHECK-NEXT:                 scf.yield %[[SELECT_1]] : index
+// CHECK-NEXT:               }
+// CHECK-NEXT:               tensor.yield %[[IF_3]] : index
+// CHECK-NEXT:             } : tensor<3xindex>
+// CHECK-NEXT:             %[[CMPI_6:.*]] = arith.cmpi eq, %[[INDEX_CAST_2]], %[[CONSTANT_14]] : index
+// CHECK-NEXT:             %[[SELECT_2:.*]] = arith.select %[[CMPI_6]], %[[DIM_9]], %[[INDEX_CAST_2]] : index
+// CHECK-NEXT:             %[[CMPI_7:.*]] = arith.cmpi eq, %[[INDEX_CAST_3]], %[[CONSTANT_14]] : index
+// CHECK-NEXT:             %[[SELECT_3:.*]] = arith.select %[[CMPI_7]], %[[DIM_10]], %[[INDEX_CAST_3]] : index
+// CHECK-NEXT:             %[[EMPTY_5:.*]] = tensor.empty(%[[SELECT_2]], %[[SELECT_3]], %[[INDEX_CAST_4]]) : tensor<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[EXPAND_0:.*]] = hipsr.expand(%[[VAL_15]]) ins(%[[VAL_18]], %[[VAL_19]] : tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) outs(%[[EMPTY_5]] : tensor<?x?x?xi1, #hipsr.mem<device>>) : tensor<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[GENERATE_1]], %[[EXPAND_0]] : tensor<3xindex>, tensor<?x?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:             hipsr.pool_domain_yield %[[EMPTY_5]], %[[EXPAND_0]] : tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<?x?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:           } -> tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<?x?x?xi1, #hipsr.mem<device>> {domain_id = 1 : i64}
 
-// The second broadcast feeds the search. Its destination holds one row per
-// input axis and, in the worst case, a column per input element; the count of
-// the columns it filled sits beside it and is read back to the host.
+// The second broadcast feeds the search:
+//
+//   - its destination holds one row per input axis, one column per element;
+//   - the count of filled columns sits beside it and travels to the host;
+//   - that count is a product over the destination, so the scf.for from
+//     shape.num_elements survives.
 // CHECK-NEXT:           %[[POOL_DOMAIN_2:.*]]:4 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_1]]#0, %[[POOL_DOMAIN_0]]#6, %[[POOL_DOMAIN_1]]#1, %[[POOL_DOMAIN_0]]#7 : !hipsr.context, tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:           ^bb0(%[[VAL_24:.*]]: !hipsr.context, %[[VAL_25:.*]]: tensor<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_26:.*]]: tensor<3xi64, #hipsr.mem<host>>, %[[VAL_27:.*]]: tensor<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_28:.*]]: tensor<3xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:             %[[EXECUTE_REGION_6:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[SHAPE_OF_6:.*]] = shape.shape_of %[[VAL_25]] : tensor<?x?x?xi1, #hipsr.mem<device>> -> tensor<3xindex>
-// CHECK-NEXT:               %[[CONSTANT_19:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[EXTRACT_3:.*]] = tensor.extract %[[VAL_26]]{{\[}}%[[CONSTANT_19]]] : tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               %[[INDEX_CAST_5:.*]] = arith.index_cast %[[EXTRACT_3]] : i64 to index
-// CHECK-NEXT:               %[[CONSTANT_20:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[EXTRACT_4:.*]] = tensor.extract %[[VAL_26]]{{\[}}%[[CONSTANT_20]]] : tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               %[[INDEX_CAST_6:.*]] = arith.index_cast %[[EXTRACT_4]] : i64 to index
-// CHECK-NEXT:               %[[CONSTANT_21:.*]] = arith.constant 2 : index
-// CHECK-NEXT:               %[[EXTRACT_5:.*]] = tensor.extract %[[VAL_26]]{{\[}}%[[CONSTANT_21]]] : tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               %[[INDEX_CAST_7:.*]] = arith.index_cast %[[EXTRACT_5]] : i64 to index
-// CHECK-NEXT:               %[[FROM_EXTENTS_4:.*]] = shape.from_extents %[[INDEX_CAST_5]], %[[INDEX_CAST_6]], %[[INDEX_CAST_7]] : index, index, index
-// CHECK-NEXT:               %[[CSTR_BROADCASTABLE_1:.*]] = shape.cstr_broadcastable %[[SHAPE_OF_6]], %[[FROM_EXTENTS_4]] : tensor<3xindex>, !shape.shape
-// CHECK-NEXT:               %[[ASSUMING_1:.*]] = shape.assuming %[[CSTR_BROADCASTABLE_1]] -> (!shape.shape) {
-// CHECK-NEXT:                 %[[BROADCAST_2:.*]] = shape.broadcast %[[SHAPE_OF_6]], %[[FROM_EXTENTS_4]] : tensor<3xindex>, !shape.shape -> !shape.shape
-// CHECK-NEXT:                 shape.assuming_yield %[[BROADCAST_2]] : !shape.shape
+// CHECK-NEXT:           ^bb0(%[[VAL_21:.*]]: !hipsr.context, %[[VAL_22:.*]]: tensor<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_23:.*]]: tensor<3xi64, #hipsr.mem<host>>, %[[VAL_24:.*]]: tensor<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_25:.*]]: tensor<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:             %[[CONSTANT_16:.*]] = arith.constant dense<1> : tensor<1xindex>
+// CHECK-NEXT:             %[[CONSTANT_17:.*]] = arith.constant 3 : index
+// CHECK-NEXT:             %[[CONSTANT_18:.*]] = arith.constant 2 : index
+// CHECK-NEXT:             %[[CONSTANT_19:.*]] = arith.constant 1 : index
+// CHECK-NEXT:             %[[CONSTANT_20:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[DIM_11:.*]] = tensor.dim %[[VAL_22]], %[[CONSTANT_20]] : tensor<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[DIM_12:.*]] = tensor.dim %[[VAL_22]], %[[CONSTANT_19]] : tensor<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[DIM_13:.*]] = tensor.dim %[[VAL_22]], %[[CONSTANT_18]] : tensor<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[FROM_ELEMENTS_8:.*]] = tensor.from_elements %[[DIM_11]], %[[DIM_12]], %[[DIM_13]] : tensor<3xindex>
+// CHECK-NEXT:             %[[EXTRACT_8:.*]] = tensor.extract %[[VAL_23]]{{\[}}%[[CONSTANT_20]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[INDEX_CAST_5:.*]] = arith.index_cast %[[EXTRACT_8]] : i64 to index
+// CHECK-NEXT:             %[[EXTRACT_9:.*]] = tensor.extract %[[VAL_23]]{{\[}}%[[CONSTANT_19]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[INDEX_CAST_6:.*]] = arith.index_cast %[[EXTRACT_9]] : i64 to index
+// CHECK-NEXT:             %[[EXTRACT_10:.*]] = tensor.extract %[[VAL_23]]{{\[}}%[[CONSTANT_18]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[INDEX_CAST_7:.*]] = arith.index_cast %[[EXTRACT_10]] : i64 to index
+// CHECK-NEXT:             %[[FROM_ELEMENTS_9:.*]] = tensor.from_elements %[[INDEX_CAST_5]], %[[INDEX_CAST_6]], %[[INDEX_CAST_7]] : tensor<3xindex>
+// CHECK-NEXT:             %[[GENERATE_2:.*]] = tensor.generate  {
+// CHECK-NEXT:             ^bb0(%[[VAL_26:.*]]: index):
+// CHECK-NEXT:               %[[CMPI_8:.*]] = arith.cmpi ult, %[[VAL_26]], %[[CONSTANT_20]] : index
+// CHECK-NEXT:               %[[IF_4:.*]] = scf.if %[[CMPI_8]] -> (index) {
+// CHECK-NEXT:                 scf.yield %[[CONSTANT_19]] : index
+// CHECK-NEXT:               } else {
+// CHECK-NEXT:                 %[[EXTRACT_11:.*]] = tensor.extract %[[FROM_ELEMENTS_8]]{{\[}}%[[VAL_26]]] : tensor<3xindex>
+// CHECK-NEXT:                 scf.yield %[[EXTRACT_11]] : index
 // CHECK-NEXT:               }
-// CHECK-NEXT:               scf.yield %[[ASSUMING_1]] : !shape.shape
+// CHECK-NEXT:               %[[CMPI_9:.*]] = arith.cmpi ult, %[[VAL_26]], %[[CONSTANT_20]] : index
+// CHECK-NEXT:               %[[IF_5:.*]] = scf.if %[[CMPI_9]] -> (index) {
+// CHECK-NEXT:                 scf.yield %[[IF_4]] : index
+// CHECK-NEXT:               } else {
+// CHECK-NEXT:                 %[[EXTRACT_12:.*]] = tensor.extract %[[FROM_ELEMENTS_9]]{{\[}}%[[VAL_26]]] : tensor<3xindex>
+// CHECK-NEXT:                 %[[CMPI_10:.*]] = arith.cmpi eq, %[[EXTRACT_12]], %[[CONSTANT_19]] : index
+// CHECK-NEXT:                 %[[SELECT_4:.*]] = arith.select %[[CMPI_10]], %[[IF_4]], %[[EXTRACT_12]] : index
+// CHECK-NEXT:                 scf.yield %[[SELECT_4]] : index
+// CHECK-NEXT:               }
+// CHECK-NEXT:               tensor.yield %[[IF_5]] : index
+// CHECK-NEXT:             } : tensor<3xindex>
+// CHECK-NEXT:             %[[FOR_1:.*]] = scf.for %[[VAL_27:.*]] = %[[CONSTANT_20]] to %[[CONSTANT_17]] step %[[CONSTANT_19]] iter_args(%[[VAL_28:.*]] = %[[CONSTANT_19]]) -> (index) {
+// CHECK-NEXT:               %[[CMPI_11:.*]] = arith.cmpi ult, %[[VAL_27]], %[[CONSTANT_20]] : index
+// CHECK-NEXT:               %[[IF_6:.*]] = scf.if %[[CMPI_11]] -> (index) {
+// CHECK-NEXT:                 scf.yield %[[CONSTANT_19]] : index
+// CHECK-NEXT:               } else {
+// CHECK-NEXT:                 %[[EXTRACT_13:.*]] = tensor.extract %[[FROM_ELEMENTS_8]]{{\[}}%[[VAL_27]]] : tensor<3xindex>
+// CHECK-NEXT:                 scf.yield %[[EXTRACT_13]] : index
+// CHECK-NEXT:               }
+// CHECK-NEXT:               %[[CMPI_12:.*]] = arith.cmpi ult, %[[VAL_27]], %[[CONSTANT_20]] : index
+// CHECK-NEXT:               %[[IF_7:.*]] = scf.if %[[CMPI_12]] -> (index) {
+// CHECK-NEXT:                 scf.yield %[[IF_6]] : index
+// CHECK-NEXT:               } else {
+// CHECK-NEXT:                 %[[EXTRACT_14:.*]] = tensor.extract %[[FROM_ELEMENTS_9]]{{\[}}%[[VAL_27]]] : tensor<3xindex>
+// CHECK-NEXT:                 %[[CMPI_13:.*]] = arith.cmpi eq, %[[EXTRACT_14]], %[[CONSTANT_19]] : index
+// CHECK-NEXT:                 %[[SELECT_5:.*]] = arith.select %[[CMPI_13]], %[[IF_6]], %[[EXTRACT_14]] : index
+// CHECK-NEXT:                 scf.yield %[[SELECT_5]] : index
+// CHECK-NEXT:               }
+// CHECK-NEXT:               %[[MULI_1:.*]] = arith.muli %[[IF_7]], %[[VAL_28]] : index
+// CHECK-NEXT:               scf.yield %[[MULI_1]] : index
 // CHECK-NEXT:             }
-// CHECK-NEXT:             %[[EXECUTE_REGION_7:.*]]:2 = scf.execute_region -> (!shape.shape, !shape.shape) {
-// CHECK-NEXT:               %[[CONST_SIZE_14:.*]] = shape.const_size 3
-// CHECK-NEXT:               %[[NUM_ELEMENTS_1:.*]] = shape.num_elements %[[EXECUTE_REGION_6]] : !shape.shape -> !shape.size
-// CHECK-NEXT:               %[[FROM_EXTENTS_5:.*]] = shape.from_extents %[[CONST_SIZE_14]], %[[NUM_ELEMENTS_1]] : !shape.size, !shape.size
-// CHECK-NEXT:               %[[CONST_SHAPE_0:.*]] = shape.const_shape [1] : !shape.shape
-// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_5]], %[[CONST_SHAPE_0]] : !shape.shape, !shape.shape
-// CHECK-NEXT:             }
-
-// The host count is a 1xi64 buffer, so its allocation needs no extent and this
-// shape goes unread.
-// CHECK-NEXT:             %[[EXECUTE_REGION_8:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               scf.yield %[[EXECUTE_REGION_7]]#1 : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[CONST_SIZE_15:.*]] = shape.const_size 0
-// CHECK-NEXT:             %[[GET_EXTENT_12:.*]] = shape.get_extent %[[EXECUTE_REGION_6]], %[[CONST_SIZE_15]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_13:.*]] = shape.size_to_index %[[GET_EXTENT_12]] : !shape.size
-// CHECK-NEXT:             %[[CONST_SIZE_16:.*]] = shape.const_size 1
-// CHECK-NEXT:             %[[GET_EXTENT_13:.*]] = shape.get_extent %[[EXECUTE_REGION_6]], %[[CONST_SIZE_16]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_14:.*]] = shape.size_to_index %[[GET_EXTENT_13]] : !shape.size
-// CHECK-NEXT:             %[[CONST_SIZE_17:.*]] = shape.const_size 2
-// CHECK-NEXT:             %[[GET_EXTENT_14:.*]] = shape.get_extent %[[EXECUTE_REGION_6]], %[[CONST_SIZE_17]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_15:.*]] = shape.size_to_index %[[GET_EXTENT_14]] : !shape.size
-// CHECK-NEXT:             %[[EMPTY_6:.*]] = tensor.empty(%[[SIZE_TO_INDEX_13]], %[[SIZE_TO_INDEX_14]], %[[SIZE_TO_INDEX_15]]) : tensor<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[CONST_SIZE_18:.*]] = shape.const_size 1
-// CHECK-NEXT:             %[[GET_EXTENT_15:.*]] = shape.get_extent %[[EXECUTE_REGION_7]]#0, %[[CONST_SIZE_18]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_16:.*]] = shape.size_to_index %[[GET_EXTENT_15]] : !shape.size
-// CHECK-NEXT:             %[[EMPTY_7:.*]] = tensor.empty(%[[SIZE_TO_INDEX_16]]) : tensor<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[FROM_ELEMENTS_10:.*]] = tensor.from_elements %[[CONSTANT_17]], %[[FOR_1]] : tensor<2xindex>
+// CHECK-NEXT:             %[[CMPI_14:.*]] = arith.cmpi eq, %[[INDEX_CAST_5]], %[[CONSTANT_19]] : index
+// CHECK-NEXT:             %[[SELECT_6:.*]] = arith.select %[[CMPI_14]], %[[DIM_11]], %[[INDEX_CAST_5]] : index
+// CHECK-NEXT:             %[[CMPI_15:.*]] = arith.cmpi eq, %[[INDEX_CAST_6]], %[[CONSTANT_19]] : index
+// CHECK-NEXT:             %[[SELECT_7:.*]] = arith.select %[[CMPI_15]], %[[DIM_12]], %[[INDEX_CAST_6]] : index
+// CHECK-NEXT:             %[[CMPI_16:.*]] = arith.cmpi eq, %[[INDEX_CAST_7]], %[[CONSTANT_19]] : index
+// CHECK-NEXT:             %[[SELECT_8:.*]] = arith.select %[[CMPI_16]], %[[DIM_13]], %[[INDEX_CAST_7]] : index
+// CHECK-NEXT:             %[[EMPTY_6:.*]] = tensor.empty(%[[SELECT_6]], %[[SELECT_7]], %[[SELECT_8]]) : tensor<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[EMPTY_7:.*]] = tensor.empty(%[[FOR_1]]) : tensor<3x?xi64, #hipsr.mem<device>>
 // CHECK-NEXT:             %[[EMPTY_8:.*]] = tensor.empty() : tensor<1xi64, #hipsr.mem<device>>
 // CHECK-NEXT:             %[[EMPTY_9:.*]] = tensor.empty() : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             %[[EXPAND_1:.*]] = hipsr.expand(%[[VAL_24]]) ins(%[[VAL_27]], %[[VAL_28]] : tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) outs(%[[EMPTY_6]] : tensor<?x?x?xi1, #hipsr.mem<device>>) : tensor<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[NONZERO_0:.*]]:2 = hipsr.nonzero(%[[VAL_24]]) ins(%[[EXPAND_1]] : tensor<?x?x?xi1, #hipsr.mem<device>>) outs(%[[EMPTY_7]], %[[EMPTY_8]] : tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>) : tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[VAL_31:.*]] = hipsr.copy_d2h(%[[VAL_24]]) ins(%[[NONZERO_0]]#1 : tensor<1xi64, #hipsr.mem<device>>) outs(%[[EMPTY_9]] : tensor<1xi64, #hipsr.mem<host>>) : tensor<1xi64, #hipsr.mem<host>>
-
-// The search sizes two buffers, so its one shape computation yields two shapes
-// and each links to the matching result.
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_6]], %[[EXPAND_1]] : tensor<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_7]]#0, %[[NONZERO_0]]#0 : tensor<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_7]]#1, %[[NONZERO_0]]#1 : tensor<1xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_8]], %[[VAL_31]] : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             hipsr.pool_domain_yield %[[EMPTY_7]], %[[NONZERO_0]]#0, %[[EMPTY_9]], %[[VAL_31]] : tensor<3x?xi64, #hipsr.mem<device>>, tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[EXPAND_1:.*]] = hipsr.expand(%[[VAL_21]]) ins(%[[VAL_24]], %[[VAL_25]] : tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) outs(%[[EMPTY_6]] : tensor<?x?x?xi1, #hipsr.mem<device>>) : tensor<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[NONZERO_0:.*]]:2 = hipsr.nonzero(%[[VAL_21]]) ins(%[[EXPAND_1]] : tensor<?x?x?xi1, #hipsr.mem<device>>) outs(%[[EMPTY_7]], %[[EMPTY_8]] : tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>) : tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[COPY_D2H_0:.*]] = hipsr.copy_d2h(%[[VAL_21]]) ins(%[[NONZERO_0]]#1 : tensor<1xi64, #hipsr.mem<device>>) outs(%[[EMPTY_9]] : tensor<1xi64, #hipsr.mem<host>>) : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[GENERATE_2]], %[[EXPAND_1]] : tensor<3xindex>, tensor<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[FROM_ELEMENTS_10]], %[[NONZERO_0]]#0 : tensor<2xindex>, tensor<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[CONSTANT_16]], %[[NONZERO_0]]#1 : tensor<1xindex>, tensor<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[CONSTANT_16]], %[[COPY_D2H_0]] : tensor<1xindex>, tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             hipsr.pool_domain_yield %[[EMPTY_7]], %[[NONZERO_0]]#0, %[[EMPTY_9]], %[[COPY_D2H_0]] : tensor<3x?xi64, #hipsr.mem<device>>, tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:           } -> tensor<3x?xi64, #hipsr.mem<device>>, tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>> {domain_id = 2 : i64}
 
-// That host count opens the next domain, where the first shape computation
-// turns it into the trailing extent so the search destination narrows to the
-// columns that hold a position. The domain takes both buffers twice, and the
-// shape computation reads only the count while the data op reads only the
-// coordinates.
+// That host count opens the next domain. Its shape graph turns the count into
+// the trailing extent, narrowing the search to the columns holding a position.
+// The domain takes both buffers twice, one pair per graph.
 // CHECK-NEXT:           %[[POOL_DOMAIN_3:.*]]:4 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_2]]#2, %[[POOL_DOMAIN_2]]#0, %[[POOL_DOMAIN_2]]#3, %[[POOL_DOMAIN_2]]#1 : !hipsr.context, tensor<1xi64, #hipsr.mem<host>>, tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<3x?xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:           ^bb0(%[[VAL_33:.*]]: !hipsr.context, %[[VAL_34:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_35:.*]]: tensor<3x?xi64, #hipsr.mem<device>>, %[[VAL_36:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_37:.*]]: tensor<3x?xi64, #hipsr.mem<device>>):
-// CHECK-NEXT:             %[[EXECUTE_REGION_9:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[CONSTANT_22:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[EXTRACT_6:.*]] = tensor.extract %[[VAL_34]]{{\[}}%[[CONSTANT_22]]] : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               %[[INDEX_CAST_8:.*]] = arith.index_cast %[[EXTRACT_6]] : i64 to index
-// CHECK-NEXT:               %[[CONSTANT_23:.*]] = arith.constant 3 : index
-// CHECK-NEXT:               %[[FROM_EXTENTS_6:.*]] = shape.from_extents %[[CONSTANT_23]], %[[INDEX_CAST_8]] : index, index
-// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_6]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[EXECUTE_REGION_10:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[CONST_SIZE_19:.*]] = shape.const_size 1
-// CHECK-NEXT:               %[[GET_EXTENT_16:.*]] = shape.get_extent %[[EXECUTE_REGION_9]], %[[CONST_SIZE_19]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:               %[[CONST_SIZE_20:.*]] = shape.const_size 0
-// CHECK-NEXT:               %[[GET_EXTENT_17:.*]] = shape.get_extent %[[EXECUTE_REGION_9]], %[[CONST_SIZE_20]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:               %[[FROM_EXTENTS_7:.*]] = shape.from_extents %[[GET_EXTENT_16]], %[[GET_EXTENT_17]] : !shape.size, !shape.size
-// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_7]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[EXECUTE_REGION_11:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[CONSTANT_24:.*]] = arith.constant 2 : index
-// CHECK-NEXT:               %[[FROM_EXTENTS_8:.*]] = shape.from_extents %[[CONSTANT_24]] : index
-// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_8]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[EXECUTE_REGION_12:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[CONST_SHAPE_1:.*]] = shape.const_shape [] : !shape.shape
-// CHECK-NEXT:               scf.yield %[[CONST_SHAPE_1]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[EXECUTE_REGION_13:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[CONSTANT_25:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[FROM_EXTENTS_9:.*]] = shape.from_extents %[[CONSTANT_25]] : index
-// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_9]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[CONST_SIZE_21:.*]] = shape.const_size 1
-// CHECK-NEXT:             %[[GET_EXTENT_18:.*]] = shape.get_extent %[[EXECUTE_REGION_9]], %[[CONST_SIZE_21]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_17:.*]] = shape.size_to_index %[[GET_EXTENT_18]] : !shape.size
-// CHECK-NEXT:             %[[EMPTY_10:.*]] = tensor.empty(%[[SIZE_TO_INDEX_17]]) : tensor<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[CONST_SIZE_22:.*]] = shape.const_size 0
-// CHECK-NEXT:             %[[GET_EXTENT_19:.*]] = shape.get_extent %[[EXECUTE_REGION_10]], %[[CONST_SIZE_22]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_18:.*]] = shape.size_to_index %[[GET_EXTENT_19]] : !shape.size
-// CHECK-NEXT:             %[[EMPTY_11:.*]] = tensor.empty(%[[SIZE_TO_INDEX_18]]) : tensor<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:           ^bb0(%[[VAL_29:.*]]: !hipsr.context, %[[VAL_30:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_31:.*]]: tensor<3x?xi64, #hipsr.mem<device>>, %[[VAL_32:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_33:.*]]: tensor<3x?xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:             %[[CONSTANT_21:.*]] = arith.constant dense<1> : tensor<1xindex>
+// CHECK-NEXT:             %[[CONSTANT_22:.*]] = arith.constant dense<2> : tensor<1xindex>
+// CHECK-NEXT:             %[[CONSTANT_23:.*]] = arith.constant dense<> : tensor<0xindex>
+// CHECK-NEXT:             %[[CONSTANT_24:.*]] = arith.constant 3 : index
+// CHECK-NEXT:             %[[CONSTANT_25:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[EXTRACT_15:.*]] = tensor.extract %[[VAL_30]]{{\[}}%[[CONSTANT_25]]] : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[INDEX_CAST_8:.*]] = arith.index_cast %[[EXTRACT_15]] : i64 to index
+// CHECK-NEXT:             %[[FROM_ELEMENTS_11:.*]] = tensor.from_elements %[[CONSTANT_24]], %[[INDEX_CAST_8]] : tensor<2xindex>
+// CHECK-NEXT:             %[[FROM_ELEMENTS_12:.*]] = tensor.from_elements %[[INDEX_CAST_8]], %[[CONSTANT_24]] : tensor<2xindex>
+// CHECK-NEXT:             %[[EMPTY_10:.*]] = tensor.empty(%[[INDEX_CAST_8]]) : tensor<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[EMPTY_11:.*]] = tensor.empty(%[[INDEX_CAST_8]]) : tensor<?x3xi64, #hipsr.mem<device>>
 // CHECK-NEXT:             %[[EMPTY_12:.*]] = tensor.empty() : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:             %[[EMPTY_13:.*]] = tensor.empty() : tensor<i64, #hipsr.mem<host>>
 // CHECK-NEXT:             %[[EMPTY_14:.*]] = tensor.empty() : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             %[[COMPUTE_3:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[VAL_36]], %[[VAL_37]] : tensor<1xi64, #hipsr.mem<host>>, tensor<3x?xi64, #hipsr.mem<device>>) outs(%[[EMPTY_10]] : tensor<3x?xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_38:.*]]: !hipsr.context, %[[VAL_39:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_40:.*]]: tensor<3x?xi64, #hipsr.mem<device>>, %[[VAL_41:.*]]: tensor<3x?xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:             %[[COMPUTE_3:.*]] = hipsr.compute(%[[VAL_29]]) ins(%[[VAL_32]], %[[VAL_33]] : tensor<1xi64, #hipsr.mem<host>>, tensor<3x?xi64, #hipsr.mem<device>>) outs(%[[EMPTY_10]] : tensor<3x?xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:             ^bb0(%[[VAL_34:.*]]: !hipsr.context, %[[VAL_35:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_36:.*]]: tensor<3x?xi64, #hipsr.mem<device>>, %[[VAL_37:.*]]: tensor<3x?xi64, #hipsr.mem<device>>):
 // CHECK-NEXT:               %[[CONSTANT_26:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[DIM_4:.*]] = tensor.dim %[[VAL_41]], %[[CONSTANT_26]] : tensor<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:               %[[EXTRACT_SLICE_0:.*]] = tensor.extract_slice %[[VAL_40]][0, 0] [3, %[[DIM_4]]] [1, 1] : tensor<3x?xi64, #hipsr.mem<device>> to tensor<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[DIM_14:.*]] = tensor.dim %[[VAL_37]], %[[CONSTANT_26]] : tensor<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[EXTRACT_SLICE_0:.*]] = tensor.extract_slice %[[VAL_36]]{{\[}}0, 0] [3, %[[DIM_14]]] [1, 1] : tensor<3x?xi64, #hipsr.mem<device>> to tensor<3x?xi64, #hipsr.mem<device>>
 // CHECK-NEXT:               hipsr.compute_yield %[[EXTRACT_SLICE_0]] : tensor<3x?xi64, #hipsr.mem<device>>
 // CHECK-NEXT:             } : tensor<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[TRANSPOSE_0:.*]] = hipsr.transpose(%[[VAL_33]]) ins(%[[COMPUTE_3]] : tensor<3x?xi64, #hipsr.mem<device>>) outs(%[[EMPTY_11]] : tensor<?x3xi64, #hipsr.mem<device>>) {perm = array<i64: 1, 0>} : tensor<?x3xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[COMPUTE_4:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[TRANSPOSE_0]] : tensor<?x3xi64, #hipsr.mem<device>>) outs(%[[EMPTY_12]] : tensor<2xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_42:.*]]: !hipsr.context, %[[VAL_43:.*]]: tensor<?x3xi64, #hipsr.mem<device>>, %[[VAL_44:.*]]: tensor<2xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:               %[[CONSTANT_27:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[DIM_5:.*]] = tensor.dim %[[VAL_43]], %[[CONSTANT_27]] : tensor<?x3xi64, #hipsr.mem<device>>
-// CHECK-NEXT:               %[[INDEX_CAST_9:.*]] = arith.index_cast %[[DIM_5]] : index to i64
-// CHECK-NEXT:               %[[CONSTANT_28:.*]] = arith.constant 3 : i64
-// CHECK-NEXT:               %[[FROM_ELEMENTS_1:.*]] = tensor.from_elements %[[INDEX_CAST_9]], %[[CONSTANT_28]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               hipsr.compute_yield %[[FROM_ELEMENTS_1]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[TRANSPOSE_0:.*]] = hipsr.transpose(%[[VAL_29]]) ins(%[[COMPUTE_3]] : tensor<3x?xi64, #hipsr.mem<device>>) outs(%[[EMPTY_11]] : tensor<?x3xi64, #hipsr.mem<device>>) {perm = array<i64: 1, 0>} : tensor<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[COMPUTE_4:.*]] = hipsr.compute(%[[VAL_29]]) ins(%[[TRANSPOSE_0]] : tensor<?x3xi64, #hipsr.mem<device>>) outs(%[[EMPTY_12]] : tensor<2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:             ^bb0(%[[VAL_38:.*]]: !hipsr.context, %[[VAL_39:.*]]: tensor<?x3xi64, #hipsr.mem<device>>, %[[VAL_40:.*]]: tensor<2xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:               %[[CONSTANT_27:.*]] = arith.constant 3 : i64
+// CHECK-NEXT:               %[[CONSTANT_28:.*]] = arith.constant 0 : index
+// CHECK-NEXT:               %[[DIM_15:.*]] = tensor.dim %[[VAL_39]], %[[CONSTANT_28]] : tensor<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[INDEX_CAST_9:.*]] = arith.index_cast %[[DIM_15]] : index to i64
+// CHECK-NEXT:               %[[FROM_ELEMENTS_13:.*]] = tensor.from_elements %[[INDEX_CAST_9]], %[[CONSTANT_27]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               hipsr.compute_yield %[[FROM_ELEMENTS_13]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:             } : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             %[[COMPUTE_5:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[COMPUTE_4]] : tensor<2xi64, #hipsr.mem<host>>) outs(%[[EMPTY_13]] : tensor<i64, #hipsr.mem<host>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_45:.*]]: !hipsr.context, %[[VAL_46:.*]]: tensor<2xi64, #hipsr.mem<host>>, %[[VAL_47:.*]]: tensor<i64, #hipsr.mem<host>>):
+// CHECK-NEXT:             %[[COMPUTE_5:.*]] = hipsr.compute(%[[VAL_29]]) ins(%[[COMPUTE_4]] : tensor<2xi64, #hipsr.mem<host>>) outs(%[[EMPTY_13]] : tensor<i64, #hipsr.mem<host>>) {
+// CHECK-NEXT:             ^bb0(%[[VAL_41:.*]]: !hipsr.context, %[[VAL_42:.*]]: tensor<2xi64, #hipsr.mem<host>>, %[[VAL_43:.*]]: tensor<i64, #hipsr.mem<host>>):
 // CHECK-NEXT:               %[[CONSTANT_29:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[EXTRACT_7:.*]] = tensor.extract %[[VAL_46]]{{\[}}%[[CONSTANT_29]]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               %[[FROM_ELEMENTS_2:.*]] = tensor.from_elements %[[EXTRACT_7]] : tensor<i64, #hipsr.mem<host>>
-// CHECK-NEXT:               hipsr.compute_yield %[[FROM_ELEMENTS_2]] : tensor<i64, #hipsr.mem<host>>
+// CHECK-NEXT:               %[[EXTRACT_16:.*]] = tensor.extract %[[VAL_42]]{{\[}}%[[CONSTANT_29]]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               %[[FROM_ELEMENTS_14:.*]] = tensor.from_elements %[[EXTRACT_16]] : tensor<i64, #hipsr.mem<host>>
+// CHECK-NEXT:               hipsr.compute_yield %[[FROM_ELEMENTS_14]] : tensor<i64, #hipsr.mem<host>>
 // CHECK-NEXT:             } : tensor<i64, #hipsr.mem<host>>
-// CHECK-NEXT:             %[[COMPUTE_6:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[COMPUTE_5]] : tensor<i64, #hipsr.mem<host>>) outs(%[[EMPTY_14]] : tensor<1xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_48:.*]]: !hipsr.context, %[[VAL_49:.*]]: tensor<i64, #hipsr.mem<host>>, %[[VAL_50:.*]]: tensor<1xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:               %[[EXPAND_SHAPE_1:.*]] = tensor.expand_shape %[[VAL_49]] [] output_shape [1] : tensor<i64, #hipsr.mem<host>> into tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[COMPUTE_6:.*]] = hipsr.compute(%[[VAL_29]]) ins(%[[COMPUTE_5]] : tensor<i64, #hipsr.mem<host>>) outs(%[[EMPTY_14]] : tensor<1xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:             ^bb0(%[[VAL_44:.*]]: !hipsr.context, %[[VAL_45:.*]]: tensor<i64, #hipsr.mem<host>>, %[[VAL_46:.*]]: tensor<1xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:               %[[EXPAND_SHAPE_1:.*]] = tensor.expand_shape %[[VAL_45]] [] output_shape [1] : tensor<i64, #hipsr.mem<host>> into tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:               hipsr.compute_yield %[[EXPAND_SHAPE_1]] : tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:             } : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_9]], %[[COMPUTE_3]] : tensor<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_10]], %[[TRANSPOSE_0]] : tensor<?x3xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_11]], %[[COMPUTE_4]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_12]], %[[COMPUTE_5]] : tensor<i64, #hipsr.mem<host>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_13]], %[[COMPUTE_6]] : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[FROM_ELEMENTS_11]], %[[COMPUTE_3]] : tensor<2xindex>, tensor<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[FROM_ELEMENTS_12]], %[[TRANSPOSE_0]] : tensor<2xindex>, tensor<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[CONSTANT_22]], %[[COMPUTE_4]] : tensor<1xindex>, tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[CONSTANT_23]], %[[COMPUTE_5]] : tensor<0xindex>, tensor<i64, #hipsr.mem<host>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[CONSTANT_21]], %[[COMPUTE_6]] : tensor<1xindex>, tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:             hipsr.pool_domain_yield %[[EMPTY_11]], %[[TRANSPOSE_0]], %[[EMPTY_14]], %[[COMPUTE_6]] : tensor<?x3xi64, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:           } -> tensor<?x3xi64, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>> {domain_id = 3 : i64}
 
 // The update window ends at that same count, and the scatter writes it into
 // the embeddings.
 // CHECK-NEXT:           %[[POOL_DOMAIN_4:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#0, %[[POOL_DOMAIN_3]]#2, %[[POOL_DOMAIN_0]]#1, %[[POOL_DOMAIN_3]]#3, %[[POOL_DOMAIN_0]]#4, %[[POOL_DOMAIN_3]]#0, %[[POOL_DOMAIN_0]]#5, %[[POOL_DOMAIN_3]]#1 : !hipsr.context, tensor<?xf16, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<?xf16, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:           ^bb0(%[[VAL_53:.*]]: !hipsr.context, %[[VAL_54:.*]]: tensor<?xf16, #hipsr.mem<device>>, %[[VAL_55:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_56:.*]]: tensor<?xf16, #hipsr.mem<device>>, %[[VAL_57:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_58:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_59:.*]]: tensor<?x3xi64, #hipsr.mem<device>>, %[[VAL_60:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_61:.*]]: tensor<?x3xi64, #hipsr.mem<device>>):
-// CHECK-NEXT:             %[[EXECUTE_REGION_14:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[CONSTANT_30:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[DIM_6:.*]] = tensor.dim %[[VAL_54]], %[[CONSTANT_30]] : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:               %[[CONSTANT_31:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[EXTRACT_8:.*]] = tensor.extract %[[VAL_55]]{{\[}}%[[CONSTANT_31]]] : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               %[[INDEX_CAST_10:.*]] = arith.index_cast %[[EXTRACT_8]] : i64 to index
-// CHECK-NEXT:               %[[CONSTANT_32:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[CMPI_0:.*]] = arith.cmpi slt, %[[INDEX_CAST_10]], %[[CONSTANT_32]] : index
-// CHECK-NEXT:               %[[ADDI_0:.*]] = arith.addi %[[INDEX_CAST_10]], %[[DIM_6]] : index
-// CHECK-NEXT:               %[[SELECT_0:.*]] = arith.select %[[CMPI_0]], %[[ADDI_0]], %[[INDEX_CAST_10]] : index
-// CHECK-NEXT:               %[[CONSTANT_33:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[MINSI_0:.*]] = arith.minsi %[[DIM_6]], %[[CONSTANT_33]] : index
-// CHECK-NEXT:               %[[MAXSI_0:.*]] = arith.maxsi %[[SELECT_0]], %[[CONSTANT_32]] : index
-// CHECK-NEXT:               %[[MINSI_1:.*]] = arith.minsi %[[MAXSI_0]], %[[DIM_6]] : index
-// CHECK-NEXT:               %[[SUBI_0:.*]] = arith.subi %[[MINSI_1]], %[[MINSI_0]] : index
-// CHECK-NEXT:               %[[MAXSI_1:.*]] = arith.maxsi %[[SUBI_0]], %[[CONSTANT_32]] : index
-// CHECK-NEXT:               %[[FROM_EXTENTS_10:.*]] = shape.from_extents %[[MAXSI_1]] : index
-// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_10]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[EXECUTE_REGION_15:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[SHAPE_OF_7:.*]] = shape.shape_of %[[VAL_58]] : tensor<?x?x4096xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:               %[[SHAPE_OF_8:.*]] = shape.shape_of %[[VAL_59]] : tensor<?x3xi64, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:               scf.yield %[[SHAPE_OF_7]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[CONST_SIZE_23:.*]] = shape.const_size 0
-// CHECK-NEXT:             %[[GET_EXTENT_20:.*]] = shape.get_extent %[[EXECUTE_REGION_14]], %[[CONST_SIZE_23]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_19:.*]] = shape.size_to_index %[[GET_EXTENT_20]] : !shape.size
-// CHECK-NEXT:             %[[EMPTY_15:.*]] = tensor.empty(%[[SIZE_TO_INDEX_19]]) : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[CONST_SIZE_24:.*]] = shape.const_size 0
-// CHECK-NEXT:             %[[GET_EXTENT_21:.*]] = shape.get_extent %[[EXECUTE_REGION_15]], %[[CONST_SIZE_24]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_20:.*]] = shape.size_to_index %[[GET_EXTENT_21]] : !shape.size
-// CHECK-NEXT:             %[[CONST_SIZE_25:.*]] = shape.const_size 1
-// CHECK-NEXT:             %[[GET_EXTENT_22:.*]] = shape.get_extent %[[EXECUTE_REGION_15]], %[[CONST_SIZE_25]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_21:.*]] = shape.size_to_index %[[GET_EXTENT_22]] : !shape.size
-// CHECK-NEXT:             %[[EMPTY_16:.*]] = tensor.empty(%[[SIZE_TO_INDEX_20]], %[[SIZE_TO_INDEX_21]]) : tensor<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[SLICE_0:.*]] = hipsr.slice(%[[VAL_53]]) ins(%[[VAL_56]] : tensor<?xf16, #hipsr.mem<device>>) ends(%[[VAL_57]] : tensor<1xi64, #hipsr.mem<host>>) outs(%[[EMPTY_15]] : tensor<?xf16, #hipsr.mem<device>>) {axes_attr = array<i64: 0>, starts_attr = array<i64: 0>, steps_attr = array<i64: 1>} : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[SCATTER_ND_0:.*]] = hipsr.scatter_nd(%[[VAL_53]]) ins(%[[VAL_60]], %[[VAL_61]], %[[SLICE_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>) outs(%[[EMPTY_16]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) : tensor<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_14]], %[[SLICE_0]] : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_15]], %[[SCATTER_ND_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:           ^bb0(%[[VAL_47:.*]]: !hipsr.context, %[[VAL_48:.*]]: tensor<?xf16, #hipsr.mem<device>>, %[[VAL_49:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_50:.*]]: tensor<?xf16, #hipsr.mem<device>>, %[[VAL_51:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_52:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_53:.*]]: tensor<?x3xi64, #hipsr.mem<device>>, %[[VAL_54:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_55:.*]]: tensor<?x3xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:             %[[CONSTANT_30:.*]] = arith.constant 4096 : index
+// CHECK-NEXT:             %[[CONSTANT_31:.*]] = arith.constant 1 : index
+// CHECK-NEXT:             %[[CONSTANT_32:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[DIM_16:.*]] = tensor.dim %[[VAL_48]], %[[CONSTANT_32]] : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[EXTRACT_17:.*]] = tensor.extract %[[VAL_49]]{{\[}}%[[CONSTANT_32]]] : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[INDEX_CAST_10:.*]] = arith.index_cast %[[EXTRACT_17]] : i64 to index
+// CHECK-NEXT:             %[[CMPI_17:.*]] = arith.cmpi slt, %[[INDEX_CAST_10]], %[[CONSTANT_32]] : index
+// CHECK-NEXT:             %[[ADDI_0:.*]] = arith.addi %[[INDEX_CAST_10]], %[[DIM_16]] : index
+// CHECK-NEXT:             %[[SELECT_9:.*]] = arith.select %[[CMPI_17]], %[[ADDI_0]], %[[INDEX_CAST_10]] : index
+// CHECK-NEXT:             %[[MINSI_0:.*]] = arith.minsi %[[DIM_16]], %[[CONSTANT_32]] : index
+// CHECK-NEXT:             %[[MAXSI_0:.*]] = arith.maxsi %[[SELECT_9]], %[[CONSTANT_32]] : index
+// CHECK-NEXT:             %[[MINSI_1:.*]] = arith.minsi %[[MAXSI_0]], %[[DIM_16]] : index
+// CHECK-NEXT:             %[[SUBI_1:.*]] = arith.subi %[[MINSI_1]], %[[MINSI_0]] : index
+// CHECK-NEXT:             %[[MAXSI_1:.*]] = arith.maxsi %[[SUBI_1]], %[[CONSTANT_32]] : index
+// CHECK-NEXT:             %[[FROM_ELEMENTS_15:.*]] = tensor.from_elements %[[MAXSI_1]] : tensor<1xindex>
+// CHECK-NEXT:             %[[DIM_17:.*]] = tensor.dim %[[VAL_52]], %[[CONSTANT_32]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[DIM_18:.*]] = tensor.dim %[[VAL_52]], %[[CONSTANT_31]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[FROM_ELEMENTS_16:.*]] = tensor.from_elements %[[DIM_17]], %[[DIM_18]], %[[CONSTANT_30]] : tensor<3xindex>
+// CHECK-NEXT:             %[[EMPTY_15:.*]] = tensor.empty(%[[MAXSI_1]]) : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[EMPTY_16:.*]] = tensor.empty(%[[DIM_17]], %[[DIM_18]]) : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[SLICE_0:.*]] = hipsr.slice(%[[VAL_47]]) ins(%[[VAL_50]] : tensor<?xf16, #hipsr.mem<device>>) ends(%[[VAL_51]] : tensor<1xi64, #hipsr.mem<host>>) outs(%[[EMPTY_15]] : tensor<?xf16, #hipsr.mem<device>>) {axes_attr = array<i64: 0>, starts_attr = array<i64: 0>, steps_attr = array<i64: 1>} : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[SCATTER_ND_0:.*]] = hipsr.scatter_nd(%[[VAL_47]]) ins(%[[VAL_54]], %[[VAL_55]], %[[SLICE_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>) outs(%[[EMPTY_16]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[FROM_ELEMENTS_15]], %[[SLICE_0]] : tensor<1xindex>, tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[FROM_ELEMENTS_16]], %[[SCATTER_ND_0]] : tensor<3xindex>, tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:             hipsr.pool_domain_yield %[[SCATTER_ND_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:           } -> tensor<?x?x4096xf16, #hipsr.mem<device>> {domain_id = 4 : i64}
 // CHECK-NEXT:           return %[[POOL_DOMAIN_4]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:         }
+// CHECK-NEXT:       }
 
 // The table's bytes stay outside the IR, so the resource section prints empty
 // once the RUN line's elision drops the blob string.
-// CHECK:              {-#
 // CHECK-EMPTY:
-// CHECK-NEXT:         #-}
+// CHECK-NEXT:       {-#
+// CHECK-EMPTY:
+// CHECK-NEXT:       #-}
   func.func @main_graph(%arg0: tensor<?x?xi64> {onnx.name = "input_ids"}, %arg1: tensor<?x4096xf16> {onnx.name = "image_features"}) -> (tensor<?x?x4096xf16> {onnx.name = "inputs_embeds"}) attributes {onnx.graph.name = "main_graph"} {
     %0 = "onnx.NoValue"() {value} : () -> none
     %1 = "onnx.Constant"() {node.outputs = ["embed_tokens.weight"], location = "embedding.onnx.data", offset = 0 : i64, size = 2034237440 : i64} : () -> tensor<248320x4096xf16>

--- a/test/lit/Dialect/Hipsr/Pipelines/sample_dynamic.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/sample_dynamic.mlir
@@ -7,6 +7,9 @@
 
 // RUN: hip-mlir-opt %s --onnx-dialect=modeled --hipsr-pipeline | FileCheck %s
 
+// Every line of the output is checked, which is also what shows that no shape
+// dialect op survives: one would have to appear on a line of its own.
+
 // CHECK-LABEL: func.func @main_graph(
 // CHECK-SAME:      %[[CTX:.+]]: !hipsr.context,
 // CHECK-SAME:      %[[A:.+]]: tensor<?x3xf16, #hipsr.mem<device>> {onnx.name = "a"},
@@ -14,84 +17,54 @@
 // CHECK-SAME:      -> (tensor<?x2xf32, #hipsr.mem<device>> {onnx.name = "y"})
 // CHECK-SAME:      attributes {onnx.graph.name = "main_graph"} {
 
-// The domains split exactly where they do in sample_static.mlir, and so do the
-// five zones inside each one: neither the barrier's position nor the shape
-// graph depends on whether the extents are known.
+// The domains split where they do in sample_static.mlir, and so do the five
+// zones inside each. Neither the barrier's position nor the shape graph depends
+// on whether the extents are known.
 // CHECK-NEXT:    %[[D0:.+]]:5 = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]] : !hipsr.context, tensor<?x3xf16, #hipsr.mem<device>>, tensor<?x4xf32, #hipsr.mem<device>>) {
 // CHECK-NEXT:    ^bb0(%[[D0_CTX:.+]]: !hipsr.context, %[[D0_A:.+]]: tensor<?x3xf16, #hipsr.mem<device>>, %[[D0_B:.+]]: tensor<?x4xf32, #hipsr.mem<device>>):
 
+// Everything constant-like leads the domain. That is the index constants, the
+// one fully static shape a recipe emits as a constant, and both weights.
+// CHECK-NEXT:      %[[C1:.+]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[EXTENTS_SHAPE_S:.+]] = arith.constant dense<2> : tensor<1xindex>
+// CHECK-NEXT:      %[[C0:.+]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[W1:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<3x1xf16>} : tensor<3x1xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[W2:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<4x2xf32>} : tensor<4x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[MM1_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[D0_A]] : tensor<?x3xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[W1_SHAPE:.+]] = shape.shape_of %[[W1]] : tensor<3x1xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[A_K_IDX:.+]] = shape.const_size 1
-// CHECK-NEXT:        %[[A_K:.+]] = shape.get_extent %[[A_SHAPE]], %[[A_K_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[A_K_SHAPE:.+]] = shape.from_extents %[[A_K]] : !shape.size
-// CHECK-NEXT:        %[[W1_K_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[W1_K:.+]] = shape.get_extent %[[W1_SHAPE]], %[[W1_K_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[W1_K_SHAPE:.+]] = shape.from_extents %[[W1_K]] : !shape.size
-// CHECK-NEXT:        %[[K_WITNESS:.+]] = shape.cstr_eq %[[A_K_SHAPE]], %[[W1_K_SHAPE]] : !shape.shape, !shape.shape
-// CHECK-NEXT:        %[[A_SPLIT_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[A_BATCH:.+]], %[[A_TAIL:.+]] = "shape.split_at"(%[[A_SHAPE]], %[[A_SPLIT_IDX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT:        %[[W1_SPLIT_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[W1_BATCH:.+]], %[[W1_TAIL:.+]] = "shape.split_at"(%[[W1_SHAPE]], %[[W1_SPLIT_IDX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT:        %[[BATCH_WITNESS:.+]] = shape.cstr_broadcastable %[[A_BATCH]], %[[W1_BATCH]] : !shape.shape, !shape.shape
-// CHECK-NEXT:        %[[WITNESS:.+]] = shape.assuming_all %[[K_WITNESS]], %[[BATCH_WITNESS]]
-// CHECK-NEXT:        %[[MM1_SHAPE_VAL:.+]] = shape.assuming %[[WITNESS]] -> (!shape.shape) {
-// CHECK-NEXT:          %[[BATCH:.+]] = shape.broadcast %[[A_BATCH]], %[[W1_BATCH]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:          %[[M_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:          %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[M_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:          %[[N_IDX:.+]] = shape.const_size 1
-// CHECK-NEXT:          %[[N:.+]] = shape.get_extent %[[W1_SHAPE]], %[[N_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:          %[[MATRIX:.+]] = shape.from_extents %[[M]], %[[N]] : !shape.size, !shape.size
-// CHECK-NEXT:          %[[RESULT:.+]] = shape.concat %[[BATCH]], %[[MATRIX]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:          shape.assuming_yield %[[RESULT]] : !shape.shape
-// CHECK-NEXT:        }
-// CHECK-NEXT:        scf.yield %[[MM1_SHAPE_VAL]] : !shape.shape
-// CHECK-NEXT:      }
 
-// CHECK-NEXT:      %[[CAST_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        scf.yield %[[MM1_SHAPE]] : !shape.shape
-// CHECK-NEXT:      }
+// Neither matmul operand has batch dimensions, so the first matmul's shape
+// graph is just its two matrix extents. M is a tensor.dim of %[[D0_A]]'s
+// dynamic axis; N is the weight's static one.
+// CHECK-NEXT:      %[[MM1_M:.+]] = tensor.dim %[[D0_A]], %[[C0]] : tensor<?x3xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[MM1_SHAPE:.+]] = tensor.from_elements %[[MM1_M]], %[[C1]] : tensor<2xindex>
 
-// The extent vector's length is still a constant -- the operand's rank fixes it
-// -- so the operand's shape goes unread here and the vector needs no extent of
-// its own below.
-// CHECK-NEXT:      %[[EXTENTS_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[B_SHAPE:.+]] = shape.shape_of %[[D0_B]] : tensor<?x4xf32, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[RANK:.+]] = arith.constant 2 : index
-// CHECK-NEXT:        %[[RANK_SHAPE:.+]] = shape.from_extents %[[RANK]] : index
-// CHECK-NEXT:        scf.yield %[[RANK_SHAPE]] : !shape.shape
-// CHECK-NEXT:      }
-
-// This is where the dynamic extent shows up: each allocation whose type leaves
-// a dimension open reads it back out of the shape computed above.
-// CHECK-NEXT:      %[[MM1_M_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:      %[[MM1_M_EXTENT:.+]] = shape.get_extent %[[MM1_SHAPE]], %[[MM1_M_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:      %[[MM1_M:.+]] = shape.size_to_index %[[MM1_M_EXTENT]] : !shape.size
+// The dynamic extent shows up here: an allocation whose type leaves a dimension
+// open needs it. Assembling the shape and reading an extent back out fold, so
+// the allocations take the tensor.dim directly.
 // CHECK-NEXT:      %[[MM1_INIT:.+]] = tensor.empty(%[[MM1_M]]) : tensor<?x1xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[CAST_M_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:      %[[CAST_M_EXTENT:.+]] = shape.get_extent %[[CAST_SHAPE]], %[[CAST_M_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:      %[[CAST_M:.+]] = shape.size_to_index %[[CAST_M_EXTENT]] : !shape.size
-// CHECK-NEXT:      %[[CAST_INIT:.+]] = tensor.empty(%[[CAST_M]]) : tensor<?x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[CAST_INIT:.+]] = tensor.empty(%[[MM1_M]]) : tensor<?x1xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[EXTENTS_INIT:.+]] = tensor.empty() : tensor<2xi64, #hipsr.mem<host>>
 
 // CHECK-NEXT:      %[[MM1:.+]] = hipsr.matmul(%[[D0_CTX]]) ins(%[[D0_A]], %[[W1]] : tensor<?x3xf16, #hipsr.mem<device>>, tensor<3x1xf16, #hipsr.mem<device>>) outs(%[[MM1_INIT]] : tensor<?x1xf16, #hipsr.mem<device>>) : tensor<?x1xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[CAST:.+]] = hipsr.cast(%[[D0_CTX]]) ins(%[[MM1]] : tensor<?x1xf16, #hipsr.mem<device>>) outs(%[[CAST_INIT]] : tensor<?x1xf32, #hipsr.mem<device>>) : tensor<?x1xf32, #hipsr.mem<device>>
+
+// The expand reads an extent vector. This is the one place a shape reaches the
+// data graph, and it arrives as a host buffer rather than a shape value.
 // CHECK-NEXT:      %[[EXTENTS:.+]] = hipsr.compute(%[[D0_CTX]]) ins(%[[D0_B]] : tensor<?x4xf32, #hipsr.mem<device>>) outs(%[[EXTENTS_INIT]] : tensor<2xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:      ^bb0(%{{.+}}: !hipsr.context, %[[BODY_B:.+]]: tensor<?x4xf32, #hipsr.mem<device>>, %{{.+}}: tensor<2xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:        %[[D1_EXT:.+]] = arith.constant 4 : i64
 // CHECK-NEXT:        %[[DIM_IDX:.+]] = arith.constant 0 : index
 // CHECK-NEXT:        %[[DIM:.+]] = tensor.dim %[[BODY_B]], %[[DIM_IDX]] : tensor<?x4xf32, #hipsr.mem<device>>
 // CHECK-NEXT:        %[[D0_EXT:.+]] = arith.index_cast %[[DIM]] : index to i64
-// CHECK-NEXT:        %[[D1_EXT:.+]] = arith.constant 4 : i64
 // CHECK-NEXT:        %[[EXTENT_VECTOR:.+]] = tensor.from_elements %[[D0_EXT]], %[[D1_EXT]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        hipsr.compute_yield %[[EXTENT_VECTOR]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:      } : tensor<2xi64, #hipsr.mem<host>>
 
-// CHECK-NEXT:      hipsr.preserve_shape %[[MM1_SHAPE]], %[[MM1]] : tensor<?x1xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[CAST_SHAPE]], %[[CAST]] : tensor<?x1xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[EXTENTS_SHAPE]], %[[EXTENTS]] : tensor<2xi64, #hipsr.mem<host>>
+// Each shape closes the domain next to the value that filled the buffer it
+// sized. Its length is part of its type. The matmul and the cast share one
+// shape, because the cast copies its input's extents.
+// CHECK-NEXT:      hipsr.preserve_shape %[[MM1_SHAPE]], %[[MM1]] : tensor<2xindex>, tensor<?x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[MM1_SHAPE]], %[[CAST]] : tensor<2xindex>, tensor<?x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[EXTENTS_SHAPE_S]], %[[EXTENTS]] : tensor<1xindex>, tensor<2xi64, #hipsr.mem<host>>
 
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[CAST_INIT]], %[[CAST]], %[[EXTENTS_INIT]], %[[EXTENTS]], %[[W2]] : tensor<?x1xf32, #hipsr.mem<device>>, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    } -> tensor<?x1xf32, #hipsr.mem<device>>, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
@@ -99,63 +72,62 @@
 // CHECK-NEXT:    %[[D1:.+]] = hipsr.pool_domain(%[[CTX]], %[[D0]]#0, %[[D0]]#2, %[[D0]]#1, %[[D0]]#3, %[[D0]]#4 : !hipsr.context, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>>) {
 // CHECK-NEXT:    ^bb0(%[[D1_CTX:.+]]: !hipsr.context, %[[D1_CAST_INIT:.+]]: tensor<?x1xf32, #hipsr.mem<device>>, %[[D1_EXTENTS_INIT:.+]]: tensor<2xi64, #hipsr.mem<host>>, %[[D1_CAST:.+]]: tensor<?x1xf32, #hipsr.mem<device>>, %[[D1_EXTENTS:.+]]: tensor<2xi64, #hipsr.mem<host>>, %[[D1_W2:.+]]: tensor<4x2xf32, #hipsr.mem<device>>):
 
-// CHECK-NEXT:      %[[EXPAND_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[IN_SHAPE:.+]] = shape.shape_of %[[D1_CAST_INIT]] : tensor<?x1xf32, #hipsr.mem<device>> -> tensor<2xindex>
-// CHECK-NEXT:        %[[I0:.+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[E0:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[I0]]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[X0:.+]] = arith.index_cast %[[E0]] : i64 to index
-// CHECK-NEXT:        %[[I1:.+]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[E1:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[I1]]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[X1:.+]] = arith.index_cast %[[E1]] : i64 to index
-// CHECK-NEXT:        %[[REQ:.+]] = shape.from_extents %[[X0]], %[[X1]] : index, index
-// CHECK-NEXT:        %[[EXPAND_WITNESS:.+]] = shape.cstr_broadcastable %[[IN_SHAPE]], %[[REQ]] : tensor<2xindex>, !shape.shape
-// CHECK-NEXT:        %[[EXPAND_SHAPE_VAL:.+]] = shape.assuming %[[EXPAND_WITNESS]] -> (!shape.shape) {
-// CHECK-NEXT:          %[[BROADCAST:.+]] = shape.broadcast %[[IN_SHAPE]], %[[REQ]] : tensor<2xindex>, !shape.shape -> !shape.shape
-// CHECK-NEXT:          shape.assuming_yield %[[BROADCAST]] : !shape.shape
-// CHECK-NEXT:        }
-// CHECK-NEXT:        scf.yield %[[EXPAND_SHAPE_VAL]] : !shape.shape
-// CHECK-NEXT:      }
+// CHECK-NEXT:      %[[D1_C2:.+]] = arith.constant 2 : index
+// CHECK-NEXT:      %[[D1_C1:.+]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[D1_C0:.+]] = arith.constant 0 : index
 
-// CHECK-NEXT:      %[[MM2_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[W2_SHAPE:.+]] = shape.shape_of %[[D1_W2]] : tensor<4x2xf32, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[E_K_IDX:.+]] = shape.const_size 1
-// CHECK-NEXT:        %[[E_K:.+]] = shape.get_extent %[[EXPAND_SHAPE]], %[[E_K_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[E_K_SHAPE:.+]] = shape.from_extents %[[E_K]] : !shape.size
-// CHECK-NEXT:        %[[W2_K_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[W2_K:.+]] = shape.get_extent %[[W2_SHAPE]], %[[W2_K_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[W2_K_SHAPE:.+]] = shape.from_extents %[[W2_K]] : !shape.size
-// CHECK-NEXT:        %[[K2_WITNESS:.+]] = shape.cstr_eq %[[E_K_SHAPE]], %[[W2_K_SHAPE]] : !shape.shape, !shape.shape
-// CHECK-NEXT:        %[[E_SPLIT_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[E_BATCH:.+]], %[[E_TAIL:.+]] = "shape.split_at"(%[[EXPAND_SHAPE]], %[[E_SPLIT_IDX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT:        %[[W2_SPLIT_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[W2_BATCH:.+]], %[[W2_TAIL:.+]] = "shape.split_at"(%[[W2_SHAPE]], %[[W2_SPLIT_IDX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT:        %[[BATCH2_WITNESS:.+]] = shape.cstr_broadcastable %[[E_BATCH]], %[[W2_BATCH]] : !shape.shape, !shape.shape
-// CHECK-NEXT:        %[[WITNESS2:.+]] = shape.assuming_all %[[K2_WITNESS]], %[[BATCH2_WITNESS]]
-// CHECK-NEXT:        %[[MM2_SHAPE_VAL:.+]] = shape.assuming %[[WITNESS2]] -> (!shape.shape) {
-// CHECK-NEXT:          %[[BATCH2:.+]] = shape.broadcast %[[E_BATCH]], %[[W2_BATCH]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:          %[[M2_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:          %[[M2:.+]] = shape.get_extent %[[EXPAND_SHAPE]], %[[M2_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:          %[[N2_IDX:.+]] = shape.const_size 1
-// CHECK-NEXT:          %[[N2:.+]] = shape.get_extent %[[W2_SHAPE]], %[[N2_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:          %[[MATRIX2:.+]] = shape.from_extents %[[M2]], %[[N2]] : !shape.size, !shape.size
-// CHECK-NEXT:          %[[RESULT2:.+]] = shape.concat %[[BATCH2]], %[[MATRIX2]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:          shape.assuming_yield %[[RESULT2]] : !shape.shape
+// The expand's own shape broadcasts its input shape against the requested
+// extents. It reads those extents out of the host buffer domain 0 handed over.
+// CHECK-NEXT:      %[[IN_D0:.+]] = tensor.dim %[[D1_CAST_INIT]], %[[D1_C0]] : tensor<?x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[IN_SHAPE:.+]] = tensor.from_elements %[[IN_D0]], %[[D1_C1]] : tensor<2xindex>
+// CHECK-NEXT:      %[[E0:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[D1_C0]]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      %[[X0:.+]] = arith.index_cast %[[E0]] : i64 to index
+// CHECK-NEXT:      %[[E1:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[D1_C1]]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      %[[X1:.+]] = arith.index_cast %[[E1]] : i64 to index
+// CHECK-NEXT:      %[[REQ:.+]] = tensor.from_elements %[[X0]], %[[X1]] : tensor<2xindex>
+// Broadcasting the two is a per-dimension select, so upstream writes it as a
+// generator body: out of range on either side yields 1, and a requested extent
+// of 1 keeps the input's.
+// CHECK-NEXT:      %[[EXPAND_SHAPE:.+]] = tensor.generate {
+// CHECK-NEXT:      ^bb0(%[[DIM:.+]]: index):
+// CHECK-NEXT:        %[[IN_OOB:.+]] = arith.cmpi ult, %[[DIM]], %[[D1_C0]] : index
+// CHECK-NEXT:        %[[IN_EXTENT:.+]] = scf.if %[[IN_OOB]] -> (index) {
+// CHECK-NEXT:          scf.yield %[[D1_C1]] : index
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          %[[IN_E:.+]] = tensor.extract %[[IN_SHAPE]]{{\[}}%[[DIM]]] : tensor<2xindex>
+// CHECK-NEXT:          scf.yield %[[IN_E]] : index
 // CHECK-NEXT:        }
-// CHECK-NEXT:        scf.yield %[[MM2_SHAPE_VAL]] : !shape.shape
-// CHECK-NEXT:      }
+// CHECK-NEXT:        %[[REQ_OOB:.+]] = arith.cmpi ult, %[[DIM]], %[[D1_C0]] : index
+// CHECK-NEXT:        %[[OUT_EXTENT:.+]] = scf.if %[[REQ_OOB]] -> (index) {
+// CHECK-NEXT:          scf.yield %[[IN_EXTENT]] : index
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          %[[REQ_E:.+]] = tensor.extract %[[REQ]]{{\[}}%[[DIM]]] : tensor<2xindex>
+// CHECK-NEXT:          %[[REQ_IS_ONE:.+]] = arith.cmpi eq, %[[REQ_E]], %[[D1_C1]] : index
+// CHECK-NEXT:          %[[PICK:.+]] = arith.select %[[REQ_IS_ONE]], %[[IN_EXTENT]], %[[REQ_E]] : index
+// CHECK-NEXT:          scf.yield %[[PICK]] : index
+// CHECK-NEXT:        }
+// CHECK-NEXT:        tensor.yield %[[OUT_EXTENT]] : index
+// CHECK-NEXT:      } : tensor<2xindex>
 
-// CHECK-NEXT:      %[[EXPAND_M_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:      %[[EXPAND_M_EXTENT:.+]] = shape.get_extent %[[EXPAND_SHAPE]], %[[EXPAND_M_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:      %[[EXPAND_M:.+]] = shape.size_to_index %[[EXPAND_M_EXTENT]] : !shape.size
+// The second matmul has no batch dimensions either, so M comes from the
+// expand's leading extent. Canonicalization has already reduced that extent to
+// the broadcast of one axis.
+// CHECK-NEXT:      %[[M2_IS_ONE:.+]] = arith.cmpi eq, %[[X0]], %[[D1_C1]] : index
+// CHECK-NEXT:      %[[M2:.+]] = arith.select %[[M2_IS_ONE]], %[[IN_D0]], %[[X0]] : index
+// CHECK-NEXT:      %[[MM2_SHAPE:.+]] = tensor.from_elements %[[M2]], %[[D1_C2]] : tensor<2xindex>
+
+// No fold can see through the tensor.generate above, so the expand's allocation
+// recomputes the same broadcast. The second matmul's allocation does fold, so
+// it reuses M directly.
+// CHECK-NEXT:      %[[EXPAND_M_IS_ONE:.+]] = arith.cmpi eq, %[[X0]], %[[D1_C1]] : index
+// CHECK-NEXT:      %[[EXPAND_M:.+]] = arith.select %[[EXPAND_M_IS_ONE]], %[[IN_D0]], %[[X0]] : index
 // CHECK-NEXT:      %[[EXPAND_INIT:.+]] = tensor.empty(%[[EXPAND_M]]) : tensor<?x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[MM2_M_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:      %[[MM2_M_EXTENT:.+]] = shape.get_extent %[[MM2_SHAPE]], %[[MM2_M_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:      %[[MM2_M:.+]] = shape.size_to_index %[[MM2_M_EXTENT]] : !shape.size
-// CHECK-NEXT:      %[[MM2_INIT:.+]] = tensor.empty(%[[MM2_M]]) : tensor<?x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[MM2_INIT:.+]] = tensor.empty(%[[M2]]) : tensor<?x2xf32, #hipsr.mem<device>>
+
 // CHECK-NEXT:      %[[EXPAND:.+]] = hipsr.expand(%[[D1_CTX]]) ins(%[[D1_CAST]], %[[D1_EXTENTS]] : tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) outs(%[[EXPAND_INIT]] : tensor<?x4xf32, #hipsr.mem<device>>) : tensor<?x4xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[MM2:.+]] = hipsr.matmul(%[[D1_CTX]]) ins(%[[EXPAND]], %[[D1_W2]] : tensor<?x4xf32, #hipsr.mem<device>>, tensor<4x2xf32, #hipsr.mem<device>>) outs(%[[MM2_INIT]] : tensor<?x2xf32, #hipsr.mem<device>>) : tensor<?x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[EXPAND_SHAPE]], %[[EXPAND]] : tensor<?x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[MM2_SHAPE]], %[[MM2]] : tensor<?x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[EXPAND_SHAPE]], %[[EXPAND]] : tensor<2xindex>, tensor<?x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[MM2_SHAPE]], %[[MM2]] : tensor<2xindex>, tensor<?x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[MM2]] : tensor<?x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    } -> tensor<?x2xf32, #hipsr.mem<device>> {domain_id = 1 : i64}
 

--- a/test/lit/Dialect/Hipsr/Pipelines/sample_static.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/sample_static.mlir
@@ -7,6 +7,9 @@
 
 // RUN: hip-mlir-opt %s --onnx-dialect=modeled --hipsr-pipeline | FileCheck %s
 
+// Every line of the output is checked, which is also what shows that no shape
+// dialect op survives: one would have to appear on a line of its own.
+
 // CHECK-LABEL: func.func @main_graph(
 // CHECK-SAME:      %[[CTX:.+]]: !hipsr.context,
 // CHECK-SAME:      %[[A:.+]]: tensor<2x3xf16, #hipsr.mem<device>> {onnx.name = "a"},
@@ -20,79 +23,46 @@
 // computations, then the allocations they size, then the data ops, and last a
 // hipsr.preserve_shape tying each shape to the value filling the buffer it
 // sized.
+//
+// Every extent here is static, so no allocation reads a shape back. The shape
+// graph sizes nothing, yet it survives because preserve_shape names it. Without
+// that use it would fold away entirely.
 // CHECK-NEXT:    %[[D0:.+]]:5 = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]] : !hipsr.context, tensor<2x3xf16, #hipsr.mem<device>>, tensor<2x4xf32, #hipsr.mem<device>>) {
 // CHECK-NEXT:    ^bb0(%[[D0_CTX:.+]]: !hipsr.context, %[[D0_A:.+]]: tensor<2x3xf16, #hipsr.mem<device>>, %[[D0_B:.+]]: tensor<2x4xf32, #hipsr.mem<device>>):
 
-// Both weights lead the domain. Only the first one has a shape a computation
-// reads; the second is here because a constant takes no operands, so the pass
-// brings every one of them over ahead of the computations.
+// Everything constant-like leads the domain, and here that is the whole shape
+// graph. Neither matmul operand has batch dimensions, so the result shape is
+// the two matrix extents, both from the operand types: one dense vector.
+// CHECK-NEXT:      %[[EXTENTS_SHAPE_S:.+]] = arith.constant dense<2> : tensor<1xindex>
 // CHECK-NEXT:      %[[W1:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<3x1xf16>} : tensor<3x1xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[W2:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<4x2xf32>} : tensor<4x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[MM1_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[D0_A]] : tensor<2x3xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[W1_SHAPE:.+]] = shape.shape_of %[[W1]] : tensor<3x1xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[A_K_IDX:.+]] = shape.const_size 1
-// CHECK-NEXT:        %[[A_K:.+]] = shape.get_extent %[[A_SHAPE]], %[[A_K_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[A_K_SHAPE:.+]] = shape.from_extents %[[A_K]] : !shape.size
-// CHECK-NEXT:        %[[W1_K_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[W1_K:.+]] = shape.get_extent %[[W1_SHAPE]], %[[W1_K_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[W1_K_SHAPE:.+]] = shape.from_extents %[[W1_K]] : !shape.size
-// CHECK-NEXT:        %[[K_WITNESS:.+]] = shape.cstr_eq %[[A_K_SHAPE]], %[[W1_K_SHAPE]] : !shape.shape, !shape.shape
-// CHECK-NEXT:        %[[A_SPLIT_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[A_BATCH:.+]], %[[A_TAIL:.+]] = "shape.split_at"(%[[A_SHAPE]], %[[A_SPLIT_IDX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT:        %[[W1_SPLIT_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[W1_BATCH:.+]], %[[W1_TAIL:.+]] = "shape.split_at"(%[[W1_SHAPE]], %[[W1_SPLIT_IDX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT:        %[[BATCH_WITNESS:.+]] = shape.cstr_broadcastable %[[A_BATCH]], %[[W1_BATCH]] : !shape.shape, !shape.shape
-// CHECK-NEXT:        %[[WITNESS:.+]] = shape.assuming_all %[[K_WITNESS]], %[[BATCH_WITNESS]]
-// CHECK-NEXT:        %[[MM1_SHAPE_VAL:.+]] = shape.assuming %[[WITNESS]] -> (!shape.shape) {
-// CHECK-NEXT:          %[[BATCH:.+]] = shape.broadcast %[[A_BATCH]], %[[W1_BATCH]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:          %[[M_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:          %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[M_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:          %[[N_IDX:.+]] = shape.const_size 1
-// CHECK-NEXT:          %[[N:.+]] = shape.get_extent %[[W1_SHAPE]], %[[N_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:          %[[MATRIX:.+]] = shape.from_extents %[[M]], %[[N]] : !shape.size, !shape.size
-// CHECK-NEXT:          %[[RESULT:.+]] = shape.concat %[[BATCH]], %[[MATRIX]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:          shape.assuming_yield %[[RESULT]] : !shape.shape
-// CHECK-NEXT:        }
-// CHECK-NEXT:        scf.yield %[[MM1_SHAPE_VAL]] : !shape.shape
-// CHECK-NEXT:      }
-
-// The cast keeps its operand's shape, so its shape computation forwards the one
-// next to it.
-// CHECK-NEXT:      %[[CAST_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        scf.yield %[[MM1_SHAPE]] : !shape.shape
-// CHECK-NEXT:      }
-
-// The extent vector's length follows the rank of the operand, not its extents,
-// so the operand's shape goes unread here.
-// CHECK-NEXT:      %[[EXTENTS_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[B_SHAPE:.+]] = shape.shape_of %[[D0_B]] : tensor<2x4xf32, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[RANK:.+]] = arith.constant 2 : index
-// CHECK-NEXT:        %[[RANK_SHAPE:.+]] = shape.from_extents %[[RANK]] : index
-// CHECK-NEXT:        scf.yield %[[RANK_SHAPE]] : !shape.shape
-// CHECK-NEXT:      }
+// CHECK-NEXT:      %[[MM1_SHAPE:.+]] = arith.constant dense<{{\[}}2, 1]> : tensor<2xindex>
 
 // Every extent is in the types, so no allocation reads a shape back.
 // CHECK-NEXT:      %[[MM1_INIT:.+]] = tensor.empty() : tensor<2x1xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[CAST_INIT:.+]] = tensor.empty() : tensor<2x1xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[EXTENTS_INIT:.+]] = tensor.empty() : tensor<2xi64, #hipsr.mem<host>>
 
+// The expand reads an extent vector, the one place a shape reaches the data
+// graph, and it arrives as a host buffer. Its operand is fully static, so
+// canonicalization folds the two extents into one dense vector.
 // CHECK-NEXT:      %[[MM1:.+]] = hipsr.matmul(%[[D0_CTX]]) ins(%[[D0_A]], %[[W1]] : tensor<2x3xf16, #hipsr.mem<device>>, tensor<3x1xf16, #hipsr.mem<device>>) outs(%[[MM1_INIT]] : tensor<2x1xf16, #hipsr.mem<device>>) : tensor<2x1xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[CAST:.+]] = hipsr.cast(%[[D0_CTX]]) ins(%[[MM1]] : tensor<2x1xf16, #hipsr.mem<device>>) outs(%[[CAST_INIT]] : tensor<2x1xf32, #hipsr.mem<device>>) : tensor<2x1xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[EXTENTS:.+]] = hipsr.compute(%[[D0_CTX]]) ins(%[[D0_B]] : tensor<2x4xf32, #hipsr.mem<device>>) outs(%[[EXTENTS_INIT]] : tensor<2xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:      ^bb0(%{{.+}}: !hipsr.context, %{{.+}}: tensor<2x4xf32, #hipsr.mem<device>>, %{{.+}}: tensor<2xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:        %[[D0_EXT:.+]] = arith.constant 2 : i64
-// CHECK-NEXT:        %[[D1_EXT:.+]] = arith.constant 4 : i64
-// CHECK-NEXT:        %[[EXTENT_VECTOR:.+]] = tensor.from_elements %[[D0_EXT]], %[[D1_EXT]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[EXTENT_VECTOR:.+]] = arith.constant dense<{{\[}}2, 4]> : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        hipsr.compute_yield %[[EXTENT_VECTOR]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:      } : tensor<2xi64, #hipsr.mem<host>>
 
-// CHECK-NEXT:      hipsr.preserve_shape %[[MM1_SHAPE]], %[[MM1]] : tensor<2x1xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[CAST_SHAPE]], %[[CAST]] : tensor<2x1xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[EXTENTS_SHAPE]], %[[EXTENTS]] : tensor<2xi64, #hipsr.mem<host>>
+// Each shape closes the domain next to the value that filled the buffer it
+// sized. Its length is part of its type. The matmul and the cast share one
+// shape, because the cast copies its input's extents.
+// CHECK-NEXT:      hipsr.preserve_shape %[[MM1_SHAPE]], %[[MM1]] : tensor<2xindex>, tensor<2x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[MM1_SHAPE]], %[[CAST]] : tensor<2xindex>, tensor<2x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[EXTENTS_SHAPE_S]], %[[EXTENTS]] : tensor<1xindex>, tensor<2xi64, #hipsr.mem<host>>
 
-// The second weight has no inputs, which keeps it in domain 0, and only the
-// yield uses it there.
+// The second weight has no use in this domain beyond the yield. It crosses the
+// barrier as a domain result, like the buffers do.
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[CAST_INIT]], %[[CAST]], %[[EXTENTS_INIT]], %[[EXTENTS]], %[[W2]] : tensor<2x1xf32, #hipsr.mem<device>>, tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    } -> tensor<2x1xf32, #hipsr.mem<device>>, tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
 
@@ -102,60 +72,56 @@
 // CHECK-NEXT:    %[[D1:.+]] = hipsr.pool_domain(%[[CTX]], %[[D0]]#0, %[[D0]]#2, %[[D0]]#1, %[[D0]]#3, %[[D0]]#4 : !hipsr.context, tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>>) {
 // CHECK-NEXT:    ^bb0(%[[D1_CTX:.+]]: !hipsr.context, %[[D1_CAST_INIT:.+]]: tensor<2x1xf32, #hipsr.mem<device>>, %[[D1_EXTENTS_INIT:.+]]: tensor<2xi64, #hipsr.mem<host>>, %[[D1_CAST:.+]]: tensor<2x1xf32, #hipsr.mem<device>>, %[[D1_EXTENTS:.+]]: tensor<2xi64, #hipsr.mem<host>>, %[[D1_W2:.+]]: tensor<4x2xf32, #hipsr.mem<device>>):
 
-// The expand's destination is the reason for the cut: its extents come out of
-// the host vector domain 0 wrote, so the barrier's shape computation reads that
-// buffer instead of a shape.
-// CHECK-NEXT:      %[[EXPAND_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[IN_SHAPE:.+]] = shape.shape_of %[[D1_CAST_INIT]] : tensor<2x1xf32, #hipsr.mem<device>> -> tensor<2xindex>
-// CHECK-NEXT:        %[[I0:.+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[E0:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[I0]]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[X0:.+]] = arith.index_cast %[[E0]] : i64 to index
-// CHECK-NEXT:        %[[I1:.+]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[E1:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[I1]]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[X1:.+]] = arith.index_cast %[[E1]] : i64 to index
-// CHECK-NEXT:        %[[REQ:.+]] = shape.from_extents %[[X0]], %[[X1]] : index, index
-// CHECK-NEXT:        %[[EXPAND_WITNESS:.+]] = shape.cstr_broadcastable %[[IN_SHAPE]], %[[REQ]] : tensor<2xindex>, !shape.shape
-// CHECK-NEXT:        %[[EXPAND_SHAPE_VAL:.+]] = shape.assuming %[[EXPAND_WITNESS]] -> (!shape.shape) {
-// CHECK-NEXT:          %[[BROADCAST:.+]] = shape.broadcast %[[IN_SHAPE]], %[[REQ]] : tensor<2xindex>, !shape.shape -> !shape.shape
-// CHECK-NEXT:          shape.assuming_yield %[[BROADCAST]] : !shape.shape
-// CHECK-NEXT:        }
-// CHECK-NEXT:        scf.yield %[[EXPAND_SHAPE_VAL]] : !shape.shape
-// CHECK-NEXT:      }
+// CHECK-NEXT:      %[[D1_C2:.+]] = arith.constant 2 : index
+// CHECK-NEXT:      %[[D1_C1:.+]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[D1_C0:.+]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[IN_SHAPE:.+]] = arith.constant dense<{{\[}}2, 1]> : tensor<2xindex>
 
-// CHECK-NEXT:      %[[MM2_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[W2_SHAPE:.+]] = shape.shape_of %[[D1_W2]] : tensor<4x2xf32, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[E_K_IDX:.+]] = shape.const_size 1
-// CHECK-NEXT:        %[[E_K:.+]] = shape.get_extent %[[EXPAND_SHAPE]], %[[E_K_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[E_K_SHAPE:.+]] = shape.from_extents %[[E_K]] : !shape.size
-// CHECK-NEXT:        %[[W2_K_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[W2_K:.+]] = shape.get_extent %[[W2_SHAPE]], %[[W2_K_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[W2_K_SHAPE:.+]] = shape.from_extents %[[W2_K]] : !shape.size
-// CHECK-NEXT:        %[[K2_WITNESS:.+]] = shape.cstr_eq %[[E_K_SHAPE]], %[[W2_K_SHAPE]] : !shape.shape, !shape.shape
-// CHECK-NEXT:        %[[E_SPLIT_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[E_BATCH:.+]], %[[E_TAIL:.+]] = "shape.split_at"(%[[EXPAND_SHAPE]], %[[E_SPLIT_IDX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT:        %[[W2_SPLIT_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[W2_BATCH:.+]], %[[W2_TAIL:.+]] = "shape.split_at"(%[[W2_SHAPE]], %[[W2_SPLIT_IDX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT:        %[[BATCH2_WITNESS:.+]] = shape.cstr_broadcastable %[[E_BATCH]], %[[W2_BATCH]] : !shape.shape, !shape.shape
-// CHECK-NEXT:        %[[WITNESS2:.+]] = shape.assuming_all %[[K2_WITNESS]], %[[BATCH2_WITNESS]]
-// CHECK-NEXT:        %[[MM2_SHAPE_VAL:.+]] = shape.assuming %[[WITNESS2]] -> (!shape.shape) {
-// CHECK-NEXT:          %[[BATCH2:.+]] = shape.broadcast %[[E_BATCH]], %[[W2_BATCH]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:          %[[M2_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:          %[[M2:.+]] = shape.get_extent %[[EXPAND_SHAPE]], %[[M2_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:          %[[N2_IDX:.+]] = shape.const_size 1
-// CHECK-NEXT:          %[[N2:.+]] = shape.get_extent %[[W2_SHAPE]], %[[N2_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:          %[[MATRIX2:.+]] = shape.from_extents %[[M2]], %[[N2]] : !shape.size, !shape.size
-// CHECK-NEXT:          %[[RESULT2:.+]] = shape.concat %[[BATCH2]], %[[MATRIX2]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:          shape.assuming_yield %[[RESULT2]] : !shape.shape
+// The expand's own shape broadcasts its input shape against the requested
+// extents, read out of the host buffer domain 0 handed over. That buffer stays
+// opaque, so these two reads survive everything static around them.
+// CHECK-NEXT:      %[[E0:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[D1_C0]]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      %[[X0:.+]] = arith.index_cast %[[E0]] : i64 to index
+// CHECK-NEXT:      %[[E1:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[D1_C1]]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      %[[X1:.+]] = arith.index_cast %[[E1]] : i64 to index
+// CHECK-NEXT:      %[[REQ:.+]] = tensor.from_elements %[[X0]], %[[X1]] : tensor<2xindex>
+// Broadcasting the two is a per-dimension select, so upstream writes it as a
+// generator body: out of range on either side yields 1, and a requested extent
+// of 1 keeps the input's.
+// CHECK-NEXT:      %[[EXPAND_SHAPE:.+]] = tensor.generate {
+// CHECK-NEXT:      ^bb0(%[[DIM:.+]]: index):
+// CHECK-NEXT:        %[[IN_OOB:.+]] = arith.cmpi ult, %[[DIM]], %[[D1_C0]] : index
+// CHECK-NEXT:        %[[IN_EXTENT:.+]] = scf.if %[[IN_OOB]] -> (index) {
+// CHECK-NEXT:          scf.yield %[[D1_C1]] : index
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          %[[IN_E:.+]] = tensor.extract %[[IN_SHAPE]]{{\[}}%[[DIM]]] : tensor<2xindex>
+// CHECK-NEXT:          scf.yield %[[IN_E]] : index
 // CHECK-NEXT:        }
-// CHECK-NEXT:        scf.yield %[[MM2_SHAPE_VAL]] : !shape.shape
-// CHECK-NEXT:      }
+// CHECK-NEXT:        %[[REQ_OOB:.+]] = arith.cmpi ult, %[[DIM]], %[[D1_C0]] : index
+// CHECK-NEXT:        %[[OUT_EXTENT:.+]] = scf.if %[[REQ_OOB]] -> (index) {
+// CHECK-NEXT:          scf.yield %[[IN_EXTENT]] : index
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          %[[REQ_E:.+]] = tensor.extract %[[REQ]]{{\[}}%[[DIM]]] : tensor<2xindex>
+// CHECK-NEXT:          %[[REQ_IS_ONE:.+]] = arith.cmpi eq, %[[REQ_E]], %[[D1_C1]] : index
+// CHECK-NEXT:          %[[PICK:.+]] = arith.select %[[REQ_IS_ONE]], %[[IN_EXTENT]], %[[REQ_E]] : index
+// CHECK-NEXT:          scf.yield %[[PICK]] : index
+// CHECK-NEXT:        }
+// CHECK-NEXT:        tensor.yield %[[OUT_EXTENT]] : index
+// CHECK-NEXT:      } : tensor<2xindex>
+
+// The second matmul has no batch dimensions either. Its shape is M broadcast
+// against the requested leading extent, then the weight's trailing extent. The
+// static side of that select is the input's own extent.
+// CHECK-NEXT:      %[[M2_IS_ONE:.+]] = arith.cmpi eq, %[[X0]], %[[D1_C1]] : index
+// CHECK-NEXT:      %[[M2:.+]] = arith.select %[[M2_IS_ONE]], %[[D1_C2]], %[[X0]] : index
+// CHECK-NEXT:      %[[MM2_SHAPE:.+]] = tensor.from_elements %[[M2]], %[[D1_C2]] : tensor<2xindex>
 
 // CHECK-NEXT:      %[[EXPAND_INIT:.+]] = tensor.empty() : tensor<2x4xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[MM2_INIT:.+]] = tensor.empty() : tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[EXPAND:.+]] = hipsr.expand(%[[D1_CTX]]) ins(%[[D1_CAST]], %[[D1_EXTENTS]] : tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) outs(%[[EXPAND_INIT]] : tensor<2x4xf32, #hipsr.mem<device>>) : tensor<2x4xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[MM2:.+]] = hipsr.matmul(%[[D1_CTX]]) ins(%[[EXPAND]], %[[D1_W2]] : tensor<2x4xf32, #hipsr.mem<device>>, tensor<4x2xf32, #hipsr.mem<device>>) outs(%[[MM2_INIT]] : tensor<2x2xf32, #hipsr.mem<device>>) : tensor<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[EXPAND_SHAPE]], %[[EXPAND]] : tensor<2x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[MM2_SHAPE]], %[[MM2]] : tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[EXPAND_SHAPE]], %[[EXPAND]] : tensor<2xindex>, tensor<2x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[MM2_SHAPE]], %[[MM2]] : tensor<2xindex>, tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[MM2]] : tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    } -> tensor<2x2xf32, #hipsr.mem<device>> {domain_id = 1 : i64}
 

--- a/test/lit/Dialect/Hipsr/Transforms/MaterializeInitTensors/invalid.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/MaterializeInitTensors/invalid.mlir
@@ -48,8 +48,8 @@ func.func @barrier_over_placeholder(%ctx: !hipsr.context, %in: tensor<?x1xf16, #
         ins(%domain_in : tensor<?x1xf16, #hipsr.mem<device>>)
         {placeholder_type = #hipsr.placeholder_type<normal>}
         : tensor<?x1xf32, #hipsr.mem<device>> shape_region {
-    ^bb0(%in_shape: !shape.shape):
-      hipsr.shape_yield %in_shape : !shape.shape
+    ^bb0(%in_shape: tensor<2xindex>):
+      hipsr.shape_yield %in_shape : tensor<2xindex>
     }
     %cast = hipsr.cast(%domain_ctx)
         ins(%domain_in : tensor<?x1xf16, #hipsr.mem<device>>)
@@ -61,8 +61,8 @@ func.func @barrier_over_placeholder(%ctx: !hipsr.context, %in: tensor<?x1xf16, #
         : tensor<?x1xf16, #hipsr.mem<device>> shape_region {
     ^bb0(%region_ctx: !hipsr.context, %region_cast: tensor<?x1xf32, #hipsr.mem<device>>):
       %cast_shape = shape.shape_of %region_cast
-          : tensor<?x1xf32, #hipsr.mem<device>> -> !shape.shape
-      hipsr.shape_yield %cast_shape : !shape.shape
+          : tensor<?x1xf32, #hipsr.mem<device>> -> tensor<2xindex>
+      hipsr.shape_yield %cast_shape : tensor<2xindex>
     }
     %out = hipsr.cast(%domain_ctx)
         ins(%cast : tensor<?x1xf32, #hipsr.mem<device>>)

--- a/test/lit/Dialect/Hipsr/Transforms/MaterializeInitTensors/materialize-init-tensors.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/MaterializeInitTensors/materialize-init-tensors.mlir
@@ -15,40 +15,37 @@
 
 // RUN: hip-mlir-opt %s -split-input-file -hipsr-materialize-init-tensors | FileCheck %s
 
-// A barrier reads the data of its inputs rather than their shapes, so its
-// region arguments become ctx and the input tensors themselves, and the pass
-// builds no shape.shape_of at region entry. Both tensor arguments are used as
-// tensors here, which is what pins that: %[[DIN]] feeds a shape.shape_of inside
-// the region yielding tensor<2xindex>, %[[DEXTENTS]] feeds a tensor.extract,
-// and a !shape.shape in either spot would not verify. Neither extent of the
-// result is in the result type: the shape comes from data the region reads,
-// which is why a barrier lands one domain past its inputs. Both
-// inputs enter the domain as block arguments, so an earlier domain filled those
-// buffers and the region reads them as they are. That is the only form the pass
-// accepts; an input this domain allocates is the error case in invalid.mlir.
+// A barrier reads the data of its inputs, not their shapes, so its region
+// arguments are ctx and the input tensors themselves:
+//
+//   - the pass builds no shape.shape_of at region entry;
+//   - %[[DIN]] feeds a shape.shape_of, which takes the value itself;
+//   - %[[DEXTENTS]] feeds a tensor.extract of i64, which no shape satisfies;
+//   - neither result extent is in the result type, so the barrier lands one
+//     domain past its inputs;
+//   - both inputs arrive as block arguments an earlier domain filled. An input
+//     this domain allocates is the error case in invalid.mlir.
 // CHECK-LABEL: func.func @barrier_domain(
 // CHECK-SAME:      %[[CTX:.+]]: !hipsr.context, %[[IN:.+]]: tensor<?x1xf32, #hipsr.mem<device>>, %[[EXTENTS:.+]]: tensor<2xi64, #hipsr.mem<host>>) -> tensor<?x?xf32, #hipsr.mem<device>> {
 // CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[IN]], %[[EXTENTS]] : !hipsr.context, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:    ^bb0(%[[DCTX:.+]]: !hipsr.context, %[[DIN:.+]]: tensor<?x1xf32, #hipsr.mem<device>>, %[[DEXTENTS:.+]]: tensor<2xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:      %[[SHAPE:.+]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:      %[[SHAPE:.+]] = scf.execute_region -> tensor<2xindex> {
 // CHECK-NEXT:        %[[IN_SHAPE:.+]] = shape.shape_of %[[DIN]] : tensor<?x1xf32, #hipsr.mem<device>> -> tensor<2xindex>
 // CHECK-NEXT:        %[[ROW_INDEX:.+]] = arith.constant 0 : index
 // CHECK-NEXT:        %[[ROWS:.+]] = tensor.extract %[[IN_SHAPE]]{{\[}}%[[ROW_INDEX]]] : tensor<2xindex>
 // CHECK-NEXT:        %[[COLUMN_INDEX:.+]] = arith.constant 1 : index
 // CHECK-NEXT:        %[[COLUMN:.+]] = tensor.extract %[[DEXTENTS]]{{\[}}%[[COLUMN_INDEX]]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[COLUMNS:.+]] = arith.index_cast %[[COLUMN]] : i64 to index
-// CHECK-NEXT:        %[[RESULT_SHAPE:.+]] = shape.from_extents %[[ROWS]], %[[COLUMNS]] : index, index
-// CHECK-NEXT:        scf.yield %[[RESULT_SHAPE]] : !shape.shape
+// CHECK-NEXT:        %[[RESULT_EXTENTS:.+]] = tensor.from_elements %[[ROWS]], %[[COLUMNS]] : tensor<2xindex>
+// CHECK-NEXT:        scf.yield %[[RESULT_EXTENTS]] : tensor<2xindex>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %[[D0_INDEX:.+]] = shape.const_size 0
-// CHECK-NEXT:      %[[D0_EXTENT:.+]] = shape.get_extent %[[SHAPE]], %[[D0_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:      %[[D0:.+]] = shape.size_to_index %[[D0_EXTENT]] : !shape.size
-// CHECK-NEXT:      %[[D1_INDEX:.+]] = shape.const_size 1
-// CHECK-NEXT:      %[[D1_EXTENT:.+]] = shape.get_extent %[[SHAPE]], %[[D1_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:      %[[D1:.+]] = shape.size_to_index %[[D1_EXTENT]] : !shape.size
+// CHECK-NEXT:      %[[D0_INDEX:.+]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[D0:.+]] = shape.get_extent %[[SHAPE]], %[[D0_INDEX]] : tensor<2xindex>, index -> index
+// CHECK-NEXT:      %[[D1_INDEX:.+]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[D1:.+]] = shape.get_extent %[[SHAPE]], %[[D1_INDEX]] : tensor<2xindex>, index -> index
 // CHECK-NEXT:      %[[INIT:.+]] = tensor.empty(%[[D0]], %[[D1]]) : tensor<?x?xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[EXPAND:.+]] = hipsr.expand(%[[DCTX]]) ins(%[[DIN]], %[[DEXTENTS]] : tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) outs(%[[INIT]] : tensor<?x?xf32, #hipsr.mem<device>>) : tensor<?x?xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[SHAPE]], %[[EXPAND]] : tensor<?x?xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[SHAPE]], %[[EXPAND]] : tensor<2xindex>, tensor<?x?xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[EXPAND]] : tensor<?x?xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    } -> tensor<?x?xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
 // CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x?xf32, #hipsr.mem<device>>
@@ -71,8 +68,8 @@ func.func @barrier_domain(%ctx: !hipsr.context, %in: tensor<?x1xf32, #hipsr.mem<
       %column_index = arith.constant 1 : index
       %column = tensor.extract %region_extents[%column_index] : tensor<2xi64, #hipsr.mem<host>>
       %columns = arith.index_cast %column : i64 to index
-      %result_shape = shape.from_extents %rows, %columns : index, index
-      hipsr.shape_yield %result_shape : !shape.shape
+      %result_shape = tensor.from_elements %rows, %columns : tensor<2xindex>
+      hipsr.shape_yield %result_shape : tensor<2xindex>
     }
     %expand = hipsr.expand(%domain_ctx)
         ins(%domain_in, %domain_extents : tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>)
@@ -109,33 +106,31 @@ func.func @barrier_domain(%ctx: !hipsr.context, %in: tensor<?x1xf32, #hipsr.mem<
 // CHECK-SAME:      %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<?x256xf16, #hipsr.mem<device>>, %[[B:.+]]: tensor<256x512xf16, #hipsr.mem<device>>, %[[C:.+]]: tensor<?x512xf16, #hipsr.mem<device>>) -> tensor<?x512xf16, #hipsr.mem<device>> {
 // CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]], %[[C]] : !hipsr.context, tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>, tensor<?x512xf16, #hipsr.mem<device>>) {
 // CHECK-NEXT:    ^bb0(%[[DCTX:.+]]: !hipsr.context, %[[DA:.+]]: tensor<?x256xf16, #hipsr.mem<device>>, %[[DB:.+]]: tensor<256x512xf16, #hipsr.mem<device>>, %[[DC:.+]]: tensor<?x512xf16, #hipsr.mem<device>>):
-// CHECK-NEXT:      %[[MATMUL_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[DA]] : tensor<?x256xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[B_SHAPE:.+]] = shape.shape_of %[[DB]] : tensor<256x512xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[M_INDEX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[M_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[N_INDEX:.+]] = shape.const_size 1
-// CHECK-NEXT:        %[[N:.+]] = shape.get_extent %[[B_SHAPE]], %[[N_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[FROM_EXTENTS:.+]] = shape.from_extents %[[M]], %[[N]] : !shape.size, !shape.size
-// CHECK-NEXT:        scf.yield %[[FROM_EXTENTS]] : !shape.shape
+// CHECK-NEXT:      %[[MATMUL_SHAPE:.+]] = scf.execute_region -> tensor<2xindex> {
+// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[DA]] : tensor<?x256xf16, #hipsr.mem<device>> -> tensor<2xindex>
+// CHECK-NEXT:        %[[B_SHAPE:.+]] = shape.shape_of %[[DB]] : tensor<256x512xf16, #hipsr.mem<device>> -> tensor<2xindex>
+// CHECK-NEXT:        %[[M_INDEX:.+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[M_INDEX]] : tensor<2xindex>, index -> index
+// CHECK-NEXT:        %[[N_INDEX:.+]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[N:.+]] = shape.get_extent %[[B_SHAPE]], %[[N_INDEX]] : tensor<2xindex>, index -> index
+// CHECK-NEXT:        %[[FROM_ELEMENTS:.+]] = tensor.from_elements %[[M]], %[[N]] : tensor<2xindex>
+// CHECK-NEXT:        scf.yield %[[FROM_ELEMENTS]] : tensor<2xindex>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %[[ADD_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[C_SHAPE:.+]] = shape.shape_of %[[DC]] : tensor<?x512xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[BROADCAST:.+]] = shape.broadcast %[[MATMUL_SHAPE]], %[[C_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:        scf.yield %[[BROADCAST]] : !shape.shape
+// CHECK-NEXT:      %[[ADD_SHAPE:.+]] = scf.execute_region -> tensor<2xindex> {
+// CHECK-NEXT:        %[[C_SHAPE:.+]] = shape.shape_of %[[DC]] : tensor<?x512xf16, #hipsr.mem<device>> -> tensor<2xindex>
+// CHECK-NEXT:        %[[BROADCAST:.+]] = shape.broadcast %[[MATMUL_SHAPE]], %[[C_SHAPE]] : tensor<2xindex>, tensor<2xindex> -> tensor<2xindex>
+// CHECK-NEXT:        scf.yield %[[BROADCAST]] : tensor<2xindex>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %[[MATMUL_D0_INDEX:.+]] = shape.const_size 0
-// CHECK-NEXT:      %[[MATMUL_D0_EXTENT:.+]] = shape.get_extent %[[MATMUL_SHAPE]], %[[MATMUL_D0_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:      %[[MATMUL_D0:.+]] = shape.size_to_index %[[MATMUL_D0_EXTENT]] : !shape.size
+// CHECK-NEXT:      %[[MATMUL_D0_INDEX:.+]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[MATMUL_D0:.+]] = shape.get_extent %[[MATMUL_SHAPE]], %[[MATMUL_D0_INDEX]] : tensor<2xindex>, index -> index
 // CHECK-NEXT:      %[[MATMUL_INIT:.+]] = tensor.empty(%[[MATMUL_D0]]) : tensor<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[ADD_D0_INDEX:.+]] = shape.const_size 0
-// CHECK-NEXT:      %[[ADD_D0_EXTENT:.+]] = shape.get_extent %[[ADD_SHAPE]], %[[ADD_D0_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:      %[[ADD_D0:.+]] = shape.size_to_index %[[ADD_D0_EXTENT]] : !shape.size
+// CHECK-NEXT:      %[[ADD_D0_INDEX:.+]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[ADD_D0:.+]] = shape.get_extent %[[ADD_SHAPE]], %[[ADD_D0_INDEX]] : tensor<2xindex>, index -> index
 // CHECK-NEXT:      %[[ADD_INIT:.+]] = tensor.empty(%[[ADD_D0]]) : tensor<?x512xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[MATMUL:.+]] = hipsr.matmul(%[[DCTX]]) ins(%[[DA]], %[[DB]] : tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>) outs(%[[MATMUL_INIT]] : tensor<?x512xf16, #hipsr.mem<device>>) : tensor<?x512xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[ADD:.+]] = hipsr.add(%[[DCTX]]) ins(%[[MATMUL]], %[[DC]] : tensor<?x512xf16, #hipsr.mem<device>>, tensor<?x512xf16, #hipsr.mem<device>>) outs(%[[ADD_INIT]] : tensor<?x512xf16, #hipsr.mem<device>>) : tensor<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[MATMUL_SHAPE]], %[[MATMUL]] : tensor<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[ADD_SHAPE]], %[[ADD]] : tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[MATMUL_SHAPE]], %[[MATMUL]] : tensor<2xindex>, tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[ADD_SHAPE]], %[[ADD]] : tensor<2xindex>, tensor<?x512xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[ADD]] : tensor<?x512xf16, #hipsr.mem<device>>
 // CHECK-NEXT:    } -> tensor<?x512xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
 // CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x512xf16, #hipsr.mem<device>>
@@ -152,15 +147,15 @@ func.func @interleaved(%ctx: !hipsr.context, %a: tensor<?x256xf16, #hipsr.mem<de
         ins(%domain_a, %domain_b : tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>)
         {placeholder_type = #hipsr.placeholder_type<normal>}
         : tensor<?x512xf16, #hipsr.mem<device>> shape_region {
-    ^bb0(%a_shape: !shape.shape, %b_shape: !shape.shape):
-      %m_index = shape.const_size 0
+    ^bb0(%a_shape: tensor<2xindex>, %b_shape: tensor<2xindex>):
+      %m_index = arith.constant 0 : index
       %m = shape.get_extent %a_shape, %m_index
-          : !shape.shape, !shape.size -> !shape.size
-      %n_index = shape.const_size 1
+          : tensor<2xindex>, index -> index
+      %n_index = arith.constant 1 : index
       %n = shape.get_extent %b_shape, %n_index
-          : !shape.shape, !shape.size -> !shape.size
-      %matmul_shape = shape.from_extents %m, %n : !shape.size, !shape.size
-      hipsr.shape_yield %matmul_shape : !shape.shape
+          : tensor<2xindex>, index -> index
+      %matmul_shape = tensor.from_elements %m, %n : tensor<2xindex>
+      hipsr.shape_yield %matmul_shape : tensor<2xindex>
     }
     %matmul = hipsr.matmul(%domain_ctx)
         ins(%domain_a, %domain_b : tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>)
@@ -169,10 +164,10 @@ func.func @interleaved(%ctx: !hipsr.context, %a: tensor<?x256xf16, #hipsr.mem<de
         ins(%matmul_init, %domain_c : tensor<?x512xf16, #hipsr.mem<device>>, tensor<?x512xf16, #hipsr.mem<device>>)
         {placeholder_type = #hipsr.placeholder_type<normal>}
         : tensor<?x512xf16, #hipsr.mem<device>> shape_region {
-    ^bb0(%lhs_shape: !shape.shape, %rhs_shape: !shape.shape):
+    ^bb0(%lhs_shape: tensor<2xindex>, %rhs_shape: tensor<2xindex>):
       %add_shape = shape.broadcast %lhs_shape, %rhs_shape
-          : !shape.shape, !shape.shape -> !shape.shape
-      hipsr.shape_yield %add_shape : !shape.shape
+          : tensor<2xindex>, tensor<2xindex> -> tensor<2xindex>
+      hipsr.shape_yield %add_shape : tensor<2xindex>
     }
     %add = hipsr.add(%domain_ctx)
         ins(%matmul, %domain_c : tensor<?x512xf16, #hipsr.mem<device>>, tensor<?x512xf16, #hipsr.mem<device>>)
@@ -195,21 +190,21 @@ func.func @interleaved(%ctx: !hipsr.context, %a: tensor<?x256xf16, #hipsr.mem<de
 // CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[A]] : !hipsr.context, tensor<2x2xf16, #hipsr.mem<device>>) {
 // CHECK-NEXT:    ^bb0(%[[DCTX:.+]]: !hipsr.context, %[[DA:.+]]: tensor<2x2xf16, #hipsr.mem<device>>):
 // CHECK-NEXT:      %[[WEIGHT:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<2x2xf32>} : tensor<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[CAST_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[DA]] : tensor<2x2xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        scf.yield %[[A_SHAPE]] : !shape.shape
+// CHECK-NEXT:      %[[CAST_SHAPE:.+]] = scf.execute_region -> tensor<2xindex> {
+// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[DA]] : tensor<2x2xf16, #hipsr.mem<device>> -> tensor<2xindex>
+// CHECK-NEXT:        scf.yield %[[A_SHAPE]] : tensor<2xindex>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      %[[ADD_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[WEIGHT_SHAPE:.+]] = shape.shape_of %[[WEIGHT]] : tensor<2x2xf32, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[BROADCAST:.+]] = shape.broadcast %[[CAST_SHAPE]], %[[WEIGHT_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:        scf.yield %[[BROADCAST]] : !shape.shape
+// CHECK-NEXT:      %[[ADD_SHAPE:.+]] = scf.execute_region -> tensor<2xindex> {
+// CHECK-NEXT:        %[[WEIGHT_SHAPE:.+]] = shape.shape_of %[[WEIGHT]] : tensor<2x2xf32, #hipsr.mem<device>> -> tensor<2xindex>
+// CHECK-NEXT:        %[[BROADCAST:.+]] = shape.broadcast %[[CAST_SHAPE]], %[[WEIGHT_SHAPE]] : tensor<2xindex>, tensor<2xindex> -> tensor<2xindex>
+// CHECK-NEXT:        scf.yield %[[BROADCAST]] : tensor<2xindex>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %[[CAST_INIT:.+]] = tensor.empty() : tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[ADD_INIT:.+]] = tensor.empty() : tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[CAST:.+]] = hipsr.cast(%[[DCTX]]) ins(%[[DA]] : tensor<2x2xf16, #hipsr.mem<device>>) outs(%[[CAST_INIT]] : tensor<2x2xf32, #hipsr.mem<device>>) : tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[ADD:.+]] = hipsr.add(%[[DCTX]]) ins(%[[CAST]], %[[WEIGHT]] : tensor<2x2xf32, #hipsr.mem<device>>, tensor<2x2xf32, #hipsr.mem<device>>) outs(%[[ADD_INIT]] : tensor<2x2xf32, #hipsr.mem<device>>) : tensor<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[CAST_SHAPE]], %[[CAST]] : tensor<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[ADD_SHAPE]], %[[ADD]] : tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[CAST_SHAPE]], %[[CAST]] : tensor<2xindex>, tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[ADD_SHAPE]], %[[ADD]] : tensor<2xindex>, tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[ADD]] : tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    } -> tensor<2x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
 // CHECK-NEXT:    return %[[DOMAIN]] : tensor<2x2xf32, #hipsr.mem<device>>
@@ -224,8 +219,8 @@ func.func @constant_between_placeholders(%ctx: !hipsr.context,
         ins(%domain_a : tensor<2x2xf16, #hipsr.mem<device>>)
         {placeholder_type = #hipsr.placeholder_type<normal>}
         : tensor<2x2xf32, #hipsr.mem<device>> shape_region {
-    ^bb0(%a_shape: !shape.shape):
-      hipsr.shape_yield %a_shape : !shape.shape
+    ^bb0(%a_shape: tensor<2xindex>):
+      hipsr.shape_yield %a_shape : tensor<2xindex>
     }
     %cast = hipsr.cast(%domain_ctx)
         ins(%domain_a : tensor<2x2xf16, #hipsr.mem<device>>)
@@ -236,10 +231,10 @@ func.func @constant_between_placeholders(%ctx: !hipsr.context,
         ins(%cast_init, %weight : tensor<2x2xf32, #hipsr.mem<device>>, tensor<2x2xf32, #hipsr.mem<device>>)
         {placeholder_type = #hipsr.placeholder_type<normal>}
         : tensor<2x2xf32, #hipsr.mem<device>> shape_region {
-    ^bb0(%lhs_shape: !shape.shape, %rhs_shape: !shape.shape):
+    ^bb0(%lhs_shape: tensor<2xindex>, %rhs_shape: tensor<2xindex>):
       %add_shape = shape.broadcast %lhs_shape, %rhs_shape
-          : !shape.shape, !shape.shape -> !shape.shape
-      hipsr.shape_yield %add_shape : !shape.shape
+          : tensor<2xindex>, tensor<2xindex> -> tensor<2xindex>
+      hipsr.shape_yield %add_shape : tensor<2xindex>
     }
     %add = hipsr.add(%domain_ctx)
         ins(%cast, %weight : tensor<2x2xf32, #hipsr.mem<device>>, tensor<2x2xf32, #hipsr.mem<device>>)

--- a/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/compute.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/compute.mlir
@@ -25,6 +25,15 @@
 // cast is destination-passing, so a bufferized cast keeps no result and every
 // use of its tensor result reads the buffer of its init instead.
 //
+// The shape regions hold extent tensors, so bufferization descends into them:
+//
+//   - each tensor.from_elements becomes a host memref.alloc, one store per
+//     extent;
+//   - the region yields that buffer, and preserve_shape reads it back with
+//     bufferization.to_tensor;
+//   - only the data operands become bare memrefs, because preserve_shape names
+//     its shape instead of reading through it.
+//
 // compute takes %cast2 as both ins and outs, so the two entry block arguments
 // name one buffer and collapsing the ins argument still holds the result in the
 // destination. The body only builds that collapse view, so the result lands in
@@ -47,18 +56,31 @@
 // CHECK-NEXT: %[[M:.+]] = memref.dim %[[IN]], %[[C0]] : memref<?x256xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[N:.+]] = memref.dim %[[IN]], %[[C1]] : memref<?x256xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[FLAT_SIZE:.+]] = arith.muli %[[M]], %[[N]] : index
-// CHECK-NEXT: %[[SHAPE1:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT: %[[S1:.+]] = shape.from_extents %[[M]], %[[N]] : index, index
-// CHECK-NEXT: scf.yield %[[S1]] : !shape.shape
+// CHECK-NEXT: %[[SHAPE1_BUF:.+]] = scf.execute_region -> memref<2xindex> {
+// CHECK-NEXT: %[[E1:.+]] = memref.alloc(){{.*}} : memref<2xindex>
+// CHECK-NEXT: %[[E1_C0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[E1_C1:.+]] = arith.constant 1 : index
+// CHECK-NEXT: memref.store %[[M]], %[[E1]]{{\[}}%[[E1_C0]]] : memref<2xindex>
+// CHECK-NEXT: memref.store %[[N]], %[[E1]]{{\[}}%[[E1_C1]]] : memref<2xindex>
+// CHECK-NEXT: scf.yield %[[E1]] : memref<2xindex>
 // CHECK-NEXT: }
-// CHECK-NEXT: %[[SHAPE2:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT: %[[S2:.+]] = shape.from_extents %[[M]], %[[N]] : index, index
-// CHECK-NEXT: scf.yield %[[S2]] : !shape.shape
+// CHECK-NEXT: %[[SHAPE1:.+]] = bufferization.to_tensor %[[SHAPE1_BUF]] : memref<2xindex> to tensor<2xindex>
+// CHECK-NEXT: %[[SHAPE2_BUF:.+]] = scf.execute_region -> memref<2xindex> {
+// CHECK-NEXT: %[[E2:.+]] = memref.alloc(){{.*}} : memref<2xindex>
+// CHECK-NEXT: %[[E2_C0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[E2_C1:.+]] = arith.constant 1 : index
+// CHECK-NEXT: memref.store %[[M]], %[[E2]]{{\[}}%[[E2_C0]]] : memref<2xindex>
+// CHECK-NEXT: memref.store %[[N]], %[[E2]]{{\[}}%[[E2_C1]]] : memref<2xindex>
+// CHECK-NEXT: scf.yield %[[E2]] : memref<2xindex>
 // CHECK-NEXT: }
-// CHECK-NEXT: %[[SHAPE3:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT: %[[S3:.+]] = shape.from_extents %[[FLAT_SIZE]] : index
-// CHECK-NEXT: scf.yield %[[S3]] : !shape.shape
+// CHECK-NEXT: %[[SHAPE2:.+]] = bufferization.to_tensor %[[SHAPE2_BUF]] : memref<2xindex> to tensor<2xindex>
+// CHECK-NEXT: %[[SHAPE3_BUF:.+]] = scf.execute_region -> memref<1xindex> {
+// CHECK-NEXT: %[[E3:.+]] = memref.alloc(){{.*}} : memref<1xindex>
+// CHECK-NEXT: %[[E3_C0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: memref.store %[[FLAT_SIZE]], %[[E3]]{{\[}}%[[E3_C0]]] : memref<1xindex>
+// CHECK-NEXT: scf.yield %[[E3]] : memref<1xindex>
 // CHECK-NEXT: }
+// CHECK-NEXT: %[[SHAPE3:.+]] = bufferization.to_tensor %[[SHAPE3_BUF]] : memref<1xindex> to tensor<1xindex>
 // CHECK-NEXT: %[[INIT1:.+]] = memref.alloc(%[[M]]){{.*}} : memref<?x256xf16, #hipsr.mem<device>>
 // CHECK-NEXT: hipsr.cast(%[[DCTX]]) ins(%[[IN]] : memref<?x256xf16, #hipsr.mem<device>>)
 // CHECK-SAME: outs(%[[INIT1]] : memref<?x256xf16, #hipsr.mem<device>>)
@@ -73,9 +95,9 @@
 // CHECK-SAME: : memref<?x256xf16, #hipsr.mem<device>> into memref<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT: hipsr.compute_yield %[[COLLAPSED]] : memref<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT: } : memref<?xf16, #hipsr.mem<device>>{{$}}
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE1]], %[[INIT1]] : memref<?x256xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE2]], %[[INIT2]] : memref<?x256xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE3]], %[[FLAT]] : memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE1]], %[[INIT1]] : tensor<2xindex>, memref<?x256xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE2]], %[[INIT2]] : tensor<2xindex>, memref<?x256xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE3]], %[[FLAT]] : tensor<1xindex>, memref<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT: hipsr.pool_domain_yield %[[FLAT]] : memref<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT: } -> memref<?xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
 // CHECK-NEXT: return %[[OUT]] : memref<?xf16, #hipsr.mem<device>>
@@ -93,17 +115,17 @@ func.func @pool_domain_mlp_flatten(
     %m = tensor.dim %input_arg, %c0 : tensor<?x256xf16, #hipsr.mem<device>>
     %n = tensor.dim %input_arg, %c1 : tensor<?x256xf16, #hipsr.mem<device>>
     %flat_size = arith.muli %m, %n : index
-    %shape1 = scf.execute_region -> !shape.shape {
-      %s = shape.from_extents %m, %n : index, index
-      scf.yield %s : !shape.shape
+    %shape1 = scf.execute_region -> tensor<2xindex> {
+      %s = tensor.from_elements %m, %n : tensor<2xindex>
+      scf.yield %s : tensor<2xindex>
     }
-    %shape2 = scf.execute_region -> !shape.shape {
-      %s = shape.from_extents %m, %n : index, index
-      scf.yield %s : !shape.shape
+    %shape2 = scf.execute_region -> tensor<2xindex> {
+      %s = tensor.from_elements %m, %n : tensor<2xindex>
+      scf.yield %s : tensor<2xindex>
     }
-    %shape3 = scf.execute_region -> !shape.shape {
-      %s = shape.from_extents %flat_size : index
-      scf.yield %s : !shape.shape
+    %shape3 = scf.execute_region -> tensor<1xindex> {
+      %s = tensor.from_elements %flat_size : tensor<1xindex>
+      scf.yield %s : tensor<1xindex>
     }
     %init1 = tensor.empty(%m) : tensor<?x256xf16, #hipsr.mem<device>>
     %init2 = tensor.empty(%m) : tensor<?x256xf16, #hipsr.mem<device>>
@@ -126,9 +148,9 @@ func.func @pool_domain_mlp_flatten(
           into tensor<?xf16, #hipsr.mem<device>>
       hipsr.compute_yield %collapsed : tensor<?xf16, #hipsr.mem<device>>
     } : tensor<?xf16, #hipsr.mem<device>>
-    hipsr.preserve_shape %shape1, %cast1 : tensor<?x256xf16, #hipsr.mem<device>>
-    hipsr.preserve_shape %shape2, %cast2 : tensor<?x256xf16, #hipsr.mem<device>>
-    hipsr.preserve_shape %shape3, %flat : tensor<?xf16, #hipsr.mem<device>>
+    hipsr.preserve_shape %shape1, %cast1 : tensor<2xindex>, tensor<?x256xf16, #hipsr.mem<device>>
+    hipsr.preserve_shape %shape2, %cast2 : tensor<2xindex>, tensor<?x256xf16, #hipsr.mem<device>>
+    hipsr.preserve_shape %shape3, %flat : tensor<1xindex>, tensor<?xf16, #hipsr.mem<device>>
     hipsr.pool_domain_yield %flat : tensor<?xf16, #hipsr.mem<device>>
   } -> tensor<?xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
   return %out : tensor<?xf16, #hipsr.mem<device>>

--- a/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/preserve_shape.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/preserve_shape.mlir
@@ -7,21 +7,33 @@
 
 // NOCOPY-NOT: memref.copy
 
+// The shape operand is an extent tensor, so bufferization descends into the
+// shape computation too:
+//
+//   - tensor.from_elements becomes a host memref.alloc, one store per extent;
+//   - preserve_shape reads that buffer back with bufferization.to_tensor;
+//   - only the data operand becomes a bare memref, because preserve_shape
+//     names its shape instead of reading through it.
 
 // CHECK-LABEL: func.func @dps_init(
 // CHECK-SAME: %[[CTX:.+]]: !hipsr.context, %[[D0:.+]]: index,
 // CHECK-SAME: -> memref<?x2048xf32, #hipsr.mem<device>> {
 // CHECK-NEXT: %[[C2048:.+]] = arith.constant 2048 : index
-// CHECK-NEXT: %[[SHAPE:.+]] = shape.from_extents %[[D0]], %[[C2048]] : index, index
+// CHECK-NEXT: %[[EXTENTS:.+]] = memref.alloc() {{.*}}: memref<2xindex>
+// CHECK-NEXT: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-NEXT: memref.store %[[D0]], %[[EXTENTS]]{{\[}}%[[C0]]] : memref<2xindex>
+// CHECK-NEXT: memref.store %[[C2048]], %[[EXTENTS]]{{\[}}%[[C1]]] : memref<2xindex>
+// CHECK-NEXT: %[[SHAPE:.+]] = bufferization.to_tensor %[[EXTENTS]] : memref<2xindex> to tensor<2xindex>
 // CHECK-NEXT: %[[ALLOC:.+]] = memref.alloc(%[[D0]]) {{.*}}: memref<?x2048xf32, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[ALLOC]] : memref<?x2048xf32, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[ALLOC]] : tensor<2xindex>, memref<?x2048xf32, #hipsr.mem<device>>
 // CHECK-NEXT: hipsr.cast(%[[CTX]]) ins({{.+}}) outs(%[[ALLOC]] : memref<?x2048xf32, #hipsr.mem<device>>)
 func.func @dps_init(%ctx: !hipsr.context, %d0: index,
                     %in: tensor<?x2048xf16, #hipsr.mem<device>>) -> tensor<?x2048xf32, #hipsr.mem<device>> {
   %c2048 = arith.constant 2048 : index
-  %shape = shape.from_extents %d0, %c2048 : index, index
+  %shape = tensor.from_elements %d0, %c2048 : tensor<2xindex>
   %init = tensor.empty(%d0) : tensor<?x2048xf32, #hipsr.mem<device>>
-  hipsr.preserve_shape %shape, %init : tensor<?x2048xf32, #hipsr.mem<device>>
+  hipsr.preserve_shape %shape, %init : tensor<2xindex>, tensor<?x2048xf32, #hipsr.mem<device>>
   %out = hipsr.cast(%ctx) ins(%in : tensor<?x2048xf16, #hipsr.mem<device>>)
                           outs(%init : tensor<?x2048xf32, #hipsr.mem<device>>) : tensor<?x2048xf32, #hipsr.mem<device>>
   return %out : tensor<?x2048xf32, #hipsr.mem<device>>
@@ -33,18 +45,23 @@ func.func @dps_init(%ctx: !hipsr.context, %d0: index,
 // CHECK-SAME: %[[CTX:.+]]: !hipsr.context, %[[D0:.+]]: index,
 // CHECK-SAME: -> memref<?x2048xf32, #hipsr.mem<device>> {
 // CHECK-NEXT: %[[C2048:.+]] = arith.constant 2048 : index
-// CHECK-NEXT: %[[SHAPE:.+]] = shape.from_extents %[[D0]], %[[C2048]] : index, index
+// CHECK-NEXT: %[[EXTENTS:.+]] = memref.alloc() {{.*}}: memref<2xindex>
+// CHECK-NEXT: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-NEXT: memref.store %[[D0]], %[[EXTENTS]]{{\[}}%[[C0]]] : memref<2xindex>
+// CHECK-NEXT: memref.store %[[C2048]], %[[EXTENTS]]{{\[}}%[[C1]]] : memref<2xindex>
+// CHECK-NEXT: %[[SHAPE:.+]] = bufferization.to_tensor %[[EXTENTS]] : memref<2xindex> to tensor<2xindex>
 // CHECK-NEXT: %[[ALLOC:.+]] = memref.alloc(%[[D0]]) {{.*}}: memref<?x2048xf32, #hipsr.mem<device>>
 // CHECK-NEXT: hipsr.cast(%[[CTX]]) ins({{.+}}) outs(%[[ALLOC]] : memref<?x2048xf32, #hipsr.mem<device>>)
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[ALLOC]] : memref<?x2048xf32, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[ALLOC]] : tensor<2xindex>, memref<?x2048xf32, #hipsr.mem<device>>
 func.func @dps_result(%ctx: !hipsr.context, %d0: index,
                       %in: tensor<?x2048xf16, #hipsr.mem<device>>) -> tensor<?x2048xf32, #hipsr.mem<device>> {
   %c2048 = arith.constant 2048 : index
-  %shape = shape.from_extents %d0, %c2048 : index, index
+  %shape = tensor.from_elements %d0, %c2048 : tensor<2xindex>
   %init = tensor.empty(%d0) : tensor<?x2048xf32, #hipsr.mem<device>>
   %out = hipsr.cast(%ctx) ins(%in : tensor<?x2048xf16, #hipsr.mem<device>>)
                           outs(%init : tensor<?x2048xf32, #hipsr.mem<device>>) : tensor<?x2048xf32, #hipsr.mem<device>>
-  hipsr.preserve_shape %shape, %out : tensor<?x2048xf32, #hipsr.mem<device>>
+  hipsr.preserve_shape %shape, %out : tensor<2xindex>, tensor<?x2048xf32, #hipsr.mem<device>>
   return %out : tensor<?x2048xf32, #hipsr.mem<device>>
 }
 
@@ -55,30 +72,36 @@ func.func @dps_result(%ctx: !hipsr.context, %d0: index,
 // CHECK-SAME: %[[D0:.+]]: index,
 // CHECK-SAME: %[[DATA:.+]]: memref<?x2048xf32, strided<[?, ?], offset: ?>, #hipsr.mem<device>>) {
 // CHECK-NEXT: %[[C2048:.+]] = arith.constant 2048 : index
-// CHECK-NEXT: %[[SHAPE:.+]] = shape.from_extents %[[D0]], %[[C2048]] : index, index
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[DATA]] : memref<?x2048xf32, strided<[?, ?], offset: ?>, #hipsr.mem<device>>
+// CHECK-NEXT: %[[EXTENTS:.+]] = memref.alloc() {{.*}}: memref<2xindex>
+// CHECK-NEXT: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-NEXT: memref.store %[[D0]], %[[EXTENTS]]{{\[}}%[[C0]]] : memref<2xindex>
+// CHECK-NEXT: memref.store %[[C2048]], %[[EXTENTS]]{{\[}}%[[C1]]] : memref<2xindex>
+// CHECK-NEXT: %[[SHAPE:.+]] = bufferization.to_tensor %[[EXTENTS]] : memref<2xindex> to tensor<2xindex>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[DATA]] : tensor<2xindex>, memref<?x2048xf32, strided<[?, ?], offset: ?>, #hipsr.mem<device>>
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 func.func @func_arg(%d0: index, %data: tensor<?x2048xf32, #hipsr.mem<device>>) {
   %c2048 = arith.constant 2048 : index
-  %shape = shape.from_extents %d0, %c2048 : index, index
-  hipsr.preserve_shape %shape, %data : tensor<?x2048xf32, #hipsr.mem<device>>
+  %shape = tensor.from_elements %d0, %c2048 : tensor<2xindex>
+  hipsr.preserve_shape %shape, %data : tensor<2xindex>, tensor<?x2048xf32, #hipsr.mem<device>>
   return
 }
 
 // -----
 
-// An opaque shape is not a tensor either, so bufferization carries it over
-// untouched just like the from_extents form. This is the shape the intended
-// producer builds, out of an scf.execute_region.
+// This function builds no extent list, so there is nothing to materialize.
+// Bufferization only turns the argument into a memref and reads it back, giving
+// preserve_shape the same to_tensor shape operand as above.
 // CHECK-LABEL: func.func @opaque_shape(
-// CHECK-SAME: %[[D0:.+]]: index, %[[SHAPE:.+]]: !shape.shape) {
+// CHECK-SAME: %[[D0:.+]]: index, %[[SHAPE_BUF:.+]]: memref<?xindex, strided<[?], offset: ?>>) {
+// CHECK-NEXT: %[[SHAPE:.+]] = bufferization.to_tensor %[[SHAPE_BUF]] : memref<?xindex, strided<[?], offset: ?>> to tensor<?xindex>
 // CHECK-NEXT: %[[ALLOC:.+]] = memref.alloc(%[[D0]]) {{.*}}: memref<?x2048xf32, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[ALLOC]] : memref<?x2048xf32, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[ALLOC]] : tensor<?xindex>, memref<?x2048xf32, #hipsr.mem<device>>
 // CHECK-NEXT: return
 // CHECK-NEXT: }
-func.func @opaque_shape(%d0: index, %shape: !shape.shape) {
+func.func @opaque_shape(%d0: index, %shape: tensor<?xindex>) {
   %init = tensor.empty(%d0) : tensor<?x2048xf32, #hipsr.mem<device>>
-  hipsr.preserve_shape %shape, %init : tensor<?x2048xf32, #hipsr.mem<device>>
+  hipsr.preserve_shape %shape, %init : tensor<?xindex>, tensor<?x2048xf32, #hipsr.mem<device>>
   return
 }

--- a/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/add.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/add.mlir
@@ -9,9 +9,9 @@
 // CHECK-SAME: %[[LHS:.+]]: tensor<?x1024xf16, #hipsr.mem<device>>,
 // CHECK-SAME: %[[RHS:.+]]: tensor<1024xf16, #hipsr.mem<device>>) {
 // CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[LHS]], %[[RHS]] : tensor<?x1024xf16, #hipsr.mem<device>>, tensor<1024xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x1024xf16, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT: ^bb0(%[[LHS_SHAPE:.+]]: !shape.shape, %[[RHS_SHAPE:.+]]: !shape.shape):
-// CHECK-NEXT: %[[BROADCAST:.+]] = shape.broadcast %[[LHS_SHAPE]], %[[RHS_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT: hipsr.shape_yield %[[BROADCAST]] : !shape.shape
+// CHECK-NEXT: ^bb0(%[[LHS_SHAPE:.+]]: tensor<2xindex>, %[[RHS_SHAPE:.+]]: tensor<1xindex>):
+// CHECK-NEXT: %[[BROADCAST:.+]] = shape.broadcast %[[LHS_SHAPE]], %[[RHS_SHAPE]] : tensor<2xindex>, tensor<1xindex> -> tensor<2xindex>
+// CHECK-NEXT: hipsr.shape_yield %[[BROADCAST]] : tensor<2xindex>
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[RESULT:.+]] = hipsr.add(%[[CTX]]) ins(%[[LHS]], %[[RHS]] : tensor<?x1024xf16, #hipsr.mem<device>>, tensor<1024xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x1024xf16, #hipsr.mem<device>>) : tensor<?x1024xf16, #hipsr.mem<device>>
 // CHECK-NEXT: return

--- a/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/cast.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/cast.mlir
@@ -7,8 +7,8 @@
 // CHECK-LABEL: func.func @cast_normal(
 // CHECK-SAME: %[[CTX:.+]]: !hipsr.context, %[[INPUT:.+]]: tensor<?x8xf32, #hipsr.mem<device>>) {
 // CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x8xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT: ^bb0(%[[INPUT_SHAPE:.+]]: !shape.shape):
-// CHECK-NEXT: hipsr.shape_yield %[[INPUT_SHAPE]] : !shape.shape
+// CHECK-NEXT: ^bb0(%[[INPUT_SHAPE:.+]]: tensor<2xindex>):
+// CHECK-NEXT: hipsr.shape_yield %[[INPUT_SHAPE]] : tensor<2xindex>
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[RESULT:.+]] = hipsr.cast(%[[CTX]]) ins(%[[INPUT]] : tensor<?x8xf32, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x8xf16, #hipsr.mem<device>>) : tensor<?x8xf16, #hipsr.mem<device>>
 // CHECK-NEXT: return

--- a/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/equal.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/equal.mlir
@@ -10,9 +10,9 @@
 // CHECK-SAME: %[[LHS:.+]]: tensor<?x1024xi64, #hipsr.mem<device>>,
 // CHECK-SAME: %[[RHS:.+]]: tensor<1024xi64, #hipsr.mem<device>>) {
 // CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[LHS]], %[[RHS]] : tensor<?x1024xi64, #hipsr.mem<device>>, tensor<1024xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x1024xi1, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT: ^bb0(%[[LHS_SHAPE:.+]]: !shape.shape, %[[RHS_SHAPE:.+]]: !shape.shape):
-// CHECK-NEXT: %[[BROADCAST:.+]] = shape.broadcast %[[LHS_SHAPE]], %[[RHS_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT: hipsr.shape_yield %[[BROADCAST]] : !shape.shape
+// CHECK-NEXT: ^bb0(%[[LHS_SHAPE:.+]]: tensor<2xindex>, %[[RHS_SHAPE:.+]]: tensor<1xindex>):
+// CHECK-NEXT: %[[BROADCAST:.+]] = shape.broadcast %[[LHS_SHAPE]], %[[RHS_SHAPE]] : tensor<2xindex>, tensor<1xindex> -> tensor<2xindex>
+// CHECK-NEXT: hipsr.shape_yield %[[BROADCAST]] : tensor<2xindex>
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[RESULT:.+]] = hipsr.equal(%[[CTX]]) ins(%[[LHS]], %[[RHS]] : tensor<?x1024xi64, #hipsr.mem<device>>, tensor<1024xi64, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x1024xi1, #hipsr.mem<device>>) : tensor<?x1024xi1, #hipsr.mem<device>>
 // CHECK-NEXT: return

--- a/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/expand.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/expand.mlir
@@ -21,13 +21,13 @@
 // CHECK-NEXT: %[[INDEX2:.+]] = arith.constant 2 : index
 // CHECK-NEXT: %[[REQUEST2_I64:.+]] = tensor.extract %[[SHAPE_REQUEST]][%[[INDEX2]]] : tensor<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT: %[[REQUEST2:.+]] = arith.index_cast %[[REQUEST2_I64]] : i64 to index
-// CHECK-NEXT: %[[REQUEST_SHAPE:.+]] = shape.from_extents %[[REQUEST0]], %[[REQUEST1]], %[[REQUEST2]] : index, index, index
-// CHECK-NEXT: %[[WITNESS:.+]] = shape.cstr_broadcastable %[[INPUT_SHAPE]], %[[REQUEST_SHAPE]] : tensor<2xindex>, !shape.shape
-// CHECK-NEXT: %[[RESULT_SHAPE:.+]] = shape.assuming %[[WITNESS]] -> (!shape.shape) {
-// CHECK-NEXT: %[[BROADCAST:.+]] = shape.broadcast %[[INPUT_SHAPE]], %[[REQUEST_SHAPE]] : tensor<2xindex>, !shape.shape -> !shape.shape
-// CHECK-NEXT: shape.assuming_yield %[[BROADCAST]] : !shape.shape
+// CHECK-NEXT: %[[REQUEST_EXTENTS:.+]] = tensor.from_elements %[[REQUEST0]], %[[REQUEST1]], %[[REQUEST2]] : tensor<3xindex>
+// CHECK-NEXT: %[[WITNESS:.+]] = shape.cstr_broadcastable %[[INPUT_SHAPE]], %[[REQUEST_EXTENTS]] : tensor<2xindex>, tensor<3xindex>
+// CHECK-NEXT: %[[RESULT_SHAPE:.+]] = shape.assuming %[[WITNESS]] -> (tensor<3xindex>) {
+// CHECK-NEXT: %[[BROADCAST:.+]] = shape.broadcast %[[INPUT_SHAPE]], %[[REQUEST_EXTENTS]] : tensor<2xindex>, tensor<3xindex> -> tensor<3xindex>
+// CHECK-NEXT: shape.assuming_yield %[[BROADCAST]] : tensor<3xindex>
 // CHECK-NEXT: }
-// CHECK-NEXT: hipsr.shape_yield %[[RESULT_SHAPE]] : !shape.shape
+// CHECK-NEXT: hipsr.shape_yield %[[RESULT_SHAPE]] : tensor<3xindex>
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[RESULT:.+]] = hipsr.expand(%[[CTX]]) ins(%[[INPUT]], %[[REQUEST]] : tensor<?x3xf16, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) outs(%[[INIT]] : tensor<?x?x?xf16, #hipsr.mem<device>>) : tensor<?x?x?xf16, #hipsr.mem<device>>
 // CHECK-NEXT: return
@@ -51,15 +51,15 @@ func.func @expand_runtime_shape(
 // CHECK-LABEL: func.func @expand_shape_attr(
 // CHECK-SAME: %[[CTX:.+]]: !hipsr.context, %[[INPUT:.+]]: tensor<?x3xf16, #hipsr.mem<device>>) {
 // CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<?x3xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x3xf16, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT: ^bb0(%[[INPUT_SHAPE:.+]]: !shape.shape):
+// CHECK-NEXT: ^bb0(%[[INPUT_SHAPE:.+]]: tensor<2xindex>):
 // CHECK-NEXT: %[[REQUEST0:.+]] = arith.constant 3 : index
-// CHECK-NEXT: %[[REQUEST_SHAPE:.+]] = shape.from_extents %[[REQUEST0]] : index
-// CHECK-NEXT: %[[WITNESS:.+]] = shape.cstr_broadcastable %[[INPUT_SHAPE]], %[[REQUEST_SHAPE]] : !shape.shape, !shape.shape
-// CHECK-NEXT: %[[RESULT_SHAPE:.+]] = shape.assuming %[[WITNESS]] -> (!shape.shape) {
-// CHECK-NEXT: %[[BROADCAST:.+]] = shape.broadcast %[[INPUT_SHAPE]], %[[REQUEST_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT: shape.assuming_yield %[[BROADCAST]] : !shape.shape
+// CHECK-NEXT: %[[REQUEST_EXTENTS:.+]] = tensor.from_elements %[[REQUEST0]] : tensor<1xindex>
+// CHECK-NEXT: %[[WITNESS:.+]] = shape.cstr_broadcastable %[[INPUT_SHAPE]], %[[REQUEST_EXTENTS]] : tensor<2xindex>, tensor<1xindex>
+// CHECK-NEXT: %[[RESULT_SHAPE:.+]] = shape.assuming %[[WITNESS]] -> (tensor<2xindex>) {
+// CHECK-NEXT: %[[BROADCAST:.+]] = shape.broadcast %[[INPUT_SHAPE]], %[[REQUEST_EXTENTS]] : tensor<2xindex>, tensor<1xindex> -> tensor<2xindex>
+// CHECK-NEXT: shape.assuming_yield %[[BROADCAST]] : tensor<2xindex>
 // CHECK-NEXT: }
-// CHECK-NEXT: hipsr.shape_yield %[[RESULT_SHAPE]] : !shape.shape
+// CHECK-NEXT: hipsr.shape_yield %[[RESULT_SHAPE]] : tensor<2xindex>
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[RESULT:.+]] = hipsr.expand(%[[CTX]]) ins(%[[INPUT]] : tensor<?x3xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x3xf16, #hipsr.mem<device>>) {shape_attr = array<i64: 3>} : tensor<?x3xf16, #hipsr.mem<device>>
 // CHECK-NEXT: return

--- a/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/gather.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/gather.mlir
@@ -3,22 +3,28 @@
 
 // RUN: hip-mlir-opt %s -hipsr-populate-shape-region | FileCheck %s
 
-// The region splits the data shape around the gathered axis and puts the whole
-// indices shape between the pieces. Nothing here depends on a rank, and a
-// dynamic dimension stays symbolic.
+// The region reads one extent per output dimension, in this order:
+//
+//   - the data dimensions before the gathered axis;
+//   - every indices dimension;
+//   - the data dimensions after the axis.
+//
+// Both ranks are known, so the loop that assembles the extents runs at compile
+// time and a dynamic dimension stays symbolic.
 // CHECK-LABEL: func.func @gather_embedding(
 // CHECK-SAME: %[[CTX:.+]]: !hipsr.context,
 // CHECK-SAME: %[[TABLE:.+]]: tensor<8x4096xf16, #hipsr.mem<device>>,
 // CHECK-SAME: %[[IDS:.+]]: tensor<?x?xi64, #hipsr.mem<device>>) {
 // CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[TABLE]], %[[IDS]] : tensor<8x4096xf16, #hipsr.mem<device>>, tensor<?x?xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x?x4096xf16, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT: ^bb0(%[[TABLE_SHAPE:.+]]: !shape.shape, %[[IDS_SHAPE:.+]]: !shape.shape):
-// CHECK-NEXT: %[[AXIS:.+]] = shape.const_size 0
-// CHECK-NEXT: %[[LEADING:.+]], %{{.+}} = "shape.split_at"(%[[TABLE_SHAPE]], %[[AXIS]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT: %[[PAST_AXIS:.+]] = shape.const_size 1
-// CHECK-NEXT: %{{.+}}, %[[TRAILING:.+]] = "shape.split_at"(%[[TABLE_SHAPE]], %[[PAST_AXIS]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT: %[[GATHERED:.+]] = shape.concat %[[LEADING]], %[[IDS_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT: %[[SHAPE:.+]] = shape.concat %[[GATHERED]], %[[TRAILING]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT: hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT: ^bb0(%[[TABLE_SHAPE:.+]]: tensor<2xindex>, %[[IDS_SHAPE:.+]]: tensor<2xindex>):
+// CHECK-NEXT: %[[IDS_D0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[IDS_E0:.+]] = shape.get_extent %[[IDS_SHAPE]], %[[IDS_D0]] : tensor<2xindex>, index -> index
+// CHECK-NEXT: %[[IDS_D1:.+]] = arith.constant 1 : index
+// CHECK-NEXT: %[[IDS_E1:.+]] = shape.get_extent %[[IDS_SHAPE]], %[[IDS_D1]] : tensor<2xindex>, index -> index
+// CHECK-NEXT: %[[TABLE_D1:.+]] = arith.constant 1 : index
+// CHECK-NEXT: %[[TABLE_E1:.+]] = shape.get_extent %[[TABLE_SHAPE]], %[[TABLE_D1]] : tensor<2xindex>, index -> index
+// CHECK-NEXT: %[[SHAPE:.+]] = tensor.from_elements %[[IDS_E0]], %[[IDS_E1]], %[[TABLE_E1]] : tensor<3xindex>
+// CHECK-NEXT: hipsr.shape_yield %[[SHAPE]] : tensor<3xindex>
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[RESULT:.+]] = hipsr.gather(%[[CTX]]) ins(%[[TABLE]], %[[IDS]] : tensor<8x4096xf16, #hipsr.mem<device>>, tensor<?x?xi64, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {axis = 0 : i64} : tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT: return
@@ -36,5 +42,41 @@ func.func @gather_embedding(%ctx: !hipsr.context,
                          tensor<?x?xi64, #hipsr.mem<device>>)
       outs(%init : tensor<?x?x4096xf16, #hipsr.mem<device>>) {axis = 0 : i64}
       : tensor<?x?x4096xf16, #hipsr.mem<device>>
+  return
+}
+
+// Gathering along an inner axis is the only case with data dimensions on both
+// sides of the indices, so it is what pins the order down.
+// CHECK-LABEL: func.func @gather_middle_axis(
+// CHECK-SAME: %[[CTX:.+]]: !hipsr.context,
+// CHECK-SAME: %[[DATA:.+]]: tensor<8x4x4096xf16, #hipsr.mem<device>>,
+// CHECK-SAME: %[[IDS:.+]]: tensor<?xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[DATA]], %[[IDS]] : tensor<8x4x4096xf16, #hipsr.mem<device>>, tensor<?xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<8x?x4096xf16, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT: ^bb0(%[[DATA_SHAPE:.+]]: tensor<3xindex>, %[[IDS_SHAPE:.+]]: tensor<1xindex>):
+// CHECK-NEXT: %[[DATA_D0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[DATA_E0:.+]] = shape.get_extent %[[DATA_SHAPE]], %[[DATA_D0]] : tensor<3xindex>, index -> index
+// CHECK-NEXT: %[[IDS_D0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[IDS_E0:.+]] = shape.get_extent %[[IDS_SHAPE]], %[[IDS_D0]] : tensor<1xindex>, index -> index
+// CHECK-NEXT: %[[DATA_D2:.+]] = arith.constant 2 : index
+// CHECK-NEXT: %[[DATA_E2:.+]] = shape.get_extent %[[DATA_SHAPE]], %[[DATA_D2]] : tensor<3xindex>, index -> index
+// CHECK-NEXT: %[[SHAPE:.+]] = tensor.from_elements %[[DATA_E0]], %[[IDS_E0]], %[[DATA_E2]] : tensor<3xindex>
+// CHECK-NEXT: hipsr.shape_yield %[[SHAPE]] : tensor<3xindex>
+// CHECK-NEXT: }
+// CHECK-NEXT: %[[RESULT:.+]] = hipsr.gather(%[[CTX]]) ins(%[[DATA]], %[[IDS]] : tensor<8x4x4096xf16, #hipsr.mem<device>>, tensor<?xi64, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<8x?x4096xf16, #hipsr.mem<device>>) {axis = 1 : i64} : tensor<8x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT: return
+// CHECK-NEXT: }
+func.func @gather_middle_axis(%ctx: !hipsr.context,
+                              %data: tensor<8x4x4096xf16, #hipsr.mem<device>>,
+                              %ids: tensor<?xi64, #hipsr.mem<device>>) {
+  %init = hipsr.placeholder(%ctx)
+      ins(%data, %ids : tensor<8x4x4096xf16, #hipsr.mem<device>>,
+                        tensor<?xi64, #hipsr.mem<device>>)
+      {placeholder_type = #hipsr.placeholder_type<normal>}
+      : tensor<8x?x4096xf16, #hipsr.mem<device>>
+  %result = hipsr.gather(%ctx)
+      ins(%data, %ids : tensor<8x4x4096xf16, #hipsr.mem<device>>,
+                        tensor<?xi64, #hipsr.mem<device>>)
+      outs(%init : tensor<8x?x4096xf16, #hipsr.mem<device>>) {axis = 1 : i64}
+      : tensor<8x?x4096xf16, #hipsr.mem<device>>
   return
 }

--- a/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/matmul.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/matmul.mlir
@@ -3,36 +3,28 @@
 
 // RUN: hip-mlir-opt %s --split-input-file -hipsr-populate-shape-region | FileCheck %s
 
-// A 2-D MatMul checks K equality, broadcasts empty batch shapes, and appends
-// M from A and N from B.
+// A 2-D MatMul only has to check that K agrees. Neither operand has batch
+// dimensions, so nothing is broadcast. The result is M from A and N from B.
 // CHECK-LABEL: func.func @matmul_2d(
 // CHECK-SAME: %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<?x?xf16, #hipsr.mem<device>>, %[[B:.+]]: tensor<?x?xf16, #hipsr.mem<device>>) {
 // CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x?xf16, #hipsr.mem<device>>, tensor<?x?xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x?xf16, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT: ^bb0(%[[A_SHAPE:.+]]: !shape.shape, %[[B_SHAPE:.+]]: !shape.shape):
-// CHECK-NEXT: %[[A_K_INDEX:.+]] = shape.const_size 1
-// CHECK-NEXT: %[[A_K:.+]] = shape.get_extent %[[A_SHAPE]], %[[A_K_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT: %[[A_K_SHAPE:.+]] = shape.from_extents %[[A_K]] : !shape.size
-// CHECK-NEXT: %[[B_K_INDEX:.+]] = shape.const_size 0
-// CHECK-NEXT: %[[B_K:.+]] = shape.get_extent %[[B_SHAPE]], %[[B_K_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT: %[[B_K_SHAPE:.+]] = shape.from_extents %[[B_K]] : !shape.size
-// CHECK-NEXT: %[[K_WITNESS:.+]] = shape.cstr_eq %[[A_K_SHAPE]], %[[B_K_SHAPE]] : !shape.shape, !shape.shape
-// CHECK-NEXT: %[[A_BATCH_INDEX:.+]] = shape.const_size 0
-// CHECK-NEXT: %[[A_BATCH:.+]], %[[A_SUFFIX:.+]] = "shape.split_at"(%[[A_SHAPE]], %[[A_BATCH_INDEX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT: %[[B_BATCH_INDEX:.+]] = shape.const_size 0
-// CHECK-NEXT: %[[B_BATCH:.+]], %[[B_SUFFIX:.+]] = "shape.split_at"(%[[B_SHAPE]], %[[B_BATCH_INDEX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT: %[[BATCH_WITNESS:.+]] = shape.cstr_broadcastable %[[A_BATCH]], %[[B_BATCH]] : !shape.shape, !shape.shape
-// CHECK-NEXT: %[[WITNESS:.+]] = shape.assuming_all %[[K_WITNESS]], %[[BATCH_WITNESS]]
-// CHECK-NEXT: %[[RESULT_SHAPE:.+]] = shape.assuming %[[WITNESS]] -> (!shape.shape) {
-// CHECK-NEXT: %[[BATCH_SHAPE:.+]] = shape.broadcast %[[A_BATCH]], %[[B_BATCH]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT: %[[M_INDEX:.+]] = shape.const_size 0
-// CHECK-NEXT: %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[M_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT: %[[N_INDEX:.+]] = shape.const_size 1
-// CHECK-NEXT: %[[N:.+]] = shape.get_extent %[[B_SHAPE]], %[[N_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT: %[[MATRIX_SHAPE:.+]] = shape.from_extents %[[M]], %[[N]] : !shape.size, !shape.size
-// CHECK-NEXT: %[[OUTPUT_SHAPE:.+]] = shape.concat %[[BATCH_SHAPE]], %[[MATRIX_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT: shape.assuming_yield %[[OUTPUT_SHAPE]] : !shape.shape
+// CHECK-NEXT: ^bb0(%[[A_SHAPE:.+]]: tensor<2xindex>, %[[B_SHAPE:.+]]: tensor<2xindex>):
+// CHECK-NEXT: %[[A_K_INDEX:.+]] = arith.constant 1 : index
+// CHECK-NEXT: %[[A_K:.+]] = shape.get_extent %[[A_SHAPE]], %[[A_K_INDEX]] : tensor<2xindex>, index -> index
+// CHECK-NEXT: %[[A_K_EXTENTS:.+]] = tensor.from_elements %[[A_K]] : tensor<1xindex>
+// CHECK-NEXT: %[[B_K_INDEX:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[B_K:.+]] = shape.get_extent %[[B_SHAPE]], %[[B_K_INDEX]] : tensor<2xindex>, index -> index
+// CHECK-NEXT: %[[B_K_EXTENTS:.+]] = tensor.from_elements %[[B_K]] : tensor<1xindex>
+// CHECK-NEXT: %[[K_WITNESS:.+]] = shape.cstr_eq %[[A_K_EXTENTS]], %[[B_K_EXTENTS]] : tensor<1xindex>, tensor<1xindex>
+// CHECK-NEXT: %[[RESULT_SHAPE:.+]] = shape.assuming %[[K_WITNESS]] -> (tensor<2xindex>) {
+// CHECK-NEXT: %[[M_INDEX:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[M_INDEX]] : tensor<2xindex>, index -> index
+// CHECK-NEXT: %[[N_INDEX:.+]] = arith.constant 1 : index
+// CHECK-NEXT: %[[N:.+]] = shape.get_extent %[[B_SHAPE]], %[[N_INDEX]] : tensor<2xindex>, index -> index
+// CHECK-NEXT: %[[OUTPUT_SHAPE:.+]] = tensor.from_elements %[[M]], %[[N]] : tensor<2xindex>
+// CHECK-NEXT: shape.assuming_yield %[[OUTPUT_SHAPE]] : tensor<2xindex>
 // CHECK-NEXT: }
-// CHECK-NEXT: hipsr.shape_yield %[[RESULT_SHAPE]] : !shape.shape
+// CHECK-NEXT: hipsr.shape_yield %[[RESULT_SHAPE]] : tensor<2xindex>
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[RESULT:.+]] = hipsr.matmul(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x?xf16, #hipsr.mem<device>>, tensor<?x?xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x?xf16, #hipsr.mem<device>>) : tensor<?x?xf16, #hipsr.mem<device>>
 // CHECK-NEXT: return
@@ -50,28 +42,29 @@ func.func @matmul_2d(%ctx: !hipsr.context, %a: tensor<?x?xf16, #hipsr.mem<device
 
 // -----
 
-// A vector A contributes no M dimension, leaving only N after empty-batch
-// broadcasting.
+// A vector A contributes no M dimension, so the assuming region reads only N.
 // CHECK-LABEL: func.func @matmul_vector_matrix(
-// CHECK: %[[INIT:.+]] = hipsr.placeholder
-// CHECK-NEXT: ^bb0(%[[A_SHAPE:.+]]: !shape.shape, %[[B_SHAPE:.+]]: !shape.shape):
-// CHECK: %[[K_WITNESS:.+]] = shape.cstr_eq
-// CHECK: %[[BATCH_WITNESS:.+]] = shape.cstr_broadcastable %[[A_BATCH:.+]], %[[B_BATCH:.+]] : !shape.shape, !shape.shape
-// CHECK-NEXT: %[[WITNESS:.+]] = shape.assuming_all %[[K_WITNESS]], %[[BATCH_WITNESS]]
-// CHECK-NEXT: %[[RESULT_SHAPE:.+]] = shape.assuming %[[WITNESS]] -> (!shape.shape) {
-// CHECK-NEXT: %[[BROADCAST:.+]] = shape.broadcast %[[A_BATCH]], %[[B_BATCH]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NOT: shape.get_extent %[[A_SHAPE]]
-// CHECK-NEXT: %[[N_INDEX:.+]] = shape.const_size 1
-// CHECK-NEXT: %[[N:.+]] = shape.get_extent %[[B_SHAPE]], %[[N_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT: %[[MATRIX_SHAPE:.+]] = shape.from_extents %[[N]] : !shape.size
-// CHECK-NEXT: %[[OUTPUT_SHAPE:.+]] = shape.concat %[[BROADCAST]], %[[MATRIX_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT: shape.assuming_yield %[[OUTPUT_SHAPE]] : !shape.shape
+// CHECK-SAME: %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<?xf16, #hipsr.mem<device>>, %[[B:.+]]: tensor<?x?xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?xf16, #hipsr.mem<device>>, tensor<?x?xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?xf16, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT: ^bb0(%[[A_SHAPE:.+]]: tensor<1xindex>, %[[B_SHAPE:.+]]: tensor<2xindex>):
+// CHECK-NEXT: %[[A_K_INDEX:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[A_K:.+]] = shape.get_extent %[[A_SHAPE]], %[[A_K_INDEX]] : tensor<1xindex>, index -> index
+// CHECK-NEXT: %[[A_K_EXTENTS:.+]] = tensor.from_elements %[[A_K]] : tensor<1xindex>
+// CHECK-NEXT: %[[B_K_INDEX:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[B_K:.+]] = shape.get_extent %[[B_SHAPE]], %[[B_K_INDEX]] : tensor<2xindex>, index -> index
+// CHECK-NEXT: %[[B_K_EXTENTS:.+]] = tensor.from_elements %[[B_K]] : tensor<1xindex>
+// CHECK-NEXT: %[[K_WITNESS:.+]] = shape.cstr_eq %[[A_K_EXTENTS]], %[[B_K_EXTENTS]] : tensor<1xindex>, tensor<1xindex>
+// CHECK-NEXT: %[[RESULT_SHAPE:.+]] = shape.assuming %[[K_WITNESS]] -> (tensor<1xindex>) {
+// CHECK-NEXT: %[[N_INDEX:.+]] = arith.constant 1 : index
+// CHECK-NEXT: %[[N:.+]] = shape.get_extent %[[B_SHAPE]], %[[N_INDEX]] : tensor<2xindex>, index -> index
+// CHECK-NEXT: %[[OUTPUT_SHAPE:.+]] = tensor.from_elements %[[N]] : tensor<1xindex>
+// CHECK-NEXT: shape.assuming_yield %[[OUTPUT_SHAPE]] : tensor<1xindex>
 // CHECK-NEXT: }
-// CHECK-NEXT: hipsr.shape_yield %[[RESULT_SHAPE]] : !shape.shape
+// CHECK-NEXT: hipsr.shape_yield %[[RESULT_SHAPE]] : tensor<1xindex>
 // CHECK-NEXT: }
-// CHECK-NEXT: %[[RESULT:.+]] = hipsr.matmul
-// CHECK-NOT: shape_region
+// CHECK-NEXT: %[[RESULT:.+]] = hipsr.matmul(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?xf16, #hipsr.mem<device>>, tensor<?x?xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?xf16, #hipsr.mem<device>>) : tensor<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT: return
+// CHECK-NEXT: }
 func.func @matmul_vector_matrix(%ctx: !hipsr.context, %a: tensor<?xf16, #hipsr.mem<device>>,
                                 %b: tensor<?x?xf16, #hipsr.mem<device>>) {
   %init = hipsr.placeholder(%ctx)
@@ -85,28 +78,29 @@ func.func @matmul_vector_matrix(%ctx: !hipsr.context, %a: tensor<?xf16, #hipsr.m
 
 // -----
 
-// A vector B contributes no N dimension, leaving only M after empty-batch
-// broadcasting.
+// A vector B contributes no N dimension, so the assuming region reads only M.
 // CHECK-LABEL: func.func @matmul_matrix_vector(
-// CHECK: %[[INIT:.+]] = hipsr.placeholder
-// CHECK-NEXT: ^bb0(%[[A_SHAPE:.+]]: !shape.shape, %[[B_SHAPE:.+]]: !shape.shape):
-// CHECK: %[[K_WITNESS:.+]] = shape.cstr_eq
-// CHECK: %[[BATCH_WITNESS:.+]] = shape.cstr_broadcastable %[[A_BATCH:.+]], %[[B_BATCH:.+]] : !shape.shape, !shape.shape
-// CHECK-NEXT: %[[WITNESS:.+]] = shape.assuming_all %[[K_WITNESS]], %[[BATCH_WITNESS]]
-// CHECK-NEXT: %[[RESULT_SHAPE:.+]] = shape.assuming %[[WITNESS]] -> (!shape.shape) {
-// CHECK-NEXT: %[[BROADCAST:.+]] = shape.broadcast %[[A_BATCH]], %[[B_BATCH]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT: %[[M_INDEX:.+]] = shape.const_size 0
-// CHECK-NEXT: %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[M_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NOT: shape.get_extent %[[B_SHAPE]]
-// CHECK-NEXT: %[[MATRIX_SHAPE:.+]] = shape.from_extents %[[M]] : !shape.size
-// CHECK-NEXT: %[[OUTPUT_SHAPE:.+]] = shape.concat %[[BROADCAST]], %[[MATRIX_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT: shape.assuming_yield %[[OUTPUT_SHAPE]] : !shape.shape
+// CHECK-SAME: %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<?x?xf16, #hipsr.mem<device>>, %[[B:.+]]: tensor<?xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x?xf16, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?xf16, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT: ^bb0(%[[A_SHAPE:.+]]: tensor<2xindex>, %[[B_SHAPE:.+]]: tensor<1xindex>):
+// CHECK-NEXT: %[[A_K_INDEX:.+]] = arith.constant 1 : index
+// CHECK-NEXT: %[[A_K:.+]] = shape.get_extent %[[A_SHAPE]], %[[A_K_INDEX]] : tensor<2xindex>, index -> index
+// CHECK-NEXT: %[[A_K_EXTENTS:.+]] = tensor.from_elements %[[A_K]] : tensor<1xindex>
+// CHECK-NEXT: %[[B_K_INDEX:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[B_K:.+]] = shape.get_extent %[[B_SHAPE]], %[[B_K_INDEX]] : tensor<1xindex>, index -> index
+// CHECK-NEXT: %[[B_K_EXTENTS:.+]] = tensor.from_elements %[[B_K]] : tensor<1xindex>
+// CHECK-NEXT: %[[K_WITNESS:.+]] = shape.cstr_eq %[[A_K_EXTENTS]], %[[B_K_EXTENTS]] : tensor<1xindex>, tensor<1xindex>
+// CHECK-NEXT: %[[RESULT_SHAPE:.+]] = shape.assuming %[[K_WITNESS]] -> (tensor<1xindex>) {
+// CHECK-NEXT: %[[M_INDEX:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[M_INDEX]] : tensor<2xindex>, index -> index
+// CHECK-NEXT: %[[OUTPUT_SHAPE:.+]] = tensor.from_elements %[[M]] : tensor<1xindex>
+// CHECK-NEXT: shape.assuming_yield %[[OUTPUT_SHAPE]] : tensor<1xindex>
 // CHECK-NEXT: }
-// CHECK-NEXT: hipsr.shape_yield %[[RESULT_SHAPE]] : !shape.shape
+// CHECK-NEXT: hipsr.shape_yield %[[RESULT_SHAPE]] : tensor<1xindex>
 // CHECK-NEXT: }
-// CHECK-NEXT: %[[RESULT:.+]] = hipsr.matmul
-// CHECK-NOT: shape_region
+// CHECK-NEXT: %[[RESULT:.+]] = hipsr.matmul(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x?xf16, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?xf16, #hipsr.mem<device>>) : tensor<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT: return
+// CHECK-NEXT: }
 func.func @matmul_matrix_vector(%ctx: !hipsr.context, %a: tensor<?x?xf16, #hipsr.mem<device>>,
                                 %b: tensor<?xf16, #hipsr.mem<device>>) {
   %init = hipsr.placeholder(%ctx)
@@ -120,25 +114,28 @@ func.func @matmul_matrix_vector(%ctx: !hipsr.context, %a: tensor<?x?xf16, #hipsr
 
 // -----
 
-// Two vectors produce one empty shape value for the scalar result.
+// Two vectors leave no extent at all, so the assuming region reads nothing and
+// the scalar result gets its rank-0 extent tensor from a constant.
 // CHECK-LABEL: func.func @matmul_dot(
-// CHECK: %[[INIT:.+]] = hipsr.placeholder
-// CHECK-NEXT: ^bb0(%[[A_SHAPE:.+]]: !shape.shape, %[[B_SHAPE:.+]]: !shape.shape):
-// CHECK: %[[K_WITNESS:.+]] = shape.cstr_eq
-// CHECK: %[[BATCH_WITNESS:.+]] = shape.cstr_broadcastable %[[A_BATCH:.+]], %[[B_BATCH:.+]] : !shape.shape, !shape.shape
-// CHECK-NEXT: %[[WITNESS:.+]] = shape.assuming_all %[[K_WITNESS]], %[[BATCH_WITNESS]]
-// CHECK-NEXT: %[[RESULT_SHAPE:.+]] = shape.assuming %[[WITNESS]] -> (!shape.shape) {
-// CHECK-NEXT: %[[BROADCAST:.+]] = shape.broadcast %[[A_BATCH]], %[[B_BATCH]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NOT: shape.get_extent
-// CHECK-NEXT: %[[EMPTY_SHAPE:.+]] = shape.from_extents{{ *}}:
-// CHECK-NEXT: %[[OUTPUT_SHAPE:.+]] = shape.concat %[[BROADCAST]], %[[EMPTY_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT: shape.assuming_yield %[[OUTPUT_SHAPE]] : !shape.shape
+// CHECK-SAME: %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<?xf16, #hipsr.mem<device>>, %[[B:.+]]: tensor<?xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?xf16, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<f16, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT: ^bb0(%[[A_SHAPE:.+]]: tensor<1xindex>, %[[B_SHAPE:.+]]: tensor<1xindex>):
+// CHECK-NEXT: %[[A_K_INDEX:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[A_K:.+]] = shape.get_extent %[[A_SHAPE]], %[[A_K_INDEX]] : tensor<1xindex>, index -> index
+// CHECK-NEXT: %[[A_K_EXTENTS:.+]] = tensor.from_elements %[[A_K]] : tensor<1xindex>
+// CHECK-NEXT: %[[B_K_INDEX:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[B_K:.+]] = shape.get_extent %[[B_SHAPE]], %[[B_K_INDEX]] : tensor<1xindex>, index -> index
+// CHECK-NEXT: %[[B_K_EXTENTS:.+]] = tensor.from_elements %[[B_K]] : tensor<1xindex>
+// CHECK-NEXT: %[[K_WITNESS:.+]] = shape.cstr_eq %[[A_K_EXTENTS]], %[[B_K_EXTENTS]] : tensor<1xindex>, tensor<1xindex>
+// CHECK-NEXT: %[[RESULT_SHAPE:.+]] = shape.assuming %[[K_WITNESS]] -> (tensor<0xindex>) {
+// CHECK-NEXT: %[[OUTPUT_SHAPE:.+]] = arith.constant dense<> : tensor<0xindex>
+// CHECK-NEXT: shape.assuming_yield %[[OUTPUT_SHAPE]] : tensor<0xindex>
 // CHECK-NEXT: }
-// CHECK-NEXT: hipsr.shape_yield %[[RESULT_SHAPE]] : !shape.shape
+// CHECK-NEXT: hipsr.shape_yield %[[RESULT_SHAPE]] : tensor<0xindex>
 // CHECK-NEXT: }
-// CHECK-NEXT: %[[RESULT:.+]] = hipsr.matmul
-// CHECK-NOT: shape_region
+// CHECK-NEXT: %[[RESULT:.+]] = hipsr.matmul(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?xf16, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<f16, #hipsr.mem<device>>) : tensor<f16, #hipsr.mem<device>>
 // CHECK-NEXT: return
+// CHECK-NEXT: }
 func.func @matmul_dot(%ctx: !hipsr.context, %a: tensor<?xf16, #hipsr.mem<device>>,
                       %b: tensor<?xf16, #hipsr.mem<device>>) {
   %init = hipsr.placeholder(%ctx)
@@ -152,30 +149,44 @@ func.func @matmul_dot(%ctx: !hipsr.context, %a: tensor<?xf16, #hipsr.mem<device>
 
 // -----
 
-// Batch prefixes of ranks two and one are right-aligned and broadcast before
-// the matrix dimensions are appended.
+// The recipe right-aligns the rank-2 and rank-1 batch prefixes and broadcasts
+// them. It then reads the result back one extent at a time to lead the result
+// shape. The broadcast rank is known, so that read-back is a compile-time loop.
 // CHECK-LABEL: func.func @matmul_batched(
 // CHECK-SAME: %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<?x1x?x?xf16, #hipsr.mem<device>>, %[[B:.+]]: tensor<3x?x?xf16, #hipsr.mem<device>>) {
 // CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x1x?x?xf16, #hipsr.mem<device>>, tensor<3x?x?xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x3x?x?xf16, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT: ^bb0(%[[A_SHAPE:.+]]: !shape.shape, %[[B_SHAPE:.+]]: !shape.shape):
-// CHECK: %[[K_WITNESS:.+]] = shape.cstr_eq
-// CHECK-NEXT: %[[A_BATCH_INDEX:.+]] = shape.const_size 2
-// CHECK-NEXT: %[[A_BATCH:.+]], %[[A_SUFFIX:.+]] = "shape.split_at"(%[[A_SHAPE]], %[[A_BATCH_INDEX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT: %[[B_BATCH_INDEX:.+]] = shape.const_size 1
-// CHECK-NEXT: %[[B_BATCH:.+]], %[[B_SUFFIX:.+]] = "shape.split_at"(%[[B_SHAPE]], %[[B_BATCH_INDEX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT: %[[BATCH_WITNESS:.+]] = shape.cstr_broadcastable %[[A_BATCH]], %[[B_BATCH]] : !shape.shape, !shape.shape
+// CHECK-NEXT: ^bb0(%[[A_SHAPE:.+]]: tensor<4xindex>, %[[B_SHAPE:.+]]: tensor<3xindex>):
+// CHECK-NEXT: %[[A_K_INDEX:.+]] = arith.constant 3 : index
+// CHECK-NEXT: %[[A_K:.+]] = shape.get_extent %[[A_SHAPE]], %[[A_K_INDEX]] : tensor<4xindex>, index -> index
+// CHECK-NEXT: %[[A_K_EXTENTS:.+]] = tensor.from_elements %[[A_K]] : tensor<1xindex>
+// CHECK-NEXT: %[[B_K_INDEX:.+]] = arith.constant 1 : index
+// CHECK-NEXT: %[[B_K:.+]] = shape.get_extent %[[B_SHAPE]], %[[B_K_INDEX]] : tensor<3xindex>, index -> index
+// CHECK-NEXT: %[[B_K_EXTENTS:.+]] = tensor.from_elements %[[B_K]] : tensor<1xindex>
+// CHECK-NEXT: %[[K_WITNESS:.+]] = shape.cstr_eq %[[A_K_EXTENTS]], %[[B_K_EXTENTS]] : tensor<1xindex>, tensor<1xindex>
+// CHECK-NEXT: %[[A_BATCH_D0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[A_BATCH_E0:.+]] = shape.get_extent %[[A_SHAPE]], %[[A_BATCH_D0]] : tensor<4xindex>, index -> index
+// CHECK-NEXT: %[[A_BATCH_D1:.+]] = arith.constant 1 : index
+// CHECK-NEXT: %[[A_BATCH_E1:.+]] = shape.get_extent %[[A_SHAPE]], %[[A_BATCH_D1]] : tensor<4xindex>, index -> index
+// CHECK-NEXT: %[[A_BATCH:.+]] = tensor.from_elements %[[A_BATCH_E0]], %[[A_BATCH_E1]] : tensor<2xindex>
+// CHECK-NEXT: %[[B_BATCH_D0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[B_BATCH_E0:.+]] = shape.get_extent %[[B_SHAPE]], %[[B_BATCH_D0]] : tensor<3xindex>, index -> index
+// CHECK-NEXT: %[[B_BATCH:.+]] = tensor.from_elements %[[B_BATCH_E0]] : tensor<1xindex>
+// CHECK-NEXT: %[[BATCH_WITNESS:.+]] = shape.cstr_broadcastable %[[A_BATCH]], %[[B_BATCH]] : tensor<2xindex>, tensor<1xindex>
 // CHECK-NEXT: %[[WITNESS:.+]] = shape.assuming_all %[[K_WITNESS]], %[[BATCH_WITNESS]]
-// CHECK-NEXT: %[[RESULT_SHAPE:.+]] = shape.assuming %[[WITNESS]] -> (!shape.shape) {
-// CHECK-NEXT: %[[BROADCAST:.+]] = shape.broadcast %[[A_BATCH]], %[[B_BATCH]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT: %[[M_INDEX:.+]] = shape.const_size 2
-// CHECK-NEXT: %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[M_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT: %[[N_INDEX:.+]] = shape.const_size 2
-// CHECK-NEXT: %[[N:.+]] = shape.get_extent %[[B_SHAPE]], %[[N_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT: %[[MATRIX_SHAPE:.+]] = shape.from_extents %[[M]], %[[N]] : !shape.size, !shape.size
-// CHECK-NEXT: %[[OUTPUT_SHAPE:.+]] = shape.concat %[[BROADCAST]], %[[MATRIX_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT: shape.assuming_yield %[[OUTPUT_SHAPE]] : !shape.shape
+// CHECK-NEXT: %[[RESULT_SHAPE:.+]] = shape.assuming %[[WITNESS]] -> (tensor<4xindex>) {
+// CHECK-NEXT: %[[BATCH:.+]] = shape.broadcast %[[A_BATCH]], %[[B_BATCH]] : tensor<2xindex>, tensor<1xindex> -> tensor<2xindex>
+// CHECK-NEXT: %[[BATCH_D0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[BATCH_E0:.+]] = shape.get_extent %[[BATCH]], %[[BATCH_D0]] : tensor<2xindex>, index -> index
+// CHECK-NEXT: %[[BATCH_D1:.+]] = arith.constant 1 : index
+// CHECK-NEXT: %[[BATCH_E1:.+]] = shape.get_extent %[[BATCH]], %[[BATCH_D1]] : tensor<2xindex>, index -> index
+// CHECK-NEXT: %[[M_INDEX:.+]] = arith.constant 2 : index
+// CHECK-NEXT: %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[M_INDEX]] : tensor<4xindex>, index -> index
+// CHECK-NEXT: %[[N_INDEX:.+]] = arith.constant 2 : index
+// CHECK-NEXT: %[[N:.+]] = shape.get_extent %[[B_SHAPE]], %[[N_INDEX]] : tensor<3xindex>, index -> index
+// CHECK-NEXT: %[[OUTPUT_SHAPE:.+]] = tensor.from_elements %[[BATCH_E0]], %[[BATCH_E1]], %[[M]], %[[N]] : tensor<4xindex>
+// CHECK-NEXT: shape.assuming_yield %[[OUTPUT_SHAPE]] : tensor<4xindex>
 // CHECK-NEXT: }
-// CHECK-NEXT: hipsr.shape_yield %[[RESULT_SHAPE]] : !shape.shape
+// CHECK-NEXT: hipsr.shape_yield %[[RESULT_SHAPE]] : tensor<4xindex>
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[RESULT:.+]] = hipsr.matmul(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<?x1x?x?xf16, #hipsr.mem<device>>, tensor<3x?x?xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x3x?x?xf16, #hipsr.mem<device>>) : tensor<?x3x?x?xf16, #hipsr.mem<device>>
 // CHECK-NEXT: return

--- a/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/min.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/min.mlir
@@ -8,9 +8,9 @@
 // CHECK-SAME: %[[LHS:.+]]: tensor<?x1024xf16, #hipsr.mem<device>>,
 // CHECK-SAME: %[[RHS:.+]]: tensor<1024xf16, #hipsr.mem<device>>) {
 // CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[LHS]], %[[RHS]] : tensor<?x1024xf16, #hipsr.mem<device>>, tensor<1024xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x1024xf16, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT: ^bb0(%[[LHS_SHAPE:.+]]: !shape.shape, %[[RHS_SHAPE:.+]]: !shape.shape):
-// CHECK-NEXT: %[[BROADCAST:.+]] = shape.broadcast %[[LHS_SHAPE]], %[[RHS_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT: hipsr.shape_yield %[[BROADCAST]] : !shape.shape
+// CHECK-NEXT: ^bb0(%[[LHS_SHAPE:.+]]: tensor<2xindex>, %[[RHS_SHAPE:.+]]: tensor<1xindex>):
+// CHECK-NEXT: %[[BROADCAST:.+]] = shape.broadcast %[[LHS_SHAPE]], %[[RHS_SHAPE]] : tensor<2xindex>, tensor<1xindex> -> tensor<2xindex>
+// CHECK-NEXT: hipsr.shape_yield %[[BROADCAST]] : tensor<2xindex>
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[RESULT:.+]] = hipsr.min(%[[CTX]]) ins(%[[LHS]], %[[RHS]] : tensor<?x1024xf16, #hipsr.mem<device>>, tensor<1024xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x1024xf16, #hipsr.mem<device>>) : tensor<?x1024xf16, #hipsr.mem<device>>
 // CHECK-NEXT: return

--- a/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/mul.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/mul.mlir
@@ -9,9 +9,9 @@
 // CHECK-SAME: %[[LHS:.+]]: tensor<?x1024xf16, #hipsr.mem<device>>,
 // CHECK-SAME: %[[RHS:.+]]: tensor<1024xf16, #hipsr.mem<device>>) {
 // CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[LHS]], %[[RHS]] : tensor<?x1024xf16, #hipsr.mem<device>>, tensor<1024xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x1024xf16, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT: ^bb0(%[[LHS_SHAPE:.+]]: !shape.shape, %[[RHS_SHAPE:.+]]: !shape.shape):
-// CHECK-NEXT: %[[BROADCAST:.+]] = shape.broadcast %[[LHS_SHAPE]], %[[RHS_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT: hipsr.shape_yield %[[BROADCAST]] : !shape.shape
+// CHECK-NEXT: ^bb0(%[[LHS_SHAPE:.+]]: tensor<2xindex>, %[[RHS_SHAPE:.+]]: tensor<1xindex>):
+// CHECK-NEXT: %[[BROADCAST:.+]] = shape.broadcast %[[LHS_SHAPE]], %[[RHS_SHAPE]] : tensor<2xindex>, tensor<1xindex> -> tensor<2xindex>
+// CHECK-NEXT: hipsr.shape_yield %[[BROADCAST]] : tensor<2xindex>
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[RESULT:.+]] = hipsr.mul(%[[CTX]]) ins(%[[LHS]], %[[RHS]] : tensor<?x1024xf16, #hipsr.mem<device>>, tensor<1024xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x1024xf16, #hipsr.mem<device>>) : tensor<?x1024xf16, #hipsr.mem<device>>
 // CHECK-NEXT: return

--- a/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/nonzero.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/nonzero.mlir
@@ -11,12 +11,13 @@
 // CHECK-SAME: %[[CTX:.+]]: !hipsr.context,
 // CHECK-SAME: %[[MASK:.+]]: tensor<?x?xi8, #hipsr.mem<device>>) {
 // CHECK-NEXT: %[[INITS:.+]]:2 = hipsr.placeholder(%[[CTX]]) ins(%[[MASK]] : tensor<?x?xi8, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<2x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT: ^bb0(%[[MASK_SHAPE:.+]]: !shape.shape):
-// CHECK-NEXT: %[[ROWS:.+]] = shape.const_size 2
-// CHECK-NEXT: %[[CAPACITY:.+]] = shape.num_elements %[[MASK_SHAPE]] : !shape.shape -> !shape.size
-// CHECK-NEXT: %[[INDICES_SHAPE:.+]] = shape.from_extents %[[ROWS]], %[[CAPACITY]] : !shape.size, !shape.size
-// CHECK-NEXT: %[[COUNT_SHAPE:.+]] = shape.const_shape [1] : !shape.shape
-// CHECK-NEXT: hipsr.shape_yield %[[INDICES_SHAPE]], %[[COUNT_SHAPE]] : !shape.shape, !shape.shape
+// CHECK-NEXT: ^bb0(%[[MASK_SHAPE:.+]]: tensor<2xindex>):
+// CHECK-NEXT: %[[ROWS:.+]] = arith.constant 2 : index
+// CHECK-NEXT: %[[CAPACITY:.+]] = shape.num_elements %[[MASK_SHAPE]] : tensor<2xindex> -> index
+// CHECK-NEXT: %[[INDICES_EXTENTS:.+]] = tensor.from_elements %[[ROWS]], %[[CAPACITY]] : tensor<2xindex>
+// CHECK-NEXT: %[[ONE:.+]] = arith.constant 1 : index
+// CHECK-NEXT: %[[COUNT_EXTENTS:.+]] = tensor.from_elements %[[ONE]] : tensor<1xindex>
+// CHECK-NEXT: hipsr.shape_yield %[[INDICES_EXTENTS]], %[[COUNT_EXTENTS]] : tensor<2xindex>, tensor<1xindex>
 // CHECK-NEXT: }
 // CHECK-NEXT: hipsr.nonzero(%[[CTX]]) ins(%[[MASK]] : tensor<?x?xi8, #hipsr.mem<device>>) outs(%[[INITS]]#0, %[[INITS]]#1 : tensor<2x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>) : tensor<2x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>
 // CHECK-NEXT: return

--- a/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/pass.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/pass.mlir
@@ -7,11 +7,11 @@
 // CHECK-LABEL: func.func @already_populated(
 // CHECK-SAME: %[[CTX:.+]]: !hipsr.context, %[[INPUT:.+]]: tensor<4x8xf32, #hipsr.mem<device>>) {
 // CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<4x8xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4x8xf16, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT: ^bb0(%{{.+}}: !shape.shape):
+// CHECK-NEXT: ^bb0(%{{.+}}: tensor<2xindex>):
 // CHECK-NEXT: %[[C4:.+]] = arith.constant 4 : index
 // CHECK-NEXT: %[[C8:.+]] = arith.constant 8 : index
-// CHECK-NEXT: %[[OUTPUT_SHAPE:.+]] = shape.from_extents %[[C4]], %[[C8]] : index, index
-// CHECK-NEXT: hipsr.shape_yield %[[OUTPUT_SHAPE]] : !shape.shape
+// CHECK-NEXT: %[[OUTPUT_SHAPE:.+]] = tensor.from_elements %[[C4]], %[[C8]] : tensor<2xindex>
+// CHECK-NEXT: hipsr.shape_yield %[[OUTPUT_SHAPE]] : tensor<2xindex>
 // CHECK-NEXT: }
 // CHECK-NEXT: %{{.+}} = hipsr.cast(%[[CTX]]) ins(%[[INPUT]] : tensor<4x8xf32, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<4x8xf16, #hipsr.mem<device>>) : tensor<4x8xf16, #hipsr.mem<device>>
 // CHECK-NEXT: return
@@ -22,11 +22,11 @@ func.func @already_populated(
       ins(%input : tensor<4x8xf32, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<normal>}
       : tensor<4x8xf16, #hipsr.mem<device>> shape_region {
-  ^bb0(%input_shape: !shape.shape):
+  ^bb0(%input_shape: tensor<2xindex>):
     %c4 = arith.constant 4 : index
     %c8 = arith.constant 8 : index
-    %output_shape = shape.from_extents %c4, %c8 : index, index
-    hipsr.shape_yield %output_shape : !shape.shape
+    %output_shape = tensor.from_elements %c4, %c8 : tensor<2xindex>
+    hipsr.shape_yield %output_shape : tensor<2xindex>
   }
   %result = hipsr.cast(%ctx)
       ins(%input : tensor<4x8xf32, #hipsr.mem<device>>)

--- a/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/scatter_nd.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/scatter_nd.mlir
@@ -12,8 +12,8 @@
 // CHECK-SAME:    %[[POSITIONS:.+]]: tensor<?x3xi64, #hipsr.mem<device>>,
 // CHECK-SAME:    %[[FEATURES:.+]]: tensor<?xf16, #hipsr.mem<device>>) {
 // CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[EMBEDS]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x?x4096xf16, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT:    ^bb0(%[[EMBEDS_SHAPE:.+]]: !shape.shape):
-// CHECK-NEXT:      hipsr.shape_yield %[[EMBEDS_SHAPE]] : !shape.shape
+// CHECK-NEXT:    ^bb0(%[[EMBEDS_SHAPE:.+]]: tensor<3xindex>):
+// CHECK-NEXT:      hipsr.shape_yield %[[EMBEDS_SHAPE]] : tensor<3xindex>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %[[RESULT:.+]] = hipsr.scatter_nd(%[[CTX]]) ins(%[[EMBEDS]], %[[POSITIONS]], %[[FEATURES]] : tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) : tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:    return

--- a/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/slice.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/slice.mlir
@@ -9,12 +9,12 @@
 // same rules as index arithmetic, because its size only arrives with the shape.
 // Axis 3, which the window leaves out, keeps the data's size.
 // CHECK-LABEL: func.func @slice_constant_window(
-// CHECK:      shape_region {
-// CHECK-NEXT: ^bb0(%[[DATA_SHAPE:.+]]: !shape.shape):
+// CHECK-SAME: %[[CTX:.+]]: !hipsr.context, %[[DATA:.+]]: tensor<8x?x6x?xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[DATA]] : tensor<8x?x6x?xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<3x?x2x?xf16, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT: ^bb0(%[[DATA_SHAPE:.+]]: tensor<4xindex>):
 // CHECK-NEXT: %[[SIZE0:.+]] = arith.constant 3 : index
-// CHECK-NEXT: %[[AXIS1:.+]] = shape.const_size 1
-// CHECK-NEXT: %[[DIM1:.+]] = shape.get_extent %[[DATA_SHAPE]], %[[AXIS1]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT: %[[DATA_SIZE1:.+]] = shape.size_to_index %[[DIM1]] : !shape.size
+// CHECK-NEXT: %[[AXIS1:.+]] = arith.constant 1 : index
+// CHECK-NEXT: %[[DATA_SIZE1:.+]] = shape.get_extent %[[DATA_SHAPE]], %[[AXIS1]] : tensor<4xindex>, index -> index
 // CHECK-NEXT: %[[ZERO:.+]] = arith.constant 0 : index
 // CHECK-NEXT: %[[START:.+]] = arith.constant 1 : index
 // CHECK-NEXT: %[[LOW:.+]] = arith.minsi %[[DATA_SIZE1]], %[[START]] : index
@@ -23,11 +23,13 @@
 // CHECK-NEXT: %[[SPAN:.+]] = arith.subi %[[HIGH]], %[[LOW]] : index
 // CHECK-NEXT: %[[SIZE1:.+]] = arith.maxsi %[[SPAN]], %[[ZERO]] : index
 // CHECK-NEXT: %[[SIZE2:.+]] = arith.constant 2 : index
-// CHECK-NEXT: %[[AXIS3:.+]] = shape.const_size 3
-// CHECK-NEXT: %[[DIM3:.+]] = shape.get_extent %[[DATA_SHAPE]], %[[AXIS3]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT: %[[SIZE3:.+]] = shape.size_to_index %[[DIM3]] : !shape.size
-// CHECK-NEXT: %[[SHAPE:.+]] = shape.from_extents %[[SIZE0]], %[[SIZE1]], %[[SIZE2]], %[[SIZE3]] : index, index, index, index
-// CHECK-NEXT: hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT: %[[AXIS3:.+]] = arith.constant 3 : index
+// CHECK-NEXT: %[[SIZE3:.+]] = shape.get_extent %[[DATA_SHAPE]], %[[AXIS3]] : tensor<4xindex>, index -> index
+// CHECK-NEXT: %[[EXTENTS:.+]] = tensor.from_elements %[[SIZE0]], %[[SIZE1]], %[[SIZE2]], %[[SIZE3]] : tensor<4xindex>
+// CHECK-NEXT: hipsr.shape_yield %[[EXTENTS]] : tensor<4xindex>
+// CHECK-NEXT: }
+// CHECK-NEXT: %[[RESULT:.+]] = hipsr.slice(%[[CTX]]) ins(%[[DATA]] : tensor<8x?x6x?xf16, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<3x?x2x?xf16, #hipsr.mem<device>>) {axes_attr = array<i64: 0, 1, -2>, ends_attr = array<i64: 1, 5, 9223372036854775807>, starts_attr = array<i64: 6, 1, -4>, steps_attr = array<i64: -2, 1, 2>} : tensor<3x?x2x?xf16, #hipsr.mem<device>>
+// CHECK-NEXT: return
 // CHECK-NEXT: }
 func.func @slice_constant_window(%ctx: !hipsr.context,
                                  %data: tensor<8x?x6x?xf16, #hipsr.mem<device>>) {
@@ -54,7 +56,27 @@ func.func @slice_constant_window(%ctx: !hipsr.context,
 // over and clamps it against the data's own size. The start is in an attribute,
 // so it needs no read, and folding drops the branch it cannot take.
 // CHECK-LABEL: func.func @slice_runtime_bound(
-// CHECK:      placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?xf16, #hipsr.mem<device>> shape_region {
+// CHECK-SAME: %[[CTX:.+]]: !hipsr.context, %[[IN:.+]]: tensor<?xf16, #hipsr.mem<device>>) {
+
+// The bound's own destination is a rank-1 host buffer, so its region is a lone
+// constant.
+// CHECK-NEXT: %[[ENDS_INIT:.+]] = hipsr.placeholder(%[[CTX]]) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<1xi64, #hipsr.mem<host>> shape_region {
+// CHECK-NEXT: %[[ONE:.+]] = arith.constant 1 : index
+// CHECK-NEXT: %[[ENDS_SHAPE:.+]] = tensor.from_elements %[[ONE]] : tensor<1xindex>
+// CHECK-NEXT: hipsr.shape_yield %[[ENDS_SHAPE]] : tensor<1xindex>
+// CHECK-NEXT: }
+
+// The compute that writes the bound is left as it was.
+// CHECK-NEXT: %[[ENDS_VALUE:.+]] = hipsr.compute(%[[CTX]]) ins(%[[IN]] : tensor<?xf16, #hipsr.mem<device>>) outs(%[[ENDS_INIT]] : tensor<1xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT: ^bb0(%{{.+}}: !hipsr.context, %[[BODY_IN:.+]]: tensor<?xf16, #hipsr.mem<device>>, %{{.+}}: tensor<1xi64, #hipsr.mem<host>>):
+// CHECK-NEXT: %[[BODY_AXIS:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[BODY_SIZE:.+]] = tensor.dim %[[BODY_IN]], %[[BODY_AXIS]] : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[BODY_ENTRY:.+]] = arith.index_cast %[[BODY_SIZE]] : index to i64
+// CHECK-NEXT: %[[BODY_ENTRIES:.+]] = tensor.from_elements %[[BODY_ENTRY]] : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT: hipsr.compute_yield %[[BODY_ENTRIES]] : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT: } : tensor<1xi64, #hipsr.mem<host>>
+
+// CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[IN]], %[[ENDS_INIT]] : tensor<?xf16, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?xf16, #hipsr.mem<device>> shape_region {
 // CHECK-NEXT: ^bb0(%{{.+}}: !hipsr.context, %[[DATA:.+]]: tensor<?xf16, #hipsr.mem<device>>, %[[ENDS:.+]]: tensor<1xi64, #hipsr.mem<host>>):
 // CHECK-NEXT: %[[AXIS:.+]] = arith.constant 0 : index
 // CHECK-NEXT: %[[DATA_SIZE:.+]] = tensor.dim %[[DATA]], %[[AXIS]]
@@ -71,16 +93,20 @@ func.func @slice_constant_window(%ctx: !hipsr.context,
 // CHECK-NEXT: %[[HIGH:.+]] = arith.minsi %[[LAST_UP]], %[[DATA_SIZE]] : index
 // CHECK-NEXT: %[[SPAN:.+]] = arith.subi %[[HIGH]], %[[LOW]] : index
 // CHECK-NEXT: %[[SIZE:.+]] = arith.maxsi %[[SPAN]], %[[ZERO]] : index
-// CHECK-NEXT: %[[SHAPE:.+]] = shape.from_extents %[[SIZE]] : index
-// CHECK-NEXT: hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT: %[[EXTENTS:.+]] = tensor.from_elements %[[SIZE]] : tensor<1xindex>
+// CHECK-NEXT: hipsr.shape_yield %[[EXTENTS]] : tensor<1xindex>
+// CHECK-NEXT: }
+// CHECK-NEXT: %[[RESULT:.+]] = hipsr.slice(%[[CTX]]) ins(%[[IN]] : tensor<?xf16, #hipsr.mem<device>>) ends(%[[ENDS_VALUE]] : tensor<1xi64, #hipsr.mem<host>>) outs(%[[INIT]] : tensor<?xf16, #hipsr.mem<device>>) {axes_attr = array<i64: 0>, starts_attr = array<i64: 0>, steps_attr = array<i64: 1>} : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT: return
+// CHECK-NEXT: }
 func.func @slice_runtime_bound(%ctx: !hipsr.context,
                                %data: tensor<?xf16, #hipsr.mem<device>>) {
   %ends_init = hipsr.placeholder(%ctx)
       {placeholder_type = #hipsr.placeholder_type<normal>}
       : tensor<1xi64, #hipsr.mem<host>> shape_region {
     %one = arith.constant 1 : index
-    %ends_shape = shape.from_extents %one : index
-    hipsr.shape_yield %ends_shape : !shape.shape
+    %ends_shape = tensor.from_elements %one : tensor<1xindex>
+    hipsr.shape_yield %ends_shape : tensor<1xindex>
   }
   %ends = hipsr.compute(%ctx) ins(%data : tensor<?xf16, #hipsr.mem<device>>)
                               outs(%ends_init : tensor<1xi64, #hipsr.mem<host>>) {

--- a/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/transpose.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/transpose.mlir
@@ -9,13 +9,13 @@
 // CHECK-SAME: %[[CTX:.+]]: !hipsr.context,
 // CHECK-SAME: %[[INPUT:.+]]: tensor<3x?xi64, #hipsr.mem<device>>) {
 // CHECK-NEXT: %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]] : tensor<3x?xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x3xi64, #hipsr.mem<device>> shape_region {
-// CHECK-NEXT: ^bb0(%[[IN_SHAPE:.+]]: !shape.shape):
-// CHECK-NEXT: %[[AXIS1:.+]] = shape.const_size 1
-// CHECK-NEXT: %[[COLS:.+]] = shape.get_extent %[[IN_SHAPE]], %[[AXIS1]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT: %[[AXIS0:.+]] = shape.const_size 0
-// CHECK-NEXT: %[[ROWS:.+]] = shape.get_extent %[[IN_SHAPE]], %[[AXIS0]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT: %[[SHAPE:.+]] = shape.from_extents %[[COLS]], %[[ROWS]] : !shape.size, !shape.size
-// CHECK-NEXT: hipsr.shape_yield %[[SHAPE]] : !shape.shape
+// CHECK-NEXT: ^bb0(%[[IN_SHAPE:.+]]: tensor<2xindex>):
+// CHECK-NEXT: %[[AXIS1:.+]] = arith.constant 1 : index
+// CHECK-NEXT: %[[COLS:.+]] = shape.get_extent %[[IN_SHAPE]], %[[AXIS1]] : tensor<2xindex>, index -> index
+// CHECK-NEXT: %[[AXIS0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[ROWS:.+]] = shape.get_extent %[[IN_SHAPE]], %[[AXIS0]] : tensor<2xindex>, index -> index
+// CHECK-NEXT: %[[EXTENTS:.+]] = tensor.from_elements %[[COLS]], %[[ROWS]] : tensor<2xindex>
+// CHECK-NEXT: hipsr.shape_yield %[[EXTENTS]] : tensor<2xindex>
 // CHECK-NEXT: }
 // CHECK-NEXT: %[[RESULT:.+]] = hipsr.transpose(%[[CTX]]) ins(%[[INPUT]] : tensor<3x?xi64, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x3xi64, #hipsr.mem<device>>) {perm = array<i64: 1, 0>} : tensor<?x3xi64, #hipsr.mem<device>>
 // CHECK-NEXT: return

--- a/test/lit/Dialect/Hipsr/Transforms/UseAllocOutput/hipsr_use_alloc_output.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/UseAllocOutput/hipsr_use_alloc_output.mlir
@@ -3,28 +3,51 @@
 
 // RUN: hip-mlir-opt %s -hipsr-use-output-allocator | FileCheck %s
 
+// The pass runs after bufferization, so every data value is a memref and the
+// extent tensor reaches preserve_shape through bufferization.to_tensor.
+//
 // A returned dynamic allocation becomes hipsr.alloc_output. Dynamic sizes come
 // from the preserved shape, not directly from the original alloc operands.
 // CHECK-LABEL: func.func @dynamic_output(
-// CHECK-SAME: %[[CTX:.*]]: !hipsr.context, %[[M:.*]]: index, %[[N:.*]]: index
-// CHECK: %[[SHAPE:.*]] = shape.from_extents %[[M]], %[[N]] : index, index
-// CHECK: shape.const_size 0
-// CHECK: shape.get_extent %[[SHAPE]], {{.*}} : !shape.shape, !shape.size -> !shape.size
-// CHECK: %[[D0:.*]] = shape.size_to_index {{.*}} : !shape.size
-// CHECK: shape.const_size 1
-// CHECK: shape.get_extent %[[SHAPE]], {{.*}} : !shape.shape, !shape.size -> !shape.size
-// CHECK: %[[D1:.*]] = shape.size_to_index {{.*}} : !shape.size
-// CHECK-NOT: memref.alloc
-// CHECK: %[[OUT:.*]] = hipsr.alloc_output(%[[CTX]], %[[D0]], %[[D1]]) {out_idx = 0 : i64} : memref<?x?xf16, #hipsr.mem<device>>
-// CHECK: hipsr.preserve_shape %[[SHAPE]], %[[OUT]] : memref<?x?xf16, #hipsr.mem<device>>
-// CHECK: return %[[OUT]]
+// CHECK-SAME: %[[CTX:.*]]: !hipsr.context, %[[M:.*]]: index, %[[N:.*]]: index) -> memref<?x?xf16, #hipsr.mem<device>> {
+
+// The buffer holding the extents is left alone. Only the data allocation the
+// function returns is replaced.
+// CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-NEXT: %[[C1:.*]] = arith.constant 1 : index
+// CHECK-NEXT: %[[EXTENTS_BUF:.*]] = memref.alloc() : memref<2xindex>
+// CHECK-NEXT: memref.store %[[M]], %[[EXTENTS_BUF]]{{\[}}%[[C0]]] : memref<2xindex>
+// CHECK-NEXT: memref.store %[[N]], %[[EXTENTS_BUF]]{{\[}}%[[C1]]] : memref<2xindex>
+// CHECK-NEXT: %[[EXTENTS:.*]] = bufferization.to_tensor %[[EXTENTS_BUF]] : memref<2xindex> to tensor<2xindex>
+
+// The pass reads the shape twice: once for the size it asks the runtime for,
+// and once for the view it would build over the result. Both are the same here
+// because the result needs no view, so the second pair has no user.
+// CHECK-NEXT: %[[D0_INDEX:.*]] = arith.constant 0 : index
+// CHECK-NEXT: %[[D0:.*]] = shape.get_extent %[[EXTENTS]], %[[D0_INDEX]] : tensor<2xindex>, index -> index
+// CHECK-NEXT: %[[D1_INDEX:.*]] = arith.constant 1 : index
+// CHECK-NEXT: %[[D1:.*]] = shape.get_extent %[[EXTENTS]], %[[D1_INDEX]] : tensor<2xindex>, index -> index
+// CHECK-NEXT: %[[VIEW_D0_INDEX:.*]] = arith.constant 0 : index
+// CHECK-NEXT: %[[VIEW_D0:.*]] = shape.get_extent %[[EXTENTS]], %[[VIEW_D0_INDEX]] : tensor<2xindex>, index -> index
+// CHECK-NEXT: %[[VIEW_D1_INDEX:.*]] = arith.constant 1 : index
+// CHECK-NEXT: %[[VIEW_D1:.*]] = shape.get_extent %[[EXTENTS]], %[[VIEW_D1_INDEX]] : tensor<2xindex>, index -> index
+
+// CHECK-NEXT: %[[OUT:.*]] = hipsr.alloc_output(%[[CTX]], %[[D0]], %[[D1]]) {out_idx = 0 : i64} : memref<?x?xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[EXTENTS]], %[[OUT]] : tensor<2xindex>, memref<?x?xf16, #hipsr.mem<device>>
+// CHECK-NEXT: return %[[OUT]] : memref<?x?xf16, #hipsr.mem<device>>
+// CHECK-NEXT: }
 func.func @dynamic_output(
     %ctx: !hipsr.context, %M: index, %N: index)
     -> memref<?x?xf16, #hipsr.mem<device>> {
-  %shape = shape.from_extents %M, %N : index, index
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %extents = memref.alloc() : memref<2xindex>
+  memref.store %M, %extents[%c0] : memref<2xindex>
+  memref.store %N, %extents[%c1] : memref<2xindex>
+  %shape = bufferization.to_tensor %extents : memref<2xindex> to tensor<2xindex>
   %out = memref.alloc(%M, %N)
       : memref<?x?xf16, #hipsr.mem<device>>
-  hipsr.preserve_shape %shape, %out : memref<?x?xf16, #hipsr.mem<device>>
+  hipsr.preserve_shape %shape, %out : tensor<2xindex>, memref<?x?xf16, #hipsr.mem<device>>
   return %out : memref<?x?xf16, #hipsr.mem<device>>
 }
 
@@ -49,28 +72,25 @@ func.func @dynamic_output(
 // CHECK-NEXT: %[[M:.*]] = memref.dim %[[IN]], %[[C0]] : memref<?x512xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[N:.*]] = memref.dim %[[W]], %[[C1]] : memref<512x256xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[FLAT_SIZE:.*]] = arith.muli %[[M]], %[[N]] : index
-// CHECK-NEXT: %[[SHAPE1:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT: %[[S1:.*]] = shape.from_extents %[[M]], %[[N]] : index, index
-// CHECK-NEXT: scf.yield %[[S1]] : !shape.shape
-// CHECK-NEXT: }
-// CHECK-NEXT: %[[SHAPE2:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT: %[[S2:.*]] = shape.from_extents %[[M]], %[[N]] : index, index
-// CHECK-NEXT: scf.yield %[[S2]] : !shape.shape
-// CHECK-NEXT: }
-// CHECK-NEXT: %[[SHAPE3:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT: %[[S3:.*]] = shape.from_extents %[[FLAT_SIZE]] : index
-// CHECK-NEXT: scf.yield %[[S3]] : !shape.shape
-// CHECK-NEXT: }
+// CHECK-NEXT: %[[E1:.*]] = memref.alloc() : memref<2xindex>
+// CHECK-NEXT: memref.store %[[M]], %[[E1]]{{\[}}%[[C0]]] : memref<2xindex>
+// CHECK-NEXT: memref.store %[[N]], %[[E1]]{{\[}}%[[C1]]] : memref<2xindex>
+// CHECK-NEXT: %[[SHAPE1:.*]] = bufferization.to_tensor %[[E1]] : memref<2xindex> to tensor<2xindex>
+// CHECK-NEXT: %[[E2:.*]] = memref.alloc() : memref<2xindex>
+// CHECK-NEXT: memref.store %[[M]], %[[E2]]{{\[}}%[[C0]]] : memref<2xindex>
+// CHECK-NEXT: memref.store %[[N]], %[[E2]]{{\[}}%[[C1]]] : memref<2xindex>
+// CHECK-NEXT: %[[SHAPE2:.*]] = bufferization.to_tensor %[[E2]] : memref<2xindex> to tensor<2xindex>
+// CHECK-NEXT: %[[E3:.*]] = memref.alloc() : memref<1xindex>
+// CHECK-NEXT: memref.store %[[FLAT_SIZE]], %[[E3]]{{\[}}%[[C0]]] : memref<1xindex>
+// CHECK-NEXT: %[[SHAPE3:.*]] = bufferization.to_tensor %[[E3]] : memref<1xindex> to tensor<1xindex>
 // CHECK-NEXT: %[[INIT1:.*]] = memref.alloc(%[[M]]) : memref<?x256xf16, #hipsr.mem<device>>
 // CHECK-NEXT: hipsr.matmul(%[[DCTX]]) ins(%[[IN]], %[[W]] : memref<?x512xf16, #hipsr.mem<device>>, memref<512x256xf16, #hipsr.mem<device>>) outs(%[[INIT1]] : memref<?x256xf16, #hipsr.mem<device>>)
 // The external (rank-1) output size comes from SHAPE3; the internal (rank-2)
 // view size comes from SHAPE2.
-// CHECK-NEXT: %[[CS_EXT0:.*]] = shape.const_size 0
-// CHECK-NEXT: %[[EXT0:.*]] = shape.get_extent %[[SHAPE3]], %[[CS_EXT0]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT: %[[EXT_SIZE:.*]] = shape.size_to_index %[[EXT0]] : !shape.size
-// CHECK-NEXT: %[[CS_INT0:.*]] = shape.const_size 0
-// CHECK-NEXT: %[[INT0:.*]] = shape.get_extent %[[SHAPE2]], %[[CS_INT0]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT: %[[INT_SIZE:.*]] = shape.size_to_index %[[INT0]] : !shape.size
+// CHECK-NEXT: %[[CS_EXT0:.*]] = arith.constant 0 : index
+// CHECK-NEXT: %[[EXT_SIZE:.*]] = shape.get_extent %[[SHAPE3]], %[[CS_EXT0]] : tensor<1xindex>, index -> index
+// CHECK-NEXT: %[[CS_INT0:.*]] = arith.constant 0 : index
+// CHECK-NEXT: %[[INT_SIZE:.*]] = shape.get_extent %[[SHAPE2]], %[[CS_INT0]] : tensor<2xindex>, index -> index
 // CHECK-NEXT: %[[C256:.*]] = arith.constant 256 : index
 // CHECK-NEXT: %[[OUTBUF:.*]] = hipsr.alloc_output(%[[DCTX]], %[[EXT_SIZE]]) {out_idx = 0 : i64} : memref<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[RC:.*]] = memref.reinterpret_cast %[[OUTBUF]] to offset: [0], sizes: [%[[INT_SIZE]], 256], strides: [256, 1] : memref<?xf16, #hipsr.mem<device>> to memref<?x256xf16, #hipsr.mem<device>>
@@ -82,10 +102,10 @@ func.func @dynamic_output(
 // CHECK-NEXT: } : memref<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[CAST_INIT:.*]] = memref.alloc(%[[FLAT_SIZE]]) : memref<?xf32, #hipsr.mem<device>>
 // CHECK-NEXT: hipsr.cast(%[[DCTX]]) ins(%[[FLAT]] : memref<?xf16, #hipsr.mem<device>>) outs(%[[CAST_INIT]] : memref<?xf32, #hipsr.mem<device>>)
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE1]], %[[INIT1]] : memref<?x256xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE2]], %[[RC]] : memref<?x256xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE3]], %[[FLAT]] : memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE3]], %[[CAST_INIT]] : memref<?xf32, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE1]], %[[INIT1]] : tensor<2xindex>, memref<?x256xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE2]], %[[RC]] : tensor<2xindex>, memref<?x256xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE3]], %[[FLAT]] : tensor<1xindex>, memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE3]], %[[CAST_INIT]] : tensor<1xindex>, memref<?xf32, #hipsr.mem<device>>
 // CHECK-NEXT: hipsr.pool_domain_yield %[[FLAT]] : memref<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT: } -> memref<?xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
 // CHECK-NEXT: return %[[OUT]] : memref<?xf16, #hipsr.mem<device>>
@@ -111,18 +131,21 @@ func.func @test_return_shape(
     %m = memref.dim %in, %c0 : memref<?x512xf16, #hipsr.mem<device>>
     %n = memref.dim %w, %c1 : memref<512x256xf16, #hipsr.mem<device>>
     %flat_size = arith.muli %m, %n : index
-    %shape1 = scf.execute_region -> !shape.shape {
-      %s1 = shape.from_extents %m, %n : index, index
-      scf.yield %s1 : !shape.shape
-    }
-    %shape2 = scf.execute_region -> !shape.shape {
-      %s2 = shape.from_extents %m, %n : index, index
-      scf.yield %s2 : !shape.shape
-    }
-    %shape3 = scf.execute_region -> !shape.shape {
-      %s3 = shape.from_extents %flat_size : index
-      scf.yield %s3 : !shape.shape
-    }
+
+    %e1 = memref.alloc() : memref<2xindex>
+    memref.store %m, %e1[%c0] : memref<2xindex>
+    memref.store %n, %e1[%c1] : memref<2xindex>
+    %shape1 = bufferization.to_tensor %e1 : memref<2xindex> to tensor<2xindex>
+
+    %e2 = memref.alloc() : memref<2xindex>
+    memref.store %m, %e2[%c0] : memref<2xindex>
+    memref.store %n, %e2[%c1] : memref<2xindex>
+    %shape2 = bufferization.to_tensor %e2 : memref<2xindex> to tensor<2xindex>
+
+    %e3 = memref.alloc() : memref<1xindex>
+    memref.store %flat_size, %e3[%c0] : memref<1xindex>
+    %shape3 = bufferization.to_tensor %e3 : memref<1xindex> to tensor<1xindex>
+
     %init1 = memref.alloc(%m) : memref<?x256xf16, #hipsr.mem<device>>
     hipsr.matmul(%dctx)
       ins(%in, %w : memref<?x512xf16, #hipsr.mem<device>>,
@@ -154,13 +177,13 @@ func.func @test_return_shape(
       outs(%cast_init : memref<?xf32, #hipsr.mem<device>>)
 
     hipsr.preserve_shape %shape1, %init1
-      : memref<?x256xf16, #hipsr.mem<device>>
+      : tensor<2xindex>, memref<?x256xf16, #hipsr.mem<device>>
     hipsr.preserve_shape %shape2, %init2
-      : memref<?x256xf16, #hipsr.mem<device>>
+      : tensor<2xindex>, memref<?x256xf16, #hipsr.mem<device>>
     hipsr.preserve_shape %shape3, %flat
-      : memref<?xf16, #hipsr.mem<device>>
+      : tensor<1xindex>, memref<?xf16, #hipsr.mem<device>>
     hipsr.preserve_shape %shape3, %cast_init
-      : memref<?xf32, #hipsr.mem<device>>
+      : tensor<1xindex>, memref<?xf32, #hipsr.mem<device>>
     hipsr.pool_domain_yield %flat
       : memref<?xf16, #hipsr.mem<device>>
   } -> memref<?xf16, #hipsr.mem<device>> {


### PR DESCRIPTION
## Summary

Shape regions now state result shapes as extent tensors (`tensor<Nxindex>`) instead of `!shape.shape`. That is the form upstream's shape passes already lower, so `--hipsr-pipeline` gains four upstream passes and no shape dialect op survives it.

## Related issue or design

None.

## Why

Shape regions were a dead end. Every result shape stayed in the shape dialect, and nothing downstream understands `!shape.shape`.

### Adding the upstream passes alone lowers nothing

The regions had to change how they use the shape dialect, not just gain a lowering pass behind them. Every converter our recipes depend on refuses a shape-typed value:

```cpp
// For now, this lowering is only defined on `tensor<?xindex>` operands, not
// on shapes.
if (isa<ShapeType>(op.getType()))
  return failure();
```

- That guard sits on the `shape_of`, `broadcast`, `const_shape`, `split_at`, `shape_eq`, `reduce` and `is_broadcastable` converters. `get_extent`, `rank` and the binary ops refuse `!shape.size` the same way, because a size can carry an error.
- A pattern that does not match is a normal failure, not an error. `--convert-shape-to-std` therefore reports success and leaves the region exactly as it found it, which is why the old pipeline looked healthy while lowering nothing.

That left two options: write project-specific patterns for `!shape.shape`, or state the regions in the form upstream already lowers. The second adds no pass and no pattern to maintain, so the recipes moved to extent tensors.

### `shape.split_at` had to go entirely

Switching types is not enough for MatMul and Gather. Even on extent tensors, the converter slices with a dynamic size and replaces the op without casting back to the declared result:

```cpp
Value head = tensor::ExtractSliceOp::create(b, adaptor.getOperand(), zero, index, one);
Value tailSize = arith::SubIOp::create(b, rank, index);
Value tail = tensor::ExtractSliceOp::create(b, adaptor.getOperand(), index, tailSize, one);
rewriter.replaceOp(op, {head, tail});
```

Both results come back as `tensor<?xindex>`, so a recipe that declares a static length fails to legalize. Both recipes know their operand ranks, so they read one extent per dimension instead.

### Static lengths make the rest fall out

Every hipsr op takes ranked operands, so a recipe already knows how many extents its result shape holds when it builds one. Keeping that length in the type, instead of erasing it to `tensor<?xindex>`:

- upstream drops the runtime rank arithmetic its dynamic path emits;
- `tensor.from_elements` and the `tensor.extract` that reads an extent back become adjacent and fold, so an allocation names its extent directly instead of routing it through a shape;
- `hipsr.shape_yield` and `hipsr.preserve_shape` can check the extent count against the rank of the value it describes.

## What

### Pipeline

Four upstream passes run after materialize-init-tensors: `remove-shape-constraints`, `shape-to-shape-lowering`, `convert-shape-to-std`, `canonicalize`.

- The constraints a recipe carries document what it assumed, and nothing downstream checks them. Dropping them rather than turning them into runtime asserts preserves the option of emitting `cf.assert` later.
- Dropping one leaves a passing witness. `convert-shape-to-std` converts only what it has a pattern for, so the `shape.assuming` that witness guarded survives it.
- Canonicalization inlines that region along with each shape computation's `execute_region`, then deletes every extent no allocation reads.

### Types

- `hipsr.shape_yield` and `hipsr.preserve_shape` take `Shape_ExtentTensorType`.
- Both verify a static extent count against the rank of the result or value it describes, so a shape that does not describe its result is rejected where it is written rather than at a later extent read.
- `preserve_shape` prints both types, so it round-trips without inferring one from the other.
- Three helpers decide a length: `getExtentTensorTypeForRank`, `getExtentTensorTypeOf`, `getBroadcastExtentTensorType`.

### Recipes

- `shape.from_extents` becomes `tensor.from_elements`, consolidated in `createExtentTensor` because 15 call sites assemble a shape from extents they learn one at a time. A rank-0 shape comes from `arith.constant`, since `from_elements` needs at least one element.
- `shape.const_size` becomes `arith.constant`.
- Reading an extent loses a step: `shape.get_extent` on an extent tensor already returns index, so `shape.size_to_index` behind it goes away.
- MatMul and Gather assemble their result in a single `tensor.from_elements`, which drops the `tensor.concat` each one ended with. MatMul also skips the batch witness and the broadcast over two empty shapes when neither operand has batch dimensions, which is the common case.

### Two things stop distinguishing themselves by type

- A barrier region passes data values while a normal region passes shapes. Both are `RankedTensorType` now, so `PlaceholderShapeRegionArgs::holdsDataValues` answers what `isa<ShapedType>` used to.
- `hipsr.preserve_shape` names a shape it does not read through, so its bufferization model overrides `hasTensorSemantics`. Without that, the default counts the shape operand, keeps reporting tensor semantics for the op it just rewrote, and bufferizes it forever.

## Test plan

| Check | Result |
|---|---|
| Full LIT suite | 458 passed, 12 unsupported, 0 failed |
| `pre-commit run --all-files` | clean |

Every LIT test this PR touches verifies its full output with `CHECK-NEXT`, rather than skipping ahead with `CHECK` or asserting absence with `CHECK-NOT`. For the three regenerated pipeline goldens that is also what shows no shape dialect op survives, since one would have to appear on a line of its own.

Completing those chains exposed a detail the abbreviated goldens hid: `hipsr-use-output-allocator` reads each result shape twice, once for the size it requests from the runtime and once for the view it would build over the result. When the result needs no view, the second pair of reads has no user. That is recorded in the golden rather than fixed here.

Gather is covered at an inner axis as well as at axis 0, because that is the only case with data dimensions on both sides of the indices.

Because the shape operand is now a tensor rather than an opaque `!shape.shape`, tests that run after bufferization were updated to stop mixing the two forms. A memref data operand now pairs with a shape that arrives through `bufferization.to_tensor`, which is what one-shot-bufferize actually emits, rather than a leftover `tensor.from_elements`.

ctest was not rerun for the static-length change. The nine failures it reported earlier on this branch were confirmed pre-existing by rebuilding and rerunning them without the change.

## Notes for reviewers

- The diff crosses the `large-pr` thresholds, but roughly half of it is regenerated LIT output. The behavior change is the four pipeline passes plus the operand types on two ops; the rest is recipes building a shape a different way.
- Splitting it further is not useful. A shape region has to be typed consistently end to end, so the op definitions, the recipes that fill them, and the goldens that record the result all move together or the verifier rejects the intermediate state.
- Read `lib/Dialect/Hipsr/Pipelines/Pipelines.cpp` first: it explains why each of the four passes is needed and in that order.

### Follow-up: the host buffer behind a bufferized shape

A shape operand that used to be `!shape.shape` was invisible to bufferization. As `tensor<Nxindex>` it is not: `tensor.from_elements` becomes a host `memref.alloc` plus stores, and `preserve_shape` reads it back through `bufferization.to_tensor`. Nobody frees or host-maps that buffer yet.

This is a gap to close before hipsr bufferizes for real, not a regression, and it does not block this PR:

- `buildHipsrPipeline` stops at the shape passes. Bufferization, `hipsr-use-output-allocator` and `hipsr-pool-alloc` appear only in LIT RUN lines, and `CompilerDriver` builds the `hip` pipeline instead.
- The `hip` pipeline already answers the same question. `hip-materialize-host-scalars` matches exactly this pattern, a static `memref.alloc` of at most 16 index or integer elements with a host store, and rewrites it onto `hip.get_host_scratch` at slot 6b, immediately before `hip-pool-allocs`.
- hipsr needs its own pass in that slot. Until it exists, a host extent buffer inside a `hipsr.pool_domain` would fail `hipsr-pool-alloc`, whose first-use check wants a DPS destination.

Changing the operand instead is the alternative, and neither form works here. A memref operand cannot hold the extent tensor the region yields before bufferization, and variadic index extents would give up the packed value that upstream's converters consume.

### Two review points answered in place

- The pipeline comment names the right pass. In the pinned LLVM, `RemoveShapeConstraints.cpp` holds only `RemoveCstrBroadcastableOp` and `RemoveCstrEqOp`, which swap a constraint for `shape.const_witness true`. The `shape.assuming` is inlined by canonicalization's `AssumingWithTrue`. Running that whole-function is intended: it is also what hoists the constants the goldens show at the top of each domain.
- The three upstream pass names are deliberately not added to `docs/pipeline_pass_menu.md`. That table describes the shipping `hip` pipeline, which these passes are not part of; `--hipsr-pipeline` is not listed there either.

## AI assistance

The migration, the pipeline wiring, and the LIT assertions were drafted with Cursor and Claude Opus 5. I reviewed the result and validated it with the full LIT suite and `pre-commit run --all-files`.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
