### PR TITLE
feat(hipsr): run hipsr-use-output-allocator in the pipeline

### DIFF
--- a/include/hip/Dialect/Hipsr/Transforms/Passes.td
+++ b/include/hip/Dialect/Hipsr/Transforms/Passes.td
@@ -249,10 +249,14 @@ def HipsrUseOutputAllocatorPass
   let summary =
       "Rewrite returned memref.alloc outputs to hipsr.alloc_output";
   let description = [{
-    Replaces each graph-output `memref.alloc` with `hipsr.alloc_output`, reusing
-    the alloc's dynamic-size operands and setting `out_idx` to its position in
-    `func.return`. Output buffers then come from the EP output allocator and are
-    owned by the EP/runtime instead of being deallocated or pooled.
+    Replaces each graph-output `memref.alloc` with `hipsr.alloc_output`, taking
+    dynamic sizes from the allocation's `hipsr.preserve_shape` and setting
+    `out_idx` to its position in `func.return`. Output buffers then come from
+    the EP output allocator and are owned by the EP/runtime instead of being
+    deallocated or pooled.
+
+    Runs after bufferization, since a shape it reads must be an index memref,
+    and before `hipsr-pool-alloc` and `hipsr-remove-preserve-shape`.
 
     An allocation counts as a graph output when `func.return` returns it either
     directly or through view-like aliases. The view operations are left in
@@ -263,6 +267,7 @@ def HipsrUseOutputAllocatorPass
     are skipped. The function signature and `func.return` are left unchanged.
   }];
   let dependentDialects = [
+    "::mlir::arith::ArithDialect",
     "::mlir::hipsr::HipsrDialect",
     "::mlir::memref::MemRefDialect"
   ];

--- a/lib/Dialect/Hipsr/Pipelines/Pipelines.cpp
+++ b/lib/Dialect/Hipsr/Pipelines/Pipelines.cpp
@@ -27,6 +27,7 @@
 //   --convert-shape-to-std
 //   --one-shot-bufferize
 //   --convert-linalg-to-loops
