### PR TITLE
build(morphizen): install the EP DLL's PDB on Windows

### DIFF
--- a/morphizen/morphizen-core/cmake/install.cmake
+++ b/morphizen/morphizen-core/cmake/install.cmake
@@ -17,6 +17,15 @@ install(
  RUNTIME DESTINATION bin
  ARCHIVE DESTINATION lib
  LIBRARY DESTINATION lib)
+if(MSVC)
+  # install(TARGETS) does not cover the linker PDB, so an installed EP DLL used
+  # outside this build tree has no symbols. The EP is loaded into a host process
+  # (onnxruntime, or the AMDGPU umbrella EP), which is exactly where a crash has
+  # to be symbolized from the install prefix alone. OPTIONAL keeps this working
+  # for a configuration that emits no PDB.
+  install(FILES $<TARGET_PDB_FILE:${morphizen_CORE_DYNAMIC_UNIQUE_ID}>
+          DESTINATION bin OPTIONAL)
+endif()
 # install(
 #  EXPORT morphizen-core-targets
 #  NAMESPACE ${PROJECT_NAME}::


### PR DESCRIPTION
## Summary

`cmake --install` left the install prefix with a `hipgpu.dll` and no matching symbols, because `install(TARGETS)` does not cover the linker PDB. This installs the EP DLL's PDB alongside it on Windows.

## Why

The EP DLL is loaded into a host process — onnxruntime, or the AMDGPU umbrella EP — which is exactly the case that has to be symbolized from the install prefix alone, without the build tree next to it.

Worse than having no PDB: any PDB copied into the prefix by hand went stale on the next install, and a debugger still resolves it by name and then reports mismatched frames. That is what prompted this change.

Scoped to this one target on purpose. The tools (`hip-compiler`, `hip-mlir-opt`, ...) run from the build tree in practice, where the path embedded in the binary already resolves, and their PDBs would add ~700 MB to the prefix. `OPTIONAL` keeps the rule working for a configuration that emits no PDB.

## Test plan

On Windows, `RelWithDebInfo`:

- Generated rule appears in `cmake_install.cmake`:
  `file(INSTALL DESTINATION "${CMAKE_INSTALL_PREFIX}/bin" TYPE FILE OPTIONAL FILES ".../bin/hipgpu.pdb")`
- Deleted the installed PDB and re-ran `cmake --install`; it reported `-- Installing: .../bin/hipgpu.pdb` and restored the file, and `install_manifest.txt` now lists it.
- `dumpbin /pdbpath:verbose hipgpu.dll` in the install prefix resolves to the local PDB. As a control, a binary whose PDB is not installed reports `(File not found)` for the local path and falls back to the build tree, confirming the lookup validates rather than matching on name alone.
- `pre-commit run` passes.

Not exercised on Linux: the rule is inside `if(MSVC)`, and ELF builds carry their debug info in the binary.

## AI assistance

Written with Cursor (Claude Opus 5), including the verification above. The author reviewed the change and owns it.
