### PR TITLE
feat(matmul_nbits): add an env switch to skip autotune and use safe defaults

### DIFF
--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -65,6 +65,19 @@
 #include <string>
 #include <unordered_map>
 
+// Master switch for this DLL's matmul_nbits autotuners (the on-device
+// GEMV/WMMA config sweeps below). The kernel does NOT read the environment
+// itself: the runtime (real/matmul_nbits.cpp) reads HIPDNN_EP_MATMUL_NBITS_AUTOTUNE
+// through its /MT-safe reader (hipdnn_ep_matmul_nbits_autotune_enabled) and
+// passes the decision into the entry points, which store it here -- the same
+// "runtime decides, kernel receives" split HIPDNN_GQA_AUTOTUNE_MODE uses (its
+// env read lives in the runtime-bitcode gqa_autotune.cpp, not the kernel).
+// DEFAULT-ON; =0 skips the sweeps and returns each tuner's best_id. Set by
+// hip_matmul_nbits / hip_matmul_nbits_dp4a before any getOrTune* runs. The
+// value is process-constant (the runtime latches it once), so every entry-point
+// write stores the same value and the unsynchronized write is benign.
+static bool g_matmul_nbits_autotune = true;
+
 /* -----------------------------------------------------------------------
  * Shared disk-persistent autotune cache (GEMV int4 / int8 paths)
  *
@@ -1273,6 +1286,12 @@ static int getOrTuneGemvConfig(
     int64_t batch, int64_t bs,
     bool col_major = false)
 {
+    // Autotune off: return the safe default without sweeping or touching the
+    // cache. Config 8 is tuneGemvConfig's best_id -- the value it keeps when no
+    // candidate beats it -- so this matches the existing no-better-found path.
+    if (!g_matmul_nbits_autotune)
+        return 8;
+
     // M=1: col_major and row_major layouts are identical (single row) —
     // reuse the row_major autotune result to avoid a redundant tuning pass.
     bool effective_col_major = (M == 1) ? false : col_major;
@@ -1411,6 +1430,10 @@ static int getOrTuneDp4aConfig(
     const __half* bi, __half* out,
     int64_t N, int64_t K, int64_t bs)
 {
+    // Autotune off: safe default (tuneDp4aConfig's best_id), no sweep/cache.
+    if (!g_matmul_nbits_autotune)
+        return 9;
+
     std::string key = std::to_string(N) + "_" + std::to_string(K) + "_" +
                       std::to_string(bs) + "_" + (zp ? "1" : "0");
 
@@ -1445,9 +1468,12 @@ extern "C" int hip_matmul_nbits_dp4a(
     const void* A, const void* B, const void* scales, const void* zp_u8,
     const void* bias, void* out,
     int64_t N, int64_t K, int64_t block_size,
-    void* a_qb_scratch, void* a_scale_scratch)
+    void* a_qb_scratch, void* a_scale_scratch,
+    int autotune_enabled)
 {
     if (K % 32 != 0) return hipErrorInvalidValue;
+    // Runtime-supplied autotune switch (see g_matmul_nbits_autotune).
+    g_matmul_nbits_autotune = (autotune_enabled != 0);
     hipStream_t stream = static_cast<hipStream_t>(stream_v);
 
     const __half*  Ah   = static_cast<const __half*>(A);
@@ -1629,6 +1655,10 @@ static int getOrTuneGemvConfigI8(
     int64_t M, int64_t N, int64_t K,
     int64_t batch, int64_t bs)
 {
+    // Autotune off: safe default (tuneGemvConfigI8's best_id), no sweep/cache.
+    if (!g_matmul_nbits_autotune)
+        return 8;
+
     const bool has_zp = (zp != nullptr);
     std::string key = gemvI8CacheKey(M, N, K, bs, has_zp);
 
@@ -2068,6 +2098,10 @@ static int getOrTuneGemvConfigU3(
     int64_t M, int64_t N, int64_t K,
     int64_t batch, int64_t bs)
 {
+    // Autotune off: safe default (tuneGemvConfigU3's best_id), no sweep/cache.
+    if (!g_matmul_nbits_autotune)
+        return 8;
+
     const bool has_zp = (zp != nullptr);
     std::string key = gemvU3CacheKey(M, N, K, bs, has_zp);
 
@@ -2474,6 +2508,10 @@ static int getOrTuneGemvConfigU2(
     int64_t M, int64_t N, int64_t K,
     int64_t batch, int64_t bs)
 {
+    // Autotune off: safe default (tuneGemvConfigU2's best_id), no sweep/cache.
+    if (!g_matmul_nbits_autotune)
+        return 8;
+
     const bool has_zp = (zp != nullptr);
     std::string key = gemvU2CacheKey(M, N, K, bs, has_zp);
 
@@ -3465,6 +3503,10 @@ static int getOrTuneWmmaConfig(
     int gs, int ngk,
     _Float16* C, int ldc, bool has_zp)
 {
+    // Autotune off: safe default (tuneWmmaConfig's best_id), no sweep/cache.
+    if (!g_matmul_nbits_autotune)
+        return 9;
+
     std::call_once(wmma_cache_init_flag, loadWmmaCache);
 
     std::string key = wmmaCacheKey(M, N, K, gs, has_zp);
@@ -3984,6 +4026,10 @@ static int getOrTuneWmmaConfigI8(
     int gs, int ngk,
     _Float16* C, int ldc, bool has_zp)
 {
+    // Autotune off: safe default (tuneWmmaConfigI8's best_id), no sweep/cache.
+    if (!g_matmul_nbits_autotune)
+        return 12;
+
     std::string key = wmmaI8CacheKey(M, N, K, gs, has_zp);
 
     std::lock_guard<std::mutex> lock(wmma_i8_tune_mutex);
@@ -4703,6 +4749,10 @@ static int getOrTuneWmmaConfigU3(
     int gs, int ngk,
     _Float16* C, int ldc, bool has_zp)
 {
+    // Autotune off: safe default (tuneWmmaConfigU3's best_id), no sweep/cache.
+    if (!g_matmul_nbits_autotune)
+        return 12;
+
     std::string key = wmmaU3CacheKey(M, N, K, gs, has_zp);
 
     std::lock_guard<std::mutex> lock(wmma_u3_tune_mutex);
@@ -5342,6 +5392,10 @@ static int getOrTuneWmmaConfigU2(
     int gs, int ngk,
     _Float16* C, int ldc, bool has_zp)
 {
+    // Autotune off: safe default (tuneWmmaConfigU2's best_id), no sweep/cache.
+    if (!g_matmul_nbits_autotune)
+        return 12;
+
     std::string key = wmmaU2CacheKey(M, N, K, gs, has_zp);
 
     std::lock_guard<std::mutex> lock(wmma_u2_tune_mutex);
@@ -5588,7 +5642,10 @@ extern "C" int hip_matmul_nbits(
     int64_t element_size_bytes,
     int64_t zp_elem_size,
     const void* pre_unpacked_zp_u8,
-    const void* pre_unpacked_zp_fp16) {
+    const void* pre_unpacked_zp_fp16,
+    int autotune_enabled) {
+  // Runtime-supplied autotune switch (see g_matmul_nbits_autotune).
+  g_matmul_nbits_autotune = (autotune_enabled != 0);
   if (bits != 2 && bits != 3 && bits != 4 && bits != 8) {
     fprintf(stderr,
             "[custom_kernels] hip_matmul_nbits: only bits=2, bits=3, bits=4 "

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -1875,7 +1875,11 @@ HIP_KERNEL_API int hip_matmul_nbits(
     // zero_points is non-null and zp_elem_size==1; zp_fp16 is only consumed
     // by the WMMA / col-major-GEMV (M>1) paths and may be null otherwise.
     const void* pre_unpacked_zp_u8,
-    const void* pre_unpacked_zp_fp16);
+    const void* pre_unpacked_zp_fp16,
+    // Autotune master switch (1 = tune, 0 = use each path's safe default). The
+    // runtime passes hipdnn_ep_matmul_nbits_autotune_enabled(); defaulted to 1
+    // so other callers (qmoe, standalone kernel tests) keep tuning unchanged.
+    int autotune_enabled = 1);
 
 /* W4A8 integer-dot-product (dp4a) GEMV for a single decode row (M==1).
  * Dynamically quantizes the fp16 activation row to per-group int8 (into
@@ -1896,7 +1900,9 @@ HIP_KERNEL_API int hip_matmul_nbits_dp4a(
     const void* A, const void* B, const void* scales, const void* zp_u8,
     const void* bias, void* out,
     int64_t N, int64_t K, int64_t block_size,
-    void* a_qb_scratch, void* a_scale_scratch);
+    void* a_qb_scratch, void* a_scale_scratch,
+    // Autotune master switch (1 = tune, 0 = safe default); see hip_matmul_nbits.
+    int autotune_enabled = 1);
 
 /* Stand-alone launchers for the zero_points unpack/convert kernels, used by
  * the asym matmul_nbits cache in lib/Runtime/real/matmul_nbits.cpp.

--- a/lib/Runtime/debug_log.h
+++ b/lib/Runtime/debug_log.h
@@ -30,6 +30,20 @@ inline bool hipdnn_ep_matmul_dp4a_enabled() {
   return enabled;
 }
 
+// Master switch for the matmul_nbits autotuners: the on-device config sweep in
+// the custom-kernel DLL (kGemvConfigs / kWmmaConfigs) and the hipBLASLt algo
+// selection on the CDNA prefill fallback. DEFAULT-ON; set
+// HIPDNN_EP_MATMUL_NBITS_AUTOTUNE=0 to skip tuning and use each path's built-in
+// safe default -- for a quick correctness run that should not pay the
+// first-call sweep, or to A/B the default configs. Latched on first read like
+// the flags above. Separate from HIPDNN_EP_AUTOTUNE (which gates the generic
+// hipBLASLt matmul), since the two tune different subsystems.
+inline bool hipdnn_ep_matmul_nbits_autotune_enabled() {
+  static const bool enabled =
+      hipdnn_ep::env_enabled_default_on("HIPDNN_EP_MATMUL_NBITS_AUTOTUNE");
+  return enabled;
+}
+
 inline bool hipdnn_ep_perf_enabled() {
   // PERF intentionally does NOT inherit from HIPDNN_EP_DEBUG: enabling PERF
   // forces a hipStreamSynchronize on every inference (so hipEventElapsedTime

--- a/lib/Runtime/real/matmul_nbits.cpp
+++ b/lib/Runtime/real/matmul_nbits.cpp
@@ -352,6 +352,13 @@ int matmul_nbits_prefill_hipblaslt(MatmulNbitsState *mst, RuntimeState *state,
     if (it != mst->prefill_algos.end()) {
       chosen = it->second;
       have_algo = chosen.has_algo;
+    } else if (!hipdnn_ep_matmul_nbits_autotune_enabled()) {
+      // Autotune off: skip enumerating and timing candidate algos and use
+      // hipBLASLt's default internal kernel (algo=nullptr). Cache the decision
+      // so the lookup above answers on later calls for this shape.
+      chosen = MatmulNbitsState::PrefillAlgo{};
+      have_algo = false;
+      mst->prefill_algos.emplace(key, chosen);
     } else {
       // Cold miss: collect candidates (perf-ranked heuristic first, then the
       // full enumeration as a fallback) and benchmark them into a scratch
@@ -610,8 +617,9 @@ int wrap_matmul_nbits(RuntimeState *state, int op_state_slot, const void *A,
       if (base) {
         void *a_qb = base;
         void *a_scale = base + scale_off;
-        int rc = hip_matmul_nbits_dp4a(stream, A, B, scales, pre_zp_u8, bias,
-                                       output, N, K, block_size, a_qb, a_scale);
+        int rc = hip_matmul_nbits_dp4a(
+            stream, A, B, scales, pre_zp_u8, bias, output, N, K, block_size,
+            a_qb, a_scale, hipdnn_ep_matmul_nbits_autotune_enabled() ? 1 : 0);
         if (rc == 0) {
           result = 0;
           goto cleanup;
@@ -658,9 +666,10 @@ int wrap_matmul_nbits(RuntimeState *state, int op_state_slot, const void *A,
     // the general kernel dispatch below.
   }
 
-  HIP_CHECK(hip_matmul_nbits(stream, A, B, scales, zero_points, bias, output, M,
-                             N, K, batch_count, bits, block_size, elem_size,
-                             zp_elem_size, pre_zp_u8, pre_zp_fp16));
+  HIP_CHECK(hip_matmul_nbits(
+      stream, A, B, scales, zero_points, bias, output, M, N, K, batch_count,
+      bits, block_size, elem_size, zp_elem_size, pre_zp_u8, pre_zp_fp16,
+      hipdnn_ep_matmul_nbits_autotune_enabled() ? 1 : 0));
 
 cleanup:
   return result;

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -379,7 +379,8 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
           hip_matmul_nbits(stream, d_gather_buf, fc1_w_e, fc1_s_e, fc1_zp_e,
                            fc1_b_e, d_fc1_buf, count, fusion_inter, hidden_size,
                            1, expert_weight_bits, block_size, elem_size,
-                           /*zp_elem_size=*/1, fc1_pre_zp_u8, fc1_pre_zp_fp16));
+                           /*zp_elem_size=*/1, fc1_pre_zp_u8, fc1_pre_zp_fp16,
+                           hipdnn_ep_matmul_nbits_autotune_enabled() ? 1 : 0));
 
       RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: expert %lld: swiglu(alpha=%.3f, "
                         "beta=%.3f, limit=%.1f)\n",
@@ -431,7 +432,8 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
       HIP_CHECK(hip_matmul_nbits(
           stream, d_act_buf, fc2_w_e, fc2_s_e, fc2_zp_e, fc2_b_e, d_fc2_buf,
           count, hidden_size, inter_size, 1, expert_weight_bits, block_size,
-          elem_size, /*zp_elem_size=*/1, fc2_pre_zp_u8, fc2_pre_zp_fp16));
+          elem_size, /*zp_elem_size=*/1, fc2_pre_zp_u8, fc2_pre_zp_fp16,
+          hipdnn_ep_matmul_nbits_autotune_enabled() ? 1 : 0));
 
       RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: expert %lld: scatter_add\n",
                         (long long)e);


