### PR TITLE
fix(gemm): keep the existing workspace when the autotune grow fails

### DIFF
--- a/lib/Runtime/real/gemm.cpp
+++ b/lib/Runtime/real/gemm.cpp
@@ -528,9 +528,20 @@ static int benchmarkGemmAlgos(
   for (int i = 0; i < returned; ++i)
     if (heurs[i].workspaceSize > maxws)
       maxws = heurs[i].workspaceSize;
+  // Size the shared workspace for the widest candidate, but never treat a
+  // failed grow as "no workspace": the shared buffer never shrinks, so the
+  // state may already own one large enough for most candidates. Halve the
+  // request until the allocator accepts it, then adopt whatever the state
+  // actually holds. Reporting zero here would leave only the workspace-free
+  // algorithms eligible below, dropping split-K from the race and costing
+  // every GEMM shape in the model at once -- worst on large batches, where
+  // the pool leaves the least room for the request to succeed.
   void *bench_ws = nullptr;
   size_t bench_ws_size = 0;
-  if (maxws > 0 && hipdnn_ep_state_ensure_workspace(state, maxws) == 0) {
+  if (maxws > 0) {
+    for (size_t budget = maxws; budget > 0; budget /= 2)
+      if (hipdnn_ep_state_ensure_workspace(state, budget) == 0)
+        break;
     bench_ws = hipdnn_ep_state_get_workspace(state);
     bench_ws_size = hipdnn_ep_state_get_workspace_size(state);
   }
@@ -547,11 +558,14 @@ static int benchmarkGemmAlgos(
                              stream);
     };
     double best_ms = 1e30;
+    int skipped_for_workspace = 0;
     for (int i = 0; i < returned; ++i) {
       // Skip candidates that need more workspace than we allocated --
       // running them with a smaller/null workspace just errors out.
-      if (heurs[i].workspaceSize > bench_ws_size)
+      if (heurs[i].workspaceSize > bench_ws_size) {
+        ++skipped_for_workspace;
         continue;
+      }
       if (run_cand(i) != HIPBLAS_STATUS_SUCCESS) // warmup
         continue;
       if (hipEventRecord(bs, stream) != hipSuccess)
@@ -570,6 +584,11 @@ static int benchmarkGemmAlgos(
         best_idx = i;
       }
     }
+    if (skipped_for_workspace)
+      RUNTIME_DEBUG_LOG("[REAL] wrap_gemm: %d/%d algo candidates skipped, need "
+                        "more than the %zu-byte workspace (M=%lld N=%lld)\n",
+                        skipped_for_workspace, returned, bench_ws_size,
+                        (long long)M, (long long)N);
   }
   if (bs)
     hipEventDestroy(bs);


### PR DESCRIPTION
## Summary

`benchmarkGemmAlgos` treated a failed workspace grow as "no workspace at all", which silently removed every workspace-hungry algorithm from the autotune race. This makes the GEMM algorithm choice depend on free VRAM at the moment of the first inference, and the penalty lands on every GEMM shape in the model simultaneously.

This is a candidate fix for the Swin regression between the Aug 27 and current daily runs. It is offered as a CI experiment: the mechanism is real and worth fixing on its own merits, but I have not been able to prove locally that it is *the* cause, for the reasons in the evidence section below.

## Why

The tuner sizes the shared workspace for the widest candidate and then gates candidates on the result:

```cpp
if (maxws > 0 && hipdnn_ep_state_ensure_workspace(state, maxws) == 0) {
  bench_ws = hipdnn_ep_state_get_workspace(state);
  bench_ws_size = hipdnn_ep_state_get_workspace_size(state);
}
...
if (heurs[i].workspaceSize > bench_ws_size)
  continue;
```

`bench_ws_size` is initialised to zero and only assigned on success, so a single failed grow to `maxws` discards the workspace the state **already owns**. The shared workspace never shrinks, so that buffer is often large enough for most candidates — but after the failed grow, every candidate with `workspaceSize > 0` is skipped and only workspace-free algorithms remain eligible. In practice that eliminates the split-K kernels.

Two properties make this nasty:

