### PR TITLE
feat(ep): support RunOptions in the plugin EP

### DIFF
--- a/morphizen/docs/architecture.md
+++ b/morphizen/docs/architecture.md
@@ -633,11 +633,6 @@ class MorphiZenEP : public OrtEp {
 
     // Compatibility validation
     GetCompiledModelCompatibilityInfoImpl() → JSON info
-
-    // Publish/clear this run's OrtRunOptions for
-    // PassContext::get_run_option()
-    OnRunStartImpl(run_options)
-    OnRunEndImpl(run_options, sync_stream)
 };
 ```
 

--- a/morphizen/docs/architecture.md
+++ b/morphizen/docs/architecture.md
@@ -633,6 +633,11 @@ class MorphiZenEP : public OrtEp {
 
     // Compatibility validation
     GetCompiledModelCompatibilityInfoImpl() → JSON info
+
+    // Publish/clear this run's OrtRunOptions for
+    // PassContext::get_run_option()
+    OnRunStartImpl(run_options)
+    OnRunEndImpl(run_options, sync_stream)
 };
 ```
 

--- a/morphizen/morphizen-core/include/morphizen/onnxruntime_morphizen_ep.hpp
+++ b/morphizen/morphizen-core/include/morphizen/onnxruntime_morphizen_ep.hpp
@@ -74,6 +74,20 @@ MORPHIZEN_DLL_SPEC int morphizen_ep_on_run_start(
         const void *state, const char *entry_name));
 
 /**
+ * @brief Called when InferenceSession::Run() finished.
+ *
+ * Drops the run_option accessor that morphizen_ep_on_run_start() installed for
+ * the calling thread. The state it captured refers to the OrtRunOptions of that
+ * run, which does not outlive the run, so it must stop being reachable from
+ * PassContext::get_run_option() once the run ends.
+ *
+ * Called by `MorphiZenEP::OnRunEndImpl()`.
+ *
+ * @return Status code indicating success or failure.
+ */
+MORPHIZEN_DLL_SPEC int morphizen_ep_on_run_end();
+
+/**
  * @brief Set DynamicOptions for the MorphiZen Execution Provider.
  *
  * Called when InferenceSession::SetEpDynamicOptions() is called.

--- a/morphizen/morphizen-core/onnxruntime_morphizen_ep.def
+++ b/morphizen/morphizen-core/onnxruntime_morphizen_ep.def
@@ -7,6 +7,7 @@ EXPORTS
     profiler_collect
     morphizen_get_version
     morphizen_ep_on_run_start
+    morphizen_ep_on_run_end
     morphizen_ep_set_ep_dynamic_options
     morphizen_get_build_info
     morphizen_get_execution_provider_deletor

--- a/morphizen/morphizen-core/onnxruntime_morphizen_ep_with_ort_bridge.def
+++ b/morphizen/morphizen-core/onnxruntime_morphizen_ep_with_ort_bridge.def
@@ -7,6 +7,7 @@ EXPORTS
     profiler_collect
     morphizen_get_version
     morphizen_ep_on_run_start
+    morphizen_ep_on_run_end
     morphizen_ep_set_ep_dynamic_options
     morphizen_get_build_info
     morphizen_get_execution_provider_deletor

--- a/morphizen/morphizen-core/src/morphizen_compile_model.cpp
+++ b/morphizen/morphizen-core/src/morphizen_compile_model.cpp
@@ -1142,10 +1142,6 @@ compile_onnx_model_3(const std::string &model_path, const Graph &onnx_graph,
                                        set_ort_status);
 }
 
-thread_local const void *g_state = nullptr;
-thread_local morphizen::DllSafe<std::string> (*g_get_config_entry)(
-    const void *state, const char *entry_name) = nullptr;
-
 int morphizen_ep_on_run_start(
     const std::vector<std::unique_ptr<morphizen::ExecutionProvider>> &eps,
     const void *state,
@@ -1159,8 +1155,12 @@ int morphizen_ep_on_run_start(
   auto p_context =
       dynamic_cast<morphizen::PassContextImp *>(ep->get_context().get());
   CHECK(p_context != nullptr);
-  g_state = state;
-  g_get_config_entry = get_config_entry;
+  set_run_option_accessor(state, get_config_entry);
+  return 0;
+}
+
+int morphizen_ep_on_run_end() {
+  set_run_option_accessor(nullptr, nullptr);
   return 0;
 }
 
@@ -1192,6 +1192,10 @@ extern "C" MORPHIZEN_DLL_SPEC int morphizen_ep_on_run_start(
     morphizen::DllSafe<std::string> (*get_config_entry)(
         const void *state, const char *entry_name)) {
   return morphizen::morphizen_ep_on_run_start(eps, state, get_config_entry);
+}
+
+extern "C" MORPHIZEN_DLL_SPEC int morphizen_ep_on_run_end() {
+  return morphizen::morphizen_ep_on_run_end();
 }
 
 extern "C" MORPHIZEN_DLL_SPEC int morphizen_ep_set_ep_dynamic_options(

--- a/morphizen/morphizen-core/src/pass_context_imp.cpp
+++ b/morphizen/morphizen-core/src/pass_context_imp.cpp
@@ -36,6 +36,19 @@ DEF_ENV_PARAM(HIP_EP_VERBOSE, "0")
 
 namespace morphizen {
 
+namespace {
+thread_local const void *g_run_option_state = nullptr;
+thread_local DllSafe<std::string> (*g_get_run_option_entry)(
+    const void *state, const char *entry_name) = nullptr;
+} // namespace
+
+void set_run_option_accessor(const void *state,
+                             DllSafe<std::string> (*get_entry)(
+                                 const void *state, const char *entry_name)) {
+  g_run_option_state = state;
+  g_get_run_option_entry = get_entry;
+}
+
 /// struct WithPass
 PassContextImp::WithPass::WithPass(PassContextImp &context, IPass &pass)
     : _context(&context) {
@@ -298,17 +311,16 @@ PassContextImp::get_session_config(const std::string &option_name,
 std::string
 PassContextImp::get_run_option(const std::string &option_name,
                                const std::string &default_value) const {
-  auto ret = default_value;
-  if (get_run_options_) {
-    // if the function exists. TODO, it might be a stale
-    // function.
-    std::shared_lock<std::shared_mutex> lock(
-        const_cast<PassContextImp *>(this)->rw_mutex_);
-    auto maybe_value = get_run_options_(option_name);
-    if (maybe_value) {
-      ret = maybe_value.value();
-    }
+  auto value = DllSafe<std::string>();
+  if (g_get_run_option_entry != nullptr && g_run_option_state != nullptr) {
+    value = g_get_run_option_entry(g_run_option_state, option_name.c_str());
   }
+  // OrtRunOptions has no API to enumerate its config entries, so logging every
+  // lookup is the only way to see which run options actually reach us.
+  const bool found = value.get() != nullptr;
+  auto ret = found ? *value : default_value;
+  LOG_VERBOSE(1) << "run_option: " << option_name << " = " << ret
+                 << (found ? "" : " (default)");
   return ret;
 }
 std::string

--- a/morphizen/morphizen-core/src/pass_context_imp.hpp
+++ b/morphizen/morphizen-core/src/pass_context_imp.hpp
@@ -5,6 +5,7 @@
 #pragma once
 #include "morphizen/morphizen.hpp"
 #include <deque>
+#include <mutex>
 
 #include <morphizen/custom_op.h>
 #include <morphizen/dll_safe.h>

--- a/morphizen/morphizen-core/src/pass_context_imp.hpp
+++ b/morphizen/morphizen-core/src/pass_context_imp.hpp
@@ -5,7 +5,6 @@
 #pragma once
 #include "morphizen/morphizen.hpp"
 #include <deque>
-#include <shared_mutex>
 
 #include <morphizen/custom_op.h>
 #include <morphizen/dll_safe.h>
@@ -20,6 +19,15 @@
 namespace morphizen {
 // Forward declaration for logger adapter
 class LoggerAdapter;
+
+// Publishes the accessor that PassContextImp::get_run_option() uses to reach
+// the OrtRunOptions of the run in progress. Installed by
+// morphizen_ep_on_run_start() and cleared by passing nulls when the run ends.
+// The accessor is per-thread, because a session may be run concurrently from
+// several threads with different OrtRunOptions.
+void set_run_option_accessor(const void *state,
+                             DllSafe<std::string> (*get_entry)(
+                                 const void *state, const char *entry_name));
 
 class CacheFileReaderImp : public CacheFileReader {
 public:
@@ -363,13 +371,6 @@ public:
   virtual std::unique_ptr<FileSystem> get_file_system() override final;
 
 private:
-  std::function<std::optional<std::string>(std::string)> get_run_options_;
-  std::shared_mutex rw_mutex_;
-  friend int morphizen_ep_on_run_start(
-      const std::vector<std::unique_ptr<morphizen::ExecutionProvider>> &eps,
-      const void *state,
-      morphizen::DllSafe<std::string> (*get_config_entry)(
-          const void *state, const char *entry_name));
   friend int morphizen_ep_set_ep_dynamic_options(
       const std::vector<std::unique_ptr<morphizen::ExecutionProvider>> &eps,
       const char *const *keys, const char *const *values, size_t kv_len);

--- a/morphizen/ort-bridge/src/morphizen-ep.cpp
+++ b/morphizen/ort-bridge/src/morphizen-ep.cpp
@@ -34,6 +34,30 @@ DEF_ENV_PARAM(XLNX_ABI_2_0_CLONE_EXTERNAL_DATA_THRESHOLD, "127")
 #define MY_LOG(n) LOG_IF(INFO, ENV_PARAM(MORPHIZEN_DEBUG_MORPHIZEN_EP) >= n)
 namespace morphizen {
 
+namespace {
+// Set for the duration of one Session::Run() on the calling thread, so that
+// PassContext::get_run_option() can reach that run's OrtRunOptions.
+struct RunConfigLookup {
+  const OrtApi *api = nullptr;
+  const OrtRunOptions *run_options = nullptr;
+};
+thread_local RunConfigLookup g_run_config_lookup;
+
+DllSafe<std::string> get_run_config_entry(const void *state,
+                                          const char *entry_name) {
+  const auto *lookup = static_cast<const RunConfigLookup *>(state);
+  if (lookup == nullptr || lookup->run_options == nullptr) {
+    return DllSafe<std::string>();
+  }
+  const char *value =
+      lookup->api->GetRunConfigEntry(lookup->run_options, entry_name);
+  if (value == nullptr) {
+    return DllSafe<std::string>();
+  }
+  return DllSafe<std::string>(std::string(value));
+}
+} // namespace
+
 /**
  * @brief Get supported nodes from graph viewer based on execution provider
  * meta definition
@@ -87,6 +111,8 @@ MorphiZenEP::MorphiZenEP(ApiPtrs apis, const std::string &name,
   OrtEp::ReleaseNodeComputeInfos = ReleaseNodeComputeInfosImpl;
   OrtEp::GetCompiledModelCompatibilityInfo =
       GetCompiledModelCompatibilityInfoImpl;
+  OrtEp::OnRunStart = OnRunStartImpl;
+  OrtEp::OnRunEnd = OnRunEndImpl;
   ir_converter = morphizen::IRConverter::to_onnx_model;
 }
 MorphiZenEP::~MorphiZenEP() {}
@@ -291,6 +317,29 @@ const char *ORT_API_CALL MorphiZenEP::GetCompiledModelCompatibilityInfoImpl(
   }
   return get_compiled_model_compatibility_info(
       (*self->execution_providers_).get(), graph);
+}
+
+OrtStatus *ORT_API_CALL MorphiZenEP::OnRunStartImpl(
+    OrtEp *this_ptr, const OrtRunOptions *run_options) noexcept {
+  MorphiZenEP *self = static_cast<MorphiZenEP *>(this_ptr);
+  if (!self->execution_providers_) {
+    return nullptr;
+  }
+  g_run_config_lookup = {&self->ort_api, run_options};
+  morphizen_ep_on_run_start(**self->execution_providers_, &g_run_config_lookup,
+                            &get_run_config_entry);
+  return nullptr;
+}
+
+OrtStatus *ORT_API_CALL MorphiZenEP::OnRunEndImpl(
+    OrtEp * /*this_ptr*/, const OrtRunOptions * /*unused*/,
+    bool /*sync_stream*/) noexcept {
+  // The OrtRunOptions does not outlive this call, so drop it before any later
+  // get_run_option() on this thread can dereference it. sync_stream is moot
+  // here because MorphiZenEpFactory::IsStreamAwareImpl() reports no stream.
+  morphizen_ep_on_run_end();
+  g_run_config_lookup = {};
+  return nullptr;
 }
 
 OrtStatus *