### PR DESCRIPTION
## Summary

Adds `HIPDNN_EP_MATMUL_NBITS_AUTOTUNE`, an environment switch that turns off the
matmul_nbits on-device autotune and makes each dispatch use its built-in safe
default config. Default ON, so production behavior is unchanged; set it to `0`
to skip the first-call config sweep and bypass the disk tune cache entirely.

## Related issue or design

None.

## Why

The tuners time every candidate config on-device for each new shape. That sweep
is worth it in production, but it is unwanted in two cases: a quick correctness
run that should not pay the first-call sweep latency, and an A/B measurement of
the built-in default configs. There was no way to opt out short of a rebuild.

## What

- New flag `hipdnn_ep_matmul_nbits_autotune_enabled()` in `debug_log.h`, next to
  `HIPDNN_EP_MATMUL_DP4A` and built on the same `env_enabled_default_on` helper,
  so it is shared by both the custom-kernel DLL and the host runtime.
- Gated the nine `getOrTune*` entries in `matmul_nbits_kernel.hip` (u4/i8/u3/u2
  GEMV, dp4a, and u4/i8/u3/u2 WMMA): when off they return the safe default and
  touch neither the GPU sweep nor the cache.
- Gated the hipBLASLt algo selection on the CDNA prefill fallback in
  `matmul_nbits.cpp`: when off it uses hipBLASLt's default internal kernel
  (`algo=nullptr`).
