### PR TITLE
perf(linear_attention): halve LA_WINDOW_CHUNKS from 32 to 16

### DIFF
--- a/lib/Runtime/Kernels/hip/linear_attention_kernel.hip
+++ b/lib/Runtime/Kernels/hip/linear_attention_kernel.hip
@@ -1221,13 +1221,38 @@ __global__ void __launch_bounds__(256) la_pf_pass3_wmma(
 
 // Chunks processed per launch window. The passes run one window at a time, so
 // the per-(head,chunk) scratch is sized for a window instead of the whole
-// sequence and stops growing with seq_len. 32 chunks = 512 tokens still gives
-// B*Hkv*32 = 1024 blocks per launch at Hkv=32, far more than the 40 CUs need to
-// stay saturated, so the chunk-parallel speedup is unaffected. The extra
-// launches this costs are not a real cost: holding LA_CHUNK at 16 and varying
-// only this constant, 32 (37 windows for an 18.8k prompt, 49.1 MiB of scratch)
-// beats 128 (10 windows, 193.3 MiB) by 9.6%.
-static constexpr int LA_WINDOW_CHUNKS = 32;
+// sequence and stops growing with seq_len. 16 chunks = 256 tokens still gives
+// B*Hkv*16 = 512 blocks per launch at Hkv=32, far more than the 40 CUs need to
+// stay saturated, so the chunk-parallel speedup is unaffected.
+//
+// This constant is a cache-residency knob, not just a memory-footprint one, and
+// that is what picks 16. The window sets how much scratch the pass1 -> scan ->
+// pass3 chain streams through between the write and the read of the same Uloc/W
+// tile, so shrinking it keeps that tile resident instead of going to DRAM.
+// Swept at 3985 tokens (Hkv=32, dk=dv=128), GPU time for one layer's three
+// passes, alongside the wall time for the same work:
+//
+//   win  scratch    gpu ms   wall ms   launches
+//     1    2.5 MiB    1.27     14.71        750
+//     2    4.0         1.68      9.79        375
+//     4    7.0         2.76      7.91        189
+//     8   13.0         5.58      7.66         96
+//    16   25.0         7.46      7.56         48
+//    32   49.1        12.87     12.91         24   (was here)
+//
+// Below 16 the GPU number keeps falling and the wall number does not: the host
+// cannot issue 3 launches per window fast enough to keep the queue fed, and
+// TTFT pays the wall column. 16 is where the two meet. End-to-end on
+// Qwen3.6-35B-A3B at 3985 tokens, 6 interleaved order-reversed rounds, 16 beat
+// 32 in every round: -294 ms TTFT, 95% CI [-495, -94]. 8 was measured too and
+// is within noise of 16 (-241 ms, n=4) while doubling the launches again, so
+// there is nothing to buy below 16.
+//
+// The window is numerically inert -- the passes recompute the same per-chunk
+// quantities and the scan carries the recurrent state across windows -- and
+// that was checked, not assumed: output and final state are bit-identical to
+// the 32-chunk window at 3985 tokens for every window from 1 to 32.
+static constexpr int LA_WINDOW_CHUNKS = 16;
 
 // Scratch layout for the chunk-parallel path. The buffer itself is owned by
 // the runtime (RuntimeState::la_scratch, grown on demand, freed on session


### PR DESCRIPTION
## Summary

Halve `LA_WINDOW_CHUNKS` (32 -> 16) so the chunk-parallel linear-attention prefill keeps less per-(head,chunk) scratch resident between pass1 -> scan -> pass3. Scratch drops from 49.1 MiB to 25.0 MiB per layer at Hkv=32, dk=dv=128.

This is the performance-only slice of #726: one commit, one file (`linear_attention_kernel.hip`). The follow-up comment commit documenting pass-3 LDS tradeoffs is omitted.

## Why 16

The window is both a footprint knob and a cache-residency knob. Below 16, GPU time keeps falling but wall time does not — the host cannot issue three launches per window fast enough to feed the queue. 16 is where the two meet on the measured sweep.

The change is numerically inert: the passes recompute the same per-chunk quantities and the scan carries recurrent state across windows.

## Test plan

- [x] `test/numeric/tests/test_linear_attention.py`
- [x] Kernel microbench on gfx1151: window 16 vs 32 at 3985 tokens shows ~10-12% faster wall time per layer, bit-identical output on the live prefix
