### PR TITLE
perf(kernels): derive the gqa and matmul_nbits hipRTC compile sets from the offline LUT

### DIFF
--- a/lib/Runtime/Kernels/CMakeLists.txt
+++ b/lib/Runtime/Kernels/CMakeLists.txt
@@ -182,33 +182,52 @@ _rtc_embed_concatenated(kGqaDeviceSource _rtc_embedded_gqa
     ${CMAKE_CURRENT_SOURCE_DIR}/include/hip_arch_compat.h
     ${CMAKE_CURRENT_SOURCE_DIR}/hip/rtc/gqa_device.h)
 
-# Derive the GQA hipRTC registration set for one arch from its offline autotune
-# LUT. Emits <out-dir>/gqa_rtc_tuned_names.h; the directory is per-arch because
-# each arch has its own LUT and the header name is fixed by the #include.
-set(_GQA_RTC_NAMES_SCRIPT
-    ${CMAKE_CURRENT_SOURCE_DIR}/hip/autotune/gqa/scripts/gen_rtc_names.py)
-function(_gqa_rtc_names ARCH OUT_DIR_VAR OUT_HEADER_VAR)
+# Derive a family's hipRTC registration set for one arch from its offline
+# autotune LUT. Emits <out-dir>/<family>_rtc_tuned_names.h; the directory is
+# per-arch because each arch has its own LUT and the header name is fixed by
+# the #include. An arch with no LUT gets a header that keeps the full set.
+function(_rtc_tuned_names FAMILY ARCH OUT_DIR_VAR OUT_HEADER_VAR)
     set(_dir ${CMAKE_CURRENT_BINARY_DIR}/rtc_names/${ARCH})
-    set(_header ${_dir}/gqa_rtc_tuned_names.h)
-    set(_lut ${CMAKE_CURRENT_SOURCE_DIR}/hip/autotune/gqa/lut/${ARCH}.json)
+    set(_header ${_dir}/${FAMILY}_rtc_tuned_names.h)
+    set(_script
+        ${CMAKE_CURRENT_SOURCE_DIR}/hip/autotune/${FAMILY}/scripts/gen_rtc_names.py)
+    set(_kernel ${CMAKE_CURRENT_SOURCE_DIR}/hip/${FAMILY}_kernel.hip)
+    set(_lut ${CMAKE_CURRENT_SOURCE_DIR}/hip/autotune/${FAMILY}/lut/${ARCH}.json)
     set(_lut_dep "")
     if(EXISTS ${_lut})
         set(_lut_dep ${_lut})
     endif()
     add_custom_command(
         OUTPUT ${_header}
-        COMMAND ${Python3_EXECUTABLE} ${_GQA_RTC_NAMES_SCRIPT}
+        COMMAND ${Python3_EXECUTABLE} ${_script}
                 --arch ${ARCH}
-                --kernel-source ${CMAKE_CURRENT_SOURCE_DIR}/hip/gqa_kernel.hip
+                --kernel-source ${_kernel}
                 --output ${_header}
-        DEPENDS ${_GQA_RTC_NAMES_SCRIPT}
-                ${CMAKE_CURRENT_SOURCE_DIR}/hip/gqa_kernel.hip
-                ${_lut_dep}
-        COMMENT "Generating GQA hipRTC name expressions for ${ARCH}"
+        DEPENDS ${_script} ${_kernel} ${_lut_dep}
+        COMMENT "Generating ${FAMILY} hipRTC name expressions for ${ARCH}"
         VERBATIM
     )
     set(${OUT_DIR_VAR} ${_dir} PARENT_SCOPE)
     set(${OUT_HEADER_VAR} ${_header} PARENT_SCOPE)