- Kept separate from `HIPDNN_EP_AUTOTUNE` (the generic hipBLASLt matmul gate);
  the two tune different subsystems.

The value returned when off is exactly the `best_id` each tuner initializes and
keeps when no candidate is faster — a config the enabled sweep already treats as
universally valid. WMMA launches through its boundary-check variant for
non-divisible `M`/`N` with a `ceil`-rounded grid, and the GEMV grid is
`ceil(N / tile_n)`, so every default launches for any shape; disabling cannot
make a kernel unlaunchable.

## Test plan

Not built or run locally (hip-ep does not build on this machine). Changes are
lint-clean and reviewed by inspection. Requested validation on a build-capable
machine:

- [ ] Unset (default): autotune runs and the tune cache is populated, identical
      to current behavior.
- [ ] `HIPDNN_EP_MATMUL_NBITS_AUTOTUNE=0`: matmul_nbits output is correct across
      the bits=4/8/3/2 GEMV and WMMA paths and the dp4a decode path, with no
      tune-cache reads or writes and no first-call sweep latency.

## Notes for reviewers

- Semantics of "off": the disabled path bypasses the disk cache completely (no
  read, no write), so a previously tuned cache is intentionally ignored while
  the switch is set. This keeps "off" deterministic and makes an A/B of the
  default configs pure. Happy to switch to "reuse an existing cache but never
  tune" if that is preferred.
- AI assistance: the flag wiring and this description were drafted with an AI
  coding assistant and reviewed by me. The single commit on this branch predates
  the disclosure trailers; per CONTRIBUTING ("do not rewrite reviewed history
  solely to add it") I am noting it here instead of amending the pushed commit.