### PR TITLE
feat(runtime): make GQA autotune mode a per-session provider option

### DIFF
--- a/backend-mlir-compiler/custom-op-mlir/src/InferenceState.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/InferenceState.cpp
@@ -54,6 +54,9 @@ void InferenceState::resolveEntryPoints(const LoadedArtifact &artifact) {
   set_output_allocator_fn_ =
       artifact.get_method<void, void *, const output_allocator_t *>(
           hipdnn::abi::kSetOutputAllocator);
+  set_provider_option_fn_ =
+      artifact.get_method<void, void *, const char *, const char *>(
+          hipdnn::abi::kRuntimeSetProviderOption);
   flush_op_profile_fn_ =
       artifact.get_method<void, void *>(hipdnn::abi::kRuntimeFlushOpProfile);
   // Perf-only hook; its name is a plain literal (not an artifact_abi.h
@@ -67,14 +70,16 @@ InferenceState::InferenceState(PrivateTag, void *state,
                                std::unique_ptr<LoadedArtifact> artifact)
     : state_(state), artifact_(std::move(artifact)), compute_fn_(nullptr),
       cleanup_fn_(nullptr), begin_compute_fn_(nullptr),
-      set_output_allocator_fn_(nullptr), flush_op_profile_fn_(nullptr),
-      add_cpu_profile_fn_(nullptr) {
+      set_output_allocator_fn_(nullptr), set_provider_option_fn_(nullptr),
+      flush_op_profile_fn_(nullptr), add_cpu_profile_fn_(nullptr) {
   resolveEntryPoints(*artifact_);
 
   MY_LOG(2) << "begin_compute symbol "
             << (begin_compute_fn_ ? "resolved" : "not exported (no-op)");
   MY_LOG(2) << "set_output_allocator symbol "
             << (set_output_allocator_fn_ ? "resolved" : "not exported (no-op)");
+  MY_LOG(2) << "set_provider_option symbol "
+            << (set_provider_option_fn_ ? "resolved" : "not exported (no-op)");
   MY_LOG(2) << "flush_op_profile symbol "
             << (flush_op_profile_fn_ ? "resolved" : "not exported (no-op)");
   MY_LOG(2) << "add_cpu_profile symbol "
@@ -189,6 +194,13 @@ void InferenceState::set_output_allocator(
   }
   if (state_) {
     set_output_allocator_fn_(state_, allocator);
+  }
+}
+
+void InferenceState::set_provider_option(const char *key,
+                                         const char *value) const {
+  if (set_provider_option_fn_ && state_) {
+    set_provider_option_fn_(state_, key, value);
   }
 }
 

--- a/backend-mlir-compiler/custom-op-mlir/src/InferenceState.h
+++ b/backend-mlir-compiler/custom-op-mlir/src/InferenceState.h
@@ -76,6 +76,11 @@ public:
   // output buffer).
   void set_output_allocator(const output_allocator_t *allocator) const;
 
+  // Copy one session-scoped provider option into the loaded artifact's
+  // RuntimeState. No-op when an older cached artifact does not export the
+  // optional setter.
+  void set_provider_option(const char *key, const char *value) const;
+
   // Invokes the optional `hipdnn_ep_runtime_begin_compute` hook to invalidate
   // per-forward-pass runtime caches (e.g. the GQA seqlens_k cache). create()
   // warns when the symbol is absent.
@@ -141,6 +146,9 @@ private:
   // begin_compute_fn_). Null when the model.dll predates the export.
   using SetOutputAllocatorFn = void (*)(void *, const output_allocator_t *);
   SetOutputAllocatorFn set_output_allocator_fn_;
+
+  using SetProviderOptionFn = void (*)(void *, const char *, const char *);
+  SetProviderOptionFn set_provider_option_fn_;
 
   // Cached function pointer for hipdnn_ep_runtime_flush_op_profile. Same
   // contract as begin_compute_fn_: resolved once at session creation, null

--- a/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
+++ b/backend-mlir-compiler/custom-op-mlir/src/MlirCustomOp.cpp
@@ -664,6 +664,13 @@ MlirCustomOp::MlirCustomOp(
   auto kind = determine_artifact_kind(metadata_.artifact_format());
   inference_state_ =
       customop::InferenceState::create(artifact_bytes, fs.get(), kind);
+
+  // Provider options are enumerable and session-scoped. Copy the complete
+  // effective map into RuntimeState once, after inference_init has created the
+  // state and before the first Compute. Runtime consumers ignore unknown keys,
+  // so adding another runtime option does not require changing this EP bridge.
+  for (const auto &[key, value] : context->get_all_provider_options())
+    inference_state_->set_provider_option(key.c_str(), value.c_str());
 }
 
 MlirCustomOp::~MlirCustomOp() {

--- a/include/hip/artifact_abi.h
+++ b/include/hip/artifact_abi.h
@@ -31,6 +31,10 @@ inline constexpr const char *kSetOutputAllocator =
     "hipdnn_ep_set_output_allocator";
 inline constexpr const char *kRuntimeFlushOpProfile =
     "hipdnn_ep_runtime_flush_op_profile";
+inline constexpr const char *kRuntimeSetProviderOption =
+    "hipdnn_ep_runtime_set_provider_option";
+inline constexpr const char *kRuntimeGetProviderOption =
+    "hipdnn_ep_runtime_get_provider_option";
 
 // Per-op-state-slots C-ABI symbol names (see
 // docs/design/op-state-slots-design.md). kOpStatesInitFn is emitted by

--- a/lib/Compiler/CompilerDriver.cpp
+++ b/lib/Compiler/CompilerDriver.cpp
@@ -190,6 +190,8 @@ bool CompilerDriver::compileImpl(mlir::ModuleOp module,
     //                                          its wall_ms window closes so the
     //                                          resolve cost doesn't pollute
     //                                          TPS)
+    //   hipdnn_ep_runtime_set/get_provider_option
+    //                                       — session-scoped runtime options
     //   hipdnn_ep_runtime_add_cpu_profile    — EP pushes its outer (whole-
     //                                          Compute) steady_clock total into
     //                                          the per-op table + trace for
@@ -207,6 +209,8 @@ bool CompilerDriver::compileImpl(mlir::ModuleOp module,
         hipdnn::abi::kRuntimeBeginCompute,
         hipdnn::abi::kSetOutputAllocator,
         hipdnn::abi::kRuntimeFlushOpProfile,
+        hipdnn::abi::kRuntimeSetProviderOption,
+        hipdnn::abi::kRuntimeGetProviderOption,
         "hipdnn_ep_runtime_add_cpu_profile"};
     std::vector<std::string> libraries;
     std::vector<std::string> library_paths;

--- a/lib/Runtime/Kernels/hip/autotune/gqa/gqa_autotune.cpp
+++ b/lib/Runtime/Kernels/hip/autotune/gqa/gqa_autotune.cpp
@@ -136,9 +136,9 @@ static int currentComputeUnits() {
 
 struct GqaAutotunePolicy {
   GqaAutotuneMode mode = GqaAutotuneMode::Lookup;
-  // A non-empty HIPDNN_GQA_AUTOTUNE_MODE outranks the provider option, even
-  // when its value was invalid and the build default was used instead.
-  bool env_mode_present = false;
+  // Seeded true when HIPDNN_GQA_AUTOTUNE_MODE spoke, which is how it keeps
+  // priority: the question is already answered. See resolve_provider_mode.
+  bool provider_mode_resolved = false;
   // One map, keyed on the packed row key. The tier is part of the key, so the
   // probe order is a loop over four keys rather than a walk over four
   // containers.
@@ -1095,17 +1095,13 @@ static const char *modeName(GqaAutotuneMode mode) {
                                          : "lookup (offline table)";
 }
 
-struct ModeChoice {
-  GqaAutotuneMode mode = kDefaultMode;
-  // Set by any non-empty value, so an invalid one still outranks the provider
-  // option; from_env additionally means the value parsed.
-  bool env_present = false;
-  bool from_env = false;
-};
-
-// Lowercased with whitespace stripped, shared by the environment variable and
-// the provider option so one cannot accept a spelling the other rejects.
-static std::string normalizeMode(const std::string &raw) {
+// Matched case-insensitively and with whitespace stripped. Writes *out only
+// when the value names a mode; an unrecognised one says so rather than quietly
+// leaving the session on the default, since the point of the switch is to
+// compare the two paths. `source` names the lever in that message: both levers
+// share this rule so they cannot drift into accepting different spellings.
+static bool parseMode(const std::string &raw, const char *source,
+                      GqaAutotuneMode *out) {
   std::string mode;
   mode.reserve(raw.size());
   for (const char c : raw) {
@@ -1113,40 +1109,22 @@ static std::string normalizeMode(const std::string &raw) {
       continue;
     mode.push_back(c >= 'A' && c <= 'Z' ? static_cast<char>(c - 'A' + 'a') : c);
   }
-  return mode;
-}
-
-static bool parseMode(const std::string &raw, GqaAutotuneMode *mode) {
-  const std::string normalized = normalizeMode(raw);
-  if (normalized == "lookup") {
-    *mode = GqaAutotuneMode::Lookup;
+  if (mode.empty())
+    return false;
+  if (mode == "lookup") {
+    *out = GqaAutotuneMode::Lookup;
     return true;
   }
-  if (normalized == "online") {
-    *mode = GqaAutotuneMode::Online;
+  if (mode == "online") {
+    *out = GqaAutotuneMode::Online;
     return true;
   }
-  return false;
-}
-
-// Matched case-insensitively and with whitespace stripped, and an unrecognised
-// value says so instead of quietly leaving the session on the default. The
-// point of the switch is to compare the two paths, so silently running the
-// other one is the failure worth a message.
-static ModeChoice chooseMode() {
-  const std::string raw = hipdnn_ep::env_string("HIPDNN_GQA_AUTOTUNE_MODE");
-  if (normalizeMode(raw).empty())
-    return {kDefaultMode, false, false};
-  GqaAutotuneMode mode;
-  if (parseMode(raw, &mode))
-    return {mode, true, true};
   if (gqaLutLogOn())
     fprintf(stderr,
-            "GQA autotune: unrecognised HIPDNN_GQA_AUTOTUNE_MODE=\"%s\" "
-            "(expected \"lookup\" or \"online\"); using the build default, "
-            "%s\n",
-            raw.c_str(), modeName(kDefaultMode));
-  return {kDefaultMode, true, false};
+            "GQA autotune: unrecognised %s=\"%s\" (expected \"lookup\" or "
+            "\"online\"); using the build default, %s\n",
+            source, raw.c_str(), modeName(kDefaultMode));
+  return false;
 }
 
 } // namespace
@@ -1154,9 +1132,13 @@ static ModeChoice chooseMode() {
 void *gqa_autotune_create(morphizen::FileSystem *fs) {
   auto policy = std::make_unique<GqaAutotunePolicy>();
   policy->compute_units = currentComputeUnits();
-  const ModeChoice choice = chooseMode();
-  policy->mode = choice.mode;
-  policy->env_mode_present = choice.env_present;
+  const std::string env_mode = hipdnn_ep::env_string("HIPDNN_GQA_AUTOTUNE_MODE");
+  policy->mode = kDefaultMode;
+  const bool from_env =
+      parseMode(env_mode, "HIPDNN_GQA_AUTOTUNE_MODE", &policy->mode);
+  // A value that failed to parse still counts as the environment having
+  // spoken, so the provider option cannot quietly take over from it.
+  policy->provider_mode_resolved = !env_mode.empty();
   // The table is compiled into runtime.bc (see lib/Runtime/CMakeLists.txt) and
   // travels with the build, so it is available to a JIT'd model with no file on
   // disk and nothing embedded per-model. The EP FileSystem is unused now that
@@ -1186,8 +1168,8 @@ void *gqa_autotune_create(morphizen::FileSystem *fs) {
   // take.
   RUNTIME_DEBUG_LOG("[Runtime DEBUG] GQA autotune mode: %s (from %s)\n",
                     modeName(policy->mode),
-                    choice.from_env ? "HIPDNN_GQA_AUTOTUNE_MODE"
-                                    : "the build default");
+                    from_env ? "HIPDNN_GQA_AUTOTUNE_MODE"
+                             : "the build default");
   return policy.release();
 }
 
@@ -1201,27 +1183,18 @@ GqaAutotuneMode gqa_autotune_mode(const void *policy) {
   return static_cast<const GqaAutotunePolicy *>(policy)->mode;
 }
 
-void gqa_autotune_apply_provider_mode(void *opaque_policy, const char *mode) {
+void gqa_autotune_resolve_provider_mode(void *opaque_policy, const char *mode) {
   auto *policy = static_cast<GqaAutotunePolicy *>(opaque_policy);
-  if (!policy || !mode || policy->env_mode_present)
+  if (!policy || policy->provider_mode_resolved)
     return;
-  const std::string raw(mode);
-  if (normalizeMode(raw).empty())
-    return;
-  GqaAutotuneMode parsed;
-  if (!parseMode(raw, &parsed)) {
-    if (gqaLutLogOn())
-      fprintf(stderr,
-              "GQA autotune: unrecognised provider option "
-              "gqa_autotune_mode=\"%s\" (expected \"lookup\" or \"online\"); "
-              "keeping %s\n",
-              raw.c_str(), modeName(policy->mode));
-    return;
-  }
-  policy->mode = parsed;
-  RUNTIME_DEBUG_LOG("[Runtime DEBUG] GQA autotune mode: %s (from provider "
-                    "option gqa_autotune_mode)\n",
-                    modeName(policy->mode));
+  // Resolved even when nothing was supplied: the flag retires the lookup, it
+  // does not record that a value arrived.
+  policy->provider_mode_resolved = true;
+  if (mode &&
+      parseMode(mode, "provider option gqa_autotune_mode", &policy->mode))
+    RUNTIME_DEBUG_LOG("[Runtime DEBUG] GQA autotune mode: %s (from provider "
+                      "option gqa_autotune_mode)\n",
+                      modeName(policy->mode));
 }
 
 GqaDecodeResult gqa_autotune_resolve_decode(void *opaque_policy,

--- a/lib/Runtime/Kernels/hip/autotune/gqa/gqa_autotune.cpp
+++ b/lib/Runtime/Kernels/hip/autotune/gqa/gqa_autotune.cpp
@@ -136,6 +136,9 @@ static int currentComputeUnits() {
 
 struct GqaAutotunePolicy {
   GqaAutotuneMode mode = GqaAutotuneMode::Lookup;
+  // A non-empty HIPDNN_GQA_AUTOTUNE_MODE outranks the provider option, even
+  // when its value was invalid and the build default was used instead.
+  bool env_mode_present = false;
   // One map, keyed on the packed row key. The tier is part of the key, so the
   // probe order is a loop over four keys rather than a walk over four
   // containers.
@@ -1094,15 +1097,15 @@ static const char *modeName(GqaAutotuneMode mode) {
 
 struct ModeChoice {
   GqaAutotuneMode mode = kDefaultMode;
+  // Set by any non-empty value, so an invalid one still outranks the provider
+  // option; from_env additionally means the value parsed.
+  bool env_present = false;
   bool from_env = false;
 };
 
-// Matched case-insensitively and with whitespace stripped, and an unrecognised
-// value says so instead of quietly leaving the session on the default. The
-// point of the switch is to compare the two paths, so silently running the
-// other one is the failure worth a message.
-static ModeChoice chooseMode() {
-  const std::string raw = hipdnn_ep::env_string("HIPDNN_GQA_AUTOTUNE_MODE");
+// Lowercased with whitespace stripped, shared by the environment variable and
+// the provider option so one cannot accept a spelling the other rejects.
+static std::string normalizeMode(const std::string &raw) {
   std::string mode;
   mode.reserve(raw.size());
   for (const char c : raw) {
@@ -1110,19 +1113,40 @@ static ModeChoice chooseMode() {
       continue;
     mode.push_back(c >= 'A' && c <= 'Z' ? static_cast<char>(c - 'A' + 'a') : c);
   }
-  if (mode.empty())
-    return {kDefaultMode, false};
-  if (mode == "lookup")
-    return {GqaAutotuneMode::Lookup, true};
-  if (mode == "online")
-    return {GqaAutotuneMode::Online, true};
+  return mode;
+}
+
+static bool parseMode(const std::string &raw, GqaAutotuneMode *mode) {
+  const std::string normalized = normalizeMode(raw);
+  if (normalized == "lookup") {
+    *mode = GqaAutotuneMode::Lookup;
+    return true;
+  }
+  if (normalized == "online") {
+    *mode = GqaAutotuneMode::Online;
+    return true;
+  }
+  return false;
+}
+
+// Matched case-insensitively and with whitespace stripped, and an unrecognised
+// value says so instead of quietly leaving the session on the default. The
+// point of the switch is to compare the two paths, so silently running the
+// other one is the failure worth a message.
+static ModeChoice chooseMode() {
+  const std::string raw = hipdnn_ep::env_string("HIPDNN_GQA_AUTOTUNE_MODE");
+  if (normalizeMode(raw).empty())
+    return {kDefaultMode, false, false};
+  GqaAutotuneMode mode;
+  if (parseMode(raw, &mode))
+    return {mode, true, true};
   if (gqaLutLogOn())
     fprintf(stderr,
             "GQA autotune: unrecognised HIPDNN_GQA_AUTOTUNE_MODE=\"%s\" "
             "(expected \"lookup\" or \"online\"); using the build default, "
             "%s\n",
             raw.c_str(), modeName(kDefaultMode));
-  return {kDefaultMode, false};
+  return {kDefaultMode, true, false};
 }
 
 } // namespace
@@ -1132,6 +1156,7 @@ void *gqa_autotune_create(morphizen::FileSystem *fs) {
   policy->compute_units = currentComputeUnits();
   const ModeChoice choice = chooseMode();
   policy->mode = choice.mode;
+  policy->env_mode_present = choice.env_present;
   // The table is compiled into runtime.bc (see lib/Runtime/CMakeLists.txt) and
   // travels with the build, so it is available to a JIT'd model with no file on
   // disk and nothing embedded per-model. The EP FileSystem is unused now that
@@ -1174,6 +1199,29 @@ GqaAutotuneMode gqa_autotune_mode(const void *policy) {
   if (!policy)
     return GqaAutotuneMode::Lookup;
   return static_cast<const GqaAutotunePolicy *>(policy)->mode;
+}
+
+void gqa_autotune_apply_provider_mode(void *opaque_policy, const char *mode) {
+  auto *policy = static_cast<GqaAutotunePolicy *>(opaque_policy);
+  if (!policy || !mode || policy->env_mode_present)
+    return;
+  const std::string raw(mode);
+  if (normalizeMode(raw).empty())
+    return;
+  GqaAutotuneMode parsed;
+  if (!parseMode(raw, &parsed)) {
+    if (gqaLutLogOn())
+      fprintf(stderr,
+              "GQA autotune: unrecognised provider option "
+              "gqa_autotune_mode=\"%s\" (expected \"lookup\" or \"online\"); "
+              "keeping %s\n",
+              raw.c_str(), modeName(policy->mode));
+    return;
+  }
+  policy->mode = parsed;
+  RUNTIME_DEBUG_LOG("[Runtime DEBUG] GQA autotune mode: %s (from provider "
+                    "option gqa_autotune_mode)\n",
+                    modeName(policy->mode));
 }
 
 GqaDecodeResult gqa_autotune_resolve_decode(void *opaque_policy,

--- a/lib/Runtime/Kernels/hip/autotune/gqa/gqa_autotune.cpp
+++ b/lib/Runtime/Kernels/hip/autotune/gqa/gqa_autotune.cpp
@@ -136,9 +136,13 @@ static int currentComputeUnits() {
 
 struct GqaAutotunePolicy {
   GqaAutotuneMode mode = GqaAutotuneMode::Lookup;
-  // Seeded true when HIPDNN_GQA_AUTOTUNE_MODE spoke, which is how it keeps
-  // priority: the question is already answered. See resolve_provider_mode.
-  bool provider_mode_resolved = false;
+  // Set once the mode is settled. Seeded true when HIPDNN_GQA_AUTOTUNE_MODE was
+  // non-empty at create() time, including when its value was unrecognised,
+  // which is how the env var keeps highest priority; otherwise set by the first
+  // gqa_autotune_apply_provider_mode call. Callers sit on the decode path and
+  // apply on every read, so this is also what stops the re-parsing and the
+  // repeated logging.
+  bool mode_settled = false;
   // One map, keyed on the packed row key. The tier is part of the key, so the
   // probe order is a loop over four keys rather than a walk over four
   // containers.
@@ -1095,13 +1099,19 @@ static const char *modeName(GqaAutotuneMode mode) {
                                          : "lookup (offline table)";
 }
 
-// Matched case-insensitively and with whitespace stripped. Writes *out only
-// when the value names a mode; an unrecognised one says so rather than quietly
-// leaving the session on the default, since the point of the switch is to
-// compare the two paths. `source` names the lever in that message: both levers
-// share this rule so they cannot drift into accepting different spellings.
-static bool parseMode(const std::string &raw, const char *source,
-                      GqaAutotuneMode *out) {
+struct ModeChoice {
+  GqaAutotuneMode mode = kDefaultMode;
+  // The value parsed, so the mode really came from the variable. This is what
+  // the create() log reports as the source.
+  bool from_env = false;
+  // The variable was set at all, parsed or not. This is what decides whether
+  // the provider option gets a turn.
+  bool env_present = false;
+};
+
+// Lowercased with whitespace stripped. Both levers go through this and
+// matchMode below, so they cannot drift into accepting different spellings.
+static std::string normalizedMode(const std::string &raw) {
   std::string mode;
   mode.reserve(raw.size());
   for (const char c : raw) {
@@ -1109,22 +1119,44 @@ static bool parseMode(const std::string &raw, const char *source,
       continue;
     mode.push_back(c >= 'A' && c <= 'Z' ? static_cast<char>(c - 'A' + 'a') : c);
   }
-  if (mode.empty())
-    return false;
-  if (mode == "lookup") {
+  return mode;
+}
+
+static bool matchMode(const std::string &normalized, GqaAutotuneMode *out) {
+  if (normalized == "lookup") {
     *out = GqaAutotuneMode::Lookup;
     return true;
   }
-  if (mode == "online") {
+  if (normalized == "online") {
     *out = GqaAutotuneMode::Online;
     return true;
   }
+  return false;
+}
+
+// Matched case-insensitively and with whitespace stripped, and an unrecognised
+// value says so instead of quietly leaving the session on the default. The
+// point of the switch is to compare the two paths, so silently running the
+// other one is the failure worth a message.
+static ModeChoice chooseMode() {
+  const std::string raw = hipdnn_ep::env_string("HIPDNN_GQA_AUTOTUNE_MODE");
+  const std::string normalized = normalizedMode(raw);
+  if (normalized.empty())
+    return {kDefaultMode, false, false};
+  GqaAutotuneMode mode = kDefaultMode;
+  if (matchMode(normalized, &mode))
+    return {mode, true, true};
   if (gqaLutLogOn())
     fprintf(stderr,
-            "GQA autotune: unrecognised %s=\"%s\" (expected \"lookup\" or "
-            "\"online\"); using the build default, %s\n",
-            source, raw.c_str(), modeName(kDefaultMode));
-  return false;
+            "GQA autotune: unrecognised HIPDNN_GQA_AUTOTUNE_MODE=\"%s\" "
+            "(expected \"lookup\" or \"online\"); using the build default, "
+            "%s\n",
+            raw.c_str(), modeName(kDefaultMode));
+  // A non-empty but unrecognised value still counts as the env var having
+  // spoken, so the provider option cannot silently override the fallback. It
+  // did not decide the mode, though, so from_env stays false and the log below
+  // still names the build default.
+  return {kDefaultMode, false, true};
 }
 
 } // namespace
@@ -1132,13 +1164,9 @@ static bool parseMode(const std::string &raw, const char *source,
 void *gqa_autotune_create(morphizen::FileSystem *fs) {
   auto policy = std::make_unique<GqaAutotunePolicy>();
   policy->compute_units = currentComputeUnits();
-  const std::string env_mode = hipdnn_ep::env_string("HIPDNN_GQA_AUTOTUNE_MODE");
-  policy->mode = kDefaultMode;
-  const bool from_env =
-      parseMode(env_mode, "HIPDNN_GQA_AUTOTUNE_MODE", &policy->mode);
-  // A value that failed to parse still counts as the environment having
-  // spoken, so the provider option cannot quietly take over from it.
-  policy->provider_mode_resolved = !env_mode.empty();
+  const ModeChoice choice = chooseMode();
+  policy->mode = choice.mode;
+  policy->mode_settled = choice.env_present;
   // The table is compiled into runtime.bc (see lib/Runtime/CMakeLists.txt) and
   // travels with the build, so it is available to a JIT'd model with no file on
   // disk and nothing embedded per-model. The EP FileSystem is unused now that
@@ -1168,8 +1196,8 @@ void *gqa_autotune_create(morphizen::FileSystem *fs) {
   // take.
   RUNTIME_DEBUG_LOG("[Runtime DEBUG] GQA autotune mode: %s (from %s)\n",
                     modeName(policy->mode),
-                    from_env ? "HIPDNN_GQA_AUTOTUNE_MODE"
-                             : "the build default");
+                    choice.from_env ? "HIPDNN_GQA_AUTOTUNE_MODE"
+                                    : "the build default");
   return policy.release();
 }
 
@@ -1183,18 +1211,30 @@ GqaAutotuneMode gqa_autotune_mode(const void *policy) {
   return static_cast<const GqaAutotunePolicy *>(policy)->mode;
 }
 
-void gqa_autotune_resolve_provider_mode(void *opaque_policy, const char *mode) {
+void gqa_autotune_apply_provider_mode(void *opaque_policy, const char *mode) {
   auto *policy = static_cast<GqaAutotunePolicy *>(opaque_policy);
-  if (!policy || policy->provider_mode_resolved)
+  if (!policy || policy->mode_settled)
     return;
-  // Resolved even when nothing was supplied: the flag retires the lookup, it
-  // does not record that a value arrived.
-  policy->provider_mode_resolved = true;
-  if (mode &&
-      parseMode(mode, "provider option gqa_autotune_mode", &policy->mode))
-    RUNTIME_DEBUG_LOG("[Runtime DEBUG] GQA autotune mode: %s (from provider "
-                      "option gqa_autotune_mode)\n",
-                      modeName(policy->mode));
+  // Settled even when nothing was supplied: the flag retires the parse and the
+  // log, it does not record that a value arrived.
+  policy->mode_settled = true;
+  const std::string normalized = normalizedMode(mode ? mode : "");
+  if (normalized.empty())
+    return;
+  GqaAutotuneMode parsed = kDefaultMode;
+  if (!matchMode(normalized, &parsed)) {
+    if (gqaLutLogOn())
+      fprintf(stderr,
+              "GQA autotune: unrecognised provider option "
+              "gqa_autotune_mode=\"%s\" (expected \"lookup\" or \"online\"); "
+              "using the build default, %s\n",
+              mode, modeName(kDefaultMode));
+    return;
+  }
+  policy->mode = parsed;
+  RUNTIME_DEBUG_LOG("[Runtime DEBUG] GQA autotune mode: %s (from provider "
+                    "option gqa_autotune_mode)\n",
+                    modeName(policy->mode));
 }
 
 GqaDecodeResult gqa_autotune_resolve_decode(void *opaque_policy,

--- a/lib/Runtime/Kernels/hip/autotune/gqa/gqa_autotune.cpp
+++ b/lib/Runtime/Kernels/hip/autotune/gqa/gqa_autotune.cpp
@@ -136,13 +136,13 @@ static int currentComputeUnits() {
 
 struct GqaAutotunePolicy {
   GqaAutotuneMode mode = GqaAutotuneMode::Lookup;
-  // Set once the mode is settled. Seeded true when HIPDNN_GQA_AUTOTUNE_MODE was
-  // non-empty at create() time, including when its value was unrecognised,
-  // which is how the env var keeps highest priority; otherwise set by the first
-  // gqa_autotune_apply_provider_mode call. Callers sit on the decode path and
-  // apply on every read, so this is also what stops the re-parsing and the
-  // repeated logging.
-  bool mode_settled = false;
+  // The mode is not decided at create() time: the provider option reaches the
+  // state after inference_init, so deciding early would mean deciding on a
+  // subset of the levers and then revising -- which is what used to leave the
+  // create()-time diagnostics reporting a mode the session did not run. It is
+  // decided on the first read instead, from every lever at once, and this flag
+  // is what keeps that read idempotent and its logging to one line.
+  bool mode_resolved = false;
   // One map, keyed on the packed row key. The tier is part of the key, so the
   // probe order is a loop over four keys rather than a walk over four
   // containers.
@@ -1101,12 +1101,8 @@ static const char *modeName(GqaAutotuneMode mode) {
 
 struct ModeChoice {
   GqaAutotuneMode mode = kDefaultMode;
-  // The value parsed, so the mode really came from the variable. This is what
-  // the create() log reports as the source.
-  bool from_env = false;
-  // The variable was set at all, parsed or not. This is what decides whether
-  // the provider option gets a turn.
-  bool env_present = false;
+  // Which lever decided it, for the log. Nothing else needs to know.
+  const char *source = "the build default";
 };
 
 // Lowercased with whitespace stripped. Both levers go through this and
@@ -1134,29 +1130,43 @@ static bool matchMode(const std::string &normalized, GqaAutotuneMode *out) {
   return false;
 }
 
-// Matched case-insensitively and with whitespace stripped, and an unrecognised
-// value says so instead of quietly leaving the session on the default. The
-// point of the switch is to compare the two paths, so silently running the
-// other one is the failure worth a message.
-static ModeChoice chooseMode() {
-  const std::string raw = hipdnn_ep::env_string("HIPDNN_GQA_AUTOTUNE_MODE");
-  const std::string normalized = normalizedMode(raw);
-  if (normalized.empty())
-    return {kDefaultMode, false, false};
-  GqaAutotuneMode mode = kDefaultMode;
-  if (matchMode(normalized, &mode))
-    return {mode, true, true};
-  if (gqaLutLogOn())
-    fprintf(stderr,
-            "GQA autotune: unrecognised HIPDNN_GQA_AUTOTUNE_MODE=\"%s\" "
-            "(expected \"lookup\" or \"online\"); using the build default, "
-            "%s\n",
-            raw.c_str(), modeName(kDefaultMode));
-  // A non-empty but unrecognised value still counts as the env var having
-  // spoken, so the provider option cannot silently override the fallback. It
-  // did not decide the mode, though, so from_env stays false and the log below
-  // still names the build default.
-  return {kDefaultMode, false, true};
+// Every lever, weighed in one pass. Both are matched case-insensitively and
+// with whitespace stripped, and an unrecognised value says so instead of
+// quietly leaving the session on the default -- the point of the switch is to
+// compare the two paths, so silently running the other one is the failure
+// worth a message.
+//
+// HIPDNN_GQA_AUTOTUNE_MODE outranks the provider option, and a non-empty but
+// unrecognised value still counts as the variable having spoken: a global
+// debugging override that was typed wrong should fall back to the documented
+// default rather than hand the session to a provider option the caller may not
+// know is set.
+static ModeChoice chooseMode(const char *provider_mode) {
+  struct Lever {
+    const char *name;
+    std::string value;
+  };
+  const Lever levers[] = {
+      {"HIPDNN_GQA_AUTOTUNE_MODE",
+       hipdnn_ep::env_string("HIPDNN_GQA_AUTOTUNE_MODE")},
+      {"provider option gqa_autotune_mode",
+       provider_mode ? std::string(provider_mode) : std::string()},
+  };
+  for (const Lever &lever : levers) {
+    const std::string normalized = normalizedMode(lever.value);
+    if (normalized.empty())
+      continue;
+    GqaAutotuneMode mode = kDefaultMode;
+    if (matchMode(normalized, &mode))
+      return {mode, lever.name};
+    if (gqaLutLogOn())
+      fprintf(stderr,
+              "GQA autotune: unrecognised %s=\"%s\" (expected \"lookup\" or "
+              "\"online\"); using the build default, %s\n",
+              lever.name, lever.value.c_str(), modeName(kDefaultMode));
+    break;
+  }
+  return {kDefaultMode, "the build default"};
 }
 
 } // namespace
@@ -1164,9 +1174,6 @@ static ModeChoice chooseMode() {
 void *gqa_autotune_create(morphizen::FileSystem *fs) {
   auto policy = std::make_unique<GqaAutotunePolicy>();
   policy->compute_units = currentComputeUnits();
-  const ModeChoice choice = chooseMode();
-  policy->mode = choice.mode;
-  policy->mode_settled = choice.env_present;
   // The table is compiled into runtime.bc (see lib/Runtime/CMakeLists.txt) and
   // travels with the build, so it is available to a JIT'd model with no file on
   // disk and nothing embedded per-model. The EP FileSystem is unused now that
@@ -1174,30 +1181,15 @@ void *gqa_autotune_create(morphizen::FileSystem *fs) {
   // SUMMARY log below report a shipped table honestly.
   (void)fs;
   loadLutFromEmbedded(*policy);
+  // Only the table is reported here. Everything that depends on the mode waits
+  // for gqa_autotune_resolve_mode, which is the first point that knows it.
   if (gqaLutLogOn())
-    fprintf(stderr,
-            "[gqa-lut] SUMMARY mode=%s table_id=%u rows=%zu invalid=%zu => %s\n",
-            modeName(policy->mode), policy->table_id, policy->rows.size(),
+    fprintf(stderr, "[gqa-lut] SUMMARY table_id=%u rows=%zu invalid=%zu => %s\n",
+            policy->table_id, policy->rows.size(),
             static_cast<size_t>(
                 policy->invalid_entries.load(std::memory_order_relaxed)),
             policy->table_id ? "TABLE (LUT active)"
                              : "HEURISTIC (no usable table loaded)");
-  // LUT load failure in lookup mode: the embedded table was rejected (arch /
-  // schema mismatch, corrupt data). Warn unconditionally so the degradation is
-  // always visible regardless of the log env var.
-  if (policy->mode == GqaAutotuneMode::Lookup && policy->table_id == 0)
-    fprintf(stderr,
-            "GQA autotune: LUT load failed -- falling back to compiled "
-            "heuristic (GQA perf will be suboptimal). Set "
-            "HIPDNN_EP_GQA_LOG_CONFIG=1 for details.\n");
-  // Says where the mode came from, not just what it is: on a build whose
-  // default was flipped there is no environment variable to inspect, so the log
-  // is the only way to tell a deliberate default from an override that did not
-  // take.
-  RUNTIME_DEBUG_LOG("[Runtime DEBUG] GQA autotune mode: %s (from %s)\n",
-                    modeName(policy->mode),
-                    choice.from_env ? "HIPDNN_GQA_AUTOTUNE_MODE"
-                                    : "the build default");
   return policy.release();
 }
 
@@ -1211,30 +1203,37 @@ GqaAutotuneMode gqa_autotune_mode(const void *policy) {
   return static_cast<const GqaAutotunePolicy *>(policy)->mode;
 }
 
-void gqa_autotune_apply_provider_mode(void *opaque_policy, const char *mode) {
+GqaAutotuneMode gqa_autotune_resolve_mode(void *opaque_policy,
+                                          const char *provider_mode) {
   auto *policy = static_cast<GqaAutotunePolicy *>(opaque_policy);
-  if (!policy || policy->mode_settled)
-    return;
-  // Settled even when nothing was supplied: the flag retires the parse and the
-  // log, it does not record that a value arrived.
-  policy->mode_settled = true;
-  const std::string normalized = normalizedMode(mode ? mode : "");
-  if (normalized.empty())
-    return;
-  GqaAutotuneMode parsed = kDefaultMode;
-  if (!matchMode(normalized, &parsed)) {
-    if (gqaLutLogOn())
-      fprintf(stderr,
-              "GQA autotune: unrecognised provider option "
-              "gqa_autotune_mode=\"%s\" (expected \"lookup\" or \"online\"); "
-              "using the build default, %s\n",
-              mode, modeName(kDefaultMode));
-    return;
-  }
-  policy->mode = parsed;
-  RUNTIME_DEBUG_LOG("[Runtime DEBUG] GQA autotune mode: %s (from provider "
-                    "option gqa_autotune_mode)\n",
-                    modeName(policy->mode));
+  if (!policy)
+    return GqaAutotuneMode::Lookup;
+  if (policy->mode_resolved)
+    return policy->mode;
+
+  const ModeChoice choice = chooseMode(provider_mode);
+  policy->mode = choice.mode;
+  policy->mode_resolved = true;
+
+  // Both of these used to run in gqa_autotune_create(). Once the provider
+  // option joined the decision that became too early: they described a mode the
+  // session might not run. They belong wherever the mode is settled.
+  //
+  // LUT load failure in lookup mode: the embedded table was rejected (arch /
+  // schema mismatch, corrupt data). Warn unconditionally so the degradation is
+  // always visible regardless of the log env var.
+  if (policy->mode == GqaAutotuneMode::Lookup && policy->table_id == 0)
+    fprintf(stderr,
+            "GQA autotune: LUT load failed -- falling back to compiled "
+            "heuristic (GQA perf will be suboptimal). Set "
+            "HIPDNN_EP_GQA_LOG_CONFIG=1 for details.\n");
+  // Says where the mode came from, not just what it is: on a build whose
+  // default was flipped there is no environment variable to inspect, so the log
+  // is the only way to tell a deliberate default from an override that did not
+  // take.
+  RUNTIME_DEBUG_LOG("[Runtime DEBUG] GQA autotune mode: %s (from %s)\n",
+                    modeName(policy->mode), choice.source);
+  return policy->mode;
 }
 
 GqaDecodeResult gqa_autotune_resolve_decode(void *opaque_policy,

--- a/lib/Runtime/Kernels/hip/autotune/gqa/gqa_autotune.h
+++ b/lib/Runtime/Kernels/hip/autotune/gqa/gqa_autotune.h
@@ -131,11 +131,11 @@ void gqa_autotune_destroy(void *policy);
 
 GqaAutotuneMode gqa_autotune_mode(const void *policy);
 
-// Apply the session's gqa_autotune_mode provider option.
-// HIPDNN_GQA_AUTOTUNE_MODE has higher priority, so this is a no-op when that
-// variable was set. `mode` is parsed into the typed policy during the call and
-// is never retained.
-void gqa_autotune_apply_provider_mode(void *policy, const char *mode);
+// Resolve the session's gqa_autotune_mode provider option. `mode` is the raw
+// value, or null when none was supplied. Runs once per policy and is a no-op
+// afterwards, so callers may invoke it on every read; HIPDNN_GQA_AUTOTUNE_MODE
+// outranks it. Parsed during the call, never retained.
+void gqa_autotune_resolve_provider_mode(void *policy, const char *mode);
 
 GqaDecodeResult gqa_autotune_resolve_decode(void *policy,
                                             const GqaDecodeRequest &request);

--- a/lib/Runtime/Kernels/hip/autotune/gqa/gqa_autotune.h
+++ b/lib/Runtime/Kernels/hip/autotune/gqa/gqa_autotune.h
@@ -130,6 +130,13 @@ void *gqa_autotune_create(morphizen::FileSystem *fs);
 void gqa_autotune_destroy(void *policy);
 
 GqaAutotuneMode gqa_autotune_mode(const void *policy);
+
+// Apply the session's gqa_autotune_mode provider option.
+// HIPDNN_GQA_AUTOTUNE_MODE has higher priority, so this is a no-op when that
+// variable was set. `mode` is parsed into the typed policy during the call and
+// is never retained.
+void gqa_autotune_apply_provider_mode(void *policy, const char *mode);
+
 GqaDecodeResult gqa_autotune_resolve_decode(void *policy,
                                             const GqaDecodeRequest &request);
 GqaPrefillResult gqa_autotune_resolve_prefill(void *policy,

--- a/lib/Runtime/Kernels/hip/autotune/gqa/gqa_autotune.h
+++ b/lib/Runtime/Kernels/hip/autotune/gqa/gqa_autotune.h
@@ -129,14 +129,21 @@ struct GqaPrefillResult {
 void *gqa_autotune_create(morphizen::FileSystem *fs);
 void gqa_autotune_destroy(void *policy);
 
+// The mode the policy settled on, or Lookup before anything resolved it. This
+// only reports the answer; gqa_autotune_resolve_mode asks the question.
 GqaAutotuneMode gqa_autotune_mode(const void *policy);
 
-// Apply the session's gqa_autotune_mode provider option. `mode` may be null
-// when none was supplied. No-op when HIPDNN_GQA_AUTOTUNE_MODE was set (env
-// keeps highest priority, including when its value was unrecognised), and a
-// no-op after the first call, so a caller on the decode path may apply on
-// every read. The string is parsed during this call and never retained.
-void gqa_autotune_apply_provider_mode(void *policy, const char *mode);
+// Decide the session's mode and return it. `provider_mode` is the raw
+// gqa_autotune_mode provider option, or null when none was supplied; it is
+// weighed against HIPDNN_GQA_AUTOTUNE_MODE and the build default in one pass.
+//
+// gqa_autotune_create() cannot do this, because the provider option only
+// reaches the runtime after inference_init. The decision therefore waits for
+// the first read and runs once per policy; later calls return the settled mode,
+// which is what lets a caller on the decode path ask on every read. The string
+// is parsed during the call and never retained.
+GqaAutotuneMode gqa_autotune_resolve_mode(void *policy,
+                                          const char *provider_mode);
 
 GqaDecodeResult gqa_autotune_resolve_decode(void *policy,
                                             const GqaDecodeRequest &request);

--- a/lib/Runtime/Kernels/hip/autotune/gqa/gqa_autotune.h
+++ b/lib/Runtime/Kernels/hip/autotune/gqa/gqa_autotune.h
@@ -131,11 +131,12 @@ void gqa_autotune_destroy(void *policy);
 
 GqaAutotuneMode gqa_autotune_mode(const void *policy);
 
-// Resolve the session's gqa_autotune_mode provider option. `mode` is the raw
-// value, or null when none was supplied. Runs once per policy and is a no-op
-// afterwards, so callers may invoke it on every read; HIPDNN_GQA_AUTOTUNE_MODE
-// outranks it. Parsed during the call, never retained.
-void gqa_autotune_resolve_provider_mode(void *policy, const char *mode);
+// Apply the session's gqa_autotune_mode provider option. `mode` may be null
+// when none was supplied. No-op when HIPDNN_GQA_AUTOTUNE_MODE was set (env
+// keeps highest priority, including when its value was unrecognised), and a
+// no-op after the first call, so a caller on the decode path may apply on
+// every read. The string is parsed during this call and never retained.
+void gqa_autotune_apply_provider_mode(void *policy, const char *mode);
 
 GqaDecodeResult gqa_autotune_resolve_decode(void *policy,
                                             const GqaDecodeRequest &request);

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -220,6 +220,23 @@ HIPDNN_EP_RT_EXPORT void
 hipdnn_ep_set_output_allocator(RuntimeState *state,
                                const hipdnn_output_allocator_t *allocator);
 
+// Copy one session-scoped EP provider option into RuntimeState. The EP calls
+// this after inference_init and before the first inference_compute for every
+// entry returned by PassContext::get_all_provider_options(). Unknown keys are
+// retained for future runtime consumers. Passing value=nullptr erases a key.
+//
+// Backwards compatibility: the EP resolves this symbol optionally. A cached
+// artifact predating this export continues to use environment variables and
+// build defaults.
+HIPDNN_EP_RT_EXPORT void
+hipdnn_ep_runtime_set_provider_option(RuntimeState *state, const char *key,
+                                      const char *value);
+
+// Return a borrowed pointer to a copied provider-option value, or nullptr when
+// absent. Valid until that key is changed or RuntimeState is destroyed.
+HIPDNN_EP_RT_EXPORT const char *
+hipdnn_ep_runtime_get_provider_option(RuntimeState *state, const char *key);
+
 // generated main_graph -> runtime (internal), forwards to the installed
 // callback. Returns a generic address-space-0 device pointer (the lowering
 // casts to the memref's address space). Returns null if none is installed.

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -900,12 +900,6 @@ hipdnn_ep_runtime_set_provider_option(RuntimeState *state, const char *key,
     state->provider_options = options;
   }
   (*options)[key] = value;
-
-#if defined(HIPDNN_EP_REAL_RUNTIME)
-  if (std::strcmp(key, "gqa_autotune_mode") == 0)
-    hipdnn_ep::gqa_autotune_apply_provider_mode(state->gqa_autotune_policy,
-                                                value);
-#endif
 }
 
 extern "C" HIPDNN_EP_RT_EXPORT const char *

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -19,6 +19,12 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <string>
+#include <unordered_map>
+
+namespace {
+using ProviderOptions = std::unordered_map<std::string, std::string>;
+}
 
 // Forward decl of static helpers defined later in this file.
 static int initialize_state_handles(RuntimeState **out_state);
@@ -183,6 +189,7 @@ static int initialize_state_handles(RuntimeState **out_state) {
   state->zp_unpack_cache = nullptr;
   state->op_profile = hipdnn_ep_perf_enabled() ? op_profile_create() : nullptr;
   state->gqa_autotune_policy = nullptr;
+  state->provider_options = nullptr;
   state->device_error_flag = nullptr;
   state->hipdnn_handle = nullptr;
   state->hipdnn_graph_registry = nullptr;
@@ -828,6 +835,9 @@ int hipdnn_ep_state_cleanup(RuntimeState *state) {
     state->op_profile = nullptr;
   }
 
+  delete static_cast<ProviderOptions *>(state->provider_options);
+  state->provider_options = nullptr;
+
   // Destroy hipBLASLt handle
   if (state->hipblas_handle) {
     hipblasLtDestroy(state->hipblas_handle);
@@ -870,6 +880,42 @@ void *hipdnn_ep_state_get_hipblas_handle(RuntimeState *state) {
 
 void *hipdnn_ep_state_get_op_profile(RuntimeState *state) {
   return state ? state->op_profile : nullptr;
+}
+
+extern "C" HIPDNN_EP_RT_EXPORT void
+hipdnn_ep_runtime_set_provider_option(RuntimeState *state, const char *key,
+                                      const char *value) {
+  if (!state || !key)
+    return;
+
+  auto *options = static_cast<ProviderOptions *>(state->provider_options);
+  if (!value) {
+    if (options)
+      options->erase(key);
+    return;
+  }
+
+  if (!options) {
+    options = new ProviderOptions();
+    state->provider_options = options;
+  }
+  (*options)[key] = value;
+
+#if defined(HIPDNN_EP_REAL_RUNTIME)
+  if (std::strcmp(key, "gqa_autotune_mode") == 0)
+    hipdnn_ep::gqa_autotune_apply_provider_mode(state->gqa_autotune_policy,
+                                                value);
+#endif
+}
+
+extern "C" HIPDNN_EP_RT_EXPORT const char *
+hipdnn_ep_runtime_get_provider_option(RuntimeState *state, const char *key) {
+  if (!state || !key || !state->provider_options)
+    return nullptr;
+  const auto *options =
+      static_cast<const ProviderOptions *>(state->provider_options);
+  const auto it = options->find(key);
+  return it == options->end() ? nullptr : it->second.c_str();
 }
 
 // Per-Compute() cache invalidation hook. Today this only resets the GQA

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -85,6 +85,17 @@
 // Dispatch helpers (shared by the fused and decomposed paths)
 //===----------------------------------------------------------------------===//
 
+// The session's effective mode. The provider option only reaches the state
+// after gqa_autotune_create() has run, so the first GQA call of the session
+// resolves it; resolve is a no-op from then on.
+static hipdnn_ep::GqaAutotuneMode gqa_autotune_mode(RuntimeState *state) {
+  void *policy = state->gqa_autotune_policy;
+  hipdnn_ep::gqa_autotune_resolve_provider_mode(
+      policy,
+      hipdnn_ep_runtime_get_provider_option(state, "gqa_autotune_mode"));
+  return hipdnn_ep::gqa_autotune_mode(policy);
+}
+
 // Env-var gate to cache seqlens_k_val across the GQA layers in a single
 // forward pass. Default ON. Caching skips the per-layer
 // hipMemcpyAsync(D2H) + hipStreamSynchronize on both paths after the first
@@ -495,8 +506,7 @@ static int gqa_forward_fused(
       // scan and therefore the split count that wins.
       const int kv_dtype = kv_dtype_abi(kv_format);
       int drc;
-      if (hipdnn_ep::gqa_autotune_mode(state->gqa_autotune_policy) ==
-          hipdnn_ep::GqaAutotuneMode::Online) {
+      if (gqa_autotune_mode(state) == hipdnn_ep::GqaAutotuneMode::Online) {
         drc = hip_gqa_flash_decode(
             stream, qSrc, present_key, present_value, output, partials,
             static_cast<int>(B), static_cast<int>(H), static_cast<int>(G),
@@ -717,8 +727,7 @@ static int gqa_forward_fused(
   }
 
   int fp_rc;
-  if (hipdnn_ep::gqa_autotune_mode(state->gqa_autotune_policy) ==
-      hipdnn_ep::GqaAutotuneMode::Online) {
+  if (gqa_autotune_mode(state) == hipdnn_ep::GqaAutotuneMode::Online) {
     fp_rc = hip_gqa_flash_prefill(
         stream, qSrc, kAttn, vAttn, output, static_cast<int>(B),
         static_cast<int>(H), static_cast<int>(G), static_cast<int>(sq),

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -85,17 +85,6 @@
 // Dispatch helpers (shared by the fused and decomposed paths)
 //===----------------------------------------------------------------------===//
 
-// The session's effective mode. The provider option only reaches the state
-// after gqa_autotune_create() has run, so the first GQA call of the session
-// resolves it; resolve is a no-op from then on.
-static hipdnn_ep::GqaAutotuneMode gqa_autotune_mode(RuntimeState *state) {
-  void *policy = state->gqa_autotune_policy;
-  hipdnn_ep::gqa_autotune_resolve_provider_mode(
-      policy,
-      hipdnn_ep_runtime_get_provider_option(state, "gqa_autotune_mode"));
-  return hipdnn_ep::gqa_autotune_mode(policy);
-}
-
 // Env-var gate to cache seqlens_k_val across the GQA layers in a single
 // forward pass. Default ON. Caching skips the per-layer
 // hipMemcpyAsync(D2H) + hipStreamSynchronize on both paths after the first
@@ -344,6 +333,13 @@ static int gqa_forward_fused(
     const void *head_sink = nullptr, bool use_smooth_softmax = false,
     int local_window_size = -1) {
 
+  // The provider option only reaches the state after gqa_autotune_create() has
+  // run, so it is applied here, ahead of the decode and prefill mode reads
+  // below. Settles on the first call and is a no-op afterwards.
+  hipdnn_ep::gqa_autotune_apply_provider_mode(
+      state->gqa_autotune_policy,
+      hipdnn_ep_runtime_get_provider_option(state, "gqa_autotune_mode"));
+
   // Any non-fp16 cache reads/writes quantized bytes on the concat/append/decode
   // path; the specific scheme is carried by kv_format (extensible to INT4/FP8).
   const bool kv_quantized = (kv_format != KvCacheFormat::Fp16);
@@ -506,7 +502,8 @@ static int gqa_forward_fused(
       // scan and therefore the split count that wins.
       const int kv_dtype = kv_dtype_abi(kv_format);
       int drc;
-      if (gqa_autotune_mode(state) == hipdnn_ep::GqaAutotuneMode::Online) {
+      if (hipdnn_ep::gqa_autotune_mode(state->gqa_autotune_policy) ==
+          hipdnn_ep::GqaAutotuneMode::Online) {
         drc = hip_gqa_flash_decode(
             stream, qSrc, present_key, present_value, output, partials,
             static_cast<int>(B), static_cast<int>(H), static_cast<int>(G),
@@ -727,7 +724,8 @@ static int gqa_forward_fused(
   }
 
   int fp_rc;
-  if (gqa_autotune_mode(state) == hipdnn_ep::GqaAutotuneMode::Online) {
+  if (hipdnn_ep::gqa_autotune_mode(state->gqa_autotune_policy) ==
+      hipdnn_ep::GqaAutotuneMode::Online) {
     fp_rc = hip_gqa_flash_prefill(
         stream, qSrc, kAttn, vAttn, output, static_cast<int>(B),
         static_cast<int>(H), static_cast<int>(G), static_cast<int>(sq),

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -333,10 +333,11 @@ static int gqa_forward_fused(
     const void *head_sink = nullptr, bool use_smooth_softmax = false,
     int local_window_size = -1) {
 
-  // The provider option only reaches the state after gqa_autotune_create() has
-  // run, so it is applied here, ahead of the decode and prefill mode reads
-  // below. Settles on the first call and is a no-op afterwards.
-  hipdnn_ep::gqa_autotune_apply_provider_mode(
+  // The autotune policy is built during inference_init, before the EP forwards
+  // the session's provider options, so the mode is decided here instead --
+  // from the environment variable and the option together, ahead of the decode
+  // and prefill reads below. Settles once; later calls take the decided mode.
+  hipdnn_ep::gqa_autotune_resolve_mode(
       state->gqa_autotune_policy,
       hipdnn_ep_runtime_get_provider_option(state, "gqa_autotune_mode"));
 

--- a/lib/Runtime/runtime_state_internal.h
+++ b/lib/Runtime/runtime_state_internal.h
@@ -206,6 +206,13 @@ struct RuntimeState {
   // ABI-facing struct opaque.
   void *gqa_autotune_policy;
 
+  // Session-scoped provider options copied from PassContext after
+  // inference_init. The concrete ProviderOptions map remains private to
+  // hipdnn_ep_runtime_state.cpp so this ABI-facing state does not expose C++
+  // containers. Lazily allocated by hipdnn_ep_runtime_set_provider_option and
+  // destroyed by hipdnn_ep_state_cleanup.
+  void *provider_options;
+
   // Device-side error flag used by kernels to report runtime-invalid inputs.
   // 0 = no error, non-zero = error code (currently -1).
   int *device_error_flag;

--- a/test/runtime/test_gqa_autotune.cpp
+++ b/test/runtime/test_gqa_autotune.cpp
@@ -15,6 +15,7 @@
 
 #include "gqa_autotune.h"
 #include "gqa_autotune_generated.h"
+#include "hip/env.h"
 #include "morphizen-foundation/file_io.hpp"
 
 #include <cstdio>
@@ -33,6 +34,31 @@ void require(bool condition, const char *expression, int line) {
 }
 
 #define REQUIRE(expr) require((expr), #expr, __LINE__)
+
+void setModeEnv(const char *value) {
+#ifdef _WIN32
+  _putenv_s("HIPDNN_GQA_AUTOTUNE_MODE", value ? value : "");
+#else
+  if (value)
+    setenv("HIPDNN_GQA_AUTOTUNE_MODE", value, 1);
+  else
+    unsetenv("HIPDNN_GQA_AUTOTUNE_MODE");
+#endif
+}
+
+class ScopedModeEnv {
+public:
+  ScopedModeEnv()
+      : original_(hipdnn_ep::env_string("HIPDNN_GQA_AUTOTUNE_MODE")) {
+    setModeEnv(nullptr);
+  }
+  ~ScopedModeEnv() {
+    setModeEnv(original_.empty() ? nullptr : original_.c_str());
+  }
+
+private:
+  std::string original_;
+};
 
 class MemoryReader final : public morphizen::FileReader {
 public:
@@ -285,11 +311,45 @@ int inspect(const char *path) {
 int main(int argc, char **argv) {
   if (argc > 1)
     return inspect(argv[1]);
+  ScopedModeEnv mode_env;
   MemoryFileSystem fs(makeLut());
   void *policy = hipdnn_ep::gqa_autotune_create(&fs);
   REQUIRE(policy != nullptr);
   REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
           hipdnn_ep::GqaAutotuneMode::Lookup);
+
+  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, " OnLiNe ");
+  REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
+          hipdnn_ep::GqaAutotuneMode::Online);
+  hipdnn_ep::gqa_autotune_destroy(policy);
+
+  policy = hipdnn_ep::gqa_autotune_create(&fs);
+  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, "invalid");
+  REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
+          hipdnn_ep::GqaAutotuneMode::Lookup);
+  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, "");
+  REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
+          hipdnn_ep::GqaAutotuneMode::Lookup);
+  hipdnn_ep::gqa_autotune_destroy(policy);
+
+  setModeEnv("lookup");
+  policy = hipdnn_ep::gqa_autotune_create(&fs);
+  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, "online");
+  REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
+          hipdnn_ep::GqaAutotuneMode::Lookup);
+  hipdnn_ep::gqa_autotune_destroy(policy);
+
+  // Even an invalid non-empty environment setting owns the highest-priority
+  // slot and preserves the historical fallback to the build default.
+  setModeEnv("invalid");
+  policy = hipdnn_ep::gqa_autotune_create(&fs);
+  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, "online");
+  REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
+          hipdnn_ep::GqaAutotuneMode::Lookup);
+  hipdnn_ep::gqa_autotune_destroy(policy);
+  setModeEnv(nullptr);
+
+  policy = hipdnn_ep::gqa_autotune_create(&fs);
 
   // 64:8:64, one sequence: batch*num_heads is 64, which no Geometry row names,
   // so the pooled heads-per-group row answers.

--- a/test/runtime/test_gqa_autotune.cpp
+++ b/test/runtime/test_gqa_autotune.cpp
@@ -318,23 +318,39 @@ int main(int argc, char **argv) {
   REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
           hipdnn_ep::GqaAutotuneMode::Lookup);
 
-  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, " OnLiNe ");
+  hipdnn_ep::gqa_autotune_resolve_provider_mode(policy, " OnLiNe ");
+  REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
+          hipdnn_ep::GqaAutotuneMode::Online);
+  // Resolution happens once, so the decode path can call it on every read: a
+  // later value cannot move a session that already answered.
+  hipdnn_ep::gqa_autotune_resolve_provider_mode(policy, "lookup");
   REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
           hipdnn_ep::GqaAutotuneMode::Online);
   hipdnn_ep::gqa_autotune_destroy(policy);
 
+  // Nothing supplied leaves the mode alone and still counts as resolved.
   policy = hipdnn_ep::gqa_autotune_create(&fs);
-  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, "invalid");
+  hipdnn_ep::gqa_autotune_resolve_provider_mode(policy, nullptr);
+  hipdnn_ep::gqa_autotune_resolve_provider_mode(policy, "online");
   REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
           hipdnn_ep::GqaAutotuneMode::Lookup);
-  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, "");
+  hipdnn_ep::gqa_autotune_destroy(policy);
+
+  policy = hipdnn_ep::gqa_autotune_create(&fs);
+  hipdnn_ep::gqa_autotune_resolve_provider_mode(policy, "invalid");
+  REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
+          hipdnn_ep::GqaAutotuneMode::Lookup);
+  hipdnn_ep::gqa_autotune_destroy(policy);
+
+  policy = hipdnn_ep::gqa_autotune_create(&fs);
+  hipdnn_ep::gqa_autotune_resolve_provider_mode(policy, "");
   REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
           hipdnn_ep::GqaAutotuneMode::Lookup);
   hipdnn_ep::gqa_autotune_destroy(policy);
 
   setModeEnv("lookup");
   policy = hipdnn_ep::gqa_autotune_create(&fs);
-  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, "online");
+  hipdnn_ep::gqa_autotune_resolve_provider_mode(policy, "online");
   REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
           hipdnn_ep::GqaAutotuneMode::Lookup);
   hipdnn_ep::gqa_autotune_destroy(policy);
@@ -343,7 +359,7 @@ int main(int argc, char **argv) {
   // slot and preserves the historical fallback to the build default.
   setModeEnv("invalid");
   policy = hipdnn_ep::gqa_autotune_create(&fs);
-  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, "online");
+  hipdnn_ep::gqa_autotune_resolve_provider_mode(policy, "online");
   REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
           hipdnn_ep::GqaAutotuneMode::Lookup);
   hipdnn_ep::gqa_autotune_destroy(policy);

--- a/test/runtime/test_gqa_autotune.cpp
+++ b/test/runtime/test_gqa_autotune.cpp
@@ -313,60 +313,53 @@ int main(int argc, char **argv) {
     return inspect(argv[1]);
   ScopedModeEnv mode_env;
   MemoryFileSystem fs(makeLut());
+  // create() no longer decides the mode -- the provider option is not
+  // available to it -- so resolve_mode weighs every lever on the first read.
   void *policy = hipdnn_ep::gqa_autotune_create(&fs);
   REQUIRE(policy != nullptr);
-  REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
-          hipdnn_ep::GqaAutotuneMode::Lookup);
-
-  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, " OnLiNe ");
-  REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
+  REQUIRE(hipdnn_ep::gqa_autotune_resolve_mode(policy, " OnLiNe ") ==
           hipdnn_ep::GqaAutotuneMode::Online);
-  // Settles on the first call, which is what lets the decode path apply on
-  // every read without re-parsing or re-logging.
-  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, "lookup");
+  // Settles once, which is what lets the decode path ask on every read: a
+  // later value cannot move a session that already answered.
+  REQUIRE(hipdnn_ep::gqa_autotune_resolve_mode(policy, "lookup") ==
+          hipdnn_ep::GqaAutotuneMode::Online);
   REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
           hipdnn_ep::GqaAutotuneMode::Online);
   hipdnn_ep::gqa_autotune_destroy(policy);
 
-  // Nothing supplied settles it too, so a later value cannot take over.
+  // Nothing supplied settles it too, on the build default.
   policy = hipdnn_ep::gqa_autotune_create(&fs);
-  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, nullptr);
-  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, "online");
-  REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
+  REQUIRE(hipdnn_ep::gqa_autotune_resolve_mode(policy, nullptr) ==
+          hipdnn_ep::GqaAutotuneMode::Lookup);
+  REQUIRE(hipdnn_ep::gqa_autotune_resolve_mode(policy, "online") ==
+          hipdnn_ep::GqaAutotuneMode::Lookup);
+  hipdnn_ep::gqa_autotune_destroy(policy);
+
+  // An unusable value falls back to the build default rather than guessing;
+  // likewise one that is only whitespace.
+  policy = hipdnn_ep::gqa_autotune_create(&fs);
+  REQUIRE(hipdnn_ep::gqa_autotune_resolve_mode(policy, "invalid") ==
           hipdnn_ep::GqaAutotuneMode::Lookup);
   hipdnn_ep::gqa_autotune_destroy(policy);
 
   policy = hipdnn_ep::gqa_autotune_create(&fs);
-  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, nullptr);
-  REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
+  REQUIRE(hipdnn_ep::gqa_autotune_resolve_mode(policy, "  ") ==
           hipdnn_ep::GqaAutotuneMode::Lookup);
   hipdnn_ep::gqa_autotune_destroy(policy);
 
-  policy = hipdnn_ep::gqa_autotune_create(&fs);
-  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, "invalid");
-  REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
-          hipdnn_ep::GqaAutotuneMode::Lookup);
-  hipdnn_ep::gqa_autotune_destroy(policy);
-
-  policy = hipdnn_ep::gqa_autotune_create(&fs);
-  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, "");
-  REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
-          hipdnn_ep::GqaAutotuneMode::Lookup);
-  hipdnn_ep::gqa_autotune_destroy(policy);
-
+  // The environment variable outranks the provider option.
   setModeEnv("lookup");
   policy = hipdnn_ep::gqa_autotune_create(&fs);
-  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, "online");
-  REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
+  REQUIRE(hipdnn_ep::gqa_autotune_resolve_mode(policy, "online") ==
           hipdnn_ep::GqaAutotuneMode::Lookup);
   hipdnn_ep::gqa_autotune_destroy(policy);
 
-  // Even an invalid non-empty environment setting owns the highest-priority
-  // slot and preserves the historical fallback to the build default.
+  // Including when it was typed wrong: a global override that did not parse
+  // falls back to the build default instead of handing the session to a
+  // provider option the caller may not know is set.
   setModeEnv("invalid");
   policy = hipdnn_ep::gqa_autotune_create(&fs);
-  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, "online");
-  REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
+  REQUIRE(hipdnn_ep::gqa_autotune_resolve_mode(policy, "online") ==
           hipdnn_ep::GqaAutotuneMode::Lookup);
   hipdnn_ep::gqa_autotune_destroy(policy);
   setModeEnv(nullptr);

--- a/test/runtime/test_gqa_autotune.cpp
+++ b/test/runtime/test_gqa_autotune.cpp
@@ -318,39 +318,45 @@ int main(int argc, char **argv) {
   REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
           hipdnn_ep::GqaAutotuneMode::Lookup);
 
-  hipdnn_ep::gqa_autotune_resolve_provider_mode(policy, " OnLiNe ");
+  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, " OnLiNe ");
   REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
           hipdnn_ep::GqaAutotuneMode::Online);
-  // Resolution happens once, so the decode path can call it on every read: a
-  // later value cannot move a session that already answered.
-  hipdnn_ep::gqa_autotune_resolve_provider_mode(policy, "lookup");
+  // Settles on the first call, which is what lets the decode path apply on
+  // every read without re-parsing or re-logging.
+  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, "lookup");
   REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
           hipdnn_ep::GqaAutotuneMode::Online);
   hipdnn_ep::gqa_autotune_destroy(policy);
 
-  // Nothing supplied leaves the mode alone and still counts as resolved.
+  // Nothing supplied settles it too, so a later value cannot take over.
   policy = hipdnn_ep::gqa_autotune_create(&fs);
-  hipdnn_ep::gqa_autotune_resolve_provider_mode(policy, nullptr);
-  hipdnn_ep::gqa_autotune_resolve_provider_mode(policy, "online");
+  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, nullptr);
+  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, "online");
   REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
           hipdnn_ep::GqaAutotuneMode::Lookup);
   hipdnn_ep::gqa_autotune_destroy(policy);
 
   policy = hipdnn_ep::gqa_autotune_create(&fs);
-  hipdnn_ep::gqa_autotune_resolve_provider_mode(policy, "invalid");
+  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, nullptr);
   REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
           hipdnn_ep::GqaAutotuneMode::Lookup);
   hipdnn_ep::gqa_autotune_destroy(policy);
 
   policy = hipdnn_ep::gqa_autotune_create(&fs);
-  hipdnn_ep::gqa_autotune_resolve_provider_mode(policy, "");
+  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, "invalid");
+  REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
+          hipdnn_ep::GqaAutotuneMode::Lookup);
+  hipdnn_ep::gqa_autotune_destroy(policy);
+
+  policy = hipdnn_ep::gqa_autotune_create(&fs);
+  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, "");
   REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
           hipdnn_ep::GqaAutotuneMode::Lookup);
   hipdnn_ep::gqa_autotune_destroy(policy);
 
   setModeEnv("lookup");
   policy = hipdnn_ep::gqa_autotune_create(&fs);
-  hipdnn_ep::gqa_autotune_resolve_provider_mode(policy, "online");
+  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, "online");
   REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
           hipdnn_ep::GqaAutotuneMode::Lookup);
   hipdnn_ep::gqa_autotune_destroy(policy);
@@ -359,7 +365,7 @@ int main(int argc, char **argv) {
   // slot and preserves the historical fallback to the build default.
   setModeEnv("invalid");
   policy = hipdnn_ep::gqa_autotune_create(&fs);
-  hipdnn_ep::gqa_autotune_resolve_provider_mode(policy, "online");
+  hipdnn_ep::gqa_autotune_apply_provider_mode(policy, "online");
   REQUIRE(hipdnn_ep::gqa_autotune_mode(policy) ==
           hipdnn_ep::GqaAutotuneMode::Lookup);
   hipdnn_ep::gqa_autotune_destroy(policy);


### PR DESCRIPTION
## Summary

Adds a session-scoped provider-option channel on `RuntimeState`, so a runtime
knob can be set per session instead of per process. GQA autotune mode is the
first consumer: it now follows

```text
HIPDNN_GQA_AUTOTUNE_MODE  >  gqa_autotune_mode provider option  >  build default
```

Existing behavior is unchanged when neither the option nor the environment
variable is set, and the environment variable keeps its current precedence and
parsing.

Callers can supply the option either way:

```cpp
ep_options["gqa_autotune_mode"] = "online";                    // AppendExecutionProvider_V2
session_options.AddConfigEntry("ep.hipgpu.gqa_autotune_mode",  // Auto EP Selection
                               "online");
```

## Related issue or design

None. Happy to open a design discussion if reviewers would prefer one before
this lands, since it adds two optional runtime exports.

## Why

`chooseMode()` runs once inside `gqa_autotune_create()`, which
`hipdnn_ep_state_init_with_fs()` calls while building the runtime state, and it
reads only `HIPDNN_GQA_AUTOTUNE_MODE`. That variable is process-wide, so two
sessions in one process cannot take different paths, and A/B testing the two
GQA paths means setting an environment variable and building a new process.

Three constraints shaped the design:

- **Run options were rejected.** `OrtRunOptions` cannot be enumerated and lives
  for one `Run()`. GQA mode is decided once per session, and online mode
  populates per-shape caches in `gqa_kernel.hip` that outlive a run, so a
  session that alternates behaves like neither pure mode. Provider options
  match the actual lifetime.
- **A TLS bridge was rejected.** `runtime.bc` cannot define `thread_local` on
  the JIT path, and keeping the storage native does not help: a native model
  DLL links its own copy of that storage (`CompilerDriver::discoverInTreeLibraries`),
  so an EP-side write would be invisible to it. Resolving an optional symbol
  from the loaded artifact instead means JIT and native artifacts both mutate
  the `RuntimeState` that owns the policy.
- **The option must not be baked into the artifact.** Storing it in model
  metadata would freeze it at compile time and force a cache invalidation to
  change it. One artifact is now reusable by sessions with different options.

## What

The EP forwards the whole effective option map once, after `inference_init`
and before the first `Compute()`:

```cpp
for (const auto &[key, value] : context->get_all_provider_options())
  inference_state_->set_provider_option(key.c_str(), value.c_str());
```

Two optional runtime exports back it:

```c
void hipdnn_ep_runtime_set_provider_option(RuntimeState *, const char *key,
                                           const char *value);
const char *hipdnn_ep_runtime_get_provider_option(RuntimeState *,
                                                  const char *key);
```

The channel only stores; it does not interpret. Consumers pull their own key at
a point that holds the `RuntimeState`, so adding a second knob needs no change
to `MlirCustomOp`, `InferenceState`, or the artifact ABI. `gqa_forward_fused()`
applies `gqa_autotune_mode` once at entry, ahead of the decode and prefill mode
reads; `gqa_autotune_create()` cannot do it because the EP forwards provider
options after `inference_init`.

The policy carries one flag, `mode_settled`, seeded true when
`HIPDNN_GQA_AUTOTUNE_MODE` spoke -- that is how the environment variable keeps
priority -- and set by the first apply otherwise. It is what makes applying from
the GQA path safe: without it a 32-layer decode would re-parse and re-log the
option once per layer. The map lookup itself still runs per call; it is a probe
into a handful of entries and is nothing against a token.

The later commits are that separation. The first commit had the setter branch on
the GQA key behind a `HIPDNN_EP_REAL_RUNTIME` guard, which gave the generic
channel a per-consumer dependency.

Values are copied into the state, so nothing depends on EP-owned string
lifetimes.

## Test plan

- `ctest -R GqaAutotuneUnitTest` (GPU-free) covers absent / valid / invalid /
  empty option values, the settle-once contract (a second apply cannot move a
  session, including after one that supplied nothing), and both directions of
  the precedence rule against `HIPDNN_GQA_AUTOTUNE_MODE` -- including an
  unrecognised environment value, which still blocks the provider option while
  the session log correctly names the build default as the source.
- Built `HipRuntime` (runtime bitcode), `test-gqa-autotune`, and
  `morphizen-custom-op-mlir` on Windows / gfx1151.
- `pre-commit run --files <changed>`: passed.

**Not yet run:** an on-GPU end-to-end check that the option changes the path a
real model takes, and any validation of the native (`artifact_format=NATIVE`)
artifact. The native path is the one the rejected TLS design would have broken,
so it is worth exercising before merge.

**Pre-existing failure:** `GqaAutotuneUnitTest` fails at the
`GqaTuneSource::HeadGroup` assertion. This reproduces at `origin/main` with all
files from this branch reverted: under `HIPDNN_EP_GQA_AUTOTUNE_GPU_FREE`,
`loadLutFromEmbedded()` is a no-op and `gqa_autotune_create()` ignores the
`FileSystem` the test supplies, so the policy has no rows and resolution falls
through to `Heuristic`. Unrelated to this change; the assertions added here run
before it and pass.

## AI assistance

Prepared with Cursor. The design alternatives (run option vs. provider option,
TLS bridge vs. optional artifact symbol, push-dispatch vs. consumer-pull) were
directed and reviewed by me, and I validated the result with the builds and
tests listed above. The commits carry a `Co-authored-by` trailer but not the
`Made-with` trailer that CONTRIBUTING.md asks for; say the word and I will add
it.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
