### PR TITLE
fix(onnx-to-hip): pack high-rank onnx.Clip and onnx.Relu to 4-D

### DIFF
--- a/lib/Conversion/OnnxToHip/PackBroadcastTo4D.cpp
+++ b/lib/Conversion/OnnxToHip/PackBroadcastTo4D.cpp
@@ -261,11 +261,15 @@ struct PackBroadcastPattern : public RewritePattern {
       return failure();
 
     // A pass-through operand that carried shape would silently disagree with
-    // the packed result, so only scalars and `none` may ride along.
+    // the packed result, so only scalars and `none` may ride along. This is a
+    // whitelist on purpose: an unranked operand carries no rank to check, so
+    // rejecting merely the ranked-and-non-scalar case would let it through.
     OperandRange trailing = op->getOperands().drop_front(numDataOperands);
     for (Value extra : trailing) {
+      if (isa<NoneType>(extra.getType()))
+        continue;
       auto extraType = dyn_cast<RankedTensorType>(extra.getType());
-      if (extraType && extraType.getRank() != 0)
+      if (!extraType || extraType.getRank() != 0)
         return failure();
     }
 

--- a/lib/Conversion/OnnxToHip/PackBroadcastTo4D.cpp
+++ b/lib/Conversion/OnnxToHip/PackBroadcastTo4D.cpp
@@ -16,7 +16,8 @@
 // but both expand into hip.max/hip.min during conversion and so hit the same
 // rank-4 ceiling in the elementwise ABI; their broadcast lives entirely on the
 // first operand, and Clip's optional min/max bounds are scalars that are
-// forwarded unchanged.
+// forwarded unchanged. A Clip supplying neither bound is an identity and is
+// left alone.
 //
 // Before:
 //   %r = "onnx.Add"(%a, %b) : (...) -> tensor<6x2500x8x1x2x4x2xf32>
@@ -265,19 +266,20 @@ struct PackBroadcastPattern : public RewritePattern {
     // whitelist on purpose: an unranked operand carries no rank to check, so
     // rejecting merely the ranked-and-non-scalar case would let it through.
     OperandRange trailing = op->getOperands().drop_front(numDataOperands);
+    bool anyTrailingPresent = false;
     for (Value extra : trailing) {
       if (isa<NoneType>(extra.getType()))
         continue;
       auto extraType = dyn_cast<RankedTensorType>(extra.getType());
       if (!extraType || extraType.getRank() != 0)
         return failure();
+      anyTrailingPresent = true;
     }
 
     // An op whose optional operands are all absent is an identity: onnx.Clip
     // with neither bound does nothing, so packing it would churn reshapes and
     // inflate the statistic for no gain.
-    auto isAbsent = [](Value v) { return isa<NoneType>(v.getType()); };
-    if (maxOperands > numDataOperands && llvm::all_of(trailing, isAbsent))
+    if (maxOperands > numDataOperands && !anyTrailingPresent)
       return failure();
 
     SmallVector<Value> dataOperands(
@@ -289,7 +291,7 @@ struct PackBroadcastPattern : public RewritePattern {
 
     OperationState state(op->getLoc(), op->getName().getStringRef());
     state.addOperands(packing->operands);
-    state.addOperands(op->getOperands().drop_front(numDataOperands));
+    state.addOperands(trailing);
     state.addTypes(packing->packedResultType);
     state.addAttributes(op->getAttrs());
     Operation *packedOp = rewriter.create(state);

--- a/lib/Conversion/OnnxToHip/PackBroadcastTo4D.cpp
+++ b/lib/Conversion/OnnxToHip/PackBroadcastTo4D.cpp
@@ -262,11 +262,19 @@ struct PackBroadcastPattern : public RewritePattern {
 
     // A pass-through operand that carried shape would silently disagree with
     // the packed result, so only scalars and `none` may ride along.
-    for (Value extra : op->getOperands().drop_front(numDataOperands)) {
+    OperandRange trailing = op->getOperands().drop_front(numDataOperands);
+    for (Value extra : trailing) {
       auto extraType = dyn_cast<RankedTensorType>(extra.getType());
       if (extraType && extraType.getRank() != 0)
         return failure();
     }
+
+    // An op whose optional operands are all absent is an identity: onnx.Clip
+    // with neither bound does nothing, so packing it would churn reshapes and
+    // inflate the statistic for no gain.
+    auto isAbsent = [](Value v) { return isa<NoneType>(v.getType()); };
+    if (maxOperands > numDataOperands && llvm::all_of(trailing, isAbsent))
+      return failure();
 
     SmallVector<Value> dataOperands(
         op->getOperands().take_front(numDataOperands));

--- a/lib/Conversion/OnnxToHip/PackBroadcastTo4D.cpp
+++ b/lib/Conversion/OnnxToHip/PackBroadcastTo4D.cpp
@@ -12,6 +12,12 @@
 // form is matched; variadic onnx.Max/onnx.Min (three or more inputs) are left
 // unchanged.
 //
+// onnx.Clip and onnx.Relu are packed the same way. They are not broadcasts,
+// but both expand into hip.max/hip.min during conversion and so hit the same
+// rank-4 ceiling in the elementwise ABI; their broadcast lives entirely on the
+// first operand, and Clip's optional min/max bounds are scalars that are
+// forwarded unchanged.
+//
 // Before:
 //   %r = "onnx.Add"(%a, %b) : (...) -> tensor<6x2500x8x1x2x4x2xf32>
 //
@@ -51,8 +57,7 @@ namespace hip {
 namespace {
 
 struct PackedBroadcast {
-  Value lhs;
-  Value rhs;
+  SmallVector<Value> operands;
   RankedTensorType packedResultType;
   RankedTensorType originalResultType;
   SmallVector<ReassociationIndices> reassociation;
@@ -116,45 +121,54 @@ collapseTensor(OpBuilder &builder, Location loc, Value value,
 }
 
 static FailureOr<PackedBroadcast> packBroadcast(OpBuilder &builder,
-                                                Location loc, Value lhs,
-                                                Value rhs,
+                                                Location loc,
+                                                ArrayRef<Value> dataOperands,
                                                 RankedTensorType resultType) {
   int64_t rank = resultType.getRank();
   if (rank <= 4 || !resultType.hasStaticShape())
     return failure();
-
-  auto lhsType = dyn_cast<RankedTensorType>(lhs.getType());
-  auto rhsType = dyn_cast<RankedTensorType>(rhs.getType());
-  if (!lhsType || !rhsType || !lhsType.hasStaticShape() ||
-      !rhsType.hasStaticShape() || lhsType.getRank() > rank ||
-      rhsType.getRank() > rank)
+  if (dataOperands.empty())
     return failure();
 
-  SmallVector<int64_t> lhsShape(rank, 1);
-  SmallVector<int64_t> rhsShape(rank, 1);
-  llvm::copy(lhsType.getShape(), lhsShape.begin() + rank - lhsType.getRank());
-  llvm::copy(rhsType.getShape(), rhsShape.begin() + rank - rhsType.getRank());
+  // Right-align every operand against the result rank so the broadcast checks
+  // below can compare them axis by axis.
+  SmallVector<SmallVector<int64_t>> operandShapes;
+  for (Value operand : dataOperands) {
+    auto type = dyn_cast<RankedTensorType>(operand.getType());
+    if (!type || !type.hasStaticShape() || type.getRank() > rank)
+      return failure();
+    SmallVector<int64_t> shape(rank, 1);
+    llvm::copy(type.getShape(), shape.begin() + rank - type.getRank());
+    operandShapes.push_back(std::move(shape));
+  }
   ArrayRef<int64_t> outShape = resultType.getShape();
 
   for (int64_t dim : llvm::seq<int64_t>(rank)) {
-    if ((lhsShape[dim] != 1 && lhsShape[dim] != outShape[dim]) ||
-        (rhsShape[dim] != 1 && rhsShape[dim] != outShape[dim]) ||
-        (outShape[dim] != lhsShape[dim] && outShape[dim] != rhsShape[dim]))
+    bool someOperandCoversOut = false;
+    for (const SmallVector<int64_t> &shape : operandShapes) {
+      if (shape[dim] != 1 && shape[dim] != outShape[dim])
+        return failure();
+      if (shape[dim] == outShape[dim])
+        someOperandCoversOut = true;
+    }
+    if (!someOperandCoversOut)
       return failure();
   }
 
   auto groupIsSafe = [&](int64_t begin, int64_t end) {
-    int64_t lhsProduct = 1;
-    int64_t rhsProduct = 1;
     int64_t outProduct = 1;
-    for (int64_t axis = begin; axis < end; ++axis) {
-      if (!multiplyDim(lhsProduct, lhsShape[axis]) ||
-          !multiplyDim(rhsProduct, rhsShape[axis]) ||
-          !multiplyDim(outProduct, outShape[axis]))
+    for (int64_t axis = begin; axis < end; ++axis)
+      if (!multiplyDim(outProduct, outShape[axis]))
+        return false;
+    for (const SmallVector<int64_t> &shape : operandShapes) {
+      int64_t product = 1;
+      for (int64_t axis = begin; axis < end; ++axis)
+        if (!multiplyDim(product, shape[axis]))
+          return false;
+      if (product != 1 && product != outProduct)
         return false;
     }
-    return (lhsProduct == 1 || lhsProduct == outProduct) &&
-           (rhsProduct == 1 || rhsProduct == outProduct);
+    return true;
   };
 
   SmallVector<ReassociationIndices> chosen;
@@ -202,10 +216,13 @@ static FailureOr<PackedBroadcast> packBroadcast(OpBuilder &builder,
     return collapseTensor(builder, loc, *aligned, chosen);
   };
 
-  FailureOr<Value> packedLhs = packOperand(lhs);
-  FailureOr<Value> packedRhs = packOperand(rhs);
-  if (failed(packedLhs) || failed(packedRhs))
-    return failure();
+  SmallVector<Value> packedOperands;
+  for (Value operand : dataOperands) {
+    FailureOr<Value> packed = packOperand(operand);
+    if (failed(packed))
+      return failure();
+    packedOperands.push_back(*packed);
+  }
 
   SmallVector<int64_t> packedResultShape;
   for (const ReassociationIndices &group : chosen) {
@@ -217,30 +234,45 @@ static FailureOr<PackedBroadcast> packBroadcast(OpBuilder &builder,
   }
   auto packedResultType = RankedTensorType::get(
       packedResultShape, resultType.getElementType(), resultType.getEncoding());
-  return PackedBroadcast{*packedLhs, *packedRhs, packedResultType, resultType,
-                         std::move(chosen)};
+  return PackedBroadcast{std::move(packedOperands), packedResultType,
+                         resultType, std::move(chosen)};
 }
 
 struct PackBroadcastPattern : public RewritePattern {
-  PackBroadcastPattern(StringRef opName, MLIRContext *ctx)
-      : RewritePattern(opName, /*benefit=*/1, ctx) {}
+  // The first `numDataOperands` operands carry the broadcast and get packed.
+  // Anything after them -- onnx.Clip's optional min/max -- rides along
+  // unchanged, so it must be a rank-0 tensor or `none`.
+  PackBroadcastPattern(StringRef opName, MLIRContext *ctx,
+                       unsigned numDataOperands)
+      : RewritePattern(opName, /*benefit=*/1, ctx),
+        numDataOperands(numDataOperands) {}
 
   LogicalResult matchAndRewrite(Operation *op,
                                 PatternRewriter &rewriter) const override {
-    if (op->getNumOperands() != 2 || op->getNumResults() != 1)
+    if (op->getNumOperands() < numDataOperands || op->getNumResults() != 1)
       return failure();
     auto resultType = dyn_cast<RankedTensorType>(op->getResult(0).getType());
     if (!resultType || resultType.getRank() <= 4)
       return failure();
 
+    // A pass-through operand that carried shape would silently disagree with
+    // the packed result, so only scalars and `none` may ride along.
+    for (Value extra : op->getOperands().drop_front(numDataOperands)) {
+      auto extraType = dyn_cast<RankedTensorType>(extra.getType());
+      if (extraType && extraType.getRank() != 0)
+        return failure();
+    }
+
+    SmallVector<Value> dataOperands(
+        op->getOperands().take_front(numDataOperands));
     FailureOr<PackedBroadcast> packing =
-        packBroadcast(rewriter, op->getLoc(), op->getOperand(0),
-                      op->getOperand(1), resultType);
+        packBroadcast(rewriter, op->getLoc(), dataOperands, resultType);
     if (failed(packing))
       return failure();
 
     OperationState state(op->getLoc(), op->getName().getStringRef());
-    state.addOperands({packing->lhs, packing->rhs});
+    state.addOperands(packing->operands);
+    state.addOperands(op->getOperands().drop_front(numDataOperands));
     state.addTypes(packing->packedResultType);
     state.addAttributes(op->getAttrs());
     Operation *packedOp = rewriter.create(state);
@@ -257,6 +289,9 @@ struct PackBroadcastPattern : public RewritePattern {
     ++NumBroadcastsPacked;
     return success();
   }
+
+private:
+  unsigned numDataOperands;
 };
 
 } // namespace
@@ -266,7 +301,12 @@ void populatePackBroadcastTo4DPatterns(RewritePatternSet &patterns,
   for (StringRef opName :
        {"onnx.Add", "onnx.Sub", "onnx.Mul", "onnx.Div", "onnx.Less",
         "onnx.Greater", "onnx.Max", "onnx.Min", "onnx.And"})
-    patterns.add<PackBroadcastPattern>(opName, ctx);
+    patterns.add<PackBroadcastPattern>(opName, ctx, /*numDataOperands=*/2);
+  // hip.max and hip.min are also produced by onnx.Clip and onnx.Relu, which
+  // carry the whole broadcast on their first operand; Clip's min/max bounds
+  // are scalars that pack through untouched.
+  for (StringRef opName : {"onnx.Clip", "onnx.Relu"})
+    patterns.add<PackBroadcastPattern>(opName, ctx, /*numDataOperands=*/1);
 }
 
 } // namespace hip

--- a/lib/Conversion/OnnxToHip/PackBroadcastTo4D.cpp
+++ b/lib/Conversion/OnnxToHip/PackBroadcastTo4D.cpp
@@ -240,16 +240,21 @@ static FailureOr<PackedBroadcast> packBroadcast(OpBuilder &builder,
 
 struct PackBroadcastPattern : public RewritePattern {
   // The first `numDataOperands` operands carry the broadcast and get packed.
-  // Anything after them -- onnx.Clip's optional min/max -- rides along
-  // unchanged, so it must be a rank-0 tensor or `none`.
+  // `maxOperands` bounds the total operand count; it exceeds
+  // `numDataOperands` only for onnx.Clip, whose optional min/max bounds ride
+  // along unchanged and so must be rank-0 tensors or `none`. Every other op
+  // is matched at an exact count, which keeps variadic onnx.Max/onnx.Min out
+  // of the pattern.
   PackBroadcastPattern(StringRef opName, MLIRContext *ctx,
-                       unsigned numDataOperands)
+                       unsigned numDataOperands, unsigned maxOperands)
       : RewritePattern(opName, /*benefit=*/1, ctx),
-        numDataOperands(numDataOperands) {}
+        numDataOperands(numDataOperands), maxOperands(maxOperands) {}
 
   LogicalResult matchAndRewrite(Operation *op,
                                 PatternRewriter &rewriter) const override {
-    if (op->getNumOperands() < numDataOperands || op->getNumResults() != 1)
+    unsigned numOperands = op->getNumOperands();
+    if (numOperands < numDataOperands || numOperands > maxOperands ||
+        op->getNumResults() != 1)
       return failure();
     auto resultType = dyn_cast<RankedTensorType>(op->getResult(0).getType());
     if (!resultType || resultType.getRank() <= 4)
@@ -292,6 +297,7 @@ struct PackBroadcastPattern : public RewritePattern {
 
 private:
   unsigned numDataOperands;
+  unsigned maxOperands;
 };
 
 } // namespace
@@ -301,12 +307,15 @@ void populatePackBroadcastTo4DPatterns(RewritePatternSet &patterns,
   for (StringRef opName :
        {"onnx.Add", "onnx.Sub", "onnx.Mul", "onnx.Div", "onnx.Less",
         "onnx.Greater", "onnx.Max", "onnx.Min", "onnx.And"})
-    patterns.add<PackBroadcastPattern>(opName, ctx, /*numDataOperands=*/2);
+    patterns.add<PackBroadcastPattern>(opName, ctx, /*numDataOperands=*/2,
+                                       /*maxOperands=*/2);
   // hip.max and hip.min are also produced by onnx.Clip and onnx.Relu, which
   // carry the whole broadcast on their first operand; Clip's min/max bounds
   // are scalars that pack through untouched.
-  for (StringRef opName : {"onnx.Clip", "onnx.Relu"})
-    patterns.add<PackBroadcastPattern>(opName, ctx, /*numDataOperands=*/1);
+  patterns.add<PackBroadcastPattern>("onnx.Relu", ctx, /*numDataOperands=*/1,
+                                     /*maxOperands=*/1);
+  patterns.add<PackBroadcastPattern>("onnx.Clip", ctx, /*numDataOperands=*/1,
+                                     /*maxOperands=*/3);
 }
 
 } // namespace hip

--- a/test/lit/Conversion/onnx-to-hip/test_clip.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_clip.mlir
@@ -61,6 +61,21 @@ module {
   // CHECK: hip.max(%[[CTX5]]) ins({{.*}}, {{.*}} : tensor<4x1x6x2500xf32>, tensor<f32>) outs({{.*}} : tensor<4x1x6x2500xf32>)
   // CHECK: tensor.expand_shape {{.*}} {{\[\[}}0], [1], [2], [3, 4]] output_shape [4, 1, 6, 2500, 1] : tensor<4x1x6x2500xf32> into tensor<4x1x6x2500x1xf32>
 
+  // A rank-5 Clip with both bounds absent is an identity, so it is left alone
+  // rather than packed: there is no hip.max/hip.min to keep under the ceiling.
+  func.func @clip_5d_no_bounds(%x: tensor<4x1x6x2500x1xf32>) -> tensor<4x1x6x2500x1xf32> {
+    %n1 = "onnx.NoValue"() {value} : () -> none
+    %n2 = "onnx.NoValue"() {value} : () -> none
+    %y = "onnx.Clip"(%x, %n1, %n2) : (tensor<4x1x6x2500x1xf32>, none, none) -> tensor<4x1x6x2500x1xf32>
+    return %y : tensor<4x1x6x2500x1xf32>
+  }
+
+  // CHECK-LABEL: func.func @clip_5d_no_bounds
+  // CHECK-SAME: (%[[CTXN:.*]]: !hip.context, %[[XN:.*]]: tensor<4x1x6x2500x1xf32>)
+  // CHECK-NOT: tensor.collapse_shape
+  // CHECK-NOT: hip.max
+  // CHECK: return %[[XN]] : tensor<4x1x6x2500x1xf32>
+
   // Rank-5 relu: same ceiling, reached through hip.max(x, 0).
   func.func @relu_5d(%x: tensor<4x1x6x2500x1xf32>) -> tensor<4x1x6x2500x1xf32> {
     %y = "onnx.Relu"(%x) : (tensor<4x1x6x2500x1xf32>) -> tensor<4x1x6x2500x1xf32>

--- a/test/lit/Conversion/onnx-to-hip/test_clip.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_clip.mlir
@@ -61,6 +61,45 @@ module {
   // CHECK: hip.max(%[[CTX5]]) ins({{.*}}, {{.*}} : tensor<4x1x6x2500xf32>, tensor<f32>) outs({{.*}} : tensor<4x1x6x2500xf32>)
   // CHECK: tensor.expand_shape {{.*}} {{\[\[}}0], [1], [2], [3, 4]] output_shape [4, 1, 6, 2500, 1] : tensor<4x1x6x2500xf32> into tensor<4x1x6x2500x1xf32>
 
+  // Two-operand spelling: the upper bound is omitted rather than passed as
+  // `none`. The trailing-operand walk sees a shorter range, not a `none`.
+  func.func @clip_5d_two_operand_form(%x: tensor<4x1x6x2500x1xf32>, %lo: tensor<f32>)
+      -> tensor<4x1x6x2500x1xf32> {
+    %y = "onnx.Clip"(%x, %lo) : (tensor<4x1x6x2500x1xf32>, tensor<f32>) -> tensor<4x1x6x2500x1xf32>
+    return %y : tensor<4x1x6x2500x1xf32>
+  }
+
+  // CHECK-LABEL: func.func @clip_5d_two_operand_form
+  // CHECK: tensor.collapse_shape {{.*}} : tensor<4x1x6x2500x1xf32> into tensor<4x1x6x2500xf32>
+  // CHECK: hip.max({{.*}}) ins({{.*}}, {{.*}} : tensor<4x1x6x2500xf32>, tensor<f32>)
+
+  // Only the upper bound is supplied, so the present bound is the second
+  // trailing operand rather than the first.
+  func.func @clip_5d_upper_bound_only(%x: tensor<4x1x6x2500x1xf32>, %hi: tensor<f32>)
+      -> tensor<4x1x6x2500x1xf32> {
+    %n = "onnx.NoValue"() {value} : () -> none
+    %y = "onnx.Clip"(%x, %n, %hi) : (tensor<4x1x6x2500x1xf32>, none, tensor<f32>) -> tensor<4x1x6x2500x1xf32>
+    return %y : tensor<4x1x6x2500x1xf32>
+  }
+
+  // CHECK-LABEL: func.func @clip_5d_upper_bound_only
+  // CHECK: tensor.collapse_shape {{.*}} : tensor<4x1x6x2500x1xf32> into tensor<4x1x6x2500xf32>
+  // CHECK: hip.min({{.*}}) ins({{.*}}, {{.*}} : tensor<4x1x6x2500xf32>, tensor<f32>)
+
+  // A bound that is a rank-1 single-element tensor rather than a rank-0 scalar
+  // is not packed: it is forwarded unchanged, so it must not carry a shape.
+  // Documented limitation, pinned here so the behavior is deliberate.
+  func.func @clip_5d_rank1_bound(%x: tensor<4x1x6x2500x1xf32>, %lo: tensor<1xf32>)
+      -> tensor<4x1x6x2500x1xf32> {
+    %n = "onnx.NoValue"() {value} : () -> none
+    %y = "onnx.Clip"(%x, %lo, %n) : (tensor<4x1x6x2500x1xf32>, tensor<1xf32>, none) -> tensor<4x1x6x2500x1xf32>
+    return %y : tensor<4x1x6x2500x1xf32>
+  }
+
+  // CHECK-LABEL: func.func @clip_5d_rank1_bound
+  // CHECK-NOT: tensor.collapse_shape
+  // CHECK: hip.max({{.*}}) ins({{.*}}, {{.*}} : tensor<4x1x6x2500x1xf32>, tensor<1xf32>)
+
   // A rank-5 Clip with both bounds absent is an identity, so it is left alone
   // rather than packed: there is no hip.max/hip.min to keep under the ceiling.
   func.func @clip_5d_no_bounds(%x: tensor<4x1x6x2500x1xf32>) -> tensor<4x1x6x2500x1xf32> {

--- a/test/lit/Conversion/onnx-to-hip/test_clip.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_clip.mlir
@@ -43,4 +43,33 @@ module {
   // CHECK-NOT: onnx.Clip
   // CHECK: hip.max
   // CHECK: hip.min
+
+  // Rank-5 input, packed to the 4-D path before the max/min decomposition.
+  // The scalar bounds are forwarded unchanged. Shape taken from bevformer's
+  // Clip_1113, which the elementwise ABI rejects above rank 4.
+  func.func @clip_5d_scalar_bounds(%x: tensor<4x1x6x2500x1xf32>, %lo: tensor<f32>)
+      -> tensor<4x1x6x2500x1xf32> {
+    %none = "onnx.NoValue"() {value} : () -> none
+    %y = "onnx.Clip"(%x, %lo, %none) : (tensor<4x1x6x2500x1xf32>, tensor<f32>, none) -> tensor<4x1x6x2500x1xf32>
+    return %y : tensor<4x1x6x2500x1xf32>
+  }
+
+  // CHECK-LABEL: func.func @clip_5d_scalar_bounds
+  // CHECK-SAME: (%[[CTX5:.*]]: !hip.context, %[[X5:.*]]: tensor<4x1x6x2500x1xf32>, %[[LO5:.*]]: tensor<f32>)
+  // CHECK-NOT: onnx.Clip
+  // CHECK: tensor.collapse_shape {{.*}} {{\[\[}}0], [1], [2], [3, 4]] : tensor<4x1x6x2500x1xf32> into tensor<4x1x6x2500xf32>
+  // CHECK: hip.max(%[[CTX5]]) ins({{.*}}, {{.*}} : tensor<4x1x6x2500xf32>, tensor<f32>) outs({{.*}} : tensor<4x1x6x2500xf32>)
+  // CHECK: tensor.expand_shape {{.*}} {{\[\[}}0], [1], [2], [3, 4]] output_shape [4, 1, 6, 2500, 1] : tensor<4x1x6x2500xf32> into tensor<4x1x6x2500x1xf32>
+
+  // Rank-5 relu: same ceiling, reached through hip.max(x, 0).
+  func.func @relu_5d(%x: tensor<4x1x6x2500x1xf32>) -> tensor<4x1x6x2500x1xf32> {
+    %y = "onnx.Relu"(%x) : (tensor<4x1x6x2500x1xf32>) -> tensor<4x1x6x2500x1xf32>
+    return %y : tensor<4x1x6x2500x1xf32>
+  }
+
+  // CHECK-LABEL: func.func @relu_5d
+  // CHECK-NOT: onnx.Relu
+  // CHECK: tensor.collapse_shape {{.*}} {{\[\[}}0], [1], [2], [3, 4]] : tensor<4x1x6x2500x1xf32> into tensor<4x1x6x2500xf32>
+  // CHECK: hip.max
+  // CHECK: tensor.expand_shape {{.*}} {{\[\[}}0], [1], [2], [3, 4]] output_shape [4, 1, 6, 2500, 1] : tensor<4x1x6x2500xf32> into tensor<4x1x6x2500x1xf32>
 }

--- a/test/lit/Conversion/onnx-to-hip/test_clip_invalid.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_clip_invalid.mlir
@@ -1,0 +1,34 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify a high-rank onnx.Clip whose bound is not a scalar is diagnosed rather
+// than rewritten. PackBroadcastTo4D forwards Clip's min/max bounds unchanged
+// while packing the data operand, so it only accepts a bound that is `none` or
+// a rank-0 tensor. An unranked bound carries no rank to check, so the guard is
+// written as a whitelist; otherwise it would be packed and the bound spliced
+// into a rank-4 hip.max.
+//
+// This file uses `--verify-diagnostics` (not FileCheck) -- the conversion is
+// expected to fail. Sister file `test_clip.mlir` covers the happy paths,
+// including the rank-5 Clip that this pass exists to make legal.
+// ============================================================================
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip --split-input-file --verify-diagnostics %s
+
+module {
+  func.func @main_graph(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+    return %arg0 : tensor<4xf32>
+  }
+
+  // An unranked bound is unsupported by the elementwise ops either way; what
+  // matters is that it is reported instead of silently packed.
+  func.func @clip_5d_unranked_bound(%x: tensor<2x3x4x5x6xf32>, %lo: tensor<*xf32>)
+      -> tensor<2x3x4x5x6xf32> {
+    %n = "onnx.NoValue"() {value} : () -> none
+    // expected-error @+1 {{'hip.max' op operand #2 must be ranked tensor or memref, but got 'tensor<*xf32>'}}
+    %y = "onnx.Clip"(%x, %lo, %n) : (tensor<2x3x4x5x6xf32>, tensor<*xf32>, none) -> tensor<2x3x4x5x6xf32>
+    return %y : tensor<2x3x4x5x6xf32>
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_clip_invalid.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_clip_invalid.mlir
@@ -27,7 +27,9 @@ module {
   func.func @clip_5d_unranked_bound(%x: tensor<2x3x4x5x6xf32>, %lo: tensor<*xf32>)
       -> tensor<2x3x4x5x6xf32> {
     %n = "onnx.NoValue"() {value} : () -> none
-    // expected-error @+1 {{'hip.max' op operand #2 must be ranked tensor or memref, but got 'tensor<*xf32>'}}
+    // Matching only the stable prefix: the trailing "but got ..." text is
+    // formatted by MLIR and can change between versions.
+    // expected-error @+1 {{'hip.max' op operand #2 must be ranked tensor or memref}}
     %y = "onnx.Clip"(%x, %lo, %n) : (tensor<2x3x4x5x6xf32>, tensor<*xf32>, none) -> tensor<2x3x4x5x6xf32>
     return %y : tensor<2x3x4x5x6xf32>
   }

--- a/test/lit/Conversion/onnx-to-hip/test_max.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_max.mlir
@@ -78,4 +78,15 @@ module {
     %r = "onnx.Max"(%a, %b) : (tensor<4x1x6x8x1xf32>, tensor<f32>) -> tensor<4x1x6x8x1xf32>
     return %r : tensor<4x1x6x8x1xf32>
   }
+
+  // --- Case 6: only the two-operand form is packed. A variadic rank-5 max is
+  // left at full rank even when every extra input is a scalar. ---
+  func.func @max_5d_variadic(%a: tensor<4x1x6x8x1xf32>, %b: tensor<f32>, %c: tensor<f32>)
+      -> tensor<4x1x6x8x1xf32> {
+    // CHECK-LABEL: func.func @max_5d_variadic
+    // CHECK-NOT: tensor.collapse_shape
+    // CHECK: hip.max({{.*}}) ins({{.*}}, {{.*}} : tensor<4x1x6x8x1xf32>, tensor<f32>) outs({{.*}} : tensor<4x1x6x8x1xf32>)
+    %r = "onnx.Max"(%a, %b, %c) : (tensor<4x1x6x8x1xf32>, tensor<f32>, tensor<f32>) -> tensor<4x1x6x8x1xf32>
+    return %r : tensor<4x1x6x8x1xf32>
+  }
 }

--- a/test/lit/Conversion/onnx-to-hip/test_max.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_max.mlir
@@ -83,9 +83,13 @@ module {
   // left at full rank even when every extra input is a scalar. ---
   func.func @max_5d_variadic(%a: tensor<4x1x6x8x1xf32>, %b: tensor<f32>, %c: tensor<f32>)
       -> tensor<4x1x6x8x1xf32> {
+    // Both chained maxes are checked so that dropping the third input during
+    // lowering fails here rather than silently changing results.
     // CHECK-LABEL: func.func @max_5d_variadic
+    // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[A:.*]]: tensor<4x1x6x8x1xf32>, %[[B:.*]]: tensor<f32>, %[[C:.*]]: tensor<f32>)
     // CHECK-NOT: tensor.collapse_shape
-    // CHECK: hip.max({{.*}}) ins({{.*}}, {{.*}} : tensor<4x1x6x8x1xf32>, tensor<f32>) outs({{.*}} : tensor<4x1x6x8x1xf32>)
+    // CHECK: %[[M1:.*]] = hip.max(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<4x1x6x8x1xf32>, tensor<f32>) outs({{.*}} : tensor<4x1x6x8x1xf32>)
+    // CHECK: hip.max(%[[CTX]]) ins(%[[M1]], %[[C]] : tensor<4x1x6x8x1xf32>, tensor<f32>) outs({{.*}} : tensor<4x1x6x8x1xf32>)
     %r = "onnx.Max"(%a, %b, %c) : (tensor<4x1x6x8x1xf32>, tensor<f32>, tensor<f32>) -> tensor<4x1x6x8x1xf32>
     return %r : tensor<4x1x6x8x1xf32>
   }


### PR DESCRIPTION
## Summary

`PackBroadcastTo4D` did not cover `onnx.Clip` or `onnx.Relu`, so a high-rank Clip reached `HipToLLVM` at full rank and failed to compile. `bevformer-tiny-temporal-sim` now compiles and runs end-to-end; before this change it aborted with `failed to legalize operation 'hip.max' that was explicitly marked illegal`.

## Related issue or design

Follow-up to #847, which introduced the pass for the binary elementwise ops. None otherwise.

## Why

`ElementwiseLowering` rejects rank > 4 because of the 4-D shape-passing ABI, and `PackBroadcastTo4D` exists to keep high-rank elementwise ops under that ceiling. `onnx.Clip` and `onnx.Relu` are not broadcasts, so they were not in the pass's op list, but both expand into `hip.max`/`hip.min` during conversion and therefore hit the same ABI limit. In `bevformer-tiny-temporal-sim`, `Clip_1113` operates on `tensor<4x1x6x2500x1xf32>`; it is the only rank-5 Clip out of 93 in the model.

Adding `"onnx.Clip"` to the existing op list was not sufficient. Clip is ternary, and `PackBroadcastPattern` opened with `op->getNumOperands() != 2`, so Clip would have been registered and then rejected on every match.

## What

- Generalize `PackBroadcastPattern` with a `numDataOperands` count. The leading operands carry the broadcast and are packed; trailing operands are forwarded unchanged.
- Bound the total operand count with `maxOperands`. It exceeds `numDataOperands` only for `onnx.Clip` (1..3); the nine binary ops match at exactly 2 and `onnx.Relu` at exactly 1, which keeps variadic `onnx.Max`/`onnx.Min` out of the pattern.
- Whitelist the pass-through operand types: an operand must be `none` or a rank-0 tensor. A blacklist would let an unranked bound through, since it has no rank to check.
- Skip the rewrite when an op's optional operands are all absent. A Clip with neither bound is an identity, and packing it did no useful work.
- Change `packBroadcast` to take an `ArrayRef<Value>` and run the per-axis broadcast check and the group-safety check across all operands instead of a fixed `lhs`/`rhs` pair.

`onnx.Relu` is included because `ReluConversion` also expands to `hip.max`, so a rank-5 Relu fails identically. bevformer's 96 Relus are all rank ≤ 4, so it is not triggering today, but it is the same exposure and the generalized pattern covers it.

Packing is exact for these two ops: both are elementwise and shape-preserving, `expand_shape` reuses the `collapse_shape` reassociation, and max/min do not accumulate, so no floating-point reassociation is introduced. Unlike the binary ops, the group-safety analysis can never reject them — with one shaped operand whose shape equals the result, every candidate group trivially satisfies `product == outProduct`.

## Test plan

- Full lit suite: 469 passed, 12 unsupported, 0 failures. The refactor touches the shared path for all nine binary ops, so the existing `test_max.mlir` / `test_add.mlir` coverage passing is the signal that the binary behavior is unchanged.
- `test_clip.mlir`: rank-5 Clip with scalar bounds (bevformer's shape), rank-5 Relu, the two-operand spelling with the upper bound omitted, the upper-bound-only spelling, the rank-1 bound left unpacked, and the bounds-less identity left unpacked.
- `test_max.mlir`: rank-5 variadic Max left unpacked, checking both chained `hip.max` ops so a dropped third input fails the test.
- `test_clip_invalid.mlir`: `--verify-diagnostics` for an unranked bound.
- `hip-onnx-runner -m bevformer-tiny-temporal-sim/model.onnx`: session created in ~8 s, inference completed, 3 output tensors, exit 0. Previously failed to compile.
- Numerics vs CPU reference on bevformer with identical seeded inputs: relative L2 of 3.13e-03, 6.61e-04, 6.71e-04 across the three outputs, consistent with ordinary fp32 GPU drift across the attention and matmul stack.
- Corner-case matrix run by hand over 15 shapes and operand spellings — rank 5 through rank 8, zero-sized dimension, all-ones shape, `i1` result via `onnx.Less`, f16, rank-mismatched broadcast, dynamic shape, rank-4 no-op, interleaved broadcast, variadic Max. Every case matched the intended pack/skip decision and the module verified. Rank-8, zero-dim and rank-5 Relu were additionally taken through `--hipdnn-pipeline` to confirm the packed form legalizes.
- `git clang-format --diff HEAD` and a full-file `clang-format` run: clean.

## Compiler IR

<details>
<summary>Before / after, rank-5 Clip</summary>

```mlir
// Before: stays rank-5, rejected by ElementwiseLowering
%1 = hip.max(%ctx) ins(%arg1, %arg2 : tensor<4x1x6x2500x1xf32>, tensor<f32>)
                   outs(%0 : tensor<4x1x6x2500x1xf32>) : tensor<4x1x6x2500x1xf32>
```

```mlir
// After
%collapsed = tensor.collapse_shape %arg1 [[0], [1], [2], [3, 4]]
    : tensor<4x1x6x2500x1xf32> into tensor<4x1x6x2500xf32>
%1 = hip.max(%ctx) ins(%collapsed, %arg2 : tensor<4x1x6x2500xf32>, tensor<f32>)
                   outs(%0 : tensor<4x1x6x2500xf32>) : tensor<4x1x6x2500xf32>
%expanded = tensor.expand_shape %1 [[0], [1], [2], [3, 4]]
    output_shape [4, 1, 6, 2500, 1] : tensor<4x1x6x2500xf32> into tensor<4x1x6x2500x1xf32>
```

</details>

## Notes for reviewers

Three known limitations, all pinned by tests rather than left implicit:

1. A bound that is a rank-1 single-element tensor rather than a rank-0 scalar is not packed, so a rank-5 Clip in that spelling still fails. Such a bound is semantically a scalar and would broadcast correctly against the packed result, so this could be loosened to accept all-ones shapes. Left strict because the ONNX spec specifies scalar bounds and no model exercises the other form. Pinned by `clip_5d_rank1_bound`.

2. Binary packing remains best-effort. An interleaved broadcast such as `tensor<2x3x4x5x6xf32>` against `tensor<1x3x1x5x1xf32>` has no safe 4-group split, since every adjacent pair mixes a broadcast axis with a present one, so the op reaches the ABI limit and fails. Unchanged from #847; bevformer contains no such case.

3. Variadic `onnx.Max`/`onnx.Min` with three or more inputs are still left unpacked, as the file header states. Pinned by `max_5d_variadic`.

The identity-Clip skip is worth calling out as a non-change in emitted IR: the conversion already folded the collapse/expand pair back out, so what the guard removes is a pointless rewrite and a misleading `NumBroadcastsPacked` increment, not a visible defect. Likewise the unranked-bound whitelist — `hip.max` rejects an unranked operand either way, so that was an invalid rewrite on the path to the same diagnostic rather than a silent miscompile.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.

## AI assistance

Diagnosis, the pattern generalization, the lit tests, the corner-case audit, and this description were prepared with Cursor (Claude Opus 5). Validated by the full lit suite, the corner-case matrix, an end-to-end bevformer compile and run, and the numeric comparison against the CPU reference recorded in the test plan.