--- a/morphizen/ort-bridge/src/morphizen-ep.cpp
+++ b/morphizen/ort-bridge/src/morphizen-ep.cpp
@@ -46,7 +46,11 @@ thread_local RunConfigLookup g_run_config_lookup;
 DllSafe<std::string> get_run_config_entry(const void *state,
                                           const char *entry_name) {
   const auto *lookup = static_cast<const RunConfigLookup *>(state);
-  if (lookup == nullptr || lookup->run_options == nullptr) {
+  // Both fields are checked rather than just run_options: OnRunStart assigns
+  // them together, but nothing enforces that, and getting it wrong would be a
+  // null dereference inside the host process.
+  if (lookup == nullptr || lookup->api == nullptr ||
+      lookup->run_options == nullptr) {
     return DllSafe<std::string>();
   }
   const char *value =

--- a/morphizen/ort-bridge/src/morphizen-ep.hpp
+++ b/morphizen/ort-bridge/src/morphizen-ep.hpp
@@ -38,6 +38,13 @@ public:
   static const char *ORT_API_CALL GetCompiledModelCompatibilityInfoImpl(
       OrtEp *this_ptr, const OrtGraph *graph) noexcept;
 
+  static OrtStatus *ORT_API_CALL
+  OnRunStartImpl(OrtEp *this_ptr, const OrtRunOptions *run_options) noexcept;
+
+  static OrtStatus *ORT_API_CALL OnRunEndImpl(OrtEp *this_ptr,
+                                              const OrtRunOptions *run_options,
+                                              bool sync_stream) noexcept;
+
 private:
   OrtStatus *GetCapability(OrtGraphWrapper &graph_wrapper,
                            OrtEpGraphSupportInfo &graph_support_info);

--- a/morphizen/unit-test/morphizen/test_pass_context.cpp
+++ b/morphizen/unit-test/morphizen/test_pass_context.cpp
@@ -95,6 +95,37 @@ protected:
 };
 } // namespace morphizen
 using namespace morphizen;