+endfunction()
+
+# hip_utils.cmake's per-.hip custom command depends on the source alone;
+# appending the generated header to its DEPENDS is what orders the generator
+# first and recompiles that TU when the LUT changes.
+function(_rtc_tuned_names_order TARGET FAMILY HEADER)
+    if(WIN32)
+        get_property(_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+        if(_is_multi_config)
+            set(_obj
+                ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_hip_objs/$<CONFIG>/${FAMILY}_kernel.obj)
+        else()
+            set(_obj ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_hip_objs/${FAMILY}_kernel.obj)
+        endif()
+        add_custom_command(OUTPUT ${_obj} APPEND DEPENDS ${HEADER})
+    else()
+        add_custom_target(${FAMILY}_rtc_names_${TARGET} DEPENDS ${HEADER})
+        add_dependencies(${TARGET} ${FAMILY}_rtc_names_${TARGET})
+    endif()
 endfunction()
 
 set(_rtc_sources
@@ -225,7 +244,8 @@ set(_rtc_sources
 foreach(_arch IN LISTS HIP_ARCHITECTURES)
     set(_target custom_kernels_${_arch})
     _matmul_nbits_lut_data_source(${_arch} _matmul_lut_src)
-    _gqa_rtc_names(${_arch} _gqa_names_dir _gqa_names_header)
+    _rtc_tuned_names(gqa ${_arch} _gqa_names_dir _gqa_names_header)
+    _rtc_tuned_names(matmul_nbits ${_arch} _mnb_names_dir _mnb_names_header)
     hip_add_library(${_target} SHARED ${_kernel_sources} ${_rtc_sources}
             ${_matmul_nbits_autotune_dir}/matmul_nbits_autotune.cpp
             ${_matmul_lut_src}
@@ -234,6 +254,7 @@ foreach(_arch IN LISTS HIP_ARCHITECTURES)
             ${CMAKE_CURRENT_SOURCE_DIR}
             ${CMAKE_CURRENT_BINARY_DIR}
             ${_gqa_names_dir}
+            ${_mnb_names_dir}
             # matmul_nbits_autotune_generated.h; flatbuffers itself is
             # header-only for reading, so no link library is needed.
             ${CMAKE_BINARY_DIR}/schemas
@@ -245,21 +266,8 @@ foreach(_arch IN LISTS HIP_ARCHITECTURES)
         DEPENDS
             HipSchemas
     )
-    # hip_utils.cmake's per-.hip custom command depends on the source alone;
-    # appending the generated header to its DEPENDS is what orders the
-    # generator first and recompiles this TU when the LUT changes.
-    if(WIN32)
-        get_property(_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-        if(_is_multi_config)
-            set(_gqa_obj ${CMAKE_CURRENT_BINARY_DIR}/${_target}_hip_objs/$<CONFIG>/gqa_kernel.obj)
-        else()
-            set(_gqa_obj ${CMAKE_CURRENT_BINARY_DIR}/${_target}_hip_objs/gqa_kernel.obj)
-        endif()
-        add_custom_command(OUTPUT ${_gqa_obj} APPEND DEPENDS ${_gqa_names_header})
-    else()
-        add_custom_target(gqa_rtc_names_${_arch} DEPENDS ${_gqa_names_header})
-        add_dependencies(${_target} gqa_rtc_names_${_arch})
-    endif()
+    _rtc_tuned_names_order(${_target} gqa ${_gqa_names_header})
+    _rtc_tuned_names_order(${_target} matmul_nbits ${_mnb_names_header})
     set_target_properties(${_target} PROPERTIES
         OUTPUT_NAME custom_kernels_${_arch}
         FOLDER "custom_kernels"

--- a/lib/Runtime/Kernels/CMakeLists.txt
+++ b/lib/Runtime/Kernels/CMakeLists.txt
@@ -182,6 +182,35 @@ _rtc_embed_concatenated(kGqaDeviceSource _rtc_embedded_gqa
     ${CMAKE_CURRENT_SOURCE_DIR}/include/hip_arch_compat.h
     ${CMAKE_CURRENT_SOURCE_DIR}/hip/rtc/gqa_device.h)
 
+# Derive the GQA hipRTC registration set for one arch from its offline autotune
+# LUT. Emits <out-dir>/gqa_rtc_tuned_names.h; the directory is per-arch because
+# each arch has its own LUT and the header name is fixed by the #include.
+set(_GQA_RTC_NAMES_SCRIPT
+    ${CMAKE_CURRENT_SOURCE_DIR}/hip/autotune/gqa/scripts/gen_rtc_names.py)
+function(_gqa_rtc_names ARCH OUT_DIR_VAR OUT_HEADER_VAR)
+    set(_dir ${CMAKE_CURRENT_BINARY_DIR}/rtc_names/${ARCH})
+    set(_header ${_dir}/gqa_rtc_tuned_names.h)
+    set(_lut ${CMAKE_CURRENT_SOURCE_DIR}/hip/autotune/gqa/lut/${ARCH}.json)
+    set(_lut_dep "")
+    if(EXISTS ${_lut})
+        set(_lut_dep ${_lut})
+    endif()
+    add_custom_command(
+        OUTPUT ${_header}
+        COMMAND ${Python3_EXECUTABLE} ${_GQA_RTC_NAMES_SCRIPT}
+                --arch ${ARCH}
+                --kernel-source ${CMAKE_CURRENT_SOURCE_DIR}/hip/gqa_kernel.hip
+                --output ${_header}
+        DEPENDS ${_GQA_RTC_NAMES_SCRIPT}
+                ${CMAKE_CURRENT_SOURCE_DIR}/hip/gqa_kernel.hip
+                ${_lut_dep}
+        COMMENT "Generating GQA hipRTC name expressions for ${ARCH}"
+        VERBATIM
+    )
+    set(${OUT_DIR_VAR} ${_dir} PARENT_SCOPE)
+    set(${OUT_HEADER_VAR} ${_header} PARENT_SCOPE)
+endfunction()
+
 set(_rtc_sources
     rtc/hiprtc_module.hip
     ${_rtc_embedded_sub}
@@ -196,6 +225,7 @@ set(_rtc_sources
 foreach(_arch IN LISTS HIP_ARCHITECTURES)
     set(_target custom_kernels_${_arch})
     _matmul_nbits_lut_data_source(${_arch} _matmul_lut_src)
+    _gqa_rtc_names(${_arch} _gqa_names_dir _gqa_names_header)
     hip_add_library(${_target} SHARED ${_kernel_sources} ${_rtc_sources}
             ${_matmul_nbits_autotune_dir}/matmul_nbits_autotune.cpp
             ${_matmul_lut_src}
@@ -203,6 +233,7 @@ foreach(_arch IN LISTS HIP_ARCHITECTURES)
             ${CMAKE_CURRENT_SOURCE_DIR}/include
             ${CMAKE_CURRENT_SOURCE_DIR}
             ${CMAKE_CURRENT_BINARY_DIR}
+            ${_gqa_names_dir}
             # matmul_nbits_autotune_generated.h; flatbuffers itself is
             # header-only for reading, so no link library is needed.
             ${CMAKE_BINARY_DIR}/schemas
@@ -214,6 +245,21 @@ foreach(_arch IN LISTS HIP_ARCHITECTURES)
         DEPENDS
             HipSchemas
     )
+    # hip_utils.cmake's per-.hip custom command depends on the source alone;
+    # appending the generated header to its DEPENDS is what orders the
+    # generator first and recompiles this TU when the LUT changes.
+    if(WIN32)
+        get_property(_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+        if(_is_multi_config)
+            set(_gqa_obj ${CMAKE_CURRENT_BINARY_DIR}/${_target}_hip_objs/$<CONFIG>/gqa_kernel.obj)
+        else()
+            set(_gqa_obj ${CMAKE_CURRENT_BINARY_DIR}/${_target}_hip_objs/gqa_kernel.obj)
+        endif()
+        add_custom_command(OUTPUT ${_gqa_obj} APPEND DEPENDS ${_gqa_names_header})
+    else()
+        add_custom_target(gqa_rtc_names_${_arch} DEPENDS ${_gqa_names_header})
+        add_dependencies(${_target} gqa_rtc_names_${_arch})
+    endif()
     set_target_properties(${_target} PROPERTIES
         OUTPUT_NAME custom_kernels_${_arch}
         FOLDER "custom_kernels"

--- a/lib/Runtime/Kernels/hip/autotune/gqa/scripts/gen_rtc_names.py
+++ b/lib/Runtime/Kernels/hip/autotune/gqa/scripts/gen_rtc_names.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+"""Emit the hipRTC name-expression subset the offline LUT can actually pick.
+
+    python gen_rtc_names.py --arch gfx1151 --output gqa_rtc_tuned_names.h
+
+gqa_kernel.hip instantiates every (head_dim, HpG, block, ...) combination its
+dispatch ladders can reach, but the autotuner only ever selects the configs
+recorded in lut/<arch>.json. Registering the rest with hipRTC costs compile
+time for code no shape resolves to, so the build narrows the registration set
+to the LUT's winners; a launch site whose name expression is left out
+transparently falls back to its AOT kernel.
+
+The instantiation set is read back out of gqa_kernel.hip's GQA_*_LIST X-macros,
+so a LUT row naming a config the dispatch ladders cannot reach is reported as
+drift and dropped rather than emitted as an unresolvable name expression.
+
+Without --lut (an arch that has never been tuned) the output only defines
+HIPDNN_GQA_RTC_TUNED_SUBSET to 0 and gqa_kernel.hip registers everything.
+"""
+import argparse
+import re
+import sys
+import json
+from pathlib import Path
+
+HERE = Path(__file__).parent
+LUT_DIR = HERE.parent / 'lut'
+KERNEL_SOURCE = HERE.parent.parent.parent / 'gqa_kernel.hip'
+
+# Both are always instantiated: the LUT records kv_dtype "Any" because the
+# quantised cache reuses the fp16 tuning.
+KV_FMTS = ['KvDtype::kF16', 'KvDtype::kI8']
+
+
+def parse_x_macro(src, name):
+    """Return the argument tuples of a `#define <name>(X) X(..) X(..)` list."""
+    m = re.search(r'#define\s+{}\(X\)((?:[^\n]*\\\n)*[^\n]*)'.format(name), src)
+    if not m:
+        raise SystemExit('gen_rtc_names: {} not found in the kernel source'
+                         .format(name))
+    body = m.group(1).replace('\\\n', ' ')
+    return [tuple(a.strip() for a in args.split(','))
+            for args in re.findall(r'X\(([^)]*)\)', body)]
+
+
+def instantiated_names(src):
+    """Every tuned name expression gqa_kernel.hip instantiates.
+
+    Mirrors the appendGqa*Names spellings; stringizing a template argument list
+    collapses each run of whitespace to one space, hence ", " between args.
+    """
+    hpgs = [a for (a,) in parse_x_macro(src, 'GQA_DECODE_HPG_LIST')]
+    head_dims = [a for (a,) in parse_x_macro(src, 'GQA_DECODE_D_LIST')]
+
+    names = set()
+    for d, hpg, bkv in parse_x_macro(src, 'GQA_DECODE_WMMA_LIST'):
+        for fmt in KV_FMTS:
+            names.add('gqa_flash_decode_wmma_kernel<{}, {}, {}, {}>'
+                      .format(d, hpg, bkv, fmt))
+    for hpg in hpgs:
+        for d in head_dims:
+            for fmt in KV_FMTS:
+                names.add('gqa_flash_decode_kernel<{}, {}, {}>'
+                          .format(d, hpg, fmt))
+    for mt, bkv, d, hw in parse_x_macro(src, 'GQA_PREFILL_V5_LIST'):
+        names.add('gqa_flash_prefill_v5_kernel<{}, {}, {}, {}>'
+                  .format(mt, bkv, d, hw))
+    for nw, bkv, d, mt in parse_x_macro(src, 'GQA_PREFILL_V7_LIST'):
+        names.add('gqa_flash_prefill_v7_kernel<{}, {}, {}, {}>'
+                  .format(nw, bkv, d, mt))
+    for nd, mt, bkv in parse_x_macro(src, 'GQA_PREFILL_V8_LIST'):
+        names.add('gqa_flash_prefill_v8_kernel<{}, {}, {}, 256>'
+                  .format(nd, mt, bkv))
+    return names, hpgs
+
+
+def winner_names(rows, hpgs, unmapped):
+    """Map every LUT row to the name expression its config would launch."""
+    names = set()
+    for r in rows:
+        phase, cfg = r['phase'], r['config']
+        d = r['head_dim'][1:]
+        # hpg 0 is the wildcard row: it can be selected for any supported
+        # grouping, so it stands for the whole ladder.
+        row_hpgs = hpgs if r['hpg'] == 0 else [str(r['hpg'])]
+        if r['kv_dtype'] != 'Any':
+            unmapped.add('kv_dtype={}'.format(r['kv_dtype']))
+            continue
+        if phase == 'Decode':
+            m = re.fullmatch(r'WmmaBkv(\d+)', cfg)
+            for hpg in row_hpgs:
+                for fmt in KV_FMTS:
+                    if cfg == 'Scalar':
+                        names.add('gqa_flash_decode_kernel<{}, {}, {}>'
+                                  .format(d, hpg, fmt))
+                    elif m:
+                        names.add('gqa_flash_decode_wmma_kernel<{}, {}, {}, {}>'
+                                  .format(d, hpg, m.group(1), fmt))
+                    else:
+                        unmapped.add('{} {}'.format(phase, cfg))
+        elif phase == 'PrefillV5':
+            m = re.fullmatch(r'MT(\d+)_BKV(\d+)', cfg)
+            if not m:
+                unmapped.add('{} {}'.format(phase, cfg))
+                continue
+            # A NoWindow row cannot select the windowed instantiation; an Any
+            # row can end up on either.
+            windows = ['false'] if r['window'] == 'NoWindow' else ['true', 'false']
+            for hw in windows:
+                names.add('gqa_flash_prefill_v5_kernel<{}, {}, {}, {}>'
+                          .format(m.group(1), m.group(2), d, hw))
+        elif phase == 'PrefillV7':
+            m = re.fullmatch(r'NW(\d+)_BKV(\d+)_MT(\d+)', cfg)
+            if not m:
+                unmapped.add('{} {}'.format(phase, cfg))
+                continue
+            names.add('gqa_flash_prefill_v7_kernel<{}, {}, {}, {}>'
+                      .format(m.group(1), m.group(2), d, m.group(3)))
+        elif phase == 'PrefillV8':
+            m = re.fullmatch(r'ND(\d+)_MT(\d+)_BKV(\d+)', cfg)
+            if not m:
+                unmapped.add('{} {}'.format(phase, cfg))
+                continue
+            names.add('gqa_flash_prefill_v8_kernel<{}, {}, {}, {}>'
+                      .format(m.group(1), m.group(2), m.group(3), d))
+        else:
+            unmapped.add('phase={}'.format(phase))
+    return names
+
+
+def natural_key(name):
+    return [int(t) if t.isdigit() else t for t in re.split(r'(\d+)', name)]
+
+
+def render(arch, lut_path, names):
+    head = [
+        '//',
+        '// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.',
+        '// Licensed under the MIT License.',
+        '//',
+        '',
+        '// Generated by hip/autotune/gqa/scripts/gen_rtc_names.py -- edits are',
+        '// overwritten by the build. Re-run the script (or just rebuild) after',
+        '// changing the LUT.',
+        '',
+        '#pragma once',
+        '',
+    ]
+    if not names:
+        head += [
+            '// No LUT-derived winner set for {}, so gqa_kernel.hip registers'.format(arch),
+            '// every instantiation.',
+            '#define HIPDNN_GQA_RTC_TUNED_SUBSET 0',
+            '',
+        ]
+        return '\n'.join(head)
+    head += [
+        '// Winners of {}, one name expression per hipRTC registration.'.format(
+            Path(lut_path).name),
+        '#define HIPDNN_GQA_RTC_TUNED_SUBSET 1',
+        '',
+        '#define HIPDNN_GQA_RTC_TUNED_NAME_LIST(X) \\',
+    ]
+    body = ['  X("{}")'.format(n) for n in sorted(names, key=natural_key)]
+    return '\n'.join(head + [' \\\n'.join(body), ''])
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--arch', required=True, help='GPU arch, e.g. gfx1151')
+    ap.add_argument('--lut', default=None,
+                    help='LUT JSON (default: lut/<arch>.json if it exists)')
+    ap.add_argument('--kernel-source', default=str(KERNEL_SOURCE),
+                    help='gqa_kernel.hip, read for the GQA_*_LIST X-macros')
+    ap.add_argument('--output', default=None,
+                    help='Header to write (default: stdout)')
+    args = ap.parse_args()
+
+    lut_path = args.lut or LUT_DIR / '{}.json'.format(args.arch)
+    src = Path(args.kernel_source).read_text(encoding='utf-8')
+    instantiated, hpgs = instantiated_names(src)
+
+    names = set()
+    if Path(lut_path).exists():
+        rows = json.loads(Path(lut_path).read_text(encoding='utf-8'))['rows']
+        unmapped = set()
+        names = winner_names(rows, hpgs, unmapped)
+        drift = sorted(names - instantiated, key=natural_key)
+        names -= set(drift)
+        for cfg in sorted(unmapped):
+            print('gen_rtc_names: {}: LUT config not understood: {}'
+                  .format(args.arch, cfg), file=sys.stderr)
+        for name in drift:
+            print('gen_rtc_names: {}: LUT wins a config gqa_kernel.hip does not '
+                  'instantiate, dropped: {}'.format(args.arch, name),
+                  file=sys.stderr)
+        print('gen_rtc_names: {}: {} of {} tuned instantiations kept'
+              .format(args.arch, len(names), len(instantiated)))
+    else:
+        print('gen_rtc_names: {}: no LUT at {}, registering every '
+              'instantiation'.format(args.arch, lut_path))
+
+    text = render(args.arch, lut_path, names)
+    if args.output:
+        Path(args.output).write_text(text, encoding='utf-8')
+    else:
+        sys.stdout.write(text)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/Runtime/Kernels/hip/autotune/matmul_nbits/scripts/gen_rtc_names.py
+++ b/lib/Runtime/Kernels/hip/autotune/matmul_nbits/scripts/gen_rtc_names.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+"""Emit the hipRTC name-expression subset the offline LUT can actually pick.
+
+    python gen_rtc_names.py --arch gfx1151 --output matmul_nbits_rtc_tuned_names.h
+
+matmul_nbits_kernel.hip instantiates every config its dispatch ladders can
+reach, but the autotuner only ever selects the ones recorded in
+lut/<arch>.json. Registering the rest with hipRTC costs compile time for code
+no shape resolves to, so the build narrows the registration set to the LUT's
+winners; a launch site whose name expression is left out transparently falls
+back to its AOT kernel.
+
+Only the bits=4 families are narrowed. The LUT's model_key is `bits=4`, so its
+three phases cover exactly the u4 GEMV (Decode), the u4 DP4A GEMV
+(DecodeDp4a) and the u4 WMMA / dequant+GEMM prefill (Prefill). The i8 / u3 / u2
+families and the shape-independent helpers have no LUT rows and stay fully
+registered.
+
+The instantiation set is read back out of matmul_nbits_kernel.hip's MNB_*_LIST
+X-macros, so a LUT row naming a config the dispatch ladders cannot reach is
+reported as drift and dropped rather than emitted as an unresolvable name
+expression.
+
+Without --lut (an arch that has never been tuned) the output only defines
+HIPDNN_MATMUL_NBITS_RTC_TUNED_SUBSET to 0 and matmul_nbits_kernel.hip
+registers everything.
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).parent
+LUT_DIR = HERE.parent / 'lut'
+KERNEL_SOURCE = HERE.parent.parent.parent / 'matmul_nbits_kernel.hip'
+
+# BC (the bounds-checked variant) and col_major are picked from the shape at
+# launch, not from the config, so a tuned config needs both spellings.
+BOOLS = ['false', 'true']
+
+
+def parse_x_macro(src, name):
+    """Return the argument tuples of a `#define <name>(X) X(..) X(..)` list."""
+    m = re.search(r'#define\s+{}\(X\)((?:[^\n]*\\\n)*[^\n]*)'.format(name), src)
+    if not m:
+        raise SystemExit('gen_rtc_names: {} not found in the kernel source'
+                         .format(name))
+    body = m.group(1).replace('\\\n', ' ')
+    return [tuple(a.strip() for a in args.split(','))
+            for args in re.findall(r'X\(([^)]*)\)', body)]
+
+
+def gemv_names(bs, tn):
+    return ['matmul_nbits_gemv_kernel<{}, {}, {}>'.format(bs, tn, b)
+            for b in BOOLS]
+
+
+def dp4a_names(bs, tn):
+    return ['matmul_nbits_gemv_dp4a_kernel<{}, {}>'.format(bs, tn)]
+
+
+def fused_names(bm, bn, wtm, wtn, weu, bk):
+    return ['MatMulNBits{}<{}, {}, {}, {}, {}, {}, {}>'
+            .format(kern, bm, bn, wtm, wtn, weu, b, bk)
+            for kern in ('WMMA_ZP', 'WMMA_NoZP') for b in BOOLS]
+
+
+def dequant_names(bm, bn, wtm, wtn, weu, bk):
+    return ['MatMulNBitsFp16GEMM<{}, {}, {}, {}, {}, {}, {}>'
+            .format(bm, bn, wtm, wtn, weu, b, bk) for b in BOOLS]
+
+
+def instantiated(src):
+    """Every name expression the three LUT-covered families instantiate.
+
+    Mirrors appendGemvNames / appendDp4aNames / appendWmmaNames; stringizing a
+    template argument list collapses each run of whitespace to one space, hence
+    ", " between args.
+    """
+    names = set()
+    for _id, bs, tn in parse_x_macro(src, 'MNB_GEMV_CONFIG_LIST'):
+        names.update(gemv_names(bs, tn))
+        names.update(dp4a_names(bs, tn))
+    for tile in parse_x_macro(src, 'MNB_WMMA_TILE_LIST'):
+        names.update(dequant_names(*tile))
+        names.update(fused_names(*tile))
+    for tile in parse_x_macro(src, 'MNB_WMMA_FUSED_ONLY_TILE_LIST'):
+        names.update(fused_names(*tile))
+    return names
+
+
+def wmma_tile_index(src):
+    """(BM, BN, wt_m, wt_n, bk) -> the tile's full X-macro argument tuple.
+
+    The dispatch ladder keys on exactly these five values, so they identify the
+    instantiation a WMMA config resolves to; WEU comes from the table.
+    """
+    index = {}
+    for lst in ('MNB_WMMA_TILE_LIST', 'MNB_WMMA_FUSED_ONLY_TILE_LIST'):
+        for tile in parse_x_macro(src, lst):
+            bm, bn, wtm, wtn, _weu, bk = tile
+            index[(int(bm), int(bn), int(wtm), int(wtn), int(bk))] = tile
+    return index
+
+
+def winner_names(lut, tiles, unmapped):
+    """Map every LUT config to the name expressions its winner would launch."""
+    cfgs = lut['configs']
+    used = {p['config'] for p in lut['points']}
+    used.update(f['config'] for f in lut['fallbacks'])
+    phase_of = {}
+    for p in lut['points']:
+        phase_of.setdefault(p['config'], set()).add(p['phase'])
+    for f in lut['fallbacks']:
+        phase_of.setdefault(f['config'], set()).add(f['phase'])
+
+    names = set()
+    for cid in sorted(used):
+        c = cfgs[cid]
+        phases = phase_of[cid]
+        if c['kind'] == 'Gemv':
+            for phase in phases:
+                if phase == 'Decode':
+                    names.update(gemv_names(c['threads'], c['tile_n']))
+                elif phase == 'DecodeDp4a':
+                    names.update(dp4a_names(c['threads'], c['tile_n']))
+                else:
+                    unmapped.add('{} on a Gemv config'.format(phase))
+        elif c['kind'] == 'Wmma':
+            key = (c['bm16'] * 16, c['bn16'] * 16, c['wt_m'], c['wt_n'], c['bk'])
+            tile = tiles.get(key)
+            if tile is None:
+                unmapped.add('Wmma tile BM={} BN={} wt=({},{}) bk={}'.format(*key))
+                continue
+            names.update(fused_names(*tile) if c['fused']
+                         else dequant_names(*tile))
+        else:
+            unmapped.add('kind={}'.format(c['kind']))
+    return names
+
+
+def natural_key(name):
+    return [int(t) if t.isdigit() else t for t in re.split(r'(\d+)', name)]
+
+
+def render(arch, lut_path, names):
+    head = [
+        '//',
+        '// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.',
+        '// Licensed under the MIT License.',
+        '//',
+        '',
+        '// Generated by hip/autotune/matmul_nbits/scripts/gen_rtc_names.py --',
+        '// edits are overwritten by the build. Re-run the script (or just',
+        '// rebuild) after changing the LUT.',
+        '',
+        '#pragma once',
+        '',
+    ]
+    if not names:
+        head += [
+            '// No LUT-derived winner set for {}, so matmul_nbits_kernel.hip'.format(arch),
+            '// registers every instantiation.',
+            '#define HIPDNN_MATMUL_NBITS_RTC_TUNED_SUBSET 0',
+            '',
+        ]
+        return '\n'.join(head)
+    head += [
+        '// Winners of {}, one name expression per hipRTC registration.'.format(
+            Path(lut_path).name),
+        '#define HIPDNN_MATMUL_NBITS_RTC_TUNED_SUBSET 1',
+        '',
+        '#define HIPDNN_MATMUL_NBITS_RTC_TUNED_NAME_LIST(X) \\',
+    ]
+    body = ['  X("{}")'.format(n) for n in sorted(names, key=natural_key)]
+    return '\n'.join(head + [' \\\n'.join(body), ''])
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--arch', required=True, help='GPU arch, e.g. gfx1151')
+    ap.add_argument('--lut', default=None,
+                    help='LUT JSON (default: lut/<arch>.json if it exists)')
+    ap.add_argument('--kernel-source', default=str(KERNEL_SOURCE),
+                    help='matmul_nbits_kernel.hip, read for the MNB_*_LIST X-macros')
+    ap.add_argument('--output', default=None,
+                    help='Header to write (default: stdout)')
+    args = ap.parse_args()
+
+    lut_path = args.lut or LUT_DIR / '{}.json'.format(args.arch)
+    src = Path(args.kernel_source).read_text(encoding='utf-8')
+    reachable = instantiated(src)
+
+    names = set()
+    if Path(lut_path).exists():
+        lut = json.loads(Path(lut_path).read_text(encoding='utf-8'))
+        unmapped = set()
+        names = winner_names(lut, wmma_tile_index(src), unmapped)
+        drift = sorted(names - reachable, key=natural_key)
+        names -= set(drift)
+        for cfg in sorted(unmapped):
+            print('gen_rtc_names: {}: LUT config not understood: {}'
+                  .format(args.arch, cfg), file=sys.stderr)
+        for name in drift:
+            print('gen_rtc_names: {}: LUT wins a config matmul_nbits_kernel.hip '
+                  'does not instantiate, dropped: {}'.format(args.arch, name),
+                  file=sys.stderr)
+        print('gen_rtc_names: {}: {} of {} tuned instantiations kept'
+              .format(args.arch, len(names), len(reachable)))
+    else:
+        print('gen_rtc_names: {}: no LUT at {}, registering every '
+              'instantiation'.format(args.arch, lut_path))
+
+    text = render(args.arch, lut_path, names)
+    if args.output:
+        Path(args.output).write_text(text, encoding='utf-8')
+    else:
+        sys.stdout.write(text)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -21,6 +21,10 @@
 
 #include "rtc/hiprtc_module.h"
 
+// Generated per arch from hip/autotune/gqa/lut/<arch>.json; see
+// hip/autotune/gqa/scripts/gen_rtc_names.py.
+#include "gqa_rtc_tuned_names.h"
+
 static constexpr int GQA_THREADS = 256;
 
 // Element-size dispatch helper for the pure data-movement kernels (transpose,
@@ -877,6 +881,16 @@ static inline void launchFlashDecodeConfig(
   #undef LAUNCH_REDUCE
 }
 
+// Not autotuned: every split-K decode config launches the same reduce, so it
+// stays registered even when the LUT narrows the decode kernels themselves.
+static void appendGqaDecodeReduceNames(std::vector<std::string>& names) {
+#define X(D_)                                                                  \
+  names.push_back(HIPDNN_RTC_STR(gqa_flash_decode_reduce_kernel<D_>));
+  GQA_DECODE_D_LIST(X)
+#undef X
+}
+
+#if !HIPDNN_GQA_RTC_TUNED_SUBSET
 static void appendGqaDecodeNames(std::vector<std::string>& names) {
 #define X(D_, HPG_, BKV_)                                                      \
   names.push_back(HIPDNN_RTC_STR(                                              \
@@ -900,11 +914,8 @@ static void appendGqaDecodeNames(std::vector<std::string>& names) {
       HIPDNN_RTC_STR(gqa_flash_decode_kernel<64, HPG_, KvDtype::kI8>));
   GQA_DECODE_HPG_LIST(X)
 #undef X
-#define X(D_)                                                                  \
-  names.push_back(HIPDNN_RTC_STR(gqa_flash_decode_reduce_kernel<D_>));
-  GQA_DECODE_D_LIST(X)
-#undef X
 }
+#endif  // !HIPDNN_GQA_RTC_TUNED_SUBSET
 
 // Candidate split counts, clamped to [1, cap] and to the useful range for skv
 // (no point launching more splits than there are 16-key tiles). Deduplicated.
@@ -1511,6 +1522,7 @@ static inline void dispatchPrefillV5(
     X(2, 64, 128, false) X(2, 32, 128, false)                                 \
     X(1, 64, 128, false) X(1, 32, 128, false)
 
+#if !HIPDNN_GQA_RTC_TUNED_SUBSET
 static void appendGqaPrefillV5Names(std::vector<std::string>& names) {
 #define X(MT_, BKV_, D_, HW_)                                                 \
     names.push_back(                                                          \
@@ -1518,6 +1530,7 @@ static void appendGqaPrefillV5Names(std::vector<std::string>& names) {
     GQA_PREFILL_V5_LIST(X)
 #undef X
 }
+#endif  // !HIPDNN_GQA_RTC_TUNED_SUBSET
 
 struct PrefillV5Cfg { int m_tiles; int bkv; };
 static inline int prefillV5Candidates(int d, PrefillV5Cfg* out) {
@@ -1668,6 +1681,7 @@ static inline void dispatchPrefillV7(
     X(4, 64, 256, 2) X(4, 32, 256, 2) X(2, 64, 256, 2)                        \
     X(2, 32, 256, 2) X(1, 64, 256, 2) X(1, 32, 256, 2)
 
+#if !HIPDNN_GQA_RTC_TUNED_SUBSET
 static void appendGqaPrefillV7Names(std::vector<std::string>& names) {
 #define X(NW_, BKV_, D_, MT_)                                                 \
     names.push_back(                                                          \
@@ -1675,6 +1689,7 @@ static void appendGqaPrefillV7Names(std::vector<std::string>& names) {
     GQA_PREFILL_V7_LIST(X)
 #undef X
 }
+#endif  // !HIPDNN_GQA_RTC_TUNED_SUBSET
 
 struct PrefillV7Cfg { int nw; int bkv; int mt; };
 static inline int prefillV7Candidates(int d, PrefillV7Cfg* out) {
@@ -1811,6 +1826,7 @@ static inline void dispatchPrefillV8(
     X(8, 1, 16) X(8, 1, 32) X(2, 2, 16) X(4, 2, 16)                           \
     X(1, 1, 16) X(1, 2, 16)
 
+#if !HIPDNN_GQA_RTC_TUNED_SUBSET
 static void appendGqaPrefillV8Names(std::vector<std::string>& names) {
 #define X(ND_, MT_, BKV_)                                                     \
     names.push_back(                                                          \
@@ -1818,6 +1834,7 @@ static void appendGqaPrefillV8Names(std::vector<std::string>& names) {
     GQA_PREFILL_V8_LIST(X)
 #undef X
 }
+#endif  // !HIPDNN_GQA_RTC_TUNED_SUBSET
 
 struct PrefillV8Cfg { int nd; int mt; int bkv; };
 
@@ -2296,6 +2313,21 @@ static void appendGqaMiscNames(std::vector<std::string>& names) {
 #undef X
 }
 
+// The autotuned families register only what the offline LUT picks; a config
+// left out resolves to nullptr and HIPDNN_RTC_LAUNCH takes its AOT kernel.
+static void appendGqaTunedNames(std::vector<std::string>& names) {
+#if HIPDNN_GQA_RTC_TUNED_SUBSET
+#define X(NAME_) names.push_back(NAME_);
+  HIPDNN_GQA_RTC_TUNED_NAME_LIST(X)
+#undef X
+#else
+  appendGqaDecodeNames(names);
+  appendGqaPrefillV5Names(names);
+  appendGqaPrefillV7Names(names);
+  appendGqaPrefillV8Names(names);
+#endif
+}
+
 static hipdnn_ep::rtc::Module& gqaRtcModule() {
   static hipdnn_ep::rtc::Module module(
       "gqa", reinterpret_cast<const char*>(kGqaDeviceSource),
@@ -2303,10 +2335,8 @@ static hipdnn_ep::rtc::Module& gqaRtcModule() {
         std::vector<std::string> names;
         appendGqaElemNames(names);
         appendGqaMiscNames(names);
-        appendGqaDecodeNames(names);
-        appendGqaPrefillV5Names(names);
-        appendGqaPrefillV7Names(names);
-        appendGqaPrefillV8Names(names);
+        appendGqaDecodeReduceNames(names);
+        appendGqaTunedNames(names);
         return names;
       }());
   return module;

--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -72,6 +72,10 @@
 
 #include "rtc/hiprtc_module.h"
 
+// Generated per arch from hip/autotune/matmul_nbits/lut/<arch>.json; see
+// hip/autotune/matmul_nbits/scripts/gen_rtc_names.py.
+#include "matmul_nbits_rtc_tuned_names.h"
+
 // Unlike the other RTC-enabled kernels, the device half of this file is not
 // split into a header: 33 device blocks are interleaved with the autotune state
 // machines. The build extracts it instead (cmake/rtc_extract_device.py) and
@@ -3850,17 +3854,30 @@ static void appendMiscNames(std::vector<std::string>& names) {
   names.push_back(HIPDNN_RTC_STR(unpack_zp_u8_to_fp16_kernel));
 }
 
+// The bits=4 families register only what the offline LUT picks; a config left
+// out resolves to nullptr and HIPDNN_RTC_LAUNCH takes its AOT kernel. The
+// i8 / u3 / u2 families have no LUT rows, so they stay fully registered.
+static void appendTunedNames(std::vector<std::string>& names) {
+#if HIPDNN_MATMUL_NBITS_RTC_TUNED_SUBSET
+#define X(NAME_) names.push_back(NAME_);
+  HIPDNN_MATMUL_NBITS_RTC_TUNED_NAME_LIST(X)
+#undef X
+#else
+  appendGemvNames(names);
+  appendDp4aNames(names);
+  appendWmmaNames(names);
+#endif
+}
+
 static hipdnn_ep::rtc::Module& mnbRtcModule() {
   static hipdnn_ep::rtc::Module module(
       "matmul_nbits", reinterpret_cast<const char*>(kMatMulNBitsDeviceSource),
       kMatMulNBitsDeviceSource_size, [] {
         std::vector<std::string> names;
-        appendGemvNames(names);
-        appendDp4aNames(names);
+        appendTunedNames(names);
         appendGemvI8Names(names);
         appendGemvU3Names(names);
         appendGemvU2Names(names);
-        appendWmmaNames(names);
         appendWmmaI8Names(names);
         appendWmmaU3Names(names);
         appendWmmaU2Names(names);

--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -76,10 +76,9 @@
 // hip/autotune/matmul_nbits/scripts/gen_rtc_names.py.
 #include "matmul_nbits_rtc_tuned_names.h"
 
-// Unlike the other RTC-enabled kernels, the device half of this file is not
-// split into a header: 33 device blocks are interleaved with the autotune state
-// machines. The build extracts it instead (cmake/rtc_extract_device.py) and
-// embeds the result here.
+// hip/rtc/matmul_nbits_device.h, included below, embedded as bytes at build
+// time with hip_arch_compat.h prepended: the device half uses HIPDNN_WAVE_SIZE
+// and the WMMA macros without including it.
 extern "C" const unsigned char kMatMulNBitsDeviceSource[];
 extern "C" const size_t kMatMulNBitsDeviceSource_size;
 


### PR DESCRIPTION
## Summary

Narrows the hipRTC compile set for gqa and matmul_nbits by deriving it from the offline autotune LUT at build time, so only the instantiations a shape can actually resolve to get compiled. Nothing in the launch path changes, and updating a LUT re-derives the set on the next build with no C++ edits.

Stacked on [#888](https://github.com/ROCm/hip-ep/pull/888) (`feat/hiprtc-sub-poc`), which is where both kernels get their hipRTC path in the first place. Per-module compile cost is reported by CI on every run.

## Related issue or design

None.

## Why

hipRTC has to know every template instantiation before it compiles, so both kernels registered all of theirs up front and paid for all of them. The offline autotune LUTs already record which configuration wins for every shape, so mapping their rows back to instantiations says which ones are worth compiling.

For gqa the dropped ones split into two groups. Some are unreachable no matter what the table says: prefill dispatches on head_dim alone (`d==64` to v5, `d==128` to v7, `d==256` to v8), so v5's `d=128` instantiations and v7's `d=64` ones have no caller. The rest are reachable but have never won a row.

matmul_nbits narrows much less, and the reason is worth recording. Its LUT covers the Decode, DecodeDp4a and Prefill phases, so the i8 / u3 / u2 families and the shape-independent helpers have no rows and stay fully registered. Within the phases it does cover, the prefill side barely narrows either: `swizzle_n` is a launch argument rather than a template one, so the LUT's distinct Wmma configurations collapse onto the same tiles the dispatch ladder already reaches. Only the GEMV side actually loses entries.

Encoding either list by hand would rot the moment a LUT is re-measured, so both are generated.

## What

`autotune/<family>/scripts/gen_rtc_names.py` reads the LUT for one arch, maps each winner back to the name expression its configuration would launch, and emits a header with the registration list. CMake runs it per arch per family through `_rtc_tuned_names()`, with the LUT and the script in `DEPENDS`, so re-measuring a table and rebuilding is the whole update procedure. The two generators are separate scripts because the mapping is per-family; the CMake plumbing is shared, since the matmul_nbits copy would otherwise have been the gqa function with three names changed.

Neither generator carries its own copy of the instantiation set -- both parse the X-macro lists out of the kernel source and intersect. A LUT row that no longer maps to a real instantiation is reported to stderr rather than silently dropped, which is what keeps the tables honest against template changes. gqa currently flags its `hpg == 6` rows, which the dispatch switch has no case for and which therefore could never have been selected; matmul_nbits flags none.

Only the registration side changes; the launch sites are untouched. An instantiation left out resolves to `nullptr`, which is already the signal for `HIPDNN_RTC_LAUNCH` to use its AOT kernel, so the unregistered ones degrade to AOT rather than failing.

An arch with no LUT gets a header that sets no subset, and the registration falls back to the full set.

## Test plan

- [x] **The registered set shrinks to what the LUT can select**, for both families: the generator reports the kept fraction at build time and the runtime logs the resulting kernel count.
- [x] **Generated names match the launch sites character for character**: for gqa the registered string literals and the stringized launch-site ones are extracted from the preprocessed host pass and compared, with zero registered-but-never-launched.
- [x] **Numerically unchanged**: `gqa_check` passes all its launch configurations (data movement, mask, softmax, decode across fp16/int8 x scalar/both WMMA tile sizes x every supported HpG and head dim, prefill v5/v7/v8).
- [x] **No end-to-end regression** on Llama-3.1-8B int4: TTFT and decode throughput are within run-to-run noise of the base branch across four alternating runs of each.
- [x] **Updating a LUT re-derives the set**: deleting the `ND8_MT1_BKV16` rows from the gqa table and rebuilding (without deleting objects) regenerates the header, recompiles the TU, and reports a correspondingly smaller count. Restored afterwards.
- [x] **An arch without a LUT still registers everything**: compiled the no-subset header for `gfx1100` and re-ran the consistency check -- full set registered, zero fallbacks.
- [x] **AOT is untouched**: `.text` byte-identical before and after.

## Notes for reviewers

The unregistered instantiations still compile into the AOT fatbin, so this shrinks hipRTC's work, not the DLL. Dropping them from the AOT build too is a separate change and would need the reachable-but-never-winning ones justified on their own -- gqa's unreachable ones are free either way.

Correctness rests on the runtime staying in lookup mode, where the LUT's fallback tier answers every shape. Online autotune (opt-in via `HIPDNN_GQA_AUTOTUNE_MODE` or `-DHIPDNN_EP_GQA_AUTOTUNE_ONLINE_DEFAULT=1`, and the LUT-miss path for matmul_nbits) benchmarks candidates instead, and any candidate outside the registered set runs its AOT kernel during that search -- correct, but no longer measuring the hipRTC build of it.

The LUTs are per-arch and only `gfx1151` has one today. A package built around one `gfx11-generic` kernel library would need a way to carry several tables, since the binary is shared but the choice of configuration is not.

Four `#if !HIPDNN_GQA_RTC_TUNED_SUBSET` blocks guard gqa's full-registration helpers so they do not warn as unused in a subset build. The alternative -- having the generator emit every instantiation explicitly when no LUT exists -- removes the conditional but also removes the property that a LUT-less arch behaves exactly as it does today.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
