### PR TITLE
feat(qdq): add QDQ Mul fusion and hip.qmul quantized elementwise op

### DIFF
--- a/.github/workflows/windows-build-real.yml
+++ b/.github/workflows/windows-build-real.yml
@@ -157,6 +157,9 @@ jobs:
           cp "${{ runner.workspace }}/install/bin/"*.dll staging/bin/ 2>/dev/null || true
           cp "${{ runner.workspace }}/install/bin/"*.exe staging/bin/ 2>/dev/null || true
 
+          # cp fusion pattern file
+          cp "${{ runner.workspace }}/install/bin/HipFusionPatterns.pdl.mlir" staging/bin/
+
           cp "${{ runner.workspace }}/amdgpu-artifacts/bin/"* staging/bin/
 
           # Smoke: every per-arch kernel DLL must be present in staging/bin/

--- a/include/hip/Dialect/IR/HipBufferize.h
+++ b/include/hip/Dialect/IR/HipBufferize.h
@@ -210,6 +210,7 @@ registerHipBufferizableOpInterfaceModels(DialectRegistry &registry) {
     SizeOp::attachInterface<HipDstBufferizableModel<SizeOp>>(*ctx);
     LoopOp::attachInterface<HipDstBufferizableModel<LoopOp>>(*ctx);
     QAddOp::attachInterface<HipDstBufferizableModel<QAddOp>>(*ctx);
+    QMulOp::attachInterface<HipDstBufferizableModel<QMulOp>>(*ctx);
     // hip.if is a DPS control-flow op (getDpsInitsMutable, results alias
     // o_init) just like hip.loop. Without this model one-shot-bufferize aborts
     // with "op was not bufferized: hip.if" for any graph containing onnx.If,

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -4885,4 +4885,39 @@ def Hip_QAddOp : Hip_DpsOp_Broadcast<"qadd",
     attr-dict (`:` type($result_tensors)^)?
   }];
 }
+
+def Hip_QMulOp : Hip_DpsOp_Broadcast<"qmul",
+                                     /*operandGetters=*/["Lhs", "Rhs"]> {
+  let summary = "Quantized elementwise mul with integrated QDQ";
+  let description = [{
+    Quantized elementwise multiply. Performs element-wise binary
+    multiplication (with Numpy-style broadcasting support).
+    This operator supports multidirectional (i.e., Numpy-style) broadcasting
+
+    both operand scales collapse into a single coefficient:
+
+      OUT = saturate(round(M * (lhs - lhs_zp) * (rhs - rhs_zp)) + output_zp)
+      M   = lhs_scale * rhs_scale / output_scale
+
+  }];
+
+  let arguments = (ins
+    Hip_ContextType:$ctx,
+    Hip_TensorOrMemRef:$lhs,           // Left operand (quant)
+    Hip_TensorOrMemRef:$rhs,           // Right operand (quant)
+    Hip_TensorOrMemRef:$output,        // Output buffer (quant)
+    F32Attr:$lhs_scale,                // Quantization scale for LHS
+    I64Attr:$lhs_zp,                   // Quantization zeropoint for LHS
+    F32Attr:$rhs_scale,                // Quantization scale for RHS
+    I64Attr:$rhs_zp,                   // Quantization zeropoint for RHS
+    F32Attr:$output_scale,             // Dequantization scale for output
+    I64Attr:$output_zp                 // Quantization zeropoint for output
+  );
+
+  let assemblyFormat = [{
+    `(` $ctx `)` `ins` `(` $lhs `,` $rhs `:` type($lhs) `,` type($rhs) `)`
+    `outs` `(` $output `:` type($output) `)`
+    attr-dict (`:` type($result_tensors)^)?
+  }];
+}
 #endif // HIP_OPS