+//   --hipsr-use-output-allocator
 void mlir::hipsr::buildHipsrPipeline(OpPassManager &pm,
                                      const HipsrPipelineOptions & /*options*/) {
   pm.addPass(createAddContextArgPass());
@@ -55,6 +56,8 @@ void mlir::hipsr::buildHipsrPipeline(OpPassManager &pm,
   // shape.broadcast becomes a tensor.generate, which bufferizes to a
   // linalg.map. That is the only linalg op this pipeline produces.
   pm.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
+
+  pm.addNestedPass<func::FuncOp>(createHipsrUseOutputAllocatorPass());
 }
 
 void mlir::hipsr::registerHipsrPipelines() {

--- a/lib/Dialect/Hipsr/Transforms/HipsrUseOutputAllocator.cpp
+++ b/lib/Dialect/Hipsr/Transforms/HipsrUseOutputAllocator.cpp
@@ -10,7 +10,6 @@
 #include "mlir/Dialect/Bufferization/Transforms/BufferViewFlowAnalysis.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/Shape/IR/Shape.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/Dominance.h"
 #include "mlir/IR/PatternMatch.h"
@@ -118,36 +117,26 @@ findAliasedPoolResults(BufferViewFlowAnalysis &aliasAnalysis, Value value) {
   return poolResults;
 }
 
-static SmallVector<Value> materializeDimensions(Value preservedShape,
-                                                MemRefType type, Location loc,
-                                                OpBuilder &builder) {
-  SmallVector<Value> dimensions;
-  dimensions.reserve(type.getRank());
-
-  for (int64_t dimension : llvm::seq<int64_t>(0, type.getRank())) {
-    Value size;
-    if (type.isDynamicDim(dimension)) {
-      assert(preservedShape && "dynamic dims require a preserved shape");
-      Value extent =
-          builder.create<shape::GetExtentOp>(loc, preservedShape, dimension);
-      size = builder.create<shape::SizeToIndexOp>(loc, extent);
-    } else {
-      size = arith::ConstantIndexOp::create(builder, loc,
-                                            type.getDimSize(dimension));
-    }
-
-    dimensions.push_back(size);
-  }
-  return dimensions;
+static bool isBufferizedShape(Value shape) {
+  return shape && isa<MemRefType>(shape.getType());
 }
 
-static SmallVector<Value> getDynamicDimensions(ArrayRef<Value> dimensions,
-                                               MemRefType type) {
-  SmallVector<Value> dynamicDimensions;
-  for (int64_t dimension : llvm::seq<int64_t>(0, type.getRank()))
-    if (type.isDynamicDim(dimension))
-      dynamicDimensions.push_back(dimensions[dimension]);
-  return dynamicDimensions;
+static SmallVector<Value> materializeDynamicDimensions(Value preservedShape,
+                                                       MemRefType type,
+                                                       Location loc,
+                                                       OpBuilder &builder) {
+  SmallVector<Value> dimensions;
+  dimensions.reserve(type.getNumDynamicDims());
+
+  for (int64_t dimension : llvm::seq<int64_t>(0, type.getRank())) {
+    if (!type.isDynamicDim(dimension)) {
+      continue;
+    }
+    Value position = arith::ConstantIndexOp::create(builder, loc, dimension);
+    dimensions.push_back(
+        memref::LoadOp::create(builder, loc, preservedShape, position));
+  }
+  return dimensions;
 }
 
 static OpFoldResult multiplyIndexValues(OpFoldResult lhs, OpFoldResult rhs,
@@ -168,15 +157,9 @@ static OpFoldResult multiplyIndexValues(OpFoldResult lhs, OpFoldResult rhs,
 
 static Value createContiguousView(OpBuilder &builder, Location loc,
                                   Value source, MemRefType targetType,
-                                  ArrayRef<Value> targetDimensions) {
-  SmallVector<OpFoldResult> sizes;
-  sizes.reserve(targetType.getRank());
-  for (int64_t dimension : llvm::seq<int64_t>(0, targetType.getRank())) {
-    if (targetType.isDynamicDim(dimension))
-      sizes.push_back(targetDimensions[dimension]);
-    else
-      sizes.push_back(builder.getIndexAttr(targetType.getDimSize(dimension)));
-  }
+                                  ValueRange dynamicDimensions) {
+  SmallVector<OpFoldResult> sizes =
+      getMixedValues(targetType.getShape(), dynamicDimensions, builder);
 
   SmallVector<OpFoldResult> strides(targetType.getRank());
   OpFoldResult runningStride = builder.getIndexAttr(1);
@@ -203,11 +186,6 @@ struct OutputInfo {
 
 struct HipsrUseOutputAllocatorPass
     : impl::HipsrUseOutputAllocatorPassBase<HipsrUseOutputAllocatorPass> {
-
-  void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<arith::ArithDialect, hipsr::HipsrDialect,
-                    memref::MemRefDialect, shape::ShapeDialect>();
-  }
 
   void runOnOperation() override {
     func::FuncOp funcOp = getOperation();
@@ -327,17 +305,19 @@ struct HipsrUseOutputAllocatorPass
 
       MemRefType internalType = allocOp.getType();
 
-      if (externalType.getNumDynamicDims() != 0 && !externalShape) {
+      if (externalType.getNumDynamicDims() != 0 &&
+          !isBufferizedShape(externalShape)) {
         returnOp.emitError()
             << "graph output " << outIdx
-            << " has dynamic dims but no preserved external shape";
+            << " has dynamic dims but no preserved external shape memref";
         signalPassFailure();
         return;
       }
 
-      if (internalType.getNumDynamicDims() != 0 && !internalShape) {
+      if (internalType.getNumDynamicDims() != 0 &&
+          !isBufferizedShape(internalShape)) {
         allocOp.emitError()
-            << "has dynamic dims but no preserved internal shape";
+            << "has dynamic dims but no preserved internal shape memref";
         signalPassFailure();
         return;
       }
@@ -413,22 +393,20 @@ struct HipsrUseOutputAllocatorPass
       Location loc = allocOp.getLoc();
       builder.setInsertionPoint(allocOp);
 
-      SmallVector<Value> externalDimensions = materializeDimensions(
+      SmallVector<Value> externalDynamicSizes = materializeDynamicDimensions(
           output.externalShape, output.externalType, loc, builder);
-      SmallVector<Value> internalDimensions = materializeDimensions(
-          output.internalShape, internalType, loc, builder);
-
-      SmallVector<Value> externalDynamicSizes =
-          getDynamicDimensions(externalDimensions, output.externalType);
       auto allocOutput = AllocOutputOp::create(
           builder, loc, output.externalType, output.context,
           externalDynamicSizes, builder.getI64IntegerAttr(output.outIdx));
 
       Value replacement = allocOutput.getResult();
       if (output.externalType != internalType ||
-          output.externalShape != output.internalShape)
+          output.externalShape != output.internalShape) {
+        SmallVector<Value> internalDimensions = materializeDynamicDimensions(
+            output.internalShape, internalType, loc, builder);
         replacement = createContiguousView(builder, loc, replacement,
                                            internalType, internalDimensions);
+      }
 
       for (Operation *user : llvm::make_early_inc_range(allocOp->getUsers()))
         if (auto dealloc = dyn_cast<memref::DeallocOp>(user))

--- a/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
@@ -118,17 +118,17 @@
 // CHECK-NEXT:        %[[ALLOC_8:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[DIM_3]], %[[ALLOC_8]]{{\[}}%[[CONSTANT_6]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[DIM_4]], %[[ALLOC_8]]{{\[}}%[[CONSTANT_5]]] : memref<2xindex>
-// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_7]]{{\[}}%[[CONSTANT_6]]] {{\[}}%[[CONSTANT_6]]] {{\[}}%[[CONSTANT_5]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_7]]{{\[}}%[[CONSTANT_5]]] {{\[}}%[[CONSTANT_5]]] {{\[}}%[[CONSTANT_5]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_7]]{{\[}}%[[CONSTANT_6]]] [%[[CONSTANT_6]]] [%[[CONSTANT_5]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_7]]{{\[}}%[[CONSTANT_5]]] [%[[CONSTANT_5]]] [%[[CONSTANT_5]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:        %[[ALLOC_9:.*]] = memref.alloc(%[[CONSTANT_1]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_9]][0] {{\[}}%[[CONSTANT_6]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_9]]{{\[}}0] [%[[CONSTANT_6]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        memref.copy %[[SUBVIEW_0]], %[[SUBVIEW_2]] : memref<?xindex, strided<[?], offset: ?>> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        %[[SUBVIEW_3:.*]] = memref.subview %[[ALLOC_9]]{{\[}}%[[CONSTANT_6]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_8]], %[[SUBVIEW_3]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        %[[ALLOC_10:.*]] = memref.alloc(%[[CONSTANT_7]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[ALLOC_10]][0] {{\[}}%[[CONSTANT_1]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[ALLOC_10]]{{\[}}0] [%[[CONSTANT_1]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_9]], %[[SUBVIEW_4]] : memref<?xindex> to memref<?xindex, strided<[1]>>
-// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_10]]{{\[}}%[[CONSTANT_1]]] {{\[}}%[[CONSTANT_5]]] [1] : memref<?xindex> to memref<?xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_10]]{{\[}}%[[CONSTANT_1]]] [%[[CONSTANT_5]]] [1] : memref<?xindex> to memref<?xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        memref.copy %[[SUBVIEW_1]], %[[SUBVIEW_5]] : memref<?xindex, strided<[?], offset: ?>> to memref<?xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        %[[LOAD_5:.*]] = memref.load %[[ALLOC_2]]{{\[}}%[[CONSTANT_6]]] : memref<1xindex>
 // CHECK-NEXT:        %[[ALLOC_11:.*]] = memref.alloc(%[[LOAD_5]]) {alignment = 64 : i64} : memref<?xf16, #hipsr.mem<device>>
@@ -154,7 +154,7 @@
 // CHECK-NEXT:          %[[CONSTANT_9:.*]] = arith.constant 0 : index
 // CHECK-NEXT:          %[[DIM_5:.*]] = memref.dim %[[VAL_10]], %[[CONSTANT_9]] : memref<?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:          %[[DIM_6:.*]] = memref.dim %[[VAL_10]], %[[CONSTANT_8]] : memref<?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:          %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[VAL_10]] {{\[\[}}0], [1, 2]] output_shape {{\[}}%[[DIM_5]], %[[DIM_6]], 1] : memref<?x?xi1, #hipsr.mem<device>> into memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[VAL_10]] {{\[\[}}0], [1, 2]] output_shape [%[[DIM_5]], %[[DIM_6]], 1] : memref<?x?xi1, #hipsr.mem<device>> into memref<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT:          hipsr.compute_yield %[[EXPAND_SHAPE_0]] : memref<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT:        } : memref<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT:        %[[ALLOC_16:.*]] = memref.alloc(%[[LOAD_10]], %[[LOAD_11]]) {alignment = 64 : i64} : memref<?x?x4096xf16, #hipsr.mem<device>>
@@ -183,46 +183,46 @@
 // CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_11]], %[[COMPUTE_0]], %[[ALLOC_12]], %[[COMPUTE_1]], %[[ALLOC_13]], %[[ALLOC_16]], %[[ALLOC_14]], %[[COMPUTE_2]] : memref<?xf16, #hipsr.mem<device>>, memref<?xf16, #hipsr.mem<device>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>, memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:      } -> memref<?xf16, #hipsr.mem<device>>, memref<?xf16, #hipsr.mem<device>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>, memref<3xi64, #hipsr.mem<host>> {domain_id = 0 : i64}
 // CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]]:2 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#2, %[[POOL_DOMAIN_0]]#6, %[[POOL_DOMAIN_0]]#3, %[[POOL_DOMAIN_0]]#7 : !hipsr.context, memref<?x?x1xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_16:.*]]: !hipsr.context, %[[VAL_17:.*]]: memref<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_18:.*]]: memref<3xi64, #hipsr.mem<host>>, %[[VAL_19:.*]]: memref<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_20:.*]]: memref<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:      ^bb0(%[[VAL_15:.*]]: !hipsr.context, %[[VAL_16:.*]]: memref<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_17:.*]]: memref<3xi64, #hipsr.mem<host>>, %[[VAL_18:.*]]: memref<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_19:.*]]: memref<3xi64, #hipsr.mem<host>>):
 // CHECK-NEXT:        %[[CONSTANT_14:.*]] = arith.constant 3 : index
 // CHECK-NEXT:        %[[CONSTANT_15:.*]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[CONSTANT_16:.*]] = arith.constant 1 : index
 // CHECK-NEXT:        %[[CONSTANT_17:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[DIM_9:.*]] = memref.dim %[[VAL_17]], %[[CONSTANT_17]] : memref<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[DIM_10:.*]] = memref.dim %[[VAL_17]], %[[CONSTANT_16]] : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_9:.*]] = memref.dim %[[VAL_16]], %[[CONSTANT_17]] : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_10:.*]] = memref.dim %[[VAL_16]], %[[CONSTANT_16]] : memref<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT:        %[[ALLOC_18:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
 // CHECK-NEXT:        memref.store %[[DIM_9]], %[[ALLOC_18]]{{\[}}%[[CONSTANT_17]]] : memref<3xindex>
 // CHECK-NEXT:        memref.store %[[DIM_10]], %[[ALLOC_18]]{{\[}}%[[CONSTANT_16]]] : memref<3xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_16]], %[[ALLOC_18]]{{\[}}%[[CONSTANT_15]]] : memref<3xindex>
-// CHECK-NEXT:        %[[LOAD_12:.*]] = memref.load %[[VAL_18]]{{\[}}%[[CONSTANT_17]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_12:.*]] = memref.load %[[VAL_17]]{{\[}}%[[CONSTANT_17]]] : memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_2:.*]] = arith.index_cast %[[LOAD_12]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_13:.*]] = memref.load %[[VAL_18]]{{\[}}%[[CONSTANT_16]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_13:.*]] = memref.load %[[VAL_17]]{{\[}}%[[CONSTANT_16]]] : memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_3:.*]] = arith.index_cast %[[LOAD_13]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_14:.*]] = memref.load %[[VAL_18]]{{\[}}%[[CONSTANT_15]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_14:.*]] = memref.load %[[VAL_17]]{{\[}}%[[CONSTANT_15]]] : memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_4:.*]] = arith.index_cast %[[LOAD_14]] : i64 to index
 // CHECK-NEXT:        %[[ALLOC_19:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
 // CHECK-NEXT:        memref.store %[[INDEX_CAST_2]], %[[ALLOC_19]]{{\[}}%[[CONSTANT_17]]] : memref<3xindex>
 // CHECK-NEXT:        memref.store %[[INDEX_CAST_3]], %[[ALLOC_19]]{{\[}}%[[CONSTANT_16]]] : memref<3xindex>
 // CHECK-NEXT:        memref.store %[[INDEX_CAST_4]], %[[ALLOC_19]]{{\[}}%[[CONSTANT_15]]] : memref<3xindex>
 // CHECK-NEXT:        %[[ALLOC_20:.*]] = memref.alloc(%[[CONSTANT_14]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_21:.*]] = %[[CONSTANT_17]] to %[[CONSTANT_14]] step %[[CONSTANT_16]] {
-// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_21]], %[[CONSTANT_17]] : index
+// CHECK-NEXT:        scf.for %[[VAL_20:.*]] = %[[CONSTANT_17]] to %[[CONSTANT_14]] step %[[CONSTANT_16]] {
+// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_20]], %[[CONSTANT_17]] : index
 // CHECK-NEXT:          %[[IF_2:.*]] = scf.if %[[CMPI_3]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[CONSTANT_16]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_15:.*]] = memref.load %[[ALLOC_18]]{{\[}}%[[VAL_21]]] : memref<3xindex>
+// CHECK-NEXT:            %[[LOAD_15:.*]] = memref.load %[[ALLOC_18]]{{\[}}%[[VAL_20]]] : memref<3xindex>
 // CHECK-NEXT:            scf.yield %[[LOAD_15]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_21]], %[[CONSTANT_17]] : index
+// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_20]], %[[CONSTANT_17]] : index
 // CHECK-NEXT:          %[[IF_3:.*]] = scf.if %[[CMPI_4]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_2]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_16:.*]] = memref.load %[[ALLOC_19]]{{\[}}%[[VAL_21]]] : memref<3xindex>
+// CHECK-NEXT:            %[[LOAD_16:.*]] = memref.load %[[ALLOC_19]]{{\[}}%[[VAL_20]]] : memref<3xindex>
 // CHECK-NEXT:            %[[CMPI_5:.*]] = arith.cmpi eq, %[[LOAD_16]], %[[CONSTANT_16]] : index
 // CHECK-NEXT:            %[[SELECT_1:.*]] = arith.select %[[CMPI_5]], %[[IF_2]], %[[LOAD_16]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_1]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_20]]{{\[}}%[[VAL_21]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_20]]{{\[}}%[[VAL_20]]] : memref<?xindex>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %[[CAST_1:.*]] = memref.cast %[[ALLOC_20]] : memref<?xindex> to memref<3xindex>
 // CHECK-NEXT:        %[[LOAD_17:.*]] = memref.load %[[ALLOC_20]]{{\[}}%[[CONSTANT_17]]] : memref<?xindex>
@@ -230,59 +230,59 @@
 // CHECK-NEXT:        %[[LOAD_19:.*]] = memref.load %[[ALLOC_20]]{{\[}}%[[CONSTANT_15]]] : memref<?xindex>
 // CHECK-NEXT:        %[[ALLOC_21:.*]] = memref.alloc(%[[LOAD_17]], %[[LOAD_18]], %[[LOAD_19]]) {alignment = 64 : i64} : memref<?x?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:        %[[ALLOC_22:.*]] = memref.alloc(%[[LOAD_17]], %[[LOAD_18]], %[[LOAD_19]]) {alignment = 64 : i64} : memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.expand(%[[VAL_16]]) ins(%[[VAL_19]], %[[VAL_20]] : memref<?x?x1xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) outs(%[[ALLOC_22]] : memref<?x?x?xi1, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.expand(%[[VAL_15]]) ins(%[[VAL_18]], %[[VAL_19]] : memref<?x?x1xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) outs(%[[ALLOC_22]] : memref<?x?x?xi1, #hipsr.mem<device>>)
 // CHECK-NEXT:        hipsr.preserve_shape %[[CAST_1]], %[[ALLOC_22]] : memref<3xindex>, memref<?x?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_21]], %[[ALLOC_22]] : memref<?x?x?xi1, #hipsr.mem<device>>, memref<?x?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:      } -> memref<?x?x?xi1, #hipsr.mem<device>>, memref<?x?x?xi1, #hipsr.mem<device>> {domain_id = 1 : i64}
 // CHECK-NEXT:      %[[POOL_DOMAIN_2:.*]]:4 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_1]]#0, %[[POOL_DOMAIN_0]]#6, %[[POOL_DOMAIN_1]]#1, %[[POOL_DOMAIN_0]]#7 : !hipsr.context, memref<?x?x?xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>, memref<?x?x?xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_24:.*]]: !hipsr.context, %[[VAL_25:.*]]: memref<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_26:.*]]: memref<3xi64, #hipsr.mem<host>>, %[[VAL_27:.*]]: memref<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_28:.*]]: memref<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:      ^bb0(%[[VAL_21:.*]]: !hipsr.context, %[[VAL_22:.*]]: memref<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_23:.*]]: memref<3xi64, #hipsr.mem<host>>, %[[VAL_24:.*]]: memref<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_25:.*]]: memref<3xi64, #hipsr.mem<host>>):
 // CHECK-NEXT:        %[[CONSTANT_18:.*]] = arith.constant 3 : index
 // CHECK-NEXT:        %[[CONSTANT_19:.*]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[CONSTANT_20:.*]] = arith.constant 1 : index
 // CHECK-NEXT:        %[[CONSTANT_21:.*]] = arith.constant 0 : index
 // CHECK-NEXT:        %[[ALLOC_23:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_20]], %[[ALLOC_23]]{{\[}}%[[CONSTANT_21]]] : memref<1xindex>
-// CHECK-NEXT:        %[[DIM_11:.*]] = memref.dim %[[VAL_25]], %[[CONSTANT_21]] : memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[DIM_12:.*]] = memref.dim %[[VAL_25]], %[[CONSTANT_20]] : memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[DIM_13:.*]] = memref.dim %[[VAL_25]], %[[CONSTANT_19]] : memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_11:.*]] = memref.dim %[[VAL_22]], %[[CONSTANT_21]] : memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_12:.*]] = memref.dim %[[VAL_22]], %[[CONSTANT_20]] : memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_13:.*]] = memref.dim %[[VAL_22]], %[[CONSTANT_19]] : memref<?x?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:        %[[ALLOC_24:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
 // CHECK-NEXT:        memref.store %[[DIM_11]], %[[ALLOC_24]]{{\[}}%[[CONSTANT_21]]] : memref<3xindex>
 // CHECK-NEXT:        memref.store %[[DIM_12]], %[[ALLOC_24]]{{\[}}%[[CONSTANT_20]]] : memref<3xindex>
 // CHECK-NEXT:        memref.store %[[DIM_13]], %[[ALLOC_24]]{{\[}}%[[CONSTANT_19]]] : memref<3xindex>
-// CHECK-NEXT:        %[[LOAD_20:.*]] = memref.load %[[VAL_26]]{{\[}}%[[CONSTANT_21]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_20:.*]] = memref.load %[[VAL_23]]{{\[}}%[[CONSTANT_21]]] : memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_5:.*]] = arith.index_cast %[[LOAD_20]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_21:.*]] = memref.load %[[VAL_26]]{{\[}}%[[CONSTANT_20]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_21:.*]] = memref.load %[[VAL_23]]{{\[}}%[[CONSTANT_20]]] : memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_6:.*]] = arith.index_cast %[[LOAD_21]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_22:.*]] = memref.load %[[VAL_26]]{{\[}}%[[CONSTANT_19]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_22:.*]] = memref.load %[[VAL_23]]{{\[}}%[[CONSTANT_19]]] : memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_7:.*]] = arith.index_cast %[[LOAD_22]] : i64 to index
 // CHECK-NEXT:        %[[ALLOC_25:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
 // CHECK-NEXT:        memref.store %[[INDEX_CAST_5]], %[[ALLOC_25]]{{\[}}%[[CONSTANT_21]]] : memref<3xindex>
 // CHECK-NEXT:        memref.store %[[INDEX_CAST_6]], %[[ALLOC_25]]{{\[}}%[[CONSTANT_20]]] : memref<3xindex>
 // CHECK-NEXT:        memref.store %[[INDEX_CAST_7]], %[[ALLOC_25]]{{\[}}%[[CONSTANT_19]]] : memref<3xindex>
 // CHECK-NEXT:        %[[ALLOC_26:.*]] = memref.alloc(%[[CONSTANT_18]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_29:.*]] = %[[CONSTANT_21]] to %[[CONSTANT_18]] step %[[CONSTANT_20]] {
-// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_29]], %[[CONSTANT_21]] : index
+// CHECK-NEXT:        scf.for %[[VAL_26:.*]] = %[[CONSTANT_21]] to %[[CONSTANT_18]] step %[[CONSTANT_20]] {
+// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_26]], %[[CONSTANT_21]] : index
 // CHECK-NEXT:          %[[IF_4:.*]] = scf.if %[[CMPI_6]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[CONSTANT_20]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_23:.*]] = memref.load %[[ALLOC_24]]{{\[}}%[[VAL_29]]] : memref<3xindex>
+// CHECK-NEXT:            %[[LOAD_23:.*]] = memref.load %[[ALLOC_24]]{{\[}}%[[VAL_26]]] : memref<3xindex>
 // CHECK-NEXT:            scf.yield %[[LOAD_23]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_29]], %[[CONSTANT_21]] : index
+// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_26]], %[[CONSTANT_21]] : index
 // CHECK-NEXT:          %[[IF_5:.*]] = scf.if %[[CMPI_7]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_4]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_24:.*]] = memref.load %[[ALLOC_25]]{{\[}}%[[VAL_29]]] : memref<3xindex>
+// CHECK-NEXT:            %[[LOAD_24:.*]] = memref.load %[[ALLOC_25]]{{\[}}%[[VAL_26]]] : memref<3xindex>
 // CHECK-NEXT:            %[[CMPI_8:.*]] = arith.cmpi eq, %[[LOAD_24]], %[[CONSTANT_20]] : index
 // CHECK-NEXT:            %[[SELECT_2:.*]] = arith.select %[[CMPI_8]], %[[IF_4]], %[[LOAD_24]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_2]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_26]]{{\[}}%[[VAL_29]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_26]]{{\[}}%[[VAL_26]]] : memref<?xindex>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %[[CAST_2:.*]] = memref.cast %[[ALLOC_26]] : memref<?xindex> to memref<3xindex>
-// CHECK-NEXT:        %[[FOR_1:.*]] = scf.for %[[VAL_30:.*]] = %[[CONSTANT_21]] to %[[CONSTANT_18]] step %[[CONSTANT_20]] iter_args(%[[VAL_31:.*]] = %[[CONSTANT_20]]) -> (index) {
-// CHECK-NEXT:          %[[LOAD_25:.*]] = memref.load %[[ALLOC_26]]{{\[}}%[[VAL_30]]] : memref<?xindex>
-// CHECK-NEXT:          %[[MULI_1:.*]] = arith.muli %[[LOAD_25]], %[[VAL_31]] : index
+// CHECK-NEXT:        %[[FOR_1:.*]] = scf.for %[[VAL_27:.*]] = %[[CONSTANT_21]] to %[[CONSTANT_18]] step %[[CONSTANT_20]] iter_args(%[[VAL_28:.*]] = %[[CONSTANT_20]]) -> (index) {
+// CHECK-NEXT:          %[[LOAD_25:.*]] = memref.load %[[ALLOC_26]]{{\[}}%[[VAL_27]]] : memref<?xindex>
+// CHECK-NEXT:          %[[MULI_1:.*]] = arith.muli %[[LOAD_25]], %[[VAL_28]] : index
 // CHECK-NEXT:          scf.yield %[[MULI_1]] : index
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %[[ALLOC_27:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
@@ -296,11 +296,11 @@
 // CHECK-NEXT:        %[[ALLOC_29:.*]] = memref.alloc(%[[LOAD_29]]) {alignment = 64 : i64} : memref<3x?xi64, #hipsr.mem<device>>
 // CHECK-NEXT:        %[[ALLOC_30:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xi64, #hipsr.mem<device>>
 // CHECK-NEXT:        %[[ALLOC_31:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.expand(%[[VAL_24]]) ins(%[[VAL_27]], %[[VAL_28]] : memref<?x?x?xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) outs(%[[ALLOC_28]] : memref<?x?x?xi1, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.expand(%[[VAL_21]]) ins(%[[VAL_24]], %[[VAL_25]] : memref<?x?x?xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) outs(%[[ALLOC_28]] : memref<?x?x?xi1, #hipsr.mem<device>>)
 // CHECK-NEXT:        %[[ALLOC_32:.*]] = memref.alloc(%[[LOAD_29]]) {alignment = 64 : i64} : memref<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.nonzero(%[[VAL_24]]) ins(%[[ALLOC_28]] : memref<?x?x?xi1, #hipsr.mem<device>>) outs(%[[ALLOC_32]], %[[ALLOC_30]] : memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.nonzero(%[[VAL_21]]) ins(%[[ALLOC_28]] : memref<?x?x?xi1, #hipsr.mem<device>>) outs(%[[ALLOC_32]], %[[ALLOC_30]] : memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<device>>)
 // CHECK-NEXT:        %[[ALLOC_33:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.copy_d2h(%[[VAL_24]]) ins(%[[ALLOC_30]] : memref<1xi64, #hipsr.mem<device>>) outs(%[[ALLOC_33]] : memref<1xi64, #hipsr.mem<host>>)
+// CHECK-NEXT:        hipsr.copy_d2h(%[[VAL_21]]) ins(%[[ALLOC_30]] : memref<1xi64, #hipsr.mem<device>>) outs(%[[ALLOC_33]] : memref<1xi64, #hipsr.mem<host>>)
 // CHECK-NEXT:        hipsr.preserve_shape %[[CAST_2]], %[[ALLOC_28]] : memref<3xindex>, memref<?x?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_27]], %[[ALLOC_32]] : memref<2xindex>, memref<3x?xi64, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_23]], %[[ALLOC_30]] : memref<1xindex>, memref<1xi64, #hipsr.mem<device>>
@@ -308,7 +308,7 @@
 // CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_29]], %[[ALLOC_32]], %[[ALLOC_31]], %[[ALLOC_33]] : memref<3x?xi64, #hipsr.mem<device>>, memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:      } -> memref<3x?xi64, #hipsr.mem<device>>, memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<1xi64, #hipsr.mem<host>> {domain_id = 2 : i64}
 // CHECK-NEXT:      %[[POOL_DOMAIN_3:.*]]:4 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_2]]#2, %[[POOL_DOMAIN_2]]#0, %[[POOL_DOMAIN_2]]#3, %[[POOL_DOMAIN_2]]#1 : !hipsr.context, memref<1xi64, #hipsr.mem<host>>, memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<3x?xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_33:.*]]: !hipsr.context, %[[VAL_34:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_35:.*]]: memref<3x?xi64, #hipsr.mem<device>>, %[[VAL_36:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_37:.*]]: memref<3x?xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:      ^bb0(%[[VAL_29:.*]]: !hipsr.context, %[[VAL_30:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_31:.*]]: memref<3x?xi64, #hipsr.mem<device>>, %[[VAL_32:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_33:.*]]: memref<3x?xi64, #hipsr.mem<device>>):
 // CHECK-NEXT:        %[[CONSTANT_22:.*]] = arith.constant 3 : index
 // CHECK-NEXT:        %[[CONSTANT_23:.*]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[CONSTANT_24:.*]] = arith.constant 0 : index
@@ -318,7 +318,7 @@
 // CHECK-NEXT:        %[[ALLOC_35:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_23]], %[[ALLOC_35]]{{\[}}%[[CONSTANT_24]]] : memref<1xindex>
 // CHECK-NEXT:        %[[ALLOC_36:.*]] = memref.alloc() {alignment = 64 : i64} : memref<0xindex>
-// CHECK-NEXT:        %[[LOAD_30:.*]] = memref.load %[[VAL_34]]{{\[}}%[[CONSTANT_24]]] : memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_30:.*]] = memref.load %[[VAL_30]]{{\[}}%[[CONSTANT_24]]] : memref<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_8:.*]] = arith.index_cast %[[LOAD_30]] : i64 to index
 // CHECK-NEXT:        %[[ALLOC_37:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_22]], %[[ALLOC_37]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
@@ -335,38 +335,38 @@
 // CHECK-NEXT:        %[[ALLOC_41:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[ALLOC_42:.*]] = memref.alloc() {alignment = 64 : i64} : memref<i64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[ALLOC_43:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[COMPUTE_3:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[VAL_36]], %[[VAL_37]] : memref<1xi64, #hipsr.mem<host>>, memref<3x?xi64, #hipsr.mem<device>>) outs(%[[ALLOC_39]] : memref<3x?xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:        ^bb0(%[[VAL_38:.*]]: !hipsr.context, %[[VAL_39:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_40:.*]]: memref<3x?xi64, #hipsr.mem<device>>, %[[VAL_41:.*]]: memref<3x?xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[COMPUTE_3:.*]] = hipsr.compute(%[[VAL_29]]) ins(%[[VAL_32]], %[[VAL_33]] : memref<1xi64, #hipsr.mem<host>>, memref<3x?xi64, #hipsr.mem<device>>) outs(%[[ALLOC_39]] : memref<3x?xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_34:.*]]: !hipsr.context, %[[VAL_35:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_36:.*]]: memref<3x?xi64, #hipsr.mem<device>>, %[[VAL_37:.*]]: memref<3x?xi64, #hipsr.mem<device>>):
 // CHECK-NEXT:          %[[CONSTANT_26:.*]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[DIM_14:.*]] = memref.dim %[[VAL_41]], %[[CONSTANT_26]] : memref<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:          %[[SUBVIEW_6:.*]] = memref.subview %[[VAL_40]][0, 0] [3, %[[DIM_14]]] [1, 1] : memref<3x?xi64, #hipsr.mem<device>> to memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[DIM_14:.*]] = memref.dim %[[VAL_37]], %[[CONSTANT_26]] : memref<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[SUBVIEW_6:.*]] = memref.subview %[[VAL_36]]{{\[}}0, 0] [3, %[[DIM_14]]] [1, 1] : memref<3x?xi64, #hipsr.mem<device>> to memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
 // CHECK-NEXT:          hipsr.compute_yield %[[SUBVIEW_6]] : memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
 // CHECK-NEXT:        } : memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
 // CHECK-NEXT:        %[[ALLOC_44:.*]] = memref.alloc(%[[LOAD_34]]) {alignment = 64 : i64} : memref<?x3xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.transpose(%[[VAL_33]]) ins(%[[COMPUTE_3]] : memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>) outs(%[[ALLOC_44]] : memref<?x3xi64, #hipsr.mem<device>>) {perm = array<i64: 1, 0>}
-// CHECK-NEXT:        %[[COMPUTE_4:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[ALLOC_44]] : memref<?x3xi64, #hipsr.mem<device>>) outs(%[[ALLOC_41]] : memref<2xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:        ^bb0(%[[VAL_42:.*]]: !hipsr.context, %[[VAL_43:.*]]: memref<?x3xi64, #hipsr.mem<device>>, %[[VAL_44:.*]]: memref<2xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:        hipsr.transpose(%[[VAL_29]]) ins(%[[COMPUTE_3]] : memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>) outs(%[[ALLOC_44]] : memref<?x3xi64, #hipsr.mem<device>>) {perm = array<i64: 1, 0>}
+// CHECK-NEXT:        %[[COMPUTE_4:.*]] = hipsr.compute(%[[VAL_29]]) ins(%[[ALLOC_44]] : memref<?x3xi64, #hipsr.mem<device>>) outs(%[[ALLOC_41]] : memref<2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_38:.*]]: !hipsr.context, %[[VAL_39:.*]]: memref<?x3xi64, #hipsr.mem<device>>, %[[VAL_40:.*]]: memref<2xi64, #hipsr.mem<host>>):
 // CHECK-NEXT:          %[[CONSTANT_27:.*]] = arith.constant 1 : index
 // CHECK-NEXT:          %[[CONSTANT_28:.*]] = arith.constant 3 : i64
 // CHECK-NEXT:          %[[CONSTANT_29:.*]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[DIM_15:.*]] = memref.dim %[[VAL_43]], %[[CONSTANT_29]] : memref<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[DIM_15:.*]] = memref.dim %[[VAL_39]], %[[CONSTANT_29]] : memref<?x3xi64, #hipsr.mem<device>>
 // CHECK-NEXT:          %[[INDEX_CAST_9:.*]] = arith.index_cast %[[DIM_15]] : index to i64
 // CHECK-NEXT:          %[[ALLOC_45:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:          memref.store %[[INDEX_CAST_9]], %[[ALLOC_45]]{{\[}}%[[CONSTANT_29]]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:          memref.store %[[CONSTANT_28]], %[[ALLOC_45]]{{\[}}%[[CONSTANT_27]]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:          hipsr.compute_yield %[[ALLOC_45]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        } : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[COMPUTE_5:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[COMPUTE_4]] : memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_42]] : memref<i64, #hipsr.mem<host>>) {
-// CHECK-NEXT:        ^bb0(%[[VAL_45:.*]]: !hipsr.context, %[[VAL_46:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_47:.*]]: memref<i64, #hipsr.mem<host>>):
+// CHECK-NEXT:        %[[COMPUTE_5:.*]] = hipsr.compute(%[[VAL_29]]) ins(%[[COMPUTE_4]] : memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_42]] : memref<i64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_41:.*]]: !hipsr.context, %[[VAL_42:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_43:.*]]: memref<i64, #hipsr.mem<host>>):
 // CHECK-NEXT:          %[[CONSTANT_30:.*]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[LOAD_35:.*]] = memref.load %[[VAL_46]]{{\[}}%[[CONSTANT_30]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          %[[LOAD_35:.*]] = memref.load %[[VAL_42]]{{\[}}%[[CONSTANT_30]]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:          %[[ALLOC_46:.*]] = memref.alloc() {alignment = 64 : i64} : memref<i64, #hipsr.mem<host>>
-// CHECK-NEXT:          memref.store %[[LOAD_35]], %[[ALLOC_46]][] : memref<i64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[LOAD_35]], %[[ALLOC_46]]{{\[}}] : memref<i64, #hipsr.mem<host>>
 // CHECK-NEXT:          hipsr.compute_yield %[[ALLOC_46]] : memref<i64, #hipsr.mem<host>>
 // CHECK-NEXT:        } : memref<i64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[COMPUTE_6:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[COMPUTE_5]] : memref<i64, #hipsr.mem<host>>) outs(%[[COMPUTE_5]] : memref<i64, #hipsr.mem<host>>) {
-// CHECK-NEXT:        ^bb0(%[[VAL_48:.*]]: !hipsr.context, %[[VAL_49:.*]]: memref<i64, #hipsr.mem<host>>, %[[VAL_50:.*]]: memref<i64, #hipsr.mem<host>>):
-// CHECK-NEXT:          %[[EXPAND_SHAPE_1:.*]] = memref.expand_shape %[[VAL_49]] [] output_shape [1] : memref<i64, #hipsr.mem<host>> into memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[COMPUTE_6:.*]] = hipsr.compute(%[[VAL_29]]) ins(%[[COMPUTE_5]] : memref<i64, #hipsr.mem<host>>) outs(%[[COMPUTE_5]] : memref<i64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_44:.*]]: !hipsr.context, %[[VAL_45:.*]]: memref<i64, #hipsr.mem<host>>, %[[VAL_46:.*]]: memref<i64, #hipsr.mem<host>>):
+// CHECK-NEXT:          %[[EXPAND_SHAPE_1:.*]] = memref.expand_shape %[[VAL_45]] [] output_shape [1] : memref<i64, #hipsr.mem<host>> into memref<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:          hipsr.compute_yield %[[EXPAND_SHAPE_1]] : memref<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        } : memref<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_37]], %[[COMPUTE_3]] : memref<2xindex>, memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
@@ -377,13 +377,13 @@
 // CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_40]], %[[ALLOC_44]], %[[ALLOC_43]], %[[COMPUTE_6]] : memref<?x3xi64, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:      } -> memref<?x3xi64, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<1xi64, #hipsr.mem<host>> {domain_id = 3 : i64}
 // CHECK-NEXT:      %[[POOL_DOMAIN_4:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#0, %[[POOL_DOMAIN_3]]#2, %[[POOL_DOMAIN_0]]#1, %[[POOL_DOMAIN_3]]#3, %[[POOL_DOMAIN_0]]#4, %[[POOL_DOMAIN_3]]#0, %[[POOL_DOMAIN_0]]#5, %[[POOL_DOMAIN_3]]#1 : !hipsr.context, memref<?xf16, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<?xf16, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_53:.*]]: !hipsr.context, %[[VAL_54:.*]]: memref<?xf16, #hipsr.mem<device>>, %[[VAL_55:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_56:.*]]: memref<?xf16, #hipsr.mem<device>>, %[[VAL_57:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_58:.*]]: memref<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_59:.*]]: memref<?x3xi64, #hipsr.mem<device>>, %[[VAL_60:.*]]: memref<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_61:.*]]: memref<?x3xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:      ^bb0(%[[VAL_47:.*]]: !hipsr.context, %[[VAL_48:.*]]: memref<?xf16, #hipsr.mem<device>>, %[[VAL_49:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_50:.*]]: memref<?xf16, #hipsr.mem<device>>, %[[VAL_51:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_52:.*]]: memref<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_53:.*]]: memref<?x3xi64, #hipsr.mem<device>>, %[[VAL_54:.*]]: memref<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_55:.*]]: memref<?x3xi64, #hipsr.mem<device>>):
 // CHECK-NEXT:        %[[CONSTANT_31:.*]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[CONSTANT_32:.*]] = arith.constant 4096 : index
 // CHECK-NEXT:        %[[CONSTANT_33:.*]] = arith.constant 1 : index
 // CHECK-NEXT:        %[[CONSTANT_34:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[DIM_16:.*]] = memref.dim %[[VAL_54]], %[[CONSTANT_34]] : memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[LOAD_36:.*]] = memref.load %[[VAL_55]]{{\[}}%[[CONSTANT_34]]] : memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[DIM_16:.*]] = memref.dim %[[VAL_48]], %[[CONSTANT_34]] : memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[LOAD_36:.*]] = memref.load %[[VAL_49]]{{\[}}%[[CONSTANT_34]]] : memref<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_10:.*]] = arith.index_cast %[[LOAD_36]] : i64 to index
 // CHECK-NEXT:        %[[CMPI_9:.*]] = arith.cmpi slt, %[[INDEX_CAST_10]], %[[CONSTANT_34]] : index
 // CHECK-NEXT:        %[[ADDI_0:.*]] = arith.addi %[[INDEX_CAST_10]], %[[DIM_16]] : index
@@ -395,22 +395,26 @@
 // CHECK-NEXT:        %[[MAXSI_1:.*]] = arith.maxsi %[[SUBI_1]], %[[CONSTANT_34]] : index
 // CHECK-NEXT:        %[[ALLOC_47:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
 // CHECK-NEXT:        memref.store %[[MAXSI_1]], %[[ALLOC_47]]{{\[}}%[[CONSTANT_34]]] : memref<1xindex>
-// CHECK-NEXT:        %[[DIM_17:.*]] = memref.dim %[[VAL_58]], %[[CONSTANT_34]] : memref<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[DIM_18:.*]] = memref.dim %[[VAL_58]], %[[CONSTANT_33]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_17:.*]] = memref.dim %[[VAL_52]], %[[CONSTANT_34]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_18:.*]] = memref.dim %[[VAL_52]], %[[CONSTANT_33]] : memref<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:        %[[ALLOC_48:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
 // CHECK-NEXT:        memref.store %[[DIM_17]], %[[ALLOC_48]]{{\[}}%[[CONSTANT_34]]] : memref<3xindex>
 // CHECK-NEXT:        memref.store %[[DIM_18]], %[[ALLOC_48]]{{\[}}%[[CONSTANT_33]]] : memref<3xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_32]], %[[ALLOC_48]]{{\[}}%[[CONSTANT_31]]] : memref<3xindex>
 // CHECK-NEXT:        %[[LOAD_37:.*]] = memref.load %[[ALLOC_47]]{{\[}}%[[CONSTANT_34]]] : memref<1xindex>
 // CHECK-NEXT:        %[[ALLOC_49:.*]] = memref.alloc(%[[LOAD_37]]) {alignment = 64 : i64} : memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[DIM_19:.*]] = memref.dim %[[VAL_58]], %[[CONSTANT_34]] : memref<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[DIM_20:.*]] = memref.dim %[[VAL_58]], %[[CONSTANT_33]] : memref<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_50:.*]] = memref.alloc(%[[DIM_19]], %[[DIM_20]]) {alignment = 64 : i64} : memref<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.slice(%[[VAL_53]]) ins(%[[VAL_56]] : memref<?xf16, #hipsr.mem<device>>) ends(%[[VAL_57]] : memref<1xi64, #hipsr.mem<host>>) outs(%[[ALLOC_49]] : memref<?xf16, #hipsr.mem<device>>) {axes_attr = array<i64: 0>, starts_attr = array<i64: 0>, steps_attr = array<i64: 1>}
-// CHECK-NEXT:        hipsr.scatter_nd(%[[VAL_53]]) ins(%[[VAL_60]], %[[VAL_61]], %[[ALLOC_49]] : memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<?xf16, #hipsr.mem<device>>) outs(%[[ALLOC_50]] : memref<?x?x4096xf16, #hipsr.mem<device>>)
+// CHECK-NEXT:        %[[DIM_19:.*]] = memref.dim %[[VAL_52]], %[[CONSTANT_34]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_20:.*]] = memref.dim %[[VAL_52]], %[[CONSTANT_33]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CONSTANT_35:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[LOAD_38:.*]] = memref.load %[[ALLOC_48]]{{\[}}%[[CONSTANT_35]]] : memref<3xindex>
+// CHECK-NEXT:        %[[CONSTANT_36:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[LOAD_39:.*]] = memref.load %[[ALLOC_48]]{{\[}}%[[CONSTANT_36]]] : memref<3xindex>
+// CHECK-NEXT:        %[[ALLOC_OUTPUT_0:.*]] = hipsr.alloc_output(%[[VAL_47]], %[[LOAD_38]], %[[LOAD_39]]) {out_idx = 0 : i64} : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.slice(%[[VAL_47]]) ins(%[[VAL_50]] : memref<?xf16, #hipsr.mem<device>>) ends(%[[VAL_51]] : memref<1xi64, #hipsr.mem<host>>) outs(%[[ALLOC_49]] : memref<?xf16, #hipsr.mem<device>>) {axes_attr = array<i64: 0>, starts_attr = array<i64: 0>, steps_attr = array<i64: 1>}
+// CHECK-NEXT:        hipsr.scatter_nd(%[[VAL_47]]) ins(%[[VAL_54]], %[[VAL_55]], %[[ALLOC_49]] : memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<?xf16, #hipsr.mem<device>>) outs(%[[ALLOC_OUTPUT_0]] : memref<?x?x4096xf16, #hipsr.mem<device>>)
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_47]], %[[ALLOC_49]] : memref<1xindex>, memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_48]], %[[ALLOC_50]] : memref<3xindex>, memref<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_50]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_48]], %[[ALLOC_OUTPUT_0]] : memref<3xindex>, memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_OUTPUT_0]] : memref<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      } -> memref<?x?x4096xf16, #hipsr.mem<device>> {domain_id = 4 : i64}
 // CHECK-NEXT:      return %[[POOL_DOMAIN_4]] : memref<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:    }

--- a/test/lit/Dialect/Hipsr/Pipelines/sample_dynamic.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/sample_dynamic.mlir
@@ -28,8 +28,8 @@
 // CHECK-NEXT:        %[[ALLOC_2:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_0]], %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_3]], %[[ALLOC_2]]{{\[}}%[[CONSTANT_3]]] : memref<2xindex>
-// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_1]]{{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_1]]{{\[}}%[[CONSTANT_4]]] [%[[CONSTANT_4]]] [%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] [%[[CONSTANT_4]]] [%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:        %[[ALLOC_3:.*]] = memref.alloc(%[[CONSTANT_4]]) {alignment = 64 : i64} : memref<?xindex>
 // CHECK-NEXT:        scf.for %[[VAL_3:.*]] = %[[CONSTANT_4]] to %[[CONSTANT_4]] step %[[CONSTANT_3]] {
 // CHECK-NEXT:          %[[CMPI_0:.*]] = arith.cmpi ult, %[[VAL_3]], %[[CONSTANT_4]] : index
@@ -55,7 +55,7 @@
 // CHECK-NEXT:        memref.store %[[DIM_1]], %[[ALLOC_4]]{{\[}}%[[CONSTANT_4]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_3]], %[[ALLOC_4]]{{\[}}%[[CONSTANT_3]]] : memref<2xindex>
 // CHECK-NEXT:        %[[ALLOC_5:.*]] = memref.alloc(%[[CONSTANT_5]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_5]][0] {{\[}}%[[CONSTANT_4]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_5]]{{\[}}0] [%[[CONSTANT_4]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_3]], %[[SUBVIEW_2]] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        %[[SUBVIEW_3:.*]] = memref.subview %[[ALLOC_5]]{{\[}}%[[CONSTANT_4]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_4]], %[[SUBVIEW_3]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
@@ -85,86 +85,88 @@
 // CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_7]], %[[ALLOC_9]], %[[ALLOC_8]], %[[COMPUTE_0]], %[[CONSTANT_1]] : memref<?x1xf32, #hipsr.mem<device>>, memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      } -> memref<?x1xf32, #hipsr.mem<device>>, memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
 // CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#0, %[[POOL_DOMAIN_0]]#2, %[[POOL_DOMAIN_0]]#1, %[[POOL_DOMAIN_0]]#3, %[[POOL_DOMAIN_0]]#4 : !hipsr.context, memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_8:.*]]: !hipsr.context, %[[VAL_9:.*]]: memref<?x1xf32, #hipsr.mem<device>>, %[[VAL_10:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_11:.*]]: memref<?x1xf32, #hipsr.mem<device>>, %[[VAL_12:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_13:.*]]: memref<4x2xf32, #hipsr.mem<device>>):
+// CHECK-NEXT:      ^bb0(%[[VAL_7:.*]]: !hipsr.context, %[[VAL_8:.*]]: memref<?x1xf32, #hipsr.mem<device>>, %[[VAL_9:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_10:.*]]: memref<?x1xf32, #hipsr.mem<device>>, %[[VAL_11:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_12:.*]]: memref<4x2xf32, #hipsr.mem<device>>):
 // CHECK-NEXT:        %[[CONSTANT_9:.*]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[CONSTANT_10:.*]] = arith.constant 4 : index
 // CHECK-NEXT:        %[[CONSTANT_11:.*]] = arith.constant 0 : index
 // CHECK-NEXT:        %[[CONSTANT_12:.*]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[DIM_3:.*]] = memref.dim %[[VAL_9]], %[[CONSTANT_11]] : memref<?x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_3:.*]] = memref.dim %[[VAL_8]], %[[CONSTANT_11]] : memref<?x1xf32, #hipsr.mem<device>>
 // CHECK-NEXT:        %[[ALLOC_11:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[DIM_3]], %[[ALLOC_11]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_12]], %[[ALLOC_11]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
-// CHECK-NEXT:        %[[LOAD_4:.*]] = memref.load %[[VAL_10]]{{\[}}%[[CONSTANT_11]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_4:.*]] = memref.load %[[VAL_9]]{{\[}}%[[CONSTANT_11]]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_1:.*]] = arith.index_cast %[[LOAD_4]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_5:.*]] = memref.load %[[VAL_10]]{{\[}}%[[CONSTANT_12]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_5:.*]] = memref.load %[[VAL_9]]{{\[}}%[[CONSTANT_12]]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_2:.*]] = arith.index_cast %[[LOAD_5]] : i64 to index
 // CHECK-NEXT:        %[[ALLOC_12:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[INDEX_CAST_1]], %[[ALLOC_12]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[INDEX_CAST_2]], %[[ALLOC_12]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
 // CHECK-NEXT:        %[[ALLOC_13:.*]] = memref.alloc(%[[CONSTANT_9]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_14:.*]] = %[[CONSTANT_11]] to %[[CONSTANT_9]] step %[[CONSTANT_12]] {
-// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_14]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:        scf.for %[[VAL_13:.*]] = %[[CONSTANT_11]] to %[[CONSTANT_9]] step %[[CONSTANT_12]] {
+// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_13]], %[[CONSTANT_11]] : index
 // CHECK-NEXT:          %[[IF_2:.*]] = scf.if %[[CMPI_3]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[CONSTANT_12]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_6:.*]] = memref.load %[[ALLOC_11]]{{\[}}%[[VAL_14]]] : memref<2xindex>
+// CHECK-NEXT:            %[[LOAD_6:.*]] = memref.load %[[ALLOC_11]]{{\[}}%[[VAL_13]]] : memref<2xindex>
 // CHECK-NEXT:            scf.yield %[[LOAD_6]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_14]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_13]], %[[CONSTANT_11]] : index
 // CHECK-NEXT:          %[[IF_3:.*]] = scf.if %[[CMPI_4]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_2]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_7:.*]] = memref.load %[[ALLOC_12]]{{\[}}%[[VAL_14]]] : memref<2xindex>
+// CHECK-NEXT:            %[[LOAD_7:.*]] = memref.load %[[ALLOC_12]]{{\[}}%[[VAL_13]]] : memref<2xindex>
 // CHECK-NEXT:            %[[CMPI_5:.*]] = arith.cmpi eq, %[[LOAD_7]], %[[CONSTANT_12]] : index
 // CHECK-NEXT:            %[[SELECT_1:.*]] = arith.select %[[CMPI_5]], %[[IF_2]], %[[LOAD_7]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_1]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_13]]{{\[}}%[[VAL_14]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_13]]{{\[}}%[[VAL_13]]] : memref<?xindex>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %[[CAST_0:.*]] = memref.cast %[[ALLOC_13]] : memref<?xindex> to memref<2xindex>
 // CHECK-NEXT:        %[[ALLOC_14:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_10]], %[[ALLOC_14]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_14]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
-// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[CAST_0]]{{\[}}%[[CONSTANT_11]]] {{\[}}%[[CONSTANT_11]]] {{\[}}%[[CONSTANT_12]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_14]]{{\[}}%[[CONSTANT_11]]] {{\[}}%[[CONSTANT_11]]] {{\[}}%[[CONSTANT_12]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[CAST_0]]{{\[}}%[[CONSTANT_11]]] [%[[CONSTANT_11]]] [%[[CONSTANT_12]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_14]]{{\[}}%[[CONSTANT_11]]] [%[[CONSTANT_11]]] [%[[CONSTANT_12]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:        %[[ALLOC_15:.*]] = memref.alloc(%[[CONSTANT_11]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_15:.*]] = %[[CONSTANT_11]] to %[[CONSTANT_11]] step %[[CONSTANT_12]] {
-// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_15]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:        scf.for %[[VAL_14:.*]] = %[[CONSTANT_11]] to %[[CONSTANT_11]] step %[[CONSTANT_12]] {
+// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_14]], %[[CONSTANT_11]] : index
 // CHECK-NEXT:          %[[IF_4:.*]] = scf.if %[[CMPI_6]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[CONSTANT_12]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_8:.*]] = memref.load %[[SUBVIEW_4]]{{\[}}%[[VAL_15]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            %[[LOAD_8:.*]] = memref.load %[[SUBVIEW_4]]{{\[}}%[[VAL_14]]] : memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:            scf.yield %[[LOAD_8]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_15]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_14]], %[[CONSTANT_11]] : index
 // CHECK-NEXT:          %[[IF_5:.*]] = scf.if %[[CMPI_7]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_4]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_9:.*]] = memref.load %[[SUBVIEW_5]]{{\[}}%[[VAL_15]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            %[[LOAD_9:.*]] = memref.load %[[SUBVIEW_5]]{{\[}}%[[VAL_14]]] : memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:            %[[CMPI_8:.*]] = arith.cmpi eq, %[[LOAD_9]], %[[CONSTANT_12]] : index
 // CHECK-NEXT:            %[[SELECT_2:.*]] = arith.select %[[CMPI_8]], %[[IF_4]], %[[LOAD_9]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_2]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_15]]{{\[}}%[[VAL_15]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_15]]{{\[}}%[[VAL_14]]] : memref<?xindex>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %[[LOAD_10:.*]] = memref.load %[[ALLOC_13]]{{\[}}%[[CONSTANT_11]]] : memref<?xindex>
 // CHECK-NEXT:        %[[ALLOC_16:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[LOAD_10]], %[[ALLOC_16]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_16]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
 // CHECK-NEXT:        %[[ALLOC_17:.*]] = memref.alloc(%[[CONSTANT_9]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_6:.*]] = memref.subview %[[ALLOC_17]][0] {{\[}}%[[CONSTANT_11]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_6:.*]] = memref.subview %[[ALLOC_17]]{{\[}}0] [%[[CONSTANT_11]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_15]], %[[SUBVIEW_6]] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        %[[SUBVIEW_7:.*]] = memref.subview %[[ALLOC_17]]{{\[}}%[[CONSTANT_11]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_16]], %[[SUBVIEW_7]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        %[[LOAD_11:.*]] = memref.load %[[ALLOC_13]]{{\[}}%[[CONSTANT_11]]] : memref<?xindex>
 // CHECK-NEXT:        %[[ALLOC_18:.*]] = memref.alloc(%[[LOAD_11]]) {alignment = 64 : i64} : memref<?x4xf32, #hipsr.mem<device>>
 // CHECK-NEXT:        %[[LOAD_12:.*]] = memref.load %[[ALLOC_17]]{{\[}}%[[CONSTANT_11]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_19:.*]] = memref.alloc(%[[LOAD_12]]) {alignment = 64 : i64} : memref<?x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.expand(%[[VAL_8]]) ins(%[[VAL_11]], %[[VAL_12]] : memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_18]] : memref<?x4xf32, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.matmul(%[[VAL_8]]) ins(%[[ALLOC_18]], %[[VAL_13]] : memref<?x4xf32, #hipsr.mem<device>>, memref<4x2xf32, #hipsr.mem<device>>) outs(%[[ALLOC_19]] : memref<?x2xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        %[[CONSTANT_13:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[LOAD_13:.*]] = memref.load %[[ALLOC_17]]{{\[}}%[[CONSTANT_13]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_OUTPUT_0:.*]] = hipsr.alloc_output(%[[VAL_7]], %[[LOAD_13]]) {out_idx = 0 : i64} : memref<?x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.expand(%[[VAL_7]]) ins(%[[VAL_10]], %[[VAL_11]] : memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_18]] : memref<?x4xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.matmul(%[[VAL_7]]) ins(%[[ALLOC_18]], %[[VAL_12]] : memref<?x4xf32, #hipsr.mem<device>>, memref<4x2xf32, #hipsr.mem<device>>) outs(%[[ALLOC_OUTPUT_0]] : memref<?x2xf32, #hipsr.mem<device>>)
 // CHECK-NEXT:        hipsr.preserve_shape %[[CAST_0]], %[[ALLOC_18]] : memref<2xindex>, memref<?x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_17]], %[[ALLOC_19]] : memref<?xindex>, memref<?x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_19]] : memref<?x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_17]], %[[ALLOC_OUTPUT_0]] : memref<?xindex>, memref<?x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_OUTPUT_0]] : memref<?x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      } -> memref<?x2xf32, #hipsr.mem<device>> {domain_id = 1 : i64}
 // CHECK-NEXT:      return %[[POOL_DOMAIN_1]] : memref<?x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    }

--- a/test/lit/Dialect/Hipsr/Pipelines/sample_static.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/sample_static.mlir
@@ -28,8 +28,8 @@
 // CHECK-NEXT:        %[[ALLOC_2:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_0]], %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_3]], %[[ALLOC_2]]{{\[}}%[[CONSTANT_3]]] : memref<2xindex>
-// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_1]]{{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_1]]{{\[}}%[[CONSTANT_4]]] [%[[CONSTANT_4]]] [%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] [%[[CONSTANT_4]]] [%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:        %[[ALLOC_3:.*]] = memref.alloc(%[[CONSTANT_4]]) {alignment = 64 : i64} : memref<?xindex>
 // CHECK-NEXT:        scf.for %[[VAL_3:.*]] = %[[CONSTANT_4]] to %[[CONSTANT_4]] step %[[CONSTANT_3]] {
 // CHECK-NEXT:          %[[CMPI_0:.*]] = arith.cmpi ult, %[[VAL_3]], %[[CONSTANT_4]] : index
@@ -54,7 +54,7 @@
 // CHECK-NEXT:        memref.store %[[CONSTANT_5]], %[[ALLOC_4]]{{\[}}%[[CONSTANT_4]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_3]], %[[ALLOC_4]]{{\[}}%[[CONSTANT_3]]] : memref<2xindex>
 // CHECK-NEXT:        %[[ALLOC_5:.*]] = memref.alloc(%[[CONSTANT_5]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_5]][0] {{\[}}%[[CONSTANT_4]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_5]]{{\[}}0] [%[[CONSTANT_4]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_3]], %[[SUBVIEW_2]] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        %[[SUBVIEW_3:.*]] = memref.subview %[[ALLOC_5]]{{\[}}%[[CONSTANT_4]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_4]], %[[SUBVIEW_3]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
@@ -75,7 +75,7 @@
 // CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_7]], %[[ALLOC_9]], %[[ALLOC_8]], %[[COMPUTE_0]], %[[CONSTANT_1]] : memref<2x1xf32, #hipsr.mem<device>>, memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      } -> memref<2x1xf32, #hipsr.mem<device>>, memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
 // CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#0, %[[POOL_DOMAIN_0]]#2, %[[POOL_DOMAIN_0]]#1, %[[POOL_DOMAIN_0]]#3, %[[POOL_DOMAIN_0]]#4 : !hipsr.context, memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_8:.*]]: !hipsr.context, %[[VAL_9:.*]]: memref<2x1xf32, #hipsr.mem<device>>, %[[VAL_10:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_11:.*]]: memref<2x1xf32, #hipsr.mem<device>>, %[[VAL_12:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_13:.*]]: memref<4x2xf32, #hipsr.mem<device>>):
+// CHECK-NEXT:      ^bb0(%[[VAL_7:.*]]: !hipsr.context, %[[VAL_8:.*]]: memref<2x1xf32, #hipsr.mem<device>>, %[[VAL_9:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_10:.*]]: memref<2x1xf32, #hipsr.mem<device>>, %[[VAL_11:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_12:.*]]: memref<4x2xf32, #hipsr.mem<device>>):
 // CHECK-NEXT:        %[[CONSTANT_6:.*]] = arith.constant 4 : index
 // CHECK-NEXT:        %[[CONSTANT_7:.*]] = arith.constant 0 : index
 // CHECK-NEXT:        %[[CONSTANT_8:.*]] = arith.constant 1 : index
@@ -83,75 +83,75 @@
 // CHECK-NEXT:        %[[ALLOC_10:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_7]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_8]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_8]]] : memref<2xindex>
-// CHECK-NEXT:        %[[LOAD_2:.*]] = memref.load %[[VAL_10]]{{\[}}%[[CONSTANT_7]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_2:.*]] = memref.load %[[VAL_9]]{{\[}}%[[CONSTANT_7]]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_0:.*]] = arith.index_cast %[[LOAD_2]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_3:.*]] = memref.load %[[VAL_10]]{{\[}}%[[CONSTANT_8]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_3:.*]] = memref.load %[[VAL_9]]{{\[}}%[[CONSTANT_8]]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_1:.*]] = arith.index_cast %[[LOAD_3]] : i64 to index
 // CHECK-NEXT:        %[[ALLOC_11:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[INDEX_CAST_0]], %[[ALLOC_11]]{{\[}}%[[CONSTANT_7]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[INDEX_CAST_1]], %[[ALLOC_11]]{{\[}}%[[CONSTANT_8]]] : memref<2xindex>
 // CHECK-NEXT:        %[[ALLOC_12:.*]] = memref.alloc(%[[CONSTANT_9]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_14:.*]] = %[[CONSTANT_7]] to %[[CONSTANT_9]] step %[[CONSTANT_8]] {
-// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_14]], %[[CONSTANT_7]] : index
+// CHECK-NEXT:        scf.for %[[VAL_13:.*]] = %[[CONSTANT_7]] to %[[CONSTANT_9]] step %[[CONSTANT_8]] {
+// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_13]], %[[CONSTANT_7]] : index
 // CHECK-NEXT:          %[[IF_2:.*]] = scf.if %[[CMPI_3]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[CONSTANT_8]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_4:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[VAL_14]]] : memref<2xindex>
+// CHECK-NEXT:            %[[LOAD_4:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[VAL_13]]] : memref<2xindex>
 // CHECK-NEXT:            scf.yield %[[LOAD_4]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_14]], %[[CONSTANT_7]] : index
+// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_13]], %[[CONSTANT_7]] : index
 // CHECK-NEXT:          %[[IF_3:.*]] = scf.if %[[CMPI_4]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_2]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_5:.*]] = memref.load %[[ALLOC_11]]{{\[}}%[[VAL_14]]] : memref<2xindex>
+// CHECK-NEXT:            %[[LOAD_5:.*]] = memref.load %[[ALLOC_11]]{{\[}}%[[VAL_13]]] : memref<2xindex>
 // CHECK-NEXT:            %[[CMPI_5:.*]] = arith.cmpi eq, %[[LOAD_5]], %[[CONSTANT_8]] : index
 // CHECK-NEXT:            %[[SELECT_1:.*]] = arith.select %[[CMPI_5]], %[[IF_2]], %[[LOAD_5]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_1]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_12]]{{\[}}%[[VAL_14]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_12]]{{\[}}%[[VAL_13]]] : memref<?xindex>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %[[CAST_0:.*]] = memref.cast %[[ALLOC_12]] : memref<?xindex> to memref<2xindex>
 // CHECK-NEXT:        %[[ALLOC_13:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_6]], %[[ALLOC_13]]{{\[}}%[[CONSTANT_7]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_13]]{{\[}}%[[CONSTANT_8]]] : memref<2xindex>
-// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[CAST_0]]{{\[}}%[[CONSTANT_7]]] {{\[}}%[[CONSTANT_7]]] {{\[}}%[[CONSTANT_8]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_13]]{{\[}}%[[CONSTANT_7]]] {{\[}}%[[CONSTANT_7]]] {{\[}}%[[CONSTANT_8]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[CAST_0]]{{\[}}%[[CONSTANT_7]]] [%[[CONSTANT_7]]] [%[[CONSTANT_8]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_13]]{{\[}}%[[CONSTANT_7]]] [%[[CONSTANT_7]]] [%[[CONSTANT_8]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:        %[[ALLOC_14:.*]] = memref.alloc(%[[CONSTANT_7]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_15:.*]] = %[[CONSTANT_7]] to %[[CONSTANT_7]] step %[[CONSTANT_8]] {
-// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_15]], %[[CONSTANT_7]] : index
+// CHECK-NEXT:        scf.for %[[VAL_14:.*]] = %[[CONSTANT_7]] to %[[CONSTANT_7]] step %[[CONSTANT_8]] {
+// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_14]], %[[CONSTANT_7]] : index
 // CHECK-NEXT:          %[[IF_4:.*]] = scf.if %[[CMPI_6]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[CONSTANT_8]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_6:.*]] = memref.load %[[SUBVIEW_4]]{{\[}}%[[VAL_15]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            %[[LOAD_6:.*]] = memref.load %[[SUBVIEW_4]]{{\[}}%[[VAL_14]]] : memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:            scf.yield %[[LOAD_6]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_15]], %[[CONSTANT_7]] : index
+// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_14]], %[[CONSTANT_7]] : index
 // CHECK-NEXT:          %[[IF_5:.*]] = scf.if %[[CMPI_7]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_4]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_7:.*]] = memref.load %[[SUBVIEW_5]]{{\[}}%[[VAL_15]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            %[[LOAD_7:.*]] = memref.load %[[SUBVIEW_5]]{{\[}}%[[VAL_14]]] : memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:            %[[CMPI_8:.*]] = arith.cmpi eq, %[[LOAD_7]], %[[CONSTANT_8]] : index
 // CHECK-NEXT:            %[[SELECT_2:.*]] = arith.select %[[CMPI_8]], %[[IF_4]], %[[LOAD_7]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_2]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_14]]{{\[}}%[[VAL_15]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_14]]{{\[}}%[[VAL_14]]] : memref<?xindex>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %[[LOAD_8:.*]] = memref.load %[[ALLOC_12]]{{\[}}%[[CONSTANT_7]]] : memref<?xindex>
 // CHECK-NEXT:        %[[ALLOC_15:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[LOAD_8]], %[[ALLOC_15]]{{\[}}%[[CONSTANT_7]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_15]]{{\[}}%[[CONSTANT_8]]] : memref<2xindex>
 // CHECK-NEXT:        %[[ALLOC_16:.*]] = memref.alloc(%[[CONSTANT_9]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_6:.*]] = memref.subview %[[ALLOC_16]][0] {{\[}}%[[CONSTANT_7]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_6:.*]] = memref.subview %[[ALLOC_16]]{{\[}}0] [%[[CONSTANT_7]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_14]], %[[SUBVIEW_6]] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        %[[SUBVIEW_7:.*]] = memref.subview %[[ALLOC_16]]{{\[}}%[[CONSTANT_7]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_15]], %[[SUBVIEW_7]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        %[[ALLOC_17:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_18:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.expand(%[[VAL_8]]) ins(%[[VAL_11]], %[[VAL_12]] : memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_17]] : memref<2x4xf32, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.matmul(%[[VAL_8]]) ins(%[[ALLOC_17]], %[[VAL_13]] : memref<2x4xf32, #hipsr.mem<device>>, memref<4x2xf32, #hipsr.mem<device>>) outs(%[[ALLOC_18]] : memref<2x2xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        %[[ALLOC_OUTPUT_0:.*]] = hipsr.alloc_output(%[[VAL_7]]) {out_idx = 0 : i64} : memref<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.expand(%[[VAL_7]]) ins(%[[VAL_10]], %[[VAL_11]] : memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_17]] : memref<2x4xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.matmul(%[[VAL_7]]) ins(%[[ALLOC_17]], %[[VAL_12]] : memref<2x4xf32, #hipsr.mem<device>>, memref<4x2xf32, #hipsr.mem<device>>) outs(%[[ALLOC_OUTPUT_0]] : memref<2x2xf32, #hipsr.mem<device>>)
 // CHECK-NEXT:        hipsr.preserve_shape %[[CAST_0]], %[[ALLOC_17]] : memref<2xindex>, memref<2x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_16]], %[[ALLOC_18]] : memref<?xindex>, memref<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_18]] : memref<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_16]], %[[ALLOC_OUTPUT_0]] : memref<?xindex>, memref<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_OUTPUT_0]] : memref<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      } -> memref<2x2xf32, #hipsr.mem<device>> {domain_id = 1 : i64}
 // CHECK-NEXT:      return %[[POOL_DOMAIN_1]] : memref<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    }

--- a/test/lit/Dialect/Hipsr/Transforms/UseAllocOutput/hipsr_use_alloc_output.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/UseAllocOutput/hipsr_use_alloc_output.mlir
@@ -1,95 +1,87 @@
 // Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // Licensed under the MIT License.
 
-// RUN: hip-mlir-opt %s -hipsr-use-output-allocator | FileCheck %s
+// RUN: hip-mlir-opt %s -split-input-file -hipsr-use-output-allocator | FileCheck %s
 
-// A returned dynamic allocation becomes hipsr.alloc_output. Dynamic sizes come
-// from the preserved shape, not directly from the original alloc operands.
-// CHECK-LABEL: func.func @dynamic_output(
-// CHECK-SAME: %[[CTX:.*]]: !hipsr.context, %[[M:.*]]: index, %[[N:.*]]: index
-// CHECK: %[[SHAPE:.*]] = shape.from_extents %[[M]], %[[N]] : index, index
-// CHECK: shape.const_size 0
-// CHECK: shape.get_extent %[[SHAPE]], {{.*}} : !shape.shape, !shape.size -> !shape.size
-// CHECK: %[[D0:.*]] = shape.size_to_index {{.*}} : !shape.size
-// CHECK: shape.const_size 1
-// CHECK: shape.get_extent %[[SHAPE]], {{.*}} : !shape.shape, !shape.size -> !shape.size
-// CHECK: %[[D1:.*]] = shape.size_to_index {{.*}} : !shape.size
-// CHECK-NOT: memref.alloc
-// CHECK: %[[OUT:.*]] = hipsr.alloc_output(%[[CTX]], %[[D0]], %[[D1]]) {out_idx = 0 : i64} : memref<?x?xf16, #hipsr.mem<device>>
-// CHECK: hipsr.preserve_shape %[[SHAPE]], %[[OUT]] : !shape.shape, memref<?x?xf16, #hipsr.mem<device>>
-// CHECK: return %[[OUT]]
+// The pass runs after bufferization, so every preserved shape here is an index
+// memref. Each case checks its whole function, because the extents the pass
+// picks and the rewritten users only mean anything as one sequence.
+
+// The extents come from the preserved shape, not from the memref.alloc
+// operands.
+// CHECK-LABEL:   func.func @dynamic_output(
+// CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[ARG1:.*]]: memref<2xindex>,
+// CHECK-SAME:      %[[ARG2:.*]]: index,
+// CHECK-SAME:      %[[ARG3:.*]]: index) -> memref<?x?xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:    %[[CONSTANT_0:.*]] = arith.constant 0 : index
+// CHECK-NEXT:    %[[LOAD_0:.*]] = memref.load %[[ARG1]]{{\[}}%[[CONSTANT_0]]] : memref<2xindex>
+// CHECK-NEXT:    %[[CONSTANT_1:.*]] = arith.constant 1 : index
+// CHECK-NEXT:    %[[LOAD_1:.*]] = memref.load %[[ARG1]]{{\[}}%[[CONSTANT_1]]] : memref<2xindex>
+// CHECK-NEXT:    %[[ALLOC_OUTPUT_0:.*]] = hipsr.alloc_output(%[[ARG0]], %[[LOAD_0]], %[[LOAD_1]]) {out_idx = 0 : i64} : memref<?x?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    hipsr.preserve_shape %[[ARG1]], %[[ALLOC_OUTPUT_0]] : memref<2xindex>, memref<?x?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    return %[[ALLOC_OUTPUT_0]] : memref<?x?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:  }
 func.func @dynamic_output(
-    %ctx: !hipsr.context, %M: index, %N: index)
+    %ctx: !hipsr.context, %shape: memref<2xindex>, %M: index, %N: index)
     -> memref<?x?xf16, #hipsr.mem<device>> {
-  %shape = shape.from_extents %M, %N : index, index
   %out = memref.alloc(%M, %N)
       : memref<?x?xf16, #hipsr.mem<device>>
-  hipsr.preserve_shape %shape, %out : !shape.shape, memref<?x?xf16, #hipsr.mem<device>>
+  hipsr.preserve_shape %shape, %out
+    : memref<2xindex>, memref<?x?xf16, #hipsr.mem<device>>
   return %out : memref<?x?xf16, #hipsr.mem<device>>
 }
 
+// -----
 
-// ---
-
-// in onnx:
-// %graph_input
-//     ↓
-// onnx.MatMul
-//     ↓
-// onnx.Add (?x256xf16)
-//     ↓
-// onnx.Reshape(?xf16) ──> func.return（%graph_output）
-//     └──────────> onnx.Cast
-
-// CHECK-LABEL: func.func @test_return_shape
-// CHECK-NEXT: %[[OUT:.*]] = hipsr.pool_domain(%[[CTX:.*]], %[[INPUT:.*]], %[[WEIGHT:.*]], %[[BIAS:.*]] : !hipsr.context, memref<?x512xf16, #hipsr.mem<device>>, memref<512x256xf16, #hipsr.mem<device>>, memref<?x256xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[DCTX:.*]]: !hipsr.context, %[[IN:.*]]: memref<?x512xf16, #hipsr.mem<device>>, %[[W:.*]]: memref<512x256xf16, #hipsr.mem<device>>, %[[B:.*]]: memref<?x256xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[C0:.*]] = arith.constant 0 : index
-// CHECK-NEXT: %[[C1:.*]] = arith.constant 1 : index
-// CHECK-NEXT: %[[M:.*]] = memref.dim %[[IN]], %[[C0]] : memref<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[N:.*]] = memref.dim %[[W]], %[[C1]] : memref<512x256xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[FLAT_SIZE:.*]] = arith.muli %[[M]], %[[N]] : index
-// CHECK-NEXT: %[[SHAPE1:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT: %[[S1:.*]] = shape.from_extents %[[M]], %[[N]] : index, index
-// CHECK-NEXT: scf.yield %[[S1]] : !shape.shape
-// CHECK-NEXT: }
-// CHECK-NEXT: %[[SHAPE2:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT: %[[S2:.*]] = shape.from_extents %[[M]], %[[N]] : index, index
-// CHECK-NEXT: scf.yield %[[S2]] : !shape.shape
-// CHECK-NEXT: }
-// CHECK-NEXT: %[[SHAPE3:.*]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT: %[[S3:.*]] = shape.from_extents %[[FLAT_SIZE]] : index
-// CHECK-NEXT: scf.yield %[[S3]] : !shape.shape
-// CHECK-NEXT: }
-// CHECK-NEXT: %[[INIT1:.*]] = memref.alloc(%[[M]]) : memref<?x256xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.matmul(%[[DCTX]]) ins(%[[IN]], %[[W]] : memref<?x512xf16, #hipsr.mem<device>>, memref<512x256xf16, #hipsr.mem<device>>) outs(%[[INIT1]] : memref<?x256xf16, #hipsr.mem<device>>)
-// The external (rank-1) output size comes from SHAPE3; the internal (rank-2)
-// view size comes from SHAPE2.
-// CHECK-NEXT: %[[CS_EXT0:.*]] = shape.const_size 0
-// CHECK-NEXT: %[[EXT0:.*]] = shape.get_extent %[[SHAPE3]], %[[CS_EXT0]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT: %[[EXT_SIZE:.*]] = shape.size_to_index %[[EXT0]] : !shape.size
-// CHECK-NEXT: %[[CS_INT0:.*]] = shape.const_size 0
-// CHECK-NEXT: %[[INT0:.*]] = shape.get_extent %[[SHAPE2]], %[[CS_INT0]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT: %[[INT_SIZE:.*]] = shape.size_to_index %[[INT0]] : !shape.size
-// CHECK-NEXT: %[[C256:.*]] = arith.constant 256 : index
-// CHECK-NEXT: %[[OUTBUF:.*]] = hipsr.alloc_output(%[[DCTX]], %[[EXT_SIZE]]) {out_idx = 0 : i64} : memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[RC:.*]] = memref.reinterpret_cast %[[OUTBUF]] to offset: [0], sizes: [%[[INT_SIZE]], 256], strides: [256, 1] : memref<?xf16, #hipsr.mem<device>> to memref<?x256xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.add(%[[DCTX]]) ins(%[[INIT1]], %[[B]] : memref<?x256xf16, #hipsr.mem<device>>, memref<?x256xf16, #hipsr.mem<device>>) outs(%[[RC]] : memref<?x256xf16, #hipsr.mem<device>>)
-// CHECK-NEXT: %[[FLAT:.*]] = hipsr.compute(%[[DCTX]]) ins(%[[RC]] : memref<?x256xf16, #hipsr.mem<device>>) outs(%[[RC]] : memref<?x256xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%{{.*}}: !hipsr.context, %[[BODY_IN:.*]]: memref<?x256xf16, #hipsr.mem<device>>, %{{.*}}: memref<?x256xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[COLLAPSED:.*]] = memref.collapse_shape %[[BODY_IN]] {{\[\[}}0, 1]] : memref<?x256xf16, #hipsr.mem<device>> into memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.compute_yield %[[COLLAPSED]] : memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } : memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[CAST_INIT:.*]] = memref.alloc(%[[FLAT_SIZE]]) : memref<?xf32, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.cast(%[[DCTX]]) ins(%[[FLAT]] : memref<?xf16, #hipsr.mem<device>>) outs(%[[CAST_INIT]] : memref<?xf32, #hipsr.mem<device>>)
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE1]], %[[INIT1]] : !shape.shape, memref<?x256xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE2]], %[[RC]] : !shape.shape, memref<?x256xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE3]], %[[FLAT]] : !shape.shape, memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.preserve_shape %[[SHAPE3]], %[[CAST_INIT]] : !shape.shape, memref<?xf32, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[FLAT]] : memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> memref<?xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT: return %[[OUT]] : memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT: }
+// The graph is MatMul -> Add -> Reshape, and a Cast also reads the returned
+// Reshape result. The return type is rank 1 while the allocation the Add
+// writes is rank 2, so the pass adds a reinterpret_cast view.
+// CHECK-LABEL:   func.func @test_return_shape(
+// CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[ARG1:.*]]: memref<?x512xf16, #hipsr.mem<device>>,
+// CHECK-SAME:      %[[ARG2:.*]]: memref<512x256xf16, #hipsr.mem<device>>,
+// CHECK-SAME:      %[[ARG3:.*]]: memref<?x256xf16, #hipsr.mem<device>>) -> memref<?xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:    %[[POOL_DOMAIN_0:.*]] = hipsr.pool_domain(%[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]] : !hipsr.context, memref<?x512xf16, #hipsr.mem<device>>, memref<512x256xf16, #hipsr.mem<device>>, memref<?x256xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:    ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: memref<?x512xf16, #hipsr.mem<device>>, %[[VAL_2:.*]]: memref<512x256xf16, #hipsr.mem<device>>, %[[VAL_3:.*]]: memref<?x256xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:      %[[CONSTANT_0:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[CONSTANT_1:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[CONSTANT_2:.*]] = arith.constant 256 : index
+// CHECK-NEXT:      %[[DIM_0:.*]] = memref.dim %[[VAL_1]], %[[CONSTANT_0]] : memref<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[DIM_1:.*]] = memref.dim %[[VAL_2]], %[[CONSTANT_1]] : memref<512x256xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[MULI_0:.*]] = arith.muli %[[DIM_0]], %[[DIM_1]] : index
+// CHECK-NEXT:      %[[ALLOC_0:.*]] = memref.alloc() : memref<2xindex>
+// CHECK-NEXT:      memref.store %[[DIM_0]], %[[ALLOC_0]]{{\[}}%[[CONSTANT_0]]] : memref<2xindex>
+// CHECK-NEXT:      memref.store %[[CONSTANT_2]], %[[ALLOC_0]]{{\[}}%[[CONSTANT_1]]] : memref<2xindex>
+// CHECK-NEXT:      %[[ALLOC_1:.*]] = memref.alloc() : memref<2xindex>
+// CHECK-NEXT:      memref.store %[[DIM_0]], %[[ALLOC_1]]{{\[}}%[[CONSTANT_0]]] : memref<2xindex>
+// CHECK-NEXT:      memref.store %[[CONSTANT_2]], %[[ALLOC_1]]{{\[}}%[[CONSTANT_1]]] : memref<2xindex>
+// CHECK-NEXT:      %[[ALLOC_2:.*]] = memref.alloc() : memref<1xindex>
+// CHECK-NEXT:      memref.store %[[MULI_0]], %[[ALLOC_2]]{{\[}}%[[CONSTANT_0]]] : memref<1xindex>
+// CHECK-NEXT:      %[[ALLOC_3:.*]] = memref.alloc(%[[DIM_0]]) : memref<?x256xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.matmul(%[[VAL_0]]) ins(%[[VAL_1]], %[[VAL_2]] : memref<?x512xf16, #hipsr.mem<device>>, memref<512x256xf16, #hipsr.mem<device>>) outs(%[[ALLOC_3]] : memref<?x256xf16, #hipsr.mem<device>>)
+// CHECK-NEXT:      %[[CONSTANT_3:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[LOAD_0:.*]] = memref.load %[[ALLOC_2]]{{\[}}%[[CONSTANT_3]]] : memref<1xindex>
+// CHECK-NEXT:      %[[ALLOC_OUTPUT_0:.*]] = hipsr.alloc_output(%[[VAL_0]], %[[LOAD_0]]) {out_idx = 0 : i64} : memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[CONSTANT_4:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[LOAD_1:.*]] = memref.load %[[ALLOC_1]]{{\[}}%[[CONSTANT_4]]] : memref<2xindex>
+// CHECK-NEXT:      %[[REINTERPRET_CAST_0:.*]] = memref.reinterpret_cast %[[ALLOC_OUTPUT_0]] to offset: [0], sizes: [%[[LOAD_1]], 256], strides: [256, 1] : memref<?xf16, #hipsr.mem<device>> to memref<?x256xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.add(%[[VAL_0]]) ins(%[[ALLOC_3]], %[[VAL_3]] : memref<?x256xf16, #hipsr.mem<device>>, memref<?x256xf16, #hipsr.mem<device>>) outs(%[[REINTERPRET_CAST_0]] : memref<?x256xf16, #hipsr.mem<device>>)
+// CHECK-NEXT:      %[[COMPUTE_0:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[REINTERPRET_CAST_0]] : memref<?x256xf16, #hipsr.mem<device>>) outs(%[[REINTERPRET_CAST_0]] : memref<?x256xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_4:.*]]: !hipsr.context, %[[VAL_5:.*]]: memref<?x256xf16, #hipsr.mem<device>>, %[[VAL_6:.*]]: memref<?x256xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[COLLAPSE_SHAPE_0:.*]] = memref.collapse_shape %[[VAL_5]] {{\[\[}}0, 1]] : memref<?x256xf16, #hipsr.mem<device>> into memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.compute_yield %[[COLLAPSE_SHAPE_0]] : memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      } : memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[ALLOC_4:.*]] = memref.alloc(%[[MULI_0]]) : memref<?xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.cast(%[[VAL_0]]) ins(%[[COMPUTE_0]] : memref<?xf16, #hipsr.mem<device>>) outs(%[[ALLOC_4]] : memref<?xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:      hipsr.preserve_shape %[[ALLOC_0]], %[[ALLOC_3]] : memref<2xindex>, memref<?x256xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[ALLOC_1]], %[[REINTERPRET_CAST_0]] : memref<2xindex>, memref<?x256xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[ALLOC_2]], %[[COMPUTE_0]] : memref<1xindex>, memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.preserve_shape %[[ALLOC_2]], %[[ALLOC_4]] : memref<1xindex>, memref<?xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      hipsr.pool_domain_yield %[[COMPUTE_0]] : memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    } -> memref<?xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT:    return %[[POOL_DOMAIN_0]] : memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:  }
 func.func @test_return_shape(
     %ctx: !hipsr.context,
     %input: memref<?x512xf16, #hipsr.mem<device>>,
@@ -107,22 +99,21 @@ func.func @test_return_shape(
        %b: memref<?x256xf16, #hipsr.mem<device>>):
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
+    %c256 = arith.constant 256 : index
 
     %m = memref.dim %in, %c0 : memref<?x512xf16, #hipsr.mem<device>>
     %n = memref.dim %w, %c1 : memref<512x256xf16, #hipsr.mem<device>>
     %flat_size = arith.muli %m, %n : index
-    %shape1 = scf.execute_region -> !shape.shape {
-      %s1 = shape.from_extents %m, %n : index, index
-      scf.yield %s1 : !shape.shape
-    }
-    %shape2 = scf.execute_region -> !shape.shape {
-      %s2 = shape.from_extents %m, %n : index, index
-      scf.yield %s2 : !shape.shape
-    }
-    %shape3 = scf.execute_region -> !shape.shape {
-      %s3 = shape.from_extents %flat_size : index
-      scf.yield %s3 : !shape.shape
-    }
+
+    %shape1 = memref.alloc() : memref<2xindex>
+    memref.store %m, %shape1[%c0] : memref<2xindex>
+    memref.store %c256, %shape1[%c1] : memref<2xindex>
+    %shape2 = memref.alloc() : memref<2xindex>
+    memref.store %m, %shape2[%c0] : memref<2xindex>
+    memref.store %c256, %shape2[%c1] : memref<2xindex>
+    %shape3 = memref.alloc() : memref<1xindex>
+    memref.store %flat_size, %shape3[%c0] : memref<1xindex>
+
     %init1 = memref.alloc(%m) : memref<?x256xf16, #hipsr.mem<device>>
     hipsr.matmul(%dctx)
       ins(%in, %w : memref<?x512xf16, #hipsr.mem<device>>,
@@ -154,13 +145,13 @@ func.func @test_return_shape(
       outs(%cast_init : memref<?xf32, #hipsr.mem<device>>)
 
     hipsr.preserve_shape %shape1, %init1
-      : !shape.shape, memref<?x256xf16, #hipsr.mem<device>>
+      : memref<2xindex>, memref<?x256xf16, #hipsr.mem<device>>
     hipsr.preserve_shape %shape2, %init2
-      : !shape.shape, memref<?x256xf16, #hipsr.mem<device>>
+      : memref<2xindex>, memref<?x256xf16, #hipsr.mem<device>>
     hipsr.preserve_shape %shape3, %flat
-      : !shape.shape, memref<?xf16, #hipsr.mem<device>>
+      : memref<1xindex>, memref<?xf16, #hipsr.mem<device>>
     hipsr.preserve_shape %shape3, %cast_init
-      : !shape.shape, memref<?xf32, #hipsr.mem<device>>
+      : memref<1xindex>, memref<?xf32, #hipsr.mem<device>>
     hipsr.pool_domain_yield %flat
       : memref<?xf16, #hipsr.mem<device>>
   } -> memref<?xf16, #hipsr.mem<device>> {

--- a/test/lit/Dialect/Hipsr/Transforms/UseAllocOutput/invalid.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/UseAllocOutput/invalid.mlir
@@ -1,0 +1,25 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s -split-input-file -verify-diagnostics -hipsr-use-output-allocator
+
+func.func @unbufferized_shape(
+    %ctx: !hipsr.context, %M: index, %N: index)
+    -> memref<?x?xf16, #hipsr.mem<device>> {
+  %shape = shape.from_extents %M, %N : index, index
+  %out = memref.alloc(%M, %N) : memref<?x?xf16, #hipsr.mem<device>>
+  hipsr.preserve_shape %shape, %out
+    : !shape.shape, memref<?x?xf16, #hipsr.mem<device>>
+  // expected-error@+1 {{graph output 0 has dynamic dims but no preserved external shape memref}}
+  return %out : memref<?x?xf16, #hipsr.mem<device>>
+}
+
+// -----
+
+func.func @missing_shape(
+    %ctx: !hipsr.context, %M: index, %N: index)
+    -> memref<?x?xf16, #hipsr.mem<device>> {
+  %out = memref.alloc(%M, %N) : memref<?x?xf16, #hipsr.mem<device>>
+  // expected-error@+1 {{graph output 0 has dynamic dims but no preserved external shape memref}}
+  return %out : memref<?x?xf16, #hipsr.mem<device>>
+}


### PR DESCRIPTION
`hipsr-use-output-allocator` was complete but never scheduled, so every graph
output stayed a plain `memref.alloc`. This adds it to the HIPSR pipeline after
`convert-linalg-to-loops`, which places it before the pool allocator (outputs
must stay runtime-owned) and before preserve-shape removal (it reads those ops
to size dynamic outputs).

Scheduling it exposed a bug. By that point the graph is bufferized, so a
preserved shape is an index memref, and the pass read extents with
`shape.get_extent`, which does not accept one. Given this input:

```mlir
#dev = #hipsr.mem<device>

func.func @graph(%ctx: !hipsr.context, %shape: memref<2xindex>, %m: index,
                 %in: memref<?x4xf32, #dev>) -> memref<?x4xf16, #dev> {
  %out = memref.alloc(%m) : memref<?x4xf16, #dev>
  hipsr.cast(%ctx) ins(%in : memref<?x4xf32, #dev>)
                   outs(%out : memref<?x4xf16, #dev>)
  hipsr.preserve_shape %shape, %out : memref<2xindex>, memref<?x4xf16, #dev>
  return %out : memref<?x4xf16, #dev>
}
```

the pass used to fail, which is why `sample_dynamic` and `embedding` stopped
verifying:

```
error: 'shape.get_extent' op operand #0 must be shape or extent tensor,
       but got 'memref<2xindex>'
```

It now reads extents with `memref.load`, and `hipsr.cast` writes straight into
the buffer the allocator returns:

```mlir
func.func @graph(%arg0: !hipsr.context, %arg1: memref<2xindex>, %arg2: index,
                 %arg3: memref<?x4xf32, #dev>) -> memref<?x4xf16, #dev> {
  %c0 = arith.constant 0 : index
  %0 = memref.load %arg1[%c0] : memref<2xindex>
  %1 = hipsr.alloc_output(%arg0, %0) {out_idx = 0 : i64} : memref<?x4xf16, #dev>
  hipsr.cast(%arg0) ins(%arg3 : memref<?x4xf32, #dev>)
                    outs(%1 : memref<?x4xf16, #dev>)
  hipsr.preserve_shape %arg1, %1 : memref<2xindex>, memref<?x4xf16, #dev>
  return %1 : memref<?x4xf16, #dev>
}
```

Running after bufferization is now the documented contract, and a clear
diagnostic rejects a shape the pass cannot read.

That output also shows the second fix. The pass used to materialize every
dimension of both the external and the internal type, so the static `4` became
an `arith.constant` nothing used, and the internal extents became `memref.load`s
that have a read effect and survive DCE. It now builds only the extents it
uses, and the internal ones only when the output needs a `reinterpret_cast`
view.

The pass's own tests separated cases with `// ---` but never passed
`-split-input-file`, so every `CHECK-LABEL` matched against a single module.
That is fixed, with whole-function checks and a new `invalid.mlir` covering the
shapes the pass rejects.

Validated with the HIPSR LIT suite: 107 tests pass, including the three
regenerated pipeline goldens.

AI assistance: the implementation, test updates, and this description were
prepared with Cursor and Claude, reviewed by me, and validated by the tests
above.
