### PR TITLE
perf(kernels): halve softmax traffic and vectorise the 4-D broadcast add

### DIFF
--- a/lib/Runtime/Kernels/hip/elementwise_binary_kernel.hip
+++ b/lib/Runtime/Kernels/hip/elementwise_binary_kernel.hip
@@ -879,6 +879,19 @@ __device__ __forceinline__ void ew_store(__half *p, uint32_t i, float v) {
   p[i] = __float2half(v);
 }
 
+__device__ __forceinline__ float ew_to_float(float v) { return v; }
+__device__ __forceinline__ float ew_to_float(__half v) {
+  return __half2float(v);
+}
+
+template <typename T> __device__ __forceinline__ T ew_cast(float v);
+template <> __device__ __forceinline__ float ew_cast<float>(float v) {
+  return v;
+}
+template <> __device__ __forceinline__ __half ew_cast<__half>(float v) {
+  return __float2half(v);
+}
+
 // op: 0=add, 1=mul, 2=min, 3=max
 __device__ __forceinline__ float ew_apply(int op, float a, float b) {
   switch (op) {
@@ -913,6 +926,199 @@ __global__ void ew_bcast4d_kernel(const T *__restrict__ lhs,
   float a = ew_load(lhs, li);
   float b = ew_load(rhs, ri);
   ew_store(output, tid, ew_apply(op, a, b));
+}
+
+// =====================================================================
+// Vectorised fast path
+//
+// Two things limit the kernel above on the attention bias/mask add, which is
+// where most of a windowed-attention model's elementwise time goes.
+//
+// `meta.out[d]` is a runtime value, so `rem % meta.out[d]` and
+// `rem /= meta.out[d]` are true integer divisions rather than shifts -- four
+// of each per element. And one thread per element means a 32-lane wave issues
+// 2-byte accesses, moving 64 bytes per memory instruction against a 128-byte
+// cache line.
+//
+// The fast path fixes both. Each thread owns V contiguous elements, chosen so
+// V elements are 16 bytes; since the innermost output extent is a multiple of
+// V, all V share the outer coordinates and one index computation serves the
+// whole group. And the index itself becomes shifts and masks, because the
+// host folds the decomposition into the fewest terms that reproduce it.
+//
+// The folding is what makes this cheap rather than merely cheaper. Axes an
+// operand is contiguous over collapse into a single masked term, so a bias of
+// shape [1,H,S,S] against [N,H,S,S] costs one AND, and a mask of shape
+// [N,1,S,S] costs one AND plus one shift -- not four divisions either way.
+// =====================================================================
+
+// At most one term per axis. Each contributes `((t >> shift) & mask) * stride`
+// to the operand index; `mask` is all-ones for a term that reaches the
+// outermost axis, where no wrap is possible.
+struct Bcast4DTerms {
+  uint32_t shift[4];
+  uint32_t mask[4];
+  uint32_t stride[4];
+  uint32_t count;
+  uint32_t contiguous; // 1 when the operand advances with the output
+};
+
+struct Bcast4DFastMeta {
+  Bcast4DTerms lhs;
+  Bcast4DTerms rhs;
+};
+
+__device__ __forceinline__ uint32_t ew_operand_index(uint32_t t,
+                                                     const Bcast4DTerms &tm) {
+  uint32_t idx = 0;
+  for (uint32_t i = 0; i < tm.count; ++i)
+    idx += ((t >> tm.shift[i]) & tm.mask[i]) * tm.stride[i];
+  return idx;
+}
+
+// V * sizeof(T) == 16, so one uint4 covers a thread's whole group.
+template <typename T, int V> union EwVec {
+  uint4 raw;
+  T e[V];
+};
+
+template <typename T, int V>
+__global__ void ew_bcast4d_fast_kernel(const T *__restrict__ lhs,
+                                        const T *__restrict__ rhs,
+                                        T *__restrict__ output,
+                                        uint32_t num_vectors, int op,
+                                        Bcast4DFastMeta meta) {
+  const uint32_t v = blockIdx.x * blockDim.x + threadIdx.x;
+  if (v >= num_vectors)
+    return;
+  const uint32_t t = v * (uint32_t)V;
+
+  EwVec<T, V> a, b, o;
+  const uint32_t li = ew_operand_index(t, meta.lhs);
+  if (meta.lhs.contiguous)
+    a.raw = *reinterpret_cast<const uint4 *>(lhs + li);
+  else
+#pragma unroll
+    for (int i = 0; i < V; ++i)
+      a.e[i] = lhs[li];
+
+  const uint32_t ri = ew_operand_index(t, meta.rhs);
+  if (meta.rhs.contiguous)
+    b.raw = *reinterpret_cast<const uint4 *>(rhs + ri);
+  else
+#pragma unroll
+    for (int i = 0; i < V; ++i)
+      b.e[i] = rhs[ri];
+
+#pragma unroll
+  for (int i = 0; i < V; ++i)
+    o.e[i] = ew_cast<T>(ew_apply(op, ew_to_float(a.e[i]), ew_to_float(b.e[i])));
+
+  *reinterpret_cast<uint4 *>(output + t) = o.raw;
+}
+
+} // namespace
+
+namespace {
+
+// log2 of a power of two, or -1 when the value is not one.
+int ew_exact_log2(uint64_t v) {
+  if (v == 0 || (v & (v - 1)) != 0)
+    return -1;
+  int s = 0;
+  while ((v >> s) != 1)
+    ++s;
+  return s;
+}
+
+// Fold the per-axis index decomposition into the fewest terms that reproduce
+// the operand's index, and report whether the result is usable at all.
+//
+// Axes are walked innermost first. A run of axes the operand is contiguous
+// over collapses into one term, because the sum over that run of
+// `coord_d * stride_d` is exactly `((t >> inner_shift) & (extent - 1)) *
+// run_stride`. An axis of extent 1 contributes nothing and cannot break a
+// run; an axis the operand broadcasts over contributes nothing and does.
+//
+// Fails when a shift or mask the folded form needs is not a power of two, or
+// when a stride would misalign a V-element vector. Every failure sends the
+// caller back to the general kernel.
+bool ew_build_terms(const uint32_t out[4], const uint32_t stride[4], int vec,
+                    Bcast4DTerms &tm) {
+  tm.count = 0;
+  // A contiguous operand is read with one vector load per thread and so has
+  // to land on a vector boundary. One that broadcasts over the innermost axis
+  // is read as a single scalar and splatted, which constrains nothing.
+  tm.contiguous = (stride[3] == 1) ? 1u : 0u;
+
+  uint64_t inner[4]; // product of out[d+1..3]
+  inner[3] = 1;
+  for (int d = 2; d >= 0; --d)
+    inner[d] = inner[d + 1] * out[d + 1];
+
+  for (int d = 3; d >= 0;) {
+    if (stride[d] == 0) {
+      --d;
+      continue;
+    }
+    const uint64_t run_stride = stride[d];
+    uint64_t extent = out[d];
+    int top = d;
+    while (top > 0) {
+      const int nxt = top - 1;
+      if (out[nxt] == 1) { // degenerate: no coordinate, no break
+        top = nxt;
+        continue;
+      }
+      if ((uint64_t)stride[nxt] != run_stride * extent)
+        break;
+      top = nxt;
+      extent *= out[top];
+    }
+
+    const int shift = ew_exact_log2(inner[d]);
+    if (shift < 0)
+      return false;
+    uint32_t mask;
+    if (top == 0) {
+      mask = 0xFFFFFFFFu; // outermost: t / inner[d] cannot wrap
+    } else {
+      if (ew_exact_log2(extent) < 0)
+        return false;
+      mask = (uint32_t)(extent - 1);
+    }
+    // A vector load needs every term to land on a V-element boundary. The
+    // innermost unit-stride run does so because its extent is a multiple of
+    // out[3]; any other term must have a stride that is.
+    const bool unit_innermost = (run_stride == 1 && shift == 0);
+    if (tm.contiguous && !unit_innermost && (run_stride % (uint64_t)vec) != 0)
+      return false;
+    if (tm.count == 4)
+      return false;
+    tm.shift[tm.count] = (uint32_t)shift;
+    tm.mask[tm.count] = mask;
+    tm.stride[tm.count] = (uint32_t)run_stride;
+    ++tm.count;
+    d = top - 1;
+  }
+  return true;
+}
+
+// Both operands must fold, the innermost extent must fill whole vectors, and
+// the buffers must be 16-byte aligned.
+bool ew_bcast4d_fast_meta(const uint32_t out[4], const Bcast4DMeta &meta,
+                          int vec, const void *lhs, const void *rhs,
+                          const void *output, uint32_t n,
+                          Bcast4DFastMeta &fast) {
+  if (out[3] % (uint32_t)vec != 0 || n % (uint32_t)vec != 0)
+    return false;
+  const uintptr_t bytes = 16;
+  if ((reinterpret_cast<uintptr_t>(lhs) % bytes) != 0 ||
+      (reinterpret_cast<uintptr_t>(rhs) % bytes) != 0 ||
+      (reinterpret_cast<uintptr_t>(output) % bytes) != 0)
+    return false;
+  return ew_build_terms(out, meta.lstride, vec, fast.lhs) &&
+         ew_build_terms(out, meta.rstride, vec, fast.rhs);
 }
 
 } // namespace
@@ -955,6 +1161,38 @@ extern "C" int hip_elementwise_binary_bcast(void *stream, const void *lhs,
   int grid_size = static_cast<int>((out_vol + kBlockSize - 1) / kBlockSize);
 
   (void)hipGetLastError();
+
+  // 16 bytes per thread: 8 halves or 4 floats.
+  Bcast4DFastMeta fast{};
+  const int vec = (hip_dtype == HIP_DTYPE_FLOAT16)   ? 8
+                  : (hip_dtype == HIP_DTYPE_FLOAT32) ? 4
+                                                     : 0;
+  if (vec && ew_bcast4d_fast_meta(meta.out, meta, vec, lhs, rhs, output, n,
+                                  fast)) {
+    const uint32_t num_vectors = n / (uint32_t)vec;
+    const int fast_grid =
+        static_cast<int>((num_vectors + kBlockSize - 1) / kBlockSize);
+    if (hip_dtype == HIP_DTYPE_FLOAT16)
+      hipLaunchKernelGGL(
+          (ew_bcast4d_fast_kernel<__half, 8>), dim3(fast_grid),
+          dim3(kBlockSize), 0, hip_stream, static_cast<const __half *>(lhs),
+          static_cast<const __half *>(rhs), static_cast<__half *>(output),
+          num_vectors, op, fast);
+    else
+      hipLaunchKernelGGL(
+          (ew_bcast4d_fast_kernel<float, 4>), dim3(fast_grid), dim3(kBlockSize),
+          0, hip_stream, static_cast<const float *>(lhs),
+          static_cast<const float *>(rhs), static_cast<float *>(output),
+          num_vectors, op, fast);
+    hipError_t ferr = hipGetLastError();
+    if (ferr != hipSuccess)
+      fprintf(stderr,
+              "[custom_kernels] hip_elementwise_binary_bcast fast path launch "
+              "failed: %s\n",
+              hipGetErrorString(ferr));
+    return static_cast<int>(ferr);
+  }
+
   switch (hip_dtype) {
   case HIP_DTYPE_FLOAT16:
     hipLaunchKernelGGL(ew_bcast4d_kernel<__half>, dim3(grid_size),

--- a/lib/Runtime/Kernels/hip/softmax_kernel.hip
+++ b/lib/Runtime/Kernels/hip/softmax_kernel.hip
@@ -9,6 +9,14 @@
 // for max + sum, then an inverse-multiply pass. Matches ONNX Softmax
 // semantics (`axis = -1` along the last dim).
 //
+// Every kernel here reads a source and writes a distinct destination, and
+// tolerates the two being the same buffer. That matters more than it looks:
+// `hip.miopen.softmax` is destination-passing with separate input and output
+// buffers, so a source-and-destination kernel lets the runtime softmax
+// straight from one to the other. An in-place-only kernel forces the caller
+// to copy input over output first, and that copy moves exactly as many bytes
+// as the softmax does -- doubling the op's traffic however good the kernel is.
+//
 // Used by the `hip_miopen_softmax` runtime entry point (lib/Runtime/real/
 // activation.cpp) for `onnx.Softmax` outside fused attention paths — most
 // notably the SigLIP / ViT self-attention scores in vision encoders. The
@@ -20,12 +28,19 @@
 //
 // Numerics: exp2f(x * LOG2E) instead of expf(x) for the native HW
 // instruction, fp32 accumulators, single max + single sum sweep per row.
-// LDS use: `num_waves * sizeof(float)` per block.
+//
+// Three launch shapes, picked by width in the entry points at the bottom:
+// one wavefront per row holding the row in registers (no LDS, no barrier),
+// one thread per element with the element in a register, and the general
+// strided form for rows too wide to cache. LDS use for the latter two is
+// `softmax_smem_floats(num_waves) * sizeof(float)` per block.
 //
 //===----------------------------------------------------------------------===//
 
 #include <hip/hip_runtime.h>
 #include <hip/hip_fp16.h>
+
+#include <cstdint>
 
 // Pulls in the HIP_KERNEL_API (dllexport) declaration of
 // hip_softmax_row_2d_inplace so this TU exports it from the per-arch SHARED
@@ -44,6 +59,10 @@
 #define LOG2E 1.44269504088896340736f
 #endif
 
+// Wavefronts per block for the wave-per-row kernels: one row each, sized so a
+// block stays at the 256-thread shape the other launches use.
+static constexpr int kWavesPerBlock = 8;
+
 namespace {
 
 __device__ inline float warp_reduce_max_f(float v) {
@@ -58,15 +77,168 @@ __device__ inline float warp_reduce_sum_f(float v) {
   return v;
 }
 
-__global__ void softmax_row_2d_inplace_kernel(__half* data, int rows,
-                                                int cols) {
+// Block-wide reductions through LDS, for the kernels whose rows span more than
+// one wavefront.
+//
+// `slot` is the cell the result is broadcast through, and callers must give
+// each reduction in a kernel its own. Broadcasting through smem[0] instead --
+// which is the obvious thing to do, since the per-wave partials are dead by
+// then -- races: after the barrier that publishes the broadcast, a fast wave
+// can store its next partial into smem[0] before a slow wave has read the
+// previous result out of it. The window is short enough that a kernel doing
+// global memory work between the two reductions usually survives it, and short
+// enough that one holding its row in registers does not.
+__device__ inline float block_reduce_max_f(float v, float* smem, int tid,
+                                             int num_waves, int slot) {
+  v = warp_reduce_max_f(v);
+  if (tid % WAVE_SIZE == 0)
+    smem[tid / WAVE_SIZE] = v;
+  __syncthreads();
+  if (tid < WAVE_SIZE) {
+    float t = (tid < num_waves) ? smem[tid] : -INFINITY;
+    t = warp_reduce_max_f(t);
+    if (tid == 0)
+      smem[slot] = t;
+  }
+  __syncthreads();
+  return smem[slot];
+}
+
+__device__ inline float block_reduce_sum_f(float v, float* smem, int tid,
+                                             int num_waves, int slot) {
+  v = warp_reduce_sum_f(v);
+  if (tid % WAVE_SIZE == 0)
+    smem[tid / WAVE_SIZE] = v;
+  __syncthreads();
+  if (tid < WAVE_SIZE) {
+    float t = (tid < num_waves) ? smem[tid] : 0.0f;
+    t = warp_reduce_sum_f(t);
+    if (tid == 0)
+      smem[slot] = t;
+  }
+  __syncthreads();
+  return smem[slot];
+}
+
+// LDS cells a block-per-row kernel needs: one partial per wave, plus a
+// dedicated broadcast cell for each of the two reductions.
+__device__ __host__ inline int softmax_smem_floats(int num_waves) {
+  return num_waves + 2;
+}
+
+// --- Register-cached variants ------------------------------------------
+//
+// The general kernel below re-reads the row from memory in each of its three
+// passes because the value it needs is not kept anywhere. When a thread owns a
+// fixed slice of the row, that value fits in a register and the row only has
+// to be read once and written once. Both variants below exploit that; they
+// differ in how a row is divided among threads.
+
+// One element per thread, block per row. Valid when `cols <= blockDim.x`, so
+// the general kernel's strided loop would run exactly one iteration anyway.
+// Reductions still cross the whole block, so the barriers remain.
+__global__ void softmax_row_2d_regcache_kernel(const __half* in, __half* out,
+                                                 int rows, int cols) {
   const int row = blockIdx.x;
   if (row >= rows)
     return;
-  __half* row_ptr = data + (size_t)row * cols;
+  const __half* in_row = in + (size_t)row * cols;
+  __half* out_row = out + (size_t)row * cols;
 
   const int tid = threadIdx.x;
-  const int wave_id = tid / WAVE_SIZE;
+  const int num_waves = blockDim.x / WAVE_SIZE;
+  const bool active = tid < cols;
+
+  extern __shared__ float smem[];
+
+  const float x = active ? __half2float(in_row[tid]) : -INFINITY;
+  const float row_max =
+      block_reduce_max_f(x, smem, tid, num_waves, num_waves);
+  const float e = active ? exp2f((x - row_max) * LOG2E) : 0.0f;
+  const float inv =
+      1.0f / block_reduce_sum_f(e, smem, tid, num_waves, num_waves + 1);
+
+  if (active)
+    out_row[tid] = __float2half(e * inv);
+}
+
+// One wavefront per row, `ELEMS` elements per lane held in registers. Valid
+// when `cols == WAVE_SIZE * ELEMS` and ELEMS is a multiple of the 16-byte
+// vector width, which is the shape every windowed-attention softmax has.
+//
+// Two things change against the block-per-row form. The row is read and
+// written in 16-byte transactions rather than 2-byte ones, so a wave moves a
+// full set of cache lines per memory instruction instead of a fraction of one.
+// And because a row never spans more than one wavefront, both reductions are
+// pure `__shfl_xor` -- the kernel needs no LDS and no `__syncthreads` at all.
+//
+// Lane vectors are strided by WAVE_SIZE rather than packed per lane so that
+// every individual load remains coalesced across the wave when ELEMS spans
+// more than one vector.
+template <int ELEMS>
+__global__ void softmax_row_2d_wave_kernel(const __half* in, __half* out,
+                                             int rows, int cols) {
+  constexpr int kVecElems = 8; // 8 halves == 16 bytes
+  constexpr int kVecs = ELEMS / kVecElems;
+
+  const int lane = threadIdx.x % WAVE_SIZE;
+  const int wave = threadIdx.x / WAVE_SIZE;
+  const int row = blockIdx.x * (int)(blockDim.x / WAVE_SIZE) + wave;
+  if (row >= rows)
+    return;
+  const uint4* in_vec =
+      reinterpret_cast<const uint4*>(in + (size_t)row * cols);
+  uint4* out_vec = reinterpret_cast<uint4*>(out + (size_t)row * cols);
+
+  uint4 raw[kVecs];
+  float x[ELEMS];
+  float local_max = -INFINITY;
+#pragma unroll
+  for (int v = 0; v < kVecs; ++v) {
+    raw[v] = in_vec[lane + v * WAVE_SIZE];
+    const __half* h = reinterpret_cast<const __half*>(&raw[v]);
+#pragma unroll
+    for (int e = 0; e < kVecElems; ++e) {
+      const float val = __half2float(h[e]);
+      x[v * kVecElems + e] = val;
+      local_max = fmaxf(local_max, val);
+    }
+  }
+  const float row_max = warp_reduce_max_f(local_max);
+
+  float local_sum = 0.0f;
+#pragma unroll
+  for (int i = 0; i < ELEMS; ++i) {
+    x[i] = exp2f((x[i] - row_max) * LOG2E);
+    local_sum += x[i];
+  }
+  const float inv = 1.0f / warp_reduce_sum_f(local_sum);
+
+#pragma unroll
+  for (int v = 0; v < kVecs; ++v) {
+    __half* h = reinterpret_cast<__half*>(&raw[v]);
+#pragma unroll
+    for (int e = 0; e < kVecElems; ++e)
+      h[e] = __float2half(x[v * kVecElems + e] * inv);
+    out_vec[lane + v * WAVE_SIZE] = raw[v];
+  }
+}
+
+// The fallback for rows too long to cache in registers. Three passes over the
+// row, so the only pass that may read what an earlier pass wrote is the third,
+// and a thread there re-reads exactly the elements it wrote itself under the
+// same `tid`-strided loop. No thread ever reads another thread's slice, which
+// is what makes the source-aliases-destination case correct without a barrier
+// beyond the ones the reductions already impose.
+__global__ void softmax_row_2d_general_kernel(const __half* in, __half* out,
+                                                int rows, int cols) {
+  const int row = blockIdx.x;
+  if (row >= rows)
+    return;
+  const __half* in_row = in + (size_t)row * cols;
+  __half* out_row = out + (size_t)row * cols;
+
+  const int tid = threadIdx.x;
   const int num_waves = blockDim.x / WAVE_SIZE;
 
   extern __shared__ float smem[];
@@ -74,55 +246,111 @@ __global__ void softmax_row_2d_inplace_kernel(__half* data, int rows,
   // Pass 1: row max.
   float local_max = -INFINITY;
   for (int j = tid; j < cols; j += blockDim.x)
-    local_max = fmaxf(local_max, __half2float(row_ptr[j]));
-  local_max = warp_reduce_max_f(local_max);
-  if (tid % WAVE_SIZE == 0)
-    smem[wave_id] = local_max;
-  __syncthreads();
-  if (tid < WAVE_SIZE) {
-    float v = (tid < num_waves) ? smem[tid] : -INFINITY;
-    v = warp_reduce_max_f(v);
-    smem[0] = v;
-  }
-  __syncthreads();
-  float row_max = smem[0];
+    local_max = fmaxf(local_max, __half2float(in_row[j]));
+  const float row_max =
+      block_reduce_max_f(local_max, smem, tid, num_waves, num_waves);
 
   // Pass 2: exp2f + sum.
   float local_sum = 0.0f;
   for (int j = tid; j < cols; j += blockDim.x) {
-    float e = exp2f((__half2float(row_ptr[j]) - row_max) * LOG2E);
-    row_ptr[j] = __float2half(e);
+    float e = exp2f((__half2float(in_row[j]) - row_max) * LOG2E);
+    out_row[j] = __float2half(e);
     local_sum += e;
   }
-  local_sum = warp_reduce_sum_f(local_sum);
-  if (tid % WAVE_SIZE == 0)
-    smem[wave_id] = local_sum;
-  __syncthreads();
-  if (tid < WAVE_SIZE) {
-    float v = (tid < num_waves) ? smem[tid] : 0.0f;
-    v = warp_reduce_sum_f(v);
-    smem[0] = v;
-  }
-  __syncthreads();
-  float row_sum = smem[0];
-  float inv = 1.0f / row_sum;
+  const float inv =
+      1.0f / block_reduce_sum_f(local_sum, smem, tid, num_waves, num_waves + 1);
 
   // Pass 3: normalize.
   for (int j = tid; j < cols; j += blockDim.x)
-    row_ptr[j] = __float2half(__half2float(row_ptr[j]) * inv);
+    out_row[j] = __float2half(__half2float(out_row[j]) * inv);
+}
+
+// fp32 counterparts of the two register-cached variants above. Only the
+// element type and the 16-byte vector width differ.
+__global__ void softmax_row_2d_regcache_fp32_kernel(const float* in, float* out,
+                                                      int rows, int cols) {
+  const int row = blockIdx.x;
+  if (row >= rows)
+    return;
+  const float* in_row = in + (size_t)row * cols;
+  float* out_row = out + (size_t)row * cols;
+
+  const int tid = threadIdx.x;
+  const int num_waves = blockDim.x / WAVE_SIZE;
+  const bool active = tid < cols;
+
+  extern __shared__ float smem[];
+
+  const float x = active ? in_row[tid] : -INFINITY;
+  const float row_max =
+      block_reduce_max_f(x, smem, tid, num_waves, num_waves);
+  const float e = active ? exp2f((x - row_max) * LOG2E) : 0.0f;
+  const float inv =
+      1.0f / block_reduce_sum_f(e, smem, tid, num_waves, num_waves + 1);
+
+  if (active)
+    out_row[tid] = e * inv;
+}
+
+template <int ELEMS>
+__global__ void softmax_row_2d_wave_fp32_kernel(const float* in, float* out,
+                                                  int rows, int cols) {
+  constexpr int kVecElems = 4; // 4 floats == 16 bytes
+  constexpr int kVecs = ELEMS / kVecElems;
+
+  const int lane = threadIdx.x % WAVE_SIZE;
+  const int wave = threadIdx.x / WAVE_SIZE;
+  const int row = blockIdx.x * (int)(blockDim.x / WAVE_SIZE) + wave;
+  if (row >= rows)
+    return;
+  const float4* in_vec =
+      reinterpret_cast<const float4*>(in + (size_t)row * cols);
+  float4* out_vec = reinterpret_cast<float4*>(out + (size_t)row * cols);
+
+  float4 raw[kVecs];
+  float x[ELEMS];
+  float local_max = -INFINITY;
+#pragma unroll
+  for (int v = 0; v < kVecs; ++v) {
+    raw[v] = in_vec[lane + v * WAVE_SIZE];
+    const float* f = reinterpret_cast<const float*>(&raw[v]);
+#pragma unroll
+    for (int e = 0; e < kVecElems; ++e) {
+      x[v * kVecElems + e] = f[e];
+      local_max = fmaxf(local_max, f[e]);
+    }
+  }
+  const float row_max = warp_reduce_max_f(local_max);
+
+  float local_sum = 0.0f;
+#pragma unroll
+  for (int i = 0; i < ELEMS; ++i) {
+    x[i] = exp2f((x[i] - row_max) * LOG2E);
+    local_sum += x[i];
+  }
+  const float inv = 1.0f / warp_reduce_sum_f(local_sum);
+
+#pragma unroll
+  for (int v = 0; v < kVecs; ++v) {
+    float* f = reinterpret_cast<float*>(&raw[v]);
+#pragma unroll
+    for (int e = 0; e < kVecElems; ++e)
+      f[e] = x[v * kVecElems + e] * inv;
+    out_vec[lane + v * WAVE_SIZE] = raw[v];
+  }
 }
 
 // fp32 variant — same algorithm, reads float instead of __half.
 // Used by Qwen VLM and other models where Softmax input is fp32.
-__global__ void softmax_row_2d_inplace_fp32_kernel(float* data, int rows,
-                                                     int cols) {
+__global__ void softmax_row_2d_general_fp32_kernel(const float* in, float* out,
+                                                     int rows, int cols) {
   const int row = blockIdx.x;
   if (row >= rows)
     return;
-  float* row_ptr = data + (size_t)row * cols;
+  const float* in_row = in + (size_t)row * cols;
+  float* out_row = out + (size_t)row * cols;
 
   const int tid = threadIdx.x;
-  const int wave_id = tid / WAVE_SIZE;
   const int num_waves = blockDim.x / WAVE_SIZE;
 
   extern __shared__ float smem[];
@@ -130,85 +358,144 @@ __global__ void softmax_row_2d_inplace_fp32_kernel(float* data, int rows,
   // Pass 1: row max.
   float local_max = -INFINITY;
   for (int j = tid; j < cols; j += blockDim.x)
-    local_max = fmaxf(local_max, row_ptr[j]);
-  local_max = warp_reduce_max_f(local_max);
-  if (tid % WAVE_SIZE == 0)
-    smem[wave_id] = local_max;
-  __syncthreads();
-  if (tid < WAVE_SIZE) {
-    float v = (tid < num_waves) ? smem[tid] : -INFINITY;
-    v = warp_reduce_max_f(v);
-    smem[0] = v;
-  }
-  __syncthreads();
-  float row_max = smem[0];
+    local_max = fmaxf(local_max, in_row[j]);
+  const float row_max =
+      block_reduce_max_f(local_max, smem, tid, num_waves, num_waves);
 
   // Pass 2: exp2f + sum.
   float local_sum = 0.0f;
   for (int j = tid; j < cols; j += blockDim.x) {
-    float e = exp2f((row_ptr[j] - row_max) * LOG2E);
-    row_ptr[j] = e;
+    float e = exp2f((in_row[j] - row_max) * LOG2E);
+    out_row[j] = e;
     local_sum += e;
   }
-  local_sum = warp_reduce_sum_f(local_sum);
-  if (tid % WAVE_SIZE == 0)
-    smem[wave_id] = local_sum;
-  __syncthreads();
-  if (tid < WAVE_SIZE) {
-    float v = (tid < num_waves) ? smem[tid] : 0.0f;
-    v = warp_reduce_sum_f(v);
-    smem[0] = v;
-  }
-  __syncthreads();
-  float row_sum = smem[0];
-  float inv = 1.0f / row_sum;
+  const float inv =
+      1.0f / block_reduce_sum_f(local_sum, smem, tid, num_waves, num_waves + 1);
 
   // Pass 3: normalize.
   for (int j = tid; j < cols; j += blockDim.x)
-    row_ptr[j] = row_ptr[j] * inv;
+    out_row[j] = out_row[j] * inv;
 }
 
 } // namespace
 
-extern "C" int hip_softmax_row_2d_inplace(void* stream_ptr, void* data,
-                                            int rows, int cols) {
-  if (!data || rows <= 0 || cols <= 0)
+extern "C" int hip_softmax_row_2d(void* stream_ptr, const void* input,
+                                    void* output, int rows, int cols) {
+  if (!input || !output || rows <= 0 || cols <= 0)
     return -1;
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
-  // Pick block size: power of two up to min(cols, 256). 32 minimum for one
-  // wave on RDNA / 64 on CDNA. SoftMax for vision attention has cols up to
-  // ~4096, well-served by 256 threads × 16 iters.
+  (void)hipGetLastError();
+
+  const __half* in = static_cast<const __half*>(input);
+  __half* out = static_cast<__half*>(output);
+
+  // Wave-per-row when the row is exactly one wavefront wide at the vector
+  // width and both buffers are 16-byte aligned; the row stride is then a
+  // multiple of 16 bytes on its own. This covers the windowed-attention
+  // widths (256 and 512 on a 32-lane wave).
+  if ((reinterpret_cast<uintptr_t>(in) % 16) == 0 &&
+      (reinterpret_cast<uintptr_t>(out) % 16) == 0) {
+    const int grid = (rows + kWavesPerBlock - 1) / kWavesPerBlock;
+    const int block = kWavesPerBlock * WAVE_SIZE;
+    if (cols == WAVE_SIZE * 8) {
+      softmax_row_2d_wave_kernel<8>
+          <<<grid, block, 0, stream>>>(in, out, rows, cols);
+      return hipGetLastError();
+    }
+    if (cols == WAVE_SIZE * 16) {
+      softmax_row_2d_wave_kernel<16>
+          <<<grid, block, 0, stream>>>(in, out, rows, cols);
+      return hipGetLastError();
+    }
+    if (cols == WAVE_SIZE * 32) {
+      softmax_row_2d_wave_kernel<32>
+          <<<grid, block, 0, stream>>>(in, out, rows, cols);
+      return hipGetLastError();
+    }
+  }
+
+  // Block per row. Pick block size: power of two up to min(cols, 256). 32
+  // minimum for one wave on RDNA / 64 on CDNA. SoftMax for vision attention
+  // has cols up to ~4096, well-served by 256 threads × 16 iters.
   int threads = 32;
   while (threads < cols && threads < 256)
     threads *= 2;
   if (threads > 256)
     threads = 256;
   int num_waves = (threads + WAVE_SIZE - 1) / WAVE_SIZE;
-  size_t smem_bytes = static_cast<size_t>(num_waves) * sizeof(float);
-  (void)hipGetLastError();
-  softmax_row_2d_inplace_kernel<<<rows, threads, smem_bytes, stream>>>(
-      static_cast<__half*>(data), rows, cols);
+  size_t smem_bytes =
+      static_cast<size_t>(softmax_smem_floats(num_waves)) * sizeof(float);
+  if (cols <= threads) {
+    softmax_row_2d_regcache_kernel<<<rows, threads, smem_bytes, stream>>>(
+        in, out, rows, cols);
+    return hipGetLastError();
+  }
+  softmax_row_2d_general_kernel<<<rows, threads, smem_bytes, stream>>>(
+      in, out, rows, cols);
   return hipGetLastError();
 }
 
 // fp32 variant — for models where Softmax input is fp32 (e.g. Qwen VLM).
-extern "C" int hip_softmax_row_2d_inplace_fp32(void* stream_ptr, void* data,
-                                                 int rows, int cols) {
-  if (!data || rows <= 0 || cols <= 0)
+extern "C" int hip_softmax_row_2d_fp32(void* stream_ptr, const void* input,
+                                         void* output, int rows, int cols) {
+  if (!input || !output || rows <= 0 || cols <= 0)
     return -1;
   hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
-  // Pick block size: power of two up to min(cols, 256). 32 minimum for one
-  // wave on RDNA / 64 on CDNA. SoftMax for vision attention has cols up to
-  // ~4096, well-served by 256 threads × 16 iters.
+  (void)hipGetLastError();
+
+  const float* in = static_cast<const float*>(input);
+  float* out = static_cast<float*>(output);
+
+  if ((reinterpret_cast<uintptr_t>(in) % 16) == 0 &&
+      (reinterpret_cast<uintptr_t>(out) % 16) == 0) {
+    const int grid = (rows + kWavesPerBlock - 1) / kWavesPerBlock;
+    const int block = kWavesPerBlock * WAVE_SIZE;
+    if (cols == WAVE_SIZE * 4) {
+      softmax_row_2d_wave_fp32_kernel<4>
+          <<<grid, block, 0, stream>>>(in, out, rows, cols);
+      return hipGetLastError();
+    }
+    if (cols == WAVE_SIZE * 8) {
+      softmax_row_2d_wave_fp32_kernel<8>
+          <<<grid, block, 0, stream>>>(in, out, rows, cols);
+      return hipGetLastError();
+    }
+    if (cols == WAVE_SIZE * 16) {
+      softmax_row_2d_wave_fp32_kernel<16>
+          <<<grid, block, 0, stream>>>(in, out, rows, cols);
+      return hipGetLastError();
+    }
+  }
+
+  // Block per row. Pick block size: power of two up to min(cols, 256). 32
+  // minimum for one wave on RDNA / 64 on CDNA. SoftMax for vision attention
+  // has cols up to ~4096, well-served by 256 threads × 16 iters.
   int threads = 32;
   while (threads < cols && threads < 256)
     threads *= 2;
   if (threads > 256)
     threads = 256;
   int num_waves = (threads + WAVE_SIZE - 1) / WAVE_SIZE;
-  size_t smem_bytes = static_cast<size_t>(num_waves) * sizeof(float);
-  (void)hipGetLastError();
-  softmax_row_2d_inplace_fp32_kernel<<<rows, threads, smem_bytes, stream>>>(
-      static_cast<float*>(data), rows, cols);
+  size_t smem_bytes =
+      static_cast<size_t>(softmax_smem_floats(num_waves)) * sizeof(float);
+  if (cols <= threads) {
+    softmax_row_2d_regcache_fp32_kernel<<<rows, threads, smem_bytes, stream>>>(
+        in, out, rows, cols);
+    return hipGetLastError();
+  }
+  softmax_row_2d_general_fp32_kernel<<<rows, threads, smem_bytes, stream>>>(
+      in, out, rows, cols);
   return hipGetLastError();
+}
+
+// Kept for callers that hold a single buffer. Every kernel above tolerates
+// its source and destination being the same pointer.
+extern "C" int hip_softmax_row_2d_inplace(void* stream_ptr, void* data,
+                                            int rows, int cols) {
+  return hip_softmax_row_2d(stream_ptr, data, data, rows, cols);
+}
+
+extern "C" int hip_softmax_row_2d_inplace_fp32(void* stream_ptr, void* data,
+                                                 int rows, int cols) {
+  return hip_softmax_row_2d_fp32(stream_ptr, data, data, rows, cols);
 }

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -773,17 +773,23 @@ HIP_KERNEL_API int hip_gqa_softmax_inplace(
     int batch_stride, const void* head_sink, int num_heads,
     int use_smooth_softmax);
 
-/* Row-wise softmax over a flattened [rows, cols] row-major fp16 buffer.
- * One block per row, softmaxes the `cols` elements of each row in-place
- * (data is overwritten with normalized probabilities). Matches ONNX
- * Softmax semantics for axis = -1 on the flattened input. Used by the
- * standalone `hip_miopen_softmax` runtime entry point. */
-HIP_KERNEL_API int hip_softmax_row_2d_inplace(void* stream, void* data, int rows, int cols);
+/* Row-wise softmax over a flattened [rows, cols] row-major fp16 buffer,
+ * reading `input` and writing normalized probabilities to `output`. Matches
+ * ONNX Softmax semantics for axis = -1 on the flattened input. `input` may
+ * equal `output`. Used by the standalone `hip_miopen_softmax` runtime entry
+ * point, which is destination-passing and would otherwise have to copy its
+ * input over its output before running an in-place kernel. */
+HIP_KERNEL_API int hip_softmax_row_2d(void* stream, const void* input, void* output, int rows, int cols);
 
 /* fp32 variant of the above — for models where Softmax input is fp32.
  * Qwen VLM vision encoder attention scores are fp32; using the fp16 kernel
  * there misinterprets the data and produces completely wrong outputs.
  * Called by hip_miopen_softmax when elem_size_bytes == 4. */
+HIP_KERNEL_API int hip_softmax_row_2d_fp32(void* stream, const void* input, void* output, int rows, int cols);
+
+/* Single-buffer forms of the two above, for callers that softmax a buffer
+ * in place. Equivalent to passing `data` as both source and destination. */
+HIP_KERNEL_API int hip_softmax_row_2d_inplace(void* stream, void* data, int rows, int cols);
 HIP_KERNEL_API int hip_softmax_row_2d_inplace_fp32(void* stream, void* data, int rows, int cols);
 
 /* Column-wise softmax: fp32 input -> fp16 output.

--- a/lib/Runtime/real/activation.cpp
+++ b/lib/Runtime/real/activation.cpp
@@ -32,15 +32,13 @@ static int hipdnn_ep_to_hip_dtype_elementwise_unary(int64_t data_type) {
 // `ConvertHipToLLVM`'s `MiopenSoftmaxOpLowering` for `onnx.Softmax` paths
 // outside fused attention (vision encoder self-attention, primarily; text
 // decoders fuse softmax inside hip.gqa and don't reach this path).
-// Dispatches to `hip_softmax_row_2d_inplace` (custom HIP kernel) —
-// row-wise softmax over a contiguous row-major [rows, cols] fp16 buffer
-// with `cols` = the softmax axis size (ONNX Softmax axis = -1 over the
-// last dim of the flattened input).
+// Dispatches to `hip_softmax_row_2d` (custom HIP kernel) — row-wise softmax
+// over a contiguous row-major [rows, cols] buffer with `cols` = the softmax
+// axis size (ONNX Softmax axis = -1 over the last dim of the flattened input).
 //
-// fp16-only today. The buffer element type is taken on faith from the
-// MemRef the lowering hands us; the runtime does not validate the dtype.
-// If a future model needs fp32 softmax, plumb an `elem_size` (or dtype
-// enum) through the lowering and dispatch in the kernel launcher.
+// The buffer element type is taken on faith from `elem_size_bytes`, which the
+// lowering derives from the MemRef type; the runtime does not otherwise
+// validate the dtype.
 //
 // Symbol name is `hip_miopen_softmax` (not `hip_softmax`) to match the
 // lowering side's `kMiopenSoftmax` constant. The kernel-level dispatch
@@ -51,8 +49,8 @@ static int hipdnn_ep_to_hip_dtype_elementwise_unary(int64_t data_type) {
 // only spawns `total_head_queries` blocks, not `total_head_queries * cols`.
 // A standalone softmax wired to that path produces NaN downstream.
 // elem_size_bytes: 2 for fp16/bf16, 4 for fp32.  The lowering passes the
-// element size derived from the MemRef type so the runtime can copy and
-// dispatch with the correct dtype.
+// element size derived from the MemRef type so the runtime can dispatch with
+// the correct dtype.
 extern "C" int hip_miopen_softmax(void *state, const void *input, void *output,
                                   int64_t rows, int64_t cols,
                                   int64_t elem_size_bytes) {
@@ -86,29 +84,20 @@ extern "C" int hip_miopen_softmax(void *state, const void *input, void *output,
 
   void *stream = hipdnn_ep_state_get_stream(st);
 
-  // Copy input -> output with the correct element size.  Previously this
-  // hardcoded sizeof(uint16_t)=2, corrupting fp32 inputs (Qwen VLM attention
-  // scores) by copying only half the data.
-  hipError_t err =
-      hipMemcpyAsync(output, input,
-                     static_cast<size_t>(rows) * static_cast<size_t>(cols) *
-                         static_cast<size_t>(elem_size_bytes),
-                     hipMemcpyDeviceToDevice, static_cast<hipStream_t>(stream));
-  if (err != hipSuccess) {
-    fprintf(stderr, "[REAL] hip_miopen_softmax: hipMemcpyAsync failed: %s\n",
-            hipGetErrorString(err));
-    return -1;
-  }
-
   RUNTIME_DEBUG_LOG(
       "[REAL] hip_miopen_softmax: rows=%lld cols=%lld elem_size=%lld\n",
       (long long)rows, (long long)cols, (long long)elem_size_bytes);
 
+  // The kernel reads `input` and writes `output` directly, and tolerates the
+  // two being the same buffer, so no staging copy is needed either way. This
+  // op used to copy input over output and softmax the copy in place, which
+  // moved as many bytes again as the softmax itself and so cost the op double
+  // its compulsory traffic regardless of how fast the kernel was.
   if (elem_size_bytes == 4)
-    return hip_softmax_row_2d_inplace_fp32(
-        stream, output, static_cast<int>(rows), static_cast<int>(cols));
-  return hip_softmax_row_2d_inplace(stream, output, static_cast<int>(rows),
-                                    static_cast<int>(cols));
+    return hip_softmax_row_2d_fp32(
+        stream, input, output, static_cast<int>(rows), static_cast<int>(cols));
+  return hip_softmax_row_2d(stream, input, output, static_cast<int>(rows),
+                            static_cast<int>(cols));
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
## Summary

Two independent memory-traffic fixes to the custom kernels that dominate
windowed-attention vision models. Both were found by measuring achieved
bandwidth against the compulsory traffic each operation must move, and both
close most of the remaining gap.

| operation | before | after | change |
|---|---:|---:|---|
| row-wise softmax | 254 ms | 56 ms | stop copying the input; wave-per-row kernel |
| 4-D broadcast add (attention bias) | 345 ms | 186 ms | vectorised fast path |

Measured on swinv2-base at 2048x3072, fp16, gfx1151, summed over all
invocations in one warm inference.

## What

**Softmax — remove the copy.** `hip_miopen_softmax` copied the entire input
tensor over the output with `hipMemcpyAsync`, then ran an in-place kernel over
the result. The copy moved exactly as many bytes as the kernel itself, so the
operation paid twice its compulsory traffic; on the dominant shape it moved
402 MB and cost about as much as the softmax.

All six row-wise kernels now take separate source and destination pointers.
Each either holds its row in registers or reads strictly ahead of what it
writes, so accepting a distinct destination is a signature change rather than a
restructure, and passing one buffer as both still behaves as before. The
previous in-place entry points remain as wrappers that do exactly that, so
external callers are unaffected. `softmax_row_2d_inplace_kernel` becomes
`softmax_row_2d_general_kernel`, since it now serves both cases.

This commit also carries the wave-per-row path, which keeps a row in registers
so it is read once and written once instead of read three times and written
twice, and a fix for a race in the multi-wave LDS reduction.

**Elementwise — widen the access.** The general 4-D broadcast kernel assigns
one element per thread, so it issues two-byte accesses and recomputes the index
with four runtime integer divisions and four modulos per element. On the
bias-add shapes the narrow access, not the arithmetic, dominated: removing the
divisions alone left the kernel well short of copy speed, while widening the
access closed the gap. Shapes whose broadcast pattern folds into a contiguous
inner run now take a vectorised path where each thread moves a wide aligned
chunk; the guard and the term folding are computed host-side, and shapes that
do not qualify use the general kernel unchanged.

## Test plan

- **Numeric (GPU vs ORT CPU), gfx1151:** 62/62 pass — 24 softmax cases covering
  the wave path, the strided fallback and chained-softmax write coverage, and
  38 elementwise cases covering both the fast path and the general kernel.
  These were run against this exact build; they are not part of this PR (see
  below).
- **fp32 softmax end to end:** L2 difference 1.3e-05 against ORT CPU over 23M
  elements, all values finite.
- **Compiler suites:** `MorphizenMLIRLitTests`, `OutputAllocatorUnitTest` and
  `StaticPlugins` pass.
- **CI on the previous head of this branch** (identical kernel sources, plus
  the tests): Linux build, mock build, real build, GPU test and pre-commit all
  green.
- **Capture evidence:** an RGP capture re-fenced on the dominant softmax shape
  now opens on the softmax kernel at dispatch 0 with no preceding gap and
  contains no `__amd_rocclr_copyBuffer`, where the previous capture contained
  exactly one immediately before the kernel.

## Notes for reviewers

- **No tests are included in this PR, by request.** The numeric cases and the
  standalone A/B microbenchmarks that back these two changes exist and pass,
  and the results above come from running them, but they are held back for a
  separate change. Note that `test/numeric/` is not currently executed by any
  CI workflow, so this does not change what CI verifies — but it does mean the
  new softmax kernels and the new elementwise fast path land without committed
  coverage a reviewer can run. I would recommend landing that follow-up
  alongside or shortly after this PR.
- **The two commits are independent** and touch disjoint kernels. They are
  presented together because they were measured together on the same model; if
  reviewing them separately is preferable, the PR splits cleanly at the commit
  boundary.
- **Aliasing.** The kernels tolerate source and destination being the same
  buffer, but the EP's pool planner assigns distinct offsets to overlapping
  lifetimes, so a graph-generated softmax cannot actually alias. The tolerance
  exists for the in-place wrappers and is exercised by the microbenchmark
  rather than by an ONNX-level test.

## AI assistance disclosure

Substantial AI assistance, disclosed per `CONTRIBUTING.md`. An AI tool (Claude
Opus 5 via Cursor) implemented these changes and wrote this description. The
work was validated by execution rather than review alone: the numeric results,
the build results and the capture evidence quoted above are from actual runs on
gfx1151 hardware, and the per-operation timings come from back-to-back A/B runs
with only the change under test differing between builds. The contributor
remains the author and is accountable for the code and the claims.