--- a/lib/Conversion/HipToLLVM/CMakeLists.txt
+++ b/lib/Conversion/HipToLLVM/CMakeLists.txt
@@ -62,7 +62,7 @@ add_library(HipToLLVM STATIC
   ResizeLowering.cpp
   GridSampleLowering.cpp
   GlobalPoolLowering.cpp
-  QAddLowering.cpp
+  QElementwiseLowering.cpp
 )
 
 add_dependencies(HipToLLVM

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -288,7 +288,7 @@ void ConvertHipToLLVMPass::runOnOperation() {
   populateResizeLoweringPatterns(typeConverter, patterns);
   populateGridSampleLoweringPatterns(typeConverter, patterns);
   populateGlobalPoolLoweringPatterns(typeConverter, patterns);
-  populateQAddLoweringPatterns(typeConverter, patterns);
+  populateQElementwiseLoweringPatterns(typeConverter, patterns);
 
   // Standard dialect lowerings
   // Bundle func/memref/arith/cf lowering with HIP lowering to minimize

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -387,6 +387,7 @@ inline SmallVector<Value, 4> extractShape4D(MemRefType type, Value descriptor,
 // Must match HIPDNN_EP_QELEMENTWISE_* in lib/Runtime/hipdnn_ep_runtime.h
 enum HipdnnQElementwiseKind : int64_t {
   kQElementwiseAdd = 0,
+  kQElementwiseMul = 1,
 };
 
 // Must match HIPDNN_EP_TENSOR_OP_* in lib/Runtime/hipdnn_ep_runtime.h
@@ -521,8 +522,8 @@ void populateGridSampleLoweringPatterns(const LLVMTypeConverter &converter,
                                         RewritePatternSet &patterns);
 void populateGlobalPoolLoweringPatterns(const LLVMTypeConverter &converter,
                                         RewritePatternSet &patterns);
-void populateQAddLoweringPatterns(const LLVMTypeConverter &converter,
-                                  RewritePatternSet &patterns);
+void populateQElementwiseLoweringPatterns(const LLVMTypeConverter &converter,
+                                          RewritePatternSet &patterns);
 } // namespace hip
 } // namespace mlir
 

--- a/lib/Conversion/HipToLLVM/QElementwiseLowering.cpp
+++ b/lib/Conversion/HipToLLVM/QElementwiseLowering.cpp
@@ -10,11 +10,15 @@ namespace hip {
 namespace {
 
 // Shared lowering for quantized elementwise ops:
-//   hip.qadd / (future) qsub, qmul, qdiv
+//   hip.qadd, hip.qmul / (future) qsub, qdiv
 //     -> wrap_qelementwise(..., kind, ..., M_a, lhs_zp, M_b, rhs_zp, output_zp)
 //
-// M_a = s_a / s_out, M_b = s_b / s_out. Runtime uses
-//   OUT = round(M_a * (A - z_a) [OP] M_b * (B - z_b)) + z_out
+// The coefficient slots carry a kind-dependent folding of the scales:
+//
+//   add: M_a = s_a / s_out, M_b = s_b / s_out
+//        OUT = round(M_a * (A - z_a) + M_b * (B - z_b)) + z_out
+//   mul: M_a = s_a * s_b / s_out, M_b unused
+//        OUT = round(M_a * (A - z_a) * (B - z_b)) + z_out
 
 template <typename OpTy, HipdnnQElementwiseKind Kind>
 struct QElementwiseLowering : public ConvertOpToLLVMPattern<OpTy> {
@@ -88,8 +92,16 @@ struct QElementwiseLowering : public ConvertOpToLLVMPattern<OpTy> {
     float outputScale = op.getOutputScale().convertToFloat();
     if (outputScale == 0.0f)
       return rewriter.notifyMatchFailure(op, "output_scale must be non-zero");
-    float mA = op.getLhsScale().convertToFloat() / outputScale;
-    float mB = op.getRhsScale().convertToFloat() / outputScale;
+    float lhsScale = op.getLhsScale().convertToFloat();
+    float rhsScale = op.getRhsScale().convertToFloat();
+    float mA, mB;
+    if constexpr (Kind == HipdnnQElementwiseKind::kQElementwiseMul) {
+      mA = lhsScale * rhsScale / outputScale;
+      mB = 1.0f;
+    } else {
+      mA = lhsScale / outputScale;
+      mB = rhsScale / outputScale;
+    }
 
     SmallVector<Value, 17> args = {
         adaptor.getCtx(),
@@ -122,11 +134,17 @@ struct QAddOpLowering
   using QElementwiseLowering::QElementwiseLowering;
 };
 
+struct QMulOpLowering
+    : public QElementwiseLowering<QMulOp,
+                                  HipdnnQElementwiseKind::kQElementwiseMul> {
+  using QElementwiseLowering::QElementwiseLowering;
+};
+
 } // namespace
 
-void populateQAddLoweringPatterns(const LLVMTypeConverter &converter,
-                                  RewritePatternSet &patterns) {
-  patterns.add<QAddOpLowering>(converter);
+void populateQElementwiseLoweringPatterns(const LLVMTypeConverter &converter,
+                                          RewritePatternSet &patterns) {
+  patterns.add<QAddOpLowering, QMulOpLowering>(converter);
 }
 
 } // namespace hip

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -40,6 +40,11 @@ if(MLIR_PDLL_EXE)
         VERBATIM)
     add_custom_target(HipPdllPatterns DEPENDS "${PDL_OUTPUT}" "${PDL_RUNTIME_OUTPUT}")
     install(FILES "${PDL_OUTPUT}" DESTINATION bin)
+    # ConvertOnnxToHipPass resolves the patterns next to the loaded EP module,
+    # so every packaging path (install tree, wheel, staged test package) has to
+    # ship this file beside the EP library. Export it for those consumers.
+    set(HIP_PDL_FUSION_PATTERNS "${PDL_OUTPUT}" CACHE INTERNAL
+        "Compiled PDL fusion patterns that must ship beside the EP library")
     message(STATUS "OnnxToHip: PDLL fusion enabled — patterns: ${PDL_OUTPUT}")
 else()
     message(WARNING "OnnxToHip: mlir-pdll not found — PDLL fusion disabled")

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -486,8 +486,8 @@ void ConvertOnnxToHipPass::runOnOperation() {
                            << pdlFusionFile;
     }
   } else {
-    module.emitError() << "Fusion PDL patterns not found at "
-                       << pdlFusionFile << "; QDQ fusion is disabled";
+    module.emitError() << "Fusion PDL patterns not found at " << pdlFusionFile
+                       << "; QDQ fusion is disabled";
     return signalPassFailure();
   }
 

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -485,6 +485,10 @@ void ConvertOnnxToHipPass::runOnOperation() {
       module.emitWarning() << "Failed to load/apply fusion PDL patterns from "
                            << pdlFusionFile;
     }
+  } else {
+    module.emitError() << "Fusion PDL patterns not found at "
+                       << pdlFusionFile << "; QDQ fusion is disabled";
+    return signalPassFailure();
   }
 
   int64_t constantOrder = 0;

--- a/lib/Conversion/OnnxToHip/pdl/HipFusionPatterns.pdll
+++ b/lib/Conversion/OnnxToHip/pdl/HipFusionPatterns.pdll
@@ -11,10 +11,19 @@
 // included exactly once.
 //===----------------------------------------------------------------------===//
 
-// Native constraints (implemented in qdq_fusion_pass.hpp)
-Constraint GetContextArg(op: Op) -> Value;
-Constraint ExtractScaleValue(val: Value) -> Attr;
-Constraint ExtractZeropointValue(op: Op, index: Attr, defaultValue: Attr) -> Attr;
+// Native helpers (implemented in qdq_fusion_pass.hpp).
+//
+// Fusability is decided by result-free constraints and the values are produced
+// by rewrites. Returning a result from a constraint shared by two patterns
+// rooted at the same op makes the PDL module fail to lower ("operand does not
+// dominate this use"), so nothing below may move back into the match section.
+Constraint HasContextArg(op: Op);
+Constraint IsSplatConstantValue(val: Value);
+Constraint HasExtractableZeropoint(op: Op, index: Attr);
+
+Rewrite GetContextArg(op: Op) -> Value;
+Rewrite ExtractScaleValue(val: Value) -> Attr;
+Rewrite ExtractZeropointValue(op: Op, index: Attr, defaultValue: Attr) -> Attr;
 
 #include "QDQAddFusion.pdll"
 #include "QDQMulFusion.pdll"

--- a/lib/Conversion/OnnxToHip/pdl/HipFusionPatterns.pdll
+++ b/lib/Conversion/OnnxToHip/pdl/HipFusionPatterns.pdll
@@ -17,3 +17,4 @@ Constraint ExtractScaleValue(val: Value) -> Attr;
 Constraint ExtractZeropointValue(op: Op, index: Attr, defaultValue: Attr) -> Attr;
 
 #include "QDQAddFusion.pdll"
+#include "QDQMulFusion.pdll"

--- a/lib/Conversion/OnnxToHip/pdl/QDQAddFusion.pdll
+++ b/lib/Conversion/OnnxToHip/pdl/QDQAddFusion.pdll
@@ -14,16 +14,26 @@ Pattern QDQAdd with benefit(10) {
   let add = op<onnx.Add>(dquant1.0, dquant2.0);
   let quant = op<onnx.QuantizeLinear>(add.0, output_scale: Value, output_tail: ValueRange) -> (output_type: Type);
 
-  let ctx = GetContextArg(quant);
-  let lhs_scale_attr = ExtractScaleValue(lhs_scale);
-  let rhs_scale_attr = ExtractScaleValue(rhs_scale);
-  let output_scale_attr = ExtractScaleValue(output_scale);
-  let lhs_zeropoint_attr = ExtractZeropointValue(dquant1, attr<"2 : i64">, attr<"0 : i64">);
-  let rhs_zeropoint_attr = ExtractZeropointValue(dquant2, attr<"2 : i64">, attr<"0 : i64">);
-  let output_zeropoint_attr = ExtractZeropointValue(quant, attr<"2 : i64">, attr<"0 : i64">);
+  // Fusability only: every scale must be a per-tensor splat constant and every
+  // zero point must be readable (or absent, which means zero).
+  HasContextArg(quant);
+  IsSplatConstantValue(lhs_scale);
+  IsSplatConstantValue(rhs_scale);
+  IsSplatConstantValue(output_scale);
+  HasExtractableZeropoint(dquant1, attr<"2 : i64">);
+  HasExtractableZeropoint(dquant2, attr<"2 : i64">);
+  HasExtractableZeropoint(quant, attr<"2 : i64">);
 
   // Replace with fused operation
   rewrite quant with {
+    let ctx = GetContextArg(quant);
+    let lhs_scale_attr = ExtractScaleValue(lhs_scale);
+    let rhs_scale_attr = ExtractScaleValue(rhs_scale);
+    let output_scale_attr = ExtractScaleValue(output_scale);
+    let lhs_zeropoint_attr = ExtractZeropointValue(dquant1, attr<"2 : i64">, attr<"0 : i64">);
+    let rhs_zeropoint_attr = ExtractZeropointValue(dquant2, attr<"2 : i64">, attr<"0 : i64">);
+    let output_zeropoint_attr = ExtractZeropointValue(quant, attr<"2 : i64">, attr<"0 : i64">);
+
     let empty = op<tensor.empty> -> (output_type);
     let qadd = op<hip.qadd>(ctx, lhs_input, rhs_input, empty.0) {
       lhs_scale = lhs_scale_attr,

--- a/lib/Conversion/OnnxToHip/pdl/QDQMulFusion.pdll
+++ b/lib/Conversion/OnnxToHip/pdl/QDQMulFusion.pdll
@@ -1,0 +1,39 @@
+//===- QDQMulFusion.pdll --------------------------------------------------===//
+//
+// PDLL pattern for QDQ Mul fusion - pure PDLL approach.
+//
+// Included by HipFusionPatterns.pdll, which declares the native constraints
+// used below. Not compilable on its own.
+//===----------------------------------------------------------------------===//
+
+Pattern QDQMul with benefit(10) {
+  // Match the QDQ chain: DequantizeLinear, DequantizeLinear -> Mul -> QuantizeLinear
+  let dquant1 = op<onnx.DequantizeLinear>(lhs_input: Value, lhs_scale: Value, lhs_tail: ValueRange);
+  let dquant2 = op<onnx.DequantizeLinear>(rhs_input: Value, rhs_scale: Value, rhs_tail: ValueRange);
+
+  let mul = op<onnx.Mul>(dquant1.0, dquant2.0);
+  let quant = op<onnx.QuantizeLinear>(mul.0, output_scale: Value, output_tail: ValueRange) -> (output_type: Type);
+
+  let ctx = GetContextArg(quant);
+  let lhs_scale_attr = ExtractScaleValue(lhs_scale);
+  let rhs_scale_attr = ExtractScaleValue(rhs_scale);
+  let output_scale_attr = ExtractScaleValue(output_scale);
+  let lhs_zeropoint_attr = ExtractZeropointValue(dquant1, attr<"2 : i64">, attr<"0 : i64">);
+  let rhs_zeropoint_attr = ExtractZeropointValue(dquant2, attr<"2 : i64">, attr<"0 : i64">);
+  let output_zeropoint_attr = ExtractZeropointValue(quant, attr<"2 : i64">, attr<"0 : i64">);
+
+  // Replace with fused operation. The two operand scales stay separate here;
+  // HipToLLVM folds them into the single coefficient the kernel consumes.
+  rewrite quant with {
+    let empty = op<tensor.empty> -> (output_type);
+    let qmul = op<hip.qmul>(ctx, lhs_input, rhs_input, empty.0) {
+      lhs_scale = lhs_scale_attr,
+      rhs_scale = rhs_scale_attr,
+      output_scale = output_scale_attr,
+      lhs_zp = lhs_zeropoint_attr,
+      rhs_zp = rhs_zeropoint_attr,
+      output_zp = output_zeropoint_attr
+    } -> (output_type);
+    replace quant with qmul;
+  };
+}

--- a/lib/Conversion/OnnxToHip/pdl/QDQMulFusion.pdll
+++ b/lib/Conversion/OnnxToHip/pdl/QDQMulFusion.pdll
@@ -14,17 +14,27 @@ Pattern QDQMul with benefit(10) {
   let mul = op<onnx.Mul>(dquant1.0, dquant2.0);
   let quant = op<onnx.QuantizeLinear>(mul.0, output_scale: Value, output_tail: ValueRange) -> (output_type: Type);
 
-  let ctx = GetContextArg(quant);
-  let lhs_scale_attr = ExtractScaleValue(lhs_scale);
-  let rhs_scale_attr = ExtractScaleValue(rhs_scale);
-  let output_scale_attr = ExtractScaleValue(output_scale);
-  let lhs_zeropoint_attr = ExtractZeropointValue(dquant1, attr<"2 : i64">, attr<"0 : i64">);
-  let rhs_zeropoint_attr = ExtractZeropointValue(dquant2, attr<"2 : i64">, attr<"0 : i64">);
-  let output_zeropoint_attr = ExtractZeropointValue(quant, attr<"2 : i64">, attr<"0 : i64">);
+  // Fusability only: every scale must be a per-tensor splat constant and every
+  // zero point must be readable (or absent, which means zero).
+  HasContextArg(quant);
+  IsSplatConstantValue(lhs_scale);
+  IsSplatConstantValue(rhs_scale);
+  IsSplatConstantValue(output_scale);
+  HasExtractableZeropoint(dquant1, attr<"2 : i64">);
+  HasExtractableZeropoint(dquant2, attr<"2 : i64">);
+  HasExtractableZeropoint(quant, attr<"2 : i64">);
 
   // Replace with fused operation. The two operand scales stay separate here;
   // HipToLLVM folds them into the single coefficient the kernel consumes.
   rewrite quant with {
+    let ctx = GetContextArg(quant);
+    let lhs_scale_attr = ExtractScaleValue(lhs_scale);
+    let rhs_scale_attr = ExtractScaleValue(rhs_scale);
+    let output_scale_attr = ExtractScaleValue(output_scale);
+    let lhs_zeropoint_attr = ExtractZeropointValue(dquant1, attr<"2 : i64">, attr<"0 : i64">);
+    let rhs_zeropoint_attr = ExtractZeropointValue(dquant2, attr<"2 : i64">, attr<"0 : i64">);
+    let output_zeropoint_attr = ExtractZeropointValue(quant, attr<"2 : i64">, attr<"0 : i64">);
+
     let empty = op<tensor.empty> -> (output_type);
     let qmul = op<hip.qmul>(ctx, lhs_input, rhs_input, empty.0) {
       lhs_scale = lhs_scale_attr,

--- a/lib/Conversion/OnnxToHip/pdl/qdq_fusion_pass.hpp
+++ b/lib/Conversion/OnnxToHip/pdl/qdq_fusion_pass.hpp
@@ -19,7 +19,6 @@
 namespace hip {
 namespace pdl {
 
-
 inline mlir::Value tryContextArg(mlir::Operation *op) {
   if (!op)
     return {};
@@ -66,9 +65,8 @@ inline std::optional<float> trySplatScale(mlir::Value value) {
 
 // ONNX makes the Q/DQ zero point optional, so an absent operand contributes
 // `absentValue` instead of rejecting the chain.
-inline std::optional<int64_t> trySplatZeropoint(mlir::Operation *op,
-                                                uint64_t index,
-                                                int64_t absentValue) {
+inline std::optional<int64_t>
+trySplatZeropoint(mlir::Operation *op, uint64_t index, int64_t absentValue) {
   if (!op)
     return std::nullopt;
   if (index >= op->getNumOperands())
@@ -164,10 +162,9 @@ extractZeropointValue(mlir::PatternRewriter &rewriter,
       args[2].dyn_cast<mlir::Attribute>());
   if (!indexAttr || !defaultValue)
     return mlir::failure();
-  std::optional<int64_t> zeropoint =
-      trySplatZeropoint(args[0].dyn_cast<mlir::Operation *>(),
-                        indexAttr.getValue().getZExtValue(),
-                        defaultValue.getInt());
+  std::optional<int64_t> zeropoint = trySplatZeropoint(
+      args[0].dyn_cast<mlir::Operation *>(),
+      indexAttr.getValue().getZExtValue(), defaultValue.getInt());
   if (!zeropoint)
     return mlir::failure();
   results.push_back(rewriter.getI64IntegerAttr(*zeropoint));

--- a/lib/Conversion/OnnxToHip/pdl/qdq_fusion_pass.hpp
+++ b/lib/Conversion/OnnxToHip/pdl/qdq_fusion_pass.hpp
@@ -14,68 +14,23 @@
 #include "mlir/Parser/Parser.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
+#include <optional>
+
 namespace hip {
 namespace pdl {
 
-// Native constraint: Get context argument from function
-// Low-level signature required by MLIR PDL infrastructure
-inline mlir::LogicalResult getContextArg(mlir::PatternRewriter &rewriter,
-                                         mlir::PDLResultList &results,
-                                         llvm::ArrayRef<mlir::PDLValue> args) {
-  // args[0] should be the operation
-  if (args.size() != 1)
-    return mlir::failure();
 
-  auto *op = args[0].dyn_cast<mlir::Operation *>();
+inline mlir::Value tryContextArg(mlir::Operation *op) {
   if (!op)
-    return mlir::failure();
-
+    return {};
   auto funcOp = op->getParentOfType<mlir::func::FuncOp>();
   if (!funcOp || funcOp.getNumArguments() == 0)
-    return mlir::failure();
-
-  // Return the context (first function argument) as a Value
-  results.push_back(funcOp.getArgument(0));
-  return mlir::success();
-}
-
-// Native constraint: Extract float value from an optional onnx.Constant operand
-// Low-level signature required by MLIR PDL infrastructure
-inline mlir::LogicalResult
-extractScaleValue(mlir::PatternRewriter &rewriter, mlir::PDLResultList &results,
-                  llvm::ArrayRef<mlir::PDLValue> args) {
-  // args[0] should be the constant value
-  if (args.size() != 1)
-    return mlir::failure();
-
-  auto constValue = args[0].dyn_cast<mlir::Value>();
-  if (!constValue)
-    return mlir::failure();
-
-  auto defOp = constValue.getDefiningOp();
-  if (!defOp)
-    return mlir::failure();
-
-  auto valueAttr = defOp->getAttr("value");
-  if (!valueAttr)
-    return mlir::failure();
-
-  auto denseAttr = mlir::dyn_cast<mlir::DenseElementsAttr>(valueAttr);
-  if (!denseAttr || !denseAttr.isSplat())
-    return mlir::failure();
-
-  float scaleValue =
-      denseAttr.getSplatValue<mlir::FloatAttr>().getValueAsDouble();
-
-  // Return the extracted float as an f32 attribute
-  results.push_back(rewriter.getF32FloatAttr(scaleValue));
-  return mlir::success();
+    return {};
+  return funcOp.getArgument(0);
 }
 
 // Element type of the quantized side of a Q/DQ op: the result for
-// QuantizeLinear, operand 0 for DequantizeLinear. It is the only tensor that
-// still carries ONNX signedness, because the importer gives inline constants --
-// including the zero point -- signless storage.
+// QuantizeLinear, operand 0 for DequantizeLinear.
 inline mlir::IntegerType getQuantizedElementType(mlir::Operation *op) {
   llvm::SmallVector<mlir::Type, 2> candidates;
   if (op->getNumOperands() > 0)
@@ -93,44 +48,129 @@ inline mlir::IntegerType getQuantizedElementType(mlir::Operation *op) {
   return {};
 }
 
-// Native constraint: Extract integer value from onnx.Constant
-// Low-level signature required by MLIR PDL infrastructure
+// Per-tensor quantization only: a non-splat scale is per-axis and would not
+// fold into a single coefficient.
+inline std::optional<float> trySplatScale(mlir::Value value) {
+  if (!value)
+    return std::nullopt;
+  mlir::Operation *defOp = value.getDefiningOp();
+  if (!defOp)
+    return std::nullopt;
+  auto denseAttr =
+      mlir::dyn_cast_or_null<mlir::DenseElementsAttr>(defOp->getAttr("value"));
+  if (!denseAttr || !denseAttr.isSplat())
+    return std::nullopt;
+  return static_cast<float>(
+      denseAttr.getSplatValue<mlir::FloatAttr>().getValueAsDouble());
+}
+
+// ONNX makes the Q/DQ zero point optional, so an absent operand contributes
+// `absentValue` instead of rejecting the chain.
+inline std::optional<int64_t> trySplatZeropoint(mlir::Operation *op,
+                                                uint64_t index,
+                                                int64_t absentValue) {
+  if (!op)
+    return std::nullopt;
+  if (index >= op->getNumOperands())
+    return absentValue;
+  mlir::Operation *defOp = op->getOperand(index).getDefiningOp();
+  if (!defOp)
+    return std::nullopt;
+  auto denseAttr =
+      mlir::dyn_cast_or_null<mlir::DenseElementsAttr>(defOp->getAttr("value"));
+  if (!denseAttr || !denseAttr.isSplat())
+    return std::nullopt;
+  auto quantType = getQuantizedElementType(op);
+  if (!quantType)
+    return std::nullopt;
+  llvm::APInt raw = denseAttr.getSplatValue<llvm::APInt>();
+  return quantType.isUnsigned() ? static_cast<int64_t>(raw.getZExtValue())
+                                : raw.getSExtValue();
+}
+
+//===----------------------------------------------------------------------===//
+// Match constraints -- result-free, so several patterns may share them.
+//===----------------------------------------------------------------------===//
+
+inline mlir::LogicalResult hasContextArg(mlir::PatternRewriter &,
+                                         mlir::PDLResultList &,
+                                         llvm::ArrayRef<mlir::PDLValue> args) {
+  if (args.size() != 1)
+    return mlir::failure();
+  return mlir::success(
+      static_cast<bool>(tryContextArg(args[0].dyn_cast<mlir::Operation *>())));
+}
+
+inline mlir::LogicalResult
+isSplatConstantValue(mlir::PatternRewriter &, mlir::PDLResultList &,
+                     llvm::ArrayRef<mlir::PDLValue> args) {
+  if (args.size() != 1)
+    return mlir::failure();
+  return mlir::success(
+      trySplatScale(args[0].dyn_cast<mlir::Value>()).has_value());
+}
+
+inline mlir::LogicalResult
+hasExtractableZeropoint(mlir::PatternRewriter &, mlir::PDLResultList &,
+                        llvm::ArrayRef<mlir::PDLValue> args) {
+  if (args.size() != 2)
+    return mlir::failure();
+  auto indexAttr = mlir::dyn_cast_or_null<mlir::IntegerAttr>(
+      args[1].dyn_cast<mlir::Attribute>());
+  if (!indexAttr)
+    return mlir::failure();
+  return mlir::success(trySplatZeropoint(args[0].dyn_cast<mlir::Operation *>(),
+                                         indexAttr.getValue().getZExtValue(), 0)
+                           .has_value());
+}
+
+//===----------------------------------------------------------------------===//
+// Rewrite functions -- reached only after the constraints above accepted.
+//===----------------------------------------------------------------------===//
+
+inline mlir::LogicalResult getContextArg(mlir::PatternRewriter &,
+                                         mlir::PDLResultList &results,
+                                         llvm::ArrayRef<mlir::PDLValue> args) {
+  if (args.size() != 1)
+    return mlir::failure();
+  mlir::Value ctx = tryContextArg(args[0].dyn_cast<mlir::Operation *>());
+  if (!ctx)
+    return mlir::failure();
+  results.push_back(ctx);
+  return mlir::success();
+}
+
+inline mlir::LogicalResult
+extractScaleValue(mlir::PatternRewriter &rewriter, mlir::PDLResultList &results,
+                  llvm::ArrayRef<mlir::PDLValue> args) {
+  if (args.size() != 1)
+    return mlir::failure();
+  std::optional<float> scale = trySplatScale(args[0].dyn_cast<mlir::Value>());
+  if (!scale)
+    return mlir::failure();
+  results.push_back(rewriter.getF32FloatAttr(*scale));
+  return mlir::success();
+}
+
 inline mlir::LogicalResult
 extractZeropointValue(mlir::PatternRewriter &rewriter,
                       mlir::PDLResultList &results,
                       llvm::ArrayRef<mlir::PDLValue> args) {
   if (args.size() != 3)
     return mlir::failure();
-  auto *op = args[0].dyn_cast<mlir::Operation *>();
   auto indexAttr = mlir::dyn_cast_or_null<mlir::IntegerAttr>(
       args[1].dyn_cast<mlir::Attribute>());
   auto defaultValue = mlir::dyn_cast_or_null<mlir::IntegerAttr>(
       args[2].dyn_cast<mlir::Attribute>());
-  if (!op || !indexAttr || !defaultValue)
+  if (!indexAttr || !defaultValue)
     return mlir::failure();
-
-  uint64_t index = indexAttr.getValue().getZExtValue();
-  if (index >= op->getNumOperands()) {
-    results.push_back(defaultValue);
-    return mlir::success();
-  }
-  auto *defOp = op->getOperand(index).getDefiningOp();
-  if (!defOp)
+  std::optional<int64_t> zeropoint =
+      trySplatZeropoint(args[0].dyn_cast<mlir::Operation *>(),
+                        indexAttr.getValue().getZExtValue(),
+                        defaultValue.getInt());
+  if (!zeropoint)
     return mlir::failure();
-  auto denseAttr =
-      mlir::dyn_cast_or_null<mlir::DenseElementsAttr>(defOp->getAttr("value"));
-  if (!denseAttr || !denseAttr.isSplat())
-    return mlir::failure();
-  // Sign-extending unsigned storage would read a ui16 zero point of 57835 back
-  // as -7701, so pick the extension that matches the quantized element type.
-  auto quantType = getQuantizedElementType(op);
-  if (!quantType)
-    return mlir::failure();
-  llvm::APInt raw = denseAttr.getSplatValue<llvm::APInt>();
-  int64_t i64Value = quantType.isUnsigned()
-                         ? static_cast<int64_t>(raw.getZExtValue())
-                         : raw.getSExtValue();
-  results.push_back(rewriter.getI64IntegerAttr(i64Value));
+  results.push_back(rewriter.getI64IntegerAttr(*zeropoint));
   return mlir::success();
 }
 
@@ -149,12 +189,16 @@ inline bool run(mlir::ModuleOp mlirModule, llvm::StringRef pdlBytecodeFile) {
 
   mlir::PDLPatternModule pdlPatterns(std::move(pdlModule));
 
-  // Register native constraints with low-level signatures
-  pdlPatterns.registerConstraintFunction("GetContextArg", getContextArg);
-  pdlPatterns.registerConstraintFunction("ExtractScaleValue",
-                                         extractScaleValue);
-  pdlPatterns.registerConstraintFunction("ExtractZeropointValue",
-                                         extractZeropointValue);
+  // Register native helpers with low-level signatures
+  pdlPatterns.registerConstraintFunction("HasContextArg", hasContextArg);
+  pdlPatterns.registerConstraintFunction("IsSplatConstantValue",
+                                         isSplatConstantValue);
+  pdlPatterns.registerConstraintFunction("HasExtractableZeropoint",
+                                         hasExtractableZeropoint);
+  pdlPatterns.registerRewriteFunction("GetContextArg", getContextArg);
+  pdlPatterns.registerRewriteFunction("ExtractScaleValue", extractScaleValue);
+  pdlPatterns.registerRewriteFunction("ExtractZeropointValue",
+                                      extractZeropointValue);
 
   mlir::RewritePatternSet patterns(ctx);
   patterns.add(std::move(pdlPatterns));

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -656,6 +656,19 @@ void QAddOp::getEffects(
 }
 
 //===----------------------------------------------------------------------===//
+// QMulOp: ins(lhs, rhs), outs(output)
+// Quantized elementwise mul with integrated QDQ scales and zero points
+//===----------------------------------------------------------------------===//
+
+MutableOperandRange QMulOp::getDpsInitsMutable() { return getOutputMutable(); }
+
+void QMulOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
+}
+
+//===----------------------------------------------------------------------===//
 // HipblasltMatmulOp: ins(A, B), outs(C)
 //===----------------------------------------------------------------------===//
 

--- a/lib/Runtime/Kernels/hip/qelementwise_kernel.hip
+++ b/lib/Runtime/Kernels/hip/qelementwise_kernel.hip
@@ -14,6 +14,7 @@
 
 #define HIP_QELEMENTWISE_MAX_RANK 8
 #define HIP_QELEMENTWISE_ADD 0
+#define HIP_QELEMENTWISE_MUL 1
 
 struct QElemDimsND {
   int64_t v[HIP_QELEMENTWISE_MAX_RANK];
@@ -84,13 +85,15 @@ __global__ void qelementwise_nd_kernel(
     rhs_idx += coord * rhs_stride.v[k];
   }
 
-  float da = M_a * (static_cast<float>(lhs[lhs_idx]) -
-                    static_cast<float>(lhs_zp));
-  float db = M_b * (static_cast<float>(rhs[rhs_idx]) -
-                    static_cast<float>(rhs_zp));
+  float da = static_cast<float>(lhs[lhs_idx]) - static_cast<float>(lhs_zp);
+  float db = static_cast<float>(rhs[rhs_idx]) - static_cast<float>(rhs_zp);
   float acc = 0.f;
   if (kind == HIP_QELEMENTWISE_ADD)
-    acc = da + db;
+    acc = M_a * da + M_b * db;
+  else if (kind == HIP_QELEMENTWISE_MUL)
+    // M_b is unused here: the host folded s_a * s_b / s_out into M_a, so the
+    // product of the integer differences takes a single rescale.
+    acc = M_a * (da * db);
   output[idx] = q_saturate<T>(rintf(acc) + static_cast<float>(output_zp));
 }
 
@@ -149,7 +152,7 @@ extern "C" int hip_qelementwise(void *stream, const void *lhs, const void *rhs,
                                 const int64_t *out_shape, int64_t out_rank,
                                 int hip_dtype, float M_a, int64_t lhs_zp,
                                 float M_b, int64_t rhs_zp, int64_t output_zp) {
-  if (kind != HIP_QELEMENTWISE_ADD) {
+  if (kind != HIP_QELEMENTWISE_ADD && kind != HIP_QELEMENTWISE_MUL) {
     fprintf(stderr, "[custom_kernels] hip_qelementwise: unsupported kind=%lld\n",
             (long long)kind);
     return -1;

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -143,10 +143,16 @@ HIP_KERNEL_API int hip_elementwise_where(
  * Operand shapes are left-padded with 1s to out_rank (NumPy broadcast).
  * Rank must be <= HIP_QELEMENTWISE_MAX_RANK (8).
  *
- * kind: 0 = add (HIPDNN_EP_QELEMENTWISE_ADD).
- * Scales are folded by lowering: M_a = s_a / s_out, M_b = s_b / s_out.
+ * kind: 0 = add (HIPDNN_EP_QELEMENTWISE_ADD),
+ *       1 = mul (HIPDNN_EP_QELEMENTWISE_MUL).
  *
- *   OUT = saturate(round(M_a * (A - z_a) [OP] M_b * (B - z_b)) + z_out)
+ * Scales are folded by lowering, and how they collapse depends on kind
+ * because multiplying the dequantized operands also multiplies their scales:
+ *
+ *   add: M_a = s_a / s_out, M_b = s_b / s_out
+ *        OUT = saturate(round(M_a * (A - z_a) + M_b * (B - z_b)) + z_out)
+ *   mul: M_a = s_a * s_b / s_out, M_b unused
+ *        OUT = saturate(round(M_a * (A - z_a) * (B - z_b)) + z_out)
  *
  * Supported hip_dtype: HIP_DTYPE_INT8, HIP_DTYPE_UINT8, HIP_DTYPE_INT16,
  * HIP_DTYPE_UINT16, HIP_DTYPE_INT32.

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -31,7 +31,10 @@ extern "C" {
 #define HIPDNN_EP_TENSOR_OP_MIN 2 // element-wise min
 #define HIPDNN_EP_TENSOR_OP_MAX 3 // element-wise max
 
+// Must match HipdnnQElementwiseKind in
+// lib/Conversion/HipToLLVM/HipToLLVMUtils.h
 #define HIPDNN_EP_QELEMENTWISE_ADD 0
+#define HIPDNN_EP_QELEMENTWISE_MUL 1
 
 static inline const char *hipdnn_ep_tensor_op_name(int64_t op) {
   switch (op) {
@@ -907,7 +910,11 @@ int wrap_elementwise_sub(RuntimeState *state, void *lhs, void *rhs,
 // up to `out_rank`, and dims of 1 broadcast against the output dim.
 //
 // lhs/rhs/output are quantized buffers of `data_type`.
-// M_a = s_a / s_out, M_b = s_b / s_out (folded by lowering).
+//
+// The coefficients are folded by lowering and their meaning depends on `kind`,
+// because a product of dequantized operands also multiplies their scales:
+//   ADD: M_a = s_a / s_out, M_b = s_b / s_out
+//   MUL: M_a = s_a * s_b / s_out, M_b unused (lowering passes 1.0f)
 int wrap_qelementwise(RuntimeState *state, void *lhs, void *rhs, void *output,
                       int64_t kind, const int64_t *lhs_shape, int64_t lhs_rank,
                       const int64_t *rhs_shape, int64_t rhs_rank,

--- a/lib/Runtime/real/qelementwise.cpp
+++ b/lib/Runtime/real/qelementwise.cpp
@@ -8,9 +8,14 @@
 // a = (A - z_a) * s_a
 // b = (B - z_b) * s_b
 // OUT = saturate(round((a [OP] b) / s_out) + z_out)
-// --->
+//
+// [OP] = Add:
 // let M_a = s_a/s_out, M_b = s_b/s_out
 // OUT = saturate(round(M_a * (A - z_a) [OP] M_b * (B - z_b)) + z_out)
+//
+// [OP] = Mul:
+// let M = s_a * s_b / s_out
+// OUT = saturate(round(M * (A - z_a) * (B - z_b)) + z_out)
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
 #include "hip_custom_kernels.h"
@@ -34,11 +39,9 @@ static int hipdnn_to_hip_dtype_qelem(int64_t hipdnn_type) {
   }
 }
 
-// Notes on function reuse: the current function declaration does not support
-// multiplication or division because the formula optimization needs to be
-// modified. Additionally, the current function interface does not provide
-// sufficient information to support mixed quantization precisions. We can
-// update it if such a case arises.
+// Notes on function reuse: Mul reuses this Add-shaped declaration unchanged --
+// its three scales collapse into M_a, leaving M_b dead. One `data_type` covers
+// both operands and the output, so mixed precisions remain inexpressible.
 int wrap_qelementwise(RuntimeState *state, void *lhs, void *rhs, void *output,
                       int64_t kind, const int64_t *lhs_shape, int64_t lhs_rank,
                       const int64_t *rhs_shape, int64_t rhs_rank,

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -49,6 +49,13 @@ if(NOT THEROCK_DIST)
     "THEROCK_DIST is empty; the wheel cannot bundle the ROCm runtime.")
 endif()
 
+if(NOT TARGET HipPdllPatterns OR NOT HIP_PDL_FUSION_PATTERNS)
+  message(FATAL_ERROR
+    "PDL fusion patterns are unavailable (mlir-pdll was not found); the wheel "
+    "would ship an EP that cannot compile any model.")
+endif()
+list(APPEND _wheel_deps HipPdllPatterns)
+
 foreach(_arch IN LISTS HIP_ARCHITECTURES)
   set(_ck_target custom_kernels_${_arch})
   if(TARGET ${_ck_target})
@@ -70,11 +77,13 @@ add_custom_target(wheel ALL
           "${_pkg_src}/setup.py"
           "${_stage}/"
   # 2. Stage native artifacts (EP lib + per-arch custom-kernels runtime
-  #    DLLs/SOs + CRT import libs) into the onnxruntime_ep_amdgpu namespace
-  #    package dir so the wheel ships them at onnxruntime_ep_amdgpu/ (platlib).
+  #    DLLs/SOs + CRT import libs + the PDL fusion patterns) into the
+  #    onnxruntime_ep_amdgpu namespace package dir so the wheel ships them at
+  #    onnxruntime_ep_amdgpu/ (platlib).
   COMMAND ${CMAKE_COMMAND} -E rm -rf "${_libs_dir}"
   COMMAND ${Python3_EXECUTABLE} "${_pkg_src}/_pack_libs.py"
           ${_dll_args}
+          --data-file "${HIP_PDL_FUSION_PATTERNS}"
           --dest "${_libs_dir}"
           --rocm-dist "${THEROCK_DIST}"
           --rocm-arch "${MORPHIZEN_HIP_ARCH}"

--- a/python/_pack_libs.py
+++ b/python/_pack_libs.py
@@ -124,6 +124,15 @@ def main():
         "multi-arch distribution carries every arch; the wheel ships one.",
     )
     ap.add_argument(
+        "--data-file",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help="Non-library file the EP loads from its own directory at runtime "
+        "(repeatable), e.g. HipFusionPatterns.pdl.mlir. Missing files are a "
+        "hard error: the EP cannot compile a model without them.",
+    )
+    ap.add_argument(
         "--extra-lib",
         action="append",
         default=[],
@@ -148,6 +157,14 @@ def main():
             return 1
         shutil.copy2(lib, dest / lib.name)
         print(f"  packaged library: {lib.name} <- {lib}")
+
+    for raw in args.data_file:
+        data = Path(raw)
+        if not data.is_file():
+            print(f"ERROR: data file not found: {data}", file=sys.stderr)
+            return 1
+        shutil.copy2(data, dest / data.name)
+        print(f"  packaged data file: {data.name} <- {data}")
 
     for raw in args.extra_lib:
         lib = Path(raw)

--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -23,4 +23,4 @@ include = ["onnxruntime_ep_hip", "onnxruntime_ep_amdgpu"]
 namespaces = true
 
 [tool.setuptools.package-data]
-"onnxruntime_ep_amdgpu" = ["*.dll", "*.lib", "*.dll.a", "*.so", "hipblaslt/library/*/*"]
+"onnxruntime_ep_amdgpu" = ["*.dll", "*.lib", "*.dll.a", "*.so", "HipFusionPatterns.pdl.mlir", "hipblaslt/library/*/*"]

--- a/test/lit/Conversion/hip-to-llvm/test_qmul.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_qmul.mlir
@@ -15,13 +15,14 @@ module {
 
     hip.qmul(%ctx) ins(%lhs, %rhs : memref<1x128x32xi8, 1>, memref<1x128x32xi8, 1>)
                    outs(%out : memref<1x128x32xi8, 1>)
-                   {lhs_scale = 1.000000e-01 : f32, lhs_zp = -5 : i64,
-                    rhs_scale = 5.000000e-02 : f32, rhs_zp = 3 : i64,
-                    output_scale = 2.000000e-01 : f32, output_zp = 7 : i64}
+                   {lhs_scale = 5.000000e-01 : f32, lhs_zp = -5 : i64,
+                    rhs_scale = 2.500000e-01 : f32, rhs_zp = 3 : i64,
+                    output_scale = 5.000000e-01 : f32, output_zp = 7 : i64}
 
-    // Lowering folds scales into M_a = s_lhs/s_out and M_b = s_rhs/s_out.
-    // CHECK-DAG: llvm.mlir.constant(2.500000e-02 : f32)
-    // CHECK-DAG: llvm.mlir.constant(1.0 : f32)
+    // Mul reuses the two-coefficient Add ABI: all three scales collapse into
+    // M_a = s_lhs * s_rhs / s_out = 0.25, leaving M_b dead at 1.0.
+    // CHECK-DAG: llvm.mlir.constant(2.500000e-01 : f32)
+    // CHECK-DAG: llvm.mlir.constant(1.000000e+00 : f32)
     // CHECK: llvm.call @wrap_qelementwise({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, i64, f32, i64, f32, i64, i64) -> i32
     return
   }

--- a/test/lit/Conversion/hip-to-llvm/test_qmul.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_qmul.mlir
@@ -1,0 +1,28 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s --convert-hip-to-llvm | FileCheck %s
+
+// CHECK: llvm.func @wrap_qelementwise(!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, i64, f32, i64, f32, i64, i64) -> i32
+
+module {
+    func.func @qmul_i8(
+      %ctx: !hip.context,
+      %lhs: memref<1x128x32xi8, 1>,
+      %rhs: memref<1x128x32xi8, 1>,
+      %out: memref<1x128x32xi8, 1>) {
+    // CHECK-LABEL: llvm.func @qmul_i8
+
+    hip.qmul(%ctx) ins(%lhs, %rhs : memref<1x128x32xi8, 1>, memref<1x128x32xi8, 1>)
+                   outs(%out : memref<1x128x32xi8, 1>)
+                   {lhs_scale = 1.000000e-01 : f32, lhs_zp = -5 : i64,
+                    rhs_scale = 5.000000e-02 : f32, rhs_zp = 3 : i64,
+                    output_scale = 2.000000e-01 : f32, output_zp = 7 : i64}
+
+    // Lowering folds scales into M_a = s_lhs/s_out and M_b = s_rhs/s_out.
+    // CHECK-DAG: llvm.mlir.constant(2.500000e-02 : f32)
+    // CHECK-DAG: llvm.mlir.constant(1.0 : f32)
+    // CHECK: llvm.call @wrap_qelementwise({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, !llvm.ptr, i64, i64, f32, i64, f32, i64, i64) -> i32
+    return
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_qmul.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_qmul.mlir
@@ -34,13 +34,13 @@ module {
 // broadcast pre-passes, so the rank-1 rhs must reach hip.qmul unpadded and
 // unpacked -- no collapse_shape/expand_shape around the fused op.
 
-// CHECK-LABEL: func.func @qmul_broadcast
+// CHECK-LABEL: func.func @main_graph
 // CHECK-SAME:  (%[[CTX:.*]]: !hip.context, %[[LHS:.*]]: tensor<1x128x32xi8>, %[[RHS:.*]]: tensor<32xi8>) -> tensor<1x128x32xi8> {
 // CHECK-NEXT:    %[[EMPTY:.*]] = tensor.empty() : tensor<1x128x32xi8>
 // CHECK-NEXT:    %[[QMUL:.*]] = hip.qmul(%[[CTX]]) ins(%[[LHS]], %[[RHS]] : tensor<1x128x32xi8>, tensor<32xi8>) outs(%[[EMPTY]] : tensor<1x128x32xi8>) {lhs_scale = 2.500000e-01 : f32, lhs_zp = -12 : i64, output_scale = 1.250000e-01 : f32, output_zp = 4 : i64, rhs_scale = 5.000000e-01 : f32, rhs_zp = 9 : i64} : tensor<1x128x32xi8>
 // CHECK-NEXT:    return %[[QMUL]] : tensor<1x128x32xi8>
 // CHECK-NEXT:  }
-  func.func @qmul_broadcast(%lhs: tensor<1x128x32xi8>,
+  func.func @main_graph(%lhs: tensor<1x128x32xi8>,
                             %rhs: tensor<32xi8>) -> tensor<1x128x32xi8> {
     %lhs_scale = "onnx.Constant"() {value = dense<0.25> : tensor<f32>} : () -> tensor<f32>
     %lhs_zp = "onnx.Constant"() {value = dense<-12> : tensor<i8>} : () -> tensor<i8>

--- a/test/lit/Conversion/onnx-to-hip/test_qmul.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_qmul.mlir
@@ -1,0 +1,67 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST: QDQ Mul Fusion Pattern (Pure PDLL approach)
+//
+// Demonstrates pure PDLL fusion with native constraints:
+// - PDLL matches the QDQ chain pattern
+// - PDLL calls native constraints to get the context, extract the f32 scales
+//   and extract the i64 zero points
+// - PDLL creates the fused hip.qmul operation
+//
+// Pattern fuses:
+//   onnx.DequantizeLinear, onnx.DequantizeLinear
+//     -> onnx.Mul -> onnx.QuantizeLinear
+// into:
+//   hip.qmul
+//
+//
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s --check-prefix=NOLEFTOVER
+// ============================================================================
+
+// The exhaustive CHECK-NEXT chains below already pin every surviving op, but
+// spell the fusion contract out once so a partial match cannot pass silently.
+// NOLEFTOVER-NOT: onnx.DequantizeLinear
+// NOLEFTOVER-NOT: onnx.Mul
+// NOLEFTOVER-NOT: onnx.QuantizeLinear
+// NOLEFTOVER-NOT: onnx.Constant
+// NOLEFTOVER-NOT: hip.constant
+
+module {
+// ONNX Mul declares NumPy broadcasting. PDL fusion runs ahead of the ONNX
+// broadcast pre-passes, so the rank-1 rhs must reach hip.qmul unpadded and
+// unpacked -- no collapse_shape/expand_shape around the fused op.
+
+// CHECK-LABEL: func.func @qmul_broadcast
+// CHECK-SAME:  (%[[CTX:.*]]: !hip.context, %[[LHS:.*]]: tensor<1x128x32xi8>, %[[RHS:.*]]: tensor<32xi8>) -> tensor<1x128x32xi8> {
+// CHECK-NEXT:    %[[EMPTY:.*]] = tensor.empty() : tensor<1x128x32xi8>
+// CHECK-NEXT:    %[[QMUL:.*]] = hip.qmul(%[[CTX]]) ins(%[[LHS]], %[[RHS]] : tensor<1x128x32xi8>, tensor<32xi8>) outs(%[[EMPTY]] : tensor<1x128x32xi8>) {lhs_scale = 2.500000e-01 : f32, lhs_zp = -12 : i64, output_scale = 1.250000e-01 : f32, output_zp = 4 : i64, rhs_scale = 5.000000e-01 : f32, rhs_zp = 9 : i64} : tensor<1x128x32xi8>
+// CHECK-NEXT:    return %[[QMUL]] : tensor<1x128x32xi8>
+// CHECK-NEXT:  }
+  func.func @qmul_broadcast(%lhs: tensor<1x128x32xi8>,
+                            %rhs: tensor<32xi8>) -> tensor<1x128x32xi8> {
+    %lhs_scale = "onnx.Constant"() {value = dense<0.25> : tensor<f32>} : () -> tensor<f32>
+    %lhs_zp = "onnx.Constant"() {value = dense<-12> : tensor<i8>} : () -> tensor<i8>
+    %rhs_scale = "onnx.Constant"() {value = dense<0.5> : tensor<f32>} : () -> tensor<f32>
+    %rhs_zp = "onnx.Constant"() {value = dense<9> : tensor<i8>} : () -> tensor<i8>
+    %output_scale = "onnx.Constant"() {value = dense<0.125> : tensor<f32>} : () -> tensor<f32>
+    %output_zp = "onnx.Constant"() {value = dense<4> : tensor<i8>} : () -> tensor<i8>
+
+    %lhs_dequantized = "onnx.DequantizeLinear"(%lhs, %lhs_scale, %lhs_zp)
+                       : (tensor<1x128x32xi8>, tensor<f32>, tensor<i8>) -> tensor<1x128x32xf32>
+
+    %rhs_dequantized = "onnx.DequantizeLinear"(%rhs, %rhs_scale, %rhs_zp)
+                       : (tensor<32xi8>, tensor<f32>, tensor<i8>) -> tensor<32xf32>
+
+    %product = "onnx.Mul"(%lhs_dequantized, %rhs_dequantized)
+               : (tensor<1x128x32xf32>, tensor<32xf32>) -> tensor<1x128x32xf32>
+
+    %result = "onnx.QuantizeLinear"(%product, %output_scale, %output_zp)
+              : (tensor<1x128x32xf32>, tensor<f32>, tensor<i8>) -> tensor<1x128x32xi8>
+
+    return %result : tensor<1x128x32xi8>
+  }
+
+}


### PR DESCRIPTION
## Motivation

Quantized models emit `DequantizeLinear -> Mul -> QuantizeLinear` chains.
Without fusion, each chain runs as three separate ops with float round-trips.
`hip.qadd` already covers the additive case, so Mul only needs the same path
with a different scale folding.

## Details

- Add `Hip_QMulOp` (`hip.qmul`) as a broadcasting DPS op carrying the QDQ
  scales/zero points, with `getDpsInitsMutable`/`getEffects` and a bufferizable
  interface model.
- Add `QDQMulFusion.pdll`, a pure-PDLL pattern that matches the QDQ Mul chain
  and rewrites it into `hip.qmul`, reusing the existing native constraints.
- Rename `QAddLowering.cpp` to `QElementwiseLowering.cpp` and make the shared
  lowering template kind-aware. For Mul the three scales collapse into a single
  coefficient (`M_a = s_a * s_b / s_out`, `M_b` unused), so the existing
  `wrap_qelementwise` ABI is reused unchanged.
- Extend the HIP kernel with `HIP_QELEMENTWISE_MUL`: the rescale now happens
  after the integer differences are combined, which keeps Add numerically
  identical while letting Mul apply one fused rescale.
- Update the runtime header and kernel docs to state the per-kind meaning of
  the coefficient slots.
- If the fused pdl mlir cannot be found, an error will be thrown.

###  Why update qdq_fusion_pass.hpp
`QDQAdd` and `QDQMul` are structurally identical and rooted on the same op
(`onnx.QuantizeLinear`). `-convert-pdl-to-pdl-interp` merges same-root patterns
into a single matcher tree and uniques every predicate the patterns share, so a
shared predicate is evaluated once, in the block where the two branches still
coincide.
That is correct for a yes/no predicate but not for a native constraint that
*returns a value*. `GetContextArg`, `ExtractScaleValue` and
`ExtractZeropointValue` were declared as result-producing `Constraint`s and
called from the match section. After uniquing, their results are defined in the
block owned by the merged node, while each pattern keeps its own
`pdl_interp.record_match` on its own branch. One branch's `record_match` then
operands a value defined in a sibling block that does not dominate it, which is
exactly what the verifier reports — hence the note pointing at "op in the same
region".

## Test Plan

- [x] `test/lit/Conversion/onnx-to-hip/test_qmul.mlir`: QDQ chain fuses into
      `hip.qmul`, rank-1 rhs stays unpadded, and no ONNX/constant ops are left
      behind.
- [x] `test/lit/Conversion/hip-to-llvm/test_qmul.mlir`: `hip.qmul` lowers to
      `wrap_qelementwise` with the folded coefficient.
- [x] Existing `hip.qadd` LIT tests still pass (kernel refactor must not change
      Add numerics).
- [x] Numeric check of quantized Mul against CPU reference on GPU, including a
      broadcast shape.

## AI assistance
The code was developed collaboratively with Cursor, and all code has been reviewed.