- It is all-or-nothing. There is no attempt at a smaller budget, so needing one byte more than the allocator will give costs the entire workspace-using candidate set.
- It is invisible. The skip is silent, the tuner still returns a "winner", and the result is cached for the process lifetime.

Because it is keyed to memory pressure, the same binary can pick fast or slow algorithms on different runs, and larger batches are affected disproportionately — their pools leave the least room for the request to succeed.

## What

- Halve the requested budget until `hipdnn_ep_state_ensure_workspace` accepts it, instead of giving up after one attempt at `maxws`.
- Query the workspace pointer and size unconditionally, so a failed grow falls back to the buffer the state already holds rather than to zero.
- Add a `RUNTIME_DEBUG_LOG` reporting how many candidates were dropped for want of workspace, so this failure mode is observable instead of silent.

No change to the selection criteria, the cache key, the fused-bias epilogue path, or the run-time workspace guarantee.

## Evidence

Per-op warm GPU timings (hipEvent) for `swinv2-base-2048`, comparing `ddb349e1` (the Aug 28 baseline) against `main` at `97a0782e`:

| op | ddb349e1 | main | delta |
|---|---|---|---|
| gemm | 174.5 ms | 245.6 ms | **+71.1** |
| elementwise | 334.3 ms | 335.1 ms | +0.8 |
| softmax | 229.9 ms | 231.0 ms | +1.1 |
| transpose | 94.8 ms | 96.0 ms | +1.2 |
| matmul | 89.2 ms | 82.1 ms | −7.1 |

Call counts are identical for all 13 ops, and every op except `gemm` matches within about a millisecond. The `gemm` delta is spread uniformly across all 18 distinct GEMM shapes rather than concentrated in one, which is the signature of an algorithm-selection change rather than a shape or graph change.

Ruling out the obvious suspects across the 21 commits in `ddb349e1..main`:

- Only #861 touches `gemm.cpp`, and its only functional change is inside the `needsBroadcast` branch. Instrumented runs show 148 of 148 `wrap_gemm` calls across `swinv2-base` and `swin-tiny` report `needsBroadcast=0` — they all take the fused-bias epilogue path — so that commit cannot affect these models.
- `Pipelines.cpp` and `PoolAllocs.cpp` are untouched in the window, so buffer layout and pass order are unchanged.
- The TheRock/hipBLASLt pin in `cmake/deps.txt` has not moved since June, so this is not a library swap.
- The measurement is hipEvent device time, which rules out the host-side changes in the window (#869, #877, #873, #801, #879).

## Test plan

- [x] `runtime_gemm.bc` compiles clean; the four remaining `-Wunused-value` warnings are pre-existing and on untouched lines.
- [x] `pre-commit run --files lib/Runtime/real/gemm.cpp` passes.
- [ ] CI daily perf on the Swin models. This is the point of the PR: if `swinv2-base 8x` returns toward its Aug 27 figure, the workspace gate was the cause.

## Notes for reviewers

I could not confirm this locally, and I want to be explicit about why rather than imply more confidence than the data supports. On my box the same unmodified binary at `ddb349e1` produced `gemm` totals ranging from 169 ms to 270 ms across eight separate processes, and `main`'s 245.6 ms sits inside that band. That spread is consistent with this same defect firing intermittently under local memory pressure, but it also means a local A/B cannot separate the fix from run-to-run variance. CI is reported to be stable, so it is the better instrument here.

One adjacent issue I deliberately left alone: if the `hipMalloc` for `bench_out` fails, the entire benchmark loop is skipped and `best_idx` stays 0, so the tuner silently degrades to the heuristic's first candidate. That is the same class of silent memory-pressure fallback, but it picks a defensible default and fixing it is a separate change.

If CI shows no movement on the Swin models, this PR should be judged purely as a correctness fix for the workspace gate, and the regression hunt should continue elsewhere.

## AI assistance

Investigation, patch, and this description were prepared with Cursor (Claude Opus 5). I have reviewed the diff and own the claims above; the measurements quoted are from runs on my own machine and are labelled where they are inconclusive.
