### PR TITLE
feat(hipsr): retype shape values so the upstream shape passes can lower them

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/HipsrPreserveShapeOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrPreserveShapeOp.td
@@ -6,8 +6,6 @@
 // value it describes, so the pair survives bufferization.
 //
 
-include "mlir/Dialect/Shape/IR/ShapeBase.td"
-
 //===----------------------------------------------------------------------===//
 // Hipsr_PreserveShapeOp
 //===----------------------------------------------------------------------===//
@@ -16,27 +14,32 @@ def Hipsr_PreserveShapeOp : Hipsr_Op<"preserve_shape",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "Tie a shape computation to the data value it describes";
   let description = [{
-    Records the association between a shape value and the data value it
-    describes. This is a metadata-only operation: it does not read or write
-    memory, produce results, or generate code.
+    Ties a shape value to the data value it describes, so later passes keep the
+    pair together. Metadata only: it reads and writes no memory, returns no
+    result, and generates no code.
+
+    `$shape` holds one extent per dimension of `$data`, in one of three forms:
 
     ```mlir
+    // As -hipsr-materialize-init-tensors emits it.
     %shape = scf.execute_region -> !shape.shape { ... }
-    %d0 = ...
     %init = tensor.empty(%d0) : tensor<?x2048xf16>
-    hipsr.preserve_shape %shape, %init : tensor<?x2048xf16>
-    ```
+    hipsr.preserve_shape %shape, %init : !shape.shape, tensor<?x2048xf16>
 
-    ```mlir
-    %alloc = memref.alloc(%d0) : memref<?x2048xf16>
-    hipsr.preserve_shape %shape, %alloc : memref<?x2048xf16>
-    ```
+    // After -hipsr-convert-shape-to-extent.
+    %shape = tensor.from_elements %d0, %c2048 : tensor<2xindex>
+    hipsr.preserve_shape %shape, %init : tensor<2xindex>, tensor<?x2048xf16>
 
-    `$shape` has the same rank as `$data`.
+    // After bufferization.
+    hipsr.preserve_shape %shape, %alloc : memref<2xindex>, memref<?x2048xf16>
+    ```
   }];
 
-  let arguments = (ins Shape_ShapeType:$shape, Hipsr_TensorOrMemRef:$data);
+  let arguments = (ins Hipsr_ShapeValue:$shape, Hipsr_TensorOrMemRef:$data);
   let results = (outs);
 
-  let assemblyFormat = "$shape `,` $data attr-dict `:` type($data)";
+  // `$shape` has more than one possible type, so print it.
+  let assemblyFormat = "$shape `,` $data attr-dict `:` type($shape) `,` type($data)";
+
+  let hasVerifier = 1;
 }

--- a/include/hip/Dialect/Hipsr/IR/HipsrTypes.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrTypes.td
@@ -8,6 +8,7 @@
 
 include "mlir/IR/OpBase.td"
 include "mlir/IR/AttrTypeBase.td"
+include "mlir/Dialect/Shape/IR/ShapeBase.td"
 include "hip/Dialect/Hipsr/IR/HipsrDialect.td"
 
 // Type constraints for ops that need a memref in a named memory space, one per
@@ -39,6 +40,14 @@ def Hipsr_HostIndexVector : Type<
          CPred<"::llvm::cast<::mlir::ShapedType>($_self).getElementType()"
                ".isInteger(64)">]>,
     "rank-1 i64 host tensor or memref">;
+
+// The three forms a shape value takes as it lowers: opaque !shape.shape, an
+// extent tensor after -hipsr-convert-shape-to-extent, then an extent memref
+// after bufferization.
+def Hipsr_ExtentMemRef : MemRefRankOf<[Index], [1]>;
+def Hipsr_ShapeValue : AnyTypeOf<[Shape_ShapeType, Shape_ExtentTensorType,
+                                  Hipsr_ExtentMemRef],
+                                 "shape, extent tensor, or extent memref">;
 
 // Base class for hipsr types.
 class Hipsr_Type<string name, string typeMnemonic> : TypeDef<Hipsr_Dialect, name> {

--- a/include/hip/Dialect/Hipsr/Transforms/Passes.td
+++ b/include/hip/Dialect/Hipsr/Transforms/Passes.td
@@ -165,6 +165,50 @@ def MaterializeInitTensorsPass
   ];
 }
 
+def ConvertShapeToExtentPass
+    : Pass<"hipsr-convert-shape-to-extent", "mlir::func::FuncOp"> {
+  let summary =
+      "Retype !shape.shape as extent tensors and !shape.size as index";
+  let description = [{
+    Retypes shape values so the upstream shape passes can lower them.
+    `!shape.shape` becomes `tensor<Nxindex>`, and `!shape.size` becomes
+    `index`.
+
+    - `--convert-shape-to-std` only matches those new types, so it does
+      nothing until this pass runs.
+    - The pass first inlines the `scf.execute_region` and `shape.assuming`
+      regions, so the conversion sees straight-line code.
+    - Run `--remove-shape-constraints` first. It makes the passing witness
+      that lets `shape.assuming` inline.
+    - Upstream has no pattern for `shape.from_extents`, `shape.concat`,
+      `shape.size_to_index`, or `shape.const_size`, so this pass lowers them.
+
+    Before:
+    ```mlir
+    %s = scf.execute_region -> !shape.shape {
+      %0 = shape.shape_of %a : tensor<?x4xf16> -> !shape.shape
+      scf.yield %0 : !shape.shape
+    }
+    %c0 = shape.const_size 0
+    %d = shape.get_extent %s, %c0 : !shape.shape, !shape.size -> !shape.size
+    ```
+
+    After:
+    ```mlir
+    %s = shape.shape_of %a : tensor<?x4xf16> -> tensor<2xindex>
+    %c0 = arith.constant 0 : index
+    %d = shape.get_extent %s, %c0 : tensor<2xindex>, index -> index
+    ```
+  }];
+  let dependentDialects = [
+    "::mlir::hipsr::HipsrDialect",
+    "::mlir::arith::ArithDialect",
+    "::mlir::scf::SCFDialect",
+    "::mlir::shape::ShapeDialect",
+    "::mlir::tensor::TensorDialect"
+  ];
+}
+
 def HipsrExternalizeConstantsPass
     : Pass<"hipsr-externalize-constants", "mlir::ModuleOp"> {
   let summary = "Externalize hipsr.constant: stamp offset/size/index, write constants file";

--- a/include/hip/InitAllPasses.h
+++ b/include/hip/InitAllPasses.h
@@ -34,6 +34,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/MemRef/Transforms/AllocationOpInterfaceImpl.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
+#include "mlir/Dialect/Shape/Transforms/Passes.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/IR/TensorInferTypeOpInterfaceImpl.h"
 #include "mlir/Dialect/Tensor/Transforms/BufferizableOpInterfaceImpl.h"
@@ -185,6 +186,9 @@ inline void registerAllPasses() {
     mlir::registerSCFToControlFlowPass();
     mlir::registerReconcileUnrealizedCastsPass();
     mlir::memref::registerResolveShapedTypeResultDimsPass();
+    // Upstream passes that lower what hipsr-convert-shape-to-extent retypes.
+    mlir::registerRemoveShapeConstraintsPass();
+    mlir::registerConvertShapeToStandardPass();
   });
 }
 

--- a/lib/Dialect/Hipsr/IR/HipsrPreserveShapeOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrPreserveShapeOp.cpp
@@ -19,3 +19,19 @@ void PreserveShapeOp::getEffects(
   effects.emplace_back(MemoryEffects::Write::get(),
                        SideEffects::DefaultResource::get());
 }
+
+// An extent tensor or memref holds one entry per dimension of $data, so its
+// length must equal the data rank. An opaque !shape.shape carries no length.
+LogicalResult PreserveShapeOp::verify() {
+  auto shapeType = dyn_cast<ShapedType>(getShape().getType());
+  auto dataType = dyn_cast<ShapedType>(getData().getType());
+  if (!shapeType || !dataType || !dataType.hasRank() ||
+      shapeType.isDynamicDim(0)) {
+    return success();
+  }
+  if (shapeType.getDimSize(0) != dataType.getRank()) {
+    return emitOpError() << "extent count " << shapeType.getDimSize(0)
+                         << " does not match data rank " << dataType.getRank();
+  }
+  return success();
+}

--- a/lib/Dialect/Hipsr/Pipelines/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/Pipelines/CMakeLists.txt
@@ -13,4 +13,6 @@ target_link_libraries(HipsrDialectPipelines PUBLIC
   MLIRPass
   MLIRIR
   MLIRSupport
+  MLIRShapeOpsTransforms
+  MLIRShapeToStandard
 )

--- a/lib/Dialect/Hipsr/Pipelines/Pipelines.cpp
+++ b/lib/Dialect/Hipsr/Pipelines/Pipelines.cpp
@@ -9,6 +9,7 @@
 #include "hip/Dialect/Hipsr/Transforms/Passes.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Shape/Transforms/Passes.h"
 #include "mlir/Pass/PassRegistry.h"
 
 // --hipsr-pipeline is equivalent to running these in order:
@@ -17,6 +18,8 @@
 //   --hipsr-populate-shape-region
 //   --hipsr-partition-pool-domains
 //   --hipsr-materialize-init-tensors
+//   --remove-shape-constraints
+//   --hipsr-convert-shape-to-extent
 void mlir::hipsr::buildHipsrPipeline(OpPassManager &pm,
                                      const HipsrPipelineOptions & /*options*/) {
   pm.addPass(createAddContextArgPass());
@@ -24,6 +27,8 @@ void mlir::hipsr::buildHipsrPipeline(OpPassManager &pm,
   pm.addNestedPass<func::FuncOp>(createPopulateShapeRegionPass());
   pm.addNestedPass<func::FuncOp>(createPartitionPoolDomainsPass());
   pm.addPass(createMaterializeInitTensorsPass());
+  pm.addNestedPass<func::FuncOp>(createRemoveShapeConstraintsPass());
+  pm.addNestedPass<func::FuncOp>(createConvertShapeToExtentPass());
 }
 
 void mlir::hipsr::registerHipsrPipelines() {

--- a/lib/Dialect/Hipsr/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/lib/Dialect/Hipsr/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -46,9 +46,11 @@ BlockArgument getEntryArgument(OpTy op, unsigned operandIndex) {
 //===----------------------------------------------------------------------===//
 
 // hipsr.preserve_shape only records that `$shape` describes `$data`. It has no
-// results and no init operand, so it is not DPS and cannot reuse
-// DstBufferizableOpInterfaceExternalModel. It touches no memory, so nothing
-// needs copying and a later DPS op can write the buffer in place.
+// result and no init operand, so it is not DPS and cannot reuse
+// DstBufferizableOpInterfaceExternalModel.
+//
+// It reads and writes neither operand, so nothing needs copying and a later
+// DPS op can write either buffer in place.
 struct PreserveShapeBufferizableModel
     : public BufferizableOpInterface::ExternalModel<
           PreserveShapeBufferizableModel, PreserveShapeOp> {
@@ -76,8 +78,20 @@ struct PreserveShapeBufferizableModel
     if (failed(dataBuf)) {
       return failure();
     }
-    replaceOpWithNewBufferizedOp<PreserveShapeOp>(
-        rewriter, op, preserveOp.getShape(), *dataBuf);
+
+    // After -hipsr-convert-shape-to-extent `$shape` is a tensor, so it needs a
+    // buffer of its own.
+    Value shape = preserveOp.getShape();
+    if (isa<TensorType>(shape.getType())) {
+      FailureOr<Value> shapeBuf = getBuffer(rewriter, shape, options, state);
+      if (failed(shapeBuf)) {
+        return failure();
+      }
+      shape = *shapeBuf;
+    }
+
+    replaceOpWithNewBufferizedOp<PreserveShapeOp>(rewriter, op, shape,
+                                                  *dataBuf);
     return success();
   }
 };

--- a/lib/Dialect/Hipsr/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/Transforms/CMakeLists.txt
@@ -6,6 +6,7 @@
 add_library(HipsrDialectTransforms STATIC
   AddContextArgPass.cpp
   BufferizableOpInterfaceImpl.cpp
+  ConvertShapeToExtentPass.cpp
   ExternalizeConstants.cpp
   HipsrPoolAllocPass.cpp
   MaterializeInitTensorsPass.cpp

--- a/lib/Dialect/Hipsr/Transforms/ConvertShapeToExtentPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/ConvertShapeToExtentPass.cpp
@@ -1,0 +1,276 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- ConvertShapeToExtentPass.cpp - Shape types to extent tensors -------===//
+//
+// Retypes shape values so the upstream shape passes can lower them.
+// !shape.shape becomes tensor<Nxindex>, and !shape.size becomes index.
+//
+// --convert-shape-to-std only matches those new types, so it does nothing
+// until this pass runs. This pass lowers four ops itself, because upstream has
+// no pattern for them: shape.from_extents, shape.concat, shape.size_to_index,
+// and shape.const_size.
+//
+//===----------------------------------------------------------------------===//
+
+#include "hip/Dialect/Hipsr/Transforms/Passes.h"
+
+#include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
+#include "hip/Dialect/Hipsr/IR/HipsrOps.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Shape/IR/Shape.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/SmallVectorExtras.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Casting.h"
+
+namespace mlir {
+namespace hipsr {
+
+#define GEN_PASS_DEF_CONVERTSHAPETOEXTENTPASS
+#include "hip/Dialect/Hipsr/Transforms/Passes.h.inc"
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Rank inference
+//===----------------------------------------------------------------------===//
+
+// Returns how many extents each shape result of `op` holds, or kDynamic when
+// the already converted `operands` do not say.
+//
+// An op missing below gets tensor<?xindex>. shape.split_at is one: upstream
+// lowers it to tensor.extract_slice, which returns tensor<?xindex> whatever
+// type we ask for.
+int64_t inferExtentCount(Operation *op, ValueRange operands) {
+  return llvm::TypeSwitch<Operation *, int64_t>(op)
+      .Case([&](shape::ShapeOfOp) {
+        auto argType = dyn_cast<ShapedType>(operands.front().getType());
+        return argType && argType.hasRank() ? argType.getRank()
+                                            : ShapedType::kDynamic;
+      })
+      .Case([](shape::ConstShapeOp constShape) {
+        return static_cast<int64_t>(constShape.getShape().size());
+      })
+      .Case([&](shape::BroadcastOp) {
+        auto extentCount = [](Value shape) {
+          if (!shape::isExtentTensorType(shape.getType())) {
+            return ShapedType::kDynamic;
+          }
+          return cast<RankedTensorType>(shape.getType()).getDimSize(0);
+        };
+        // Broadcasting left-pads shorter shapes with ones, so the result is as
+        // long as the longest operand.
+        SmallVector<int64_t> counts =
+            llvm::map_to_vector(operands, extentCount);
+        if (ShapedType::isDynamicShape(counts)) {
+          return ShapedType::kDynamic;
+        }
+        return *llvm::max_element(counts);
+      })
+      .Case([&](shape::FromExtentsOp) {
+        return static_cast<int64_t>(operands.size());
+      })
+      .Default([](Operation *) { return ShapedType::kDynamic; });
+}
+
+//===----------------------------------------------------------------------===//
+// Retyping the operations upstream can already lower
+//===----------------------------------------------------------------------===//
+
+// Retypes an op and leaves the real lowering to --convert-shape-to-std.
+//
+// Operands and results have to change together. shape's verifySizeOrIndexOp
+// keeps a result opaque while any operand can still carry an error.
+//
+// Before: %0 = shape.shape_of %a : tensor<?x4xf16> -> !shape.shape
+// After:  %0 = shape.shape_of %a : tensor<?x4xf16> -> tensor<2xindex>
+template <typename OpTy>
+struct RetypeShapeOp : public OpConversionPattern<OpTy> {
+  using OpConversionPattern<OpTy>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(OpTy op, typename OpTy::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    ValueRange operands = adaptor.getOperands();
+    int64_t extentCount = inferExtentCount(op, operands);
+
+    // !shape.shape becomes an extent tensor of `extentCount` extents.
+    // !shape.size becomes index. Every other type stays as it is.
+    SmallVector<Type> resultTypes =
+        llvm::map_to_vector(op->getResultTypes(), [extentCount](Type type) {
+          return llvm::TypeSwitch<Type, Type>(type)
+              .Case([&](shape::ShapeType shapeType) {
+                return shape::getExtentTensorType(shapeType.getContext(),
+                                                  extentCount);
+              })
+              .Case([](shape::SizeType sizeType) {
+                return IndexType::get(sizeType.getContext());
+              })
+              .Default(type);
+        });
+    Operation *retyped =
+        rewriter.create(op.getLoc(), op->getName().getIdentifier(), operands,
+                        resultTypes, op->getAttrs());
+    rewriter.replaceOp(op, retyped->getResults());
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Lowering the operations upstream has no pattern for
+//===----------------------------------------------------------------------===//
+
+// Before: %0 = shape.from_extents %a, %b : index, index
+// After:  %0 = tensor.from_elements %a, %b : tensor<2xindex>
+struct LowerFromExtents : public OpConversionPattern<shape::FromExtentsOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(shape::FromExtentsOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    ValueRange extents = adaptor.getExtents();
+    if (!llvm::all_of(extents.getTypes(), llvm::IsaPred<IndexType>)) {
+      return rewriter.notifyMatchFailure(op, "extents are not indices yet");
+    }
+    rewriter.replaceOpWithNewOp<tensor::FromElementsOp>(
+        op,
+        shape::getExtentTensorType(getContext(), inferExtentCount(op, extents)),
+        extents);
+    return success();
+  }
+};
+
+// Before: %0 = shape.concat %a, %b : tensor<2xindex>, tensor<1xindex>
+//                                    -> !shape.shape
+// After:  %0 = tensor.concat dim(0) %a, %b
+//             : (tensor<2xindex>, tensor<1xindex>) -> tensor<3xindex>
+struct LowerConcat : public OpConversionPattern<shape::ConcatOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(shape::ConcatOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    ValueRange inputs = adaptor.getOperands();
+    if (!llvm::all_of(inputs.getTypes(), shape::isExtentTensorType)) {
+      return rewriter.notifyMatchFailure(op, "operands are not extent tensors "
+                                             "yet");
+    }
+    rewriter.replaceOpWithNewOp<tensor::ConcatOp>(
+        op, tensor::ConcatOp::inferResultType(/*dim=*/0, inputs.getTypes()),
+        /*dim=*/0, inputs);
+    return success();
+  }
+};
+
+// Before: %0 = shape.size_to_index %e : index
+// After:  every use reads %e directly
+struct LowerSizeToIndex : public OpConversionPattern<shape::SizeToIndexOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(shape::SizeToIndexOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!isa<IndexType>(adaptor.getArg().getType())) {
+      return rewriter.notifyMatchFailure(op, "operand is not an index yet");
+    }
+    rewriter.replaceOp(op, adaptor.getArg());
+    return success();
+  }
+};
+
+// ODS pins the result of shape.const_size to !shape.size, so it cannot be
+// retyped. Leaving it alone does not work either: verifySizeOrIndexOp turns
+// every consumer's result back into a shape type.
+//
+// Before: %0 = shape.const_size 2
+// After:  %0 = arith.constant 2 : index
+struct LowerConstSize : public OpConversionPattern<shape::ConstSizeOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(shape::ConstSizeOp op, OpAdaptor /*adaptor*/,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<arith::ConstantIndexOp>(
+        op, op.getValue().getSExtValue());
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Pass
+//===----------------------------------------------------------------------===//
+
+struct ConvertShapeToExtentPass
+    : impl::ConvertShapeToExtentPassBase<ConvertShapeToExtentPass> {
+  void runOnOperation() override {
+    func::FuncOp function = getOperation();
+    MLIRContext *context = &getContext();
+
+    // Inline the shape regions so the conversion below sees straight-line
+    // code. Upstream has no pattern for scf.execute_region.
+    //
+    // This runs fewer patterns than --canonicalize, with folding off, because
+    // two of them break shape-typed IR:
+    // - ShapeOfOpToConstShapeOp builds a tensor.cast to !shape.shape.
+    // - BroadcastOp::fold returns an index tensor attribute for any result
+    //   type.
+    //
+    // Folding off also leaves the hipsr.compute bodies alone.
+    RewritePatternSet inliners(context);
+    scf::ExecuteRegionOp::getCanonicalizationPatterns(inliners, context);
+    shape::AssumingOp::getCanonicalizationPatterns(inliners, context);
+    if (failed(applyPatternsGreedily(
+            function, std::move(inliners),
+            GreedyRewriteConfig().enableFolding(false)))) {
+      return signalPassFailure();
+    }
+
+    // True when `op` no longer uses !shape.shape or !shape.size.
+    auto isRetyped = [](Operation *op) {
+      constexpr auto isOpaque =
+          llvm::IsaPred<shape::ShapeType, shape::SizeType>;
+      return llvm::none_of(op->getOperandTypes(), isOpaque) &&
+             llvm::none_of(op->getResultTypes(), isOpaque);
+    };
+
+    ConversionTarget target(*context);
+    target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
+    target.addDynamicallyLegalDialect<shape::ShapeDialect>(isRetyped);
+    target.addDynamicallyLegalOp<PreserveShapeOp>(isRetyped);
+    target.addIllegalOp<shape::ConcatOp, shape::ConstSizeOp,
+                        shape::FromExtentsOp, shape::SizeToIndexOp>();
+
+    RewritePatternSet patterns(context);
+    patterns
+        .add<LowerConcat, LowerConstSize, LowerFromExtents, LowerSizeToIndex>(
+            context);
+    patterns.add<
+        RetypeShapeOp<shape::BroadcastOp>, RetypeShapeOp<shape::ConstShapeOp>,
+        RetypeShapeOp<shape::CstrBroadcastableOp>,
+        RetypeShapeOp<shape::CstrEqOp>, RetypeShapeOp<shape::GetExtentOp>,
+        RetypeShapeOp<shape::NumElementsOp>, RetypeShapeOp<shape::ShapeOfOp>,
+        RetypeShapeOp<shape::SplitAtOp>, RetypeShapeOp<PreserveShapeOp>>(
+        context);
+
+    if (failed(applyPartialConversion(function, target, std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+
+} // namespace
+
+} // namespace hipsr
+} // namespace mlir

--- a/test/lit/Dialect/Hipsr/IR/preserve_shape.mlir
+++ b/test/lit/Dialect/Hipsr/IR/preserve_shape.mlir
@@ -9,14 +9,14 @@
 // CHECK-NEXT: %[[C2048:.+]] = arith.constant 2048 : index
 // CHECK-NEXT: %[[SHAPE:.+]] = shape.from_extents %[[D0]], %[[C2048]] : index, index
 // CHECK-NEXT: %[[INIT:.+]] = tensor.empty(%[[D0]]) : tensor<?x2048xf16>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[INIT]] : tensor<?x2048xf16>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[INIT]] : !shape.shape, tensor<?x2048xf16>
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 func.func @tensor_form(%d0: index) {
   %c2048 = arith.constant 2048 : index
   %shape = shape.from_extents %d0, %c2048 : index, index
   %init = tensor.empty(%d0) : tensor<?x2048xf16>
-  hipsr.preserve_shape %shape, %init : tensor<?x2048xf16>
+  hipsr.preserve_shape %shape, %init : !shape.shape, tensor<?x2048xf16>
   return
 }
 
@@ -30,14 +30,14 @@ func.func @tensor_form(%d0: index) {
 // CHECK-NEXT: %[[C2048:.+]] = arith.constant 2048 : index
 // CHECK-NEXT: %[[SHAPE:.+]] = shape.from_extents %[[D0]], %[[C2048]] : index, index
 // CHECK-NEXT: %[[INIT:.+]] = tensor.empty(%[[D0]]) : tensor<?x2048xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[INIT]] : tensor<?x2048xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[INIT]] : !shape.shape, tensor<?x2048xf16, #hipsr.mem<device>>
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 func.func @tensor_form_device(%d0: index) {
   %c2048 = arith.constant 2048 : index
   %shape = shape.from_extents %d0, %c2048 : index, index
   %init = tensor.empty(%d0) : tensor<?x2048xf16, #hipsr.mem<device>>
-  hipsr.preserve_shape %shape, %init : tensor<?x2048xf16, #hipsr.mem<device>>
+  hipsr.preserve_shape %shape, %init : !shape.shape, tensor<?x2048xf16, #hipsr.mem<device>>
   return
 }
 
@@ -50,14 +50,14 @@ func.func @tensor_form_device(%d0: index) {
 // CHECK-NEXT: %[[C2048:.+]] = arith.constant 2048 : index
 // CHECK-NEXT: %[[SHAPE:.+]] = shape.from_extents %[[D0]], %[[C2048]] : index, index
 // CHECK-NEXT: %[[ALLOC:.+]] = memref.alloc(%[[D0]]) : memref<?x2048xf16>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[ALLOC]] : memref<?x2048xf16>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[ALLOC]] : !shape.shape, memref<?x2048xf16>
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 func.func @memref_form(%d0: index) {
   %c2048 = arith.constant 2048 : index
   %shape = shape.from_extents %d0, %c2048 : index, index
   %alloc = memref.alloc(%d0) : memref<?x2048xf16>
-  hipsr.preserve_shape %shape, %alloc : memref<?x2048xf16>
+  hipsr.preserve_shape %shape, %alloc : !shape.shape, memref<?x2048xf16>
   return
 }
 
@@ -69,14 +69,14 @@ func.func @memref_form(%d0: index) {
 // CHECK-NEXT: %[[C4:.+]] = arith.constant 4 : index
 // CHECK-NEXT: %[[C8:.+]] = arith.constant 8 : index
 // CHECK-NEXT: %[[SHAPE:.+]] = shape.from_extents %[[C4]], %[[C8]] : index, index
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[DATA]] : memref<4x8xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[DATA]] : !shape.shape, memref<4x8xf16, #hipsr.mem<device>>
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 func.func @device_memref_form(%data: memref<4x8xf16, #hipsr.mem<device>>) {
   %c4 = arith.constant 4 : index
   %c8 = arith.constant 8 : index
   %shape = shape.from_extents %c4, %c8 : index, index
-  hipsr.preserve_shape %shape, %data : memref<4x8xf16, #hipsr.mem<device>>
+  hipsr.preserve_shape %shape, %data : !shape.shape, memref<4x8xf16, #hipsr.mem<device>>
   return
 }
 
@@ -88,12 +88,12 @@ func.func @device_memref_form(%data: memref<4x8xf16, #hipsr.mem<device>>) {
 // CHECK-LABEL: func.func @opaque_shape(
 // CHECK-SAME: %[[D0:.+]]: index, %[[SHAPE:.+]]: !shape.shape) {
 // CHECK-NEXT: %[[INIT:.+]] = tensor.empty(%[[D0]]) : tensor<?x2048xf16>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[INIT]] : tensor<?x2048xf16>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[INIT]] : !shape.shape, tensor<?x2048xf16>
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 func.func @opaque_shape(%d0: index, %shape: !shape.shape) {
   %init = tensor.empty(%d0) : tensor<?x2048xf16>
-  hipsr.preserve_shape %shape, %init : tensor<?x2048xf16>
+  hipsr.preserve_shape %shape, %init : !shape.shape, tensor<?x2048xf16>
   return
 }
 
@@ -103,6 +103,6 @@ func.func @opaque_shape(%d0: index, %shape: !shape.shape) {
 // shape to describe.
 func.func @unranked_data(%shape: !shape.shape, %data: tensor<*xf16>) {
   // expected-error @+1 {{operand #1 must be ranked tensor or memref}}
-  hipsr.preserve_shape %shape, %data : tensor<*xf16>
+  hipsr.preserve_shape %shape, %data : !shape.shape, tensor<*xf16>
   return
 }

--- a/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
@@ -61,390 +61,283 @@
 // The four zones of a domain
 // --------------------------
 //
-// hipsr-materialize-init-tensors leaves each domain body in order: the
-// scf.execute_region shape computations, then the tensor.empty allocations that
-// read their dynamic extents back out of those shapes, then the data ops, then
-// a hipsr.preserve_shape per allocation tying the shape that sized it to the
+// hipsr-materialize-init-tensors leaves each domain body in order: the shape
+// computations, then the tensor.empty allocations that read their dynamic
+// extents back out of those shapes, then the data ops, then a
+// hipsr.preserve_shape per allocation tying the shape that sized it to the
 // result that fills it. A constant a shape computation reads moves up with it;
 // the rest stay where conversion left them.
+//
+// The shape computations are flat, and carry extent tensors rather than
+// !shape.shape. hipsr-convert-shape-to-extent inlined the scf.execute_region
+// and shape.assuming that materialization wraps each one in, and
+// remove-shape-constraints erased the witnesses and hoisted the constants they
+// left behind to the top of each block. The inlining is why the boundary
+// between one computation and the next is no longer marked in the output: the
+// zone is still a contiguous run, but it now reads as one straight line.
 //===----------------------------------------------------------------------===//
 
 // RUN: %python %S/../../../Inputs/make_external_data.py %t/embedding.onnx.data 2034237440 && cd %t && hip-mlir-opt --onnx-dialect=modeled --hipsr-pipeline --mlir-elide-resource-strings-if-larger=32 %s | FileCheck %s
 
 module {
 
-// The context becomes argument 0 and every symbolic extent survives.
 // CHECK-LABEL:   func.func @main_graph(
-// CHECK-SAME:      %[[ARG0:[^,]*]]: !hipsr.context,
-// CHECK-SAME:      %[[ARG1:[^,]*]]: tensor<?x?xi64, #hipsr.mem<device>> {onnx.name = "input_ids"},
-// CHECK-SAME:      %[[ARG2:[^,]*]]: tensor<?x4096xf16, #hipsr.mem<device>> {onnx.name = "image_features"}) -> (tensor<?x?x4096xf16, #hipsr.mem<device>> {onnx.name = "inputs_embeds"}) attributes {onnx.graph.name = "main_graph"} {
-
+// CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[ARG1:.*]]: tensor<?x?xi64, #hipsr.mem<device>> {onnx.name = "input_ids"},
+// CHECK-SAME:      %[[ARG2:.*]]: tensor<?x4096xf16, #hipsr.mem<device>> {onnx.name = "image_features"}) -> (tensor<?x?x4096xf16, #hipsr.mem<device>> {onnx.name = "inputs_embeds"}) attributes {onnx.graph.name = "main_graph"} {
 // Domain 0 takes everything whose shape follows from the graph inputs alone:
 // the embedding lookup, the bool mask, and the shape vector the broadcasts
-// downstream will read. Its six constants come first, in conversion order, so
-// each stays ahead of the two shape computations that read one, then the five
-// computations follow.
+// downstream will read. The index constants the shape computations share come
+// first, then the two weights, then the computations themselves.
 // CHECK-NEXT:           %[[POOL_DOMAIN_0:.*]]:8 = hipsr.pool_domain(%[[ARG0]], %[[ARG2]], %[[ARG1]] : !hipsr.context, tensor<?x4096xf16, #hipsr.mem<device>>, tensor<?x?xi64, #hipsr.mem<device>>) {
 // CHECK-NEXT:           ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: tensor<?x4096xf16, #hipsr.mem<device>>, %[[VAL_2:.*]]: tensor<?x?xi64, #hipsr.mem<device>>):
-// CHECK-NEXT:             %[[CONSTANT_5:.*]] = hipsr.constant {value = dense_resource<"file|embedding.onnx.data|0"> : tensor<248320x4096xf16, #hipsr.mem<device>>} : tensor<248320x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[CONSTANT_7:.*]] = arith.constant dense<248056> : tensor<i64>
-// CHECK-NEXT:             %[[CONSTANT_8:.*]] = hipsr.constant {value = dense<-1> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[CONSTANT_9:.*]] = arith.constant dense<0> : tensor<i64>
-// CHECK-NEXT:             %[[CONSTANT_10:.*]] = hipsr.constant {value = dense<0> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[CONSTANT_1:.*]] = hipsr.constant {value = dense<248056> : tensor<i64>} : tensor<i64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[EXECUTE_REGION_0:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[SHAPE_OF_0:.*]] = shape.shape_of %[[VAL_1]] : tensor<?x4096xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:               %[[NUM_ELEMENTS_0:.*]] = shape.num_elements %[[SHAPE_OF_0]] : !shape.shape -> !shape.size
-// CHECK-NEXT:               %[[SIZE_TO_INDEX_0:.*]] = shape.size_to_index %[[NUM_ELEMENTS_0]] : !shape.size
-// CHECK-NEXT:               %[[CONSTANT_0:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[DIVUI_0:.*]] = arith.divui %[[SIZE_TO_INDEX_0]], %[[CONSTANT_0]] : index
-// CHECK-NEXT:               %[[FROM_EXTENTS_0:.*]] = shape.from_extents %[[DIVUI_0]] : index
-// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_0]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[EXECUTE_REGION_1:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[SHAPE_OF_1:.*]] = shape.shape_of %[[VAL_2]] : tensor<?x?xi64, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:               %[[SHAPE_OF_2:.*]] = shape.shape_of %[[CONSTANT_1]] : tensor<i64, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:               %[[BROADCAST_0:.*]] = shape.broadcast %[[SHAPE_OF_1]], %[[SHAPE_OF_2]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:               scf.yield %[[BROADCAST_0]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[EXECUTE_REGION_2:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[CONST_SIZE_0:.*]] = shape.const_size 0
-// CHECK-NEXT:               %[[GET_EXTENT_0:.*]] = shape.get_extent %[[EXECUTE_REGION_1]], %[[CONST_SIZE_0]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:               %[[SIZE_TO_INDEX_1:.*]] = shape.size_to_index %[[GET_EXTENT_0]] : !shape.size
-// CHECK-NEXT:               %[[CONST_SIZE_1:.*]] = shape.const_size 1
-// CHECK-NEXT:               %[[GET_EXTENT_1:.*]] = shape.get_extent %[[EXECUTE_REGION_1]], %[[CONST_SIZE_1]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:               %[[SIZE_TO_INDEX_2:.*]] = shape.size_to_index %[[GET_EXTENT_1]] : !shape.size
-// CHECK-NEXT:               %[[CONSTANT_2:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[CONSTANT_3:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[CONSTANT_4:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[FROM_EXTENTS_1:.*]] = shape.from_extents %[[SIZE_TO_INDEX_1]], %[[SIZE_TO_INDEX_2]], %[[CONSTANT_4]] : index, index, index
-// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_1]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[EXECUTE_REGION_3:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[SHAPE_OF_3:.*]] = shape.shape_of %[[CONSTANT_5]] : tensor<248320x4096xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:               %[[SHAPE_OF_4:.*]] = shape.shape_of %[[VAL_2]] : tensor<?x?xi64, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:               %[[CONST_SIZE_2:.*]] = shape.const_size 0
-// CHECK-NEXT:               %[[VAL_3:.*]], %[[VAL_4:.*]] = "shape.split_at"(%[[SHAPE_OF_3]], %[[CONST_SIZE_2]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT:               %[[CONST_SIZE_3:.*]] = shape.const_size 1
-// CHECK-NEXT:               %[[VAL_5:.*]], %[[VAL_6:.*]] = "shape.split_at"(%[[SHAPE_OF_3]], %[[CONST_SIZE_3]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT:               %[[CONCAT_0:.*]] = shape.concat %[[VAL_3]], %[[SHAPE_OF_4]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:               %[[CONCAT_1:.*]] = shape.concat %[[CONCAT_0]], %[[VAL_6]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:               scf.yield %[[CONCAT_1]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[EXECUTE_REGION_4:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[CONSTANT_6:.*]] = arith.constant 3 : index
-// CHECK-NEXT:               %[[FROM_EXTENTS_2:.*]] = shape.from_extents %[[CONSTANT_6]] : index
-// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_2]] : !shape.shape
-// CHECK-NEXT:             }
-
+// CHECK-NEXT:             %[[CONST_SHAPE_0:.*]] = shape.const_shape [3] : tensor<1xindex>
+// CHECK-NEXT:             %[[CONSTANT_0:.*]] = arith.constant 1 : index
+// CHECK-NEXT:             %[[CONSTANT_1:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[CONSTANT_2:.*]] = arith.constant 1 : index
+// CHECK-NEXT:             %[[CONSTANT_3:.*]] = hipsr.constant {value = dense_resource<"file|embedding.onnx.data|0"> : tensor<248320x4096xf16, #hipsr.mem<device>>} : tensor<248320x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[CONSTANT_4:.*]] = hipsr.constant {value = dense<248056> : tensor<i64>} : tensor<i64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[SHAPE_OF_0:.*]] = shape.shape_of %[[VAL_1]] : tensor<?x4096xf16, #hipsr.mem<device>> -> tensor<2xindex>
+// CHECK-NEXT:             %[[NUM_ELEMENTS_0:.*]] = shape.num_elements %[[SHAPE_OF_0]] : tensor<2xindex> -> index
+// CHECK-NEXT:             %[[FROM_ELEMENTS_0:.*]] = tensor.from_elements %[[NUM_ELEMENTS_0]] : tensor<1xindex>
+// CHECK-NEXT:             %[[SHAPE_OF_1:.*]] = shape.shape_of %[[VAL_2]] : tensor<?x?xi64, #hipsr.mem<device>> -> tensor<2xindex>
+// CHECK-NEXT:             %[[SHAPE_OF_2:.*]] = shape.shape_of %[[CONSTANT_4]] : tensor<i64, #hipsr.mem<device>> -> tensor<0xindex>
+// CHECK-NEXT:             %[[BROADCAST_0:.*]] = shape.broadcast %[[SHAPE_OF_1]], %[[SHAPE_OF_2]] : tensor<2xindex>, tensor<0xindex> -> tensor<2xindex>
+// CHECK-NEXT:             %[[GET_EXTENT_0:.*]] = shape.get_extent %[[BROADCAST_0]], %[[CONSTANT_1]] : tensor<2xindex>, index -> index
+// CHECK-NEXT:             %[[GET_EXTENT_1:.*]] = shape.get_extent %[[BROADCAST_0]], %[[CONSTANT_0]] : tensor<2xindex>, index -> index
+// CHECK-NEXT:             %[[FROM_ELEMENTS_1:.*]] = tensor.from_elements %[[GET_EXTENT_0]], %[[GET_EXTENT_1]], %[[CONSTANT_2]] : tensor<3xindex>
+// CHECK-NEXT:             %[[SHAPE_OF_3:.*]] = shape.shape_of %[[CONSTANT_3]] : tensor<248320x4096xf16, #hipsr.mem<device>> -> tensor<2xindex>
+// CHECK-NEXT:             %[[SHAPE_OF_4:.*]] = shape.shape_of %[[VAL_2]] : tensor<?x?xi64, #hipsr.mem<device>> -> tensor<2xindex>
+// CHECK-NEXT:             %[[VAL_3:.*]], %[[VAL_4:.*]] = "shape.split_at"(%[[SHAPE_OF_3]], %[[CONSTANT_1]]) : (tensor<2xindex>, index) -> (tensor<?xindex>, tensor<?xindex>)
+// CHECK-NEXT:             %[[VAL_5:.*]], %[[VAL_6:.*]] = "shape.split_at"(%[[SHAPE_OF_3]], %[[CONSTANT_0]]) : (tensor<2xindex>, index) -> (tensor<?xindex>, tensor<?xindex>)
+// CHECK-NEXT:             %[[CONCAT_0:.*]] = tensor.concat dim(0) %[[VAL_3]], %[[SHAPE_OF_4]] : (tensor<?xindex>, tensor<2xindex>) -> tensor<?xindex>
+// CHECK-NEXT:             %[[CONCAT_1:.*]] = tensor.concat dim(0) %[[CONCAT_0]], %[[VAL_6]] : (tensor<?xindex>, tensor<?xindex>) -> tensor<?xindex>
 // The allocation zone. Each tensor.empty takes its dynamic extents from the
-// shape yielded above; a fully static result type needs none.
-// CHECK-NEXT:             %[[CONST_SIZE_4:.*]] = shape.const_size 0
-// CHECK-NEXT:             %[[GET_EXTENT_2:.*]] = shape.get_extent %[[EXECUTE_REGION_0]], %[[CONST_SIZE_4]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_3:.*]] = shape.size_to_index %[[GET_EXTENT_2]] : !shape.size
-// CHECK-NEXT:             %[[EMPTY_0:.*]] = tensor.empty(%[[SIZE_TO_INDEX_3]]) : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[CONST_SIZE_5:.*]] = shape.const_size 0
-// CHECK-NEXT:             %[[GET_EXTENT_3:.*]] = shape.get_extent %[[EXECUTE_REGION_1]], %[[CONST_SIZE_5]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_4:.*]] = shape.size_to_index %[[GET_EXTENT_3]] : !shape.size
-// CHECK-NEXT:             %[[CONST_SIZE_6:.*]] = shape.const_size 1
-// CHECK-NEXT:             %[[GET_EXTENT_4:.*]] = shape.get_extent %[[EXECUTE_REGION_1]], %[[CONST_SIZE_6]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_5:.*]] = shape.size_to_index %[[GET_EXTENT_4]] : !shape.size
-// CHECK-NEXT:             %[[EMPTY_1:.*]] = tensor.empty(%[[SIZE_TO_INDEX_4]], %[[SIZE_TO_INDEX_5]]) : tensor<?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[CONST_SIZE_7:.*]] = shape.const_size 0
-// CHECK-NEXT:             %[[GET_EXTENT_5:.*]] = shape.get_extent %[[EXECUTE_REGION_2]], %[[CONST_SIZE_7]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_6:.*]] = shape.size_to_index %[[GET_EXTENT_5]] : !shape.size
-// CHECK-NEXT:             %[[CONST_SIZE_8:.*]] = shape.const_size 1
-// CHECK-NEXT:             %[[GET_EXTENT_6:.*]] = shape.get_extent %[[EXECUTE_REGION_2]], %[[CONST_SIZE_8]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_7:.*]] = shape.size_to_index %[[GET_EXTENT_6]] : !shape.size
-// CHECK-NEXT:             %[[EMPTY_2:.*]] = tensor.empty(%[[SIZE_TO_INDEX_6]], %[[SIZE_TO_INDEX_7]]) : tensor<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[CONST_SIZE_9:.*]] = shape.const_size 0
-// CHECK-NEXT:             %[[GET_EXTENT_7:.*]] = shape.get_extent %[[EXECUTE_REGION_3]], %[[CONST_SIZE_9]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_8:.*]] = shape.size_to_index %[[GET_EXTENT_7]] : !shape.size
-// CHECK-NEXT:             %[[CONST_SIZE_10:.*]] = shape.const_size 1
-// CHECK-NEXT:             %[[GET_EXTENT_8:.*]] = shape.get_extent %[[EXECUTE_REGION_3]], %[[CONST_SIZE_10]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_9:.*]] = shape.size_to_index %[[GET_EXTENT_8]] : !shape.size
-// CHECK-NEXT:             %[[EMPTY_3:.*]] = tensor.empty(%[[SIZE_TO_INDEX_8]], %[[SIZE_TO_INDEX_9]]) : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// shape that sized it; a fully static result type needs none. The gather's
+// shape came through shape.concat, which upstream cannot lower, so this pass
+// rewrote it to tensor.concat; its extent count is dynamic because split_at
+// feeds it, which is why %[[EMPTY_3]] reads a tensor<?xindex>.
+// CHECK-NEXT:             %[[GET_EXTENT_2:.*]] = shape.get_extent %[[FROM_ELEMENTS_0]], %[[CONSTANT_1]] : tensor<1xindex>, index -> index
+// CHECK-NEXT:             %[[EMPTY_0:.*]] = tensor.empty(%[[GET_EXTENT_2]]) : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[GET_EXTENT_3:.*]] = shape.get_extent %[[BROADCAST_0]], %[[CONSTANT_1]] : tensor<2xindex>, index -> index
+// CHECK-NEXT:             %[[GET_EXTENT_4:.*]] = shape.get_extent %[[BROADCAST_0]], %[[CONSTANT_0]] : tensor<2xindex>, index -> index
+// CHECK-NEXT:             %[[EMPTY_1:.*]] = tensor.empty(%[[GET_EXTENT_3]], %[[GET_EXTENT_4]]) : tensor<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[GET_EXTENT_5:.*]] = shape.get_extent %[[FROM_ELEMENTS_1]], %[[CONSTANT_1]] : tensor<3xindex>, index -> index
+// CHECK-NEXT:             %[[GET_EXTENT_6:.*]] = shape.get_extent %[[FROM_ELEMENTS_1]], %[[CONSTANT_0]] : tensor<3xindex>, index -> index
+// CHECK-NEXT:             %[[EMPTY_2:.*]] = tensor.empty(%[[GET_EXTENT_5]], %[[GET_EXTENT_6]]) : tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[GET_EXTENT_7:.*]] = shape.get_extent %[[CONCAT_1]], %[[CONSTANT_1]] : tensor<?xindex>, index -> index
+// CHECK-NEXT:             %[[GET_EXTENT_8:.*]] = shape.get_extent %[[CONCAT_1]], %[[CONSTANT_0]] : tensor<?xindex>, index -> index
+// CHECK-NEXT:             %[[EMPTY_3:.*]] = tensor.empty(%[[GET_EXTENT_7]], %[[GET_EXTENT_8]]) : tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:             %[[EMPTY_4:.*]] = tensor.empty() : tensor<3xi64, #hipsr.mem<host>>
-
 // The data zone, in conversion order, each op now initialized by a tensor.empty.
 // CHECK-NEXT:             %[[COMPUTE_0:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[VAL_1]] : tensor<?x4096xf16, #hipsr.mem<device>>) outs(%[[EMPTY_0]] : tensor<?xf16, #hipsr.mem<device>>) {
 // CHECK-NEXT:             ^bb0(%[[VAL_7:.*]]: !hipsr.context, %[[VAL_8:.*]]: tensor<?x4096xf16, #hipsr.mem<device>>, %[[VAL_9:.*]]: tensor<?xf16, #hipsr.mem<device>>):
 // CHECK-NEXT:               %[[COLLAPSE_SHAPE_0:.*]] = tensor.collapse_shape %[[VAL_8]] {{\[\[}}0, 1]] : tensor<?x4096xf16, #hipsr.mem<device>> into tensor<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT:               hipsr.compute_yield %[[COLLAPSE_SHAPE_0]] : tensor<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT:             } : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[EQUAL_0:.*]] = hipsr.equal(%[[VAL_0]]) ins(%[[VAL_2]], %[[CONSTANT_1]] : tensor<?x?xi64, #hipsr.mem<device>>, tensor<i64, #hipsr.mem<device>>) outs(%[[EMPTY_1]] : tensor<?x?xi1, #hipsr.mem<device>>) : tensor<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[EQUAL_0:.*]] = hipsr.equal(%[[VAL_0]]) ins(%[[VAL_2]], %[[CONSTANT_4]] : tensor<?x?xi64, #hipsr.mem<device>>, tensor<i64, #hipsr.mem<device>>) outs(%[[EMPTY_1]] : tensor<?x?xi1, #hipsr.mem<device>>) : tensor<?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:             %[[COMPUTE_1:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[EQUAL_0]] : tensor<?x?xi1, #hipsr.mem<device>>) outs(%[[EMPTY_2]] : tensor<?x?x1xi1, #hipsr.mem<device>>) {
 // CHECK-NEXT:             ^bb0(%[[VAL_10:.*]]: !hipsr.context, %[[VAL_11:.*]]: tensor<?x?xi1, #hipsr.mem<device>>, %[[VAL_12:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>):
-// CHECK-NEXT:               %[[CONSTANT_11:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[DIM_0:.*]] = tensor.dim %[[VAL_12]], %[[CONSTANT_11]] : tensor<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:               %[[CONSTANT_12:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[DIM_1:.*]] = tensor.dim %[[VAL_12]], %[[CONSTANT_12]] : tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[CONSTANT_5:.*]] = arith.constant 1 : index
+// CHECK-NEXT:               %[[CONSTANT_6:.*]] = arith.constant 0 : index
+// CHECK-NEXT:               %[[DIM_0:.*]] = tensor.dim %[[VAL_12]], %[[CONSTANT_6]] : tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[DIM_1:.*]] = tensor.dim %[[VAL_12]], %[[CONSTANT_5]] : tensor<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT:               %[[EXPAND_SHAPE_0:.*]] = tensor.expand_shape %[[VAL_11]] {{\[\[}}0], [1, 2]] output_shape {{\[}}%[[DIM_0]], %[[DIM_1]], 1] : tensor<?x?xi1, #hipsr.mem<device>> into tensor<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT:               hipsr.compute_yield %[[EXPAND_SHAPE_0]] : tensor<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT:             } : tensor<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[GATHER_0:.*]] = hipsr.gather(%[[VAL_0]]) ins(%[[CONSTANT_5]], %[[VAL_2]] : tensor<248320x4096xf16, #hipsr.mem<device>>, tensor<?x?xi64, #hipsr.mem<device>>) outs(%[[EMPTY_3]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {axis = 0 : i64} : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[GATHER_0:.*]] = hipsr.gather(%[[VAL_0]]) ins(%[[CONSTANT_3]], %[[VAL_2]] : tensor<248320x4096xf16, #hipsr.mem<device>>, tensor<?x?xi64, #hipsr.mem<device>>) outs(%[[EMPTY_3]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {axis = 0 : i64} : tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:             %[[COMPUTE_2:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[GATHER_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[EMPTY_4]] : tensor<3xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:             ^bb0(%[[VAL_13:.*]]: !hipsr.context, %[[VAL_14:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_15:.*]]: tensor<3xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:               %[[CONSTANT_13:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[DIM_2:.*]] = tensor.dim %[[VAL_14]], %[[CONSTANT_13]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[CONSTANT_7:.*]] = arith.constant 4096 : i64
+// CHECK-NEXT:               %[[CONSTANT_8:.*]] = arith.constant 1 : index
+// CHECK-NEXT:               %[[CONSTANT_9:.*]] = arith.constant 0 : index
+// CHECK-NEXT:               %[[DIM_2:.*]] = tensor.dim %[[VAL_14]], %[[CONSTANT_9]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:               %[[INDEX_CAST_0:.*]] = arith.index_cast %[[DIM_2]] : index to i64
-// CHECK-NEXT:               %[[CONSTANT_14:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[DIM_3:.*]] = tensor.dim %[[VAL_14]], %[[CONSTANT_14]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[DIM_3:.*]] = tensor.dim %[[VAL_14]], %[[CONSTANT_8]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:               %[[INDEX_CAST_1:.*]] = arith.index_cast %[[DIM_3]] : index to i64
-// CHECK-NEXT:               %[[CONSTANT_15:.*]] = arith.constant 4096 : i64
-// CHECK-NEXT:               %[[FROM_ELEMENTS_0:.*]] = tensor.from_elements %[[INDEX_CAST_0]], %[[INDEX_CAST_1]], %[[CONSTANT_15]] : tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               hipsr.compute_yield %[[FROM_ELEMENTS_0]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               %[[FROM_ELEMENTS_2:.*]] = tensor.from_elements %[[INDEX_CAST_0]], %[[INDEX_CAST_1]], %[[CONSTANT_7]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               hipsr.compute_yield %[[FROM_ELEMENTS_2]] : tensor<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:             } : tensor<3xi64, #hipsr.mem<host>>
-
 // The link zone. One hipsr.preserve_shape per allocation, in allocation order,
 // each naming the result of the op that fills that buffer, so a later pass can
 // still read the shape once bufferization has replaced the tensor values with
-// the buffers behind them.
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_0]], %[[COMPUTE_0]] : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_1]], %[[EQUAL_0]] : tensor<?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_2]], %[[COMPUTE_1]] : tensor<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_3]], %[[GATHER_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_4]], %[[COMPUTE_2]] : tensor<3xi64, #hipsr.mem<host>>
+// the buffers behind them. The extent tensors here bufferize to extent memrefs,
+// which the relaxed hipsr.preserve_shape ODS also admits.
+// CHECK-NEXT:             hipsr.preserve_shape %[[FROM_ELEMENTS_0]], %[[COMPUTE_0]] : tensor<1xindex>, tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[BROADCAST_0]], %[[EQUAL_0]] : tensor<2xindex>, tensor<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[FROM_ELEMENTS_1]], %[[COMPUTE_1]] : tensor<3xindex>, tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[CONCAT_1]], %[[GATHER_0]] : tensor<?xindex>, tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[CONST_SHAPE_0]], %[[COMPUTE_2]] : tensor<1xindex>, tensor<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:             hipsr.pool_domain_yield %[[EMPTY_0]], %[[COMPUTE_0]], %[[EMPTY_2]], %[[COMPUTE_1]], %[[EMPTY_3]], %[[GATHER_0]], %[[EMPTY_4]], %[[COMPUTE_2]] : tensor<?xf16, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:           } -> tensor<?xf16, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<3xi64, #hipsr.mem<host>> {domain_id = 0 : i64}
-
 // Each broadcast reads its extents from a host shape vector rather than from
 // the type, so each one opens a domain whose shape computation extracts them
 // with tensor.extract and rebuilds the destination shape.
 // CHECK-NEXT:           %[[POOL_DOMAIN_1:.*]]:2 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#2, %[[POOL_DOMAIN_0]]#6, %[[POOL_DOMAIN_0]]#3, %[[POOL_DOMAIN_0]]#7 : !hipsr.context, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:           ^bb0(%[[VAL_17:.*]]: !hipsr.context, %[[VAL_18:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_19:.*]]: tensor<3xi64, #hipsr.mem<host>>, %[[VAL_20:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_21:.*]]: tensor<3xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:             %[[EXECUTE_REGION_5:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[SHAPE_OF_5:.*]] = shape.shape_of %[[VAL_18]] : tensor<?x?x1xi1, #hipsr.mem<device>> -> tensor<3xindex>
-// CHECK-NEXT:               %[[CONSTANT_16:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[EXTRACT_0:.*]] = tensor.extract %[[VAL_19]]{{\[}}%[[CONSTANT_16]]] : tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               %[[INDEX_CAST_2:.*]] = arith.index_cast %[[EXTRACT_0]] : i64 to index
-// CHECK-NEXT:               %[[CONSTANT_17:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[EXTRACT_1:.*]] = tensor.extract %[[VAL_19]]{{\[}}%[[CONSTANT_17]]] : tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               %[[INDEX_CAST_3:.*]] = arith.index_cast %[[EXTRACT_1]] : i64 to index
-// CHECK-NEXT:               %[[CONSTANT_18:.*]] = arith.constant 2 : index
-// CHECK-NEXT:               %[[EXTRACT_2:.*]] = tensor.extract %[[VAL_19]]{{\[}}%[[CONSTANT_18]]] : tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               %[[INDEX_CAST_4:.*]] = arith.index_cast %[[EXTRACT_2]] : i64 to index
-// CHECK-NEXT:               %[[FROM_EXTENTS_3:.*]] = shape.from_extents %[[INDEX_CAST_2]], %[[INDEX_CAST_3]], %[[INDEX_CAST_4]] : index, index, index
-// CHECK-NEXT:               %[[CSTR_BROADCASTABLE_0:.*]] = shape.cstr_broadcastable %[[SHAPE_OF_5]], %[[FROM_EXTENTS_3]] : tensor<3xindex>, !shape.shape
-// CHECK-NEXT:               %[[ASSUMING_0:.*]] = shape.assuming %[[CSTR_BROADCASTABLE_0]] -> (!shape.shape) {
-// CHECK-NEXT:                 %[[BROADCAST_1:.*]] = shape.broadcast %[[SHAPE_OF_5]], %[[FROM_EXTENTS_3]] : tensor<3xindex>, !shape.shape -> !shape.shape
-// CHECK-NEXT:                 shape.assuming_yield %[[BROADCAST_1]] : !shape.shape
-// CHECK-NEXT:               }
-// CHECK-NEXT:               scf.yield %[[ASSUMING_0]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[CONST_SIZE_11:.*]] = shape.const_size 0
-// CHECK-NEXT:             %[[GET_EXTENT_9:.*]] = shape.get_extent %[[EXECUTE_REGION_5]], %[[CONST_SIZE_11]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_10:.*]] = shape.size_to_index %[[GET_EXTENT_9]] : !shape.size
-// CHECK-NEXT:             %[[CONST_SIZE_12:.*]] = shape.const_size 1
-// CHECK-NEXT:             %[[GET_EXTENT_10:.*]] = shape.get_extent %[[EXECUTE_REGION_5]], %[[CONST_SIZE_12]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_11:.*]] = shape.size_to_index %[[GET_EXTENT_10]] : !shape.size
-// CHECK-NEXT:             %[[CONST_SIZE_13:.*]] = shape.const_size 2
-// CHECK-NEXT:             %[[GET_EXTENT_11:.*]] = shape.get_extent %[[EXECUTE_REGION_5]], %[[CONST_SIZE_13]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_12:.*]] = shape.size_to_index %[[GET_EXTENT_11]] : !shape.size
-// CHECK-NEXT:             %[[EMPTY_5:.*]] = tensor.empty(%[[SIZE_TO_INDEX_10]], %[[SIZE_TO_INDEX_11]], %[[SIZE_TO_INDEX_12]]) : tensor<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[CONSTANT_10:.*]] = arith.constant 2 : index
+// CHECK-NEXT:             %[[CONSTANT_11:.*]] = arith.constant 1 : index
+// CHECK-NEXT:             %[[CONSTANT_12:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[CONSTANT_13:.*]] = arith.constant 2 : index
+// CHECK-NEXT:             %[[CONSTANT_14:.*]] = arith.constant 1 : index
+// CHECK-NEXT:             %[[CONSTANT_15:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[SHAPE_OF_5:.*]] = shape.shape_of %[[VAL_18]] : tensor<?x?x1xi1, #hipsr.mem<device>> -> tensor<3xindex>
+// CHECK-NEXT:             %[[EXTRACT_0:.*]] = tensor.extract %[[VAL_19]]{{\[}}%[[CONSTANT_15]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[INDEX_CAST_2:.*]] = arith.index_cast %[[EXTRACT_0]] : i64 to index
+// CHECK-NEXT:             %[[EXTRACT_1:.*]] = tensor.extract %[[VAL_19]]{{\[}}%[[CONSTANT_14]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[INDEX_CAST_3:.*]] = arith.index_cast %[[EXTRACT_1]] : i64 to index
+// CHECK-NEXT:             %[[EXTRACT_2:.*]] = tensor.extract %[[VAL_19]]{{\[}}%[[CONSTANT_13]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[INDEX_CAST_4:.*]] = arith.index_cast %[[EXTRACT_2]] : i64 to index
+// CHECK-NEXT:             %[[FROM_ELEMENTS_3:.*]] = tensor.from_elements %[[INDEX_CAST_2]], %[[INDEX_CAST_3]], %[[INDEX_CAST_4]] : tensor<3xindex>
+// CHECK-NEXT:             %[[BROADCAST_1:.*]] = shape.broadcast %[[SHAPE_OF_5]], %[[FROM_ELEMENTS_3]] : tensor<3xindex>, tensor<3xindex> -> tensor<3xindex>
+// CHECK-NEXT:             %[[GET_EXTENT_9:.*]] = shape.get_extent %[[BROADCAST_1]], %[[CONSTANT_12]] : tensor<3xindex>, index -> index
+// CHECK-NEXT:             %[[GET_EXTENT_10:.*]] = shape.get_extent %[[BROADCAST_1]], %[[CONSTANT_11]] : tensor<3xindex>, index -> index
+// CHECK-NEXT:             %[[GET_EXTENT_11:.*]] = shape.get_extent %[[BROADCAST_1]], %[[CONSTANT_10]] : tensor<3xindex>, index -> index
+// CHECK-NEXT:             %[[EMPTY_5:.*]] = tensor.empty(%[[GET_EXTENT_9]], %[[GET_EXTENT_10]], %[[GET_EXTENT_11]]) : tensor<?x?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:             %[[EXPAND_0:.*]] = hipsr.expand(%[[VAL_17]]) ins(%[[VAL_20]], %[[VAL_21]] : tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) outs(%[[EMPTY_5]] : tensor<?x?x?xi1, #hipsr.mem<device>>) : tensor<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_5]], %[[EXPAND_0]] : tensor<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[BROADCAST_1]], %[[EXPAND_0]] : tensor<3xindex>, tensor<?x?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:             hipsr.pool_domain_yield %[[EMPTY_5]], %[[EXPAND_0]] : tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<?x?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:           } -> tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<?x?x?xi1, #hipsr.mem<device>> {domain_id = 1 : i64}
-
 // The second broadcast feeds the search. Its destination holds one row per
 // input axis and, in the worst case, a column per input element; the count of
-// the columns it filled sits beside it and is read back to the host.
+// the columns it filled sits beside it and is read back to the host. The
+// search sizes two buffers, so its shape computation produces two shapes, and
+// the second is a constant the allocation never needs to read.
 // CHECK-NEXT:           %[[POOL_DOMAIN_2:.*]]:4 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_1]]#0, %[[POOL_DOMAIN_0]]#6, %[[POOL_DOMAIN_1]]#1, %[[POOL_DOMAIN_0]]#7 : !hipsr.context, tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:           ^bb0(%[[VAL_24:.*]]: !hipsr.context, %[[VAL_25:.*]]: tensor<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_26:.*]]: tensor<3xi64, #hipsr.mem<host>>, %[[VAL_27:.*]]: tensor<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_28:.*]]: tensor<3xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:             %[[EXECUTE_REGION_6:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[SHAPE_OF_6:.*]] = shape.shape_of %[[VAL_25]] : tensor<?x?x?xi1, #hipsr.mem<device>> -> tensor<3xindex>
-// CHECK-NEXT:               %[[CONSTANT_19:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[EXTRACT_3:.*]] = tensor.extract %[[VAL_26]]{{\[}}%[[CONSTANT_19]]] : tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               %[[INDEX_CAST_5:.*]] = arith.index_cast %[[EXTRACT_3]] : i64 to index
-// CHECK-NEXT:               %[[CONSTANT_20:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[EXTRACT_4:.*]] = tensor.extract %[[VAL_26]]{{\[}}%[[CONSTANT_20]]] : tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               %[[INDEX_CAST_6:.*]] = arith.index_cast %[[EXTRACT_4]] : i64 to index
-// CHECK-NEXT:               %[[CONSTANT_21:.*]] = arith.constant 2 : index
-// CHECK-NEXT:               %[[EXTRACT_5:.*]] = tensor.extract %[[VAL_26]]{{\[}}%[[CONSTANT_21]]] : tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               %[[INDEX_CAST_7:.*]] = arith.index_cast %[[EXTRACT_5]] : i64 to index
-// CHECK-NEXT:               %[[FROM_EXTENTS_4:.*]] = shape.from_extents %[[INDEX_CAST_5]], %[[INDEX_CAST_6]], %[[INDEX_CAST_7]] : index, index, index
-// CHECK-NEXT:               %[[CSTR_BROADCASTABLE_1:.*]] = shape.cstr_broadcastable %[[SHAPE_OF_6]], %[[FROM_EXTENTS_4]] : tensor<3xindex>, !shape.shape
-// CHECK-NEXT:               %[[ASSUMING_1:.*]] = shape.assuming %[[CSTR_BROADCASTABLE_1]] -> (!shape.shape) {
-// CHECK-NEXT:                 %[[BROADCAST_2:.*]] = shape.broadcast %[[SHAPE_OF_6]], %[[FROM_EXTENTS_4]] : tensor<3xindex>, !shape.shape -> !shape.shape
-// CHECK-NEXT:                 shape.assuming_yield %[[BROADCAST_2]] : !shape.shape
-// CHECK-NEXT:               }
-// CHECK-NEXT:               scf.yield %[[ASSUMING_1]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[EXECUTE_REGION_7:.*]]:2 = scf.execute_region -> (!shape.shape, !shape.shape) {
-// CHECK-NEXT:               %[[CONST_SIZE_14:.*]] = shape.const_size 3
-// CHECK-NEXT:               %[[NUM_ELEMENTS_1:.*]] = shape.num_elements %[[EXECUTE_REGION_6]] : !shape.shape -> !shape.size
-// CHECK-NEXT:               %[[FROM_EXTENTS_5:.*]] = shape.from_extents %[[CONST_SIZE_14]], %[[NUM_ELEMENTS_1]] : !shape.size, !shape.size
-// CHECK-NEXT:               %[[CONST_SHAPE_0:.*]] = shape.const_shape [1] : !shape.shape
-// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_5]], %[[CONST_SHAPE_0]] : !shape.shape, !shape.shape
-// CHECK-NEXT:             }
-
-// The host count is a 1xi64 buffer, so its allocation needs no extent and this
-// shape goes unread.
-// CHECK-NEXT:             %[[EXECUTE_REGION_8:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               scf.yield %[[EXECUTE_REGION_7]]#1 : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[CONST_SIZE_15:.*]] = shape.const_size 0
-// CHECK-NEXT:             %[[GET_EXTENT_12:.*]] = shape.get_extent %[[EXECUTE_REGION_6]], %[[CONST_SIZE_15]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_13:.*]] = shape.size_to_index %[[GET_EXTENT_12]] : !shape.size
-// CHECK-NEXT:             %[[CONST_SIZE_16:.*]] = shape.const_size 1
-// CHECK-NEXT:             %[[GET_EXTENT_13:.*]] = shape.get_extent %[[EXECUTE_REGION_6]], %[[CONST_SIZE_16]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_14:.*]] = shape.size_to_index %[[GET_EXTENT_13]] : !shape.size
-// CHECK-NEXT:             %[[CONST_SIZE_17:.*]] = shape.const_size 2
-// CHECK-NEXT:             %[[GET_EXTENT_14:.*]] = shape.get_extent %[[EXECUTE_REGION_6]], %[[CONST_SIZE_17]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_15:.*]] = shape.size_to_index %[[GET_EXTENT_14]] : !shape.size
-// CHECK-NEXT:             %[[EMPTY_6:.*]] = tensor.empty(%[[SIZE_TO_INDEX_13]], %[[SIZE_TO_INDEX_14]], %[[SIZE_TO_INDEX_15]]) : tensor<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[CONST_SIZE_18:.*]] = shape.const_size 1
-// CHECK-NEXT:             %[[GET_EXTENT_15:.*]] = shape.get_extent %[[EXECUTE_REGION_7]]#0, %[[CONST_SIZE_18]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_16:.*]] = shape.size_to_index %[[GET_EXTENT_15]] : !shape.size
-// CHECK-NEXT:             %[[EMPTY_7:.*]] = tensor.empty(%[[SIZE_TO_INDEX_16]]) : tensor<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[CONSTANT_16:.*]] = arith.constant 2 : index
+// CHECK-NEXT:             %[[CONSTANT_17:.*]] = arith.constant 1 : index
+// CHECK-NEXT:             %[[CONSTANT_18:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[CONST_SHAPE_1:.*]] = shape.const_shape [1] : tensor<1xindex>
+// CHECK-NEXT:             %[[CONSTANT_19:.*]] = arith.constant 3 : index
+// CHECK-NEXT:             %[[CONSTANT_20:.*]] = arith.constant 2 : index
+// CHECK-NEXT:             %[[CONSTANT_21:.*]] = arith.constant 1 : index
+// CHECK-NEXT:             %[[CONSTANT_22:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[SHAPE_OF_6:.*]] = shape.shape_of %[[VAL_25]] : tensor<?x?x?xi1, #hipsr.mem<device>> -> tensor<3xindex>
+// CHECK-NEXT:             %[[EXTRACT_3:.*]] = tensor.extract %[[VAL_26]]{{\[}}%[[CONSTANT_22]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[INDEX_CAST_5:.*]] = arith.index_cast %[[EXTRACT_3]] : i64 to index
+// CHECK-NEXT:             %[[EXTRACT_4:.*]] = tensor.extract %[[VAL_26]]{{\[}}%[[CONSTANT_21]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[INDEX_CAST_6:.*]] = arith.index_cast %[[EXTRACT_4]] : i64 to index
+// CHECK-NEXT:             %[[EXTRACT_5:.*]] = tensor.extract %[[VAL_26]]{{\[}}%[[CONSTANT_20]]] : tensor<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[INDEX_CAST_7:.*]] = arith.index_cast %[[EXTRACT_5]] : i64 to index
+// CHECK-NEXT:             %[[FROM_ELEMENTS_4:.*]] = tensor.from_elements %[[INDEX_CAST_5]], %[[INDEX_CAST_6]], %[[INDEX_CAST_7]] : tensor<3xindex>
+// CHECK-NEXT:             %[[BROADCAST_2:.*]] = shape.broadcast %[[SHAPE_OF_6]], %[[FROM_ELEMENTS_4]] : tensor<3xindex>, tensor<3xindex> -> tensor<3xindex>
+// CHECK-NEXT:             %[[NUM_ELEMENTS_1:.*]] = shape.num_elements %[[BROADCAST_2]] : tensor<3xindex> -> index
+// CHECK-NEXT:             %[[FROM_ELEMENTS_5:.*]] = tensor.from_elements %[[CONSTANT_19]], %[[NUM_ELEMENTS_1]] : tensor<2xindex>
+// CHECK-NEXT:             %[[GET_EXTENT_12:.*]] = shape.get_extent %[[BROADCAST_2]], %[[CONSTANT_18]] : tensor<3xindex>, index -> index
+// CHECK-NEXT:             %[[GET_EXTENT_13:.*]] = shape.get_extent %[[BROADCAST_2]], %[[CONSTANT_17]] : tensor<3xindex>, index -> index
+// CHECK-NEXT:             %[[GET_EXTENT_14:.*]] = shape.get_extent %[[BROADCAST_2]], %[[CONSTANT_16]] : tensor<3xindex>, index -> index
+// CHECK-NEXT:             %[[EMPTY_6:.*]] = tensor.empty(%[[GET_EXTENT_12]], %[[GET_EXTENT_13]], %[[GET_EXTENT_14]]) : tensor<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[GET_EXTENT_15:.*]] = shape.get_extent %[[FROM_ELEMENTS_5]], %[[CONSTANT_17]] : tensor<2xindex>, index -> index
+// CHECK-NEXT:             %[[EMPTY_7:.*]] = tensor.empty(%[[GET_EXTENT_15]]) : tensor<3x?xi64, #hipsr.mem<device>>
 // CHECK-NEXT:             %[[EMPTY_8:.*]] = tensor.empty() : tensor<1xi64, #hipsr.mem<device>>
 // CHECK-NEXT:             %[[EMPTY_9:.*]] = tensor.empty() : tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:             %[[EXPAND_1:.*]] = hipsr.expand(%[[VAL_24]]) ins(%[[VAL_27]], %[[VAL_28]] : tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) outs(%[[EMPTY_6]] : tensor<?x?x?xi1, #hipsr.mem<device>>) : tensor<?x?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:             %[[NONZERO_0:.*]]:2 = hipsr.nonzero(%[[VAL_24]]) ins(%[[EXPAND_1]] : tensor<?x?x?xi1, #hipsr.mem<device>>) outs(%[[EMPTY_7]], %[[EMPTY_8]] : tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>) : tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[VAL_31:.*]] = hipsr.copy_d2h(%[[VAL_24]]) ins(%[[NONZERO_0]]#1 : tensor<1xi64, #hipsr.mem<device>>) outs(%[[EMPTY_9]] : tensor<1xi64, #hipsr.mem<host>>) : tensor<1xi64, #hipsr.mem<host>>
-
-// The search sizes two buffers, so its one shape computation yields two shapes
-// and each links to the matching result.
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_6]], %[[EXPAND_1]] : tensor<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_7]]#0, %[[NONZERO_0]]#0 : tensor<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_7]]#1, %[[NONZERO_0]]#1 : tensor<1xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_8]], %[[VAL_31]] : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             hipsr.pool_domain_yield %[[EMPTY_7]], %[[NONZERO_0]]#0, %[[EMPTY_9]], %[[VAL_31]] : tensor<3x?xi64, #hipsr.mem<device>>, tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[VAL_29:.*]] = hipsr.copy_d2h(%[[VAL_24]]) ins(%[[NONZERO_0]]#1 : tensor<1xi64, #hipsr.mem<device>>) outs(%[[EMPTY_9]] : tensor<1xi64, #hipsr.mem<host>>) : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[BROADCAST_2]], %[[EXPAND_1]] : tensor<3xindex>, tensor<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[FROM_ELEMENTS_5]], %[[NONZERO_0]]#0 : tensor<2xindex>, tensor<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[CONST_SHAPE_1]], %[[NONZERO_0]]#1 : tensor<1xindex>, tensor<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[CONST_SHAPE_1]], %[[VAL_29]] : tensor<1xindex>, tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             hipsr.pool_domain_yield %[[EMPTY_7]], %[[NONZERO_0]]#0, %[[EMPTY_9]], %[[VAL_29]] : tensor<3x?xi64, #hipsr.mem<device>>, tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:           } -> tensor<3x?xi64, #hipsr.mem<device>>, tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>> {domain_id = 2 : i64}
-
 // That host count opens the next domain, where the first shape computation
 // turns it into the trailing extent so the search destination narrows to the
 // columns that hold a position. The domain takes both buffers twice, and the
 // shape computation reads only the count while the data op reads only the
 // coordinates.
 // CHECK-NEXT:           %[[POOL_DOMAIN_3:.*]]:4 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_2]]#2, %[[POOL_DOMAIN_2]]#0, %[[POOL_DOMAIN_2]]#3, %[[POOL_DOMAIN_2]]#1 : !hipsr.context, tensor<1xi64, #hipsr.mem<host>>, tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<3x?xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:           ^bb0(%[[VAL_33:.*]]: !hipsr.context, %[[VAL_34:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_35:.*]]: tensor<3x?xi64, #hipsr.mem<device>>, %[[VAL_36:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_37:.*]]: tensor<3x?xi64, #hipsr.mem<device>>):
-// CHECK-NEXT:             %[[EXECUTE_REGION_9:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[CONSTANT_22:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[EXTRACT_6:.*]] = tensor.extract %[[VAL_34]]{{\[}}%[[CONSTANT_22]]] : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               %[[INDEX_CAST_8:.*]] = arith.index_cast %[[EXTRACT_6]] : i64 to index
-// CHECK-NEXT:               %[[CONSTANT_23:.*]] = arith.constant 3 : index
-// CHECK-NEXT:               %[[FROM_EXTENTS_6:.*]] = shape.from_extents %[[CONSTANT_23]], %[[INDEX_CAST_8]] : index, index
-// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_6]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[EXECUTE_REGION_10:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[CONST_SIZE_19:.*]] = shape.const_size 1
-// CHECK-NEXT:               %[[GET_EXTENT_16:.*]] = shape.get_extent %[[EXECUTE_REGION_9]], %[[CONST_SIZE_19]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:               %[[CONST_SIZE_20:.*]] = shape.const_size 0
-// CHECK-NEXT:               %[[GET_EXTENT_17:.*]] = shape.get_extent %[[EXECUTE_REGION_9]], %[[CONST_SIZE_20]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:               %[[FROM_EXTENTS_7:.*]] = shape.from_extents %[[GET_EXTENT_16]], %[[GET_EXTENT_17]] : !shape.size, !shape.size
-// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_7]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[EXECUTE_REGION_11:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[CONSTANT_24:.*]] = arith.constant 2 : index
-// CHECK-NEXT:               %[[FROM_EXTENTS_8:.*]] = shape.from_extents %[[CONSTANT_24]] : index
-// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_8]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[EXECUTE_REGION_12:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[CONST_SHAPE_1:.*]] = shape.const_shape [] : !shape.shape
-// CHECK-NEXT:               scf.yield %[[CONST_SHAPE_1]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[EXECUTE_REGION_13:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[CONSTANT_25:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[FROM_EXTENTS_9:.*]] = shape.from_extents %[[CONSTANT_25]] : index
-// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_9]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[CONST_SIZE_21:.*]] = shape.const_size 1
-// CHECK-NEXT:             %[[GET_EXTENT_18:.*]] = shape.get_extent %[[EXECUTE_REGION_9]], %[[CONST_SIZE_21]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_17:.*]] = shape.size_to_index %[[GET_EXTENT_18]] : !shape.size
-// CHECK-NEXT:             %[[EMPTY_10:.*]] = tensor.empty(%[[SIZE_TO_INDEX_17]]) : tensor<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[CONST_SIZE_22:.*]] = shape.const_size 0
-// CHECK-NEXT:             %[[GET_EXTENT_19:.*]] = shape.get_extent %[[EXECUTE_REGION_10]], %[[CONST_SIZE_22]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_18:.*]] = shape.size_to_index %[[GET_EXTENT_19]] : !shape.size
-// CHECK-NEXT:             %[[EMPTY_11:.*]] = tensor.empty(%[[SIZE_TO_INDEX_18]]) : tensor<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:           ^bb0(%[[VAL_31:.*]]: !hipsr.context, %[[VAL_32:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_33:.*]]: tensor<3x?xi64, #hipsr.mem<device>>, %[[VAL_34:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_35:.*]]: tensor<3x?xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:             %[[CONST_SHAPE_2:.*]] = shape.const_shape [1] : tensor<1xindex>
+// CHECK-NEXT:             %[[CONST_SHAPE_3:.*]] = shape.const_shape [2] : tensor<1xindex>
+// CHECK-NEXT:             %[[CONST_SHAPE_4:.*]] = shape.const_shape [] : tensor<0xindex>
+// CHECK-NEXT:             %[[CONSTANT_23:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[CONSTANT_24:.*]] = arith.constant 1 : index
+// CHECK-NEXT:             %[[CONSTANT_25:.*]] = arith.constant 3 : index
+// CHECK-NEXT:             %[[CONSTANT_26:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[EXTRACT_6:.*]] = tensor.extract %[[VAL_32]]{{\[}}%[[CONSTANT_26]]] : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[INDEX_CAST_8:.*]] = arith.index_cast %[[EXTRACT_6]] : i64 to index
+// CHECK-NEXT:             %[[FROM_ELEMENTS_6:.*]] = tensor.from_elements %[[CONSTANT_25]], %[[INDEX_CAST_8]] : tensor<2xindex>
+// CHECK-NEXT:             %[[GET_EXTENT_16:.*]] = shape.get_extent %[[FROM_ELEMENTS_6]], %[[CONSTANT_24]] : tensor<2xindex>, index -> index
+// CHECK-NEXT:             %[[GET_EXTENT_17:.*]] = shape.get_extent %[[FROM_ELEMENTS_6]], %[[CONSTANT_23]] : tensor<2xindex>, index -> index
+// CHECK-NEXT:             %[[FROM_ELEMENTS_7:.*]] = tensor.from_elements %[[GET_EXTENT_16]], %[[GET_EXTENT_17]] : tensor<2xindex>
+// CHECK-NEXT:             %[[GET_EXTENT_18:.*]] = shape.get_extent %[[FROM_ELEMENTS_6]], %[[CONSTANT_24]] : tensor<2xindex>, index -> index
+// CHECK-NEXT:             %[[EMPTY_10:.*]] = tensor.empty(%[[GET_EXTENT_18]]) : tensor<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[GET_EXTENT_19:.*]] = shape.get_extent %[[FROM_ELEMENTS_7]], %[[CONSTANT_23]] : tensor<2xindex>, index -> index
+// CHECK-NEXT:             %[[EMPTY_11:.*]] = tensor.empty(%[[GET_EXTENT_19]]) : tensor<?x3xi64, #hipsr.mem<device>>
 // CHECK-NEXT:             %[[EMPTY_12:.*]] = tensor.empty() : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:             %[[EMPTY_13:.*]] = tensor.empty() : tensor<i64, #hipsr.mem<host>>
 // CHECK-NEXT:             %[[EMPTY_14:.*]] = tensor.empty() : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             %[[COMPUTE_3:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[VAL_36]], %[[VAL_37]] : tensor<1xi64, #hipsr.mem<host>>, tensor<3x?xi64, #hipsr.mem<device>>) outs(%[[EMPTY_10]] : tensor<3x?xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_38:.*]]: !hipsr.context, %[[VAL_39:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_40:.*]]: tensor<3x?xi64, #hipsr.mem<device>>, %[[VAL_41:.*]]: tensor<3x?xi64, #hipsr.mem<device>>):
-// CHECK-NEXT:               %[[CONSTANT_26:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[DIM_4:.*]] = tensor.dim %[[VAL_41]], %[[CONSTANT_26]] : tensor<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:               %[[EXTRACT_SLICE_0:.*]] = tensor.extract_slice %[[VAL_40]][0, 0] [3, %[[DIM_4]]] [1, 1] : tensor<3x?xi64, #hipsr.mem<device>> to tensor<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[COMPUTE_3:.*]] = hipsr.compute(%[[VAL_31]]) ins(%[[VAL_34]], %[[VAL_35]] : tensor<1xi64, #hipsr.mem<host>>, tensor<3x?xi64, #hipsr.mem<device>>) outs(%[[EMPTY_10]] : tensor<3x?xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:             ^bb0(%[[VAL_36:.*]]: !hipsr.context, %[[VAL_37:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_38:.*]]: tensor<3x?xi64, #hipsr.mem<device>>, %[[VAL_39:.*]]: tensor<3x?xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:               %[[CONSTANT_27:.*]] = arith.constant 1 : index
+// CHECK-NEXT:               %[[DIM_4:.*]] = tensor.dim %[[VAL_39]], %[[CONSTANT_27]] : tensor<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[EXTRACT_SLICE_0:.*]] = tensor.extract_slice %[[VAL_38]][0, 0] [3, %[[DIM_4]]] [1, 1] : tensor<3x?xi64, #hipsr.mem<device>> to tensor<3x?xi64, #hipsr.mem<device>>
 // CHECK-NEXT:               hipsr.compute_yield %[[EXTRACT_SLICE_0]] : tensor<3x?xi64, #hipsr.mem<device>>
 // CHECK-NEXT:             } : tensor<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[TRANSPOSE_0:.*]] = hipsr.transpose(%[[VAL_33]]) ins(%[[COMPUTE_3]] : tensor<3x?xi64, #hipsr.mem<device>>) outs(%[[EMPTY_11]] : tensor<?x3xi64, #hipsr.mem<device>>) {perm = array<i64: 1, 0>} : tensor<?x3xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[COMPUTE_4:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[TRANSPOSE_0]] : tensor<?x3xi64, #hipsr.mem<device>>) outs(%[[EMPTY_12]] : tensor<2xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_42:.*]]: !hipsr.context, %[[VAL_43:.*]]: tensor<?x3xi64, #hipsr.mem<device>>, %[[VAL_44:.*]]: tensor<2xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:               %[[CONSTANT_27:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[DIM_5:.*]] = tensor.dim %[[VAL_43]], %[[CONSTANT_27]] : tensor<?x3xi64, #hipsr.mem<device>>
-// CHECK-NEXT:               %[[INDEX_CAST_9:.*]] = arith.index_cast %[[DIM_5]] : index to i64
+// CHECK-NEXT:             %[[TRANSPOSE_0:.*]] = hipsr.transpose(%[[VAL_31]]) ins(%[[COMPUTE_3]] : tensor<3x?xi64, #hipsr.mem<device>>) outs(%[[EMPTY_11]] : tensor<?x3xi64, #hipsr.mem<device>>) {perm = array<i64: 1, 0>} : tensor<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[COMPUTE_4:.*]] = hipsr.compute(%[[VAL_31]]) ins(%[[TRANSPOSE_0]] : tensor<?x3xi64, #hipsr.mem<device>>) outs(%[[EMPTY_12]] : tensor<2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:             ^bb0(%[[VAL_40:.*]]: !hipsr.context, %[[VAL_41:.*]]: tensor<?x3xi64, #hipsr.mem<device>>, %[[VAL_42:.*]]: tensor<2xi64, #hipsr.mem<host>>):
 // CHECK-NEXT:               %[[CONSTANT_28:.*]] = arith.constant 3 : i64
-// CHECK-NEXT:               %[[FROM_ELEMENTS_1:.*]] = tensor.from_elements %[[INDEX_CAST_9]], %[[CONSTANT_28]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               hipsr.compute_yield %[[FROM_ELEMENTS_1]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             } : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             %[[COMPUTE_5:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[COMPUTE_4]] : tensor<2xi64, #hipsr.mem<host>>) outs(%[[EMPTY_13]] : tensor<i64, #hipsr.mem<host>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_45:.*]]: !hipsr.context, %[[VAL_46:.*]]: tensor<2xi64, #hipsr.mem<host>>, %[[VAL_47:.*]]: tensor<i64, #hipsr.mem<host>>):
 // CHECK-NEXT:               %[[CONSTANT_29:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[EXTRACT_7:.*]] = tensor.extract %[[VAL_46]]{{\[}}%[[CONSTANT_29]]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               %[[FROM_ELEMENTS_2:.*]] = tensor.from_elements %[[EXTRACT_7]] : tensor<i64, #hipsr.mem<host>>
-// CHECK-NEXT:               hipsr.compute_yield %[[FROM_ELEMENTS_2]] : tensor<i64, #hipsr.mem<host>>
+// CHECK-NEXT:               %[[DIM_5:.*]] = tensor.dim %[[VAL_41]], %[[CONSTANT_29]] : tensor<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:               %[[INDEX_CAST_9:.*]] = arith.index_cast %[[DIM_5]] : index to i64
+// CHECK-NEXT:               %[[FROM_ELEMENTS_8:.*]] = tensor.from_elements %[[INDEX_CAST_9]], %[[CONSTANT_28]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               hipsr.compute_yield %[[FROM_ELEMENTS_8]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             } : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[COMPUTE_5:.*]] = hipsr.compute(%[[VAL_31]]) ins(%[[COMPUTE_4]] : tensor<2xi64, #hipsr.mem<host>>) outs(%[[EMPTY_13]] : tensor<i64, #hipsr.mem<host>>) {
+// CHECK-NEXT:             ^bb0(%[[VAL_43:.*]]: !hipsr.context, %[[VAL_44:.*]]: tensor<2xi64, #hipsr.mem<host>>, %[[VAL_45:.*]]: tensor<i64, #hipsr.mem<host>>):
+// CHECK-NEXT:               %[[CONSTANT_30:.*]] = arith.constant 0 : index
+// CHECK-NEXT:               %[[EXTRACT_7:.*]] = tensor.extract %[[VAL_44]]{{\[}}%[[CONSTANT_30]]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:               %[[FROM_ELEMENTS_9:.*]] = tensor.from_elements %[[EXTRACT_7]] : tensor<i64, #hipsr.mem<host>>
+// CHECK-NEXT:               hipsr.compute_yield %[[FROM_ELEMENTS_9]] : tensor<i64, #hipsr.mem<host>>
 // CHECK-NEXT:             } : tensor<i64, #hipsr.mem<host>>
-// CHECK-NEXT:             %[[COMPUTE_6:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[COMPUTE_5]] : tensor<i64, #hipsr.mem<host>>) outs(%[[EMPTY_14]] : tensor<1xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_48:.*]]: !hipsr.context, %[[VAL_49:.*]]: tensor<i64, #hipsr.mem<host>>, %[[VAL_50:.*]]: tensor<1xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:               %[[EXPAND_SHAPE_1:.*]] = tensor.expand_shape %[[VAL_49]] [] output_shape [1] : tensor<i64, #hipsr.mem<host>> into tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[COMPUTE_6:.*]] = hipsr.compute(%[[VAL_31]]) ins(%[[COMPUTE_5]] : tensor<i64, #hipsr.mem<host>>) outs(%[[EMPTY_14]] : tensor<1xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:             ^bb0(%[[VAL_46:.*]]: !hipsr.context, %[[VAL_47:.*]]: tensor<i64, #hipsr.mem<host>>, %[[VAL_48:.*]]: tensor<1xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:               %[[EXPAND_SHAPE_1:.*]] = tensor.expand_shape %[[VAL_47]] [] output_shape [1] : tensor<i64, #hipsr.mem<host>> into tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:               hipsr.compute_yield %[[EXPAND_SHAPE_1]] : tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:             } : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_9]], %[[COMPUTE_3]] : tensor<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_10]], %[[TRANSPOSE_0]] : tensor<?x3xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_11]], %[[COMPUTE_4]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_12]], %[[COMPUTE_5]] : tensor<i64, #hipsr.mem<host>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_13]], %[[COMPUTE_6]] : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[FROM_ELEMENTS_6]], %[[COMPUTE_3]] : tensor<2xindex>, tensor<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[FROM_ELEMENTS_7]], %[[TRANSPOSE_0]] : tensor<2xindex>, tensor<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[CONST_SHAPE_3]], %[[COMPUTE_4]] : tensor<1xindex>, tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[CONST_SHAPE_4]], %[[COMPUTE_5]] : tensor<0xindex>, tensor<i64, #hipsr.mem<host>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[CONST_SHAPE_2]], %[[COMPUTE_6]] : tensor<1xindex>, tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:             hipsr.pool_domain_yield %[[EMPTY_11]], %[[TRANSPOSE_0]], %[[EMPTY_14]], %[[COMPUTE_6]] : tensor<?x3xi64, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:           } -> tensor<?x3xi64, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>> {domain_id = 3 : i64}
-
 // The update window ends at that same count, and the scatter writes it into
 // the embeddings.
 // CHECK-NEXT:           %[[POOL_DOMAIN_4:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#0, %[[POOL_DOMAIN_3]]#2, %[[POOL_DOMAIN_0]]#1, %[[POOL_DOMAIN_3]]#3, %[[POOL_DOMAIN_0]]#4, %[[POOL_DOMAIN_3]]#0, %[[POOL_DOMAIN_0]]#5, %[[POOL_DOMAIN_3]]#1 : !hipsr.context, tensor<?xf16, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<?xf16, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:           ^bb0(%[[VAL_53:.*]]: !hipsr.context, %[[VAL_54:.*]]: tensor<?xf16, #hipsr.mem<device>>, %[[VAL_55:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_56:.*]]: tensor<?xf16, #hipsr.mem<device>>, %[[VAL_57:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_58:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_59:.*]]: tensor<?x3xi64, #hipsr.mem<device>>, %[[VAL_60:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_61:.*]]: tensor<?x3xi64, #hipsr.mem<device>>):
-// CHECK-NEXT:             %[[EXECUTE_REGION_14:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[CONSTANT_30:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[DIM_6:.*]] = tensor.dim %[[VAL_54]], %[[CONSTANT_30]] : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:               %[[CONSTANT_31:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[EXTRACT_8:.*]] = tensor.extract %[[VAL_55]]{{\[}}%[[CONSTANT_31]]] : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               %[[INDEX_CAST_10:.*]] = arith.index_cast %[[EXTRACT_8]] : i64 to index
-// CHECK-NEXT:               %[[CONSTANT_32:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[CMPI_0:.*]] = arith.cmpi slt, %[[INDEX_CAST_10]], %[[CONSTANT_32]] : index
-// CHECK-NEXT:               %[[ADDI_0:.*]] = arith.addi %[[INDEX_CAST_10]], %[[DIM_6]] : index
-// CHECK-NEXT:               %[[SELECT_0:.*]] = arith.select %[[CMPI_0]], %[[ADDI_0]], %[[INDEX_CAST_10]] : index
-// CHECK-NEXT:               %[[CONSTANT_33:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[MINSI_0:.*]] = arith.minsi %[[DIM_6]], %[[CONSTANT_33]] : index
-// CHECK-NEXT:               %[[MAXSI_0:.*]] = arith.maxsi %[[SELECT_0]], %[[CONSTANT_32]] : index
-// CHECK-NEXT:               %[[MINSI_1:.*]] = arith.minsi %[[MAXSI_0]], %[[DIM_6]] : index
-// CHECK-NEXT:               %[[SUBI_0:.*]] = arith.subi %[[MINSI_1]], %[[MINSI_0]] : index
-// CHECK-NEXT:               %[[MAXSI_1:.*]] = arith.maxsi %[[SUBI_0]], %[[CONSTANT_32]] : index
-// CHECK-NEXT:               %[[FROM_EXTENTS_10:.*]] = shape.from_extents %[[MAXSI_1]] : index
-// CHECK-NEXT:               scf.yield %[[FROM_EXTENTS_10]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[EXECUTE_REGION_15:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:               %[[SHAPE_OF_7:.*]] = shape.shape_of %[[VAL_58]] : tensor<?x?x4096xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:               %[[SHAPE_OF_8:.*]] = shape.shape_of %[[VAL_59]] : tensor<?x3xi64, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:               scf.yield %[[SHAPE_OF_7]] : !shape.shape
-// CHECK-NEXT:             }
-// CHECK-NEXT:             %[[CONST_SIZE_23:.*]] = shape.const_size 0
-// CHECK-NEXT:             %[[GET_EXTENT_20:.*]] = shape.get_extent %[[EXECUTE_REGION_14]], %[[CONST_SIZE_23]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_19:.*]] = shape.size_to_index %[[GET_EXTENT_20]] : !shape.size
-// CHECK-NEXT:             %[[EMPTY_15:.*]] = tensor.empty(%[[SIZE_TO_INDEX_19]]) : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[CONST_SIZE_24:.*]] = shape.const_size 0
-// CHECK-NEXT:             %[[GET_EXTENT_21:.*]] = shape.get_extent %[[EXECUTE_REGION_15]], %[[CONST_SIZE_24]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_20:.*]] = shape.size_to_index %[[GET_EXTENT_21]] : !shape.size
-// CHECK-NEXT:             %[[CONST_SIZE_25:.*]] = shape.const_size 1
-// CHECK-NEXT:             %[[GET_EXTENT_22:.*]] = shape.get_extent %[[EXECUTE_REGION_15]], %[[CONST_SIZE_25]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:             %[[SIZE_TO_INDEX_21:.*]] = shape.size_to_index %[[GET_EXTENT_22]] : !shape.size
-// CHECK-NEXT:             %[[EMPTY_16:.*]] = tensor.empty(%[[SIZE_TO_INDEX_20]], %[[SIZE_TO_INDEX_21]]) : tensor<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[SLICE_0:.*]] = hipsr.slice(%[[VAL_53]]) ins(%[[VAL_56]] : tensor<?xf16, #hipsr.mem<device>>) ends(%[[VAL_57]] : tensor<1xi64, #hipsr.mem<host>>) outs(%[[EMPTY_15]] : tensor<?xf16, #hipsr.mem<device>>) {axes_attr = array<i64: 0>, starts_attr = array<i64: 0>, steps_attr = array<i64: 1>} : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[SCATTER_ND_0:.*]] = hipsr.scatter_nd(%[[VAL_53]]) ins(%[[VAL_60]], %[[VAL_61]], %[[SLICE_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>) outs(%[[EMPTY_16]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) : tensor<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_14]], %[[SLICE_0]] : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[EXECUTE_REGION_15]], %[[SCATTER_ND_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:           ^bb0(%[[VAL_51:.*]]: !hipsr.context, %[[VAL_52:.*]]: tensor<?xf16, #hipsr.mem<device>>, %[[VAL_53:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_54:.*]]: tensor<?xf16, #hipsr.mem<device>>, %[[VAL_55:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_56:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_57:.*]]: tensor<?x3xi64, #hipsr.mem<device>>, %[[VAL_58:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_59:.*]]: tensor<?x3xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:             %[[CONSTANT_31:.*]] = arith.constant 1 : index
+// CHECK-NEXT:             %[[CONSTANT_32:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[CONSTANT_33:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[DIM_6:.*]] = tensor.dim %[[VAL_52]], %[[CONSTANT_33]] : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[EXTRACT_8:.*]] = tensor.extract %[[VAL_53]]{{\[}}%[[CONSTANT_33]]] : tensor<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:             %[[INDEX_CAST_10:.*]] = arith.index_cast %[[EXTRACT_8]] : i64 to index
+// CHECK-NEXT:             %[[CMPI_0:.*]] = arith.cmpi slt, %[[INDEX_CAST_10]], %[[CONSTANT_33]] : index
+// CHECK-NEXT:             %[[ADDI_0:.*]] = arith.addi %[[INDEX_CAST_10]], %[[DIM_6]] : index
+// CHECK-NEXT:             %[[SELECT_0:.*]] = arith.select %[[CMPI_0]], %[[ADDI_0]], %[[INDEX_CAST_10]] : index
+// CHECK-NEXT:             %[[MINSI_0:.*]] = arith.minsi %[[DIM_6]], %[[CONSTANT_33]] : index
+// CHECK-NEXT:             %[[MAXSI_0:.*]] = arith.maxsi %[[SELECT_0]], %[[CONSTANT_33]] : index
+// CHECK-NEXT:             %[[MINSI_1:.*]] = arith.minsi %[[MAXSI_0]], %[[DIM_6]] : index
+// CHECK-NEXT:             %[[SUBI_0:.*]] = arith.subi %[[MINSI_1]], %[[MINSI_0]] : index
+// CHECK-NEXT:             %[[MAXSI_1:.*]] = arith.maxsi %[[SUBI_0]], %[[CONSTANT_33]] : index
+// CHECK-NEXT:             %[[FROM_ELEMENTS_10:.*]] = tensor.from_elements %[[MAXSI_1]] : tensor<1xindex>
+// CHECK-NEXT:             %[[SHAPE_OF_7:.*]] = shape.shape_of %[[VAL_56]] : tensor<?x?x4096xf16, #hipsr.mem<device>> -> tensor<3xindex>
+// CHECK-NEXT:             %[[GET_EXTENT_20:.*]] = shape.get_extent %[[FROM_ELEMENTS_10]], %[[CONSTANT_32]] : tensor<1xindex>, index -> index
+// CHECK-NEXT:             %[[EMPTY_15:.*]] = tensor.empty(%[[GET_EXTENT_20]]) : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[GET_EXTENT_21:.*]] = shape.get_extent %[[SHAPE_OF_7]], %[[CONSTANT_32]] : tensor<3xindex>, index -> index
+// CHECK-NEXT:             %[[GET_EXTENT_22:.*]] = shape.get_extent %[[SHAPE_OF_7]], %[[CONSTANT_31]] : tensor<3xindex>, index -> index
+// CHECK-NEXT:             %[[EMPTY_16:.*]] = tensor.empty(%[[GET_EXTENT_21]], %[[GET_EXTENT_22]]) : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[SLICE_0:.*]] = hipsr.slice(%[[VAL_51]]) ins(%[[VAL_54]] : tensor<?xf16, #hipsr.mem<device>>) ends(%[[VAL_55]] : tensor<1xi64, #hipsr.mem<host>>) outs(%[[EMPTY_15]] : tensor<?xf16, #hipsr.mem<device>>) {axes_attr = array<i64: 0>, starts_attr = array<i64: 0>, steps_attr = array<i64: 1>} : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[SCATTER_ND_0:.*]] = hipsr.scatter_nd(%[[VAL_51]]) ins(%[[VAL_58]], %[[VAL_59]], %[[SLICE_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>) outs(%[[EMPTY_16]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) : tensor<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[FROM_ELEMENTS_10]], %[[SLICE_0]] : tensor<1xindex>, tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.preserve_shape %[[SHAPE_OF_7]], %[[SCATTER_ND_0]] : tensor<3xindex>, tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:             hipsr.pool_domain_yield %[[SCATTER_ND_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:           } -> tensor<?x?x4096xf16, #hipsr.mem<device>> {domain_id = 4 : i64}
 // CHECK-NEXT:           return %[[POOL_DOMAIN_4]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:         }
+
 
 // The table's bytes stay outside the IR, so the resource section prints empty
 // once the RUN line's elision drops the blob string.

--- a/test/lit/Dialect/Hipsr/Pipelines/sample_dynamic.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/sample_dynamic.mlir
@@ -16,146 +16,96 @@
 
 // The domains split exactly where they do in sample_static.mlir, and so do the
 // five zones inside each one: neither the barrier's position nor the shape
-// graph depends on whether the extents are known.
+// graph depends on whether the extents are known. sample_static.mlir carries
+// the commentary on the shape graph itself; what is worth reading here is where
+// an extent gets read back out of it, which is the only thing that differs.
 // CHECK-NEXT:    %[[D0:.+]]:5 = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]] : !hipsr.context, tensor<?x3xf16, #hipsr.mem<device>>, tensor<?x4xf32, #hipsr.mem<device>>) {
 // CHECK-NEXT:    ^bb0(%[[D0_CTX:.+]]: !hipsr.context, %[[D0_A:.+]]: tensor<?x3xf16, #hipsr.mem<device>>, %[[D0_B:.+]]: tensor<?x4xf32, #hipsr.mem<device>>):
 
+// CHECK-NEXT:      %[[EXTENTS_SHAPE:.+]] = shape.const_shape [2] : tensor<1xindex>
+// CHECK-NEXT:      %[[C0:.+]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[C1:.+]] = arith.constant 1 : index
 // CHECK-NEXT:      %[[W1:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<3x1xf16>} : tensor<3x1xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[W2:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<4x2xf32>} : tensor<4x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[MM1_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[D0_A]] : tensor<?x3xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[W1_SHAPE:.+]] = shape.shape_of %[[W1]] : tensor<3x1xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[A_K_IDX:.+]] = shape.const_size 1
-// CHECK-NEXT:        %[[A_K:.+]] = shape.get_extent %[[A_SHAPE]], %[[A_K_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[A_K_SHAPE:.+]] = shape.from_extents %[[A_K]] : !shape.size
-// CHECK-NEXT:        %[[W1_K_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[W1_K:.+]] = shape.get_extent %[[W1_SHAPE]], %[[W1_K_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[W1_K_SHAPE:.+]] = shape.from_extents %[[W1_K]] : !shape.size
-// CHECK-NEXT:        %[[K_WITNESS:.+]] = shape.cstr_eq %[[A_K_SHAPE]], %[[W1_K_SHAPE]] : !shape.shape, !shape.shape
-// CHECK-NEXT:        %[[A_SPLIT_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[A_BATCH:.+]], %[[A_TAIL:.+]] = "shape.split_at"(%[[A_SHAPE]], %[[A_SPLIT_IDX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT:        %[[W1_SPLIT_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[W1_BATCH:.+]], %[[W1_TAIL:.+]] = "shape.split_at"(%[[W1_SHAPE]], %[[W1_SPLIT_IDX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT:        %[[BATCH_WITNESS:.+]] = shape.cstr_broadcastable %[[A_BATCH]], %[[W1_BATCH]] : !shape.shape, !shape.shape
-// CHECK-NEXT:        %[[WITNESS:.+]] = shape.assuming_all %[[K_WITNESS]], %[[BATCH_WITNESS]]
-// CHECK-NEXT:        %[[MM1_SHAPE_VAL:.+]] = shape.assuming %[[WITNESS]] -> (!shape.shape) {
-// CHECK-NEXT:          %[[BATCH:.+]] = shape.broadcast %[[A_BATCH]], %[[W1_BATCH]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:          %[[M_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:          %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[M_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:          %[[N_IDX:.+]] = shape.const_size 1
-// CHECK-NEXT:          %[[N:.+]] = shape.get_extent %[[W1_SHAPE]], %[[N_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:          %[[MATRIX:.+]] = shape.from_extents %[[M]], %[[N]] : !shape.size, !shape.size
-// CHECK-NEXT:          %[[RESULT:.+]] = shape.concat %[[BATCH]], %[[MATRIX]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:          shape.assuming_yield %[[RESULT]] : !shape.shape
-// CHECK-NEXT:        }
-// CHECK-NEXT:        scf.yield %[[MM1_SHAPE_VAL]] : !shape.shape
-// CHECK-NEXT:      }
+// CHECK-NEXT:      %[[A_SHAPE:.+]] = shape.shape_of %[[D0_A]] : tensor<?x3xf16, #hipsr.mem<device>> -> tensor<2xindex>
+// CHECK-NEXT:      %[[W1_SHAPE:.+]] = shape.shape_of %[[W1]] : tensor<3x1xf16, #hipsr.mem<device>> -> tensor<2xindex>
+// CHECK-NEXT:      %[[A_BATCH:.+]], %[[A_TAIL:.+]] = "shape.split_at"(%[[A_SHAPE]], %[[C0]]) : (tensor<2xindex>, index) -> (tensor<?xindex>, tensor<?xindex>)
+// CHECK-NEXT:      %[[W1_BATCH:.+]], %[[W1_TAIL:.+]] = "shape.split_at"(%[[W1_SHAPE]], %[[C0]]) : (tensor<2xindex>, index) -> (tensor<?xindex>, tensor<?xindex>)
+// CHECK-NEXT:      %[[BATCH:.+]] = shape.broadcast %[[A_BATCH]], %[[W1_BATCH]] : tensor<?xindex>, tensor<?xindex> -> tensor<?xindex>
+// CHECK-NEXT:      %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[C0]] : tensor<2xindex>, index -> index
+// CHECK-NEXT:      %[[N:.+]] = shape.get_extent %[[W1_SHAPE]], %[[C1]] : tensor<2xindex>, index -> index
+// CHECK-NEXT:      %[[MATRIX:.+]] = tensor.from_elements %[[M]], %[[N]] : tensor<2xindex>
+// CHECK-NEXT:      %[[MM1_SHAPE:.+]] = tensor.concat dim(0) %[[BATCH]], %[[MATRIX]] : (tensor<?xindex>, tensor<2xindex>) -> tensor<?xindex>
 
-// CHECK-NEXT:      %[[CAST_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        scf.yield %[[MM1_SHAPE]] : !shape.shape
-// CHECK-NEXT:      }
-
-// The extent vector's length is still a constant -- the operand's rank fixes it
-// -- so the operand's shape goes unread here and the vector needs no extent of
-// its own below.
-// CHECK-NEXT:      %[[EXTENTS_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[B_SHAPE:.+]] = shape.shape_of %[[D0_B]] : tensor<?x4xf32, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[RANK:.+]] = arith.constant 2 : index
-// CHECK-NEXT:        %[[RANK_SHAPE:.+]] = shape.from_extents %[[RANK]] : index
-// CHECK-NEXT:        scf.yield %[[RANK_SHAPE]] : !shape.shape
-// CHECK-NEXT:      }
-
-// This is where the dynamic extent shows up: each allocation whose type leaves
-// a dimension open reads it back out of the shape computed above.
-// CHECK-NEXT:      %[[MM1_M_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:      %[[MM1_M_EXTENT:.+]] = shape.get_extent %[[MM1_SHAPE]], %[[MM1_M_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:      %[[MM1_M:.+]] = shape.size_to_index %[[MM1_M_EXTENT]] : !shape.size
-// CHECK-NEXT:      %[[MM1_INIT:.+]] = tensor.empty(%[[MM1_M]]) : tensor<?x1xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[CAST_M_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:      %[[CAST_M_EXTENT:.+]] = shape.get_extent %[[CAST_SHAPE]], %[[CAST_M_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:      %[[CAST_M:.+]] = shape.size_to_index %[[CAST_M_EXTENT]] : !shape.size
-// CHECK-NEXT:      %[[CAST_INIT:.+]] = tensor.empty(%[[CAST_M]]) : tensor<?x1xf32, #hipsr.mem<device>>
+// This is the difference from sample_static.mlir. The rows extent is not in the
+// type, so each allocation reads it back out of the shape that sized it, with
+// its own shape.get_extent. Both reads name the same shape, because the cast
+// forwards its operand's; CSE is left to run later rather than being built in
+// here. The host extent vector is still fully static, so it needs no read.
+// CHECK-NEXT:      %[[MM1_ROWS:.+]] = shape.get_extent %[[MM1_SHAPE]], %[[C0]] : tensor<?xindex>, index -> index
+// CHECK-NEXT:      %[[MM1_INIT:.+]] = tensor.empty(%[[MM1_ROWS]]) : tensor<?x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[CAST_ROWS:.+]] = shape.get_extent %[[MM1_SHAPE]], %[[C0]] : tensor<?xindex>, index -> index
+// CHECK-NEXT:      %[[CAST_INIT:.+]] = tensor.empty(%[[CAST_ROWS]]) : tensor<?x1xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[EXTENTS_INIT:.+]] = tensor.empty() : tensor<2xi64, #hipsr.mem<host>>
 
 // CHECK-NEXT:      %[[MM1:.+]] = hipsr.matmul(%[[D0_CTX]]) ins(%[[D0_A]], %[[W1]] : tensor<?x3xf16, #hipsr.mem<device>>, tensor<3x1xf16, #hipsr.mem<device>>) outs(%[[MM1_INIT]] : tensor<?x1xf16, #hipsr.mem<device>>) : tensor<?x1xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[CAST:.+]] = hipsr.cast(%[[D0_CTX]]) ins(%[[MM1]] : tensor<?x1xf16, #hipsr.mem<device>>) outs(%[[CAST_INIT]] : tensor<?x1xf32, #hipsr.mem<device>>) : tensor<?x1xf32, #hipsr.mem<device>>
+
+// The onnx.Shape lowering reads the dynamic extent off the data operand rather
+// than folding to a constant vector the way it does in sample_static.mlir.
 // CHECK-NEXT:      %[[EXTENTS:.+]] = hipsr.compute(%[[D0_CTX]]) ins(%[[D0_B]] : tensor<?x4xf32, #hipsr.mem<device>>) outs(%[[EXTENTS_INIT]] : tensor<2xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:      ^bb0(%{{.+}}: !hipsr.context, %[[BODY_B:.+]]: tensor<?x4xf32, #hipsr.mem<device>>, %{{.+}}: tensor<2xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:        %[[DIM_IDX:.+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[DIM:.+]] = tensor.dim %[[BODY_B]], %[[DIM_IDX]] : tensor<?x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[D0_EXT:.+]] = arith.index_cast %[[DIM]] : index to i64
+// CHECK-NEXT:      ^bb0(%{{.+}}: !hipsr.context, %[[C_B:.+]]: tensor<?x4xf32, #hipsr.mem<device>>, %{{.+}}: tensor<2xi64, #hipsr.mem<host>>):
 // CHECK-NEXT:        %[[D1_EXT:.+]] = arith.constant 4 : i64
+// CHECK-NEXT:        %[[DIM_IDX:.+]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[DIM:.+]] = tensor.dim %[[C_B]], %[[DIM_IDX]] : tensor<?x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[D0_EXT:.+]] = arith.index_cast %[[DIM]] : index to i64
 // CHECK-NEXT:        %[[EXTENT_VECTOR:.+]] = tensor.from_elements %[[D0_EXT]], %[[D1_EXT]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        hipsr.compute_yield %[[EXTENT_VECTOR]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:      } : tensor<2xi64, #hipsr.mem<host>>
 
-// CHECK-NEXT:      hipsr.preserve_shape %[[MM1_SHAPE]], %[[MM1]] : tensor<?x1xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[CAST_SHAPE]], %[[CAST]] : tensor<?x1xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[EXTENTS_SHAPE]], %[[EXTENTS]] : tensor<2xi64, #hipsr.mem<host>>
-
+// CHECK-NEXT:      hipsr.preserve_shape %[[MM1_SHAPE]], %[[MM1]] : tensor<?xindex>, tensor<?x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[MM1_SHAPE]], %[[CAST]] : tensor<?xindex>, tensor<?x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[EXTENTS_SHAPE]], %[[EXTENTS]] : tensor<1xindex>, tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[CAST_INIT]], %[[CAST]], %[[EXTENTS_INIT]], %[[EXTENTS]], %[[W2]] : tensor<?x1xf32, #hipsr.mem<device>>, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    } -> tensor<?x1xf32, #hipsr.mem<device>>, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
 
 // CHECK-NEXT:    %[[D1:.+]] = hipsr.pool_domain(%[[CTX]], %[[D0]]#0, %[[D0]]#2, %[[D0]]#1, %[[D0]]#3, %[[D0]]#4 : !hipsr.context, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>>) {
 // CHECK-NEXT:    ^bb0(%[[D1_CTX:.+]]: !hipsr.context, %[[D1_CAST_INIT:.+]]: tensor<?x1xf32, #hipsr.mem<device>>, %[[D1_EXTENTS_INIT:.+]]: tensor<2xi64, #hipsr.mem<host>>, %[[D1_CAST:.+]]: tensor<?x1xf32, #hipsr.mem<device>>, %[[D1_EXTENTS:.+]]: tensor<2xi64, #hipsr.mem<host>>, %[[D1_W2:.+]]: tensor<4x2xf32, #hipsr.mem<device>>):
+// CHECK-NEXT:      %[[D1_C0:.+]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[D1_C1:.+]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[EXTRACT_I1:.+]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[EXTRACT_I0:.+]] = arith.constant 0 : index
 
-// CHECK-NEXT:      %[[EXPAND_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[IN_SHAPE:.+]] = shape.shape_of %[[D1_CAST_INIT]] : tensor<?x1xf32, #hipsr.mem<device>> -> tensor<2xindex>
-// CHECK-NEXT:        %[[I0:.+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[E0:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[I0]]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[X0:.+]] = arith.index_cast %[[E0]] : i64 to index
-// CHECK-NEXT:        %[[I1:.+]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[E1:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[I1]]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[X1:.+]] = arith.index_cast %[[E1]] : i64 to index
-// CHECK-NEXT:        %[[REQ:.+]] = shape.from_extents %[[X0]], %[[X1]] : index, index
-// CHECK-NEXT:        %[[EXPAND_WITNESS:.+]] = shape.cstr_broadcastable %[[IN_SHAPE]], %[[REQ]] : tensor<2xindex>, !shape.shape
-// CHECK-NEXT:        %[[EXPAND_SHAPE_VAL:.+]] = shape.assuming %[[EXPAND_WITNESS]] -> (!shape.shape) {
-// CHECK-NEXT:          %[[BROADCAST:.+]] = shape.broadcast %[[IN_SHAPE]], %[[REQ]] : tensor<2xindex>, !shape.shape -> !shape.shape
-// CHECK-NEXT:          shape.assuming_yield %[[BROADCAST]] : !shape.shape
-// CHECK-NEXT:        }
-// CHECK-NEXT:        scf.yield %[[EXPAND_SHAPE_VAL]] : !shape.shape
-// CHECK-NEXT:      }
+// The barrier reads the host vector domain 0 wrote, which is where the dynamic
+// extent crosses back into the shape graph.
+// CHECK-NEXT:      %[[IN_SHAPE:.+]] = shape.shape_of %[[D1_CAST_INIT]] : tensor<?x1xf32, #hipsr.mem<device>> -> tensor<2xindex>
+// CHECK-NEXT:      %[[E0:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[EXTRACT_I0]]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      %[[X0:.+]] = arith.index_cast %[[E0]] : i64 to index
+// CHECK-NEXT:      %[[E1:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[EXTRACT_I1]]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      %[[X1:.+]] = arith.index_cast %[[E1]] : i64 to index
+// CHECK-NEXT:      %[[REQ:.+]] = tensor.from_elements %[[X0]], %[[X1]] : tensor<2xindex>
+// CHECK-NEXT:      %[[EXPAND_SHAPE:.+]] = shape.broadcast %[[IN_SHAPE]], %[[REQ]] : tensor<2xindex>, tensor<2xindex> -> tensor<2xindex>
 
-// CHECK-NEXT:      %[[MM2_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[W2_SHAPE:.+]] = shape.shape_of %[[D1_W2]] : tensor<4x2xf32, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[E_K_IDX:.+]] = shape.const_size 1
-// CHECK-NEXT:        %[[E_K:.+]] = shape.get_extent %[[EXPAND_SHAPE]], %[[E_K_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[E_K_SHAPE:.+]] = shape.from_extents %[[E_K]] : !shape.size
-// CHECK-NEXT:        %[[W2_K_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[W2_K:.+]] = shape.get_extent %[[W2_SHAPE]], %[[W2_K_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[W2_K_SHAPE:.+]] = shape.from_extents %[[W2_K]] : !shape.size
-// CHECK-NEXT:        %[[K2_WITNESS:.+]] = shape.cstr_eq %[[E_K_SHAPE]], %[[W2_K_SHAPE]] : !shape.shape, !shape.shape
-// CHECK-NEXT:        %[[E_SPLIT_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[E_BATCH:.+]], %[[E_TAIL:.+]] = "shape.split_at"(%[[EXPAND_SHAPE]], %[[E_SPLIT_IDX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT:        %[[W2_SPLIT_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[W2_BATCH:.+]], %[[W2_TAIL:.+]] = "shape.split_at"(%[[W2_SHAPE]], %[[W2_SPLIT_IDX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT:        %[[BATCH2_WITNESS:.+]] = shape.cstr_broadcastable %[[E_BATCH]], %[[W2_BATCH]] : !shape.shape, !shape.shape
-// CHECK-NEXT:        %[[WITNESS2:.+]] = shape.assuming_all %[[K2_WITNESS]], %[[BATCH2_WITNESS]]
-// CHECK-NEXT:        %[[MM2_SHAPE_VAL:.+]] = shape.assuming %[[WITNESS2]] -> (!shape.shape) {
-// CHECK-NEXT:          %[[BATCH2:.+]] = shape.broadcast %[[E_BATCH]], %[[W2_BATCH]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:          %[[M2_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:          %[[M2:.+]] = shape.get_extent %[[EXPAND_SHAPE]], %[[M2_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:          %[[N2_IDX:.+]] = shape.const_size 1
-// CHECK-NEXT:          %[[N2:.+]] = shape.get_extent %[[W2_SHAPE]], %[[N2_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:          %[[MATRIX2:.+]] = shape.from_extents %[[M2]], %[[N2]] : !shape.size, !shape.size
-// CHECK-NEXT:          %[[RESULT2:.+]] = shape.concat %[[BATCH2]], %[[MATRIX2]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:          shape.assuming_yield %[[RESULT2]] : !shape.shape
-// CHECK-NEXT:        }
-// CHECK-NEXT:        scf.yield %[[MM2_SHAPE_VAL]] : !shape.shape
-// CHECK-NEXT:      }
+// CHECK-NEXT:      %[[W2_SHAPE:.+]] = shape.shape_of %[[D1_W2]] : tensor<4x2xf32, #hipsr.mem<device>> -> tensor<2xindex>
+// CHECK-NEXT:      %[[E_BATCH:.+]], %[[E_TAIL:.+]] = "shape.split_at"(%[[EXPAND_SHAPE]], %[[D1_C0]]) : (tensor<2xindex>, index) -> (tensor<?xindex>, tensor<?xindex>)
+// CHECK-NEXT:      %[[W2_BATCH:.+]], %[[W2_TAIL:.+]] = "shape.split_at"(%[[W2_SHAPE]], %[[D1_C0]]) : (tensor<2xindex>, index) -> (tensor<?xindex>, tensor<?xindex>)
+// CHECK-NEXT:      %[[BATCH2:.+]] = shape.broadcast %[[E_BATCH]], %[[W2_BATCH]] : tensor<?xindex>, tensor<?xindex> -> tensor<?xindex>
+// CHECK-NEXT:      %[[M2:.+]] = shape.get_extent %[[EXPAND_SHAPE]], %[[D1_C0]] : tensor<2xindex>, index -> index
+// CHECK-NEXT:      %[[N2:.+]] = shape.get_extent %[[W2_SHAPE]], %[[D1_C1]] : tensor<2xindex>, index -> index
+// CHECK-NEXT:      %[[MATRIX2:.+]] = tensor.from_elements %[[M2]], %[[N2]] : tensor<2xindex>
+// CHECK-NEXT:      %[[MM2_SHAPE:.+]] = tensor.concat dim(0) %[[BATCH2]], %[[MATRIX2]] : (tensor<?xindex>, tensor<2xindex>) -> tensor<?xindex>
 
-// CHECK-NEXT:      %[[EXPAND_M_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:      %[[EXPAND_M_EXTENT:.+]] = shape.get_extent %[[EXPAND_SHAPE]], %[[EXPAND_M_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:      %[[EXPAND_M:.+]] = shape.size_to_index %[[EXPAND_M_EXTENT]] : !shape.size
-// CHECK-NEXT:      %[[EXPAND_INIT:.+]] = tensor.empty(%[[EXPAND_M]]) : tensor<?x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[MM2_M_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:      %[[MM2_M_EXTENT:.+]] = shape.get_extent %[[MM2_SHAPE]], %[[MM2_M_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:      %[[MM2_M:.+]] = shape.size_to_index %[[MM2_M_EXTENT]] : !shape.size
-// CHECK-NEXT:      %[[MM2_INIT:.+]] = tensor.empty(%[[MM2_M]]) : tensor<?x2xf32, #hipsr.mem<device>>
+// Each allocation reads the shape that sized it, so the expand's rows come from
+// the broadcast and the matmul's from the concat.
+// CHECK-NEXT:      %[[EXPAND_ROWS:.+]] = shape.get_extent %[[EXPAND_SHAPE]], %[[D1_C0]] : tensor<2xindex>, index -> index
+// CHECK-NEXT:      %[[EXPAND_INIT:.+]] = tensor.empty(%[[EXPAND_ROWS]]) : tensor<?x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[MM2_ROWS:.+]] = shape.get_extent %[[MM2_SHAPE]], %[[D1_C0]] : tensor<?xindex>, index -> index
+// CHECK-NEXT:      %[[MM2_INIT:.+]] = tensor.empty(%[[MM2_ROWS]]) : tensor<?x2xf32, #hipsr.mem<device>>
+
 // CHECK-NEXT:      %[[EXPAND:.+]] = hipsr.expand(%[[D1_CTX]]) ins(%[[D1_CAST]], %[[D1_EXTENTS]] : tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) outs(%[[EXPAND_INIT]] : tensor<?x4xf32, #hipsr.mem<device>>) : tensor<?x4xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[MM2:.+]] = hipsr.matmul(%[[D1_CTX]]) ins(%[[EXPAND]], %[[D1_W2]] : tensor<?x4xf32, #hipsr.mem<device>>, tensor<4x2xf32, #hipsr.mem<device>>) outs(%[[MM2_INIT]] : tensor<?x2xf32, #hipsr.mem<device>>) : tensor<?x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[EXPAND_SHAPE]], %[[EXPAND]] : tensor<?x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[MM2_SHAPE]], %[[MM2]] : tensor<?x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[EXPAND_SHAPE]], %[[EXPAND]] : tensor<2xindex>, tensor<?x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[MM2_SHAPE]], %[[MM2]] : tensor<?xindex>, tensor<?x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[MM2]] : tensor<?x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    } -> tensor<?x2xf32, #hipsr.mem<device>> {domain_id = 1 : i64}
 

--- a/test/lit/Dialect/Hipsr/Pipelines/sample_static.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/sample_static.mlir
@@ -20,57 +20,51 @@
 // computations, then the allocations they size, then the data ops, and last a
 // hipsr.preserve_shape tying each shape to the value filling the buffer it
 // sized.
+//
+// The shape computations are flat here, and carry extent tensors rather than
+// !shape.shape. -hipsr-convert-shape-to-extent inlined the scf.execute_region
+// and shape.assuming that -hipsr-materialize-init-tensors wraps them in, and
+// -remove-shape-constraints erased the shape.cstr_eq, shape.cstr_broadcastable,
+// and shape.assuming_all that produced the witness.
 // CHECK-NEXT:    %[[D0:.+]]:5 = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]] : !hipsr.context, tensor<2x3xf16, #hipsr.mem<device>>, tensor<2x4xf32, #hipsr.mem<device>>) {
 // CHECK-NEXT:    ^bb0(%[[D0_CTX:.+]]: !hipsr.context, %[[D0_A:.+]]: tensor<2x3xf16, #hipsr.mem<device>>, %[[D0_B:.+]]: tensor<2x4xf32, #hipsr.mem<device>>):
 
-// Both weights lead the domain. Only the first one has a shape a computation
-// reads; the second is here because a constant takes no operands, so the pass
-// brings every one of them over ahead of the computations.
+// The extent vector's length follows the rank of the operand, not its extents,
+// so the operand's shape goes unread and the whole computation is the constant
+// 2. Constants lead the block ahead of even the weights, because the greedy
+// driver in -remove-shape-constraints hoists them there.
+// CHECK-NEXT:      %[[EXTENTS_SHAPE:.+]] = shape.const_shape [2] : tensor<1xindex>
+// CHECK-NEXT:      %[[C0:.+]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[C1:.+]] = arith.constant 1 : index
+
+// Both weights lead the operations. Only the first one has a shape a
+// computation reads; the second is here because a constant takes no operands,
+// so the pass brings every one of them over ahead of the computations.
 // CHECK-NEXT:      %[[W1:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<3x1xf16>} : tensor<3x1xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[W2:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<4x2xf32>} : tensor<4x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[MM1_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[D0_A]] : tensor<2x3xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[W1_SHAPE:.+]] = shape.shape_of %[[W1]] : tensor<3x1xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[A_K_IDX:.+]] = shape.const_size 1
-// CHECK-NEXT:        %[[A_K:.+]] = shape.get_extent %[[A_SHAPE]], %[[A_K_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[A_K_SHAPE:.+]] = shape.from_extents %[[A_K]] : !shape.size
-// CHECK-NEXT:        %[[W1_K_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[W1_K:.+]] = shape.get_extent %[[W1_SHAPE]], %[[W1_K_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[W1_K_SHAPE:.+]] = shape.from_extents %[[W1_K]] : !shape.size
-// CHECK-NEXT:        %[[K_WITNESS:.+]] = shape.cstr_eq %[[A_K_SHAPE]], %[[W1_K_SHAPE]] : !shape.shape, !shape.shape
-// CHECK-NEXT:        %[[A_SPLIT_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[A_BATCH:.+]], %[[A_TAIL:.+]] = "shape.split_at"(%[[A_SHAPE]], %[[A_SPLIT_IDX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT:        %[[W1_SPLIT_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[W1_BATCH:.+]], %[[W1_TAIL:.+]] = "shape.split_at"(%[[W1_SHAPE]], %[[W1_SPLIT_IDX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT:        %[[BATCH_WITNESS:.+]] = shape.cstr_broadcastable %[[A_BATCH]], %[[W1_BATCH]] : !shape.shape, !shape.shape
-// CHECK-NEXT:        %[[WITNESS:.+]] = shape.assuming_all %[[K_WITNESS]], %[[BATCH_WITNESS]]
-// CHECK-NEXT:        %[[MM1_SHAPE_VAL:.+]] = shape.assuming %[[WITNESS]] -> (!shape.shape) {
-// CHECK-NEXT:          %[[BATCH:.+]] = shape.broadcast %[[A_BATCH]], %[[W1_BATCH]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:          %[[M_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:          %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[M_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:          %[[N_IDX:.+]] = shape.const_size 1
-// CHECK-NEXT:          %[[N:.+]] = shape.get_extent %[[W1_SHAPE]], %[[N_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:          %[[MATRIX:.+]] = shape.from_extents %[[M]], %[[N]] : !shape.size, !shape.size
-// CHECK-NEXT:          %[[RESULT:.+]] = shape.concat %[[BATCH]], %[[MATRIX]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:          shape.assuming_yield %[[RESULT]] : !shape.shape
-// CHECK-NEXT:        }
-// CHECK-NEXT:        scf.yield %[[MM1_SHAPE_VAL]] : !shape.shape
-// CHECK-NEXT:      }
 
-// The cast keeps its operand's shape, so its shape computation forwards the one
-// next to it.
-// CHECK-NEXT:      %[[CAST_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        scf.yield %[[MM1_SHAPE]] : !shape.shape
-// CHECK-NEXT:      }
+// The matmul shape: broadcast the batch dimensions, then append M from the lhs
+// and N from the rhs. shape.shape_of recovers a static rank from its operand,
+// which is what keeps the two shape.get_extent reads statically indexable.
+//
+// The split_at results stay tensor<?xindex> on purpose. --convert-shape-to-std
+// lowers split_at to a tensor.extract_slice whose size is computed, so it
+// produces tensor<?xindex> whatever result type it is asked for; claiming a
+// static rank here would leave the extract_slice unable to replace it. That
+// dynamic rank is then carried by the broadcast and the concat below.
+// CHECK-NEXT:      %[[A_SHAPE:.+]] = shape.shape_of %[[D0_A]] : tensor<2x3xf16, #hipsr.mem<device>> -> tensor<2xindex>
+// CHECK-NEXT:      %[[W1_SHAPE:.+]] = shape.shape_of %[[W1]] : tensor<3x1xf16, #hipsr.mem<device>> -> tensor<2xindex>
+// CHECK-NEXT:      %[[A_BATCH:.+]], %[[A_TAIL:.+]] = "shape.split_at"(%[[A_SHAPE]], %[[C0]]) : (tensor<2xindex>, index) -> (tensor<?xindex>, tensor<?xindex>)
+// CHECK-NEXT:      %[[W1_BATCH:.+]], %[[W1_TAIL:.+]] = "shape.split_at"(%[[W1_SHAPE]], %[[C0]]) : (tensor<2xindex>, index) -> (tensor<?xindex>, tensor<?xindex>)
+// CHECK-NEXT:      %[[BATCH:.+]] = shape.broadcast %[[A_BATCH]], %[[W1_BATCH]] : tensor<?xindex>, tensor<?xindex> -> tensor<?xindex>
+// CHECK-NEXT:      %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[C0]] : tensor<2xindex>, index -> index
+// CHECK-NEXT:      %[[N:.+]] = shape.get_extent %[[W1_SHAPE]], %[[C1]] : tensor<2xindex>, index -> index
+// CHECK-NEXT:      %[[MATRIX:.+]] = tensor.from_elements %[[M]], %[[N]] : tensor<2xindex>
+// CHECK-NEXT:      %[[MM1_SHAPE:.+]] = tensor.concat dim(0) %[[BATCH]], %[[MATRIX]] : (tensor<?xindex>, tensor<2xindex>) -> tensor<?xindex>
 
-// The extent vector's length follows the rank of the operand, not its extents,
-// so the operand's shape goes unread here.
-// CHECK-NEXT:      %[[EXTENTS_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[B_SHAPE:.+]] = shape.shape_of %[[D0_B]] : tensor<2x4xf32, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[RANK:.+]] = arith.constant 2 : index
-// CHECK-NEXT:        %[[RANK_SHAPE:.+]] = shape.from_extents %[[RANK]] : index
-// CHECK-NEXT:        scf.yield %[[RANK_SHAPE]] : !shape.shape
-// CHECK-NEXT:      }
+// The cast keeps its operand's shape, so it has no computation of its own left:
+// inlining the forwarding scf.execute_region leaves the matmul's shape reaching
+// the cast's hipsr.preserve_shape directly.
 
 // Every extent is in the types, so no allocation reads a shape back.
 // CHECK-NEXT:      %[[MM1_INIT:.+]] = tensor.empty() : tensor<2x1xf16, #hipsr.mem<device>>
@@ -81,15 +75,13 @@
 // CHECK-NEXT:      %[[CAST:.+]] = hipsr.cast(%[[D0_CTX]]) ins(%[[MM1]] : tensor<2x1xf16, #hipsr.mem<device>>) outs(%[[CAST_INIT]] : tensor<2x1xf32, #hipsr.mem<device>>) : tensor<2x1xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[EXTENTS:.+]] = hipsr.compute(%[[D0_CTX]]) ins(%[[D0_B]] : tensor<2x4xf32, #hipsr.mem<device>>) outs(%[[EXTENTS_INIT]] : tensor<2xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:      ^bb0(%{{.+}}: !hipsr.context, %{{.+}}: tensor<2x4xf32, #hipsr.mem<device>>, %{{.+}}: tensor<2xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:        %[[D0_EXT:.+]] = arith.constant 2 : i64
-// CHECK-NEXT:        %[[D1_EXT:.+]] = arith.constant 4 : i64
-// CHECK-NEXT:        %[[EXTENT_VECTOR:.+]] = tensor.from_elements %[[D0_EXT]], %[[D1_EXT]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[EXTENT_VECTOR:.+]] = arith.constant dense<[2, 4]> : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        hipsr.compute_yield %[[EXTENT_VECTOR]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:      } : tensor<2xi64, #hipsr.mem<host>>
 
-// CHECK-NEXT:      hipsr.preserve_shape %[[MM1_SHAPE]], %[[MM1]] : tensor<2x1xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[CAST_SHAPE]], %[[CAST]] : tensor<2x1xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[EXTENTS_SHAPE]], %[[EXTENTS]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[MM1_SHAPE]], %[[MM1]] : tensor<?xindex>, tensor<2x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[MM1_SHAPE]], %[[CAST]] : tensor<?xindex>, tensor<2x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[EXTENTS_SHAPE]], %[[EXTENTS]] : tensor<1xindex>, tensor<2xi64, #hipsr.mem<host>>
 
 // The second weight has no inputs, which keeps it in domain 0, and only the
 // yield uses it there.
@@ -101,61 +93,39 @@
 // operations keep following results.
 // CHECK-NEXT:    %[[D1:.+]] = hipsr.pool_domain(%[[CTX]], %[[D0]]#0, %[[D0]]#2, %[[D0]]#1, %[[D0]]#3, %[[D0]]#4 : !hipsr.context, tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>>) {
 // CHECK-NEXT:    ^bb0(%[[D1_CTX:.+]]: !hipsr.context, %[[D1_CAST_INIT:.+]]: tensor<2x1xf32, #hipsr.mem<device>>, %[[D1_EXTENTS_INIT:.+]]: tensor<2xi64, #hipsr.mem<host>>, %[[D1_CAST:.+]]: tensor<2x1xf32, #hipsr.mem<device>>, %[[D1_EXTENTS:.+]]: tensor<2xi64, #hipsr.mem<host>>, %[[D1_W2:.+]]: tensor<4x2xf32, #hipsr.mem<device>>):
+// CHECK-NEXT:      %[[D1_C0:.+]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[D1_C1:.+]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[EXTRACT_I1:.+]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[EXTRACT_I0:.+]] = arith.constant 0 : index
 
 // The expand's destination is the reason for the cut: its extents come out of
 // the host vector domain 0 wrote, so the barrier's shape computation reads that
-// buffer instead of a shape.
-// CHECK-NEXT:      %[[EXPAND_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[IN_SHAPE:.+]] = shape.shape_of %[[D1_CAST_INIT]] : tensor<2x1xf32, #hipsr.mem<device>> -> tensor<2xindex>
-// CHECK-NEXT:        %[[I0:.+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[E0:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[I0]]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[X0:.+]] = arith.index_cast %[[E0]] : i64 to index
-// CHECK-NEXT:        %[[I1:.+]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[E1:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[I1]]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[X1:.+]] = arith.index_cast %[[E1]] : i64 to index
-// CHECK-NEXT:        %[[REQ:.+]] = shape.from_extents %[[X0]], %[[X1]] : index, index
-// CHECK-NEXT:        %[[EXPAND_WITNESS:.+]] = shape.cstr_broadcastable %[[IN_SHAPE]], %[[REQ]] : tensor<2xindex>, !shape.shape
-// CHECK-NEXT:        %[[EXPAND_SHAPE_VAL:.+]] = shape.assuming %[[EXPAND_WITNESS]] -> (!shape.shape) {
-// CHECK-NEXT:          %[[BROADCAST:.+]] = shape.broadcast %[[IN_SHAPE]], %[[REQ]] : tensor<2xindex>, !shape.shape -> !shape.shape
-// CHECK-NEXT:          shape.assuming_yield %[[BROADCAST]] : !shape.shape
-// CHECK-NEXT:        }
-// CHECK-NEXT:        scf.yield %[[EXPAND_SHAPE_VAL]] : !shape.shape
-// CHECK-NEXT:      }
+// buffer instead of a shape. Both operands of the broadcast have a static rank,
+// so its result does too, which is why the expand's preserve_shape below takes
+// a tensor<2xindex> where the matmul's takes a tensor<?xindex>.
+// CHECK-NEXT:      %[[IN_SHAPE:.+]] = shape.shape_of %[[D1_CAST_INIT]] : tensor<2x1xf32, #hipsr.mem<device>> -> tensor<2xindex>
+// CHECK-NEXT:      %[[E0:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[EXTRACT_I0]]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      %[[X0:.+]] = arith.index_cast %[[E0]] : i64 to index
+// CHECK-NEXT:      %[[E1:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[EXTRACT_I1]]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      %[[X1:.+]] = arith.index_cast %[[E1]] : i64 to index
+// CHECK-NEXT:      %[[REQ:.+]] = tensor.from_elements %[[X0]], %[[X1]] : tensor<2xindex>
+// CHECK-NEXT:      %[[EXPAND_SHAPE:.+]] = shape.broadcast %[[IN_SHAPE]], %[[REQ]] : tensor<2xindex>, tensor<2xindex> -> tensor<2xindex>
 
-// CHECK-NEXT:      %[[MM2_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[W2_SHAPE:.+]] = shape.shape_of %[[D1_W2]] : tensor<4x2xf32, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[E_K_IDX:.+]] = shape.const_size 1
-// CHECK-NEXT:        %[[E_K:.+]] = shape.get_extent %[[EXPAND_SHAPE]], %[[E_K_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[E_K_SHAPE:.+]] = shape.from_extents %[[E_K]] : !shape.size
-// CHECK-NEXT:        %[[W2_K_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[W2_K:.+]] = shape.get_extent %[[W2_SHAPE]], %[[W2_K_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[W2_K_SHAPE:.+]] = shape.from_extents %[[W2_K]] : !shape.size
-// CHECK-NEXT:        %[[K2_WITNESS:.+]] = shape.cstr_eq %[[E_K_SHAPE]], %[[W2_K_SHAPE]] : !shape.shape, !shape.shape
-// CHECK-NEXT:        %[[E_SPLIT_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[E_BATCH:.+]], %[[E_TAIL:.+]] = "shape.split_at"(%[[EXPAND_SHAPE]], %[[E_SPLIT_IDX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT:        %[[W2_SPLIT_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[W2_BATCH:.+]], %[[W2_TAIL:.+]] = "shape.split_at"(%[[W2_SHAPE]], %[[W2_SPLIT_IDX]]) : (!shape.shape, !shape.size) -> (!shape.shape, !shape.shape)
-// CHECK-NEXT:        %[[BATCH2_WITNESS:.+]] = shape.cstr_broadcastable %[[E_BATCH]], %[[W2_BATCH]] : !shape.shape, !shape.shape
-// CHECK-NEXT:        %[[WITNESS2:.+]] = shape.assuming_all %[[K2_WITNESS]], %[[BATCH2_WITNESS]]
-// CHECK-NEXT:        %[[MM2_SHAPE_VAL:.+]] = shape.assuming %[[WITNESS2]] -> (!shape.shape) {
-// CHECK-NEXT:          %[[BATCH2:.+]] = shape.broadcast %[[E_BATCH]], %[[W2_BATCH]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:          %[[M2_IDX:.+]] = shape.const_size 0
-// CHECK-NEXT:          %[[M2:.+]] = shape.get_extent %[[EXPAND_SHAPE]], %[[M2_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:          %[[N2_IDX:.+]] = shape.const_size 1
-// CHECK-NEXT:          %[[N2:.+]] = shape.get_extent %[[W2_SHAPE]], %[[N2_IDX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:          %[[MATRIX2:.+]] = shape.from_extents %[[M2]], %[[N2]] : !shape.size, !shape.size
-// CHECK-NEXT:          %[[RESULT2:.+]] = shape.concat %[[BATCH2]], %[[MATRIX2]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:          shape.assuming_yield %[[RESULT2]] : !shape.shape
-// CHECK-NEXT:        }
-// CHECK-NEXT:        scf.yield %[[MM2_SHAPE_VAL]] : !shape.shape
-// CHECK-NEXT:      }
+// CHECK-NEXT:      %[[W2_SHAPE:.+]] = shape.shape_of %[[D1_W2]] : tensor<4x2xf32, #hipsr.mem<device>> -> tensor<2xindex>
+// CHECK-NEXT:      %[[E_BATCH:.+]], %[[E_TAIL:.+]] = "shape.split_at"(%[[EXPAND_SHAPE]], %[[D1_C0]]) : (tensor<2xindex>, index) -> (tensor<?xindex>, tensor<?xindex>)
+// CHECK-NEXT:      %[[W2_BATCH:.+]], %[[W2_TAIL:.+]] = "shape.split_at"(%[[W2_SHAPE]], %[[D1_C0]]) : (tensor<2xindex>, index) -> (tensor<?xindex>, tensor<?xindex>)
+// CHECK-NEXT:      %[[BATCH2:.+]] = shape.broadcast %[[E_BATCH]], %[[W2_BATCH]] : tensor<?xindex>, tensor<?xindex> -> tensor<?xindex>
+// CHECK-NEXT:      %[[M2:.+]] = shape.get_extent %[[EXPAND_SHAPE]], %[[D1_C0]] : tensor<2xindex>, index -> index
+// CHECK-NEXT:      %[[N2:.+]] = shape.get_extent %[[W2_SHAPE]], %[[D1_C1]] : tensor<2xindex>, index -> index
+// CHECK-NEXT:      %[[MATRIX2:.+]] = tensor.from_elements %[[M2]], %[[N2]] : tensor<2xindex>
+// CHECK-NEXT:      %[[MM2_SHAPE:.+]] = tensor.concat dim(0) %[[BATCH2]], %[[MATRIX2]] : (tensor<?xindex>, tensor<2xindex>) -> tensor<?xindex>
 
 // CHECK-NEXT:      %[[EXPAND_INIT:.+]] = tensor.empty() : tensor<2x4xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[MM2_INIT:.+]] = tensor.empty() : tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[EXPAND:.+]] = hipsr.expand(%[[D1_CTX]]) ins(%[[D1_CAST]], %[[D1_EXTENTS]] : tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) outs(%[[EXPAND_INIT]] : tensor<2x4xf32, #hipsr.mem<device>>) : tensor<2x4xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[MM2:.+]] = hipsr.matmul(%[[D1_CTX]]) ins(%[[EXPAND]], %[[D1_W2]] : tensor<2x4xf32, #hipsr.mem<device>>, tensor<4x2xf32, #hipsr.mem<device>>) outs(%[[MM2_INIT]] : tensor<2x2xf32, #hipsr.mem<device>>) : tensor<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[EXPAND_SHAPE]], %[[EXPAND]] : tensor<2x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[MM2_SHAPE]], %[[MM2]] : tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[EXPAND_SHAPE]], %[[EXPAND]] : tensor<2xindex>, tensor<2x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[MM2_SHAPE]], %[[MM2]] : tensor<?xindex>, tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[MM2]] : tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    } -> tensor<2x2xf32, #hipsr.mem<device>> {domain_id = 1 : i64}
 

--- a/test/lit/Dialect/Hipsr/Transforms/ConvertShapeToExtent/convert-shape-to-extent.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/ConvertShapeToExtent/convert-shape-to-extent.mlir
@@ -1,0 +1,88 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+//===----------------------------------------------------------------------===//
+// Positive coverage for -hipsr-convert-shape-to-extent.
+//
+// Each case checks its whole function with CHECK-NEXT, so the CHECK block is
+// the expected output. Anything left over breaks the chain: a !shape.shape, an
+// uninlined region, or an unrealized_conversion_cast.
+//
+// Error paths live in invalid.mlir.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt %s -split-input-file -hipsr-convert-shape-to-extent | FileCheck %s
+
+// Every pattern at once, on operands whose rank the conversion can read.
+//
+// - The prologue inlines the shape.assuming and the scf.execute_region, so the
+//   witness goes dead and the body flattens.
+// - shape_of reads the rank off its operand, giving 2 and 3 extents.
+// - broadcast left-pads with ones, so its result takes the longer rank, 3.
+// - from_extents becomes tensor.from_elements, and concat becomes
+//   tensor.concat with 2 + 3 extents. Upstream has no pattern for either.
+// - const_size becomes arith.constant, and size_to_index folds into its
+//   operand.
+// - get_extent, num_elements, and preserve_shape are only retyped.
+// CHECK-LABEL: func.func @convert_shape_ops(
+// CHECK-SAME:      %[[A:.+]]: tensor<?x4xf16>, %[[B:.+]]: tensor<8x?x4xf16>) -> (tensor<?x4xf16, #hipsr.mem<device>>, index) {
+// CHECK-NEXT:    %[[C4:.+]] = arith.constant 4 : index
+// CHECK-NEXT:    %[[C0:.+]] = arith.constant 0 : index
+// CHECK-NEXT:    %[[SA:.+]] = shape.shape_of %[[A]] : tensor<?x4xf16> -> tensor<2xindex>
+// CHECK-NEXT:    %[[SB:.+]] = shape.shape_of %[[B]] : tensor<8x?x4xf16> -> tensor<3xindex>
+// CHECK-NEXT:    %[[BCAST:.+]] = shape.broadcast %[[SA]], %[[SB]] : tensor<2xindex>, tensor<3xindex> -> tensor<3xindex>
+// CHECK-NEXT:    %[[D0:.+]] = shape.get_extent %[[BCAST]], %[[C0]] : tensor<3xindex>, index -> index
+// CHECK-NEXT:    %[[SA2:.+]] = shape.shape_of %[[A]] : tensor<?x4xf16> -> tensor<2xindex>
+// CHECK-NEXT:    %[[CAT:.+]] = tensor.concat dim(0) %[[SA2]], %[[BCAST]] : (tensor<2xindex>, tensor<3xindex>) -> tensor<5xindex>
+// CHECK-NEXT:    %[[COUNT:.+]] = shape.num_elements %[[CAT]] : tensor<5xindex> -> index
+// CHECK-NEXT:    %[[SHAPE:.+]] = tensor.from_elements %[[D0]], %[[C4]] : tensor<2xindex>
+// CHECK-NEXT:    %[[INIT:.+]] = tensor.empty(%[[D0]]) : tensor<?x4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    hipsr.preserve_shape %[[SHAPE]], %[[INIT]] : tensor<2xindex>, tensor<?x4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    return %[[INIT]], %[[COUNT]] : tensor<?x4xf16, #hipsr.mem<device>>, index
+// CHECK-NEXT:  }
+func.func @convert_shape_ops(%a: tensor<?x4xf16>, %b: tensor<8x?x4xf16>)
+    -> (tensor<?x4xf16, #hipsr.mem<device>>, index) {
+  %w = shape.const_witness true
+  %bcast = shape.assuming %w -> !shape.shape {
+    %r = scf.execute_region -> !shape.shape {
+      %sa = shape.shape_of %a : tensor<?x4xf16> -> !shape.shape
+      scf.yield %sa : !shape.shape
+    }
+    %sb = shape.shape_of %b : tensor<8x?x4xf16> -> !shape.shape
+    %bc = shape.broadcast %r, %sb : !shape.shape, !shape.shape -> !shape.shape
+    shape.assuming_yield %bc : !shape.shape
+  }
+
+  %c0 = shape.const_size 0
+  %e0 = shape.get_extent %bcast, %c0 : !shape.shape, !shape.size -> !shape.size
+  %d0 = shape.size_to_index %e0 : !shape.size
+
+  %sa2 = shape.shape_of %a : tensor<?x4xf16> -> !shape.shape
+  %cat = shape.concat %sa2, %bcast : !shape.shape, !shape.shape -> !shape.shape
+  %n = shape.num_elements %cat : !shape.shape -> !shape.size
+  %count = shape.size_to_index %n : !shape.size
+
+  %c4 = arith.constant 4 : index
+  %fe = shape.from_extents %d0, %c4 : index, index
+  %init = tensor.empty(%d0) : tensor<?x4xf16, #hipsr.mem<device>>
+  hipsr.preserve_shape %fe, %init : !shape.shape, tensor<?x4xf16, #hipsr.mem<device>>
+  return %init, %count : tensor<?x4xf16, #hipsr.mem<device>>, index
+}
+
+// -----
+
+// An unranked operand gives no rank to read, so the result falls back to
+// tensor<?xindex> instead of failing. Upstream still lowers it; only the
+// static indexing is lost.
+// CHECK-LABEL: func.func @unranked_operand_falls_back(
+// CHECK-SAME:      %[[A:.+]]: tensor<*xf16>) -> index {
+// CHECK-NEXT:    %[[SHAPE:.+]] = shape.shape_of %[[A]] : tensor<*xf16> -> tensor<?xindex>
+// CHECK-NEXT:    %[[COUNT:.+]] = shape.num_elements %[[SHAPE]] : tensor<?xindex> -> index
+// CHECK-NEXT:    return %[[COUNT]] : index
+// CHECK-NEXT:  }
+func.func @unranked_operand_falls_back(%a: tensor<*xf16>) -> index {
+  %s = shape.shape_of %a : tensor<*xf16> -> !shape.shape
+  %n = shape.num_elements %s : !shape.shape -> !shape.size
+  %i = shape.size_to_index %n : !shape.size
+  return %i : index
+}

--- a/test/lit/Dialect/Hipsr/Transforms/ConvertShapeToExtent/invalid.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/ConvertShapeToExtent/invalid.mlir
@@ -1,0 +1,54 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+//===----------------------------------------------------------------------===//
+// Error paths of -hipsr-convert-shape-to-extent and of the relaxed
+// hipsr.preserve_shape verifier. Positive coverage lives in
+// convert-shape-to-extent.mlir.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt %s -split-input-file -verify-diagnostics -hipsr-convert-shape-to-extent
+
+// The prologue inlines a shape.assuming only when its witness is a passing
+// shape.const_witness, which -remove-shape-constraints creates. A surviving
+// witness means that pass did not run.
+//
+// The pass has no pattern for the region, so the region keeps its !shape.size
+// result and the conversion reports it as illegal.
+func.func @assuming_region_survives(%a: tensor<?x4xf16>, %b: tensor<?x4xf16>) -> index {
+  %sa = shape.shape_of %a : tensor<?x4xf16> -> !shape.shape
+  %sb = shape.shape_of %b : tensor<?x4xf16> -> !shape.shape
+  %w = shape.cstr_eq %sa, %sb : !shape.shape, !shape.shape
+  // expected-error@+1 {{failed to legalize operation 'shape.assuming'}}
+  %s = shape.assuming %w -> !shape.size {
+    %0 = shape.shape_of %a : tensor<?x4xf16> -> !shape.shape
+    %n = shape.num_elements %0 : !shape.shape -> !shape.size
+    shape.assuming_yield %n : !shape.size
+  }
+  %i = shape.size_to_index %s : !shape.size
+  return %i : index
+}
+
+// -----
+
+// Accepting extent tensors and memrefs widens the operand type, so only the
+// element type still separates a shape from ordinary data. An i64 host buffer
+// is the likely mistake.
+func.func @shape_operand_is_not_an_extent_tensor(%extents: tensor<2xi64>,
+                                                 %data: tensor<?x4xf16>) {
+  // expected-error@+1 {{operand #0 must be shape, extent tensor, or extent memref}}
+  hipsr.preserve_shape %extents, %data : tensor<2xi64>, tensor<?x4xf16>
+  return
+}
+
+// -----
+
+// An extent tensor carries its length, so the verifier can compare it with the
+// data rank. An opaque !shape.shape carries no length, so the check only
+// applies after conversion.
+func.func @extent_count_disagrees_with_data_rank(%d0: index, %data: tensor<?x4xf16>) {
+  %shape = tensor.from_elements %d0 : tensor<1xindex>
+  // expected-error@+1 {{extent count 1 does not match data rank 2}}
+  hipsr.preserve_shape %shape, %data : tensor<1xindex>, tensor<?x4xf16>
+  return
+}

--- a/test/lit/Dialect/Hipsr/Transforms/MaterializeInitTensors/materialize-init-tensors.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/MaterializeInitTensors/materialize-init-tensors.mlir
@@ -48,7 +48,7 @@
 // CHECK-NEXT:      %[[D1:.+]] = shape.size_to_index %[[D1_EXTENT]] : !shape.size
 // CHECK-NEXT:      %[[INIT:.+]] = tensor.empty(%[[D0]], %[[D1]]) : tensor<?x?xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[EXPAND:.+]] = hipsr.expand(%[[DCTX]]) ins(%[[DIN]], %[[DEXTENTS]] : tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) outs(%[[INIT]] : tensor<?x?xf32, #hipsr.mem<device>>) : tensor<?x?xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[SHAPE]], %[[EXPAND]] : tensor<?x?xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[SHAPE]], %[[EXPAND]] : !shape.shape, tensor<?x?xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[EXPAND]] : tensor<?x?xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    } -> tensor<?x?xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
 // CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x?xf32, #hipsr.mem<device>>
@@ -134,8 +134,8 @@ func.func @barrier_domain(%ctx: !hipsr.context, %in: tensor<?x1xf32, #hipsr.mem<
 // CHECK-NEXT:      %[[ADD_INIT:.+]] = tensor.empty(%[[ADD_D0]]) : tensor<?x512xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[MATMUL:.+]] = hipsr.matmul(%[[DCTX]]) ins(%[[DA]], %[[DB]] : tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>) outs(%[[MATMUL_INIT]] : tensor<?x512xf16, #hipsr.mem<device>>) : tensor<?x512xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[ADD:.+]] = hipsr.add(%[[DCTX]]) ins(%[[MATMUL]], %[[DC]] : tensor<?x512xf16, #hipsr.mem<device>>, tensor<?x512xf16, #hipsr.mem<device>>) outs(%[[ADD_INIT]] : tensor<?x512xf16, #hipsr.mem<device>>) : tensor<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[MATMUL_SHAPE]], %[[MATMUL]] : tensor<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[ADD_SHAPE]], %[[ADD]] : tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[MATMUL_SHAPE]], %[[MATMUL]] : !shape.shape, tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[ADD_SHAPE]], %[[ADD]] : !shape.shape, tensor<?x512xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[ADD]] : tensor<?x512xf16, #hipsr.mem<device>>
 // CHECK-NEXT:    } -> tensor<?x512xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
 // CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x512xf16, #hipsr.mem<device>>
@@ -208,8 +208,8 @@ func.func @interleaved(%ctx: !hipsr.context, %a: tensor<?x256xf16, #hipsr.mem<de
 // CHECK-NEXT:      %[[ADD_INIT:.+]] = tensor.empty() : tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[CAST:.+]] = hipsr.cast(%[[DCTX]]) ins(%[[DA]] : tensor<2x2xf16, #hipsr.mem<device>>) outs(%[[CAST_INIT]] : tensor<2x2xf32, #hipsr.mem<device>>) : tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[ADD:.+]] = hipsr.add(%[[DCTX]]) ins(%[[CAST]], %[[WEIGHT]] : tensor<2x2xf32, #hipsr.mem<device>>, tensor<2x2xf32, #hipsr.mem<device>>) outs(%[[ADD_INIT]] : tensor<2x2xf32, #hipsr.mem<device>>) : tensor<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[CAST_SHAPE]], %[[CAST]] : tensor<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[ADD_SHAPE]], %[[ADD]] : tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[CAST_SHAPE]], %[[CAST]] : !shape.shape, tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[ADD_SHAPE]], %[[ADD]] : !shape.shape, tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      hipsr.pool_domain_yield %[[ADD]] : tensor<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    } -> tensor<2x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
 // CHECK-NEXT:    return %[[DOMAIN]] : tensor<2x2xf32, #hipsr.mem<device>>

--- a/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/compute.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/compute.mlir
@@ -73,9 +73,9 @@
 // CHECK-SAME: : memref<?x256xf16, #hipsr.mem<device>> into memref<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT: hipsr.compute_yield %[[COLLAPSED]] : memref<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT: } : memref<?xf16, #hipsr.mem<device>>{{$}}
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE1]], %[[INIT1]] : memref<?x256xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE2]], %[[INIT2]] : memref<?x256xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE3]], %[[FLAT]] : memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE1]], %[[INIT1]] : !shape.shape, memref<?x256xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE2]], %[[INIT2]] : !shape.shape, memref<?x256xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE3]], %[[FLAT]] : !shape.shape, memref<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT: hipsr.pool_domain_yield %[[FLAT]] : memref<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT: } -> memref<?xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
 // CHECK-NEXT: return %[[OUT]] : memref<?xf16, #hipsr.mem<device>>
@@ -126,9 +126,9 @@ func.func @pool_domain_mlp_flatten(
           into tensor<?xf16, #hipsr.mem<device>>
       hipsr.compute_yield %collapsed : tensor<?xf16, #hipsr.mem<device>>
     } : tensor<?xf16, #hipsr.mem<device>>
-    hipsr.preserve_shape %shape1, %cast1 : tensor<?x256xf16, #hipsr.mem<device>>
-    hipsr.preserve_shape %shape2, %cast2 : tensor<?x256xf16, #hipsr.mem<device>>
-    hipsr.preserve_shape %shape3, %flat : tensor<?xf16, #hipsr.mem<device>>
+    hipsr.preserve_shape %shape1, %cast1 : !shape.shape, tensor<?x256xf16, #hipsr.mem<device>>
+    hipsr.preserve_shape %shape2, %cast2 : !shape.shape, tensor<?x256xf16, #hipsr.mem<device>>
+    hipsr.preserve_shape %shape3, %flat : !shape.shape, tensor<?xf16, #hipsr.mem<device>>
     hipsr.pool_domain_yield %flat : tensor<?xf16, #hipsr.mem<device>>
   } -> tensor<?xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
   return %out : tensor<?xf16, #hipsr.mem<device>>

--- a/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/preserve_shape.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/preserve_shape.mlir
@@ -14,14 +14,14 @@
 // CHECK-NEXT: %[[C2048:.+]] = arith.constant 2048 : index
 // CHECK-NEXT: %[[SHAPE:.+]] = shape.from_extents %[[D0]], %[[C2048]] : index, index
 // CHECK-NEXT: %[[ALLOC:.+]] = memref.alloc(%[[D0]]) {{.*}}: memref<?x2048xf32, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[ALLOC]] : memref<?x2048xf32, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[ALLOC]] : !shape.shape, memref<?x2048xf32, #hipsr.mem<device>>
 // CHECK-NEXT: hipsr.cast(%[[CTX]]) ins({{.+}}) outs(%[[ALLOC]] : memref<?x2048xf32, #hipsr.mem<device>>)
 func.func @dps_init(%ctx: !hipsr.context, %d0: index,
                     %in: tensor<?x2048xf16, #hipsr.mem<device>>) -> tensor<?x2048xf32, #hipsr.mem<device>> {
   %c2048 = arith.constant 2048 : index
   %shape = shape.from_extents %d0, %c2048 : index, index
   %init = tensor.empty(%d0) : tensor<?x2048xf32, #hipsr.mem<device>>
-  hipsr.preserve_shape %shape, %init : tensor<?x2048xf32, #hipsr.mem<device>>
+  hipsr.preserve_shape %shape, %init : !shape.shape, tensor<?x2048xf32, #hipsr.mem<device>>
   %out = hipsr.cast(%ctx) ins(%in : tensor<?x2048xf16, #hipsr.mem<device>>)
                           outs(%init : tensor<?x2048xf32, #hipsr.mem<device>>) : tensor<?x2048xf32, #hipsr.mem<device>>
   return %out : tensor<?x2048xf32, #hipsr.mem<device>>
@@ -36,7 +36,7 @@ func.func @dps_init(%ctx: !hipsr.context, %d0: index,
 // CHECK-NEXT: %[[SHAPE:.+]] = shape.from_extents %[[D0]], %[[C2048]] : index, index
 // CHECK-NEXT: %[[ALLOC:.+]] = memref.alloc(%[[D0]]) {{.*}}: memref<?x2048xf32, #hipsr.mem<device>>
 // CHECK-NEXT: hipsr.cast(%[[CTX]]) ins({{.+}}) outs(%[[ALLOC]] : memref<?x2048xf32, #hipsr.mem<device>>)
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[ALLOC]] : memref<?x2048xf32, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[ALLOC]] : !shape.shape, memref<?x2048xf32, #hipsr.mem<device>>
 func.func @dps_result(%ctx: !hipsr.context, %d0: index,
                       %in: tensor<?x2048xf16, #hipsr.mem<device>>) -> tensor<?x2048xf32, #hipsr.mem<device>> {
   %c2048 = arith.constant 2048 : index
@@ -44,7 +44,7 @@ func.func @dps_result(%ctx: !hipsr.context, %d0: index,
   %init = tensor.empty(%d0) : tensor<?x2048xf32, #hipsr.mem<device>>
   %out = hipsr.cast(%ctx) ins(%in : tensor<?x2048xf16, #hipsr.mem<device>>)
                           outs(%init : tensor<?x2048xf32, #hipsr.mem<device>>) : tensor<?x2048xf32, #hipsr.mem<device>>
-  hipsr.preserve_shape %shape, %out : tensor<?x2048xf32, #hipsr.mem<device>>
+  hipsr.preserve_shape %shape, %out : !shape.shape, tensor<?x2048xf32, #hipsr.mem<device>>
   return %out : tensor<?x2048xf32, #hipsr.mem<device>>
 }
 
@@ -56,13 +56,13 @@ func.func @dps_result(%ctx: !hipsr.context, %d0: index,
 // CHECK-SAME: %[[DATA:.+]]: memref<?x2048xf32, strided<[?, ?], offset: ?>, #hipsr.mem<device>>) {
 // CHECK-NEXT: %[[C2048:.+]] = arith.constant 2048 : index
 // CHECK-NEXT: %[[SHAPE:.+]] = shape.from_extents %[[D0]], %[[C2048]] : index, index
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[DATA]] : memref<?x2048xf32, strided<[?, ?], offset: ?>, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[DATA]] : !shape.shape, memref<?x2048xf32, strided<[?, ?], offset: ?>, #hipsr.mem<device>>
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 func.func @func_arg(%d0: index, %data: tensor<?x2048xf32, #hipsr.mem<device>>) {
   %c2048 = arith.constant 2048 : index
   %shape = shape.from_extents %d0, %c2048 : index, index
-  hipsr.preserve_shape %shape, %data : tensor<?x2048xf32, #hipsr.mem<device>>
+  hipsr.preserve_shape %shape, %data : !shape.shape, tensor<?x2048xf32, #hipsr.mem<device>>
   return
 }
 
@@ -74,11 +74,11 @@ func.func @func_arg(%d0: index, %data: tensor<?x2048xf32, #hipsr.mem<device>>) {
 // CHECK-LABEL: func.func @opaque_shape(
 // CHECK-SAME: %[[D0:.+]]: index, %[[SHAPE:.+]]: !shape.shape) {
 // CHECK-NEXT: %[[ALLOC:.+]] = memref.alloc(%[[D0]]) {{.*}}: memref<?x2048xf32, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[ALLOC]] : memref<?x2048xf32, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE]], %[[ALLOC]] : !shape.shape, memref<?x2048xf32, #hipsr.mem<device>>
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 func.func @opaque_shape(%d0: index, %shape: !shape.shape) {
   %init = tensor.empty(%d0) : tensor<?x2048xf32, #hipsr.mem<device>>
-  hipsr.preserve_shape %shape, %init : tensor<?x2048xf32, #hipsr.mem<device>>
+  hipsr.preserve_shape %shape, %init : !shape.shape, tensor<?x2048xf32, #hipsr.mem<device>>
   return
 }

--- a/test/lit/Dialect/Hipsr/Transforms/UseAllocOutput/hipsr_use_alloc_output.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/UseAllocOutput/hipsr_use_alloc_output.mlir
@@ -16,7 +16,7 @@
 // CHECK: %[[D1:.*]] = shape.size_to_index {{.*}} : !shape.size
 // CHECK-NOT: memref.alloc
 // CHECK: %[[OUT:.*]] = hipsr.alloc_output(%[[CTX]], %[[D0]], %[[D1]]) {out_idx = 0 : i64} : memref<?x?xf16, #hipsr.mem<device>>
-// CHECK: hipsr.preserve_shape %[[SHAPE]], %[[OUT]] : memref<?x?xf16, #hipsr.mem<device>>
+// CHECK: hipsr.preserve_shape %[[SHAPE]], %[[OUT]] : !shape.shape, memref<?x?xf16, #hipsr.mem<device>>
 // CHECK: return %[[OUT]]
 func.func @dynamic_output(
     %ctx: !hipsr.context, %M: index, %N: index)
@@ -24,7 +24,7 @@ func.func @dynamic_output(
   %shape = shape.from_extents %M, %N : index, index
   %out = memref.alloc(%M, %N)
       : memref<?x?xf16, #hipsr.mem<device>>
-  hipsr.preserve_shape %shape, %out : memref<?x?xf16, #hipsr.mem<device>>
+  hipsr.preserve_shape %shape, %out : !shape.shape, memref<?x?xf16, #hipsr.mem<device>>
   return %out : memref<?x?xf16, #hipsr.mem<device>>
 }
 
@@ -82,10 +82,10 @@ func.func @dynamic_output(
 // CHECK-NEXT: } : memref<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[CAST_INIT:.*]] = memref.alloc(%[[FLAT_SIZE]]) : memref<?xf32, #hipsr.mem<device>>
 // CHECK-NEXT: hipsr.cast(%[[DCTX]]) ins(%[[FLAT]] : memref<?xf16, #hipsr.mem<device>>) outs(%[[CAST_INIT]] : memref<?xf32, #hipsr.mem<device>>)
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE1]], %[[INIT1]] : memref<?x256xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE2]], %[[RC]] : memref<?x256xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE3]], %[[FLAT]] : memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE3]], %[[CAST_INIT]] : memref<?xf32, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE1]], %[[INIT1]] : !shape.shape, memref<?x256xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE2]], %[[RC]] : !shape.shape, memref<?x256xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE3]], %[[FLAT]] : !shape.shape, memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE3]], %[[CAST_INIT]] : !shape.shape, memref<?xf32, #hipsr.mem<device>>
 // CHECK-NEXT: hipsr.pool_domain_yield %[[FLAT]] : memref<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT: } -> memref<?xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
 // CHECK-NEXT: return %[[OUT]] : memref<?xf16, #hipsr.mem<device>>
@@ -154,13 +154,13 @@ func.func @test_return_shape(
       outs(%cast_init : memref<?xf32, #hipsr.mem<device>>)
 
     hipsr.preserve_shape %shape1, %init1
-      : memref<?x256xf16, #hipsr.mem<device>>
+      : !shape.shape, memref<?x256xf16, #hipsr.mem<device>>
     hipsr.preserve_shape %shape2, %init2
-      : memref<?x256xf16, #hipsr.mem<device>>
+      : !shape.shape, memref<?x256xf16, #hipsr.mem<device>>
     hipsr.preserve_shape %shape3, %flat
-      : memref<?xf16, #hipsr.mem<device>>
+      : !shape.shape, memref<?xf16, #hipsr.mem<device>>
     hipsr.preserve_shape %shape3, %cast_init
-      : memref<?xf32, #hipsr.mem<device>>
+      : !shape.shape, memref<?xf32, #hipsr.mem<device>>
     hipsr.pool_domain_yield %flat
       : memref<?xf16, #hipsr.mem<device>>
   } -> memref<?xf16, #hipsr.mem<device>> {


### PR DESCRIPTION
## Summary

Adds `hipsr-convert-shape-to-extent`. The pass retypes `!shape.shape` to
`tensor<Nxindex>` and `!shape.size` to `index`, so the upstream shape passes can
lower the shape math that `hipsr-materialize-init-tensors` emits.

## Why

`--convert-shape-to-std` only matches extent tensors and `index`, so it changed
nothing on our shape-typed IR. Retyping turns it into a real lowering, and it
lets One-Shot Bufferize run on the shape path.

## What

- The pass inlines the `scf.execute_region` and `shape.assuming` regions first,
  so the conversion sees straight-line code.
- It retypes the ops upstream can lower, and lowers the four it cannot:
  `shape.from_extents`, `shape.concat`, `shape.size_to_index`, and
  `shape.const_size`.
- It narrows the extent tensor when the operands give the rank.
  `shape.const_shape` and `shape.from_extents` need this, because MLIR type
  inference and `tensor.from_elements` fix those result types.
- `hipsr.preserve_shape` now accepts all three forms of its shape operand:
  `!shape.shape`, an extent tensor, then an extent memref after bufferization.
  A verifier compares the extent count against the data rank.
- The pipeline runs `-remove-shape-constraints` first, because inlining a
  `shape.assuming` needs the passing witness that pass creates.

```mlir
// Before
%s = scf.execute_region -> !shape.shape {
  %0 = shape.shape_of %a : tensor<?x4xf16> -> !shape.shape
  scf.yield %0 : !shape.shape
}
%c0 = shape.const_size 0
%d = shape.get_extent %s, %c0 : !shape.shape, !shape.size -> !shape.size

// After
%s = shape.shape_of %a : tensor<?x4xf16> -> tensor<2xindex>
%c0 = arith.constant 0 : index
%d = shape.get_extent %s, %c0 : tensor<2xindex>, index -> index
```

## Test plan

- LIT suite: 473 passed. New `ConvertShapeToExtent/convert-shape-to-extent.mlir`
  and `invalid.mlir`, plus regenerated pipeline, bufferize, and
  `preserve_shape` expectations.
- Checked by hand that no shape op survives `--convert-shape-to-std` on
  `sample_static.mlir` and `sample_dynamic.mlir`, and that One-Shot Bufferize
  needs no `allow-unknown-ops` for the shape path.
- `pre-commit run --all-files` is clean.

## Notes for reviewers

- `docs/pipeline_pass_menu.md` still needs the two new pipeline entries. I left
  it out of this push; happy to add it before this leaves draft.
- Nothing in CI covers the chain past this pass, so a later change that
  reintroduces a shape op upstream cannot lower would not be caught here.
- `hipsr.constant`, `hipsr.matmul`, and `hipsr.expand` still fail full
  bufferization. That is unchanged by this PR.

## AI assistance

AI-assisted (Claude Opus 5 through Cursor): the pass, the ODS and bufferization
changes, the LIT tests, and this description. I validated the result with the
LIT suite and `pre-commit`, reviewed every line, and own the design decisions.