+
+// The accessor is per-thread process state, so clear it before returning to
+// keep the remaining tests on this thread unaffected.
+TEST_F(PassContextTest, GetRunOption) {
+  const std::map<std::string, std::string> run_options{
+      {"qnn.htp_perf_mode", "burst"}};
+  auto get_entry = [](const void *state,
+                      const char *name) -> morphizen::DllSafe<std::string> {
+    const auto &options =
+        *static_cast<const std::map<std::string, std::string> *>(state);
+    auto it = options.find(name);
+    if (it == options.end()) {
+      return morphizen::DllSafe<std::string>();
+    }
+    return morphizen::DllSafe<std::string>(it->second);
+  };
+
+  // No accessor installed yet: every lookup falls back to the default.
+  EXPECT_EQ(passContext->get_run_option("qnn.htp_perf_mode", "default"),
+            "default");
+
+  morphizen::set_run_option_accessor(&run_options, get_entry);
+  EXPECT_EQ(passContext->get_run_option("qnn.htp_perf_mode", "default"),
+            "burst");
+  EXPECT_EQ(passContext->get_run_option("absent.key", "default"), "default");
+
+  morphizen::set_run_option_accessor(nullptr, nullptr);
+  EXPECT_EQ(passContext->get_run_option("qnn.htp_perf_mode", "default"),
+            "default");
+}
+
 TEST_F(PassContextConfigTest, Config) {
 #ifdef MORPHIZEN_ENABLE_MLIR_BACKEND
   // TODO(Issue #058): MLIR model node names differ from ONNX

--- a/morphizen/unit-test/morphizen/test_pass_context.cpp
+++ b/morphizen/unit-test/morphizen/test_pass_context.cpp
@@ -100,7 +100,7 @@ using namespace morphizen;
 // keep the remaining tests on this thread unaffected.
 TEST_F(PassContextTest, GetRunOption) {
   const std::map<std::string, std::string> run_options{
-      {"qnn.htp_perf_mode", "burst"}};
+      {"test.key", "test-value"}};
   auto get_entry = [](const void *state,
                       const char *name) -> morphizen::DllSafe<std::string> {
     const auto &options =
@@ -113,17 +113,14 @@ TEST_F(PassContextTest, GetRunOption) {
   };
 
   // No accessor installed yet: every lookup falls back to the default.
-  EXPECT_EQ(passContext->get_run_option("qnn.htp_perf_mode", "default"),
-            "default");
+  EXPECT_EQ(passContext->get_run_option("test.key", "default"), "default");
 
   morphizen::set_run_option_accessor(&run_options, get_entry);
-  EXPECT_EQ(passContext->get_run_option("qnn.htp_perf_mode", "default"),
-            "burst");
-  EXPECT_EQ(passContext->get_run_option("absent.key", "default"), "default");
+  EXPECT_EQ(passContext->get_run_option("test.key", "default"), "test-value");
+  EXPECT_EQ(passContext->get_run_option("test.absent", "default"), "default");
 
   morphizen::set_run_option_accessor(nullptr, nullptr);
-  EXPECT_EQ(passContext->get_run_option("qnn.htp_perf_mode", "default"),
-            "default");
+  EXPECT_EQ(passContext->get_run_option("test.key", "default"), "default");
 }
 
 TEST_F(PassContextConfigTest, Config) {

--- a/tools/hip-onnx-runner/hip-onnx-runner.cpp
+++ b/tools/hip-onnx-runner/hip-onnx-runner.cpp
@@ -872,6 +872,18 @@ int main(int argc, char *argv[]) {
       "graph; the value only sizes the input tensors. Symbolic dims without a "
       "matching override default to 1.",
       "");
+  mo.add_option(
+      "", "log-level",
+      "ORT log severity for the env and the session: 0=verbose, 1=info, "
+      "2=warning, 3=error, 4=fatal. The EP routes its glog output through the "
+      "ORT logger, so 1 or 0 is required to see any EP debug logging.",
+      "3");
+  mo.add_option(
+      "", "run-option",
+      "Add a RunOptions config entry for every Run(): 'key=value' (repeatable "
+      "or comma-separated), e.g. --run-option my.key=value. Reaches passes and "
+      "custom ops through PassContext::get_run_option().",
+      "");
   mo.add_option("", "dump-compiler-mlir",
                 "Dump MLIR fed to hip-compiler (mlir_bytecode_dump.mlir) and "
                 "per-pass snapshots; sets MorphiZen env before EP load",
@@ -965,7 +977,15 @@ int main(int argc, char *argv[]) {
   }
 
   // ORT environment
-  Ort::Env env(ORT_LOGGING_LEVEL_ERROR, "hip-onnx-runner");
+  const int log_level_raw = mo.get<int>("log-level");
+  if (log_level_raw < 0 || log_level_raw > 4) {
+    std::cerr << "Error: --log-level must be 0..4, got: " << log_level_raw
+              << "\n";
+    return 1;
+  }
+  const auto ort_log_level =
+      static_cast<OrtLoggingLevel>(static_cast<unsigned>(log_level_raw));
+  Ort::Env env(ort_log_level, "hip-onnx-runner");
 
   const std::string kEpName = "hipgpu";
 #ifdef _WIN32
@@ -1018,7 +1038,7 @@ int main(int argc, char *argv[]) {
 
   // Session options
   Ort::SessionOptions session_opts;
-  session_opts.SetLogSeverityLevel(ORT_LOGGING_LEVEL_ERROR);
+  session_opts.SetLogSeverityLevel(log_level_raw);
   if (graph_optimization_level != -1) {
     std::cout << "Setting graph_optimization_level to "
               << graph_optimization_level << "\n";
@@ -1234,15 +1254,31 @@ int main(int argc, char *argv[]) {
     }
   }
 
+  // RunOptions config entries. The EP hands these to PassContext for the
+  // duration of each Run(), so passes and custom ops can read them by key.
+  Ort::RunOptions run_options;
+  for (const std::string &entry : mo.get_vector<std::string>("run-option")) {
+    const auto eq = entry.find('=');
+    if (eq == std::string::npos || eq == 0) {
+      std::cerr << "Error: --run-option expects 'key=value', got: " << entry
+                << "\n";
+      return 1;
+    }
+    const std::string key = trim_string(entry.substr(0, eq));
+    const std::string value = trim_string(entry.substr(eq + 1));
+    run_options.AddConfigEntry(key.c_str(), value.c_str());
+    std::cout << "Run option '" << key << "' -> '" << value << "'\n";
+  }
+
   // Run inference
   std::cout << "Running inference...\n";
   std::vector<Ort::Value> outputs;
   {
     auto t0 = std::chrono::steady_clock::now();
     try {
-      outputs = session->Run(Ort::RunOptions{}, input_names.data(),
-                             input_tensors.data(), input_count,
-                             output_names.data(), output_count);
+      outputs =
+          session->Run(run_options, input_names.data(), input_tensors.data(),
+                       input_count, output_names.data(), output_count);
       std::cout << "Inference: "
                 << static_cast<int64_t>(elapsed_since(t0) * 1e6) << " us\n";
       std::cout << "OK - " << outputs.size() << " output tensor(s)\n";


### PR DESCRIPTION
## Summary

`PassContext::get_run_option()` always returned the caller's default value, so anything a user set through `Ort::RunOptions::AddConfigEntry()` never reached passes or custom ops. This wires the plugin EP's per-run configuration through to `PassContext` and adds a unit test for the contract.

After this change:

```cpp
Ort::RunOptions run_options;
run_options.AddConfigEntry("your.key", "value");
session.Run(run_options, ...);
```

```cpp
// in a pass or custom op
auto v = context->get_run_option("your.key", "default");  // -> "value"
```

## Why

Both ends of the plumbing were missing: the plugin EP never implemented `OrtEp::OnRunStart`, and `get_run_option()` read a `std::function` member that no code ever assigned.

## What

- `MorphiZenEP::OnRunStartImpl` / `OnRunEndImpl` implement the ORT callback pair, routing the run's `OrtRunOptions` to morphizen-core through a new `set_run_option_accessor()` seam.
- New exported `morphizen_ep_on_run_end()` clears the accessor; `ort-bridge` cannot reach the internal seam directly.
- Removes the dead `get_run_options_` member, its `shared_mutex`, and the `friend` declaration that existed only to write it.
- `get_run_option()` logs each lookup under `HIP_EP_VERBOSE=1`, marking `(default)` on a miss. `OrtRunOptions` has no API to enumerate its entries, so instrumenting the lookup is the only way to see which options arrive.
- `hip-onnx-runner` gains `--run-option key=value` and `--log-level 0..4`. It previously passed a default-constructed `Ort::RunOptions{}` and hardcoded `ORT_LOGGING_LEVEL_ERROR`, at which every `LOG(INFO)` the EP emits is dropped — `LoggerAdapter` clears `FLAGS_logtostderr` and maps the ORT severity onto `FLAGS_minloglevel`, so `GLOG_logtostderr` has no effect either. Both flags are needed together to observe a run option at all.

## Test plan

- New `PassContextTest.GetRunOption` covers key present, key absent, and no accessor installed; passes.
- End-to-end on Windows/gfx1151 with a single-MatMul model: with a temporary probe in `MlirCustomOp::Compute()` reading a key, `--run-option k=v` produced the value in the custom op, and omitting the flag produced the caller's default. Both directions were checked because a miss and broken plumbing look identical. The probe was not kept — see below.
- `--run-option` rejects input without `=`, and `--log-level` rejects values outside 0..4.

## AI assistance

Implemented with Cursor (Claude Opus 5), including the concurrency analysis against the ORT plugin-EP headers and this description. All claims were validated by the builds and runs listed above; the author reviewed the diff and owns the design decisions.
