### PR TITLE
feat(hipsr): bufferize the hipsr pipeline with One-Shot Bufferize

### DIFF
--- a/include/hip/InitAllPasses.h
+++ b/include/hip/InitAllPasses.h
@@ -192,7 +192,6 @@ inline void registerAllPasses() {
     mlir::registerReconcileUnrealizedCastsPass();
     mlir::memref::registerResolveShapedTypeResultDimsPass();
     mlir::registerConvertLinalgToLoopsPass();
-    // Upstream passes that lower what hipsr-convert-shape-to-extent retypes.
     mlir::registerRemoveShapeConstraintsPass();
     mlir::registerShapeToShapeLoweringPass();
     mlir::registerConvertShapeToStandardPass();

--- a/include/hip/InitAllPasses.h
+++ b/include/hip/InitAllPasses.h
@@ -30,10 +30,13 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Passes.h"
 #include "mlir/Dialect/Linalg/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/MemRef/Transforms/AllocationOpInterfaceImpl.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SCF/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/Dialect/Shape/Transforms/Passes.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/IR/TensorInferTypeOpInterfaceImpl.h"
@@ -71,6 +74,7 @@ inline void registerAllDialects(mlir::DialectRegistry &registry) {
   registry.insert<mlir::arith::ArithDialect>();
   registry.insert<mlir::func::FuncDialect>();
   registry.insert<mlir::memref::MemRefDialect>();
+  registry.insert<mlir::scf::SCFDialect>();
   registry.insert<mlir::tensor::TensorDialect>();
   registry.insert<mlir::linalg::LinalgDialect>();
   registry.insert<mlir::bufferization::BufferizationDialect>();
@@ -87,6 +91,7 @@ inline void registerAllDialects(mlir::DialectRegistry &registry) {
   mlir::tensor::registerBufferizableOpInterfaceExternalModels(registry);
   mlir::tensor::registerInferTypeOpInterfaceExternalModels(registry);
   mlir::linalg::registerBufferizableOpInterfaceExternalModels(registry);
+  mlir::scf::registerBufferizableOpInterfaceExternalModels(registry);
   mlir::bufferization::func_ext::registerBufferizableOpInterfaceExternalModels(
       registry);
   mlir::memref::registerAllocationOpInterfaceExternalModels(registry);
@@ -186,8 +191,10 @@ inline void registerAllPasses() {
     mlir::registerSCFToControlFlowPass();
     mlir::registerReconcileUnrealizedCastsPass();
     mlir::memref::registerResolveShapedTypeResultDimsPass();
+    mlir::registerConvertLinalgToLoopsPass();
     // Upstream passes that lower what hipsr-convert-shape-to-extent retypes.
     mlir::registerRemoveShapeConstraintsPass();
+    mlir::registerShapeToShapeLoweringPass();
     mlir::registerConvertShapeToStandardPass();
   });
 }

--- a/lib/Compiler/CMakeLists.txt
+++ b/lib/Compiler/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(LibHipCompiler PUBLIC
   MLIRBufferizationTransforms
   MLIRTensorInferTypeOpInterfaceImpl
   MLIRSCFDialect
+  MLIRSCFTransforms
   MLIRSCFToControlFlow
   MLIRParser
   MLIRLLVMToLLVMIRTranslation

--- a/lib/Conversion/OnnxToHipsr/UnsqueezeConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/UnsqueezeConversion.cpp
@@ -36,8 +36,9 @@
 //     hipsr.compute_yield %out
 //   } : tensor<2x3x1xf16, #hipsr.mem<device>>
 //
-// A dynamic input dimension is read off %x_shape in the region. The body reads
-// it off %dest, which already carries the result dimensions.
+// A dynamic input dimension is read off %x_shape in the region and off %x in
+// the body. The body leaves %dest alone so that bufferization can hold the
+// result in %x's buffer.
 //
 //===----------------------------------------------------------------------===//
 
@@ -171,8 +172,10 @@ void populateShapeRegion(OpBuilder &builder, PlaceholderOp placeholder,
 // The compute body
 //===----------------------------------------------------------------------===//
 
-// The destination already carries the result dimensions, so the expand takes
-// them off it rather than computing them again.
+// The expand infers its dimensions from the input, the same way the shape
+// region does. The destination carries them too, but reading it would leave the
+// destination argument used, and bufferization only holds the result in the
+// input's buffer when the body never touches that argument.
 void populateComputeBody(OpBuilder &builder, ComputeOp computeOp,
                          ArrayRef<ReassociationIndices> reassociation) {
   OpBuilder::InsertionGuard guard(builder);
@@ -186,10 +189,16 @@ void populateComputeBody(OpBuilder &builder, ComputeOp computeOp,
   builder.setInsertionPointToStart(body);
 
   Value input = body->getArgument(1);
-  Value dest = body->getArguments().back();
+  auto resultType =
+      cast<RankedTensorType>(body->getArguments().back().getType());
+  FailureOr<SmallVector<OpFoldResult>> resultDims =
+      tensor::ExpandShapeOp::inferOutputShape(
+          builder, loc, resultType, reassociation,
+          tensor::getMixedSizes(builder, loc, input));
+  assert(succeeded(resultDims) &&
+         "a group holds one input dimension, so only it can be dynamic");
   Value expanded = tensor::ExpandShapeOp::create(
-      builder, loc, dest.getType(), input, reassociation,
-      tensor::getMixedSizes(builder, loc, dest));
+      builder, loc, resultType, input, reassociation, *resultDims);
   ComputeYieldOp::create(builder, loc, ValueRange{expanded});
 }
 

--- a/lib/Conversion/OnnxToHipsr/UnsqueezeConversion.cpp
+++ b/lib/Conversion/OnnxToHipsr/UnsqueezeConversion.cpp
@@ -36,9 +36,7 @@
 //     hipsr.compute_yield %out
 //   } : tensor<2x3x1xf16, #hipsr.mem<device>>
 //
-// A dynamic input dimension is read off %x_shape in the region and off %x in
-// the body. The body leaves %dest alone so that bufferization can hold the
-// result in %x's buffer.
+// A dynamic input dimension is read off %x_shape in the region.
 //
 //===----------------------------------------------------------------------===//
 
@@ -172,10 +170,6 @@ void populateShapeRegion(OpBuilder &builder, PlaceholderOp placeholder,
 // The compute body
 //===----------------------------------------------------------------------===//
 
-// The expand infers its dimensions from the input, the same way the shape
-// region does. The destination carries them too, but reading it would leave the
-// destination argument used, and bufferization only holds the result in the
-// input's buffer when the body never touches that argument.
 void populateComputeBody(OpBuilder &builder, ComputeOp computeOp,
                          ArrayRef<ReassociationIndices> reassociation) {
   OpBuilder::InsertionGuard guard(builder);

--- a/lib/Dialect/Hipsr/Pipelines/CMakeLists.txt
+++ b/lib/Dialect/Hipsr/Pipelines/CMakeLists.txt
@@ -15,4 +15,6 @@ target_link_libraries(HipsrDialectPipelines PUBLIC
   MLIRSupport
   MLIRShapeOpsTransforms
   MLIRShapeToStandard
+  MLIRBufferizationTransforms
+  MLIRLinalgTransforms
 )

--- a/lib/Dialect/Hipsr/Pipelines/Pipelines.cpp
+++ b/lib/Dialect/Hipsr/Pipelines/Pipelines.cpp
@@ -37,16 +37,14 @@ void mlir::hipsr::buildHipsrPipeline(OpPassManager &pm,
   pm.addNestedPass<func::FuncOp>(createRemoveShapeConstraintsPass());
   pm.addNestedPass<func::FuncOp>(createConvertShapeToExtentPass());
 
-  // convert-shape-to-std cannot lower shape.num_elements, so
-  // shape-to-shape-lowering rewrites it as a shape.reduce first.
-  // It runs after hipsr-convert-shape-to-extent because ReduceOpConverter
-  // rejects a !shape.shape operand.
+  // convert-shape-to-std cannot lower shape.num_elements, so rewrite it as a
+  // shape.reduce first. This must follow hipsr-convert-shape-to-extent, since
+  // ReduceOpConverter rejects a !shape.shape operand.
   pm.addNestedPass<func::FuncOp>(createShapeToShapeLoweringPass());
   pm.addPass(createConvertShapeToStandardPass());
 
-  // useEncodingForMemorySpace keeps the memory space, so
-  // tensor<4xf16, #hipsr.mem<device>> bufferizes to
-  // memref<4xf16, #hipsr.mem<device>>.
+  // useEncodingForMemorySpace turns the #hipsr.mem<...> tensor encoding into
+  // the memref memory space.
   bufferization::OneShotBufferizePassOptions bufferizeOptions;
   bufferizeOptions.bufferizeFunctionBoundaries = true;
   bufferizeOptions.functionBoundaryTypeConversion =
@@ -54,9 +52,8 @@ void mlir::hipsr::buildHipsrPipeline(OpPassManager &pm,
   bufferizeOptions.useEncodingForMemorySpace = true;
   pm.addPass(bufferization::createOneShotBufferizePass(bufferizeOptions));
 
-  // shape.broadcast lowers to tensor.generate, which bufferizes to a
-  // memref.alloc and a linalg.map. That linalg.map is the only linalg op this
-  // pipeline produces.
+  // shape.broadcast becomes a tensor.generate, which bufferizes to a
+  // linalg.map. That is the only linalg op this pipeline produces.
   pm.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
 }
 

--- a/lib/Dialect/Hipsr/Pipelines/Pipelines.cpp
+++ b/lib/Dialect/Hipsr/Pipelines/Pipelines.cpp
@@ -8,7 +8,10 @@
 #include "hip/Conversion/OnnxToHipsr/OnnxToHipsr.h"
 #include "hip/Dialect/Hipsr/Transforms/Passes.h"
 
+#include "mlir/Conversion/ShapeToStandard/ShapeToStandard.h"
+#include "mlir/Dialect/Bufferization/Transforms/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/Passes.h"
 #include "mlir/Dialect/Shape/Transforms/Passes.h"
 #include "mlir/Pass/PassRegistry.h"
 
@@ -20,6 +23,10 @@
 //   --hipsr-materialize-init-tensors
 //   --remove-shape-constraints
 //   --hipsr-convert-shape-to-extent
+//   --shape-to-shape-lowering
+//   --convert-shape-to-std
+//   --one-shot-bufferize
+//   --convert-linalg-to-loops
 void mlir::hipsr::buildHipsrPipeline(OpPassManager &pm,
                                      const HipsrPipelineOptions & /*options*/) {
   pm.addPass(createAddContextArgPass());
@@ -29,6 +36,28 @@ void mlir::hipsr::buildHipsrPipeline(OpPassManager &pm,
   pm.addPass(createMaterializeInitTensorsPass());
   pm.addNestedPass<func::FuncOp>(createRemoveShapeConstraintsPass());
   pm.addNestedPass<func::FuncOp>(createConvertShapeToExtentPass());
+
+  // convert-shape-to-std cannot lower shape.num_elements, so
+  // shape-to-shape-lowering rewrites it as a shape.reduce first.
+  // It runs after hipsr-convert-shape-to-extent because ReduceOpConverter
+  // rejects a !shape.shape operand.
+  pm.addNestedPass<func::FuncOp>(createShapeToShapeLoweringPass());
+  pm.addPass(createConvertShapeToStandardPass());
+
+  // useEncodingForMemorySpace keeps the memory space, so
+  // tensor<4xf16, #hipsr.mem<device>> bufferizes to
+  // memref<4xf16, #hipsr.mem<device>>.
+  bufferization::OneShotBufferizePassOptions bufferizeOptions;
+  bufferizeOptions.bufferizeFunctionBoundaries = true;
+  bufferizeOptions.functionBoundaryTypeConversion =
+      bufferization::LayoutMapOption::IdentityLayoutMap;
+  bufferizeOptions.useEncodingForMemorySpace = true;
+  pm.addPass(bufferization::createOneShotBufferizePass(bufferizeOptions));
+
+  // shape.broadcast lowers to tensor.generate, which bufferizes to a
+  // memref.alloc and a linalg.map. That linalg.map is the only linalg op this
+  // pipeline produces.
+  pm.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
 }
 
 void mlir::hipsr::registerHipsrPipelines() {

--- a/lib/Dialect/Hipsr/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/lib/Dialect/Hipsr/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -108,7 +108,6 @@ struct PreserveShapeBufferizableModel
 struct ConstantBufferizableModel
     : public BufferizableOpInterface::ExternalModel<ConstantBufferizableModel,
                                                     ConstantOp> {
-  // The runtime owns the blob, so a DPS op with a constant init must copy.
   bool isWritable(Operation *, Value, const AnalysisState &) const {
     return false;
   }
@@ -139,7 +138,6 @@ struct ConstantBufferizableModel
       return failure();
     }
 
-    // index, offset, and size describe the blob, not the type, so they stay.
     replaceOpWithNewBufferizedOp<ConstantOp>(
         rewriter, op, *bufferType, constantOp.getValue(),
         constantOp.getIndexAttr(), constantOp.getOffsetAttr(),

--- a/lib/Dialect/Hipsr/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/lib/Dialect/Hipsr/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -97,6 +97,58 @@ struct PreserveShapeBufferizableModel
 };
 
 //===----------------------------------------------------------------------===//
+// ConstantOp
+//===----------------------------------------------------------------------===//
+
+// hipsr.constant points into the constants blob, which the runtime owns. It
+// bufferizes like upstream arith.constant.
+//
+// Before: %0 = hipsr.constant {...} : tensor<4x2xf32, #hipsr.mem<device>>
+// After:  %0 = hipsr.constant {...} : memref<4x2xf32, #hipsr.mem<device>>
+struct ConstantBufferizableModel
+    : public BufferizableOpInterface::ExternalModel<ConstantBufferizableModel,
+                                                    ConstantOp> {
+  // The runtime owns the blob, so a DPS op with a constant init must copy.
+  bool isWritable(Operation *, Value, const AnalysisState &) const {
+    return false;
+  }
+
+  FailureOr<BufferLikeType> getBufferType(Operation *op, Value value,
+                                          const BufferizationOptions &options,
+                                          const BufferizationState &,
+                                          SmallVector<Value> &) const {
+    auto tensorType = cast<TensorType>(value.getType());
+    std::optional<Attribute> memorySpace =
+        options.defaultMemorySpaceFn(tensorType);
+    if (!memorySpace) {
+      return op->emitError("could not infer memory space");
+    }
+    // A constant is contiguous, so use the identity layout. The default from
+    // unknownTypeConverterFn has a fully dynamic layout.
+    return cast<BufferLikeType>(
+        getMemRefTypeWithStaticIdentityLayout(tensorType, *memorySpace));
+  }
+
+  LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
+                          const BufferizationOptions &options,
+                          BufferizationState &state) const {
+    auto constantOp = cast<ConstantOp>(op);
+    FailureOr<BufferLikeType> bufferType =
+        bufferization::getBufferType(constantOp.getResult(), options, state);
+    if (failed(bufferType)) {
+      return failure();
+    }
+
+    // index, offset, and size describe the blob, not the type, so they stay.
+    replaceOpWithNewBufferizedOp<ConstantOp>(
+        rewriter, op, *bufferType, constantOp.getValue(),
+        constantOp.getIndexAttr(), constantOp.getOffsetAttr(),
+        constantOp.getSizeAttr());
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // ComputeOp / ComputeYieldOp
 //===----------------------------------------------------------------------===//
 
@@ -219,7 +271,11 @@ struct ComputeOpBufferization
     for (auto [outIdx, output] : llvm::enumerate(computeOp.getOutputs())) {
       int32_t aliasedInputIdx = -1; // -1 means no aliasing
 
-      if (isa<TensorType>(output.getType())) {
+      // Reusing the input buffer also changes the type of the matching entry
+      // argument, so only do this when the body never reads that argument.
+      BlockArgument destination = getEntryArgument(
+          computeOp, computeOp.getOutputs().getBeginOperandIndex() + outIdx);
+      if (isa<TensorType>(output.getType()) && destination.use_empty()) {
         // Find which input (if any) this output aliases
         for (auto [inIdx, input] : llvm::enumerate(computeOp.getInputs())) {
           if (!isa<TensorType>(input.getType())) {
@@ -654,8 +710,11 @@ void mlir::hipsr::registerBufferizableOpInterfaceExternalModels(
     ComputeYieldOp::attachInterface<ComputeYieldOpBufferization>(*ctx);
     PoolDomainOp::attachInterface<PoolDomainOpBufferization>(*ctx);
     PoolDomainYieldOp::attachInterface<PoolDomainYieldOpBufferization>(*ctx);
+    MatMulOp::attachInterface<DpsBufferizableModel<MatMulOp>>(*ctx);
+    ExpandOp::attachInterface<DpsBufferizableModel<ExpandOp>>(*ctx);
     CastOp::attachInterface<DpsBufferizableModel<CastOp>>(*ctx);
     CopyD2HOp::attachInterface<DpsBufferizableModel<CopyD2HOp>>(*ctx);
+    AddOp::attachInterface<DpsBufferizableModel<AddOp>>(*ctx);
     MulOp::attachInterface<DpsBufferizableModel<MulOp>>(*ctx);
     MinOp::attachInterface<DpsBufferizableModel<MinOp>>(*ctx);
     EqualOp::attachInterface<DpsBufferizableModel<EqualOp>>(*ctx);
@@ -663,5 +722,7 @@ void mlir::hipsr::registerBufferizableOpInterfaceExternalModels(
     GatherOp::attachInterface<DpsBufferizableModel<GatherOp>>(*ctx);
     SliceOp::attachInterface<DpsBufferizableModel<SliceOp>>(*ctx);
     ScatterNDOp::attachInterface<DpsBufferizableModel<ScatterNDOp>>(*ctx);
+    NonZeroOp::attachInterface<DpsBufferizableModel<NonZeroOp>>(*ctx);
+    ConstantOp::attachInterface<ConstantBufferizableModel>(*ctx);
   });
 }

--- a/test/lit/Conversion/onnx-to-hipsr/unsqueeze.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/unsqueeze.mlir
@@ -14,8 +14,8 @@
 // RUN: hip-mlir-opt %s --onnx-dialect=modeled --split-input-file -allow-unregistered-dialect -convert-onnx-to-hipsr | FileCheck %s
 
 // A trailing axis on a fully dynamic input, which is what an embedding graph
-// inserts on a token mask. Every dynamic dimension is read off the input's
-// shape, and the expand takes its dimensions off the destination.
+// inserts on a token mask. The region reads every dynamic dimension off the
+// input's shape, and the body reads them off the input itself.
 // CHECK-LABEL: func.func @trailing_axis(
 // CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
 // CHECK-SAME:    %[[INPUT:.*]]: tensor<?x?xi1, #hipsr.mem<device>>) -> tensor<?x?x1xi1, #hipsr.mem<device>> {
@@ -36,12 +36,15 @@
 // CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?xi1, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x?x1xi1, #hipsr.mem<device>>) {
-// CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x?xi1, #hipsr.mem<device>>, %[[DEST:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>):
+// CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x?xi1, #hipsr.mem<device>>, %{{.*}}: tensor<?x?x1xi1, #hipsr.mem<device>>):
 // CHECK-NEXT:      %[[C0:.*]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[DEST_ROWS:.*]] = tensor.dim %[[DEST]], %[[C0]] : tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[IN_ROWS:.*]] = tensor.dim %[[IN]], %[[C0]] : tensor<?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[C1:.*]] = arith.constant 1 : index
-// CHECK-NEXT:      %[[DEST_COLS:.*]] = tensor.dim %[[DEST]], %[[C1]] : tensor<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[OUT:.*]] = tensor.expand_shape %[[IN]] {{\[}}[0], [1, 2]] output_shape {{\[}}%[[DEST_ROWS]], %[[DEST_COLS]], 1] : tensor<?x?xi1, #hipsr.mem<device>> into tensor<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[IN_COLS:.*]] = tensor.dim %[[IN]], %[[C1]] : tensor<?x?xi1, #hipsr.mem<device>>
+// One unused divisor per dynamic group, as in the region above.
+// CHECK-NEXT:      arith.constant 1 : index
+// CHECK-NEXT:      arith.constant 1 : index
+// CHECK-NEXT:      %[[OUT:.*]] = tensor.expand_shape %[[IN]] {{\[}}[0], [1, 2]] output_shape {{\[}}%[[IN_ROWS]], %[[IN_COLS]], 1] : tensor<?x?xi1, #hipsr.mem<device>> into tensor<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT:      hipsr.compute_yield %[[OUT]] : tensor<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT:    } : tensor<?x?x1xi1, #hipsr.mem<device>>{{$}}
 // CHECK-NEXT:    return %[[RESULT]] : tensor<?x?x1xi1, #hipsr.mem<device>>
@@ -57,7 +60,7 @@ func.func @trailing_axis(%ctx: !hipsr.context,
 // -----
 
 // The axes resolve a dimension the declared tensor<?x?x?xi1> leaves dynamic.
-// The unit lands between the two dimensions the input gives, so the destination
+// The unit lands between the two dimensions the input gives, so the result
 // carries its dynamic dimensions at axes 0 and 2.
 // CHECK-LABEL: func.func @interior_axis(
 // CHECK-SAME:    %[[CTX:.*]]: !hipsr.context,
@@ -79,12 +82,15 @@ func.func @trailing_axis(%ctx: !hipsr.context,
 // CHECK-NEXT:      hipsr.shape_yield %[[SHAPE]] : !shape.shape
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %[[RESULT:.*]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : tensor<?x?xi1, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<?x1x?xi1, #hipsr.mem<device>>) {
-// CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x?xi1, #hipsr.mem<device>>, %[[DEST:.*]]: tensor<?x1x?xi1, #hipsr.mem<device>>):
+// CHECK-NEXT:    ^bb0(%{{.*}}: !hipsr.context, %[[IN:.*]]: tensor<?x?xi1, #hipsr.mem<device>>, %{{.*}}: tensor<?x1x?xi1, #hipsr.mem<device>>):
 // CHECK-NEXT:      %[[C0:.*]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[DEST_ROWS:.*]] = tensor.dim %[[DEST]], %[[C0]] : tensor<?x1x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[C2:.*]] = arith.constant 2 : index
-// CHECK-NEXT:      %[[DEST_COLS:.*]] = tensor.dim %[[DEST]], %[[C2]] : tensor<?x1x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[OUT:.*]] = tensor.expand_shape %[[IN]] {{\[}}[0], [1, 2]] output_shape {{\[}}%[[DEST_ROWS]], 1, %[[DEST_COLS]]] : tensor<?x?xi1, #hipsr.mem<device>> into tensor<?x1x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[IN_ROWS:.*]] = tensor.dim %[[IN]], %[[C0]] : tensor<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[C1:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[IN_COLS:.*]] = tensor.dim %[[IN]], %[[C1]] : tensor<?x?xi1, #hipsr.mem<device>>
+// One unused divisor per dynamic group, as in the region above.
+// CHECK-NEXT:      arith.constant 1 : index
+// CHECK-NEXT:      arith.constant 1 : index
+// CHECK-NEXT:      %[[OUT:.*]] = tensor.expand_shape %[[IN]] {{\[}}[0], [1, 2]] output_shape {{\[}}%[[IN_ROWS]], 1, %[[IN_COLS]]] : tensor<?x?xi1, #hipsr.mem<device>> into tensor<?x1x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:      hipsr.compute_yield %[[OUT]] : tensor<?x1x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:    } : tensor<?x1x?xi1, #hipsr.mem<device>>{{$}}
 // CHECK-NEXT:    return %[[RESULT]] : tensor<?x1x?xi1, #hipsr.mem<device>>

--- a/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
@@ -6,6 +6,40 @@
 // domains. Each domain starts with a shape computation that reads a host
 // buffer an earlier domain filled.
 //
+// Pool domains and what cuts them
+// -------------------------------
+//
+// A domain is one pool allocation, so every buffer inside it must be sized
+// before it runs. The pipeline therefore starts a new domain wherever a shape
+// depends on a value the host cannot know until the previous domain has
+// finished.
+//
+//   domain 0   collapse(image_features)              -> flat
+//              equal(input_ids, 248056) -> unsqueeze -> mask
+//              gather(table, input_ids)              -> embeds
+//              shape(embeds)                         -> extents  host 3xi64
+//                   |
+//                   |  extents: the broadcast destination is not in any type
+//                   v
+//   domain 1   expand(mask, extents)                 -> mask3d
+//                   |
+//                   |  extents: the second broadcast reads them again
+//                   v
+//   domain 2   expand(mask3d, extents)               -> mask3d'
+//              nonzero(mask3d')                      -> coords 3x?, count
+//              copy_d2h(count)                       -> count    host 1xi64
+//                   |
+//                   |  count: how many coordinates the search actually found
+//                   v
+//   domain 3   extract_slice(coords, count)          -> coords 3x?
+//              transpose(coords)                     -> coords ?x3
+//              shape -> gather -> unsqueeze          -> window   host 1xi64
+//                   |
+//                   |  window: where the update slice ends
+//                   v
+//   domain 4   slice(flat, window)                   -> updates
+//              scatter_nd(embeds, coords, updates)   -> inputs_embeds
+//
 // This is the only pipeline test that reaches shape.num_elements. Its two
 // reducing scf.for loops show that shape-to-shape-lowering ran.
 //

--- a/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
@@ -114,12 +114,12 @@
 // CHECK-NEXT:        } : memref<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT:        %[[ALLOC_15:.*]] = memref.alloc(%[[LOAD_6]], %[[LOAD_7]]) {alignment = 64 : i64} : memref<?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.equal(%[[VAL_0]]) ins(%[[VAL_2]], %[[CONSTANT_3]] : memref<?x?xi64, #hipsr.mem<device>>, memref<i64, #hipsr.mem<device>>) outs(%[[ALLOC_15]] : memref<?x?xi1, #hipsr.mem<device>>)
-// CHECK-NEXT:        %[[COMPUTE_1:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[ALLOC_15]] : memref<?x?xi1, #hipsr.mem<device>>) outs(%[[ALLOC_12]] : memref<?x?x1xi1, #hipsr.mem<device>>) {
-// CHECK-NEXT:        ^bb0(%[[VAL_9:.*]]: !hipsr.context, %[[VAL_10:.*]]: memref<?x?xi1, #hipsr.mem<device>>, %[[VAL_11:.*]]: memref<?x?x1xi1, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[COMPUTE_1:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[ALLOC_15]] : memref<?x?xi1, #hipsr.mem<device>>) outs(%[[ALLOC_15]] : memref<?x?xi1, #hipsr.mem<device>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_9:.*]]: !hipsr.context, %[[VAL_10:.*]]: memref<?x?xi1, #hipsr.mem<device>>, %[[VAL_11:.*]]: memref<?x?xi1, #hipsr.mem<device>>):
 // CHECK-NEXT:          %[[CONSTANT_8:.*]] = arith.constant 1 : index
 // CHECK-NEXT:          %[[CONSTANT_9:.*]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[DIM_5:.*]] = memref.dim %[[VAL_11]], %[[CONSTANT_9]] : memref<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:          %[[DIM_6:.*]] = memref.dim %[[VAL_11]], %[[CONSTANT_8]] : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[DIM_5:.*]] = memref.dim %[[VAL_10]], %[[CONSTANT_9]] : memref<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[DIM_6:.*]] = memref.dim %[[VAL_10]], %[[CONSTANT_8]] : memref<?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:          %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[VAL_10]] {{\[\[}}0], [1, 2]] output_shape {{\[}}%[[DIM_5]], %[[DIM_6]], 1] : memref<?x?xi1, #hipsr.mem<device>> into memref<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT:          hipsr.compute_yield %[[EXPAND_SHAPE_0]] : memref<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT:        } : memref<?x?x1xi1, #hipsr.mem<device>>

--- a/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
@@ -1,349 +1,392 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
+
+// The hipsr pipeline on an embedding graph with dynamic shapes. NonZero makes
+// the scatter index count depend on the data, so the pipeline cuts five pool
+// domains. Each domain starts with a shape computation that reads a host
+// buffer an earlier domain filled.
 //
-//===----------------------------------------------------------------------===//
-// Pipeline test: hipsr pipeline on a dynamically shaped embedding graph.
+// This is the only pipeline test that reaches shape.num_elements. Its two
+// reducing scf.for loops show that shape-to-shape-lowering ran.
 //
-// The input is the ONNX-MLIR form of a text-embedding graph that scatters image
-// features into token embeddings. Every batch and sequence extent stays
-// symbolic, and NonZero makes the scatter index count data-dependent, so the
-// pipeline must never freeze an extent to a constant.
-//
-// The graph is importer output with one edit: the omitted `steps` operand of
-// onnx.Slice is spelled onnx.NoValue. The embedding table stays as imported, an
-// external byte range naming the model's two-gigabyte weight file, so the RUN
-// line creates a file of exactly that size for the conversion to map. Only its
-// length matters: the compiler records the path and offset and never reads the
-// weights, so the contents are left undefined.
-//
-// The whole output is checked. The pipeline decides how many pool domains to
-// cut, where each cut sits, and what every shape computation does, so a partial
-// check would let those move unnoticed.
-//
-// Pool domains and what cuts them
-// -------------------------------
-//
-// A domain is one pool allocation, so every buffer inside it must be sized
-// before it runs. The pipeline therefore starts a new domain wherever a shape
-// depends on a value the host cannot know until the previous domain has
-// finished. Each cut below reads the host tensor named on the arrow.
-//
-//   domain 0   collapse(image_features)              -> flat
-//              equal(input_ids, 248056) -> unsqueeze -> mask
-//              gather(table, input_ids)              -> embeds
-//              shape(embeds)                         -> extents  host 3xi64
-//                   |
-//                   |  extents: the broadcast destination is not in any type
-//                   v
-//   domain 1   expand(mask, extents)                 -> mask3d
-//                   |
-//                   |  extents: the second broadcast reads them again
-//                   v
-//   domain 2   expand(mask3d, extents)               -> mask3d'
-//              nonzero(mask3d')                      -> coords 3x?, count
-//              copy_d2h(count)                       -> count    host 1xi64
-//                   |
-//                   |  count: how many coordinates the search actually found
-//                   v
-//   domain 3   extract_slice(coords, count)          -> coords 3x?
-//              transpose(coords)                     -> coords ?x3
-//              shape -> gather -> unsqueeze          -> window   host 1xi64
-//                   |
-//                   |  window: where the update slice ends
-//                   v
-//   domain 4   slice(flat, window)                   -> updates
-//              scatter_nd(embeds, coords, updates)   -> inputs_embeds
-//
-// Everything in domain 0 is shaped by the argument types alone. Domains 1
-// through 4 each open with a shape computation that extracts extents from a
-// host buffer an earlier domain filled, which is what a cut looks like below.
-//
-// The four zones of a domain
-// --------------------------
-//
-// hipsr-materialize-init-tensors leaves each domain body in order: the shape
-// computations, then the tensor.empty allocations that read their dynamic
-// extents back out of those shapes, then the data ops, then a
-// hipsr.preserve_shape per allocation tying the shape that sized it to the
-// result that fills it. A constant a shape computation reads moves up with it;
-// the rest stay where conversion left them.
-//
-// The shape computations are flat, and carry extent tensors rather than
-// !shape.shape. hipsr-convert-shape-to-extent inlined the scf.execute_region
-// and shape.assuming that materialization wraps each one in, and
-// remove-shape-constraints erased the witnesses and hoisted the constants they
-// left behind to the top of each block. The inlining is why the boundary
-// between one computation and the next is no longer marked in the output: the
-// zone is still a contiguous run, but it now reads as one straight line.
-//===----------------------------------------------------------------------===//
+// The embedding table lives in an external file, so the RUN line creates a
+// file of the right length to map. Only the length matters; nothing reads the
+// weights.
 
 // RUN: %python %S/../../../Inputs/make_external_data.py %t/embedding.onnx.data 2034237440 && cd %t && hip-mlir-opt --onnx-dialect=modeled --hipsr-pipeline --mlir-elide-resource-strings-if-larger=32 %s | FileCheck %s
 
-module {
-
 // CHECK-LABEL:   func.func @main_graph(
 // CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
-// CHECK-SAME:      %[[ARG1:.*]]: tensor<?x?xi64, #hipsr.mem<device>> {onnx.name = "input_ids"},
-// CHECK-SAME:      %[[ARG2:.*]]: tensor<?x4096xf16, #hipsr.mem<device>> {onnx.name = "image_features"}) -> (tensor<?x?x4096xf16, #hipsr.mem<device>> {onnx.name = "inputs_embeds"}) attributes {onnx.graph.name = "main_graph"} {
-// Domain 0 takes everything whose shape follows from the graph inputs alone:
-// the embedding lookup, the bool mask, and the shape vector the broadcasts
-// downstream will read. The index constants the shape computations share come
-// first, then the two weights, then the computations themselves.
-// CHECK-NEXT:           %[[POOL_DOMAIN_0:.*]]:8 = hipsr.pool_domain(%[[ARG0]], %[[ARG2]], %[[ARG1]] : !hipsr.context, tensor<?x4096xf16, #hipsr.mem<device>>, tensor<?x?xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:           ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: tensor<?x4096xf16, #hipsr.mem<device>>, %[[VAL_2:.*]]: tensor<?x?xi64, #hipsr.mem<device>>):
-// CHECK-NEXT:             %[[CONST_SHAPE_0:.*]] = shape.const_shape [3] : tensor<1xindex>
-// CHECK-NEXT:             %[[CONSTANT_0:.*]] = arith.constant 1 : index
-// CHECK-NEXT:             %[[CONSTANT_1:.*]] = arith.constant 0 : index
-// CHECK-NEXT:             %[[CONSTANT_2:.*]] = arith.constant 1 : index
-// CHECK-NEXT:             %[[CONSTANT_3:.*]] = hipsr.constant {value = dense_resource<"file|embedding.onnx.data|0"> : tensor<248320x4096xf16, #hipsr.mem<device>>} : tensor<248320x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[CONSTANT_4:.*]] = hipsr.constant {value = dense<248056> : tensor<i64>} : tensor<i64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[SHAPE_OF_0:.*]] = shape.shape_of %[[VAL_1]] : tensor<?x4096xf16, #hipsr.mem<device>> -> tensor<2xindex>
-// CHECK-NEXT:             %[[NUM_ELEMENTS_0:.*]] = shape.num_elements %[[SHAPE_OF_0]] : tensor<2xindex> -> index
-// CHECK-NEXT:             %[[FROM_ELEMENTS_0:.*]] = tensor.from_elements %[[NUM_ELEMENTS_0]] : tensor<1xindex>
-// CHECK-NEXT:             %[[SHAPE_OF_1:.*]] = shape.shape_of %[[VAL_2]] : tensor<?x?xi64, #hipsr.mem<device>> -> tensor<2xindex>
-// CHECK-NEXT:             %[[SHAPE_OF_2:.*]] = shape.shape_of %[[CONSTANT_4]] : tensor<i64, #hipsr.mem<device>> -> tensor<0xindex>
-// CHECK-NEXT:             %[[BROADCAST_0:.*]] = shape.broadcast %[[SHAPE_OF_1]], %[[SHAPE_OF_2]] : tensor<2xindex>, tensor<0xindex> -> tensor<2xindex>
-// CHECK-NEXT:             %[[GET_EXTENT_0:.*]] = shape.get_extent %[[BROADCAST_0]], %[[CONSTANT_1]] : tensor<2xindex>, index -> index
-// CHECK-NEXT:             %[[GET_EXTENT_1:.*]] = shape.get_extent %[[BROADCAST_0]], %[[CONSTANT_0]] : tensor<2xindex>, index -> index
-// CHECK-NEXT:             %[[FROM_ELEMENTS_1:.*]] = tensor.from_elements %[[GET_EXTENT_0]], %[[GET_EXTENT_1]], %[[CONSTANT_2]] : tensor<3xindex>
-// CHECK-NEXT:             %[[SHAPE_OF_3:.*]] = shape.shape_of %[[CONSTANT_3]] : tensor<248320x4096xf16, #hipsr.mem<device>> -> tensor<2xindex>
-// CHECK-NEXT:             %[[SHAPE_OF_4:.*]] = shape.shape_of %[[VAL_2]] : tensor<?x?xi64, #hipsr.mem<device>> -> tensor<2xindex>
-// CHECK-NEXT:             %[[VAL_3:.*]], %[[VAL_4:.*]] = "shape.split_at"(%[[SHAPE_OF_3]], %[[CONSTANT_1]]) : (tensor<2xindex>, index) -> (tensor<?xindex>, tensor<?xindex>)
-// CHECK-NEXT:             %[[VAL_5:.*]], %[[VAL_6:.*]] = "shape.split_at"(%[[SHAPE_OF_3]], %[[CONSTANT_0]]) : (tensor<2xindex>, index) -> (tensor<?xindex>, tensor<?xindex>)
-// CHECK-NEXT:             %[[CONCAT_0:.*]] = tensor.concat dim(0) %[[VAL_3]], %[[SHAPE_OF_4]] : (tensor<?xindex>, tensor<2xindex>) -> tensor<?xindex>
-// CHECK-NEXT:             %[[CONCAT_1:.*]] = tensor.concat dim(0) %[[CONCAT_0]], %[[VAL_6]] : (tensor<?xindex>, tensor<?xindex>) -> tensor<?xindex>
-// The allocation zone. Each tensor.empty takes its dynamic extents from the
-// shape that sized it; a fully static result type needs none. The gather's
-// shape came through shape.concat, which upstream cannot lower, so this pass
-// rewrote it to tensor.concat; its extent count is dynamic because split_at
-// feeds it, which is why %[[EMPTY_3]] reads a tensor<?xindex>.
-// CHECK-NEXT:             %[[GET_EXTENT_2:.*]] = shape.get_extent %[[FROM_ELEMENTS_0]], %[[CONSTANT_1]] : tensor<1xindex>, index -> index
-// CHECK-NEXT:             %[[EMPTY_0:.*]] = tensor.empty(%[[GET_EXTENT_2]]) : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[GET_EXTENT_3:.*]] = shape.get_extent %[[BROADCAST_0]], %[[CONSTANT_1]] : tensor<2xindex>, index -> index
-// CHECK-NEXT:             %[[GET_EXTENT_4:.*]] = shape.get_extent %[[BROADCAST_0]], %[[CONSTANT_0]] : tensor<2xindex>, index -> index
-// CHECK-NEXT:             %[[EMPTY_1:.*]] = tensor.empty(%[[GET_EXTENT_3]], %[[GET_EXTENT_4]]) : tensor<?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[GET_EXTENT_5:.*]] = shape.get_extent %[[FROM_ELEMENTS_1]], %[[CONSTANT_1]] : tensor<3xindex>, index -> index
-// CHECK-NEXT:             %[[GET_EXTENT_6:.*]] = shape.get_extent %[[FROM_ELEMENTS_1]], %[[CONSTANT_0]] : tensor<3xindex>, index -> index
-// CHECK-NEXT:             %[[EMPTY_2:.*]] = tensor.empty(%[[GET_EXTENT_5]], %[[GET_EXTENT_6]]) : tensor<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[GET_EXTENT_7:.*]] = shape.get_extent %[[CONCAT_1]], %[[CONSTANT_1]] : tensor<?xindex>, index -> index
-// CHECK-NEXT:             %[[GET_EXTENT_8:.*]] = shape.get_extent %[[CONCAT_1]], %[[CONSTANT_0]] : tensor<?xindex>, index -> index
-// CHECK-NEXT:             %[[EMPTY_3:.*]] = tensor.empty(%[[GET_EXTENT_7]], %[[GET_EXTENT_8]]) : tensor<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[EMPTY_4:.*]] = tensor.empty() : tensor<3xi64, #hipsr.mem<host>>
-// The data zone, in conversion order, each op now initialized by a tensor.empty.
-// CHECK-NEXT:             %[[COMPUTE_0:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[VAL_1]] : tensor<?x4096xf16, #hipsr.mem<device>>) outs(%[[EMPTY_0]] : tensor<?xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_7:.*]]: !hipsr.context, %[[VAL_8:.*]]: tensor<?x4096xf16, #hipsr.mem<device>>, %[[VAL_9:.*]]: tensor<?xf16, #hipsr.mem<device>>):
-// CHECK-NEXT:               %[[COLLAPSE_SHAPE_0:.*]] = tensor.collapse_shape %[[VAL_8]] {{\[\[}}0, 1]] : tensor<?x4096xf16, #hipsr.mem<device>> into tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:               hipsr.compute_yield %[[COLLAPSE_SHAPE_0]] : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             } : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[EQUAL_0:.*]] = hipsr.equal(%[[VAL_0]]) ins(%[[VAL_2]], %[[CONSTANT_4]] : tensor<?x?xi64, #hipsr.mem<device>>, tensor<i64, #hipsr.mem<device>>) outs(%[[EMPTY_1]] : tensor<?x?xi1, #hipsr.mem<device>>) : tensor<?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[COMPUTE_1:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[EQUAL_0]] : tensor<?x?xi1, #hipsr.mem<device>>) outs(%[[EMPTY_2]] : tensor<?x?x1xi1, #hipsr.mem<device>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_10:.*]]: !hipsr.context, %[[VAL_11:.*]]: tensor<?x?xi1, #hipsr.mem<device>>, %[[VAL_12:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>):
-// CHECK-NEXT:               %[[CONSTANT_5:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[CONSTANT_6:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[DIM_0:.*]] = tensor.dim %[[VAL_12]], %[[CONSTANT_6]] : tensor<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:               %[[DIM_1:.*]] = tensor.dim %[[VAL_12]], %[[CONSTANT_5]] : tensor<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:               %[[EXPAND_SHAPE_0:.*]] = tensor.expand_shape %[[VAL_11]] {{\[\[}}0], [1, 2]] output_shape {{\[}}%[[DIM_0]], %[[DIM_1]], 1] : tensor<?x?xi1, #hipsr.mem<device>> into tensor<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:               hipsr.compute_yield %[[EXPAND_SHAPE_0]] : tensor<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             } : tensor<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[GATHER_0:.*]] = hipsr.gather(%[[VAL_0]]) ins(%[[CONSTANT_3]], %[[VAL_2]] : tensor<248320x4096xf16, #hipsr.mem<device>>, tensor<?x?xi64, #hipsr.mem<device>>) outs(%[[EMPTY_3]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) {axis = 0 : i64} : tensor<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[COMPUTE_2:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[GATHER_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[EMPTY_4]] : tensor<3xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_13:.*]]: !hipsr.context, %[[VAL_14:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_15:.*]]: tensor<3xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:               %[[CONSTANT_7:.*]] = arith.constant 4096 : i64
-// CHECK-NEXT:               %[[CONSTANT_8:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[CONSTANT_9:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[DIM_2:.*]] = tensor.dim %[[VAL_14]], %[[CONSTANT_9]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:               %[[INDEX_CAST_0:.*]] = arith.index_cast %[[DIM_2]] : index to i64
-// CHECK-NEXT:               %[[DIM_3:.*]] = tensor.dim %[[VAL_14]], %[[CONSTANT_8]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:               %[[INDEX_CAST_1:.*]] = arith.index_cast %[[DIM_3]] : index to i64
-// CHECK-NEXT:               %[[FROM_ELEMENTS_2:.*]] = tensor.from_elements %[[INDEX_CAST_0]], %[[INDEX_CAST_1]], %[[CONSTANT_7]] : tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               hipsr.compute_yield %[[FROM_ELEMENTS_2]] : tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             } : tensor<3xi64, #hipsr.mem<host>>
-// The link zone. One hipsr.preserve_shape per allocation, in allocation order,
-// each naming the result of the op that fills that buffer, so a later pass can
-// still read the shape once bufferization has replaced the tensor values with
-// the buffers behind them. The extent tensors here bufferize to extent memrefs,
-// which the relaxed hipsr.preserve_shape ODS also admits.
-// CHECK-NEXT:             hipsr.preserve_shape %[[FROM_ELEMENTS_0]], %[[COMPUTE_0]] : tensor<1xindex>, tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[BROADCAST_0]], %[[EQUAL_0]] : tensor<2xindex>, tensor<?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[FROM_ELEMENTS_1]], %[[COMPUTE_1]] : tensor<3xindex>, tensor<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[CONCAT_1]], %[[GATHER_0]] : tensor<?xindex>, tensor<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[CONST_SHAPE_0]], %[[COMPUTE_2]] : tensor<1xindex>, tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             hipsr.pool_domain_yield %[[EMPTY_0]], %[[COMPUTE_0]], %[[EMPTY_2]], %[[COMPUTE_1]], %[[EMPTY_3]], %[[GATHER_0]], %[[EMPTY_4]], %[[COMPUTE_2]] : tensor<?xf16, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:           } -> tensor<?xf16, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<3xi64, #hipsr.mem<host>> {domain_id = 0 : i64}
-// Each broadcast reads its extents from a host shape vector rather than from
-// the type, so each one opens a domain whose shape computation extracts them
-// with tensor.extract and rebuilds the destination shape.
-// CHECK-NEXT:           %[[POOL_DOMAIN_1:.*]]:2 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#2, %[[POOL_DOMAIN_0]]#6, %[[POOL_DOMAIN_0]]#3, %[[POOL_DOMAIN_0]]#7 : !hipsr.context, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:           ^bb0(%[[VAL_17:.*]]: !hipsr.context, %[[VAL_18:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_19:.*]]: tensor<3xi64, #hipsr.mem<host>>, %[[VAL_20:.*]]: tensor<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_21:.*]]: tensor<3xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:             %[[CONSTANT_10:.*]] = arith.constant 2 : index
-// CHECK-NEXT:             %[[CONSTANT_11:.*]] = arith.constant 1 : index
-// CHECK-NEXT:             %[[CONSTANT_12:.*]] = arith.constant 0 : index
-// CHECK-NEXT:             %[[CONSTANT_13:.*]] = arith.constant 2 : index
-// CHECK-NEXT:             %[[CONSTANT_14:.*]] = arith.constant 1 : index
-// CHECK-NEXT:             %[[CONSTANT_15:.*]] = arith.constant 0 : index
-// CHECK-NEXT:             %[[SHAPE_OF_5:.*]] = shape.shape_of %[[VAL_18]] : tensor<?x?x1xi1, #hipsr.mem<device>> -> tensor<3xindex>
-// CHECK-NEXT:             %[[EXTRACT_0:.*]] = tensor.extract %[[VAL_19]]{{\[}}%[[CONSTANT_15]]] : tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             %[[INDEX_CAST_2:.*]] = arith.index_cast %[[EXTRACT_0]] : i64 to index
-// CHECK-NEXT:             %[[EXTRACT_1:.*]] = tensor.extract %[[VAL_19]]{{\[}}%[[CONSTANT_14]]] : tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             %[[INDEX_CAST_3:.*]] = arith.index_cast %[[EXTRACT_1]] : i64 to index
-// CHECK-NEXT:             %[[EXTRACT_2:.*]] = tensor.extract %[[VAL_19]]{{\[}}%[[CONSTANT_13]]] : tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             %[[INDEX_CAST_4:.*]] = arith.index_cast %[[EXTRACT_2]] : i64 to index
-// CHECK-NEXT:             %[[FROM_ELEMENTS_3:.*]] = tensor.from_elements %[[INDEX_CAST_2]], %[[INDEX_CAST_3]], %[[INDEX_CAST_4]] : tensor<3xindex>
-// CHECK-NEXT:             %[[BROADCAST_1:.*]] = shape.broadcast %[[SHAPE_OF_5]], %[[FROM_ELEMENTS_3]] : tensor<3xindex>, tensor<3xindex> -> tensor<3xindex>
-// CHECK-NEXT:             %[[GET_EXTENT_9:.*]] = shape.get_extent %[[BROADCAST_1]], %[[CONSTANT_12]] : tensor<3xindex>, index -> index
-// CHECK-NEXT:             %[[GET_EXTENT_10:.*]] = shape.get_extent %[[BROADCAST_1]], %[[CONSTANT_11]] : tensor<3xindex>, index -> index
-// CHECK-NEXT:             %[[GET_EXTENT_11:.*]] = shape.get_extent %[[BROADCAST_1]], %[[CONSTANT_10]] : tensor<3xindex>, index -> index
-// CHECK-NEXT:             %[[EMPTY_5:.*]] = tensor.empty(%[[GET_EXTENT_9]], %[[GET_EXTENT_10]], %[[GET_EXTENT_11]]) : tensor<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[EXPAND_0:.*]] = hipsr.expand(%[[VAL_17]]) ins(%[[VAL_20]], %[[VAL_21]] : tensor<?x?x1xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) outs(%[[EMPTY_5]] : tensor<?x?x?xi1, #hipsr.mem<device>>) : tensor<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[BROADCAST_1]], %[[EXPAND_0]] : tensor<3xindex>, tensor<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.pool_domain_yield %[[EMPTY_5]], %[[EXPAND_0]] : tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:           } -> tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<?x?x?xi1, #hipsr.mem<device>> {domain_id = 1 : i64}
-// The second broadcast feeds the search. Its destination holds one row per
-// input axis and, in the worst case, a column per input element; the count of
-// the columns it filled sits beside it and is read back to the host. The
-// search sizes two buffers, so its shape computation produces two shapes, and
-// the second is a constant the allocation never needs to read.
-// CHECK-NEXT:           %[[POOL_DOMAIN_2:.*]]:4 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_1]]#0, %[[POOL_DOMAIN_0]]#6, %[[POOL_DOMAIN_1]]#1, %[[POOL_DOMAIN_0]]#7 : !hipsr.context, tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>, tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:           ^bb0(%[[VAL_24:.*]]: !hipsr.context, %[[VAL_25:.*]]: tensor<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_26:.*]]: tensor<3xi64, #hipsr.mem<host>>, %[[VAL_27:.*]]: tensor<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_28:.*]]: tensor<3xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:             %[[CONSTANT_16:.*]] = arith.constant 2 : index
-// CHECK-NEXT:             %[[CONSTANT_17:.*]] = arith.constant 1 : index
-// CHECK-NEXT:             %[[CONSTANT_18:.*]] = arith.constant 0 : index
-// CHECK-NEXT:             %[[CONST_SHAPE_1:.*]] = shape.const_shape [1] : tensor<1xindex>
-// CHECK-NEXT:             %[[CONSTANT_19:.*]] = arith.constant 3 : index
-// CHECK-NEXT:             %[[CONSTANT_20:.*]] = arith.constant 2 : index
-// CHECK-NEXT:             %[[CONSTANT_21:.*]] = arith.constant 1 : index
-// CHECK-NEXT:             %[[CONSTANT_22:.*]] = arith.constant 0 : index
-// CHECK-NEXT:             %[[SHAPE_OF_6:.*]] = shape.shape_of %[[VAL_25]] : tensor<?x?x?xi1, #hipsr.mem<device>> -> tensor<3xindex>
-// CHECK-NEXT:             %[[EXTRACT_3:.*]] = tensor.extract %[[VAL_26]]{{\[}}%[[CONSTANT_22]]] : tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             %[[INDEX_CAST_5:.*]] = arith.index_cast %[[EXTRACT_3]] : i64 to index
-// CHECK-NEXT:             %[[EXTRACT_4:.*]] = tensor.extract %[[VAL_26]]{{\[}}%[[CONSTANT_21]]] : tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             %[[INDEX_CAST_6:.*]] = arith.index_cast %[[EXTRACT_4]] : i64 to index
-// CHECK-NEXT:             %[[EXTRACT_5:.*]] = tensor.extract %[[VAL_26]]{{\[}}%[[CONSTANT_20]]] : tensor<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             %[[INDEX_CAST_7:.*]] = arith.index_cast %[[EXTRACT_5]] : i64 to index
-// CHECK-NEXT:             %[[FROM_ELEMENTS_4:.*]] = tensor.from_elements %[[INDEX_CAST_5]], %[[INDEX_CAST_6]], %[[INDEX_CAST_7]] : tensor<3xindex>
-// CHECK-NEXT:             %[[BROADCAST_2:.*]] = shape.broadcast %[[SHAPE_OF_6]], %[[FROM_ELEMENTS_4]] : tensor<3xindex>, tensor<3xindex> -> tensor<3xindex>
-// CHECK-NEXT:             %[[NUM_ELEMENTS_1:.*]] = shape.num_elements %[[BROADCAST_2]] : tensor<3xindex> -> index
-// CHECK-NEXT:             %[[FROM_ELEMENTS_5:.*]] = tensor.from_elements %[[CONSTANT_19]], %[[NUM_ELEMENTS_1]] : tensor<2xindex>
-// CHECK-NEXT:             %[[GET_EXTENT_12:.*]] = shape.get_extent %[[BROADCAST_2]], %[[CONSTANT_18]] : tensor<3xindex>, index -> index
-// CHECK-NEXT:             %[[GET_EXTENT_13:.*]] = shape.get_extent %[[BROADCAST_2]], %[[CONSTANT_17]] : tensor<3xindex>, index -> index
-// CHECK-NEXT:             %[[GET_EXTENT_14:.*]] = shape.get_extent %[[BROADCAST_2]], %[[CONSTANT_16]] : tensor<3xindex>, index -> index
-// CHECK-NEXT:             %[[EMPTY_6:.*]] = tensor.empty(%[[GET_EXTENT_12]], %[[GET_EXTENT_13]], %[[GET_EXTENT_14]]) : tensor<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[GET_EXTENT_15:.*]] = shape.get_extent %[[FROM_ELEMENTS_5]], %[[CONSTANT_17]] : tensor<2xindex>, index -> index
-// CHECK-NEXT:             %[[EMPTY_7:.*]] = tensor.empty(%[[GET_EXTENT_15]]) : tensor<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[EMPTY_8:.*]] = tensor.empty() : tensor<1xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[EMPTY_9:.*]] = tensor.empty() : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             %[[EXPAND_1:.*]] = hipsr.expand(%[[VAL_24]]) ins(%[[VAL_27]], %[[VAL_28]] : tensor<?x?x?xi1, #hipsr.mem<device>>, tensor<3xi64, #hipsr.mem<host>>) outs(%[[EMPTY_6]] : tensor<?x?x?xi1, #hipsr.mem<device>>) : tensor<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[NONZERO_0:.*]]:2 = hipsr.nonzero(%[[VAL_24]]) ins(%[[EXPAND_1]] : tensor<?x?x?xi1, #hipsr.mem<device>>) outs(%[[EMPTY_7]], %[[EMPTY_8]] : tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>) : tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[VAL_29:.*]] = hipsr.copy_d2h(%[[VAL_24]]) ins(%[[NONZERO_0]]#1 : tensor<1xi64, #hipsr.mem<device>>) outs(%[[EMPTY_9]] : tensor<1xi64, #hipsr.mem<host>>) : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[BROADCAST_2]], %[[EXPAND_1]] : tensor<3xindex>, tensor<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[FROM_ELEMENTS_5]], %[[NONZERO_0]]#0 : tensor<2xindex>, tensor<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[CONST_SHAPE_1]], %[[NONZERO_0]]#1 : tensor<1xindex>, tensor<1xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[CONST_SHAPE_1]], %[[VAL_29]] : tensor<1xindex>, tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             hipsr.pool_domain_yield %[[EMPTY_7]], %[[NONZERO_0]]#0, %[[EMPTY_9]], %[[VAL_29]] : tensor<3x?xi64, #hipsr.mem<device>>, tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:           } -> tensor<3x?xi64, #hipsr.mem<device>>, tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>> {domain_id = 2 : i64}
-// That host count opens the next domain, where the first shape computation
-// turns it into the trailing extent so the search destination narrows to the
-// columns that hold a position. The domain takes both buffers twice, and the
-// shape computation reads only the count while the data op reads only the
-// coordinates.
-// CHECK-NEXT:           %[[POOL_DOMAIN_3:.*]]:4 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_2]]#2, %[[POOL_DOMAIN_2]]#0, %[[POOL_DOMAIN_2]]#3, %[[POOL_DOMAIN_2]]#1 : !hipsr.context, tensor<1xi64, #hipsr.mem<host>>, tensor<3x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<3x?xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:           ^bb0(%[[VAL_31:.*]]: !hipsr.context, %[[VAL_32:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_33:.*]]: tensor<3x?xi64, #hipsr.mem<device>>, %[[VAL_34:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_35:.*]]: tensor<3x?xi64, #hipsr.mem<device>>):
-// CHECK-NEXT:             %[[CONST_SHAPE_2:.*]] = shape.const_shape [1] : tensor<1xindex>
-// CHECK-NEXT:             %[[CONST_SHAPE_3:.*]] = shape.const_shape [2] : tensor<1xindex>
-// CHECK-NEXT:             %[[CONST_SHAPE_4:.*]] = shape.const_shape [] : tensor<0xindex>
-// CHECK-NEXT:             %[[CONSTANT_23:.*]] = arith.constant 0 : index
-// CHECK-NEXT:             %[[CONSTANT_24:.*]] = arith.constant 1 : index
-// CHECK-NEXT:             %[[CONSTANT_25:.*]] = arith.constant 3 : index
-// CHECK-NEXT:             %[[CONSTANT_26:.*]] = arith.constant 0 : index
-// CHECK-NEXT:             %[[EXTRACT_6:.*]] = tensor.extract %[[VAL_32]]{{\[}}%[[CONSTANT_26]]] : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             %[[INDEX_CAST_8:.*]] = arith.index_cast %[[EXTRACT_6]] : i64 to index
-// CHECK-NEXT:             %[[FROM_ELEMENTS_6:.*]] = tensor.from_elements %[[CONSTANT_25]], %[[INDEX_CAST_8]] : tensor<2xindex>
-// CHECK-NEXT:             %[[GET_EXTENT_16:.*]] = shape.get_extent %[[FROM_ELEMENTS_6]], %[[CONSTANT_24]] : tensor<2xindex>, index -> index
-// CHECK-NEXT:             %[[GET_EXTENT_17:.*]] = shape.get_extent %[[FROM_ELEMENTS_6]], %[[CONSTANT_23]] : tensor<2xindex>, index -> index
-// CHECK-NEXT:             %[[FROM_ELEMENTS_7:.*]] = tensor.from_elements %[[GET_EXTENT_16]], %[[GET_EXTENT_17]] : tensor<2xindex>
-// CHECK-NEXT:             %[[GET_EXTENT_18:.*]] = shape.get_extent %[[FROM_ELEMENTS_6]], %[[CONSTANT_24]] : tensor<2xindex>, index -> index
-// CHECK-NEXT:             %[[EMPTY_10:.*]] = tensor.empty(%[[GET_EXTENT_18]]) : tensor<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[GET_EXTENT_19:.*]] = shape.get_extent %[[FROM_ELEMENTS_7]], %[[CONSTANT_23]] : tensor<2xindex>, index -> index
-// CHECK-NEXT:             %[[EMPTY_11:.*]] = tensor.empty(%[[GET_EXTENT_19]]) : tensor<?x3xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[EMPTY_12:.*]] = tensor.empty() : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             %[[EMPTY_13:.*]] = tensor.empty() : tensor<i64, #hipsr.mem<host>>
-// CHECK-NEXT:             %[[EMPTY_14:.*]] = tensor.empty() : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             %[[COMPUTE_3:.*]] = hipsr.compute(%[[VAL_31]]) ins(%[[VAL_34]], %[[VAL_35]] : tensor<1xi64, #hipsr.mem<host>>, tensor<3x?xi64, #hipsr.mem<device>>) outs(%[[EMPTY_10]] : tensor<3x?xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_36:.*]]: !hipsr.context, %[[VAL_37:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_38:.*]]: tensor<3x?xi64, #hipsr.mem<device>>, %[[VAL_39:.*]]: tensor<3x?xi64, #hipsr.mem<device>>):
-// CHECK-NEXT:               %[[CONSTANT_27:.*]] = arith.constant 1 : index
-// CHECK-NEXT:               %[[DIM_4:.*]] = tensor.dim %[[VAL_39]], %[[CONSTANT_27]] : tensor<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:               %[[EXTRACT_SLICE_0:.*]] = tensor.extract_slice %[[VAL_38]][0, 0] [3, %[[DIM_4]]] [1, 1] : tensor<3x?xi64, #hipsr.mem<device>> to tensor<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:               hipsr.compute_yield %[[EXTRACT_SLICE_0]] : tensor<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             } : tensor<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[TRANSPOSE_0:.*]] = hipsr.transpose(%[[VAL_31]]) ins(%[[COMPUTE_3]] : tensor<3x?xi64, #hipsr.mem<device>>) outs(%[[EMPTY_11]] : tensor<?x3xi64, #hipsr.mem<device>>) {perm = array<i64: 1, 0>} : tensor<?x3xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[COMPUTE_4:.*]] = hipsr.compute(%[[VAL_31]]) ins(%[[TRANSPOSE_0]] : tensor<?x3xi64, #hipsr.mem<device>>) outs(%[[EMPTY_12]] : tensor<2xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_40:.*]]: !hipsr.context, %[[VAL_41:.*]]: tensor<?x3xi64, #hipsr.mem<device>>, %[[VAL_42:.*]]: tensor<2xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:               %[[CONSTANT_28:.*]] = arith.constant 3 : i64
-// CHECK-NEXT:               %[[CONSTANT_29:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[DIM_5:.*]] = tensor.dim %[[VAL_41]], %[[CONSTANT_29]] : tensor<?x3xi64, #hipsr.mem<device>>
-// CHECK-NEXT:               %[[INDEX_CAST_9:.*]] = arith.index_cast %[[DIM_5]] : index to i64
-// CHECK-NEXT:               %[[FROM_ELEMENTS_8:.*]] = tensor.from_elements %[[INDEX_CAST_9]], %[[CONSTANT_28]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               hipsr.compute_yield %[[FROM_ELEMENTS_8]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             } : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             %[[COMPUTE_5:.*]] = hipsr.compute(%[[VAL_31]]) ins(%[[COMPUTE_4]] : tensor<2xi64, #hipsr.mem<host>>) outs(%[[EMPTY_13]] : tensor<i64, #hipsr.mem<host>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_43:.*]]: !hipsr.context, %[[VAL_44:.*]]: tensor<2xi64, #hipsr.mem<host>>, %[[VAL_45:.*]]: tensor<i64, #hipsr.mem<host>>):
-// CHECK-NEXT:               %[[CONSTANT_30:.*]] = arith.constant 0 : index
-// CHECK-NEXT:               %[[EXTRACT_7:.*]] = tensor.extract %[[VAL_44]]{{\[}}%[[CONSTANT_30]]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               %[[FROM_ELEMENTS_9:.*]] = tensor.from_elements %[[EXTRACT_7]] : tensor<i64, #hipsr.mem<host>>
-// CHECK-NEXT:               hipsr.compute_yield %[[FROM_ELEMENTS_9]] : tensor<i64, #hipsr.mem<host>>
-// CHECK-NEXT:             } : tensor<i64, #hipsr.mem<host>>
-// CHECK-NEXT:             %[[COMPUTE_6:.*]] = hipsr.compute(%[[VAL_31]]) ins(%[[COMPUTE_5]] : tensor<i64, #hipsr.mem<host>>) outs(%[[EMPTY_14]] : tensor<1xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:             ^bb0(%[[VAL_46:.*]]: !hipsr.context, %[[VAL_47:.*]]: tensor<i64, #hipsr.mem<host>>, %[[VAL_48:.*]]: tensor<1xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:               %[[EXPAND_SHAPE_1:.*]] = tensor.expand_shape %[[VAL_47]] [] output_shape [1] : tensor<i64, #hipsr.mem<host>> into tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:               hipsr.compute_yield %[[EXPAND_SHAPE_1]] : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             } : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[FROM_ELEMENTS_6]], %[[COMPUTE_3]] : tensor<2xindex>, tensor<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[FROM_ELEMENTS_7]], %[[TRANSPOSE_0]] : tensor<2xindex>, tensor<?x3xi64, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[CONST_SHAPE_3]], %[[COMPUTE_4]] : tensor<1xindex>, tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[CONST_SHAPE_4]], %[[COMPUTE_5]] : tensor<0xindex>, tensor<i64, #hipsr.mem<host>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[CONST_SHAPE_2]], %[[COMPUTE_6]] : tensor<1xindex>, tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             hipsr.pool_domain_yield %[[EMPTY_11]], %[[TRANSPOSE_0]], %[[EMPTY_14]], %[[COMPUTE_6]] : tensor<?x3xi64, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:           } -> tensor<?x3xi64, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<1xi64, #hipsr.mem<host>> {domain_id = 3 : i64}
-// The update window ends at that same count, and the scatter writes it into
-// the embeddings.
-// CHECK-NEXT:           %[[POOL_DOMAIN_4:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#0, %[[POOL_DOMAIN_3]]#2, %[[POOL_DOMAIN_0]]#1, %[[POOL_DOMAIN_3]]#3, %[[POOL_DOMAIN_0]]#4, %[[POOL_DOMAIN_3]]#0, %[[POOL_DOMAIN_0]]#5, %[[POOL_DOMAIN_3]]#1 : !hipsr.context, tensor<?xf16, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<?xf16, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:           ^bb0(%[[VAL_51:.*]]: !hipsr.context, %[[VAL_52:.*]]: tensor<?xf16, #hipsr.mem<device>>, %[[VAL_53:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_54:.*]]: tensor<?xf16, #hipsr.mem<device>>, %[[VAL_55:.*]]: tensor<1xi64, #hipsr.mem<host>>, %[[VAL_56:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_57:.*]]: tensor<?x3xi64, #hipsr.mem<device>>, %[[VAL_58:.*]]: tensor<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_59:.*]]: tensor<?x3xi64, #hipsr.mem<device>>):
-// CHECK-NEXT:             %[[CONSTANT_31:.*]] = arith.constant 1 : index
-// CHECK-NEXT:             %[[CONSTANT_32:.*]] = arith.constant 0 : index
-// CHECK-NEXT:             %[[CONSTANT_33:.*]] = arith.constant 0 : index
-// CHECK-NEXT:             %[[DIM_6:.*]] = tensor.dim %[[VAL_52]], %[[CONSTANT_33]] : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[EXTRACT_8:.*]] = tensor.extract %[[VAL_53]]{{\[}}%[[CONSTANT_33]]] : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:             %[[INDEX_CAST_10:.*]] = arith.index_cast %[[EXTRACT_8]] : i64 to index
-// CHECK-NEXT:             %[[CMPI_0:.*]] = arith.cmpi slt, %[[INDEX_CAST_10]], %[[CONSTANT_33]] : index
-// CHECK-NEXT:             %[[ADDI_0:.*]] = arith.addi %[[INDEX_CAST_10]], %[[DIM_6]] : index
-// CHECK-NEXT:             %[[SELECT_0:.*]] = arith.select %[[CMPI_0]], %[[ADDI_0]], %[[INDEX_CAST_10]] : index
-// CHECK-NEXT:             %[[MINSI_0:.*]] = arith.minsi %[[DIM_6]], %[[CONSTANT_33]] : index
-// CHECK-NEXT:             %[[MAXSI_0:.*]] = arith.maxsi %[[SELECT_0]], %[[CONSTANT_33]] : index
-// CHECK-NEXT:             %[[MINSI_1:.*]] = arith.minsi %[[MAXSI_0]], %[[DIM_6]] : index
-// CHECK-NEXT:             %[[SUBI_0:.*]] = arith.subi %[[MINSI_1]], %[[MINSI_0]] : index
-// CHECK-NEXT:             %[[MAXSI_1:.*]] = arith.maxsi %[[SUBI_0]], %[[CONSTANT_33]] : index
-// CHECK-NEXT:             %[[FROM_ELEMENTS_10:.*]] = tensor.from_elements %[[MAXSI_1]] : tensor<1xindex>
-// CHECK-NEXT:             %[[SHAPE_OF_7:.*]] = shape.shape_of %[[VAL_56]] : tensor<?x?x4096xf16, #hipsr.mem<device>> -> tensor<3xindex>
-// CHECK-NEXT:             %[[GET_EXTENT_20:.*]] = shape.get_extent %[[FROM_ELEMENTS_10]], %[[CONSTANT_32]] : tensor<1xindex>, index -> index
-// CHECK-NEXT:             %[[EMPTY_15:.*]] = tensor.empty(%[[GET_EXTENT_20]]) : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[GET_EXTENT_21:.*]] = shape.get_extent %[[SHAPE_OF_7]], %[[CONSTANT_32]] : tensor<3xindex>, index -> index
-// CHECK-NEXT:             %[[GET_EXTENT_22:.*]] = shape.get_extent %[[SHAPE_OF_7]], %[[CONSTANT_31]] : tensor<3xindex>, index -> index
-// CHECK-NEXT:             %[[EMPTY_16:.*]] = tensor.empty(%[[GET_EXTENT_21]], %[[GET_EXTENT_22]]) : tensor<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[SLICE_0:.*]] = hipsr.slice(%[[VAL_51]]) ins(%[[VAL_54]] : tensor<?xf16, #hipsr.mem<device>>) ends(%[[VAL_55]] : tensor<1xi64, #hipsr.mem<host>>) outs(%[[EMPTY_15]] : tensor<?xf16, #hipsr.mem<device>>) {axes_attr = array<i64: 0>, starts_attr = array<i64: 0>, steps_attr = array<i64: 1>} : tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[SCATTER_ND_0:.*]] = hipsr.scatter_nd(%[[VAL_51]]) ins(%[[VAL_58]], %[[VAL_59]], %[[SLICE_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>, tensor<?x3xi64, #hipsr.mem<device>>, tensor<?xf16, #hipsr.mem<device>>) outs(%[[EMPTY_16]] : tensor<?x?x4096xf16, #hipsr.mem<device>>) : tensor<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[FROM_ELEMENTS_10]], %[[SLICE_0]] : tensor<1xindex>, tensor<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.preserve_shape %[[SHAPE_OF_7]], %[[SCATTER_ND_0]] : tensor<3xindex>, tensor<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.pool_domain_yield %[[SCATTER_ND_0]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:           } -> tensor<?x?x4096xf16, #hipsr.mem<device>> {domain_id = 4 : i64}
-// CHECK-NEXT:           return %[[POOL_DOMAIN_4]] : tensor<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:         }
-
-
-// The table's bytes stay outside the IR, so the resource section prints empty
-// once the RUN line's elision drops the blob string.
-// CHECK:              {-#
+// CHECK-SAME:      %[[ARG1:.*]]: memref<?x?xi64, #hipsr.mem<device>> {onnx.name = "input_ids"},
+// CHECK-SAME:      %[[ARG2:.*]]: memref<?x4096xf16, #hipsr.mem<device>> {onnx.name = "image_features"}) -> (memref<?x?x4096xf16, #hipsr.mem<device>> {onnx.name = "inputs_embeds"}) attributes {onnx.graph.name = "main_graph"} {
+// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]]:8 = hipsr.pool_domain(%[[ARG0]], %[[ARG2]], %[[ARG1]] : !hipsr.context, memref<?x4096xf16, #hipsr.mem<device>>, memref<?x?xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: memref<?x4096xf16, #hipsr.mem<device>>, %[[VAL_2:.*]]: memref<?x?xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[CONSTANT_0:.*]] = arith.constant 248320 : index
+// CHECK-NEXT:        %[[CONSTANT_1:.*]] = arith.constant 2 : index
+// CHECK-NEXT:        %[[CONSTANT_2:.*]] = arith.constant 4096 : index
+// CHECK-NEXT:        %[[CONSTANT_3:.*]] = hipsr.constant {value = dense<248056> : tensor<i64>} : memref<i64, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CONSTANT_4:.*]] = hipsr.constant {value = dense_resource<"file|embedding.onnx.data|0"> : tensor<248320x4096xf16, #hipsr.mem<device>>} : memref<248320x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CONSTANT_5:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[CONSTANT_6:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[CONSTANT_7:.*]] = arith.constant 3 : index
+// CHECK-NEXT:        %[[ALLOC_0:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_7]], %[[ALLOC_0]]{{\[}}%[[CONSTANT_6]]] : memref<1xindex>
+// CHECK-NEXT:        %[[DIM_0:.*]] = memref.dim %[[VAL_1]], %[[CONSTANT_6]] : memref<?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_1:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[DIM_0]], %[[ALLOC_1]]{{\[}}%[[CONSTANT_6]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_2]], %[[ALLOC_1]]{{\[}}%[[CONSTANT_5]]] : memref<2xindex>
+// CHECK-NEXT:        %[[FOR_0:.*]] = scf.for %[[VAL_3:.*]] = %[[CONSTANT_6]] to %[[CONSTANT_1]] step %[[CONSTANT_5]] iter_args(%[[VAL_4:.*]] = %[[CONSTANT_5]]) -> (index) {
+// CHECK-NEXT:          %[[LOAD_0:.*]] = memref.load %[[ALLOC_1]]{{\[}}%[[VAL_3]]] : memref<2xindex>
+// CHECK-NEXT:          %[[MULI_0:.*]] = arith.muli %[[LOAD_0]], %[[VAL_4]] : index
+// CHECK-NEXT:          scf.yield %[[MULI_0]] : index
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[ALLOC_2:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
+// CHECK-NEXT:        memref.store %[[FOR_0]], %[[ALLOC_2]]{{\[}}%[[CONSTANT_6]]] : memref<1xindex>
+// CHECK-NEXT:        %[[DIM_1:.*]] = memref.dim %[[VAL_2]], %[[CONSTANT_6]] : memref<?x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_2:.*]] = memref.dim %[[VAL_2]], %[[CONSTANT_5]] : memref<?x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_3:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[DIM_1]], %[[ALLOC_3]]{{\[}}%[[CONSTANT_6]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[DIM_2]], %[[ALLOC_3]]{{\[}}%[[CONSTANT_5]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_4:.*]] = memref.alloc() {alignment = 64 : i64} : memref<0xindex>
+// CHECK-NEXT:        %[[ALLOC_5:.*]] = memref.alloc(%[[CONSTANT_1]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        scf.for %[[VAL_5:.*]] = %[[CONSTANT_6]] to %[[CONSTANT_1]] step %[[CONSTANT_5]] {
+// CHECK-NEXT:          %[[CMPI_0:.*]] = arith.cmpi ult, %[[VAL_5]], %[[CONSTANT_6]] : index
+// CHECK-NEXT:          %[[IF_0:.*]] = scf.if %[[CMPI_0]] -> (index) {
+// CHECK-NEXT:            scf.yield %[[CONSTANT_5]] : index
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[LOAD_1:.*]] = memref.load %[[ALLOC_3]]{{\[}}%[[VAL_5]]] : memref<2xindex>
+// CHECK-NEXT:            scf.yield %[[LOAD_1]] : index
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[CMPI_1:.*]] = arith.cmpi ult, %[[VAL_5]], %[[CONSTANT_1]] : index
+// CHECK-NEXT:          %[[IF_1:.*]] = scf.if %[[CMPI_1]] -> (index) {
+// CHECK-NEXT:            scf.yield %[[IF_0]] : index
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[SUBI_0:.*]] = arith.subi %[[VAL_5]], %[[CONSTANT_1]] : index
+// CHECK-NEXT:            %[[LOAD_2:.*]] = memref.load %[[ALLOC_4]]{{\[}}%[[SUBI_0]]] : memref<0xindex>
+// CHECK-NEXT:            %[[CMPI_2:.*]] = arith.cmpi eq, %[[LOAD_2]], %[[CONSTANT_5]] : index
+// CHECK-NEXT:            %[[SELECT_0:.*]] = arith.select %[[CMPI_2]], %[[IF_0]], %[[LOAD_2]] : index
+// CHECK-NEXT:            scf.yield %[[SELECT_0]] : index
+// CHECK-NEXT:          }
+// CHECK-NEXT:          memref.store %[[IF_1]], %[[ALLOC_5]]{{\[}}%[[VAL_5]]] : memref<?xindex>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[CAST_0:.*]] = memref.cast %[[ALLOC_5]] : memref<?xindex> to memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_3:.*]] = memref.load %[[ALLOC_5]]{{\[}}%[[CONSTANT_6]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_4:.*]] = memref.load %[[ALLOC_5]]{{\[}}%[[CONSTANT_5]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_6:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[LOAD_3]], %[[ALLOC_6]]{{\[}}%[[CONSTANT_6]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[LOAD_4]], %[[ALLOC_6]]{{\[}}%[[CONSTANT_5]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_5]], %[[ALLOC_6]]{{\[}}%[[CONSTANT_1]]] : memref<3xindex>
+// CHECK-NEXT:        %[[ALLOC_7:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_0]], %[[ALLOC_7]]{{\[}}%[[CONSTANT_6]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_2]], %[[ALLOC_7]]{{\[}}%[[CONSTANT_5]]] : memref<2xindex>
+// CHECK-NEXT:        %[[DIM_3:.*]] = memref.dim %[[VAL_2]], %[[CONSTANT_6]] : memref<?x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_4:.*]] = memref.dim %[[VAL_2]], %[[CONSTANT_5]] : memref<?x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_8:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[DIM_3]], %[[ALLOC_8]]{{\[}}%[[CONSTANT_6]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[DIM_4]], %[[ALLOC_8]]{{\[}}%[[CONSTANT_5]]] : memref<2xindex>
+// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_7]]{{\[}}%[[CONSTANT_6]]] {{\[}}%[[CONSTANT_6]]] {{\[}}%[[CONSTANT_5]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_7]]{{\[}}%[[CONSTANT_5]]] {{\[}}%[[CONSTANT_5]]] {{\[}}%[[CONSTANT_5]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[ALLOC_9:.*]] = memref.alloc(%[[CONSTANT_1]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_9]][0] {{\[}}%[[CONSTANT_6]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        memref.copy %[[SUBVIEW_0]], %[[SUBVIEW_2]] : memref<?xindex, strided<[?], offset: ?>> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_3:.*]] = memref.subview %[[ALLOC_9]]{{\[}}%[[CONSTANT_6]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        memref.copy %[[ALLOC_8]], %[[SUBVIEW_3]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        %[[ALLOC_10:.*]] = memref.alloc(%[[CONSTANT_7]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[ALLOC_10]][0] {{\[}}%[[CONSTANT_1]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        memref.copy %[[ALLOC_9]], %[[SUBVIEW_4]] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_10]]{{\[}}%[[CONSTANT_1]]] {{\[}}%[[CONSTANT_5]]] [1] : memref<?xindex> to memref<?xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        memref.copy %[[SUBVIEW_1]], %[[SUBVIEW_5]] : memref<?xindex, strided<[?], offset: ?>> to memref<?xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        %[[LOAD_5:.*]] = memref.load %[[ALLOC_2]]{{\[}}%[[CONSTANT_6]]] : memref<1xindex>
+// CHECK-NEXT:        %[[ALLOC_11:.*]] = memref.alloc(%[[LOAD_5]]) {alignment = 64 : i64} : memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[LOAD_6:.*]] = memref.load %[[ALLOC_5]]{{\[}}%[[CONSTANT_6]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_7:.*]] = memref.load %[[ALLOC_5]]{{\[}}%[[CONSTANT_5]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_8:.*]] = memref.load %[[ALLOC_6]]{{\[}}%[[CONSTANT_6]]] : memref<3xindex>
+// CHECK-NEXT:        %[[LOAD_9:.*]] = memref.load %[[ALLOC_6]]{{\[}}%[[CONSTANT_5]]] : memref<3xindex>
+// CHECK-NEXT:        %[[ALLOC_12:.*]] = memref.alloc(%[[LOAD_8]], %[[LOAD_9]]) {alignment = 64 : i64} : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[LOAD_10:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[CONSTANT_6]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_11:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[CONSTANT_5]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_13:.*]] = memref.alloc(%[[LOAD_10]], %[[LOAD_11]]) {alignment = 64 : i64} : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_14:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[COMPUTE_0:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[VAL_1]] : memref<?x4096xf16, #hipsr.mem<device>>) outs(%[[VAL_1]] : memref<?x4096xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_6:.*]]: !hipsr.context, %[[VAL_7:.*]]: memref<?x4096xf16, #hipsr.mem<device>>, %[[VAL_8:.*]]: memref<?x4096xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:          %[[COLLAPSE_SHAPE_0:.*]] = memref.collapse_shape %[[VAL_7]] {{\[\[}}0, 1]] : memref<?x4096xf16, #hipsr.mem<device>> into memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:          hipsr.compute_yield %[[COLLAPSE_SHAPE_0]] : memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        } : memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_15:.*]] = memref.alloc(%[[LOAD_6]], %[[LOAD_7]]) {alignment = 64 : i64} : memref<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.equal(%[[VAL_0]]) ins(%[[VAL_2]], %[[CONSTANT_3]] : memref<?x?xi64, #hipsr.mem<device>>, memref<i64, #hipsr.mem<device>>) outs(%[[ALLOC_15]] : memref<?x?xi1, #hipsr.mem<device>>)
+// CHECK-NEXT:        %[[COMPUTE_1:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[ALLOC_15]] : memref<?x?xi1, #hipsr.mem<device>>) outs(%[[ALLOC_12]] : memref<?x?x1xi1, #hipsr.mem<device>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_9:.*]]: !hipsr.context, %[[VAL_10:.*]]: memref<?x?xi1, #hipsr.mem<device>>, %[[VAL_11:.*]]: memref<?x?x1xi1, #hipsr.mem<device>>):
+// CHECK-NEXT:          %[[CONSTANT_8:.*]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[CONSTANT_9:.*]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[DIM_5:.*]] = memref.dim %[[VAL_11]], %[[CONSTANT_9]] : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[DIM_6:.*]] = memref.dim %[[VAL_11]], %[[CONSTANT_8]] : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[VAL_10]] {{\[\[}}0], [1, 2]] output_shape {{\[}}%[[DIM_5]], %[[DIM_6]], 1] : memref<?x?xi1, #hipsr.mem<device>> into memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:          hipsr.compute_yield %[[EXPAND_SHAPE_0]] : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        } : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_16:.*]] = memref.alloc(%[[LOAD_10]], %[[LOAD_11]]) {alignment = 64 : i64} : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.gather(%[[VAL_0]]) ins(%[[CONSTANT_4]], %[[VAL_2]] : memref<248320x4096xf16, #hipsr.mem<device>>, memref<?x?xi64, #hipsr.mem<device>>) outs(%[[ALLOC_16]] : memref<?x?x4096xf16, #hipsr.mem<device>>) {axis = 0 : i64}
+// CHECK-NEXT:        %[[COMPUTE_2:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[ALLOC_16]] : memref<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[ALLOC_14]] : memref<3xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_12:.*]]: !hipsr.context, %[[VAL_13:.*]]: memref<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_14:.*]]: memref<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:          %[[CONSTANT_10:.*]] = arith.constant 2 : index
+// CHECK-NEXT:          %[[CONSTANT_11:.*]] = arith.constant 4096 : i64
+// CHECK-NEXT:          %[[CONSTANT_12:.*]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[CONSTANT_13:.*]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[DIM_7:.*]] = memref.dim %[[VAL_13]], %[[CONSTANT_13]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[INDEX_CAST_0:.*]] = arith.index_cast %[[DIM_7]] : index to i64
+// CHECK-NEXT:          %[[DIM_8:.*]] = memref.dim %[[VAL_13]], %[[CONSTANT_12]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[INDEX_CAST_1:.*]] = arith.index_cast %[[DIM_8]] : index to i64
+// CHECK-NEXT:          %[[ALLOC_17:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[INDEX_CAST_0]], %[[ALLOC_17]]{{\[}}%[[CONSTANT_13]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[INDEX_CAST_1]], %[[ALLOC_17]]{{\[}}%[[CONSTANT_12]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[CONSTANT_11]], %[[ALLOC_17]]{{\[}}%[[CONSTANT_10]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          hipsr.compute_yield %[[ALLOC_17]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        } : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_2]], %[[COMPUTE_0]] : memref<1xindex>, memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_0]], %[[ALLOC_15]] : memref<2xindex>, memref<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_6]], %[[COMPUTE_1]] : memref<3xindex>, memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_10]], %[[ALLOC_16]] : memref<?xindex>, memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_0]], %[[COMPUTE_2]] : memref<1xindex>, memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_11]], %[[COMPUTE_0]], %[[ALLOC_12]], %[[COMPUTE_1]], %[[ALLOC_13]], %[[ALLOC_16]], %[[ALLOC_14]], %[[COMPUTE_2]] : memref<?xf16, #hipsr.mem<device>>, memref<?xf16, #hipsr.mem<device>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>, memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      } -> memref<?xf16, #hipsr.mem<device>>, memref<?xf16, #hipsr.mem<device>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>, memref<3xi64, #hipsr.mem<host>> {domain_id = 0 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]]:2 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#2, %[[POOL_DOMAIN_0]]#6, %[[POOL_DOMAIN_0]]#3, %[[POOL_DOMAIN_0]]#7 : !hipsr.context, memref<?x?x1xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_16:.*]]: !hipsr.context, %[[VAL_17:.*]]: memref<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_18:.*]]: memref<3xi64, #hipsr.mem<host>>, %[[VAL_19:.*]]: memref<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_20:.*]]: memref<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:        %[[CONSTANT_14:.*]] = arith.constant 3 : index
+// CHECK-NEXT:        %[[CONSTANT_15:.*]] = arith.constant 2 : index
+// CHECK-NEXT:        %[[CONSTANT_16:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[CONSTANT_17:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[DIM_9:.*]] = memref.dim %[[VAL_17]], %[[CONSTANT_17]] : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_10:.*]] = memref.dim %[[VAL_17]], %[[CONSTANT_16]] : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_18:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_9]], %[[ALLOC_18]]{{\[}}%[[CONSTANT_17]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_10]], %[[ALLOC_18]]{{\[}}%[[CONSTANT_16]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_16]], %[[ALLOC_18]]{{\[}}%[[CONSTANT_15]]] : memref<3xindex>
+// CHECK-NEXT:        %[[LOAD_12:.*]] = memref.load %[[VAL_18]]{{\[}}%[[CONSTANT_17]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_2:.*]] = arith.index_cast %[[LOAD_12]] : i64 to index
+// CHECK-NEXT:        %[[LOAD_13:.*]] = memref.load %[[VAL_18]]{{\[}}%[[CONSTANT_16]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_3:.*]] = arith.index_cast %[[LOAD_13]] : i64 to index
+// CHECK-NEXT:        %[[LOAD_14:.*]] = memref.load %[[VAL_18]]{{\[}}%[[CONSTANT_15]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_4:.*]] = arith.index_cast %[[LOAD_14]] : i64 to index
+// CHECK-NEXT:        %[[ALLOC_19:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_2]], %[[ALLOC_19]]{{\[}}%[[CONSTANT_17]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_3]], %[[ALLOC_19]]{{\[}}%[[CONSTANT_16]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_4]], %[[ALLOC_19]]{{\[}}%[[CONSTANT_15]]] : memref<3xindex>
+// CHECK-NEXT:        %[[ALLOC_20:.*]] = memref.alloc(%[[CONSTANT_14]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        scf.for %[[VAL_21:.*]] = %[[CONSTANT_17]] to %[[CONSTANT_14]] step %[[CONSTANT_16]] {
+// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_21]], %[[CONSTANT_17]] : index
+// CHECK-NEXT:          %[[IF_2:.*]] = scf.if %[[CMPI_3]] -> (index) {
+// CHECK-NEXT:            scf.yield %[[CONSTANT_16]] : index
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[LOAD_15:.*]] = memref.load %[[ALLOC_18]]{{\[}}%[[VAL_21]]] : memref<3xindex>
+// CHECK-NEXT:            scf.yield %[[LOAD_15]] : index
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_21]], %[[CONSTANT_17]] : index
+// CHECK-NEXT:          %[[IF_3:.*]] = scf.if %[[CMPI_4]] -> (index) {
+// CHECK-NEXT:            scf.yield %[[IF_2]] : index
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[LOAD_16:.*]] = memref.load %[[ALLOC_19]]{{\[}}%[[VAL_21]]] : memref<3xindex>
+// CHECK-NEXT:            %[[CMPI_5:.*]] = arith.cmpi eq, %[[LOAD_16]], %[[CONSTANT_16]] : index
+// CHECK-NEXT:            %[[SELECT_1:.*]] = arith.select %[[CMPI_5]], %[[IF_2]], %[[LOAD_16]] : index
+// CHECK-NEXT:            scf.yield %[[SELECT_1]] : index
+// CHECK-NEXT:          }
+// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_20]]{{\[}}%[[VAL_21]]] : memref<?xindex>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[CAST_1:.*]] = memref.cast %[[ALLOC_20]] : memref<?xindex> to memref<3xindex>
+// CHECK-NEXT:        %[[LOAD_17:.*]] = memref.load %[[ALLOC_20]]{{\[}}%[[CONSTANT_17]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_18:.*]] = memref.load %[[ALLOC_20]]{{\[}}%[[CONSTANT_16]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_19:.*]] = memref.load %[[ALLOC_20]]{{\[}}%[[CONSTANT_15]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_21:.*]] = memref.alloc(%[[LOAD_17]], %[[LOAD_18]], %[[LOAD_19]]) {alignment = 64 : i64} : memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_22:.*]] = memref.alloc(%[[LOAD_17]], %[[LOAD_18]], %[[LOAD_19]]) {alignment = 64 : i64} : memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.expand(%[[VAL_16]]) ins(%[[VAL_19]], %[[VAL_20]] : memref<?x?x1xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) outs(%[[ALLOC_22]] : memref<?x?x?xi1, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_1]], %[[ALLOC_22]] : memref<3xindex>, memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_21]], %[[ALLOC_22]] : memref<?x?x?xi1, #hipsr.mem<device>>, memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> memref<?x?x?xi1, #hipsr.mem<device>>, memref<?x?x?xi1, #hipsr.mem<device>> {domain_id = 1 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_2:.*]]:4 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_1]]#0, %[[POOL_DOMAIN_0]]#6, %[[POOL_DOMAIN_1]]#1, %[[POOL_DOMAIN_0]]#7 : !hipsr.context, memref<?x?x?xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>, memref<?x?x?xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_24:.*]]: !hipsr.context, %[[VAL_25:.*]]: memref<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_26:.*]]: memref<3xi64, #hipsr.mem<host>>, %[[VAL_27:.*]]: memref<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_28:.*]]: memref<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:        %[[CONSTANT_18:.*]] = arith.constant 3 : index
+// CHECK-NEXT:        %[[CONSTANT_19:.*]] = arith.constant 2 : index
+// CHECK-NEXT:        %[[CONSTANT_20:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[CONSTANT_21:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[ALLOC_23:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_20]], %[[ALLOC_23]]{{\[}}%[[CONSTANT_21]]] : memref<1xindex>
+// CHECK-NEXT:        %[[DIM_11:.*]] = memref.dim %[[VAL_25]], %[[CONSTANT_21]] : memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_12:.*]] = memref.dim %[[VAL_25]], %[[CONSTANT_20]] : memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_13:.*]] = memref.dim %[[VAL_25]], %[[CONSTANT_19]] : memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_24:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_11]], %[[ALLOC_24]]{{\[}}%[[CONSTANT_21]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_12]], %[[ALLOC_24]]{{\[}}%[[CONSTANT_20]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_13]], %[[ALLOC_24]]{{\[}}%[[CONSTANT_19]]] : memref<3xindex>
+// CHECK-NEXT:        %[[LOAD_20:.*]] = memref.load %[[VAL_26]]{{\[}}%[[CONSTANT_21]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_5:.*]] = arith.index_cast %[[LOAD_20]] : i64 to index
+// CHECK-NEXT:        %[[LOAD_21:.*]] = memref.load %[[VAL_26]]{{\[}}%[[CONSTANT_20]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_6:.*]] = arith.index_cast %[[LOAD_21]] : i64 to index
+// CHECK-NEXT:        %[[LOAD_22:.*]] = memref.load %[[VAL_26]]{{\[}}%[[CONSTANT_19]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_7:.*]] = arith.index_cast %[[LOAD_22]] : i64 to index
+// CHECK-NEXT:        %[[ALLOC_25:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_5]], %[[ALLOC_25]]{{\[}}%[[CONSTANT_21]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_6]], %[[ALLOC_25]]{{\[}}%[[CONSTANT_20]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_7]], %[[ALLOC_25]]{{\[}}%[[CONSTANT_19]]] : memref<3xindex>
+// CHECK-NEXT:        %[[ALLOC_26:.*]] = memref.alloc(%[[CONSTANT_18]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        scf.for %[[VAL_29:.*]] = %[[CONSTANT_21]] to %[[CONSTANT_18]] step %[[CONSTANT_20]] {
+// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_29]], %[[CONSTANT_21]] : index
+// CHECK-NEXT:          %[[IF_4:.*]] = scf.if %[[CMPI_6]] -> (index) {
+// CHECK-NEXT:            scf.yield %[[CONSTANT_20]] : index
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[LOAD_23:.*]] = memref.load %[[ALLOC_24]]{{\[}}%[[VAL_29]]] : memref<3xindex>
+// CHECK-NEXT:            scf.yield %[[LOAD_23]] : index
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_29]], %[[CONSTANT_21]] : index
+// CHECK-NEXT:          %[[IF_5:.*]] = scf.if %[[CMPI_7]] -> (index) {
+// CHECK-NEXT:            scf.yield %[[IF_4]] : index
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[LOAD_24:.*]] = memref.load %[[ALLOC_25]]{{\[}}%[[VAL_29]]] : memref<3xindex>
+// CHECK-NEXT:            %[[CMPI_8:.*]] = arith.cmpi eq, %[[LOAD_24]], %[[CONSTANT_20]] : index
+// CHECK-NEXT:            %[[SELECT_2:.*]] = arith.select %[[CMPI_8]], %[[IF_4]], %[[LOAD_24]] : index
+// CHECK-NEXT:            scf.yield %[[SELECT_2]] : index
+// CHECK-NEXT:          }
+// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_26]]{{\[}}%[[VAL_29]]] : memref<?xindex>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[CAST_2:.*]] = memref.cast %[[ALLOC_26]] : memref<?xindex> to memref<3xindex>
+// CHECK-NEXT:        %[[FOR_1:.*]] = scf.for %[[VAL_30:.*]] = %[[CONSTANT_21]] to %[[CONSTANT_18]] step %[[CONSTANT_20]] iter_args(%[[VAL_31:.*]] = %[[CONSTANT_20]]) -> (index) {
+// CHECK-NEXT:          %[[LOAD_25:.*]] = memref.load %[[ALLOC_26]]{{\[}}%[[VAL_30]]] : memref<?xindex>
+// CHECK-NEXT:          %[[MULI_1:.*]] = arith.muli %[[LOAD_25]], %[[VAL_31]] : index
+// CHECK-NEXT:          scf.yield %[[MULI_1]] : index
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[ALLOC_27:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_18]], %[[ALLOC_27]]{{\[}}%[[CONSTANT_21]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[FOR_1]], %[[ALLOC_27]]{{\[}}%[[CONSTANT_20]]] : memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_26:.*]] = memref.load %[[ALLOC_26]]{{\[}}%[[CONSTANT_21]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_27:.*]] = memref.load %[[ALLOC_26]]{{\[}}%[[CONSTANT_20]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_28:.*]] = memref.load %[[ALLOC_26]]{{\[}}%[[CONSTANT_19]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_28:.*]] = memref.alloc(%[[LOAD_26]], %[[LOAD_27]], %[[LOAD_28]]) {alignment = 64 : i64} : memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[LOAD_29:.*]] = memref.load %[[ALLOC_27]]{{\[}}%[[CONSTANT_20]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_29:.*]] = memref.alloc(%[[LOAD_29]]) {alignment = 64 : i64} : memref<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_30:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_31:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.expand(%[[VAL_24]]) ins(%[[VAL_27]], %[[VAL_28]] : memref<?x?x?xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) outs(%[[ALLOC_28]] : memref<?x?x?xi1, #hipsr.mem<device>>)
+// CHECK-NEXT:        %[[ALLOC_32:.*]] = memref.alloc(%[[LOAD_29]]) {alignment = 64 : i64} : memref<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.nonzero(%[[VAL_24]]) ins(%[[ALLOC_28]] : memref<?x?x?xi1, #hipsr.mem<device>>) outs(%[[ALLOC_32]], %[[ALLOC_30]] : memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<device>>)
+// CHECK-NEXT:        %[[ALLOC_33:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.copy_d2h(%[[VAL_24]]) ins(%[[ALLOC_30]] : memref<1xi64, #hipsr.mem<device>>) outs(%[[ALLOC_33]] : memref<1xi64, #hipsr.mem<host>>)
+// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_2]], %[[ALLOC_28]] : memref<3xindex>, memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_27]], %[[ALLOC_32]] : memref<2xindex>, memref<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_23]], %[[ALLOC_30]] : memref<1xindex>, memref<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_23]], %[[ALLOC_33]] : memref<1xindex>, memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_29]], %[[ALLOC_32]], %[[ALLOC_31]], %[[ALLOC_33]] : memref<3x?xi64, #hipsr.mem<device>>, memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      } -> memref<3x?xi64, #hipsr.mem<device>>, memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<1xi64, #hipsr.mem<host>> {domain_id = 2 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_3:.*]]:4 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_2]]#2, %[[POOL_DOMAIN_2]]#0, %[[POOL_DOMAIN_2]]#3, %[[POOL_DOMAIN_2]]#1 : !hipsr.context, memref<1xi64, #hipsr.mem<host>>, memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<3x?xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_33:.*]]: !hipsr.context, %[[VAL_34:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_35:.*]]: memref<3x?xi64, #hipsr.mem<device>>, %[[VAL_36:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_37:.*]]: memref<3x?xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[CONSTANT_22:.*]] = arith.constant 3 : index
+// CHECK-NEXT:        %[[CONSTANT_23:.*]] = arith.constant 2 : index
+// CHECK-NEXT:        %[[CONSTANT_24:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[CONSTANT_25:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[ALLOC_34:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_25]], %[[ALLOC_34]]{{\[}}%[[CONSTANT_24]]] : memref<1xindex>
+// CHECK-NEXT:        %[[ALLOC_35:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_23]], %[[ALLOC_35]]{{\[}}%[[CONSTANT_24]]] : memref<1xindex>
+// CHECK-NEXT:        %[[ALLOC_36:.*]] = memref.alloc() {alignment = 64 : i64} : memref<0xindex>
+// CHECK-NEXT:        %[[LOAD_30:.*]] = memref.load %[[VAL_34]]{{\[}}%[[CONSTANT_24]]] : memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_8:.*]] = arith.index_cast %[[LOAD_30]] : i64 to index
+// CHECK-NEXT:        %[[ALLOC_37:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_22]], %[[ALLOC_37]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_8]], %[[ALLOC_37]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_31:.*]] = memref.load %[[ALLOC_37]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_32:.*]] = memref.load %[[ALLOC_37]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_38:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[LOAD_31]], %[[ALLOC_38]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[LOAD_32]], %[[ALLOC_38]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_33:.*]] = memref.load %[[ALLOC_37]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_39:.*]] = memref.alloc(%[[LOAD_33]]) {alignment = 64 : i64} : memref<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[LOAD_34:.*]] = memref.load %[[ALLOC_38]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_40:.*]] = memref.alloc(%[[LOAD_34]]) {alignment = 64 : i64} : memref<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_41:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[ALLOC_42:.*]] = memref.alloc() {alignment = 64 : i64} : memref<i64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[ALLOC_43:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[COMPUTE_3:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[VAL_36]], %[[VAL_37]] : memref<1xi64, #hipsr.mem<host>>, memref<3x?xi64, #hipsr.mem<device>>) outs(%[[ALLOC_39]] : memref<3x?xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_38:.*]]: !hipsr.context, %[[VAL_39:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_40:.*]]: memref<3x?xi64, #hipsr.mem<device>>, %[[VAL_41:.*]]: memref<3x?xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:          %[[CONSTANT_26:.*]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[DIM_14:.*]] = memref.dim %[[VAL_41]], %[[CONSTANT_26]] : memref<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[SUBVIEW_6:.*]] = memref.subview %[[VAL_40]][0, 0] [3, %[[DIM_14]]] [1, 1] : memref<3x?xi64, #hipsr.mem<device>> to memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
+// CHECK-NEXT:          hipsr.compute_yield %[[SUBVIEW_6]] : memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
+// CHECK-NEXT:        } : memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_44:.*]] = memref.alloc(%[[LOAD_34]]) {alignment = 64 : i64} : memref<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.transpose(%[[VAL_33]]) ins(%[[COMPUTE_3]] : memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>) outs(%[[ALLOC_44]] : memref<?x3xi64, #hipsr.mem<device>>) {perm = array<i64: 1, 0>}
+// CHECK-NEXT:        %[[COMPUTE_4:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[ALLOC_44]] : memref<?x3xi64, #hipsr.mem<device>>) outs(%[[ALLOC_41]] : memref<2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_42:.*]]: !hipsr.context, %[[VAL_43:.*]]: memref<?x3xi64, #hipsr.mem<device>>, %[[VAL_44:.*]]: memref<2xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:          %[[CONSTANT_27:.*]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[CONSTANT_28:.*]] = arith.constant 3 : i64
+// CHECK-NEXT:          %[[CONSTANT_29:.*]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[DIM_15:.*]] = memref.dim %[[VAL_43]], %[[CONSTANT_29]] : memref<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[INDEX_CAST_9:.*]] = arith.index_cast %[[DIM_15]] : index to i64
+// CHECK-NEXT:          %[[ALLOC_45:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[INDEX_CAST_9]], %[[ALLOC_45]]{{\[}}%[[CONSTANT_29]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[CONSTANT_28]], %[[ALLOC_45]]{{\[}}%[[CONSTANT_27]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          hipsr.compute_yield %[[ALLOC_45]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        } : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[COMPUTE_5:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[COMPUTE_4]] : memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_42]] : memref<i64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_45:.*]]: !hipsr.context, %[[VAL_46:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_47:.*]]: memref<i64, #hipsr.mem<host>>):
+// CHECK-NEXT:          %[[CONSTANT_30:.*]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[LOAD_35:.*]] = memref.load %[[VAL_46]]{{\[}}%[[CONSTANT_30]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          %[[ALLOC_46:.*]] = memref.alloc() {alignment = 64 : i64} : memref<i64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[LOAD_35]], %[[ALLOC_46]][] : memref<i64, #hipsr.mem<host>>
+// CHECK-NEXT:          hipsr.compute_yield %[[ALLOC_46]] : memref<i64, #hipsr.mem<host>>
+// CHECK-NEXT:        } : memref<i64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[COMPUTE_6:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[COMPUTE_5]] : memref<i64, #hipsr.mem<host>>) outs(%[[COMPUTE_5]] : memref<i64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_48:.*]]: !hipsr.context, %[[VAL_49:.*]]: memref<i64, #hipsr.mem<host>>, %[[VAL_50:.*]]: memref<i64, #hipsr.mem<host>>):
+// CHECK-NEXT:          %[[EXPAND_SHAPE_1:.*]] = memref.expand_shape %[[VAL_49]] [] output_shape [1] : memref<i64, #hipsr.mem<host>> into memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          hipsr.compute_yield %[[EXPAND_SHAPE_1]] : memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        } : memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_37]], %[[COMPUTE_3]] : memref<2xindex>, memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_38]], %[[ALLOC_44]] : memref<2xindex>, memref<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_35]], %[[COMPUTE_4]] : memref<1xindex>, memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_36]], %[[COMPUTE_5]] : memref<0xindex>, memref<i64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_34]], %[[COMPUTE_6]] : memref<1xindex>, memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_40]], %[[ALLOC_44]], %[[ALLOC_43]], %[[COMPUTE_6]] : memref<?x3xi64, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      } -> memref<?x3xi64, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<1xi64, #hipsr.mem<host>> {domain_id = 3 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_4:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#0, %[[POOL_DOMAIN_3]]#2, %[[POOL_DOMAIN_0]]#1, %[[POOL_DOMAIN_3]]#3, %[[POOL_DOMAIN_0]]#4, %[[POOL_DOMAIN_3]]#0, %[[POOL_DOMAIN_0]]#5, %[[POOL_DOMAIN_3]]#1 : !hipsr.context, memref<?xf16, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<?xf16, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_53:.*]]: !hipsr.context, %[[VAL_54:.*]]: memref<?xf16, #hipsr.mem<device>>, %[[VAL_55:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_56:.*]]: memref<?xf16, #hipsr.mem<device>>, %[[VAL_57:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_58:.*]]: memref<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_59:.*]]: memref<?x3xi64, #hipsr.mem<device>>, %[[VAL_60:.*]]: memref<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_61:.*]]: memref<?x3xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[CONSTANT_31:.*]] = arith.constant 2 : index
+// CHECK-NEXT:        %[[CONSTANT_32:.*]] = arith.constant 4096 : index
+// CHECK-NEXT:        %[[CONSTANT_33:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[CONSTANT_34:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[DIM_16:.*]] = memref.dim %[[VAL_54]], %[[CONSTANT_34]] : memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[LOAD_36:.*]] = memref.load %[[VAL_55]]{{\[}}%[[CONSTANT_34]]] : memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_10:.*]] = arith.index_cast %[[LOAD_36]] : i64 to index
+// CHECK-NEXT:        %[[CMPI_9:.*]] = arith.cmpi slt, %[[INDEX_CAST_10]], %[[CONSTANT_34]] : index
+// CHECK-NEXT:        %[[ADDI_0:.*]] = arith.addi %[[INDEX_CAST_10]], %[[DIM_16]] : index
+// CHECK-NEXT:        %[[SELECT_3:.*]] = arith.select %[[CMPI_9]], %[[ADDI_0]], %[[INDEX_CAST_10]] : index
+// CHECK-NEXT:        %[[MINSI_0:.*]] = arith.minsi %[[DIM_16]], %[[CONSTANT_34]] : index
+// CHECK-NEXT:        %[[MAXSI_0:.*]] = arith.maxsi %[[SELECT_3]], %[[CONSTANT_34]] : index
+// CHECK-NEXT:        %[[MINSI_1:.*]] = arith.minsi %[[MAXSI_0]], %[[DIM_16]] : index
+// CHECK-NEXT:        %[[SUBI_1:.*]] = arith.subi %[[MINSI_1]], %[[MINSI_0]] : index
+// CHECK-NEXT:        %[[MAXSI_1:.*]] = arith.maxsi %[[SUBI_1]], %[[CONSTANT_34]] : index
+// CHECK-NEXT:        %[[ALLOC_47:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
+// CHECK-NEXT:        memref.store %[[MAXSI_1]], %[[ALLOC_47]]{{\[}}%[[CONSTANT_34]]] : memref<1xindex>
+// CHECK-NEXT:        %[[DIM_17:.*]] = memref.dim %[[VAL_58]], %[[CONSTANT_34]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_18:.*]] = memref.dim %[[VAL_58]], %[[CONSTANT_33]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_48:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_17]], %[[ALLOC_48]]{{\[}}%[[CONSTANT_34]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_18]], %[[ALLOC_48]]{{\[}}%[[CONSTANT_33]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_32]], %[[ALLOC_48]]{{\[}}%[[CONSTANT_31]]] : memref<3xindex>
+// CHECK-NEXT:        %[[LOAD_37:.*]] = memref.load %[[ALLOC_47]]{{\[}}%[[CONSTANT_34]]] : memref<1xindex>
+// CHECK-NEXT:        %[[ALLOC_49:.*]] = memref.alloc(%[[LOAD_37]]) {alignment = 64 : i64} : memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_19:.*]] = memref.dim %[[VAL_58]], %[[CONSTANT_34]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_20:.*]] = memref.dim %[[VAL_58]], %[[CONSTANT_33]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_50:.*]] = memref.alloc(%[[DIM_19]], %[[DIM_20]]) {alignment = 64 : i64} : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.slice(%[[VAL_53]]) ins(%[[VAL_56]] : memref<?xf16, #hipsr.mem<device>>) ends(%[[VAL_57]] : memref<1xi64, #hipsr.mem<host>>) outs(%[[ALLOC_49]] : memref<?xf16, #hipsr.mem<device>>) {axes_attr = array<i64: 0>, starts_attr = array<i64: 0>, steps_attr = array<i64: 1>}
+// CHECK-NEXT:        hipsr.scatter_nd(%[[VAL_53]]) ins(%[[VAL_60]], %[[VAL_61]], %[[ALLOC_49]] : memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<?xf16, #hipsr.mem<device>>) outs(%[[ALLOC_50]] : memref<?x?x4096xf16, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_47]], %[[ALLOC_49]] : memref<1xindex>, memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_48]], %[[ALLOC_50]] : memref<3xindex>, memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_50]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> memref<?x?x4096xf16, #hipsr.mem<device>> {domain_id = 4 : i64}
+// CHECK-NEXT:      return %[[POOL_DOMAIN_4]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
 // CHECK-EMPTY:
-// CHECK-NEXT:         #-}
+// CHECK-NEXT:  {-#
+// CHECK-EMPTY:
+// CHECK-NEXT:  #-}
+
+module {
   func.func @main_graph(%arg0: tensor<?x?xi64> {onnx.name = "input_ids"}, %arg1: tensor<?x4096xf16> {onnx.name = "image_features"}) -> (tensor<?x?x4096xf16> {onnx.name = "inputs_embeds"}) attributes {onnx.graph.name = "main_graph"} {
     %0 = "onnx.NoValue"() {value} : () -> none
     %1 = "onnx.Constant"() {node.outputs = ["embed_tokens.weight"], location = "embedding.onnx.data", offset = 0 : i64, size = 2034237440 : i64} : () -> tensor<248320x4096xf16>

--- a/test/lit/Dialect/Hipsr/Pipelines/sample_dynamic.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/sample_dynamic.mlir
@@ -1,116 +1,175 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
-//
-//===----------------------------------------------------------------------===//
-// A sample for testing --hipsr-pipeline, with a dynamic leading extent.
-//===----------------------------------------------------------------------===//
+
+// The same graph as sample_static.mlir, but with a dynamic leading extent. It
+// enters the shape graph as a memref.dim, and every allocation reads its row
+// count back out of the shape buffer that sized it.
 
 // RUN: hip-mlir-opt %s --onnx-dialect=modeled --hipsr-pipeline | FileCheck %s
 
-// CHECK-LABEL: func.func @main_graph(
-// CHECK-SAME:      %[[CTX:.+]]: !hipsr.context,
-// CHECK-SAME:      %[[A:.+]]: tensor<?x3xf16, #hipsr.mem<device>> {onnx.name = "a"},
-// CHECK-SAME:      %[[B:.+]]: tensor<?x4xf32, #hipsr.mem<device>> {onnx.name = "b"})
-// CHECK-SAME:      -> (tensor<?x2xf32, #hipsr.mem<device>> {onnx.name = "y"})
-// CHECK-SAME:      attributes {onnx.graph.name = "main_graph"} {
-
-// The domains split exactly where they do in sample_static.mlir, and so do the
-// five zones inside each one: neither the barrier's position nor the shape
-// graph depends on whether the extents are known. sample_static.mlir carries
-// the commentary on the shape graph itself; what is worth reading here is where
-// an extent gets read back out of it, which is the only thing that differs.
-// CHECK-NEXT:    %[[D0:.+]]:5 = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]] : !hipsr.context, tensor<?x3xf16, #hipsr.mem<device>>, tensor<?x4xf32, #hipsr.mem<device>>) {
-// CHECK-NEXT:    ^bb0(%[[D0_CTX:.+]]: !hipsr.context, %[[D0_A:.+]]: tensor<?x3xf16, #hipsr.mem<device>>, %[[D0_B:.+]]: tensor<?x4xf32, #hipsr.mem<device>>):
-
-// CHECK-NEXT:      %[[EXTENTS_SHAPE:.+]] = shape.const_shape [2] : tensor<1xindex>
-// CHECK-NEXT:      %[[C0:.+]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[C1:.+]] = arith.constant 1 : index
-// CHECK-NEXT:      %[[W1:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<3x1xf16>} : tensor<3x1xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[W2:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<4x2xf32>} : tensor<4x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[A_SHAPE:.+]] = shape.shape_of %[[D0_A]] : tensor<?x3xf16, #hipsr.mem<device>> -> tensor<2xindex>
-// CHECK-NEXT:      %[[W1_SHAPE:.+]] = shape.shape_of %[[W1]] : tensor<3x1xf16, #hipsr.mem<device>> -> tensor<2xindex>
-// CHECK-NEXT:      %[[A_BATCH:.+]], %[[A_TAIL:.+]] = "shape.split_at"(%[[A_SHAPE]], %[[C0]]) : (tensor<2xindex>, index) -> (tensor<?xindex>, tensor<?xindex>)
-// CHECK-NEXT:      %[[W1_BATCH:.+]], %[[W1_TAIL:.+]] = "shape.split_at"(%[[W1_SHAPE]], %[[C0]]) : (tensor<2xindex>, index) -> (tensor<?xindex>, tensor<?xindex>)
-// CHECK-NEXT:      %[[BATCH:.+]] = shape.broadcast %[[A_BATCH]], %[[W1_BATCH]] : tensor<?xindex>, tensor<?xindex> -> tensor<?xindex>
-// CHECK-NEXT:      %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[C0]] : tensor<2xindex>, index -> index
-// CHECK-NEXT:      %[[N:.+]] = shape.get_extent %[[W1_SHAPE]], %[[C1]] : tensor<2xindex>, index -> index
-// CHECK-NEXT:      %[[MATRIX:.+]] = tensor.from_elements %[[M]], %[[N]] : tensor<2xindex>
-// CHECK-NEXT:      %[[MM1_SHAPE:.+]] = tensor.concat dim(0) %[[BATCH]], %[[MATRIX]] : (tensor<?xindex>, tensor<2xindex>) -> tensor<?xindex>
-
-// This is the difference from sample_static.mlir. The rows extent is not in the
-// type, so each allocation reads it back out of the shape that sized it, with
-// its own shape.get_extent. Both reads name the same shape, because the cast
-// forwards its operand's; CSE is left to run later rather than being built in
-// here. The host extent vector is still fully static, so it needs no read.
-// CHECK-NEXT:      %[[MM1_ROWS:.+]] = shape.get_extent %[[MM1_SHAPE]], %[[C0]] : tensor<?xindex>, index -> index
-// CHECK-NEXT:      %[[MM1_INIT:.+]] = tensor.empty(%[[MM1_ROWS]]) : tensor<?x1xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[CAST_ROWS:.+]] = shape.get_extent %[[MM1_SHAPE]], %[[C0]] : tensor<?xindex>, index -> index
-// CHECK-NEXT:      %[[CAST_INIT:.+]] = tensor.empty(%[[CAST_ROWS]]) : tensor<?x1xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[EXTENTS_INIT:.+]] = tensor.empty() : tensor<2xi64, #hipsr.mem<host>>
-
-// CHECK-NEXT:      %[[MM1:.+]] = hipsr.matmul(%[[D0_CTX]]) ins(%[[D0_A]], %[[W1]] : tensor<?x3xf16, #hipsr.mem<device>>, tensor<3x1xf16, #hipsr.mem<device>>) outs(%[[MM1_INIT]] : tensor<?x1xf16, #hipsr.mem<device>>) : tensor<?x1xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[CAST:.+]] = hipsr.cast(%[[D0_CTX]]) ins(%[[MM1]] : tensor<?x1xf16, #hipsr.mem<device>>) outs(%[[CAST_INIT]] : tensor<?x1xf32, #hipsr.mem<device>>) : tensor<?x1xf32, #hipsr.mem<device>>
-
-// The onnx.Shape lowering reads the dynamic extent off the data operand rather
-// than folding to a constant vector the way it does in sample_static.mlir.
-// CHECK-NEXT:      %[[EXTENTS:.+]] = hipsr.compute(%[[D0_CTX]]) ins(%[[D0_B]] : tensor<?x4xf32, #hipsr.mem<device>>) outs(%[[EXTENTS_INIT]] : tensor<2xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:      ^bb0(%{{.+}}: !hipsr.context, %[[C_B:.+]]: tensor<?x4xf32, #hipsr.mem<device>>, %{{.+}}: tensor<2xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:        %[[D1_EXT:.+]] = arith.constant 4 : i64
-// CHECK-NEXT:        %[[DIM_IDX:.+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[DIM:.+]] = tensor.dim %[[C_B]], %[[DIM_IDX]] : tensor<?x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[D0_EXT:.+]] = arith.index_cast %[[DIM]] : index to i64
-// CHECK-NEXT:        %[[EXTENT_VECTOR:.+]] = tensor.from_elements %[[D0_EXT]], %[[D1_EXT]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.compute_yield %[[EXTENT_VECTOR]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:      } : tensor<2xi64, #hipsr.mem<host>>
-
-// CHECK-NEXT:      hipsr.preserve_shape %[[MM1_SHAPE]], %[[MM1]] : tensor<?xindex>, tensor<?x1xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[MM1_SHAPE]], %[[CAST]] : tensor<?xindex>, tensor<?x1xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[EXTENTS_SHAPE]], %[[EXTENTS]] : tensor<1xindex>, tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:      hipsr.pool_domain_yield %[[CAST_INIT]], %[[CAST]], %[[EXTENTS_INIT]], %[[EXTENTS]], %[[W2]] : tensor<?x1xf32, #hipsr.mem<device>>, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:    } -> tensor<?x1xf32, #hipsr.mem<device>>, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
-
-// CHECK-NEXT:    %[[D1:.+]] = hipsr.pool_domain(%[[CTX]], %[[D0]]#0, %[[D0]]#2, %[[D0]]#1, %[[D0]]#3, %[[D0]]#4 : !hipsr.context, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>>) {
-// CHECK-NEXT:    ^bb0(%[[D1_CTX:.+]]: !hipsr.context, %[[D1_CAST_INIT:.+]]: tensor<?x1xf32, #hipsr.mem<device>>, %[[D1_EXTENTS_INIT:.+]]: tensor<2xi64, #hipsr.mem<host>>, %[[D1_CAST:.+]]: tensor<?x1xf32, #hipsr.mem<device>>, %[[D1_EXTENTS:.+]]: tensor<2xi64, #hipsr.mem<host>>, %[[D1_W2:.+]]: tensor<4x2xf32, #hipsr.mem<device>>):
-// CHECK-NEXT:      %[[D1_C0:.+]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[D1_C1:.+]] = arith.constant 1 : index
-// CHECK-NEXT:      %[[EXTRACT_I1:.+]] = arith.constant 1 : index
-// CHECK-NEXT:      %[[EXTRACT_I0:.+]] = arith.constant 0 : index
-
-// The barrier reads the host vector domain 0 wrote, which is where the dynamic
-// extent crosses back into the shape graph.
-// CHECK-NEXT:      %[[IN_SHAPE:.+]] = shape.shape_of %[[D1_CAST_INIT]] : tensor<?x1xf32, #hipsr.mem<device>> -> tensor<2xindex>
-// CHECK-NEXT:      %[[E0:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[EXTRACT_I0]]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:      %[[X0:.+]] = arith.index_cast %[[E0]] : i64 to index
-// CHECK-NEXT:      %[[E1:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[EXTRACT_I1]]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:      %[[X1:.+]] = arith.index_cast %[[E1]] : i64 to index
-// CHECK-NEXT:      %[[REQ:.+]] = tensor.from_elements %[[X0]], %[[X1]] : tensor<2xindex>
-// CHECK-NEXT:      %[[EXPAND_SHAPE:.+]] = shape.broadcast %[[IN_SHAPE]], %[[REQ]] : tensor<2xindex>, tensor<2xindex> -> tensor<2xindex>
-
-// CHECK-NEXT:      %[[W2_SHAPE:.+]] = shape.shape_of %[[D1_W2]] : tensor<4x2xf32, #hipsr.mem<device>> -> tensor<2xindex>
-// CHECK-NEXT:      %[[E_BATCH:.+]], %[[E_TAIL:.+]] = "shape.split_at"(%[[EXPAND_SHAPE]], %[[D1_C0]]) : (tensor<2xindex>, index) -> (tensor<?xindex>, tensor<?xindex>)
-// CHECK-NEXT:      %[[W2_BATCH:.+]], %[[W2_TAIL:.+]] = "shape.split_at"(%[[W2_SHAPE]], %[[D1_C0]]) : (tensor<2xindex>, index) -> (tensor<?xindex>, tensor<?xindex>)
-// CHECK-NEXT:      %[[BATCH2:.+]] = shape.broadcast %[[E_BATCH]], %[[W2_BATCH]] : tensor<?xindex>, tensor<?xindex> -> tensor<?xindex>
-// CHECK-NEXT:      %[[M2:.+]] = shape.get_extent %[[EXPAND_SHAPE]], %[[D1_C0]] : tensor<2xindex>, index -> index
-// CHECK-NEXT:      %[[N2:.+]] = shape.get_extent %[[W2_SHAPE]], %[[D1_C1]] : tensor<2xindex>, index -> index
-// CHECK-NEXT:      %[[MATRIX2:.+]] = tensor.from_elements %[[M2]], %[[N2]] : tensor<2xindex>
-// CHECK-NEXT:      %[[MM2_SHAPE:.+]] = tensor.concat dim(0) %[[BATCH2]], %[[MATRIX2]] : (tensor<?xindex>, tensor<2xindex>) -> tensor<?xindex>
-
-// Each allocation reads the shape that sized it, so the expand's rows come from
-// the broadcast and the matmul's from the concat.
-// CHECK-NEXT:      %[[EXPAND_ROWS:.+]] = shape.get_extent %[[EXPAND_SHAPE]], %[[D1_C0]] : tensor<2xindex>, index -> index
-// CHECK-NEXT:      %[[EXPAND_INIT:.+]] = tensor.empty(%[[EXPAND_ROWS]]) : tensor<?x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[MM2_ROWS:.+]] = shape.get_extent %[[MM2_SHAPE]], %[[D1_C0]] : tensor<?xindex>, index -> index
-// CHECK-NEXT:      %[[MM2_INIT:.+]] = tensor.empty(%[[MM2_ROWS]]) : tensor<?x2xf32, #hipsr.mem<device>>
-
-// CHECK-NEXT:      %[[EXPAND:.+]] = hipsr.expand(%[[D1_CTX]]) ins(%[[D1_CAST]], %[[D1_EXTENTS]] : tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) outs(%[[EXPAND_INIT]] : tensor<?x4xf32, #hipsr.mem<device>>) : tensor<?x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[MM2:.+]] = hipsr.matmul(%[[D1_CTX]]) ins(%[[EXPAND]], %[[D1_W2]] : tensor<?x4xf32, #hipsr.mem<device>>, tensor<4x2xf32, #hipsr.mem<device>>) outs(%[[MM2_INIT]] : tensor<?x2xf32, #hipsr.mem<device>>) : tensor<?x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[EXPAND_SHAPE]], %[[EXPAND]] : tensor<2xindex>, tensor<?x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[MM2_SHAPE]], %[[MM2]] : tensor<?xindex>, tensor<?x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.pool_domain_yield %[[MM2]] : tensor<?x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:    } -> tensor<?x2xf32, #hipsr.mem<device>> {domain_id = 1 : i64}
-
-// CHECK-NEXT:    return %[[D1]] : tensor<?x2xf32, #hipsr.mem<device>>
+// CHECK-LABEL:   func.func @main_graph(
+// CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[ARG1:.*]]: memref<?x3xf16, #hipsr.mem<device>> {onnx.name = "a"},
+// CHECK-SAME:      %[[ARG2:.*]]: memref<?x4xf32, #hipsr.mem<device>> {onnx.name = "b"}) -> (memref<?x2xf32, #hipsr.mem<device>> {onnx.name = "y"}) attributes {onnx.graph.name = "main_graph"} {
+// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]]:5 = hipsr.pool_domain(%[[ARG0]], %[[ARG1]], %[[ARG2]] : !hipsr.context, memref<?x3xf16, #hipsr.mem<device>>, memref<?x4xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: memref<?x3xf16, #hipsr.mem<device>>, %[[VAL_2:.*]]: memref<?x4xf32, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[CONSTANT_0:.*]] = arith.constant 3 : index
+// CHECK-NEXT:        %[[CONSTANT_1:.*]] = hipsr.constant {value = dense<{{\[\[}}1.000000e+00, 2.000000e+00], [3.000000e+00, 4.000000e+00], [5.000000e+00, 6.000000e+00], [7.000000e+00, 8.000000e+00]]> : tensor<4x2xf32>} : memref<4x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CONSTANT_2:.*]] = hipsr.constant {value = dense<{{\[\[}}1.000000e+00], [2.000000e+00], [3.000000e+00]]> : tensor<3x1xf16>} : memref<3x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CONSTANT_3:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[CONSTANT_4:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[CONSTANT_5:.*]] = arith.constant 2 : index
+// CHECK-NEXT:        %[[ALLOC_0:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_5]], %[[ALLOC_0]]{{\[}}%[[CONSTANT_4]]] : memref<1xindex>
+// CHECK-NEXT:        %[[DIM_0:.*]] = memref.dim %[[VAL_1]], %[[CONSTANT_4]] : memref<?x3xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_1:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[DIM_0]], %[[ALLOC_1]]{{\[}}%[[CONSTANT_4]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_0]], %[[ALLOC_1]]{{\[}}%[[CONSTANT_3]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_2:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_0]], %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_3]], %[[ALLOC_2]]{{\[}}%[[CONSTANT_3]]] : memref<2xindex>
+// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_1]]{{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[ALLOC_3:.*]] = memref.alloc(%[[CONSTANT_4]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        scf.for %[[VAL_3:.*]] = %[[CONSTANT_4]] to %[[CONSTANT_4]] step %[[CONSTANT_3]] {
+// CHECK-NEXT:          %[[CMPI_0:.*]] = arith.cmpi ult, %[[VAL_3]], %[[CONSTANT_4]] : index
+// CHECK-NEXT:          %[[IF_0:.*]] = scf.if %[[CMPI_0]] -> (index) {
+// CHECK-NEXT:            scf.yield %[[CONSTANT_3]] : index
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[LOAD_0:.*]] = memref.load %[[SUBVIEW_0]]{{\[}}%[[VAL_3]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            scf.yield %[[LOAD_0]] : index
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[CMPI_1:.*]] = arith.cmpi ult, %[[VAL_3]], %[[CONSTANT_4]] : index
+// CHECK-NEXT:          %[[IF_1:.*]] = scf.if %[[CMPI_1]] -> (index) {
+// CHECK-NEXT:            scf.yield %[[IF_0]] : index
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[LOAD_1:.*]] = memref.load %[[SUBVIEW_1]]{{\[}}%[[VAL_3]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            %[[CMPI_2:.*]] = arith.cmpi eq, %[[LOAD_1]], %[[CONSTANT_3]] : index
+// CHECK-NEXT:            %[[SELECT_0:.*]] = arith.select %[[CMPI_2]], %[[IF_0]], %[[LOAD_1]] : index
+// CHECK-NEXT:            scf.yield %[[SELECT_0]] : index
+// CHECK-NEXT:          }
+// CHECK-NEXT:          memref.store %[[IF_1]], %[[ALLOC_3]]{{\[}}%[[VAL_3]]] : memref<?xindex>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[DIM_1:.*]] = memref.dim %[[VAL_1]], %[[CONSTANT_4]] : memref<?x3xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_4:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[DIM_1]], %[[ALLOC_4]]{{\[}}%[[CONSTANT_4]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_3]], %[[ALLOC_4]]{{\[}}%[[CONSTANT_3]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_5:.*]] = memref.alloc(%[[CONSTANT_5]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_5]][0] {{\[}}%[[CONSTANT_4]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        memref.copy %[[ALLOC_3]], %[[SUBVIEW_2]] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_3:.*]] = memref.subview %[[ALLOC_5]]{{\[}}%[[CONSTANT_4]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        memref.copy %[[ALLOC_4]], %[[SUBVIEW_3]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        %[[LOAD_2:.*]] = memref.load %[[ALLOC_5]]{{\[}}%[[CONSTANT_4]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_6:.*]] = memref.alloc(%[[LOAD_2]]) {alignment = 64 : i64} : memref<?x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[LOAD_3:.*]] = memref.load %[[ALLOC_5]]{{\[}}%[[CONSTANT_4]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_7:.*]] = memref.alloc(%[[LOAD_3]]) {alignment = 64 : i64} : memref<?x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_8:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.matmul(%[[VAL_0]]) ins(%[[VAL_1]], %[[CONSTANT_2]] : memref<?x3xf16, #hipsr.mem<device>>, memref<3x1xf16, #hipsr.mem<device>>) outs(%[[ALLOC_6]] : memref<?x1xf16, #hipsr.mem<device>>)
+// CHECK-NEXT:        %[[ALLOC_9:.*]] = memref.alloc(%[[LOAD_3]]) {alignment = 64 : i64} : memref<?x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.cast(%[[VAL_0]]) ins(%[[ALLOC_6]] : memref<?x1xf16, #hipsr.mem<device>>) outs(%[[ALLOC_9]] : memref<?x1xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        %[[COMPUTE_0:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[VAL_2]] : memref<?x4xf32, #hipsr.mem<device>>) outs(%[[ALLOC_8]] : memref<2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_4:.*]]: !hipsr.context, %[[VAL_5:.*]]: memref<?x4xf32, #hipsr.mem<device>>, %[[VAL_6:.*]]: memref<2xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:          %[[CONSTANT_6:.*]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[CONSTANT_7:.*]] = arith.constant 4 : i64
+// CHECK-NEXT:          %[[CONSTANT_8:.*]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[DIM_2:.*]] = memref.dim %[[VAL_5]], %[[CONSTANT_8]] : memref<?x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[INDEX_CAST_0:.*]] = arith.index_cast %[[DIM_2]] : index to i64
+// CHECK-NEXT:          %[[ALLOC_10:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[INDEX_CAST_0]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_8]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[CONSTANT_7]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_6]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          hipsr.compute_yield %[[ALLOC_10]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        } : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_5]], %[[ALLOC_6]] : memref<?xindex>, memref<?x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_5]], %[[ALLOC_9]] : memref<?xindex>, memref<?x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_0]], %[[COMPUTE_0]] : memref<1xindex>, memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_7]], %[[ALLOC_9]], %[[ALLOC_8]], %[[COMPUTE_0]], %[[CONSTANT_1]] : memref<?x1xf32, #hipsr.mem<device>>, memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> memref<?x1xf32, #hipsr.mem<device>>, memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#0, %[[POOL_DOMAIN_0]]#2, %[[POOL_DOMAIN_0]]#1, %[[POOL_DOMAIN_0]]#3, %[[POOL_DOMAIN_0]]#4 : !hipsr.context, memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_8:.*]]: !hipsr.context, %[[VAL_9:.*]]: memref<?x1xf32, #hipsr.mem<device>>, %[[VAL_10:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_11:.*]]: memref<?x1xf32, #hipsr.mem<device>>, %[[VAL_12:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_13:.*]]: memref<4x2xf32, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[CONSTANT_9:.*]] = arith.constant 2 : index
+// CHECK-NEXT:        %[[CONSTANT_10:.*]] = arith.constant 4 : index
+// CHECK-NEXT:        %[[CONSTANT_11:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[CONSTANT_12:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[DIM_3:.*]] = memref.dim %[[VAL_9]], %[[CONSTANT_11]] : memref<?x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_11:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[DIM_3]], %[[ALLOC_11]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_12]], %[[ALLOC_11]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_4:.*]] = memref.load %[[VAL_10]]{{\[}}%[[CONSTANT_11]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_1:.*]] = arith.index_cast %[[LOAD_4]] : i64 to index
+// CHECK-NEXT:        %[[LOAD_5:.*]] = memref.load %[[VAL_10]]{{\[}}%[[CONSTANT_12]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_2:.*]] = arith.index_cast %[[LOAD_5]] : i64 to index
+// CHECK-NEXT:        %[[ALLOC_12:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_1]], %[[ALLOC_12]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_2]], %[[ALLOC_12]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_13:.*]] = memref.alloc(%[[CONSTANT_9]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        scf.for %[[VAL_14:.*]] = %[[CONSTANT_11]] to %[[CONSTANT_9]] step %[[CONSTANT_12]] {
+// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_14]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:          %[[IF_2:.*]] = scf.if %[[CMPI_3]] -> (index) {
+// CHECK-NEXT:            scf.yield %[[CONSTANT_12]] : index
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[LOAD_6:.*]] = memref.load %[[ALLOC_11]]{{\[}}%[[VAL_14]]] : memref<2xindex>
+// CHECK-NEXT:            scf.yield %[[LOAD_6]] : index
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_14]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:          %[[IF_3:.*]] = scf.if %[[CMPI_4]] -> (index) {
+// CHECK-NEXT:            scf.yield %[[IF_2]] : index
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[LOAD_7:.*]] = memref.load %[[ALLOC_12]]{{\[}}%[[VAL_14]]] : memref<2xindex>
+// CHECK-NEXT:            %[[CMPI_5:.*]] = arith.cmpi eq, %[[LOAD_7]], %[[CONSTANT_12]] : index
+// CHECK-NEXT:            %[[SELECT_1:.*]] = arith.select %[[CMPI_5]], %[[IF_2]], %[[LOAD_7]] : index
+// CHECK-NEXT:            scf.yield %[[SELECT_1]] : index
+// CHECK-NEXT:          }
+// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_13]]{{\[}}%[[VAL_14]]] : memref<?xindex>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[CAST_0:.*]] = memref.cast %[[ALLOC_13]] : memref<?xindex> to memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_14:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_10]], %[[ALLOC_14]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_14]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
+// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[CAST_0]]{{\[}}%[[CONSTANT_11]]] {{\[}}%[[CONSTANT_11]]] {{\[}}%[[CONSTANT_12]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_14]]{{\[}}%[[CONSTANT_11]]] {{\[}}%[[CONSTANT_11]]] {{\[}}%[[CONSTANT_12]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[ALLOC_15:.*]] = memref.alloc(%[[CONSTANT_11]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        scf.for %[[VAL_15:.*]] = %[[CONSTANT_11]] to %[[CONSTANT_11]] step %[[CONSTANT_12]] {
+// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_15]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:          %[[IF_4:.*]] = scf.if %[[CMPI_6]] -> (index) {
+// CHECK-NEXT:            scf.yield %[[CONSTANT_12]] : index
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[LOAD_8:.*]] = memref.load %[[SUBVIEW_4]]{{\[}}%[[VAL_15]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            scf.yield %[[LOAD_8]] : index
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_15]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:          %[[IF_5:.*]] = scf.if %[[CMPI_7]] -> (index) {
+// CHECK-NEXT:            scf.yield %[[IF_4]] : index
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[LOAD_9:.*]] = memref.load %[[SUBVIEW_5]]{{\[}}%[[VAL_15]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            %[[CMPI_8:.*]] = arith.cmpi eq, %[[LOAD_9]], %[[CONSTANT_12]] : index
+// CHECK-NEXT:            %[[SELECT_2:.*]] = arith.select %[[CMPI_8]], %[[IF_4]], %[[LOAD_9]] : index
+// CHECK-NEXT:            scf.yield %[[SELECT_2]] : index
+// CHECK-NEXT:          }
+// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_15]]{{\[}}%[[VAL_15]]] : memref<?xindex>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[LOAD_10:.*]] = memref.load %[[ALLOC_13]]{{\[}}%[[CONSTANT_11]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_16:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[LOAD_10]], %[[ALLOC_16]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_16]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_17:.*]] = memref.alloc(%[[CONSTANT_9]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        %[[SUBVIEW_6:.*]] = memref.subview %[[ALLOC_17]][0] {{\[}}%[[CONSTANT_11]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        memref.copy %[[ALLOC_15]], %[[SUBVIEW_6]] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_7:.*]] = memref.subview %[[ALLOC_17]]{{\[}}%[[CONSTANT_11]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        memref.copy %[[ALLOC_16]], %[[SUBVIEW_7]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        %[[LOAD_11:.*]] = memref.load %[[ALLOC_13]]{{\[}}%[[CONSTANT_11]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_18:.*]] = memref.alloc(%[[LOAD_11]]) {alignment = 64 : i64} : memref<?x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[LOAD_12:.*]] = memref.load %[[ALLOC_17]]{{\[}}%[[CONSTANT_11]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_19:.*]] = memref.alloc(%[[LOAD_12]]) {alignment = 64 : i64} : memref<?x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.expand(%[[VAL_8]]) ins(%[[VAL_11]], %[[VAL_12]] : memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_18]] : memref<?x4xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.matmul(%[[VAL_8]]) ins(%[[ALLOC_18]], %[[VAL_13]] : memref<?x4xf32, #hipsr.mem<device>>, memref<4x2xf32, #hipsr.mem<device>>) outs(%[[ALLOC_19]] : memref<?x2xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_0]], %[[ALLOC_18]] : memref<2xindex>, memref<?x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_17]], %[[ALLOC_19]] : memref<?xindex>, memref<?x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_19]] : memref<?x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> memref<?x2xf32, #hipsr.mem<device>> {domain_id = 1 : i64}
+// CHECK-NEXT:      return %[[POOL_DOMAIN_1]] : memref<?x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:    }
 // CHECK-NEXT:  }
+
 func.func @main_graph(%a: tensor<?x3xf16> {onnx.name = "a"},
                       %b: tensor<?x4xf32> {onnx.name = "b"})
     -> (tensor<?x2xf32> {onnx.name = "y"})

--- a/test/lit/Dialect/Hipsr/Pipelines/sample_static.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/sample_static.mlir
@@ -1,136 +1,162 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
-//
-//===----------------------------------------------------------------------===//
-// A sample for testing --hipsr-pipeline, with every extent static.
-//===----------------------------------------------------------------------===//
+
+// The hipsr pipeline on a graph where every extent is static. The shape graph
+// folds to constants, so no allocation has to read an extent back.
 
 // RUN: hip-mlir-opt %s --onnx-dialect=modeled --hipsr-pipeline | FileCheck %s
 
-// CHECK-LABEL: func.func @main_graph(
-// CHECK-SAME:      %[[CTX:.+]]: !hipsr.context,
-// CHECK-SAME:      %[[A:.+]]: tensor<2x3xf16, #hipsr.mem<device>> {onnx.name = "a"},
-// CHECK-SAME:      %[[B:.+]]: tensor<2x4xf32, #hipsr.mem<device>> {onnx.name = "b"})
-// CHECK-SAME:      -> (tensor<2x2xf32, #hipsr.mem<device>> {onnx.name = "y"})
-// CHECK-SAME:      attributes {onnx.graph.name = "main_graph"} {
+// CHECK:         memref.global "private" constant @__constant_2xi64 : memref<2xi64, #hipsr.mem<host>> = dense<[2, 4]> {alignment = 64 : i64}
 
-// The barrier the expand needs splits the graph in two. Everything up to it
-// lands in domain 0, which yields both halves of the shape and data graphs for
-// domain 1 to pick up. Inside a domain the constants come first, then the shape
-// computations, then the allocations they size, then the data ops, and last a
-// hipsr.preserve_shape tying each shape to the value filling the buffer it
-// sized.
-//
-// The shape computations are flat here, and carry extent tensors rather than
-// !shape.shape. -hipsr-convert-shape-to-extent inlined the scf.execute_region
-// and shape.assuming that -hipsr-materialize-init-tensors wraps them in, and
-// -remove-shape-constraints erased the shape.cstr_eq, shape.cstr_broadcastable,
-// and shape.assuming_all that produced the witness.
-// CHECK-NEXT:    %[[D0:.+]]:5 = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]] : !hipsr.context, tensor<2x3xf16, #hipsr.mem<device>>, tensor<2x4xf32, #hipsr.mem<device>>) {
-// CHECK-NEXT:    ^bb0(%[[D0_CTX:.+]]: !hipsr.context, %[[D0_A:.+]]: tensor<2x3xf16, #hipsr.mem<device>>, %[[D0_B:.+]]: tensor<2x4xf32, #hipsr.mem<device>>):
-
-// The extent vector's length follows the rank of the operand, not its extents,
-// so the operand's shape goes unread and the whole computation is the constant
-// 2. Constants lead the block ahead of even the weights, because the greedy
-// driver in -remove-shape-constraints hoists them there.
-// CHECK-NEXT:      %[[EXTENTS_SHAPE:.+]] = shape.const_shape [2] : tensor<1xindex>
-// CHECK-NEXT:      %[[C0:.+]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[C1:.+]] = arith.constant 1 : index
-
-// Both weights lead the operations. Only the first one has a shape a
-// computation reads; the second is here because a constant takes no operands,
-// so the pass brings every one of them over ahead of the computations.
-// CHECK-NEXT:      %[[W1:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<3x1xf16>} : tensor<3x1xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[W2:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<4x2xf32>} : tensor<4x2xf32, #hipsr.mem<device>>
-
-// The matmul shape: broadcast the batch dimensions, then append M from the lhs
-// and N from the rhs. shape.shape_of recovers a static rank from its operand,
-// which is what keeps the two shape.get_extent reads statically indexable.
-//
-// The split_at results stay tensor<?xindex> on purpose. --convert-shape-to-std
-// lowers split_at to a tensor.extract_slice whose size is computed, so it
-// produces tensor<?xindex> whatever result type it is asked for; claiming a
-// static rank here would leave the extract_slice unable to replace it. That
-// dynamic rank is then carried by the broadcast and the concat below.
-// CHECK-NEXT:      %[[A_SHAPE:.+]] = shape.shape_of %[[D0_A]] : tensor<2x3xf16, #hipsr.mem<device>> -> tensor<2xindex>
-// CHECK-NEXT:      %[[W1_SHAPE:.+]] = shape.shape_of %[[W1]] : tensor<3x1xf16, #hipsr.mem<device>> -> tensor<2xindex>
-// CHECK-NEXT:      %[[A_BATCH:.+]], %[[A_TAIL:.+]] = "shape.split_at"(%[[A_SHAPE]], %[[C0]]) : (tensor<2xindex>, index) -> (tensor<?xindex>, tensor<?xindex>)
-// CHECK-NEXT:      %[[W1_BATCH:.+]], %[[W1_TAIL:.+]] = "shape.split_at"(%[[W1_SHAPE]], %[[C0]]) : (tensor<2xindex>, index) -> (tensor<?xindex>, tensor<?xindex>)
-// CHECK-NEXT:      %[[BATCH:.+]] = shape.broadcast %[[A_BATCH]], %[[W1_BATCH]] : tensor<?xindex>, tensor<?xindex> -> tensor<?xindex>
-// CHECK-NEXT:      %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[C0]] : tensor<2xindex>, index -> index
-// CHECK-NEXT:      %[[N:.+]] = shape.get_extent %[[W1_SHAPE]], %[[C1]] : tensor<2xindex>, index -> index
-// CHECK-NEXT:      %[[MATRIX:.+]] = tensor.from_elements %[[M]], %[[N]] : tensor<2xindex>
-// CHECK-NEXT:      %[[MM1_SHAPE:.+]] = tensor.concat dim(0) %[[BATCH]], %[[MATRIX]] : (tensor<?xindex>, tensor<2xindex>) -> tensor<?xindex>
-
-// The cast keeps its operand's shape, so it has no computation of its own left:
-// inlining the forwarding scf.execute_region leaves the matmul's shape reaching
-// the cast's hipsr.preserve_shape directly.
-
-// Every extent is in the types, so no allocation reads a shape back.
-// CHECK-NEXT:      %[[MM1_INIT:.+]] = tensor.empty() : tensor<2x1xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[CAST_INIT:.+]] = tensor.empty() : tensor<2x1xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[EXTENTS_INIT:.+]] = tensor.empty() : tensor<2xi64, #hipsr.mem<host>>
-
-// CHECK-NEXT:      %[[MM1:.+]] = hipsr.matmul(%[[D0_CTX]]) ins(%[[D0_A]], %[[W1]] : tensor<2x3xf16, #hipsr.mem<device>>, tensor<3x1xf16, #hipsr.mem<device>>) outs(%[[MM1_INIT]] : tensor<2x1xf16, #hipsr.mem<device>>) : tensor<2x1xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[CAST:.+]] = hipsr.cast(%[[D0_CTX]]) ins(%[[MM1]] : tensor<2x1xf16, #hipsr.mem<device>>) outs(%[[CAST_INIT]] : tensor<2x1xf32, #hipsr.mem<device>>) : tensor<2x1xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[EXTENTS:.+]] = hipsr.compute(%[[D0_CTX]]) ins(%[[D0_B]] : tensor<2x4xf32, #hipsr.mem<device>>) outs(%[[EXTENTS_INIT]] : tensor<2xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:      ^bb0(%{{.+}}: !hipsr.context, %{{.+}}: tensor<2x4xf32, #hipsr.mem<device>>, %{{.+}}: tensor<2xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:        %[[EXTENT_VECTOR:.+]] = arith.constant dense<[2, 4]> : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.compute_yield %[[EXTENT_VECTOR]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:      } : tensor<2xi64, #hipsr.mem<host>>
-
-// CHECK-NEXT:      hipsr.preserve_shape %[[MM1_SHAPE]], %[[MM1]] : tensor<?xindex>, tensor<2x1xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[MM1_SHAPE]], %[[CAST]] : tensor<?xindex>, tensor<2x1xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[EXTENTS_SHAPE]], %[[EXTENTS]] : tensor<1xindex>, tensor<2xi64, #hipsr.mem<host>>
-
-// The second weight has no inputs, which keeps it in domain 0, and only the
-// yield uses it there.
-// CHECK-NEXT:      hipsr.pool_domain_yield %[[CAST_INIT]], %[[CAST]], %[[EXTENTS_INIT]], %[[EXTENTS]], %[[W2]] : tensor<2x1xf32, #hipsr.mem<device>>, tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:    } -> tensor<2x1xf32, #hipsr.mem<device>>, tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
-
-// Domain 1 takes the shape-graph results first and the data results after, so
-// the barrier keeps reading the buffers the shape graph names while the
-// operations keep following results.
-// CHECK-NEXT:    %[[D1:.+]] = hipsr.pool_domain(%[[CTX]], %[[D0]]#0, %[[D0]]#2, %[[D0]]#1, %[[D0]]#3, %[[D0]]#4 : !hipsr.context, tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>, tensor<4x2xf32, #hipsr.mem<device>>) {
-// CHECK-NEXT:    ^bb0(%[[D1_CTX:.+]]: !hipsr.context, %[[D1_CAST_INIT:.+]]: tensor<2x1xf32, #hipsr.mem<device>>, %[[D1_EXTENTS_INIT:.+]]: tensor<2xi64, #hipsr.mem<host>>, %[[D1_CAST:.+]]: tensor<2x1xf32, #hipsr.mem<device>>, %[[D1_EXTENTS:.+]]: tensor<2xi64, #hipsr.mem<host>>, %[[D1_W2:.+]]: tensor<4x2xf32, #hipsr.mem<device>>):
-// CHECK-NEXT:      %[[D1_C0:.+]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[D1_C1:.+]] = arith.constant 1 : index
-// CHECK-NEXT:      %[[EXTRACT_I1:.+]] = arith.constant 1 : index
-// CHECK-NEXT:      %[[EXTRACT_I0:.+]] = arith.constant 0 : index
-
-// The expand's destination is the reason for the cut: its extents come out of
-// the host vector domain 0 wrote, so the barrier's shape computation reads that
-// buffer instead of a shape. Both operands of the broadcast have a static rank,
-// so its result does too, which is why the expand's preserve_shape below takes
-// a tensor<2xindex> where the matmul's takes a tensor<?xindex>.
-// CHECK-NEXT:      %[[IN_SHAPE:.+]] = shape.shape_of %[[D1_CAST_INIT]] : tensor<2x1xf32, #hipsr.mem<device>> -> tensor<2xindex>
-// CHECK-NEXT:      %[[E0:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[EXTRACT_I0]]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:      %[[X0:.+]] = arith.index_cast %[[E0]] : i64 to index
-// CHECK-NEXT:      %[[E1:.+]] = tensor.extract %[[D1_EXTENTS_INIT]]{{\[}}%[[EXTRACT_I1]]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:      %[[X1:.+]] = arith.index_cast %[[E1]] : i64 to index
-// CHECK-NEXT:      %[[REQ:.+]] = tensor.from_elements %[[X0]], %[[X1]] : tensor<2xindex>
-// CHECK-NEXT:      %[[EXPAND_SHAPE:.+]] = shape.broadcast %[[IN_SHAPE]], %[[REQ]] : tensor<2xindex>, tensor<2xindex> -> tensor<2xindex>
-
-// CHECK-NEXT:      %[[W2_SHAPE:.+]] = shape.shape_of %[[D1_W2]] : tensor<4x2xf32, #hipsr.mem<device>> -> tensor<2xindex>
-// CHECK-NEXT:      %[[E_BATCH:.+]], %[[E_TAIL:.+]] = "shape.split_at"(%[[EXPAND_SHAPE]], %[[D1_C0]]) : (tensor<2xindex>, index) -> (tensor<?xindex>, tensor<?xindex>)
-// CHECK-NEXT:      %[[W2_BATCH:.+]], %[[W2_TAIL:.+]] = "shape.split_at"(%[[W2_SHAPE]], %[[D1_C0]]) : (tensor<2xindex>, index) -> (tensor<?xindex>, tensor<?xindex>)
-// CHECK-NEXT:      %[[BATCH2:.+]] = shape.broadcast %[[E_BATCH]], %[[W2_BATCH]] : tensor<?xindex>, tensor<?xindex> -> tensor<?xindex>
-// CHECK-NEXT:      %[[M2:.+]] = shape.get_extent %[[EXPAND_SHAPE]], %[[D1_C0]] : tensor<2xindex>, index -> index
-// CHECK-NEXT:      %[[N2:.+]] = shape.get_extent %[[W2_SHAPE]], %[[D1_C1]] : tensor<2xindex>, index -> index
-// CHECK-NEXT:      %[[MATRIX2:.+]] = tensor.from_elements %[[M2]], %[[N2]] : tensor<2xindex>
-// CHECK-NEXT:      %[[MM2_SHAPE:.+]] = tensor.concat dim(0) %[[BATCH2]], %[[MATRIX2]] : (tensor<?xindex>, tensor<2xindex>) -> tensor<?xindex>
-
-// CHECK-NEXT:      %[[EXPAND_INIT:.+]] = tensor.empty() : tensor<2x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[MM2_INIT:.+]] = tensor.empty() : tensor<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[EXPAND:.+]] = hipsr.expand(%[[D1_CTX]]) ins(%[[D1_CAST]], %[[D1_EXTENTS]] : tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) outs(%[[EXPAND_INIT]] : tensor<2x4xf32, #hipsr.mem<device>>) : tensor<2x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[MM2:.+]] = hipsr.matmul(%[[D1_CTX]]) ins(%[[EXPAND]], %[[D1_W2]] : tensor<2x4xf32, #hipsr.mem<device>>, tensor<4x2xf32, #hipsr.mem<device>>) outs(%[[MM2_INIT]] : tensor<2x2xf32, #hipsr.mem<device>>) : tensor<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[EXPAND_SHAPE]], %[[EXPAND]] : tensor<2xindex>, tensor<2x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[MM2_SHAPE]], %[[MM2]] : tensor<?xindex>, tensor<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.pool_domain_yield %[[MM2]] : tensor<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:    } -> tensor<2x2xf32, #hipsr.mem<device>> {domain_id = 1 : i64}
-
-// CHECK-NEXT:    return %[[D1]] : tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-LABEL:   func.func @main_graph(
+// CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[ARG1:.*]]: memref<2x3xf16, #hipsr.mem<device>> {onnx.name = "a"},
+// CHECK-SAME:      %[[ARG2:.*]]: memref<2x4xf32, #hipsr.mem<device>> {onnx.name = "b"}) -> (memref<2x2xf32, #hipsr.mem<device>> {onnx.name = "y"}) attributes {onnx.graph.name = "main_graph"} {
+// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]]:5 = hipsr.pool_domain(%[[ARG0]], %[[ARG1]], %[[ARG2]] : !hipsr.context, memref<2x3xf16, #hipsr.mem<device>>, memref<2x4xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: memref<2x3xf16, #hipsr.mem<device>>, %[[VAL_2:.*]]: memref<2x4xf32, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[CONSTANT_0:.*]] = arith.constant 3 : index
+// CHECK-NEXT:        %[[CONSTANT_1:.*]] = hipsr.constant {value = dense<{{\[\[}}1.000000e+00, 2.000000e+00], [3.000000e+00, 4.000000e+00], [5.000000e+00, 6.000000e+00], [7.000000e+00, 8.000000e+00]]> : tensor<4x2xf32>} : memref<4x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CONSTANT_2:.*]] = hipsr.constant {value = dense<{{\[\[}}1.000000e+00], [2.000000e+00], [3.000000e+00]]> : tensor<3x1xf16>} : memref<3x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CONSTANT_3:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[CONSTANT_4:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[CONSTANT_5:.*]] = arith.constant 2 : index
+// CHECK-NEXT:        %[[ALLOC_0:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_5]], %[[ALLOC_0]]{{\[}}%[[CONSTANT_4]]] : memref<1xindex>
+// CHECK-NEXT:        %[[ALLOC_1:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_5]], %[[ALLOC_1]]{{\[}}%[[CONSTANT_4]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_0]], %[[ALLOC_1]]{{\[}}%[[CONSTANT_3]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_2:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_0]], %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_3]], %[[ALLOC_2]]{{\[}}%[[CONSTANT_3]]] : memref<2xindex>
+// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_1]]{{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[ALLOC_3:.*]] = memref.alloc(%[[CONSTANT_4]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        scf.for %[[VAL_3:.*]] = %[[CONSTANT_4]] to %[[CONSTANT_4]] step %[[CONSTANT_3]] {
+// CHECK-NEXT:          %[[CMPI_0:.*]] = arith.cmpi ult, %[[VAL_3]], %[[CONSTANT_4]] : index
+// CHECK-NEXT:          %[[IF_0:.*]] = scf.if %[[CMPI_0]] -> (index) {
+// CHECK-NEXT:            scf.yield %[[CONSTANT_3]] : index
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[LOAD_0:.*]] = memref.load %[[SUBVIEW_0]]{{\[}}%[[VAL_3]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            scf.yield %[[LOAD_0]] : index
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[CMPI_1:.*]] = arith.cmpi ult, %[[VAL_3]], %[[CONSTANT_4]] : index
+// CHECK-NEXT:          %[[IF_1:.*]] = scf.if %[[CMPI_1]] -> (index) {
+// CHECK-NEXT:            scf.yield %[[IF_0]] : index
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[LOAD_1:.*]] = memref.load %[[SUBVIEW_1]]{{\[}}%[[VAL_3]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            %[[CMPI_2:.*]] = arith.cmpi eq, %[[LOAD_1]], %[[CONSTANT_3]] : index
+// CHECK-NEXT:            %[[SELECT_0:.*]] = arith.select %[[CMPI_2]], %[[IF_0]], %[[LOAD_1]] : index
+// CHECK-NEXT:            scf.yield %[[SELECT_0]] : index
+// CHECK-NEXT:          }
+// CHECK-NEXT:          memref.store %[[IF_1]], %[[ALLOC_3]]{{\[}}%[[VAL_3]]] : memref<?xindex>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[ALLOC_4:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_5]], %[[ALLOC_4]]{{\[}}%[[CONSTANT_4]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_3]], %[[ALLOC_4]]{{\[}}%[[CONSTANT_3]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_5:.*]] = memref.alloc(%[[CONSTANT_5]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_5]][0] {{\[}}%[[CONSTANT_4]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        memref.copy %[[ALLOC_3]], %[[SUBVIEW_2]] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_3:.*]] = memref.subview %[[ALLOC_5]]{{\[}}%[[CONSTANT_4]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        memref.copy %[[ALLOC_4]], %[[SUBVIEW_3]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        %[[ALLOC_6:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_7:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_8:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.matmul(%[[VAL_0]]) ins(%[[VAL_1]], %[[CONSTANT_2]] : memref<2x3xf16, #hipsr.mem<device>>, memref<3x1xf16, #hipsr.mem<device>>) outs(%[[ALLOC_6]] : memref<2x1xf16, #hipsr.mem<device>>)
+// CHECK-NEXT:        %[[ALLOC_9:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.cast(%[[VAL_0]]) ins(%[[ALLOC_6]] : memref<2x1xf16, #hipsr.mem<device>>) outs(%[[ALLOC_9]] : memref<2x1xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        %[[COMPUTE_0:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[VAL_2]] : memref<2x4xf32, #hipsr.mem<device>>) outs(%[[ALLOC_8]] : memref<2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_4:.*]]: !hipsr.context, %[[VAL_5:.*]]: memref<2x4xf32, #hipsr.mem<device>>, %[[VAL_6:.*]]: memref<2xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:          %[[GET_GLOBAL_0:.*]] = memref.get_global @__constant_2xi64 : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          hipsr.compute_yield %[[GET_GLOBAL_0]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        } : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_5]], %[[ALLOC_6]] : memref<?xindex>, memref<2x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_5]], %[[ALLOC_9]] : memref<?xindex>, memref<2x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_0]], %[[COMPUTE_0]] : memref<1xindex>, memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_7]], %[[ALLOC_9]], %[[ALLOC_8]], %[[COMPUTE_0]], %[[CONSTANT_1]] : memref<2x1xf32, #hipsr.mem<device>>, memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> memref<2x1xf32, #hipsr.mem<device>>, memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#0, %[[POOL_DOMAIN_0]]#2, %[[POOL_DOMAIN_0]]#1, %[[POOL_DOMAIN_0]]#3, %[[POOL_DOMAIN_0]]#4 : !hipsr.context, memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_8:.*]]: !hipsr.context, %[[VAL_9:.*]]: memref<2x1xf32, #hipsr.mem<device>>, %[[VAL_10:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_11:.*]]: memref<2x1xf32, #hipsr.mem<device>>, %[[VAL_12:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_13:.*]]: memref<4x2xf32, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[CONSTANT_6:.*]] = arith.constant 4 : index
+// CHECK-NEXT:        %[[CONSTANT_7:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[CONSTANT_8:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[CONSTANT_9:.*]] = arith.constant 2 : index
+// CHECK-NEXT:        %[[ALLOC_10:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_7]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_8]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_8]]] : memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_2:.*]] = memref.load %[[VAL_10]]{{\[}}%[[CONSTANT_7]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_0:.*]] = arith.index_cast %[[LOAD_2]] : i64 to index
+// CHECK-NEXT:        %[[LOAD_3:.*]] = memref.load %[[VAL_10]]{{\[}}%[[CONSTANT_8]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_1:.*]] = arith.index_cast %[[LOAD_3]] : i64 to index
+// CHECK-NEXT:        %[[ALLOC_11:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_0]], %[[ALLOC_11]]{{\[}}%[[CONSTANT_7]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_1]], %[[ALLOC_11]]{{\[}}%[[CONSTANT_8]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_12:.*]] = memref.alloc(%[[CONSTANT_9]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        scf.for %[[VAL_14:.*]] = %[[CONSTANT_7]] to %[[CONSTANT_9]] step %[[CONSTANT_8]] {
+// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_14]], %[[CONSTANT_7]] : index
+// CHECK-NEXT:          %[[IF_2:.*]] = scf.if %[[CMPI_3]] -> (index) {
+// CHECK-NEXT:            scf.yield %[[CONSTANT_8]] : index
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[LOAD_4:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[VAL_14]]] : memref<2xindex>
+// CHECK-NEXT:            scf.yield %[[LOAD_4]] : index
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_14]], %[[CONSTANT_7]] : index
+// CHECK-NEXT:          %[[IF_3:.*]] = scf.if %[[CMPI_4]] -> (index) {
+// CHECK-NEXT:            scf.yield %[[IF_2]] : index
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[LOAD_5:.*]] = memref.load %[[ALLOC_11]]{{\[}}%[[VAL_14]]] : memref<2xindex>
+// CHECK-NEXT:            %[[CMPI_5:.*]] = arith.cmpi eq, %[[LOAD_5]], %[[CONSTANT_8]] : index
+// CHECK-NEXT:            %[[SELECT_1:.*]] = arith.select %[[CMPI_5]], %[[IF_2]], %[[LOAD_5]] : index
+// CHECK-NEXT:            scf.yield %[[SELECT_1]] : index
+// CHECK-NEXT:          }
+// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_12]]{{\[}}%[[VAL_14]]] : memref<?xindex>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[CAST_0:.*]] = memref.cast %[[ALLOC_12]] : memref<?xindex> to memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_13:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_6]], %[[ALLOC_13]]{{\[}}%[[CONSTANT_7]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_13]]{{\[}}%[[CONSTANT_8]]] : memref<2xindex>
+// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[CAST_0]]{{\[}}%[[CONSTANT_7]]] {{\[}}%[[CONSTANT_7]]] {{\[}}%[[CONSTANT_8]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_13]]{{\[}}%[[CONSTANT_7]]] {{\[}}%[[CONSTANT_7]]] {{\[}}%[[CONSTANT_8]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[ALLOC_14:.*]] = memref.alloc(%[[CONSTANT_7]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        scf.for %[[VAL_15:.*]] = %[[CONSTANT_7]] to %[[CONSTANT_7]] step %[[CONSTANT_8]] {
+// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_15]], %[[CONSTANT_7]] : index
+// CHECK-NEXT:          %[[IF_4:.*]] = scf.if %[[CMPI_6]] -> (index) {
+// CHECK-NEXT:            scf.yield %[[CONSTANT_8]] : index
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[LOAD_6:.*]] = memref.load %[[SUBVIEW_4]]{{\[}}%[[VAL_15]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            scf.yield %[[LOAD_6]] : index
+// CHECK-NEXT:          }
+// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_15]], %[[CONSTANT_7]] : index
+// CHECK-NEXT:          %[[IF_5:.*]] = scf.if %[[CMPI_7]] -> (index) {
+// CHECK-NEXT:            scf.yield %[[IF_4]] : index
+// CHECK-NEXT:          } else {
+// CHECK-NEXT:            %[[LOAD_7:.*]] = memref.load %[[SUBVIEW_5]]{{\[}}%[[VAL_15]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            %[[CMPI_8:.*]] = arith.cmpi eq, %[[LOAD_7]], %[[CONSTANT_8]] : index
+// CHECK-NEXT:            %[[SELECT_2:.*]] = arith.select %[[CMPI_8]], %[[IF_4]], %[[LOAD_7]] : index
+// CHECK-NEXT:            scf.yield %[[SELECT_2]] : index
+// CHECK-NEXT:          }
+// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_14]]{{\[}}%[[VAL_15]]] : memref<?xindex>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[LOAD_8:.*]] = memref.load %[[ALLOC_12]]{{\[}}%[[CONSTANT_7]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_15:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[LOAD_8]], %[[ALLOC_15]]{{\[}}%[[CONSTANT_7]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_15]]{{\[}}%[[CONSTANT_8]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_16:.*]] = memref.alloc(%[[CONSTANT_9]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        %[[SUBVIEW_6:.*]] = memref.subview %[[ALLOC_16]][0] {{\[}}%[[CONSTANT_7]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        memref.copy %[[ALLOC_14]], %[[SUBVIEW_6]] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_7:.*]] = memref.subview %[[ALLOC_16]]{{\[}}%[[CONSTANT_7]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        memref.copy %[[ALLOC_15]], %[[SUBVIEW_7]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        %[[ALLOC_17:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_18:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.expand(%[[VAL_8]]) ins(%[[VAL_11]], %[[VAL_12]] : memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_17]] : memref<2x4xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.matmul(%[[VAL_8]]) ins(%[[ALLOC_17]], %[[VAL_13]] : memref<2x4xf32, #hipsr.mem<device>>, memref<4x2xf32, #hipsr.mem<device>>) outs(%[[ALLOC_18]] : memref<2x2xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_0]], %[[ALLOC_17]] : memref<2xindex>, memref<2x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_16]], %[[ALLOC_18]] : memref<?xindex>, memref<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_18]] : memref<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> memref<2x2xf32, #hipsr.mem<device>> {domain_id = 1 : i64}
+// CHECK-NEXT:      return %[[POOL_DOMAIN_1]] : memref<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:    }
 // CHECK-NEXT:  }
+
 func.func @main_graph(%a: tensor<2x3xf16> {onnx.name = "a"},
                       %b: tensor<2x4xf32> {onnx.name = "b"})
     -> (tensor<2x2xf32> {onnx.name = "y"})

--- a/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/add.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/add.mlir
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --split-input-file --one-shot-bufferize="bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map use-encoding-for-memory-space" %s | FileCheck %s
+
+// Both adds lose their result and write through the outs buffer instead, so
+// the return hands back those buffers. The static init allocates from its
+// type. The dynamic one gets its extent from a memref.dim of the operand.
+// CHECK-LABEL: func.func @add(
+// CHECK-SAME: %[[CTX:.+]]: !hipsr.context,
+// CHECK-SAME: %[[LHS:.+]]: memref<4x1024xf16, #hipsr.mem<device>>,
+// CHECK-SAME: %[[DYN:.+]]: memref<?x1024xf16, #hipsr.mem<device>>,
+// CHECK-SAME: %[[RHS:.+]]: memref<1024xf16, #hipsr.mem<device>>)
+// CHECK-SAME: -> (memref<4x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[OUT:.+]] = memref.alloc() {{.*}}: memref<4x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.add(%[[CTX]]) ins(%[[LHS]], %[[RHS]] : memref<4x1024xf16, #hipsr.mem<device>>, memref<1024xf16, #hipsr.mem<device>>)
+// CHECK-SAME: outs(%[[OUT]] : memref<4x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: %[[ROWS:.+]] = memref.dim %[[DYN]], %[[C0]] : memref<?x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[DYN_OUT:.+]] = memref.alloc(%[[ROWS]]) {{.*}}: memref<?x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.add(%[[CTX]]) ins(%[[DYN]], %[[RHS]] : memref<?x1024xf16, #hipsr.mem<device>>, memref<1024xf16, #hipsr.mem<device>>)
+// CHECK-SAME: outs(%[[DYN_OUT]] : memref<?x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: return %[[OUT]], %[[DYN_OUT]] : memref<4x1024xf16, #hipsr.mem<device>>, memref<?x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: }
+func.func @add(%ctx: !hipsr.context,
+               %lhs: tensor<4x1024xf16, #hipsr.mem<device>>,
+               %dyn: tensor<?x1024xf16, #hipsr.mem<device>>,
+               %rhs: tensor<1024xf16, #hipsr.mem<device>>)
+    -> (tensor<4x1024xf16, #hipsr.mem<device>>, tensor<?x1024xf16, #hipsr.mem<device>>) {
+  %c0 = arith.constant 0 : index
+  %init = tensor.empty() : tensor<4x1024xf16, #hipsr.mem<device>>
+  %0 = hipsr.add(%ctx) ins(%lhs, %rhs : tensor<4x1024xf16, #hipsr.mem<device>>, tensor<1024xf16, #hipsr.mem<device>>)
+      outs(%init : tensor<4x1024xf16, #hipsr.mem<device>>)
+      : tensor<4x1024xf16, #hipsr.mem<device>>
+  %rows = tensor.dim %dyn, %c0 : tensor<?x1024xf16, #hipsr.mem<device>>
+  %dyn_init = tensor.empty(%rows) : tensor<?x1024xf16, #hipsr.mem<device>>
+  %1 = hipsr.add(%ctx) ins(%dyn, %rhs : tensor<?x1024xf16, #hipsr.mem<device>>, tensor<1024xf16, #hipsr.mem<device>>)
+      outs(%dyn_init : tensor<?x1024xf16, #hipsr.mem<device>>)
+      : tensor<?x1024xf16, #hipsr.mem<device>>
+  return %0, %1 : tensor<4x1024xf16, #hipsr.mem<device>>, tensor<?x1024xf16, #hipsr.mem<device>>
+}

--- a/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/compute.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/compute.mlir
@@ -133,3 +133,95 @@ func.func @pool_domain_mlp_flatten(
   } -> tensor<?xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
   return %out : tensor<?xf16, #hipsr.mem<device>>
 }
+
+// -----
+// Two copies of one compute op that differ only in whether the body reads its
+// destination entry argument. Holding a result in an input's buffer also
+// retypes that argument, so bufferization only does it when the body never
+// touches the argument.
+//
+// The destination is a rank wider than the input here. Reusing the input buffer
+// for @compute_reads_destination would hand the body a memref<?x?xi1> where it
+// reads a tensor<?x?x1xi1>, so the destination keeps an allocation of its own.
+// CHECK-LABEL: func.func @compute_reads_destination(
+// CHECK-SAME: %[[CTX:.+]]: !hipsr.context, %[[ROWS:.+]]: index, %[[COLS:.+]]: index,
+// CHECK-SAME: %[[INPUT:.+]]: memref<?x?xi1, #hipsr.mem<device>>) -> memref<?x?x1xi1, #hipsr.mem<device>> {
+// CHECK-NEXT: %[[DEST:.+]] = memref.alloc(%[[ROWS]], %[[COLS]]){{.*}} : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT: %[[OUT:.+]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : memref<?x?xi1, #hipsr.mem<device>>)
+// CHECK-SAME: outs(%[[DEST]] : memref<?x?x1xi1, #hipsr.mem<device>>) {
+// CHECK-NEXT: ^bb0(%{{.+}}: !hipsr.context, %[[IN:.+]]: memref<?x?xi1, #hipsr.mem<device>>,
+// CHECK-SAME: %[[BODY_DEST:.+]]: memref<?x?x1xi1, #hipsr.mem<device>>):
+// CHECK-NEXT: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-NEXT: %[[D0:.+]] = memref.dim %[[BODY_DEST]], %[[C0]] : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT: %[[D1:.+]] = memref.dim %[[BODY_DEST]], %[[C1]] : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT: %[[EXPANDED:.+]] = memref.expand_shape %[[IN]] {{\[\[}}0], [1, 2]] output_shape {{\[}}%[[D0]], %[[D1]], 1]
+// CHECK-SAME: : memref<?x?xi1, #hipsr.mem<device>> into memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.compute_yield %[[EXPANDED]] : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT: } : memref<?x?x1xi1, #hipsr.mem<device>>{{$}}
+// CHECK-NEXT: return %[[OUT]] : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT: }
+func.func @compute_reads_destination(
+    %ctx: !hipsr.context, %rows: index, %cols: index,
+    %input: tensor<?x?xi1, #hipsr.mem<device>>)
+    -> tensor<?x?x1xi1, #hipsr.mem<device>> {
+  %init = tensor.empty(%rows, %cols) : tensor<?x?x1xi1, #hipsr.mem<device>>
+  %out = hipsr.compute(%ctx)
+      ins(%input : tensor<?x?xi1, #hipsr.mem<device>>)
+      outs(%init : tensor<?x?x1xi1, #hipsr.mem<device>>) {
+  ^bb0(%body_ctx: !hipsr.context, %in: tensor<?x?xi1, #hipsr.mem<device>>,
+       %dest: tensor<?x?x1xi1, #hipsr.mem<device>>):
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %d0 = tensor.dim %dest, %c0 : tensor<?x?x1xi1, #hipsr.mem<device>>
+    %d1 = tensor.dim %dest, %c1 : tensor<?x?x1xi1, #hipsr.mem<device>>
+    %expanded = tensor.expand_shape %in [[0], [1, 2]] output_shape [%d0, %d1, 1]
+        : tensor<?x?xi1, #hipsr.mem<device>>
+        into tensor<?x?x1xi1, #hipsr.mem<device>>
+    hipsr.compute_yield %expanded : tensor<?x?x1xi1, #hipsr.mem<device>>
+  } : tensor<?x?x1xi1, #hipsr.mem<device>>
+  return %out : tensor<?x?x1xi1, #hipsr.mem<device>>
+}
+
+// The dimensions come off the input here, which leaves the destination argument
+// unused, so the result lands in the input's buffer and tensor.empty allocates
+// nothing. The destination argument comes back a rank lower with it, which is
+// what the body above could not have tolerated.
+// CHECK-LABEL: func.func @compute_ignores_destination(
+// CHECK-SAME: %[[CTX:.+]]: !hipsr.context, %{{.+}}: index, %{{.+}}: index,
+// CHECK-SAME: %[[INPUT:.+]]: memref<?x?xi1, #hipsr.mem<device>>) -> memref<?x?x1xi1, #hipsr.mem<device>> {
+// CHECK-NEXT: %[[OUT:.+]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : memref<?x?xi1, #hipsr.mem<device>>)
+// CHECK-SAME: outs(%[[INPUT]] : memref<?x?xi1, #hipsr.mem<device>>) {
+// CHECK-NEXT: ^bb0(%{{.+}}: !hipsr.context, %[[IN:.+]]: memref<?x?xi1, #hipsr.mem<device>>,
+// CHECK-SAME: %{{.+}}: memref<?x?xi1, #hipsr.mem<device>>):
+// CHECK-NEXT: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-NEXT: %[[D0:.+]] = memref.dim %[[IN]], %[[C0]] : memref<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT: %[[D1:.+]] = memref.dim %[[IN]], %[[C1]] : memref<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT: %[[EXPANDED:.+]] = memref.expand_shape %[[IN]] {{\[\[}}0], [1, 2]] output_shape {{\[}}%[[D0]], %[[D1]], 1]
+// CHECK-SAME: : memref<?x?xi1, #hipsr.mem<device>> into memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.compute_yield %[[EXPANDED]] : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT: } : memref<?x?x1xi1, #hipsr.mem<device>>{{$}}
+// CHECK-NEXT: return %[[OUT]] : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT: }
+func.func @compute_ignores_destination(
+    %ctx: !hipsr.context, %rows: index, %cols: index,
+    %input: tensor<?x?xi1, #hipsr.mem<device>>)
+    -> tensor<?x?x1xi1, #hipsr.mem<device>> {
+  %init = tensor.empty(%rows, %cols) : tensor<?x?x1xi1, #hipsr.mem<device>>
+  %out = hipsr.compute(%ctx)
+      ins(%input : tensor<?x?xi1, #hipsr.mem<device>>)
+      outs(%init : tensor<?x?x1xi1, #hipsr.mem<device>>) {
+  ^bb0(%body_ctx: !hipsr.context, %in: tensor<?x?xi1, #hipsr.mem<device>>,
+       %dest: tensor<?x?x1xi1, #hipsr.mem<device>>):
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %d0 = tensor.dim %in, %c0 : tensor<?x?xi1, #hipsr.mem<device>>
+    %d1 = tensor.dim %in, %c1 : tensor<?x?xi1, #hipsr.mem<device>>
+    %expanded = tensor.expand_shape %in [[0], [1, 2]] output_shape [%d0, %d1, 1]
+        : tensor<?x?xi1, #hipsr.mem<device>>
+        into tensor<?x?x1xi1, #hipsr.mem<device>>
+    hipsr.compute_yield %expanded : tensor<?x?x1xi1, #hipsr.mem<device>>
+  } : tensor<?x?x1xi1, #hipsr.mem<device>>
+  return %out : tensor<?x?x1xi1, #hipsr.mem<device>>
+}

--- a/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/compute.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/compute.mlir
@@ -135,33 +135,30 @@ func.func @pool_domain_mlp_flatten(
 }
 
 // -----
-// Two copies of one compute op that differ only in whether the body reads its
-// destination entry argument. Holding a result in an input's buffer also
-// retypes that argument, so bufferization only does it when the body never
-// touches the argument.
-//
-// The destination is a rank wider than the input here. Reusing the input buffer
-// for @compute_reads_destination would hand the body a memref<?x?xi1> where it
-// reads a tensor<?x?x1xi1>, so the destination keeps an allocation of its own.
-// CHECK-LABEL: func.func @compute_reads_destination(
+// A compute body that reads its init entry argument. Holding a result in an
+// input's buffer also retypes that argument, so bufferization only does it when
+// the body never touches the argument. The init is a rank wider than the input
+// here, so the reuse would leave the body reading a memref<?x?xi1> as a
+// memref<?x?x1xi1>. The init keeps an allocation of its own instead.
+// CHECK-LABEL: func.func @compute_reads_init(
 // CHECK-SAME: %[[CTX:.+]]: !hipsr.context, %[[ROWS:.+]]: index, %[[COLS:.+]]: index,
 // CHECK-SAME: %[[INPUT:.+]]: memref<?x?xi1, #hipsr.mem<device>>) -> memref<?x?x1xi1, #hipsr.mem<device>> {
-// CHECK-NEXT: %[[DEST:.+]] = memref.alloc(%[[ROWS]], %[[COLS]]){{.*}} : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT: %[[INIT:.+]] = memref.alloc(%[[ROWS]], %[[COLS]]){{.*}} : memref<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT: %[[OUT:.+]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : memref<?x?xi1, #hipsr.mem<device>>)
-// CHECK-SAME: outs(%[[DEST]] : memref<?x?x1xi1, #hipsr.mem<device>>) {
+// CHECK-SAME: outs(%[[INIT]] : memref<?x?x1xi1, #hipsr.mem<device>>) {
 // CHECK-NEXT: ^bb0(%{{.+}}: !hipsr.context, %[[IN:.+]]: memref<?x?xi1, #hipsr.mem<device>>,
-// CHECK-SAME: %[[BODY_DEST:.+]]: memref<?x?x1xi1, #hipsr.mem<device>>):
+// CHECK-SAME: %[[BODY_INIT:.+]]: memref<?x?x1xi1, #hipsr.mem<device>>):
 // CHECK-NEXT: %[[C0:.+]] = arith.constant 0 : index
 // CHECK-NEXT: %[[C1:.+]] = arith.constant 1 : index
-// CHECK-NEXT: %[[D0:.+]] = memref.dim %[[BODY_DEST]], %[[C0]] : memref<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT: %[[D1:.+]] = memref.dim %[[BODY_DEST]], %[[C1]] : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT: %[[D0:.+]] = memref.dim %[[BODY_INIT]], %[[C0]] : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT: %[[D1:.+]] = memref.dim %[[BODY_INIT]], %[[C1]] : memref<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT: %[[EXPANDED:.+]] = memref.expand_shape %[[IN]] {{\[\[}}0], [1, 2]] output_shape {{\[}}%[[D0]], %[[D1]], 1]
 // CHECK-SAME: : memref<?x?xi1, #hipsr.mem<device>> into memref<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT: hipsr.compute_yield %[[EXPANDED]] : memref<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT: } : memref<?x?x1xi1, #hipsr.mem<device>>{{$}}
 // CHECK-NEXT: return %[[OUT]] : memref<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT: }
-func.func @compute_reads_destination(
+func.func @compute_reads_init(
     %ctx: !hipsr.context, %rows: index, %cols: index,
     %input: tensor<?x?xi1, #hipsr.mem<device>>)
     -> tensor<?x?x1xi1, #hipsr.mem<device>> {
@@ -170,54 +167,11 @@ func.func @compute_reads_destination(
       ins(%input : tensor<?x?xi1, #hipsr.mem<device>>)
       outs(%init : tensor<?x?x1xi1, #hipsr.mem<device>>) {
   ^bb0(%body_ctx: !hipsr.context, %in: tensor<?x?xi1, #hipsr.mem<device>>,
-       %dest: tensor<?x?x1xi1, #hipsr.mem<device>>):
+       %init_arg: tensor<?x?x1xi1, #hipsr.mem<device>>):
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
-    %d0 = tensor.dim %dest, %c0 : tensor<?x?x1xi1, #hipsr.mem<device>>
-    %d1 = tensor.dim %dest, %c1 : tensor<?x?x1xi1, #hipsr.mem<device>>
-    %expanded = tensor.expand_shape %in [[0], [1, 2]] output_shape [%d0, %d1, 1]
-        : tensor<?x?xi1, #hipsr.mem<device>>
-        into tensor<?x?x1xi1, #hipsr.mem<device>>
-    hipsr.compute_yield %expanded : tensor<?x?x1xi1, #hipsr.mem<device>>
-  } : tensor<?x?x1xi1, #hipsr.mem<device>>
-  return %out : tensor<?x?x1xi1, #hipsr.mem<device>>
-}
-
-// The dimensions come off the input here, which leaves the destination argument
-// unused, so the result lands in the input's buffer and tensor.empty allocates
-// nothing. The destination argument comes back a rank lower with it, which is
-// what the body above could not have tolerated.
-// CHECK-LABEL: func.func @compute_ignores_destination(
-// CHECK-SAME: %[[CTX:.+]]: !hipsr.context, %{{.+}}: index, %{{.+}}: index,
-// CHECK-SAME: %[[INPUT:.+]]: memref<?x?xi1, #hipsr.mem<device>>) -> memref<?x?x1xi1, #hipsr.mem<device>> {
-// CHECK-NEXT: %[[OUT:.+]] = hipsr.compute(%[[CTX]]) ins(%[[INPUT]] : memref<?x?xi1, #hipsr.mem<device>>)
-// CHECK-SAME: outs(%[[INPUT]] : memref<?x?xi1, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%{{.+}}: !hipsr.context, %[[IN:.+]]: memref<?x?xi1, #hipsr.mem<device>>,
-// CHECK-SAME: %{{.+}}: memref<?x?xi1, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[C0:.+]] = arith.constant 0 : index
-// CHECK-NEXT: %[[C1:.+]] = arith.constant 1 : index
-// CHECK-NEXT: %[[D0:.+]] = memref.dim %[[IN]], %[[C0]] : memref<?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT: %[[D1:.+]] = memref.dim %[[IN]], %[[C1]] : memref<?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT: %[[EXPANDED:.+]] = memref.expand_shape %[[IN]] {{\[\[}}0], [1, 2]] output_shape {{\[}}%[[D0]], %[[D1]], 1]
-// CHECK-SAME: : memref<?x?xi1, #hipsr.mem<device>> into memref<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.compute_yield %[[EXPANDED]] : memref<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT: } : memref<?x?x1xi1, #hipsr.mem<device>>{{$}}
-// CHECK-NEXT: return %[[OUT]] : memref<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT: }
-func.func @compute_ignores_destination(
-    %ctx: !hipsr.context, %rows: index, %cols: index,
-    %input: tensor<?x?xi1, #hipsr.mem<device>>)
-    -> tensor<?x?x1xi1, #hipsr.mem<device>> {
-  %init = tensor.empty(%rows, %cols) : tensor<?x?x1xi1, #hipsr.mem<device>>
-  %out = hipsr.compute(%ctx)
-      ins(%input : tensor<?x?xi1, #hipsr.mem<device>>)
-      outs(%init : tensor<?x?x1xi1, #hipsr.mem<device>>) {
-  ^bb0(%body_ctx: !hipsr.context, %in: tensor<?x?xi1, #hipsr.mem<device>>,
-       %dest: tensor<?x?x1xi1, #hipsr.mem<device>>):
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %d0 = tensor.dim %in, %c0 : tensor<?x?xi1, #hipsr.mem<device>>
-    %d1 = tensor.dim %in, %c1 : tensor<?x?xi1, #hipsr.mem<device>>
+    %d0 = tensor.dim %init_arg, %c0 : tensor<?x?x1xi1, #hipsr.mem<device>>
+    %d1 = tensor.dim %init_arg, %c1 : tensor<?x?x1xi1, #hipsr.mem<device>>
     %expanded = tensor.expand_shape %in [[0], [1, 2]] output_shape [%d0, %d1, 1]
         : tensor<?x?xi1, #hipsr.mem<device>>
         into tensor<?x?x1xi1, #hipsr.mem<device>>

--- a/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/constant.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/constant.mlir
@@ -1,0 +1,68 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+//===----------------------------------------------------------------------===//
+// hipsr.constant bufferizes like arith.constant: the result is an
+// identity-layout memref that nobody may write, and the blob attributes stay.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --split-input-file --one-shot-bufferize="bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map use-encoding-for-memory-space" %s | FileCheck %s
+
+// The #hipsr.mem<device> encoding becomes the memref memory space, and the
+// layout is the static identity instead of the fully dynamic default. index,
+// offset, and size describe the blob, not the type, so they stay unchanged.
+// CHECK-LABEL: func.func @constant_result(
+// CHECK-SAME: %{{.+}}: !hipsr.context)
+// CHECK-SAME: -> (memref<3x1xf16, #hipsr.mem<device>>, memref<4x2xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT: %[[INLINE:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<3x1xf16>} : memref<3x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[EXTERNALIZED:.+]] = hipsr.constant {index = 3 : i64, offset = 128 : i64, size = 32 : i64, value = dense<{{.*}}> : tensor<4x2xf32>} : memref<4x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT: return %[[INLINE]], %[[EXTERNALIZED]] : memref<3x1xf16, #hipsr.mem<device>>, memref<4x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT: }
+func.func @constant_result(%ctx: !hipsr.context)
+    -> (tensor<3x1xf16, #hipsr.mem<device>>, tensor<4x2xf32, #hipsr.mem<device>>) {
+  %inline = hipsr.constant {value = dense<[[1.0], [2.0], [3.0]]> : tensor<3x1xf16>}
+      : tensor<3x1xf16, #hipsr.mem<device>>
+  %externalized = hipsr.constant {value = dense<[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]]> : tensor<4x2xf32>,
+                                  index = 3 : i64, offset = 128 : i64, size = 32 : i64}
+      : tensor<4x2xf32, #hipsr.mem<device>>
+  return %inline, %externalized : tensor<3x1xf16, #hipsr.mem<device>>, tensor<4x2xf32, #hipsr.mem<device>>
+}
+
+// -----
+
+// The two ways a DPS op can take a constant. The matmul only reads it, so it
+// uses the blob buffer directly. The cast writes its destination, and
+// isWritable returns false, so the analysis copies the constant first.
+// CHECK-LABEL: func.func @constant_as_operand(
+// CHECK-SAME: %[[CTX:.+]]: !hipsr.context,
+// CHECK-SAME: %[[A:.+]]: memref<2x3xf16, #hipsr.mem<device>>,
+// CHECK-SAME: %[[IN:.+]]: memref<4x2xf32, #hipsr.mem<device>>)
+// CHECK-SAME: -> (memref<2x1xf16, #hipsr.mem<device>>, memref<4x2xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT: %[[W:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<3x1xf16>} : memref<3x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[OUT:.+]] = memref.alloc() {{.*}}: memref<2x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.matmul(%[[CTX]]) ins(%[[A]], %[[W]] : memref<2x3xf16, #hipsr.mem<device>>, memref<3x1xf16, #hipsr.mem<device>>)
+// CHECK-SAME: outs(%[[OUT]] : memref<2x1xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: %[[BLOB:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<4x2xf32>} : memref<4x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT: %[[COPY:.+]] = memref.alloc() {{.*}}: memref<4x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT: memref.copy %[[BLOB]], %[[COPY]] : memref<4x2xf32, #hipsr.mem<device>> to memref<4x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.cast(%[[CTX]]) ins(%[[IN]] : memref<4x2xf32, #hipsr.mem<device>>)
+// CHECK-SAME: outs(%[[COPY]] : memref<4x2xf32, #hipsr.mem<device>>)
+// CHECK-NEXT: return %[[OUT]], %[[COPY]] : memref<2x1xf16, #hipsr.mem<device>>, memref<4x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT: }
+func.func @constant_as_operand(%ctx: !hipsr.context,
+                               %a: tensor<2x3xf16, #hipsr.mem<device>>,
+                               %in: tensor<4x2xf32, #hipsr.mem<device>>)
+    -> (tensor<2x1xf16, #hipsr.mem<device>>, tensor<4x2xf32, #hipsr.mem<device>>) {
+  %w = hipsr.constant {value = dense<[[1.0], [2.0], [3.0]]> : tensor<3x1xf16>}
+      : tensor<3x1xf16, #hipsr.mem<device>>
+  %init = tensor.empty() : tensor<2x1xf16, #hipsr.mem<device>>
+  %0 = hipsr.matmul(%ctx) ins(%a, %w : tensor<2x3xf16, #hipsr.mem<device>>, tensor<3x1xf16, #hipsr.mem<device>>)
+      outs(%init : tensor<2x1xf16, #hipsr.mem<device>>)
+      : tensor<2x1xf16, #hipsr.mem<device>>
+  %blob = hipsr.constant {value = dense<[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]]> : tensor<4x2xf32>}
+      : tensor<4x2xf32, #hipsr.mem<device>>
+  %1 = hipsr.cast(%ctx) ins(%in : tensor<4x2xf32, #hipsr.mem<device>>)
+      outs(%blob : tensor<4x2xf32, #hipsr.mem<device>>)
+      : tensor<4x2xf32, #hipsr.mem<device>>
+  return %0, %1 : tensor<2x1xf16, #hipsr.mem<device>>, tensor<4x2xf32, #hipsr.mem<device>>
+}

--- a/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/expand.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/expand.mlir
@@ -1,0 +1,57 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+//===----------------------------------------------------------------------===//
+// hipsr.expand keeps its data on the device and its extents on the host. Each
+// operand keeps the memory space from its own encoding, so the two bufferize
+// into different spaces.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --split-input-file --one-shot-bufferize="bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map use-encoding-for-memory-space" %s | FileCheck %s
+
+// The first expand takes its shape from a host argument. The second builds a
+// shape, which lands in a host allocation, while the data allocation next to
+// it stays on the device.
+// CHECK-LABEL: func.func @expand(
+// CHECK-SAME: %[[CTX:.+]]: !hipsr.context,
+// CHECK-SAME: %[[INPUT:.+]]: memref<2x1xf32, #hipsr.mem<device>>,
+// CHECK-SAME: %[[SHAPE:.+]]: memref<2xi64, #hipsr.mem<host>>,
+// CHECK-SAME: %[[DYN:.+]]: memref<?x1xf32, #hipsr.mem<device>>)
+// CHECK-SAME: -> (memref<2x4xf32, #hipsr.mem<device>>, memref<?x4xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[C4:.+]] = arith.constant 4 : i64
+// CHECK-NEXT: %[[OUT:.+]] = memref.alloc() {{.*}}: memref<2x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.expand(%[[CTX]]) ins(%[[INPUT]], %[[SHAPE]] : memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>)
+// CHECK-SAME: outs(%[[OUT]] : memref<2x4xf32, #hipsr.mem<device>>)
+// CHECK-NEXT: %[[ROWS:.+]] = memref.dim %[[DYN]], %[[C0]] : memref<?x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT: %[[ROWS_I64:.+]] = arith.index_cast %[[ROWS]] : index to i64
+// CHECK-NEXT: %[[BUILT:.+]] = memref.alloc() {{.*}}: memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT: %[[STORE0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[STORE1:.+]] = arith.constant 1 : index
+// CHECK-NEXT: memref.store %[[ROWS_I64]], %[[BUILT]]{{\[}}%[[STORE0]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT: memref.store %[[C4]], %[[BUILT]]{{\[}}%[[STORE1]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT: %[[DYN_OUT:.+]] = memref.alloc(%[[ROWS]]) {{.*}}: memref<?x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.expand(%[[CTX]]) ins(%[[DYN]], %[[BUILT]] : memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>)
+// CHECK-SAME: outs(%[[DYN_OUT]] : memref<?x4xf32, #hipsr.mem<device>>)
+// CHECK-NEXT: return %[[OUT]], %[[DYN_OUT]] : memref<2x4xf32, #hipsr.mem<device>>, memref<?x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT: }
+func.func @expand(%ctx: !hipsr.context,
+                  %input: tensor<2x1xf32, #hipsr.mem<device>>,
+                  %shape: tensor<2xi64, #hipsr.mem<host>>,
+                  %dyn: tensor<?x1xf32, #hipsr.mem<device>>)
+    -> (tensor<2x4xf32, #hipsr.mem<device>>, tensor<?x4xf32, #hipsr.mem<device>>) {
+  %c0 = arith.constant 0 : index
+  %c4 = arith.constant 4 : i64
+  %init = tensor.empty() : tensor<2x4xf32, #hipsr.mem<device>>
+  %0 = hipsr.expand(%ctx) ins(%input, %shape : tensor<2x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>)
+      outs(%init : tensor<2x4xf32, #hipsr.mem<device>>)
+      : tensor<2x4xf32, #hipsr.mem<device>>
+  %rows = tensor.dim %dyn, %c0 : tensor<?x1xf32, #hipsr.mem<device>>
+  %rows_i64 = arith.index_cast %rows : index to i64
+  %built = tensor.from_elements %rows_i64, %c4 : tensor<2xi64, #hipsr.mem<host>>
+  %dyn_init = tensor.empty(%rows) : tensor<?x4xf32, #hipsr.mem<device>>
+  %1 = hipsr.expand(%ctx) ins(%dyn, %built : tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>)
+      outs(%dyn_init : tensor<?x4xf32, #hipsr.mem<device>>)
+      : tensor<?x4xf32, #hipsr.mem<device>>
+  return %0, %1 : tensor<2x4xf32, #hipsr.mem<device>>, tensor<?x4xf32, #hipsr.mem<device>>
+}

--- a/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/matmul.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/matmul.mlir
@@ -1,0 +1,40 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --split-input-file --one-shot-bufferize="bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map use-encoding-for-memory-space" %s | FileCheck %s
+
+// The plain matmul allocates from its result type. The batched one has a
+// dynamic batch extent, so it reads that extent from the lhs buffer.
+// CHECK-LABEL: func.func @matmul(
+// CHECK-SAME: %[[CTX:.+]]: !hipsr.context,
+// CHECK-SAME: %[[A:.+]]: memref<64x4096xf16, #hipsr.mem<device>>,
+// CHECK-SAME: %[[BATCHED:.+]]: memref<?x64x4096xf16, #hipsr.mem<device>>,
+// CHECK-SAME: %[[B:.+]]: memref<4096x1024xf16, #hipsr.mem<device>>)
+// CHECK-SAME: -> (memref<64x1024xf16, #hipsr.mem<device>>, memref<?x64x1024xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[OUT:.+]] = memref.alloc() {{.*}}: memref<64x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.matmul(%[[CTX]]) ins(%[[A]], %[[B]] : memref<64x4096xf16, #hipsr.mem<device>>, memref<4096x1024xf16, #hipsr.mem<device>>)
+// CHECK-SAME: outs(%[[OUT]] : memref<64x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: %[[BATCH:.+]] = memref.dim %[[BATCHED]], %[[C0]] : memref<?x64x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[BATCHED_OUT:.+]] = memref.alloc(%[[BATCH]]) {{.*}}: memref<?x64x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.matmul(%[[CTX]]) ins(%[[BATCHED]], %[[B]] : memref<?x64x4096xf16, #hipsr.mem<device>>, memref<4096x1024xf16, #hipsr.mem<device>>)
+// CHECK-SAME: outs(%[[BATCHED_OUT]] : memref<?x64x1024xf16, #hipsr.mem<device>>)
+// CHECK-NEXT: return %[[OUT]], %[[BATCHED_OUT]] : memref<64x1024xf16, #hipsr.mem<device>>, memref<?x64x1024xf16, #hipsr.mem<device>>
+// CHECK-NEXT: }
+func.func @matmul(%ctx: !hipsr.context,
+                  %a: tensor<64x4096xf16, #hipsr.mem<device>>,
+                  %batched: tensor<?x64x4096xf16, #hipsr.mem<device>>,
+                  %b: tensor<4096x1024xf16, #hipsr.mem<device>>)
+    -> (tensor<64x1024xf16, #hipsr.mem<device>>, tensor<?x64x1024xf16, #hipsr.mem<device>>) {
+  %c0 = arith.constant 0 : index
+  %init = tensor.empty() : tensor<64x1024xf16, #hipsr.mem<device>>
+  %0 = hipsr.matmul(%ctx) ins(%a, %b : tensor<64x4096xf16, #hipsr.mem<device>>, tensor<4096x1024xf16, #hipsr.mem<device>>)
+      outs(%init : tensor<64x1024xf16, #hipsr.mem<device>>)
+      : tensor<64x1024xf16, #hipsr.mem<device>>
+  %batch = tensor.dim %batched, %c0 : tensor<?x64x4096xf16, #hipsr.mem<device>>
+  %batched_init = tensor.empty(%batch) : tensor<?x64x1024xf16, #hipsr.mem<device>>
+  %1 = hipsr.matmul(%ctx) ins(%batched, %b : tensor<?x64x4096xf16, #hipsr.mem<device>>, tensor<4096x1024xf16, #hipsr.mem<device>>)
+      outs(%batched_init : tensor<?x64x1024xf16, #hipsr.mem<device>>)
+      : tensor<?x64x1024xf16, #hipsr.mem<device>>
+  return %0, %1 : tensor<64x1024xf16, #hipsr.mem<device>>, tensor<?x64x1024xf16, #hipsr.mem<device>>
+}

--- a/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/nonzero.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/nonzero.mlir
@@ -1,0 +1,56 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+//===----------------------------------------------------------------------===//
+// hipsr.nonzero has two inits and two results, so it shows that each result
+// takes the buffer of its own init. The bufferized op keeps no result.
+//===----------------------------------------------------------------------===//
+
+// RUN: hip-mlir-opt --split-input-file --one-shot-bufferize="bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map use-encoding-for-memory-space" %s | FileCheck %s
+
+// The coordinate buffer holds one column per input element, so the second
+// nonzero pairs a dynamic indices init with a static one-element count.
+// CHECK-LABEL: func.func @nonzero(
+// CHECK-SAME: %[[CTX:.+]]: !hipsr.context,
+// CHECK-SAME: %[[MASK:.+]]: memref<2x3xi1, #hipsr.mem<device>>,
+// CHECK-SAME: %[[DYN:.+]]: memref<?x?xi1, #hipsr.mem<device>>)
+// CHECK-SAME: -> (memref<2x6xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<device>>, memref<2x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-NEXT: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-NEXT: %[[IDS:.+]] = memref.alloc() {{.*}}: memref<2x6xi64, #hipsr.mem<device>>
+// CHECK-NEXT: %[[COUNT:.+]] = memref.alloc() {{.*}}: memref<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.nonzero(%[[CTX]]) ins(%[[MASK]] : memref<2x3xi1, #hipsr.mem<device>>)
+// CHECK-SAME: outs(%[[IDS]], %[[COUNT]] : memref<2x6xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<device>>)
+// CHECK-NEXT: %[[D0:.+]] = memref.dim %[[DYN]], %[[C0]] : memref<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT: %[[D1:.+]] = memref.dim %[[DYN]], %[[C1]] : memref<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT: %[[CAPACITY:.+]] = arith.muli %[[D0]], %[[D1]] : index
+// CHECK-NEXT: %[[DYN_IDS:.+]] = memref.alloc(%[[CAPACITY]]) {{.*}}: memref<2x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT: %[[DYN_COUNT:.+]] = memref.alloc() {{.*}}: memref<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.nonzero(%[[CTX]]) ins(%[[DYN]] : memref<?x?xi1, #hipsr.mem<device>>)
+// CHECK-SAME: outs(%[[DYN_IDS]], %[[DYN_COUNT]] : memref<2x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<device>>)
+// CHECK-NEXT: return %[[IDS]], %[[COUNT]], %[[DYN_IDS]], %[[DYN_COUNT]] : memref<2x6xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<device>>, memref<2x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT: }
+func.func @nonzero(%ctx: !hipsr.context,
+                   %mask: tensor<2x3xi1, #hipsr.mem<device>>,
+                   %dyn: tensor<?x?xi1, #hipsr.mem<device>>)
+    -> (tensor<2x6xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>,
+        tensor<2x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %ids_init = tensor.empty() : tensor<2x6xi64, #hipsr.mem<device>>
+  %count_init = tensor.empty() : tensor<1xi64, #hipsr.mem<device>>
+  %ids, %count = hipsr.nonzero(%ctx) ins(%mask : tensor<2x3xi1, #hipsr.mem<device>>)
+      outs(%ids_init, %count_init : tensor<2x6xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>)
+      : tensor<2x6xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>
+  %d0 = tensor.dim %dyn, %c0 : tensor<?x?xi1, #hipsr.mem<device>>
+  %d1 = tensor.dim %dyn, %c1 : tensor<?x?xi1, #hipsr.mem<device>>
+  %capacity = arith.muli %d0, %d1 : index
+  %dyn_ids_init = tensor.empty(%capacity) : tensor<2x?xi64, #hipsr.mem<device>>
+  %dyn_count_init = tensor.empty() : tensor<1xi64, #hipsr.mem<device>>
+  %dyn_ids, %dyn_count = hipsr.nonzero(%ctx) ins(%dyn : tensor<?x?xi1, #hipsr.mem<device>>)
+      outs(%dyn_ids_init, %dyn_count_init : tensor<2x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>)
+      : tensor<2x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>
+  return %ids, %count, %dyn_ids, %dyn_count
+      : tensor<2x6xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>,
+        tensor<2x?xi64, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<device>>
+}


### PR DESCRIPTION
## Summary

The hipsr pipeline now ends in memrefs instead of tensors. `buildHipsrPipeline`
continues past `hipsr-convert-shape-to-extent` with four passes:

- `shape-to-shape-lowering` rewrites `shape.num_elements` as a `shape.reduce`,
  which `convert-shape-to-std` cannot lower on its own.
- `convert-shape-to-std` clears the remaining shape ops.
- `one-shot-bufferize` converts tensors to memrefs.
- `convert-linalg-to-loops` lowers the `linalg.map` that `shape.broadcast`
  leaves behind.

## Why

#900 retyped the shape math so the upstream shape passes could lower it. That
was the last thing blocking One-Shot Bufferize on this pipeline, and the rest of
the lowering needs buffers.

## What

`one-shot-bufferize` runs with `bufferize-function-boundaries`, an identity
layout map, and `use-encoding-for-memory-space`, so
`tensor<4xf16, #hipsr.mem<device>>` becomes `memref<4xf16, #hipsr.mem<device>>`.

New bufferization models:

- `hipsr.constant` points into the constants blob, which the runtime owns, so it
  bufferizes like upstream `arith.constant`: an identity-layout memref that
  nobody may write, with the blob attributes unchanged.
- `matmul`, `expand`, `add`, and `nonzero` get the shared destination-passing
  model.

`hipsr.compute` now reuses an input buffer for an output only when the body
never reads the matching destination argument, because that reuse also changes
the argument's type.

New per-op tests live under
`test/lit/Dialect/Hipsr/Transforms/OneShotBufferize/`. Regenerating the three
pipeline tests against the bufferized output is most of the diff.

Written with AI assistance. I reviewed the result and validated it with the LIT
suite.
