### PR TITLE
fix(hipsr): let barrier placeholders read the value, not the destination

### DIFF
--- a/include/hip/Dialect/Hipsr/Transforms/Passes.td
+++ b/include/hip/Dialect/Hipsr/Transforms/Passes.td
@@ -69,6 +69,10 @@ def PartitionPoolDomainsPass
     init. Its result and the matching DPS data result are returned separately
     when both are used by a later domain.
 
+    A barrier waits on data, so the pass points its inputs at the DPS results
+    before it assigns domains. The conversion had wired them to the inits,
+    which for a `hipsr.compute` is a different value from the result.
+
     Before:
     ```mlir
     func.func @graph(%ctx: !hipsr.context, %input: tensor<4xf32>)
@@ -93,7 +97,7 @@ def PartitionPoolDomainsPass
     ```mlir
     func.func @graph(%ctx: !hipsr.context, %input: tensor<4xf32>)
         -> tensor<4xf32> {
-      %0:2 = hipsr.pool_domain(
+      %0 = hipsr.pool_domain(
           %ctx, %input : !hipsr.context, tensor<4xf32>) {
       ^bb0(%domain_ctx: !hipsr.context, %domain_input: tensor<4xf32>):
         %init0 = hipsr.placeholder(%domain_ctx)
@@ -103,16 +107,13 @@ def PartitionPoolDomainsPass
         %data0 = hipsr.cast(%domain_ctx)
             ins(%domain_input : tensor<4xf32>)
             outs(%init0 : tensor<4xf16>) : tensor<4xf16>
-        hipsr.pool_domain_yield %init0, %data0
-            : tensor<4xf16>, tensor<4xf16>
-      } -> tensor<4xf16>, tensor<4xf16> {domain_id = 0 : i64}
-      %1 = hipsr.pool_domain(%ctx, %0#0, %0#1
-          : !hipsr.context, tensor<4xf16>, tensor<4xf16>) {
-      ^bb0(%domain_ctx: !hipsr.context,
-           %domain_shape_input: tensor<4xf16>,
-           %domain_data_input: tensor<4xf16>):
+        hipsr.pool_domain_yield %data0 : tensor<4xf16>
+      } -> tensor<4xf16> {domain_id = 0 : i64}
+      %1 = hipsr.pool_domain(%ctx, %0
+          : !hipsr.context, tensor<4xf16>) {
+      ^bb0(%domain_ctx: !hipsr.context, %domain_data_input: tensor<4xf16>):
         %init1 = hipsr.placeholder(%domain_ctx)
-            ins(%domain_shape_input : tensor<4xf16>)
+            ins(%domain_data_input : tensor<4xf16>)
             {placeholder_type = #hipsr.placeholder_type<barrier>}
             : tensor<4xf32>
         %data1 = hipsr.cast(%domain_ctx)

--- a/lib/Dialect/Hipsr/Transforms/PartitionPoolDomains.cpp
+++ b/lib/Dialect/Hipsr/Transforms/PartitionPoolDomains.cpp
@@ -26,6 +26,35 @@ namespace hipsr {
 
 namespace {
 
+// Points each barrier at the DPS results it waits on, not the inits the
+// conversion wired up. A DPS op returns its init after writing it, but a
+// hipsr.compute result is a separate value its init only names a destination
+// for, so waiting on the init waits on nothing the body produced:
+//
+//   %init = hipsr.placeholder(%ctx) ins(%in) {normal} : tensor<4xf16>
+//   %data = hipsr.compute(%ctx) ins(%in) outs(%init) { ... } : tensor<4xf16>
+//
+//   // Before: waits on %init, a buffer the body never wrote
+//   %wait = hipsr.placeholder(%ctx) ins(%init) {barrier} : tensor<4xf16>
+//   // After
+//   %wait = hipsr.placeholder(%ctx) ins(%data) {barrier} : tensor<4xf16>
+void makeBarriersReadDpsResults(Block &block) {
+  for (PlaceholderOp placeholder : block.getOps<PlaceholderOp>()) {
+    if (placeholder.getPlaceholderType() != PlaceholderType::Barrier) {
+      continue;
+    }
+    placeholder.getInputsMutable().assign(
+        llvm::map_to_vector(placeholder.getInputs(), [](Value init) -> Value {
+          for (OpOperand &use : init.getUses()) {
+            if (OpResult result = getResultForDestination(use)) {
+              return result;
+            }
+          }
+          return init;
+        }));
+  }
+}
+
 namespace partition_analysis {
 
 struct Domain {
@@ -283,6 +312,8 @@ struct PartitionPoolDomainsPass
       return;
     }
     Value context = entryBlock.getArgument(0);
+
+    makeBarriersReadDpsResults(entryBlock);
 
     partition_analysis::DomainAssignment assignment =
         partition_analysis::buildDomainAssignment(entryBlock);

--- a/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
@@ -53,7 +53,7 @@
 // CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
 // CHECK-SAME:      %[[ARG1:.*]]: memref<?x?xi64, #hipsr.mem<device>> {onnx.name = "input_ids"},
 // CHECK-SAME:      %[[ARG2:.*]]: memref<?x4096xf16, #hipsr.mem<device>> {onnx.name = "image_features"}) -> (memref<?x?x4096xf16, #hipsr.mem<device>> {onnx.name = "inputs_embeds"}) attributes {onnx.graph.name = "main_graph"} {
-// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]]:8 = hipsr.pool_domain(%[[ARG0]], %[[ARG2]], %[[ARG1]] : !hipsr.context, memref<?x4096xf16, #hipsr.mem<device>>, memref<?x?xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]]:5 = hipsr.pool_domain(%[[ARG0]], %[[ARG2]], %[[ARG1]] : !hipsr.context, memref<?x4096xf16, #hipsr.mem<device>>, memref<?x?xi64, #hipsr.mem<device>>) {
 // CHECK-NEXT:      ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: memref<?x4096xf16, #hipsr.mem<device>>, %[[VAL_2:.*]]: memref<?x?xi64, #hipsr.mem<device>>):
 // CHECK-NEXT:        %[[CONSTANT_0:.*]] = arith.constant 248320 : index
 // CHECK-NEXT:        %[[CONSTANT_1:.*]] = arith.constant 2 : index
@@ -118,48 +118,43 @@
 // CHECK-NEXT:        %[[ALLOC_8:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[DIM_3]], %[[ALLOC_8]]{{\[}}%[[CONSTANT_6]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[DIM_4]], %[[ALLOC_8]]{{\[}}%[[CONSTANT_5]]] : memref<2xindex>
-// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_7]]{{\[}}%[[CONSTANT_6]]] [%[[CONSTANT_6]]] [%[[CONSTANT_5]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_7]]{{\[}}%[[CONSTANT_5]]] [%[[CONSTANT_5]]] [%[[CONSTANT_5]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_7]]{{\[}}%[[CONSTANT_6]]] {{\[}}%[[CONSTANT_6]]] {{\[}}%[[CONSTANT_5]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_7]]{{\[}}%[[CONSTANT_5]]] {{\[}}%[[CONSTANT_5]]] {{\[}}%[[CONSTANT_5]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:        %[[ALLOC_9:.*]] = memref.alloc(%[[CONSTANT_1]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_9]]{{\[}}0] [%[[CONSTANT_6]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_9]][0] {{\[}}%[[CONSTANT_6]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        memref.copy %[[SUBVIEW_0]], %[[SUBVIEW_2]] : memref<?xindex, strided<[?], offset: ?>> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        %[[SUBVIEW_3:.*]] = memref.subview %[[ALLOC_9]]{{\[}}%[[CONSTANT_6]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_8]], %[[SUBVIEW_3]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        %[[ALLOC_10:.*]] = memref.alloc(%[[CONSTANT_7]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[ALLOC_10]]{{\[}}0] [%[[CONSTANT_1]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[ALLOC_10]][0] {{\[}}%[[CONSTANT_1]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_9]], %[[SUBVIEW_4]] : memref<?xindex> to memref<?xindex, strided<[1]>>
-// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_10]]{{\[}}%[[CONSTANT_1]]] [%[[CONSTANT_5]]] [1] : memref<?xindex> to memref<?xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_10]]{{\[}}%[[CONSTANT_1]]] {{\[}}%[[CONSTANT_5]]] [1] : memref<?xindex> to memref<?xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        memref.copy %[[SUBVIEW_1]], %[[SUBVIEW_5]] : memref<?xindex, strided<[?], offset: ?>> to memref<?xindex, strided<[1], offset: ?>>
-// CHECK-NEXT:        %[[LOAD_5:.*]] = memref.load %[[ALLOC_2]]{{\[}}%[[CONSTANT_6]]] : memref<1xindex>
-// CHECK-NEXT:        %[[ALLOC_11:.*]] = memref.alloc(%[[LOAD_5]]) {alignment = 64 : i64} : memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[LOAD_6:.*]] = memref.load %[[ALLOC_5]]{{\[}}%[[CONSTANT_6]]] : memref<?xindex>
-// CHECK-NEXT:        %[[LOAD_7:.*]] = memref.load %[[ALLOC_5]]{{\[}}%[[CONSTANT_5]]] : memref<?xindex>
-// CHECK-NEXT:        %[[LOAD_8:.*]] = memref.load %[[ALLOC_6]]{{\[}}%[[CONSTANT_6]]] : memref<3xindex>
-// CHECK-NEXT:        %[[LOAD_9:.*]] = memref.load %[[ALLOC_6]]{{\[}}%[[CONSTANT_5]]] : memref<3xindex>
-// CHECK-NEXT:        %[[ALLOC_12:.*]] = memref.alloc(%[[LOAD_8]], %[[LOAD_9]]) {alignment = 64 : i64} : memref<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[LOAD_10:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[CONSTANT_6]]] : memref<?xindex>
-// CHECK-NEXT:        %[[LOAD_11:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[CONSTANT_5]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_13:.*]] = memref.alloc(%[[LOAD_10]], %[[LOAD_11]]) {alignment = 64 : i64} : memref<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_14:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_5:.*]] = memref.load %[[ALLOC_5]]{{\[}}%[[CONSTANT_6]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_6:.*]] = memref.load %[[ALLOC_5]]{{\[}}%[[CONSTANT_5]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_7:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[CONSTANT_6]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_8:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[CONSTANT_5]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_11:.*]] = memref.alloc(%[[LOAD_7]], %[[LOAD_8]]) {alignment = 64 : i64} : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_12:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[COMPUTE_0:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[VAL_1]] : memref<?x4096xf16, #hipsr.mem<device>>) outs(%[[VAL_1]] : memref<?x4096xf16, #hipsr.mem<device>>) {
 // CHECK-NEXT:        ^bb0(%[[VAL_6:.*]]: !hipsr.context, %[[VAL_7:.*]]: memref<?x4096xf16, #hipsr.mem<device>>, %[[VAL_8:.*]]: memref<?x4096xf16, #hipsr.mem<device>>):
 // CHECK-NEXT:          %[[COLLAPSE_SHAPE_0:.*]] = memref.collapse_shape %[[VAL_7]] {{\[\[}}0, 1]] : memref<?x4096xf16, #hipsr.mem<device>> into memref<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT:          hipsr.compute_yield %[[COLLAPSE_SHAPE_0]] : memref<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT:        } : memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_15:.*]] = memref.alloc(%[[LOAD_6]], %[[LOAD_7]]) {alignment = 64 : i64} : memref<?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.equal(%[[VAL_0]]) ins(%[[VAL_2]], %[[CONSTANT_3]] : memref<?x?xi64, #hipsr.mem<device>>, memref<i64, #hipsr.mem<device>>) outs(%[[ALLOC_15]] : memref<?x?xi1, #hipsr.mem<device>>)
-// CHECK-NEXT:        %[[COMPUTE_1:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[ALLOC_15]] : memref<?x?xi1, #hipsr.mem<device>>) outs(%[[ALLOC_15]] : memref<?x?xi1, #hipsr.mem<device>>) {
+// CHECK-NEXT:        %[[ALLOC_13:.*]] = memref.alloc(%[[LOAD_5]], %[[LOAD_6]]) {alignment = 64 : i64} : memref<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.equal(%[[VAL_0]]) ins(%[[VAL_2]], %[[CONSTANT_3]] : memref<?x?xi64, #hipsr.mem<device>>, memref<i64, #hipsr.mem<device>>) outs(%[[ALLOC_13]] : memref<?x?xi1, #hipsr.mem<device>>)
+// CHECK-NEXT:        %[[COMPUTE_1:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[ALLOC_13]] : memref<?x?xi1, #hipsr.mem<device>>) outs(%[[ALLOC_13]] : memref<?x?xi1, #hipsr.mem<device>>) {
 // CHECK-NEXT:        ^bb0(%[[VAL_9:.*]]: !hipsr.context, %[[VAL_10:.*]]: memref<?x?xi1, #hipsr.mem<device>>, %[[VAL_11:.*]]: memref<?x?xi1, #hipsr.mem<device>>):
 // CHECK-NEXT:          %[[CONSTANT_8:.*]] = arith.constant 1 : index
 // CHECK-NEXT:          %[[CONSTANT_9:.*]] = arith.constant 0 : index
 // CHECK-NEXT:          %[[DIM_5:.*]] = memref.dim %[[VAL_10]], %[[CONSTANT_9]] : memref<?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:          %[[DIM_6:.*]] = memref.dim %[[VAL_10]], %[[CONSTANT_8]] : memref<?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:          %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[VAL_10]] {{\[\[}}0], [1, 2]] output_shape [%[[DIM_5]], %[[DIM_6]], 1] : memref<?x?xi1, #hipsr.mem<device>> into memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[VAL_10]] {{\[\[}}0], [1, 2]] output_shape {{\[}}%[[DIM_5]], %[[DIM_6]], 1] : memref<?x?xi1, #hipsr.mem<device>> into memref<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT:          hipsr.compute_yield %[[EXPAND_SHAPE_0]] : memref<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT:        } : memref<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_16:.*]] = memref.alloc(%[[LOAD_10]], %[[LOAD_11]]) {alignment = 64 : i64} : memref<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.gather(%[[VAL_0]]) ins(%[[CONSTANT_4]], %[[VAL_2]] : memref<248320x4096xf16, #hipsr.mem<device>>, memref<?x?xi64, #hipsr.mem<device>>) outs(%[[ALLOC_16]] : memref<?x?x4096xf16, #hipsr.mem<device>>) {axis = 0 : i64}
-// CHECK-NEXT:        %[[COMPUTE_2:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[ALLOC_16]] : memref<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[ALLOC_14]] : memref<3xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        %[[ALLOC_14:.*]] = memref.alloc(%[[LOAD_7]], %[[LOAD_8]]) {alignment = 64 : i64} : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.gather(%[[VAL_0]]) ins(%[[CONSTANT_4]], %[[VAL_2]] : memref<248320x4096xf16, #hipsr.mem<device>>, memref<?x?xi64, #hipsr.mem<device>>) outs(%[[ALLOC_14]] : memref<?x?x4096xf16, #hipsr.mem<device>>) {axis = 0 : i64}
+// CHECK-NEXT:        %[[COMPUTE_2:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[ALLOC_14]] : memref<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[ALLOC_12]] : memref<3xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:        ^bb0(%[[VAL_12:.*]]: !hipsr.context, %[[VAL_13:.*]]: memref<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_14:.*]]: memref<3xi64, #hipsr.mem<host>>):
 // CHECK-NEXT:          %[[CONSTANT_10:.*]] = arith.constant 2 : index
 // CHECK-NEXT:          %[[CONSTANT_11:.*]] = arith.constant 4096 : i64
@@ -169,222 +164,218 @@
 // CHECK-NEXT:          %[[INDEX_CAST_0:.*]] = arith.index_cast %[[DIM_7]] : index to i64
 // CHECK-NEXT:          %[[DIM_8:.*]] = memref.dim %[[VAL_13]], %[[CONSTANT_12]] : memref<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:          %[[INDEX_CAST_1:.*]] = arith.index_cast %[[DIM_8]] : index to i64
-// CHECK-NEXT:          %[[ALLOC_17:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:          memref.store %[[INDEX_CAST_0]], %[[ALLOC_17]]{{\[}}%[[CONSTANT_13]]] : memref<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:          memref.store %[[INDEX_CAST_1]], %[[ALLOC_17]]{{\[}}%[[CONSTANT_12]]] : memref<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:          memref.store %[[CONSTANT_11]], %[[ALLOC_17]]{{\[}}%[[CONSTANT_10]]] : memref<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:          hipsr.compute_yield %[[ALLOC_17]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          %[[ALLOC_15:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[INDEX_CAST_0]], %[[ALLOC_15]]{{\[}}%[[CONSTANT_13]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[INDEX_CAST_1]], %[[ALLOC_15]]{{\[}}%[[CONSTANT_12]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[CONSTANT_11]], %[[ALLOC_15]]{{\[}}%[[CONSTANT_10]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          hipsr.compute_yield %[[ALLOC_15]] : memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        } : memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_2]], %[[COMPUTE_0]] : memref<1xindex>, memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_0]], %[[ALLOC_15]] : memref<2xindex>, memref<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_0]], %[[ALLOC_13]] : memref<2xindex>, memref<?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_6]], %[[COMPUTE_1]] : memref<3xindex>, memref<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_10]], %[[ALLOC_16]] : memref<?xindex>, memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_10]], %[[ALLOC_14]] : memref<?xindex>, memref<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_0]], %[[COMPUTE_2]] : memref<1xindex>, memref<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_11]], %[[COMPUTE_0]], %[[ALLOC_12]], %[[COMPUTE_1]], %[[ALLOC_13]], %[[ALLOC_16]], %[[ALLOC_14]], %[[COMPUTE_2]] : memref<?xf16, #hipsr.mem<device>>, memref<?xf16, #hipsr.mem<device>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>, memref<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:      } -> memref<?xf16, #hipsr.mem<device>>, memref<?xf16, #hipsr.mem<device>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>, memref<3xi64, #hipsr.mem<host>> {domain_id = 0 : i64}
-// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]]:2 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#2, %[[POOL_DOMAIN_0]]#6, %[[POOL_DOMAIN_0]]#3, %[[POOL_DOMAIN_0]]#7 : !hipsr.context, memref<?x?x1xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_15:.*]]: !hipsr.context, %[[VAL_16:.*]]: memref<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_17:.*]]: memref<3xi64, #hipsr.mem<host>>, %[[VAL_18:.*]]: memref<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_19:.*]]: memref<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[COMPUTE_0]], %[[COMPUTE_1]], %[[ALLOC_11]], %[[ALLOC_14]], %[[COMPUTE_2]] : memref<?xf16, #hipsr.mem<device>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      } -> memref<?xf16, #hipsr.mem<device>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>> {domain_id = 0 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]] = hipsr.pool_domain(%[[ARG0]], %[[VAL_15:.*]]#1, %[[VAL_15]]#4 : !hipsr.context, memref<?x?x1xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_16:.*]]: !hipsr.context, %[[VAL_17:.*]]: memref<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_18:.*]]: memref<3xi64, #hipsr.mem<host>>):
 // CHECK-NEXT:        %[[CONSTANT_14:.*]] = arith.constant 3 : index
 // CHECK-NEXT:        %[[CONSTANT_15:.*]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[CONSTANT_16:.*]] = arith.constant 1 : index
 // CHECK-NEXT:        %[[CONSTANT_17:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[DIM_9:.*]] = memref.dim %[[VAL_16]], %[[CONSTANT_17]] : memref<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[DIM_10:.*]] = memref.dim %[[VAL_16]], %[[CONSTANT_16]] : memref<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_18:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[DIM_9]], %[[ALLOC_18]]{{\[}}%[[CONSTANT_17]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[DIM_10]], %[[ALLOC_18]]{{\[}}%[[CONSTANT_16]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_16]], %[[ALLOC_18]]{{\[}}%[[CONSTANT_15]]] : memref<3xindex>
-// CHECK-NEXT:        %[[LOAD_12:.*]] = memref.load %[[VAL_17]]{{\[}}%[[CONSTANT_17]]] : memref<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[INDEX_CAST_2:.*]] = arith.index_cast %[[LOAD_12]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_13:.*]] = memref.load %[[VAL_17]]{{\[}}%[[CONSTANT_16]]] : memref<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[INDEX_CAST_3:.*]] = arith.index_cast %[[LOAD_13]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_14:.*]] = memref.load %[[VAL_17]]{{\[}}%[[CONSTANT_15]]] : memref<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[INDEX_CAST_4:.*]] = arith.index_cast %[[LOAD_14]] : i64 to index
-// CHECK-NEXT:        %[[ALLOC_19:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_2]], %[[ALLOC_19]]{{\[}}%[[CONSTANT_17]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_3]], %[[ALLOC_19]]{{\[}}%[[CONSTANT_16]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_4]], %[[ALLOC_19]]{{\[}}%[[CONSTANT_15]]] : memref<3xindex>
-// CHECK-NEXT:        %[[ALLOC_20:.*]] = memref.alloc(%[[CONSTANT_14]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_20:.*]] = %[[CONSTANT_17]] to %[[CONSTANT_14]] step %[[CONSTANT_16]] {
-// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_20]], %[[CONSTANT_17]] : index
+// CHECK-NEXT:        %[[DIM_9:.*]] = memref.dim %[[VAL_17]], %[[CONSTANT_17]] : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_10:.*]] = memref.dim %[[VAL_17]], %[[CONSTANT_16]] : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_16:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_9]], %[[ALLOC_16]]{{\[}}%[[CONSTANT_17]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_10]], %[[ALLOC_16]]{{\[}}%[[CONSTANT_16]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_16]], %[[ALLOC_16]]{{\[}}%[[CONSTANT_15]]] : memref<3xindex>
+// CHECK-NEXT:        %[[LOAD_9:.*]] = memref.load %[[VAL_18]]{{\[}}%[[CONSTANT_17]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_2:.*]] = arith.index_cast %[[LOAD_9]] : i64 to index
+// CHECK-NEXT:        %[[LOAD_10:.*]] = memref.load %[[VAL_18]]{{\[}}%[[CONSTANT_16]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_3:.*]] = arith.index_cast %[[LOAD_10]] : i64 to index
+// CHECK-NEXT:        %[[LOAD_11:.*]] = memref.load %[[VAL_18]]{{\[}}%[[CONSTANT_15]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_4:.*]] = arith.index_cast %[[LOAD_11]] : i64 to index
+// CHECK-NEXT:        %[[ALLOC_17:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_2]], %[[ALLOC_17]]{{\[}}%[[CONSTANT_17]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_3]], %[[ALLOC_17]]{{\[}}%[[CONSTANT_16]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_4]], %[[ALLOC_17]]{{\[}}%[[CONSTANT_15]]] : memref<3xindex>
+// CHECK-NEXT:        %[[ALLOC_18:.*]] = memref.alloc(%[[CONSTANT_14]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        scf.for %[[VAL_19:.*]] = %[[CONSTANT_17]] to %[[CONSTANT_14]] step %[[CONSTANT_16]] {
+// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_19]], %[[CONSTANT_17]] : index
 // CHECK-NEXT:          %[[IF_2:.*]] = scf.if %[[CMPI_3]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[CONSTANT_16]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_15:.*]] = memref.load %[[ALLOC_18]]{{\[}}%[[VAL_20]]] : memref<3xindex>
-// CHECK-NEXT:            scf.yield %[[LOAD_15]] : index
+// CHECK-NEXT:            %[[LOAD_12:.*]] = memref.load %[[ALLOC_16]]{{\[}}%[[VAL_19]]] : memref<3xindex>
+// CHECK-NEXT:            scf.yield %[[LOAD_12]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_20]], %[[CONSTANT_17]] : index
+// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_19]], %[[CONSTANT_17]] : index
 // CHECK-NEXT:          %[[IF_3:.*]] = scf.if %[[CMPI_4]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_2]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_16:.*]] = memref.load %[[ALLOC_19]]{{\[}}%[[VAL_20]]] : memref<3xindex>
-// CHECK-NEXT:            %[[CMPI_5:.*]] = arith.cmpi eq, %[[LOAD_16]], %[[CONSTANT_16]] : index
-// CHECK-NEXT:            %[[SELECT_1:.*]] = arith.select %[[CMPI_5]], %[[IF_2]], %[[LOAD_16]] : index
+// CHECK-NEXT:            %[[LOAD_13:.*]] = memref.load %[[ALLOC_17]]{{\[}}%[[VAL_19]]] : memref<3xindex>
+// CHECK-NEXT:            %[[CMPI_5:.*]] = arith.cmpi eq, %[[LOAD_13]], %[[CONSTANT_16]] : index
+// CHECK-NEXT:            %[[SELECT_1:.*]] = arith.select %[[CMPI_5]], %[[IF_2]], %[[LOAD_13]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_1]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_20]]{{\[}}%[[VAL_20]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_18]]{{\[}}%[[VAL_19]]] : memref<?xindex>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[CAST_1:.*]] = memref.cast %[[ALLOC_20]] : memref<?xindex> to memref<3xindex>
-// CHECK-NEXT:        %[[LOAD_17:.*]] = memref.load %[[ALLOC_20]]{{\[}}%[[CONSTANT_17]]] : memref<?xindex>
-// CHECK-NEXT:        %[[LOAD_18:.*]] = memref.load %[[ALLOC_20]]{{\[}}%[[CONSTANT_16]]] : memref<?xindex>
-// CHECK-NEXT:        %[[LOAD_19:.*]] = memref.load %[[ALLOC_20]]{{\[}}%[[CONSTANT_15]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_21:.*]] = memref.alloc(%[[LOAD_17]], %[[LOAD_18]], %[[LOAD_19]]) {alignment = 64 : i64} : memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_22:.*]] = memref.alloc(%[[LOAD_17]], %[[LOAD_18]], %[[LOAD_19]]) {alignment = 64 : i64} : memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.expand(%[[VAL_15]]) ins(%[[VAL_18]], %[[VAL_19]] : memref<?x?x1xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) outs(%[[ALLOC_22]] : memref<?x?x?xi1, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_1]], %[[ALLOC_22]] : memref<3xindex>, memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_21]], %[[ALLOC_22]] : memref<?x?x?xi1, #hipsr.mem<device>>, memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:      } -> memref<?x?x?xi1, #hipsr.mem<device>>, memref<?x?x?xi1, #hipsr.mem<device>> {domain_id = 1 : i64}
-// CHECK-NEXT:      %[[POOL_DOMAIN_2:.*]]:4 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_1]]#0, %[[POOL_DOMAIN_0]]#6, %[[POOL_DOMAIN_1]]#1, %[[POOL_DOMAIN_0]]#7 : !hipsr.context, memref<?x?x?xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>, memref<?x?x?xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_21:.*]]: !hipsr.context, %[[VAL_22:.*]]: memref<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_23:.*]]: memref<3xi64, #hipsr.mem<host>>, %[[VAL_24:.*]]: memref<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_25:.*]]: memref<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:        %[[CAST_1:.*]] = memref.cast %[[ALLOC_18]] : memref<?xindex> to memref<3xindex>
+// CHECK-NEXT:        %[[LOAD_14:.*]] = memref.load %[[ALLOC_18]]{{\[}}%[[CONSTANT_17]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_15:.*]] = memref.load %[[ALLOC_18]]{{\[}}%[[CONSTANT_16]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_16:.*]] = memref.load %[[ALLOC_18]]{{\[}}%[[CONSTANT_15]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_19:.*]] = memref.alloc(%[[LOAD_14]], %[[LOAD_15]], %[[LOAD_16]]) {alignment = 64 : i64} : memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.expand(%[[VAL_16]]) ins(%[[VAL_17]], %[[VAL_18]] : memref<?x?x1xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) outs(%[[ALLOC_19]] : memref<?x?x?xi1, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_1]], %[[ALLOC_19]] : memref<3xindex>, memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_19]] : memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> memref<?x?x?xi1, #hipsr.mem<device>> {domain_id = 1 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_2:.*]]:2 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_1]], %[[VAL_20:.*]]#4 : !hipsr.context, memref<?x?x?xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_21:.*]]: !hipsr.context, %[[VAL_22:.*]]: memref<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_23:.*]]: memref<3xi64, #hipsr.mem<host>>):
 // CHECK-NEXT:        %[[CONSTANT_18:.*]] = arith.constant 3 : index
 // CHECK-NEXT:        %[[CONSTANT_19:.*]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[CONSTANT_20:.*]] = arith.constant 1 : index
 // CHECK-NEXT:        %[[CONSTANT_21:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[ALLOC_23:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_20]], %[[ALLOC_23]]{{\[}}%[[CONSTANT_21]]] : memref<1xindex>
+// CHECK-NEXT:        %[[ALLOC_20:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_20]], %[[ALLOC_20]]{{\[}}%[[CONSTANT_21]]] : memref<1xindex>
 // CHECK-NEXT:        %[[DIM_11:.*]] = memref.dim %[[VAL_22]], %[[CONSTANT_21]] : memref<?x?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:        %[[DIM_12:.*]] = memref.dim %[[VAL_22]], %[[CONSTANT_20]] : memref<?x?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:        %[[DIM_13:.*]] = memref.dim %[[VAL_22]], %[[CONSTANT_19]] : memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_24:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[DIM_11]], %[[ALLOC_24]]{{\[}}%[[CONSTANT_21]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[DIM_12]], %[[ALLOC_24]]{{\[}}%[[CONSTANT_20]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[DIM_13]], %[[ALLOC_24]]{{\[}}%[[CONSTANT_19]]] : memref<3xindex>
-// CHECK-NEXT:        %[[LOAD_20:.*]] = memref.load %[[VAL_23]]{{\[}}%[[CONSTANT_21]]] : memref<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[INDEX_CAST_5:.*]] = arith.index_cast %[[LOAD_20]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_21:.*]] = memref.load %[[VAL_23]]{{\[}}%[[CONSTANT_20]]] : memref<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[INDEX_CAST_6:.*]] = arith.index_cast %[[LOAD_21]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_22:.*]] = memref.load %[[VAL_23]]{{\[}}%[[CONSTANT_19]]] : memref<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[INDEX_CAST_7:.*]] = arith.index_cast %[[LOAD_22]] : i64 to index
-// CHECK-NEXT:        %[[ALLOC_25:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_5]], %[[ALLOC_25]]{{\[}}%[[CONSTANT_21]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_6]], %[[ALLOC_25]]{{\[}}%[[CONSTANT_20]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_7]], %[[ALLOC_25]]{{\[}}%[[CONSTANT_19]]] : memref<3xindex>
-// CHECK-NEXT:        %[[ALLOC_26:.*]] = memref.alloc(%[[CONSTANT_18]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_26:.*]] = %[[CONSTANT_21]] to %[[CONSTANT_18]] step %[[CONSTANT_20]] {
-// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_26]], %[[CONSTANT_21]] : index
+// CHECK-NEXT:        %[[ALLOC_21:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_11]], %[[ALLOC_21]]{{\[}}%[[CONSTANT_21]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_12]], %[[ALLOC_21]]{{\[}}%[[CONSTANT_20]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_13]], %[[ALLOC_21]]{{\[}}%[[CONSTANT_19]]] : memref<3xindex>
+// CHECK-NEXT:        %[[LOAD_17:.*]] = memref.load %[[VAL_23]]{{\[}}%[[CONSTANT_21]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_5:.*]] = arith.index_cast %[[LOAD_17]] : i64 to index
+// CHECK-NEXT:        %[[LOAD_18:.*]] = memref.load %[[VAL_23]]{{\[}}%[[CONSTANT_20]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_6:.*]] = arith.index_cast %[[LOAD_18]] : i64 to index
+// CHECK-NEXT:        %[[LOAD_19:.*]] = memref.load %[[VAL_23]]{{\[}}%[[CONSTANT_19]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_7:.*]] = arith.index_cast %[[LOAD_19]] : i64 to index
+// CHECK-NEXT:        %[[ALLOC_22:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_5]], %[[ALLOC_22]]{{\[}}%[[CONSTANT_21]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_6]], %[[ALLOC_22]]{{\[}}%[[CONSTANT_20]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_7]], %[[ALLOC_22]]{{\[}}%[[CONSTANT_19]]] : memref<3xindex>
+// CHECK-NEXT:        %[[ALLOC_23:.*]] = memref.alloc(%[[CONSTANT_18]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        scf.for %[[VAL_24:.*]] = %[[CONSTANT_21]] to %[[CONSTANT_18]] step %[[CONSTANT_20]] {
+// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_24]], %[[CONSTANT_21]] : index
 // CHECK-NEXT:          %[[IF_4:.*]] = scf.if %[[CMPI_6]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[CONSTANT_20]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_23:.*]] = memref.load %[[ALLOC_24]]{{\[}}%[[VAL_26]]] : memref<3xindex>
-// CHECK-NEXT:            scf.yield %[[LOAD_23]] : index
+// CHECK-NEXT:            %[[LOAD_20:.*]] = memref.load %[[ALLOC_21]]{{\[}}%[[VAL_24]]] : memref<3xindex>
+// CHECK-NEXT:            scf.yield %[[LOAD_20]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_26]], %[[CONSTANT_21]] : index
+// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_24]], %[[CONSTANT_21]] : index
 // CHECK-NEXT:          %[[IF_5:.*]] = scf.if %[[CMPI_7]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_4]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_24:.*]] = memref.load %[[ALLOC_25]]{{\[}}%[[VAL_26]]] : memref<3xindex>
-// CHECK-NEXT:            %[[CMPI_8:.*]] = arith.cmpi eq, %[[LOAD_24]], %[[CONSTANT_20]] : index
-// CHECK-NEXT:            %[[SELECT_2:.*]] = arith.select %[[CMPI_8]], %[[IF_4]], %[[LOAD_24]] : index
+// CHECK-NEXT:            %[[LOAD_21:.*]] = memref.load %[[ALLOC_22]]{{\[}}%[[VAL_24]]] : memref<3xindex>
+// CHECK-NEXT:            %[[CMPI_8:.*]] = arith.cmpi eq, %[[LOAD_21]], %[[CONSTANT_20]] : index
+// CHECK-NEXT:            %[[SELECT_2:.*]] = arith.select %[[CMPI_8]], %[[IF_4]], %[[LOAD_21]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_2]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_26]]{{\[}}%[[VAL_26]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_23]]{{\[}}%[[VAL_24]]] : memref<?xindex>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[CAST_2:.*]] = memref.cast %[[ALLOC_26]] : memref<?xindex> to memref<3xindex>
-// CHECK-NEXT:        %[[FOR_1:.*]] = scf.for %[[VAL_27:.*]] = %[[CONSTANT_21]] to %[[CONSTANT_18]] step %[[CONSTANT_20]] iter_args(%[[VAL_28:.*]] = %[[CONSTANT_20]]) -> (index) {
-// CHECK-NEXT:          %[[LOAD_25:.*]] = memref.load %[[ALLOC_26]]{{\[}}%[[VAL_27]]] : memref<?xindex>
-// CHECK-NEXT:          %[[MULI_1:.*]] = arith.muli %[[LOAD_25]], %[[VAL_28]] : index
+// CHECK-NEXT:        %[[CAST_2:.*]] = memref.cast %[[ALLOC_23]] : memref<?xindex> to memref<3xindex>
+// CHECK-NEXT:        %[[FOR_1:.*]] = scf.for %[[VAL_25:.*]] = %[[CONSTANT_21]] to %[[CONSTANT_18]] step %[[CONSTANT_20]] iter_args(%[[VAL_26:.*]] = %[[CONSTANT_20]]) -> (index) {
+// CHECK-NEXT:          %[[LOAD_22:.*]] = memref.load %[[ALLOC_23]]{{\[}}%[[VAL_25]]] : memref<?xindex>
+// CHECK-NEXT:          %[[MULI_1:.*]] = arith.muli %[[LOAD_22]], %[[VAL_26]] : index
 // CHECK-NEXT:          scf.yield %[[MULI_1]] : index
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[ALLOC_27:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_18]], %[[ALLOC_27]]{{\[}}%[[CONSTANT_21]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[FOR_1]], %[[ALLOC_27]]{{\[}}%[[CONSTANT_20]]] : memref<2xindex>
-// CHECK-NEXT:        %[[LOAD_26:.*]] = memref.load %[[ALLOC_26]]{{\[}}%[[CONSTANT_21]]] : memref<?xindex>
-// CHECK-NEXT:        %[[LOAD_27:.*]] = memref.load %[[ALLOC_26]]{{\[}}%[[CONSTANT_20]]] : memref<?xindex>
-// CHECK-NEXT:        %[[LOAD_28:.*]] = memref.load %[[ALLOC_26]]{{\[}}%[[CONSTANT_19]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_28:.*]] = memref.alloc(%[[LOAD_26]], %[[LOAD_27]], %[[LOAD_28]]) {alignment = 64 : i64} : memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[LOAD_29:.*]] = memref.load %[[ALLOC_27]]{{\[}}%[[CONSTANT_20]]] : memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_29:.*]] = memref.alloc(%[[LOAD_29]]) {alignment = 64 : i64} : memref<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_30:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_31:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.expand(%[[VAL_21]]) ins(%[[VAL_24]], %[[VAL_25]] : memref<?x?x?xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) outs(%[[ALLOC_28]] : memref<?x?x?xi1, #hipsr.mem<device>>)
-// CHECK-NEXT:        %[[ALLOC_32:.*]] = memref.alloc(%[[LOAD_29]]) {alignment = 64 : i64} : memref<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.nonzero(%[[VAL_21]]) ins(%[[ALLOC_28]] : memref<?x?x?xi1, #hipsr.mem<device>>) outs(%[[ALLOC_32]], %[[ALLOC_30]] : memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<device>>)
-// CHECK-NEXT:        %[[ALLOC_33:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.copy_d2h(%[[VAL_21]]) ins(%[[ALLOC_30]] : memref<1xi64, #hipsr.mem<device>>) outs(%[[ALLOC_33]] : memref<1xi64, #hipsr.mem<host>>)
-// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_2]], %[[ALLOC_28]] : memref<3xindex>, memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_27]], %[[ALLOC_32]] : memref<2xindex>, memref<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_23]], %[[ALLOC_30]] : memref<1xindex>, memref<1xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_23]], %[[ALLOC_33]] : memref<1xindex>, memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_29]], %[[ALLOC_32]], %[[ALLOC_31]], %[[ALLOC_33]] : memref<3x?xi64, #hipsr.mem<device>>, memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:      } -> memref<3x?xi64, #hipsr.mem<device>>, memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<1xi64, #hipsr.mem<host>> {domain_id = 2 : i64}
-// CHECK-NEXT:      %[[POOL_DOMAIN_3:.*]]:4 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_2]]#2, %[[POOL_DOMAIN_2]]#0, %[[POOL_DOMAIN_2]]#3, %[[POOL_DOMAIN_2]]#1 : !hipsr.context, memref<1xi64, #hipsr.mem<host>>, memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<3x?xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_29:.*]]: !hipsr.context, %[[VAL_30:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_31:.*]]: memref<3x?xi64, #hipsr.mem<device>>, %[[VAL_32:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_33:.*]]: memref<3x?xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[ALLOC_24:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_18]], %[[ALLOC_24]]{{\[}}%[[CONSTANT_21]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[FOR_1]], %[[ALLOC_24]]{{\[}}%[[CONSTANT_20]]] : memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_23:.*]] = memref.load %[[ALLOC_23]]{{\[}}%[[CONSTANT_21]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_24:.*]] = memref.load %[[ALLOC_23]]{{\[}}%[[CONSTANT_20]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_25:.*]] = memref.load %[[ALLOC_23]]{{\[}}%[[CONSTANT_19]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_25:.*]] = memref.alloc(%[[LOAD_23]], %[[LOAD_24]], %[[LOAD_25]]) {alignment = 64 : i64} : memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[LOAD_26:.*]] = memref.load %[[ALLOC_24]]{{\[}}%[[CONSTANT_20]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_26:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.expand(%[[VAL_21]]) ins(%[[VAL_22]], %[[VAL_23]] : memref<?x?x?xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) outs(%[[ALLOC_25]] : memref<?x?x?xi1, #hipsr.mem<device>>)
+// CHECK-NEXT:        %[[ALLOC_27:.*]] = memref.alloc(%[[LOAD_26]]) {alignment = 64 : i64} : memref<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.nonzero(%[[VAL_21]]) ins(%[[ALLOC_25]] : memref<?x?x?xi1, #hipsr.mem<device>>) outs(%[[ALLOC_27]], %[[ALLOC_26]] : memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<device>>)
+// CHECK-NEXT:        %[[ALLOC_28:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.copy_d2h(%[[VAL_21]]) ins(%[[ALLOC_26]] : memref<1xi64, #hipsr.mem<device>>) outs(%[[ALLOC_28]] : memref<1xi64, #hipsr.mem<host>>)
+// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_2]], %[[ALLOC_25]] : memref<3xindex>, memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_24]], %[[ALLOC_27]] : memref<2xindex>, memref<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_20]], %[[ALLOC_26]] : memref<1xindex>, memref<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_20]], %[[ALLOC_28]] : memref<1xindex>, memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_27]], %[[ALLOC_28]] : memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      } -> memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>> {domain_id = 2 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_3:.*]]:3 = hipsr.pool_domain(%[[ARG0]], %[[VAL_27:.*]]#1, %[[VAL_27]]#0 : !hipsr.context, memref<1xi64, #hipsr.mem<host>>, memref<3x?xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_28:.*]]: !hipsr.context, %[[VAL_29:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_30:.*]]: memref<3x?xi64, #hipsr.mem<device>>):
 // CHECK-NEXT:        %[[CONSTANT_22:.*]] = arith.constant 3 : index
 // CHECK-NEXT:        %[[CONSTANT_23:.*]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[CONSTANT_24:.*]] = arith.constant 0 : index
 // CHECK-NEXT:        %[[CONSTANT_25:.*]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[ALLOC_34:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_25]], %[[ALLOC_34]]{{\[}}%[[CONSTANT_24]]] : memref<1xindex>
-// CHECK-NEXT:        %[[ALLOC_35:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_23]], %[[ALLOC_35]]{{\[}}%[[CONSTANT_24]]] : memref<1xindex>
-// CHECK-NEXT:        %[[ALLOC_36:.*]] = memref.alloc() {alignment = 64 : i64} : memref<0xindex>
-// CHECK-NEXT:        %[[LOAD_30:.*]] = memref.load %[[VAL_30]]{{\[}}%[[CONSTANT_24]]] : memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[INDEX_CAST_8:.*]] = arith.index_cast %[[LOAD_30]] : i64 to index
-// CHECK-NEXT:        %[[ALLOC_37:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_22]], %[[ALLOC_37]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_8]], %[[ALLOC_37]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
-// CHECK-NEXT:        %[[LOAD_31:.*]] = memref.load %[[ALLOC_37]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
-// CHECK-NEXT:        %[[LOAD_32:.*]] = memref.load %[[ALLOC_37]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_38:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[LOAD_31]], %[[ALLOC_38]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[LOAD_32]], %[[ALLOC_38]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
-// CHECK-NEXT:        %[[LOAD_33:.*]] = memref.load %[[ALLOC_37]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_39:.*]] = memref.alloc(%[[LOAD_33]]) {alignment = 64 : i64} : memref<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[LOAD_34:.*]] = memref.load %[[ALLOC_38]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_40:.*]] = memref.alloc(%[[LOAD_34]]) {alignment = 64 : i64} : memref<?x3xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_41:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[ALLOC_42:.*]] = memref.alloc() {alignment = 64 : i64} : memref<i64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[ALLOC_43:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[COMPUTE_3:.*]] = hipsr.compute(%[[VAL_29]]) ins(%[[VAL_32]], %[[VAL_33]] : memref<1xi64, #hipsr.mem<host>>, memref<3x?xi64, #hipsr.mem<device>>) outs(%[[ALLOC_39]] : memref<3x?xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:        ^bb0(%[[VAL_34:.*]]: !hipsr.context, %[[VAL_35:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_36:.*]]: memref<3x?xi64, #hipsr.mem<device>>, %[[VAL_37:.*]]: memref<3x?xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[ALLOC_29:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_25]], %[[ALLOC_29]]{{\[}}%[[CONSTANT_24]]] : memref<1xindex>
+// CHECK-NEXT:        %[[ALLOC_30:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_23]], %[[ALLOC_30]]{{\[}}%[[CONSTANT_24]]] : memref<1xindex>
+// CHECK-NEXT:        %[[ALLOC_31:.*]] = memref.alloc() {alignment = 64 : i64} : memref<0xindex>
+// CHECK-NEXT:        %[[LOAD_27:.*]] = memref.load %[[VAL_29]]{{\[}}%[[CONSTANT_24]]] : memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_8:.*]] = arith.index_cast %[[LOAD_27]] : i64 to index
+// CHECK-NEXT:        %[[ALLOC_32:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_22]], %[[ALLOC_32]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_8]], %[[ALLOC_32]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_28:.*]] = memref.load %[[ALLOC_32]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_29:.*]] = memref.load %[[ALLOC_32]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_33:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[LOAD_28]], %[[ALLOC_33]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[LOAD_29]], %[[ALLOC_33]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_30:.*]] = memref.load %[[ALLOC_32]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_34:.*]] = memref.alloc(%[[LOAD_30]]) {alignment = 64 : i64} : memref<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[LOAD_31:.*]] = memref.load %[[ALLOC_33]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_35:.*]] = memref.alloc(%[[LOAD_31]]) {alignment = 64 : i64} : memref<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_36:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[ALLOC_37:.*]] = memref.alloc() {alignment = 64 : i64} : memref<i64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[COMPUTE_3:.*]] = hipsr.compute(%[[VAL_28]]) ins(%[[VAL_29]], %[[VAL_30]] : memref<1xi64, #hipsr.mem<host>>, memref<3x?xi64, #hipsr.mem<device>>) outs(%[[ALLOC_34]] : memref<3x?xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_31:.*]]: !hipsr.context, %[[VAL_32:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_33:.*]]: memref<3x?xi64, #hipsr.mem<device>>, %[[VAL_34:.*]]: memref<3x?xi64, #hipsr.mem<device>>):
 // CHECK-NEXT:          %[[CONSTANT_26:.*]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[DIM_14:.*]] = memref.dim %[[VAL_37]], %[[CONSTANT_26]] : memref<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:          %[[SUBVIEW_6:.*]] = memref.subview %[[VAL_36]]{{\[}}0, 0] [3, %[[DIM_14]]] [1, 1] : memref<3x?xi64, #hipsr.mem<device>> to memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[DIM_14:.*]] = memref.dim %[[VAL_34]], %[[CONSTANT_26]] : memref<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[SUBVIEW_6:.*]] = memref.subview %[[VAL_33]][0, 0] [3, %[[DIM_14]]] [1, 1] : memref<3x?xi64, #hipsr.mem<device>> to memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
 // CHECK-NEXT:          hipsr.compute_yield %[[SUBVIEW_6]] : memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
 // CHECK-NEXT:        } : memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_44:.*]] = memref.alloc(%[[LOAD_34]]) {alignment = 64 : i64} : memref<?x3xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.transpose(%[[VAL_29]]) ins(%[[COMPUTE_3]] : memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>) outs(%[[ALLOC_44]] : memref<?x3xi64, #hipsr.mem<device>>) {perm = array<i64: 1, 0>}
-// CHECK-NEXT:        %[[COMPUTE_4:.*]] = hipsr.compute(%[[VAL_29]]) ins(%[[ALLOC_44]] : memref<?x3xi64, #hipsr.mem<device>>) outs(%[[ALLOC_41]] : memref<2xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:        ^bb0(%[[VAL_38:.*]]: !hipsr.context, %[[VAL_39:.*]]: memref<?x3xi64, #hipsr.mem<device>>, %[[VAL_40:.*]]: memref<2xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:        %[[ALLOC_38:.*]] = memref.alloc(%[[LOAD_31]]) {alignment = 64 : i64} : memref<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.transpose(%[[VAL_28]]) ins(%[[COMPUTE_3]] : memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>) outs(%[[ALLOC_38]] : memref<?x3xi64, #hipsr.mem<device>>) {perm = array<i64: 1, 0>}
+// CHECK-NEXT:        %[[COMPUTE_4:.*]] = hipsr.compute(%[[VAL_28]]) ins(%[[ALLOC_38]] : memref<?x3xi64, #hipsr.mem<device>>) outs(%[[ALLOC_36]] : memref<2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_35:.*]]: !hipsr.context, %[[VAL_36:.*]]: memref<?x3xi64, #hipsr.mem<device>>, %[[VAL_37:.*]]: memref<2xi64, #hipsr.mem<host>>):
 // CHECK-NEXT:          %[[CONSTANT_27:.*]] = arith.constant 1 : index
 // CHECK-NEXT:          %[[CONSTANT_28:.*]] = arith.constant 3 : i64
 // CHECK-NEXT:          %[[CONSTANT_29:.*]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[DIM_15:.*]] = memref.dim %[[VAL_39]], %[[CONSTANT_29]] : memref<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[DIM_15:.*]] = memref.dim %[[VAL_36]], %[[CONSTANT_29]] : memref<?x3xi64, #hipsr.mem<device>>
 // CHECK-NEXT:          %[[INDEX_CAST_9:.*]] = arith.index_cast %[[DIM_15]] : index to i64
-// CHECK-NEXT:          %[[ALLOC_45:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:          memref.store %[[INDEX_CAST_9]], %[[ALLOC_45]]{{\[}}%[[CONSTANT_29]]] : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:          memref.store %[[CONSTANT_28]], %[[ALLOC_45]]{{\[}}%[[CONSTANT_27]]] : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:          hipsr.compute_yield %[[ALLOC_45]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          %[[ALLOC_39:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[INDEX_CAST_9]], %[[ALLOC_39]]{{\[}}%[[CONSTANT_29]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[CONSTANT_28]], %[[ALLOC_39]]{{\[}}%[[CONSTANT_27]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          hipsr.compute_yield %[[ALLOC_39]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        } : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[COMPUTE_5:.*]] = hipsr.compute(%[[VAL_29]]) ins(%[[COMPUTE_4]] : memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_42]] : memref<i64, #hipsr.mem<host>>) {
-// CHECK-NEXT:        ^bb0(%[[VAL_41:.*]]: !hipsr.context, %[[VAL_42:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_43:.*]]: memref<i64, #hipsr.mem<host>>):
+// CHECK-NEXT:        %[[COMPUTE_5:.*]] = hipsr.compute(%[[VAL_28]]) ins(%[[COMPUTE_4]] : memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_37]] : memref<i64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_38:.*]]: !hipsr.context, %[[VAL_39:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_40:.*]]: memref<i64, #hipsr.mem<host>>):
 // CHECK-NEXT:          %[[CONSTANT_30:.*]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[LOAD_35:.*]] = memref.load %[[VAL_42]]{{\[}}%[[CONSTANT_30]]] : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:          %[[ALLOC_46:.*]] = memref.alloc() {alignment = 64 : i64} : memref<i64, #hipsr.mem<host>>
-// CHECK-NEXT:          memref.store %[[LOAD_35]], %[[ALLOC_46]]{{\[}}] : memref<i64, #hipsr.mem<host>>
-// CHECK-NEXT:          hipsr.compute_yield %[[ALLOC_46]] : memref<i64, #hipsr.mem<host>>
+// CHECK-NEXT:          %[[LOAD_32:.*]] = memref.load %[[VAL_39]]{{\[}}%[[CONSTANT_30]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          %[[ALLOC_40:.*]] = memref.alloc() {alignment = 64 : i64} : memref<i64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[LOAD_32]], %[[ALLOC_40]][] : memref<i64, #hipsr.mem<host>>
+// CHECK-NEXT:          hipsr.compute_yield %[[ALLOC_40]] : memref<i64, #hipsr.mem<host>>
 // CHECK-NEXT:        } : memref<i64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[COMPUTE_6:.*]] = hipsr.compute(%[[VAL_29]]) ins(%[[COMPUTE_5]] : memref<i64, #hipsr.mem<host>>) outs(%[[COMPUTE_5]] : memref<i64, #hipsr.mem<host>>) {
-// CHECK-NEXT:        ^bb0(%[[VAL_44:.*]]: !hipsr.context, %[[VAL_45:.*]]: memref<i64, #hipsr.mem<host>>, %[[VAL_46:.*]]: memref<i64, #hipsr.mem<host>>):
-// CHECK-NEXT:          %[[EXPAND_SHAPE_1:.*]] = memref.expand_shape %[[VAL_45]] [] output_shape [1] : memref<i64, #hipsr.mem<host>> into memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[COMPUTE_6:.*]] = hipsr.compute(%[[VAL_28]]) ins(%[[COMPUTE_5]] : memref<i64, #hipsr.mem<host>>) outs(%[[COMPUTE_5]] : memref<i64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_41:.*]]: !hipsr.context, %[[VAL_42:.*]]: memref<i64, #hipsr.mem<host>>, %[[VAL_43:.*]]: memref<i64, #hipsr.mem<host>>):
+// CHECK-NEXT:          %[[EXPAND_SHAPE_1:.*]] = memref.expand_shape %[[VAL_42]] [] output_shape [1] : memref<i64, #hipsr.mem<host>> into memref<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:          hipsr.compute_yield %[[EXPAND_SHAPE_1]] : memref<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        } : memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_37]], %[[COMPUTE_3]] : memref<2xindex>, memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_38]], %[[ALLOC_44]] : memref<2xindex>, memref<?x3xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_35]], %[[COMPUTE_4]] : memref<1xindex>, memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_36]], %[[COMPUTE_5]] : memref<0xindex>, memref<i64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_34]], %[[COMPUTE_6]] : memref<1xindex>, memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_40]], %[[ALLOC_44]], %[[ALLOC_43]], %[[COMPUTE_6]] : memref<?x3xi64, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:      } -> memref<?x3xi64, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<1xi64, #hipsr.mem<host>> {domain_id = 3 : i64}
-// CHECK-NEXT:      %[[POOL_DOMAIN_4:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#0, %[[POOL_DOMAIN_3]]#2, %[[POOL_DOMAIN_0]]#1, %[[POOL_DOMAIN_3]]#3, %[[POOL_DOMAIN_0]]#4, %[[POOL_DOMAIN_3]]#0, %[[POOL_DOMAIN_0]]#5, %[[POOL_DOMAIN_3]]#1 : !hipsr.context, memref<?xf16, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<?xf16, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_47:.*]]: !hipsr.context, %[[VAL_48:.*]]: memref<?xf16, #hipsr.mem<device>>, %[[VAL_49:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_50:.*]]: memref<?xf16, #hipsr.mem<device>>, %[[VAL_51:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_52:.*]]: memref<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_53:.*]]: memref<?x3xi64, #hipsr.mem<device>>, %[[VAL_54:.*]]: memref<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_55:.*]]: memref<?x3xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_32]], %[[COMPUTE_3]] : memref<2xindex>, memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_33]], %[[ALLOC_38]] : memref<2xindex>, memref<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_30]], %[[COMPUTE_4]] : memref<1xindex>, memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_31]], %[[COMPUTE_5]] : memref<0xindex>, memref<i64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_29]], %[[COMPUTE_6]] : memref<1xindex>, memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_35]], %[[ALLOC_38]], %[[COMPUTE_6]] : memref<?x3xi64, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      } -> memref<?x3xi64, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>> {domain_id = 3 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_4:.*]] = hipsr.pool_domain(%[[ARG0]], %[[VAL_44:.*]]#0, %[[VAL_45:.*]]#2, %[[VAL_44]]#2, %[[VAL_45]]#0, %[[VAL_44]]#3, %[[VAL_45]]#1 : !hipsr.context, memref<?xf16, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_46:.*]]: !hipsr.context, %[[VAL_47:.*]]: memref<?xf16, #hipsr.mem<device>>, %[[VAL_48:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_49:.*]]: memref<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_50:.*]]: memref<?x3xi64, #hipsr.mem<device>>, %[[VAL_51:.*]]: memref<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_52:.*]]: memref<?x3xi64, #hipsr.mem<device>>):
 // CHECK-NEXT:        %[[CONSTANT_31:.*]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[CONSTANT_32:.*]] = arith.constant 4096 : index
 // CHECK-NEXT:        %[[CONSTANT_33:.*]] = arith.constant 1 : index
 // CHECK-NEXT:        %[[CONSTANT_34:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[DIM_16:.*]] = memref.dim %[[VAL_48]], %[[CONSTANT_34]] : memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[LOAD_36:.*]] = memref.load %[[VAL_49]]{{\[}}%[[CONSTANT_34]]] : memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[INDEX_CAST_10:.*]] = arith.index_cast %[[LOAD_36]] : i64 to index
+// CHECK-NEXT:        %[[DIM_16:.*]] = memref.dim %[[VAL_47]], %[[CONSTANT_34]] : memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[LOAD_33:.*]] = memref.load %[[VAL_48]]{{\[}}%[[CONSTANT_34]]] : memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_10:.*]] = arith.index_cast %[[LOAD_33]] : i64 to index
 // CHECK-NEXT:        %[[CMPI_9:.*]] = arith.cmpi slt, %[[INDEX_CAST_10]], %[[CONSTANT_34]] : index
 // CHECK-NEXT:        %[[ADDI_0:.*]] = arith.addi %[[INDEX_CAST_10]], %[[DIM_16]] : index
 // CHECK-NEXT:        %[[SELECT_3:.*]] = arith.select %[[CMPI_9]], %[[ADDI_0]], %[[INDEX_CAST_10]] : index
@@ -393,36 +384,32 @@
 // CHECK-NEXT:        %[[MINSI_1:.*]] = arith.minsi %[[MAXSI_0]], %[[DIM_16]] : index
 // CHECK-NEXT:        %[[SUBI_1:.*]] = arith.subi %[[MINSI_1]], %[[MINSI_0]] : index
 // CHECK-NEXT:        %[[MAXSI_1:.*]] = arith.maxsi %[[SUBI_1]], %[[CONSTANT_34]] : index
-// CHECK-NEXT:        %[[ALLOC_47:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
-// CHECK-NEXT:        memref.store %[[MAXSI_1]], %[[ALLOC_47]]{{\[}}%[[CONSTANT_34]]] : memref<1xindex>
-// CHECK-NEXT:        %[[DIM_17:.*]] = memref.dim %[[VAL_52]], %[[CONSTANT_34]] : memref<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[DIM_18:.*]] = memref.dim %[[VAL_52]], %[[CONSTANT_33]] : memref<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_48:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[DIM_17]], %[[ALLOC_48]]{{\[}}%[[CONSTANT_34]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[DIM_18]], %[[ALLOC_48]]{{\[}}%[[CONSTANT_33]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_32]], %[[ALLOC_48]]{{\[}}%[[CONSTANT_31]]] : memref<3xindex>
-// CHECK-NEXT:        %[[LOAD_37:.*]] = memref.load %[[ALLOC_47]]{{\[}}%[[CONSTANT_34]]] : memref<1xindex>
-// CHECK-NEXT:        %[[ALLOC_49:.*]] = memref.alloc(%[[LOAD_37]]) {alignment = 64 : i64} : memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[DIM_19:.*]] = memref.dim %[[VAL_52]], %[[CONSTANT_34]] : memref<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[DIM_20:.*]] = memref.dim %[[VAL_52]], %[[CONSTANT_33]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_41:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
+// CHECK-NEXT:        memref.store %[[MAXSI_1]], %[[ALLOC_41]]{{\[}}%[[CONSTANT_34]]] : memref<1xindex>
+// CHECK-NEXT:        %[[DIM_17:.*]] = memref.dim %[[VAL_49]], %[[CONSTANT_34]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_18:.*]] = memref.dim %[[VAL_49]], %[[CONSTANT_33]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_42:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_17]], %[[ALLOC_42]]{{\[}}%[[CONSTANT_34]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_18]], %[[ALLOC_42]]{{\[}}%[[CONSTANT_33]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_32]], %[[ALLOC_42]]{{\[}}%[[CONSTANT_31]]] : memref<3xindex>
+// CHECK-NEXT:        %[[LOAD_34:.*]] = memref.load %[[ALLOC_41]]{{\[}}%[[CONSTANT_34]]] : memref<1xindex>
+// CHECK-NEXT:        %[[ALLOC_43:.*]] = memref.alloc(%[[LOAD_34]]) {alignment = 64 : i64} : memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_19:.*]] = memref.dim %[[VAL_49]], %[[CONSTANT_34]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_20:.*]] = memref.dim %[[VAL_49]], %[[CONSTANT_33]] : memref<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:        %[[CONSTANT_35:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[LOAD_38:.*]] = memref.load %[[ALLOC_48]]{{\[}}%[[CONSTANT_35]]] : memref<3xindex>
+// CHECK-NEXT:        %[[LOAD_35:.*]] = memref.load %[[ALLOC_42]]{{\[}}%[[CONSTANT_35]]] : memref<3xindex>
 // CHECK-NEXT:        %[[CONSTANT_36:.*]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[LOAD_39:.*]] = memref.load %[[ALLOC_48]]{{\[}}%[[CONSTANT_36]]] : memref<3xindex>
-// CHECK-NEXT:        %[[ALLOC_OUTPUT_0:.*]] = hipsr.alloc_output(%[[VAL_47]], %[[LOAD_38]], %[[LOAD_39]]) {out_idx = 0 : i64} : memref<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.slice(%[[VAL_47]]) ins(%[[VAL_50]] : memref<?xf16, #hipsr.mem<device>>) ends(%[[VAL_51]] : memref<1xi64, #hipsr.mem<host>>) outs(%[[ALLOC_49]] : memref<?xf16, #hipsr.mem<device>>) {axes_attr = array<i64: 0>, starts_attr = array<i64: 0>, steps_attr = array<i64: 1>}
-// CHECK-NEXT:        hipsr.scatter_nd(%[[VAL_47]]) ins(%[[VAL_54]], %[[VAL_55]], %[[ALLOC_49]] : memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<?xf16, #hipsr.mem<device>>) outs(%[[ALLOC_OUTPUT_0]] : memref<?x?x4096xf16, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_47]], %[[ALLOC_49]] : memref<1xindex>, memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_48]], %[[ALLOC_OUTPUT_0]] : memref<3xindex>, memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[LOAD_36:.*]] = memref.load %[[ALLOC_42]]{{\[}}%[[CONSTANT_36]]] : memref<3xindex>
+// CHECK-NEXT:        %[[ALLOC_OUTPUT_0:.*]] = hipsr.alloc_output(%[[VAL_46]], %[[LOAD_35]], %[[LOAD_36]]) {out_idx = 0 : i64} : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.slice(%[[VAL_46]]) ins(%[[VAL_47]] : memref<?xf16, #hipsr.mem<device>>) ends(%[[VAL_48]] : memref<1xi64, #hipsr.mem<host>>) outs(%[[ALLOC_43]] : memref<?xf16, #hipsr.mem<device>>) {axes_attr = array<i64: 0>, starts_attr = array<i64: 0>, steps_attr = array<i64: 1>}
+// CHECK-NEXT:        hipsr.scatter_nd(%[[VAL_46]]) ins(%[[VAL_51]], %[[VAL_52]], %[[ALLOC_43]] : memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<?xf16, #hipsr.mem<device>>) outs(%[[ALLOC_OUTPUT_0]] : memref<?x?x4096xf16, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_41]], %[[ALLOC_43]] : memref<1xindex>, memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_42]], %[[ALLOC_OUTPUT_0]] : memref<3xindex>, memref<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_OUTPUT_0]] : memref<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      } -> memref<?x?x4096xf16, #hipsr.mem<device>> {domain_id = 4 : i64}
 // CHECK-NEXT:      return %[[POOL_DOMAIN_4]] : memref<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:    }
-// CHECK-NEXT:  }
-// CHECK-EMPTY:
-// CHECK-NEXT:  {-#
-// CHECK-EMPTY:
-// CHECK-NEXT:  #-}
+
 
 module {
   func.func @main_graph(%arg0: tensor<?x?xi64> {onnx.name = "input_ids"}, %arg1: tensor<?x4096xf16> {onnx.name = "image_features"}) -> (tensor<?x?x4096xf16> {onnx.name = "inputs_embeds"}) attributes {onnx.graph.name = "main_graph"} {

--- a/test/lit/Dialect/Hipsr/Pipelines/sample_dynamic.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/sample_dynamic.mlir
@@ -11,7 +11,7 @@
 // CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
 // CHECK-SAME:      %[[ARG1:.*]]: memref<?x3xf16, #hipsr.mem<device>> {onnx.name = "a"},
 // CHECK-SAME:      %[[ARG2:.*]]: memref<?x4xf32, #hipsr.mem<device>> {onnx.name = "b"}) -> (memref<?x2xf32, #hipsr.mem<device>> {onnx.name = "y"}) attributes {onnx.graph.name = "main_graph"} {
-// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]]:5 = hipsr.pool_domain(%[[ARG0]], %[[ARG1]], %[[ARG2]] : !hipsr.context, memref<?x3xf16, #hipsr.mem<device>>, memref<?x4xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]]:3 = hipsr.pool_domain(%[[ARG0]], %[[ARG1]], %[[ARG2]] : !hipsr.context, memref<?x3xf16, #hipsr.mem<device>>, memref<?x4xf32, #hipsr.mem<device>>) {
 // CHECK-NEXT:      ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: memref<?x3xf16, #hipsr.mem<device>>, %[[VAL_2:.*]]: memref<?x4xf32, #hipsr.mem<device>>):
 // CHECK-NEXT:        %[[CONSTANT_0:.*]] = arith.constant 3 : index
 // CHECK-NEXT:        %[[CONSTANT_1:.*]] = hipsr.constant {value = dense<{{\[\[}}1.000000e+00, 2.000000e+00], [3.000000e+00, 4.000000e+00], [5.000000e+00, 6.000000e+00], [7.000000e+00, 8.000000e+00]]> : tensor<4x2xf32>} : memref<4x2xf32, #hipsr.mem<device>>
@@ -28,8 +28,8 @@
 // CHECK-NEXT:        %[[ALLOC_2:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_0]], %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_3]], %[[ALLOC_2]]{{\[}}%[[CONSTANT_3]]] : memref<2xindex>
-// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_1]]{{\[}}%[[CONSTANT_4]]] [%[[CONSTANT_4]]] [%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] [%[[CONSTANT_4]]] [%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_1]]{{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:        %[[ALLOC_3:.*]] = memref.alloc(%[[CONSTANT_4]]) {alignment = 64 : i64} : memref<?xindex>
 // CHECK-NEXT:        scf.for %[[VAL_3:.*]] = %[[CONSTANT_4]] to %[[CONSTANT_4]] step %[[CONSTANT_3]] {
 // CHECK-NEXT:          %[[CMPI_0:.*]] = arith.cmpi ult, %[[VAL_3]], %[[CONSTANT_4]] : index
@@ -55,122 +55,121 @@
 // CHECK-NEXT:        memref.store %[[DIM_1]], %[[ALLOC_4]]{{\[}}%[[CONSTANT_4]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_3]], %[[ALLOC_4]]{{\[}}%[[CONSTANT_3]]] : memref<2xindex>
 // CHECK-NEXT:        %[[ALLOC_5:.*]] = memref.alloc(%[[CONSTANT_5]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_5]]{{\[}}0] [%[[CONSTANT_4]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_5]][0] {{\[}}%[[CONSTANT_4]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_3]], %[[SUBVIEW_2]] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        %[[SUBVIEW_3:.*]] = memref.subview %[[ALLOC_5]]{{\[}}%[[CONSTANT_4]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_4]], %[[SUBVIEW_3]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        %[[LOAD_2:.*]] = memref.load %[[ALLOC_5]]{{\[}}%[[CONSTANT_4]]] : memref<?xindex>
 // CHECK-NEXT:        %[[ALLOC_6:.*]] = memref.alloc(%[[LOAD_2]]) {alignment = 64 : i64} : memref<?x1xf16, #hipsr.mem<device>>
 // CHECK-NEXT:        %[[LOAD_3:.*]] = memref.load %[[ALLOC_5]]{{\[}}%[[CONSTANT_4]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_7:.*]] = memref.alloc(%[[LOAD_3]]) {alignment = 64 : i64} : memref<?x1xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_8:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[ALLOC_7:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        hipsr.matmul(%[[VAL_0]]) ins(%[[VAL_1]], %[[CONSTANT_2]] : memref<?x3xf16, #hipsr.mem<device>>, memref<3x1xf16, #hipsr.mem<device>>) outs(%[[ALLOC_6]] : memref<?x1xf16, #hipsr.mem<device>>)
-// CHECK-NEXT:        %[[ALLOC_9:.*]] = memref.alloc(%[[LOAD_3]]) {alignment = 64 : i64} : memref<?x1xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.cast(%[[VAL_0]]) ins(%[[ALLOC_6]] : memref<?x1xf16, #hipsr.mem<device>>) outs(%[[ALLOC_9]] : memref<?x1xf32, #hipsr.mem<device>>)
-// CHECK-NEXT:        %[[COMPUTE_0:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[VAL_2]] : memref<?x4xf32, #hipsr.mem<device>>) outs(%[[ALLOC_8]] : memref<2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        %[[ALLOC_8:.*]] = memref.alloc(%[[LOAD_3]]) {alignment = 64 : i64} : memref<?x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.cast(%[[VAL_0]]) ins(%[[ALLOC_6]] : memref<?x1xf16, #hipsr.mem<device>>) outs(%[[ALLOC_8]] : memref<?x1xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        %[[COMPUTE_0:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[VAL_2]] : memref<?x4xf32, #hipsr.mem<device>>) outs(%[[ALLOC_7]] : memref<2xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:        ^bb0(%[[VAL_4:.*]]: !hipsr.context, %[[VAL_5:.*]]: memref<?x4xf32, #hipsr.mem<device>>, %[[VAL_6:.*]]: memref<2xi64, #hipsr.mem<host>>):
 // CHECK-NEXT:          %[[CONSTANT_6:.*]] = arith.constant 1 : index
 // CHECK-NEXT:          %[[CONSTANT_7:.*]] = arith.constant 4 : i64
 // CHECK-NEXT:          %[[CONSTANT_8:.*]] = arith.constant 0 : index
 // CHECK-NEXT:          %[[DIM_2:.*]] = memref.dim %[[VAL_5]], %[[CONSTANT_8]] : memref<?x4xf32, #hipsr.mem<device>>
 // CHECK-NEXT:          %[[INDEX_CAST_0:.*]] = arith.index_cast %[[DIM_2]] : index to i64
-// CHECK-NEXT:          %[[ALLOC_10:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:          memref.store %[[INDEX_CAST_0]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_8]]] : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:          memref.store %[[CONSTANT_7]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_6]]] : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:          hipsr.compute_yield %[[ALLOC_10]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          %[[ALLOC_9:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[INDEX_CAST_0]], %[[ALLOC_9]]{{\[}}%[[CONSTANT_8]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[CONSTANT_7]], %[[ALLOC_9]]{{\[}}%[[CONSTANT_6]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          hipsr.compute_yield %[[ALLOC_9]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        } : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_5]], %[[ALLOC_6]] : memref<?xindex>, memref<?x1xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_5]], %[[ALLOC_9]] : memref<?xindex>, memref<?x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_5]], %[[ALLOC_8]] : memref<?xindex>, memref<?x1xf32, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_0]], %[[COMPUTE_0]] : memref<1xindex>, memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_7]], %[[ALLOC_9]], %[[ALLOC_8]], %[[COMPUTE_0]], %[[CONSTANT_1]] : memref<?x1xf32, #hipsr.mem<device>>, memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      } -> memref<?x1xf32, #hipsr.mem<device>>, memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#0, %[[POOL_DOMAIN_0]]#2, %[[POOL_DOMAIN_0]]#1, %[[POOL_DOMAIN_0]]#3, %[[POOL_DOMAIN_0]]#4 : !hipsr.context, memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_7:.*]]: !hipsr.context, %[[VAL_8:.*]]: memref<?x1xf32, #hipsr.mem<device>>, %[[VAL_9:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_10:.*]]: memref<?x1xf32, #hipsr.mem<device>>, %[[VAL_11:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_12:.*]]: memref<4x2xf32, #hipsr.mem<device>>):
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_8]], %[[COMPUTE_0]], %[[CONSTANT_1]] : memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]] = hipsr.pool_domain(%[[ARG0]], %[[VAL_7:.*]]#0, %[[VAL_7]]#1, %[[VAL_7]]#2 : !hipsr.context, memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_8:.*]]: !hipsr.context, %[[VAL_9:.*]]: memref<?x1xf32, #hipsr.mem<device>>, %[[VAL_10:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_11:.*]]: memref<4x2xf32, #hipsr.mem<device>>):
 // CHECK-NEXT:        %[[CONSTANT_9:.*]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[CONSTANT_10:.*]] = arith.constant 4 : index
 // CHECK-NEXT:        %[[CONSTANT_11:.*]] = arith.constant 0 : index
 // CHECK-NEXT:        %[[CONSTANT_12:.*]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[DIM_3:.*]] = memref.dim %[[VAL_8]], %[[CONSTANT_11]] : memref<?x1xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_11:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[DIM_3]], %[[ALLOC_11]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_12]], %[[ALLOC_11]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
-// CHECK-NEXT:        %[[LOAD_4:.*]] = memref.load %[[VAL_9]]{{\[}}%[[CONSTANT_11]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[DIM_3:.*]] = memref.dim %[[VAL_9]], %[[CONSTANT_11]] : memref<?x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_10:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[DIM_3]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_12]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_4:.*]] = memref.load %[[VAL_10]]{{\[}}%[[CONSTANT_11]]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_1:.*]] = arith.index_cast %[[LOAD_4]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_5:.*]] = memref.load %[[VAL_9]]{{\[}}%[[CONSTANT_12]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_5:.*]] = memref.load %[[VAL_10]]{{\[}}%[[CONSTANT_12]]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_2:.*]] = arith.index_cast %[[LOAD_5]] : i64 to index
-// CHECK-NEXT:        %[[ALLOC_12:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_1]], %[[ALLOC_12]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_2]], %[[ALLOC_12]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_13:.*]] = memref.alloc(%[[CONSTANT_9]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_13:.*]] = %[[CONSTANT_11]] to %[[CONSTANT_9]] step %[[CONSTANT_12]] {
-// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_13]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:        %[[ALLOC_11:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_1]], %[[ALLOC_11]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_2]], %[[ALLOC_11]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_12:.*]] = memref.alloc(%[[CONSTANT_9]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        scf.for %[[VAL_12:.*]] = %[[CONSTANT_11]] to %[[CONSTANT_9]] step %[[CONSTANT_12]] {
+// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_12]], %[[CONSTANT_11]] : index
 // CHECK-NEXT:          %[[IF_2:.*]] = scf.if %[[CMPI_3]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[CONSTANT_12]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_6:.*]] = memref.load %[[ALLOC_11]]{{\[}}%[[VAL_13]]] : memref<2xindex>
+// CHECK-NEXT:            %[[LOAD_6:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[VAL_12]]] : memref<2xindex>
 // CHECK-NEXT:            scf.yield %[[LOAD_6]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_13]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_12]], %[[CONSTANT_11]] : index
 // CHECK-NEXT:          %[[IF_3:.*]] = scf.if %[[CMPI_4]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_2]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_7:.*]] = memref.load %[[ALLOC_12]]{{\[}}%[[VAL_13]]] : memref<2xindex>
+// CHECK-NEXT:            %[[LOAD_7:.*]] = memref.load %[[ALLOC_11]]{{\[}}%[[VAL_12]]] : memref<2xindex>
 // CHECK-NEXT:            %[[CMPI_5:.*]] = arith.cmpi eq, %[[LOAD_7]], %[[CONSTANT_12]] : index
 // CHECK-NEXT:            %[[SELECT_1:.*]] = arith.select %[[CMPI_5]], %[[IF_2]], %[[LOAD_7]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_1]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_13]]{{\[}}%[[VAL_13]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_12]]{{\[}}%[[VAL_12]]] : memref<?xindex>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[CAST_0:.*]] = memref.cast %[[ALLOC_13]] : memref<?xindex> to memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_14:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_10]], %[[ALLOC_14]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_14]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
-// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[CAST_0]]{{\[}}%[[CONSTANT_11]]] [%[[CONSTANT_11]]] [%[[CONSTANT_12]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_14]]{{\[}}%[[CONSTANT_11]]] [%[[CONSTANT_11]]] [%[[CONSTANT_12]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[ALLOC_15:.*]] = memref.alloc(%[[CONSTANT_11]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_14:.*]] = %[[CONSTANT_11]] to %[[CONSTANT_11]] step %[[CONSTANT_12]] {
-// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_14]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:        %[[CAST_0:.*]] = memref.cast %[[ALLOC_12]] : memref<?xindex> to memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_13:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_10]], %[[ALLOC_13]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_13]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
+// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[CAST_0]]{{\[}}%[[CONSTANT_11]]] {{\[}}%[[CONSTANT_11]]] {{\[}}%[[CONSTANT_12]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_13]]{{\[}}%[[CONSTANT_11]]] {{\[}}%[[CONSTANT_11]]] {{\[}}%[[CONSTANT_12]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[ALLOC_14:.*]] = memref.alloc(%[[CONSTANT_11]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        scf.for %[[VAL_13:.*]] = %[[CONSTANT_11]] to %[[CONSTANT_11]] step %[[CONSTANT_12]] {
+// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_13]], %[[CONSTANT_11]] : index
 // CHECK-NEXT:          %[[IF_4:.*]] = scf.if %[[CMPI_6]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[CONSTANT_12]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_8:.*]] = memref.load %[[SUBVIEW_4]]{{\[}}%[[VAL_14]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            %[[LOAD_8:.*]] = memref.load %[[SUBVIEW_4]]{{\[}}%[[VAL_13]]] : memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:            scf.yield %[[LOAD_8]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_14]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_13]], %[[CONSTANT_11]] : index
 // CHECK-NEXT:          %[[IF_5:.*]] = scf.if %[[CMPI_7]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_4]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_9:.*]] = memref.load %[[SUBVIEW_5]]{{\[}}%[[VAL_14]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            %[[LOAD_9:.*]] = memref.load %[[SUBVIEW_5]]{{\[}}%[[VAL_13]]] : memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:            %[[CMPI_8:.*]] = arith.cmpi eq, %[[LOAD_9]], %[[CONSTANT_12]] : index
 // CHECK-NEXT:            %[[SELECT_2:.*]] = arith.select %[[CMPI_8]], %[[IF_4]], %[[LOAD_9]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_2]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_15]]{{\[}}%[[VAL_14]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_14]]{{\[}}%[[VAL_13]]] : memref<?xindex>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[LOAD_10:.*]] = memref.load %[[ALLOC_13]]{{\[}}%[[CONSTANT_11]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_16:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[LOAD_10]], %[[ALLOC_16]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_16]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_17:.*]] = memref.alloc(%[[CONSTANT_9]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_6:.*]] = memref.subview %[[ALLOC_17]]{{\[}}0] [%[[CONSTANT_11]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
-// CHECK-NEXT:        memref.copy %[[ALLOC_15]], %[[SUBVIEW_6]] : memref<?xindex> to memref<?xindex, strided<[1]>>
-// CHECK-NEXT:        %[[SUBVIEW_7:.*]] = memref.subview %[[ALLOC_17]]{{\[}}%[[CONSTANT_11]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
-// CHECK-NEXT:        memref.copy %[[ALLOC_16]], %[[SUBVIEW_7]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
-// CHECK-NEXT:        %[[LOAD_11:.*]] = memref.load %[[ALLOC_13]]{{\[}}%[[CONSTANT_11]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_18:.*]] = memref.alloc(%[[LOAD_11]]) {alignment = 64 : i64} : memref<?x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[LOAD_12:.*]] = memref.load %[[ALLOC_17]]{{\[}}%[[CONSTANT_11]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_10:.*]] = memref.load %[[ALLOC_12]]{{\[}}%[[CONSTANT_11]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_15:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[LOAD_10]], %[[ALLOC_15]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_15]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_16:.*]] = memref.alloc(%[[CONSTANT_9]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        %[[SUBVIEW_6:.*]] = memref.subview %[[ALLOC_16]][0] {{\[}}%[[CONSTANT_11]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        memref.copy %[[ALLOC_14]], %[[SUBVIEW_6]] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_7:.*]] = memref.subview %[[ALLOC_16]]{{\[}}%[[CONSTANT_11]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        memref.copy %[[ALLOC_15]], %[[SUBVIEW_7]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        %[[LOAD_11:.*]] = memref.load %[[ALLOC_12]]{{\[}}%[[CONSTANT_11]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_17:.*]] = memref.alloc(%[[LOAD_11]]) {alignment = 64 : i64} : memref<?x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[LOAD_12:.*]] = memref.load %[[ALLOC_16]]{{\[}}%[[CONSTANT_11]]] : memref<?xindex>
 // CHECK-NEXT:        %[[CONSTANT_13:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[LOAD_13:.*]] = memref.load %[[ALLOC_17]]{{\[}}%[[CONSTANT_13]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_OUTPUT_0:.*]] = hipsr.alloc_output(%[[VAL_7]], %[[LOAD_13]]) {out_idx = 0 : i64} : memref<?x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.expand(%[[VAL_7]]) ins(%[[VAL_10]], %[[VAL_11]] : memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_18]] : memref<?x4xf32, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.matmul(%[[VAL_7]]) ins(%[[ALLOC_18]], %[[VAL_12]] : memref<?x4xf32, #hipsr.mem<device>>, memref<4x2xf32, #hipsr.mem<device>>) outs(%[[ALLOC_OUTPUT_0]] : memref<?x2xf32, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_0]], %[[ALLOC_18]] : memref<2xindex>, memref<?x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_17]], %[[ALLOC_OUTPUT_0]] : memref<?xindex>, memref<?x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[LOAD_13:.*]] = memref.load %[[ALLOC_16]]{{\[}}%[[CONSTANT_13]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_OUTPUT_0:.*]] = hipsr.alloc_output(%[[VAL_8]], %[[LOAD_13]]) {out_idx = 0 : i64} : memref<?x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.expand(%[[VAL_8]]) ins(%[[VAL_9]], %[[VAL_10]] : memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_17]] : memref<?x4xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.matmul(%[[VAL_8]]) ins(%[[ALLOC_17]], %[[VAL_11]] : memref<?x4xf32, #hipsr.mem<device>>, memref<4x2xf32, #hipsr.mem<device>>) outs(%[[ALLOC_OUTPUT_0]] : memref<?x2xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_0]], %[[ALLOC_17]] : memref<2xindex>, memref<?x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_16]], %[[ALLOC_OUTPUT_0]] : memref<?xindex>, memref<?x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_OUTPUT_0]] : memref<?x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      } -> memref<?x2xf32, #hipsr.mem<device>> {domain_id = 1 : i64}
 // CHECK-NEXT:      return %[[POOL_DOMAIN_1]] : memref<?x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    }
-// CHECK-NEXT:  }
+
 
 func.func @main_graph(%a: tensor<?x3xf16> {onnx.name = "a"},
                       %b: tensor<?x4xf32> {onnx.name = "b"})

--- a/test/lit/Dialect/Hipsr/Pipelines/sample_static.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/sample_static.mlir
@@ -6,13 +6,13 @@
 
 // RUN: hip-mlir-opt %s --onnx-dialect=modeled --hipsr-pipeline | FileCheck %s
 
-// CHECK:         memref.global "private" constant @__constant_2xi64 : memref<2xi64, #hipsr.mem<host>> = dense<[2, 4]> {alignment = 64 : i64}
+// CHECK-LABEL:   memref.global "private" constant @__constant_2xi64 : memref<2xi64, #hipsr.mem<host>> = dense<[2, 4]> {alignment = 64 : i64}
 
 // CHECK-LABEL:   func.func @main_graph(
 // CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
 // CHECK-SAME:      %[[ARG1:.*]]: memref<2x3xf16, #hipsr.mem<device>> {onnx.name = "a"},
 // CHECK-SAME:      %[[ARG2:.*]]: memref<2x4xf32, #hipsr.mem<device>> {onnx.name = "b"}) -> (memref<2x2xf32, #hipsr.mem<device>> {onnx.name = "y"}) attributes {onnx.graph.name = "main_graph"} {
-// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]]:5 = hipsr.pool_domain(%[[ARG0]], %[[ARG1]], %[[ARG2]] : !hipsr.context, memref<2x3xf16, #hipsr.mem<device>>, memref<2x4xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]]:3 = hipsr.pool_domain(%[[ARG0]], %[[ARG1]], %[[ARG2]] : !hipsr.context, memref<2x3xf16, #hipsr.mem<device>>, memref<2x4xf32, #hipsr.mem<device>>) {
 // CHECK-NEXT:      ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: memref<2x3xf16, #hipsr.mem<device>>, %[[VAL_2:.*]]: memref<2x4xf32, #hipsr.mem<device>>):
 // CHECK-NEXT:        %[[CONSTANT_0:.*]] = arith.constant 3 : index
 // CHECK-NEXT:        %[[CONSTANT_1:.*]] = hipsr.constant {value = dense<{{\[\[}}1.000000e+00, 2.000000e+00], [3.000000e+00, 4.000000e+00], [5.000000e+00, 6.000000e+00], [7.000000e+00, 8.000000e+00]]> : tensor<4x2xf32>} : memref<4x2xf32, #hipsr.mem<device>>
@@ -28,8 +28,8 @@
 // CHECK-NEXT:        %[[ALLOC_2:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_0]], %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_3]], %[[ALLOC_2]]{{\[}}%[[CONSTANT_3]]] : memref<2xindex>
-// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_1]]{{\[}}%[[CONSTANT_4]]] [%[[CONSTANT_4]]] [%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] [%[[CONSTANT_4]]] [%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_1]]{{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:        %[[ALLOC_3:.*]] = memref.alloc(%[[CONSTANT_4]]) {alignment = 64 : i64} : memref<?xindex>
 // CHECK-NEXT:        scf.for %[[VAL_3:.*]] = %[[CONSTANT_4]] to %[[CONSTANT_4]] step %[[CONSTANT_3]] {
 // CHECK-NEXT:          %[[CMPI_0:.*]] = arith.cmpi ult, %[[VAL_3]], %[[CONSTANT_4]] : index
@@ -54,108 +54,107 @@
 // CHECK-NEXT:        memref.store %[[CONSTANT_5]], %[[ALLOC_4]]{{\[}}%[[CONSTANT_4]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_3]], %[[ALLOC_4]]{{\[}}%[[CONSTANT_3]]] : memref<2xindex>
 // CHECK-NEXT:        %[[ALLOC_5:.*]] = memref.alloc(%[[CONSTANT_5]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_5]]{{\[}}0] [%[[CONSTANT_4]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_5]][0] {{\[}}%[[CONSTANT_4]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_3]], %[[SUBVIEW_2]] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        %[[SUBVIEW_3:.*]] = memref.subview %[[ALLOC_5]]{{\[}}%[[CONSTANT_4]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_4]], %[[SUBVIEW_3]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        %[[ALLOC_6:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2x1xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_7:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2x1xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_8:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[ALLOC_7:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        hipsr.matmul(%[[VAL_0]]) ins(%[[VAL_1]], %[[CONSTANT_2]] : memref<2x3xf16, #hipsr.mem<device>>, memref<3x1xf16, #hipsr.mem<device>>) outs(%[[ALLOC_6]] : memref<2x1xf16, #hipsr.mem<device>>)
-// CHECK-NEXT:        %[[ALLOC_9:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2x1xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.cast(%[[VAL_0]]) ins(%[[ALLOC_6]] : memref<2x1xf16, #hipsr.mem<device>>) outs(%[[ALLOC_9]] : memref<2x1xf32, #hipsr.mem<device>>)
-// CHECK-NEXT:        %[[COMPUTE_0:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[VAL_2]] : memref<2x4xf32, #hipsr.mem<device>>) outs(%[[ALLOC_8]] : memref<2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        %[[ALLOC_8:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.cast(%[[VAL_0]]) ins(%[[ALLOC_6]] : memref<2x1xf16, #hipsr.mem<device>>) outs(%[[ALLOC_8]] : memref<2x1xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        %[[COMPUTE_0:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[VAL_2]] : memref<2x4xf32, #hipsr.mem<device>>) outs(%[[ALLOC_7]] : memref<2xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:        ^bb0(%[[VAL_4:.*]]: !hipsr.context, %[[VAL_5:.*]]: memref<2x4xf32, #hipsr.mem<device>>, %[[VAL_6:.*]]: memref<2xi64, #hipsr.mem<host>>):
 // CHECK-NEXT:          %[[GET_GLOBAL_0:.*]] = memref.get_global @__constant_2xi64 : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:          hipsr.compute_yield %[[GET_GLOBAL_0]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        } : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_5]], %[[ALLOC_6]] : memref<?xindex>, memref<2x1xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_5]], %[[ALLOC_9]] : memref<?xindex>, memref<2x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_5]], %[[ALLOC_8]] : memref<?xindex>, memref<2x1xf32, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_0]], %[[COMPUTE_0]] : memref<1xindex>, memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_7]], %[[ALLOC_9]], %[[ALLOC_8]], %[[COMPUTE_0]], %[[CONSTANT_1]] : memref<2x1xf32, #hipsr.mem<device>>, memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      } -> memref<2x1xf32, #hipsr.mem<device>>, memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#0, %[[POOL_DOMAIN_0]]#2, %[[POOL_DOMAIN_0]]#1, %[[POOL_DOMAIN_0]]#3, %[[POOL_DOMAIN_0]]#4 : !hipsr.context, memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_7:.*]]: !hipsr.context, %[[VAL_8:.*]]: memref<2x1xf32, #hipsr.mem<device>>, %[[VAL_9:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_10:.*]]: memref<2x1xf32, #hipsr.mem<device>>, %[[VAL_11:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_12:.*]]: memref<4x2xf32, #hipsr.mem<device>>):
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_8]], %[[COMPUTE_0]], %[[CONSTANT_1]] : memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]] = hipsr.pool_domain(%[[ARG0]], %[[VAL_7:.*]]#0, %[[VAL_7]]#1, %[[VAL_7]]#2 : !hipsr.context, memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_8:.*]]: !hipsr.context, %[[VAL_9:.*]]: memref<2x1xf32, #hipsr.mem<device>>, %[[VAL_10:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_11:.*]]: memref<4x2xf32, #hipsr.mem<device>>):
 // CHECK-NEXT:        %[[CONSTANT_6:.*]] = arith.constant 4 : index
 // CHECK-NEXT:        %[[CONSTANT_7:.*]] = arith.constant 0 : index
 // CHECK-NEXT:        %[[CONSTANT_8:.*]] = arith.constant 1 : index
 // CHECK-NEXT:        %[[CONSTANT_9:.*]] = arith.constant 2 : index
-// CHECK-NEXT:        %[[ALLOC_10:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_7]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_8]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_8]]] : memref<2xindex>
-// CHECK-NEXT:        %[[LOAD_2:.*]] = memref.load %[[VAL_9]]{{\[}}%[[CONSTANT_7]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[ALLOC_9:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_9]]{{\[}}%[[CONSTANT_7]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_8]], %[[ALLOC_9]]{{\[}}%[[CONSTANT_8]]] : memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_2:.*]] = memref.load %[[VAL_10]]{{\[}}%[[CONSTANT_7]]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_0:.*]] = arith.index_cast %[[LOAD_2]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_3:.*]] = memref.load %[[VAL_9]]{{\[}}%[[CONSTANT_8]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_3:.*]] = memref.load %[[VAL_10]]{{\[}}%[[CONSTANT_8]]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_1:.*]] = arith.index_cast %[[LOAD_3]] : i64 to index
-// CHECK-NEXT:        %[[ALLOC_11:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_0]], %[[ALLOC_11]]{{\[}}%[[CONSTANT_7]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_1]], %[[ALLOC_11]]{{\[}}%[[CONSTANT_8]]] : memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_12:.*]] = memref.alloc(%[[CONSTANT_9]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_13:.*]] = %[[CONSTANT_7]] to %[[CONSTANT_9]] step %[[CONSTANT_8]] {
-// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_13]], %[[CONSTANT_7]] : index
+// CHECK-NEXT:        %[[ALLOC_10:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_0]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_7]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_1]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_8]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_11:.*]] = memref.alloc(%[[CONSTANT_9]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        scf.for %[[VAL_12:.*]] = %[[CONSTANT_7]] to %[[CONSTANT_9]] step %[[CONSTANT_8]] {
+// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_12]], %[[CONSTANT_7]] : index
 // CHECK-NEXT:          %[[IF_2:.*]] = scf.if %[[CMPI_3]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[CONSTANT_8]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_4:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[VAL_13]]] : memref<2xindex>
+// CHECK-NEXT:            %[[LOAD_4:.*]] = memref.load %[[ALLOC_9]]{{\[}}%[[VAL_12]]] : memref<2xindex>
 // CHECK-NEXT:            scf.yield %[[LOAD_4]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_13]], %[[CONSTANT_7]] : index
+// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_12]], %[[CONSTANT_7]] : index
 // CHECK-NEXT:          %[[IF_3:.*]] = scf.if %[[CMPI_4]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_2]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_5:.*]] = memref.load %[[ALLOC_11]]{{\[}}%[[VAL_13]]] : memref<2xindex>
+// CHECK-NEXT:            %[[LOAD_5:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[VAL_12]]] : memref<2xindex>
 // CHECK-NEXT:            %[[CMPI_5:.*]] = arith.cmpi eq, %[[LOAD_5]], %[[CONSTANT_8]] : index
 // CHECK-NEXT:            %[[SELECT_1:.*]] = arith.select %[[CMPI_5]], %[[IF_2]], %[[LOAD_5]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_1]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_12]]{{\[}}%[[VAL_13]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_11]]{{\[}}%[[VAL_12]]] : memref<?xindex>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[CAST_0:.*]] = memref.cast %[[ALLOC_12]] : memref<?xindex> to memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_13:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_6]], %[[ALLOC_13]]{{\[}}%[[CONSTANT_7]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_13]]{{\[}}%[[CONSTANT_8]]] : memref<2xindex>
-// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[CAST_0]]{{\[}}%[[CONSTANT_7]]] [%[[CONSTANT_7]]] [%[[CONSTANT_8]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_13]]{{\[}}%[[CONSTANT_7]]] [%[[CONSTANT_7]]] [%[[CONSTANT_8]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[ALLOC_14:.*]] = memref.alloc(%[[CONSTANT_7]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_14:.*]] = %[[CONSTANT_7]] to %[[CONSTANT_7]] step %[[CONSTANT_8]] {
-// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_14]], %[[CONSTANT_7]] : index
+// CHECK-NEXT:        %[[CAST_0:.*]] = memref.cast %[[ALLOC_11]] : memref<?xindex> to memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_12:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_6]], %[[ALLOC_12]]{{\[}}%[[CONSTANT_7]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_12]]{{\[}}%[[CONSTANT_8]]] : memref<2xindex>
+// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[CAST_0]]{{\[}}%[[CONSTANT_7]]] {{\[}}%[[CONSTANT_7]]] {{\[}}%[[CONSTANT_8]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_12]]{{\[}}%[[CONSTANT_7]]] {{\[}}%[[CONSTANT_7]]] {{\[}}%[[CONSTANT_8]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[ALLOC_13:.*]] = memref.alloc(%[[CONSTANT_7]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        scf.for %[[VAL_13:.*]] = %[[CONSTANT_7]] to %[[CONSTANT_7]] step %[[CONSTANT_8]] {
+// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_13]], %[[CONSTANT_7]] : index
 // CHECK-NEXT:          %[[IF_4:.*]] = scf.if %[[CMPI_6]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[CONSTANT_8]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_6:.*]] = memref.load %[[SUBVIEW_4]]{{\[}}%[[VAL_14]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            %[[LOAD_6:.*]] = memref.load %[[SUBVIEW_4]]{{\[}}%[[VAL_13]]] : memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:            scf.yield %[[LOAD_6]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_14]], %[[CONSTANT_7]] : index
+// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_13]], %[[CONSTANT_7]] : index
 // CHECK-NEXT:          %[[IF_5:.*]] = scf.if %[[CMPI_7]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_4]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_7:.*]] = memref.load %[[SUBVIEW_5]]{{\[}}%[[VAL_14]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            %[[LOAD_7:.*]] = memref.load %[[SUBVIEW_5]]{{\[}}%[[VAL_13]]] : memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:            %[[CMPI_8:.*]] = arith.cmpi eq, %[[LOAD_7]], %[[CONSTANT_8]] : index
 // CHECK-NEXT:            %[[SELECT_2:.*]] = arith.select %[[CMPI_8]], %[[IF_4]], %[[LOAD_7]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_2]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_14]]{{\[}}%[[VAL_14]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_13]]{{\[}}%[[VAL_13]]] : memref<?xindex>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[LOAD_8:.*]] = memref.load %[[ALLOC_12]]{{\[}}%[[CONSTANT_7]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_15:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[LOAD_8]], %[[ALLOC_15]]{{\[}}%[[CONSTANT_7]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_15]]{{\[}}%[[CONSTANT_8]]] : memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_16:.*]] = memref.alloc(%[[CONSTANT_9]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_6:.*]] = memref.subview %[[ALLOC_16]]{{\[}}0] [%[[CONSTANT_7]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
-// CHECK-NEXT:        memref.copy %[[ALLOC_14]], %[[SUBVIEW_6]] : memref<?xindex> to memref<?xindex, strided<[1]>>
-// CHECK-NEXT:        %[[SUBVIEW_7:.*]] = memref.subview %[[ALLOC_16]]{{\[}}%[[CONSTANT_7]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
-// CHECK-NEXT:        memref.copy %[[ALLOC_15]], %[[SUBVIEW_7]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
-// CHECK-NEXT:        %[[ALLOC_17:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_OUTPUT_0:.*]] = hipsr.alloc_output(%[[VAL_7]]) {out_idx = 0 : i64} : memref<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.expand(%[[VAL_7]]) ins(%[[VAL_10]], %[[VAL_11]] : memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_17]] : memref<2x4xf32, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.matmul(%[[VAL_7]]) ins(%[[ALLOC_17]], %[[VAL_12]] : memref<2x4xf32, #hipsr.mem<device>>, memref<4x2xf32, #hipsr.mem<device>>) outs(%[[ALLOC_OUTPUT_0]] : memref<2x2xf32, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_0]], %[[ALLOC_17]] : memref<2xindex>, memref<2x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_16]], %[[ALLOC_OUTPUT_0]] : memref<?xindex>, memref<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[LOAD_8:.*]] = memref.load %[[ALLOC_11]]{{\[}}%[[CONSTANT_7]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_14:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[LOAD_8]], %[[ALLOC_14]]{{\[}}%[[CONSTANT_7]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_14]]{{\[}}%[[CONSTANT_8]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_15:.*]] = memref.alloc(%[[CONSTANT_9]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        %[[SUBVIEW_6:.*]] = memref.subview %[[ALLOC_15]][0] {{\[}}%[[CONSTANT_7]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        memref.copy %[[ALLOC_13]], %[[SUBVIEW_6]] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_7:.*]] = memref.subview %[[ALLOC_15]]{{\[}}%[[CONSTANT_7]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        memref.copy %[[ALLOC_14]], %[[SUBVIEW_7]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        %[[ALLOC_16:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_OUTPUT_0:.*]] = hipsr.alloc_output(%[[VAL_8]]) {out_idx = 0 : i64} : memref<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.expand(%[[VAL_8]]) ins(%[[VAL_9]], %[[VAL_10]] : memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_16]] : memref<2x4xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.matmul(%[[VAL_8]]) ins(%[[ALLOC_16]], %[[VAL_11]] : memref<2x4xf32, #hipsr.mem<device>>, memref<4x2xf32, #hipsr.mem<device>>) outs(%[[ALLOC_OUTPUT_0]] : memref<2x2xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_0]], %[[ALLOC_16]] : memref<2xindex>, memref<2x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_15]], %[[ALLOC_OUTPUT_0]] : memref<?xindex>, memref<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_OUTPUT_0]] : memref<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      } -> memref<2x2xf32, #hipsr.mem<device>> {domain_id = 1 : i64}
 // CHECK-NEXT:      return %[[POOL_DOMAIN_1]] : memref<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    }
-// CHECK-NEXT:  }
+
 
 func.func @main_graph(%a: tensor<2x3xf16> {onnx.name = "a"},
                       %b: tensor<2x4xf32> {onnx.name = "b"})

--- a/test/lit/Dialect/Hipsr/Transforms/PartitionPoolDomains/analysis_report.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PartitionPoolDomains/analysis_report.mlir
@@ -9,7 +9,7 @@
 // expected-remark@+1 {{hipsr-partition-pool-domains: operation domains [0->0,1->0,2->1,3->1,4->1,5->1,6->1,7->1]}}
 func.func @parallel_barriers(
     %ctx: !hipsr.context, %input: tensor<?x8xf16, #hipsr.mem<device>>) -> tensor<?x8xf16, #hipsr.mem<device>> {
-  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 0 ops [0=hipsr.placeholder,1=hipsr.cast] results [0#0,1#0]}}
+  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 0 ops [0=hipsr.placeholder,1=hipsr.cast] results [1#0]}}
   %root_init = hipsr.placeholder(%ctx)
       ins(%input : tensor<?x8xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16, #hipsr.mem<device>>
@@ -59,7 +59,7 @@ func.func @root_barrier(
 // expected-remark@+1 {{hipsr-partition-pool-domains: operation domains [0->0,1->0,2->1,3->1,4->1,5->1,6->1,7->1]}}
 func.func @normal_after_barrier(
     %ctx: !hipsr.context, %input: tensor<?x8xf16, #hipsr.mem<device>>) -> tensor<?x8xf16, #hipsr.mem<device>> {
-  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 0 ops [0=hipsr.placeholder,1=hipsr.cast] results [0#0,1#0]}}
+  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 0 ops [0=hipsr.placeholder,1=hipsr.cast] results [1#0]}}
   %root_init = hipsr.placeholder(%ctx)
       ins(%input : tensor<?x8xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16, #hipsr.mem<device>>
@@ -94,21 +94,21 @@ func.func @normal_after_barrier(
 // expected-remark@+1 {{hipsr-partition-pool-domains: operation domains [0->0,1->0,2->1,3->1,4->2,5->2,6->1,7->1,8->0,9->0,10->1,11->1,12->3,13->3]}}
 func.func @mixed_depth_branches(
     %ctx: !hipsr.context, %input: tensor<?x8xf16, #hipsr.mem<device>>) -> tensor<?x8xf16, #hipsr.mem<device>> {
-  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 0 ops [0=hipsr.placeholder,1=hipsr.cast,8=hipsr.placeholder,9=hipsr.cast] results [0#0,1#0,8#0,9#0]}}
+  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 0 ops [0=hipsr.placeholder,1=hipsr.cast,8=hipsr.placeholder,9=hipsr.cast] results [1#0,8#0,9#0]}}
   %root_init = hipsr.placeholder(%ctx)
       ins(%input : tensor<?x8xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16, #hipsr.mem<device>>
   %root = hipsr.cast(%ctx) ins(%input : tensor<?x8xf16, #hipsr.mem<device>>)
       outs(%root_init : tensor<?x8xf16, #hipsr.mem<device>>) : tensor<?x8xf16, #hipsr.mem<device>>
 
-  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 1 ops [2=hipsr.placeholder,3=hipsr.cast,6=hipsr.placeholder,7=hipsr.cast,10=hipsr.placeholder,11=hipsr.add] results [2#0,3#0,10#0,11#0]}}
+  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 1 ops [2=hipsr.placeholder,3=hipsr.cast,6=hipsr.placeholder,7=hipsr.cast,10=hipsr.placeholder,11=hipsr.add] results [3#0,11#0]}}
   %deep1_init = hipsr.placeholder(%ctx)
       ins(%root_init : tensor<?x8xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x8xf16, #hipsr.mem<device>>
   %deep1 = hipsr.cast(%ctx) ins(%root : tensor<?x8xf16, #hipsr.mem<device>>)
       outs(%deep1_init : tensor<?x8xf16, #hipsr.mem<device>>) : tensor<?x8xf16, #hipsr.mem<device>>
 
-  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 2 ops [4=hipsr.placeholder,5=hipsr.cast] results [4#0,5#0]}}
+  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 2 ops [4=hipsr.placeholder,5=hipsr.cast] results [5#0]}}
   %deep2_init = hipsr.placeholder(%ctx)
       ins(%deep1_init : tensor<?x8xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x8xf16, #hipsr.mem<device>>
@@ -152,7 +152,7 @@ func.func @mixed_depth_branches(
 func.func @multi_result_domain_results(
     %ctx: !hipsr.context, %input: tensor<?x8xf16, #hipsr.mem<device>>)
     -> (tensor<?x8xf16, #hipsr.mem<device>>, tensor<?x8xf16, #hipsr.mem<device>>) {
-  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 0 ops [0=hipsr.placeholder,1=hipsr.compute] results [0#0,0#1,1#0,1#1]}}
+  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 0 ops [0=hipsr.placeholder,1=hipsr.compute] results [1#0,1#1]}}
   %root_inits:2 = hipsr.placeholder(%ctx)
       ins(%input : tensor<?x8xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<normal>}

--- a/test/lit/Dialect/Hipsr/Transforms/PartitionPoolDomains/materialization.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PartitionPoolDomains/materialization.mlir
@@ -6,8 +6,9 @@
 // Diagram notation:
 //   name [N, D0] = a normal placeholder and its DPS consumer in domain 0
 //   name [B, D1] = a barrier placeholder and its DPS consumer in domain 1
-// Diagrams flow from top to bottom. Between paired nodes, each arrow carries
-// matching shape and data dependencies.
+// Diagrams flow from top to bottom. An arrow into a normal node carries the
+// producer's placeholder result as well as its data result, and an arrow into a
+// barrier carries only the data result its two nodes both read.
 //
 // Normal placeholders stay in the current domain, while barriers advance to
 // the next domain.
@@ -31,23 +32,23 @@
 //
 // CHECK-LABEL: func.func @mixed_chain(
 // CHECK-SAME: %[[CTX:.*]]: !hipsr.context, %[[INPUT:.*]]: tensor<4xf32, #hipsr.mem<device>>) -> tensor<4xf16, #hipsr.mem<device>> {
-// CHECK-NEXT: %[[DOMAIN0:.*]]:2 = hipsr.pool_domain(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<4xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT: %[[DOMAIN0:.*]] = hipsr.pool_domain(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<4xf32, #hipsr.mem<device>>) {
 // CHECK-NEXT: ^bb0(%[[CTX0:.*]]: !hipsr.context, %[[INPUT0:.*]]: tensor<4xf32, #hipsr.mem<device>>):
 // CHECK-NEXT: %[[INIT0:.*]] = hipsr.placeholder(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[DATA0:.*]] = hipsr.cast(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[INIT0]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[INIT0]], %[[DATA0]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT: %[[DOMAIN1:.*]]:2 = hipsr.pool_domain(%[[CTX]], %[[DOMAIN0]]#0, %[[DOMAIN0]]#1 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX1:.*]]: !hipsr.context, %[[SHAPE_INPUT1:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[DATA_INPUT1:.*]]: tensor<4xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[INIT1:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[SHAPE_INPUT1]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf32, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.pool_domain_yield %[[DATA0]] : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT: %[[DOMAIN1:.*]] = hipsr.pool_domain(%[[CTX]], %[[DOMAIN0]] : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT: ^bb0(%[[CTX1:.*]]: !hipsr.context, %[[DATA_INPUT1:.*]]: tensor<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT: %[[INIT1:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[DATA_INPUT1]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf32, #hipsr.mem<device>>
 // CHECK-NEXT: %[[DATA1:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[DATA_INPUT1]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[INIT1]] : tensor<4xf32, #hipsr.mem<device>>) : tensor<4xf32, #hipsr.mem<device>>
 // CHECK-NEXT: %[[INIT2:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[INIT1]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[DATA2:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[DATA1]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[INIT2]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[INIT2]], %[[DATA2]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 1 : i64}
-// CHECK-NEXT: %[[DOMAIN2:.*]] = hipsr.pool_domain(%[[CTX]], %[[DOMAIN1]]#0, %[[DOMAIN1]]#1 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX2:.*]]: !hipsr.context, %[[SHAPE_INPUT2:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[DATA_INPUT2:.*]]: tensor<4xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[INIT3:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[SHAPE_INPUT2]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf32, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.pool_domain_yield %[[DATA2]] : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>> {domain_id = 1 : i64}
+// CHECK-NEXT: %[[DOMAIN2:.*]] = hipsr.pool_domain(%[[CTX]], %[[DOMAIN1]] : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT: ^bb0(%[[CTX2:.*]]: !hipsr.context, %[[DATA_INPUT2:.*]]: tensor<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT: %[[INIT3:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[DATA_INPUT2]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf32, #hipsr.mem<device>>
 // CHECK-NEXT: %[[DATA3:.*]] = hipsr.cast(%[[CTX2]]) ins(%[[DATA_INPUT2]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[INIT3]] : tensor<4xf32, #hipsr.mem<device>>) : tensor<4xf32, #hipsr.mem<device>>
 // CHECK-NEXT: %[[INIT4:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[INIT3]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[DATA4:.*]] = hipsr.cast(%[[CTX2]]) ins(%[[DATA3]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[INIT4]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
@@ -127,40 +128,40 @@ func.func @mixed_chain(
 //
 // CHECK-LABEL: func.func @multi_branch(
 // CHECK-SAME: %[[CTX:.*]]: !hipsr.context, %[[INPUT:.*]]: tensor<4xf32, #hipsr.mem<device>>) -> tensor<4xf16, #hipsr.mem<device>> {
-// CHECK-NEXT: %[[DOMAIN0:.*]]:4 = hipsr.pool_domain(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<4xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT: %[[DOMAIN0:.*]]:3 = hipsr.pool_domain(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<4xf32, #hipsr.mem<device>>) {
 // CHECK-NEXT: ^bb0(%[[CTX0:.*]]: !hipsr.context, %[[INPUT0:.*]]: tensor<4xf32, #hipsr.mem<device>>):
 // CHECK-NEXT: %[[ROOT_INIT:.*]] = hipsr.placeholder(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[ROOT:.*]] = hipsr.cast(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[ROOT_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[INDEPENDENT_INIT:.*]] = hipsr.placeholder(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[INDEPENDENT:.*]] = hipsr.cast(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[INDEPENDENT_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[ROOT_INIT]], %[[ROOT]], %[[INDEPENDENT_INIT]], %[[INDEPENDENT]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT: %[[DOMAIN1:.*]]:4 = hipsr.pool_domain(%[[CTX]], %[[DOMAIN0]]#0, %[[DOMAIN0]]#1 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX1:.*]]: !hipsr.context, %[[ROOT_SHAPE1:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[ROOT_DATA1:.*]]: tensor<4xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[LHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[ROOT_SHAPE1]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.pool_domain_yield %[[ROOT]], %[[INDEPENDENT_INIT]], %[[INDEPENDENT]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT: %[[DOMAIN1:.*]]:3 = hipsr.pool_domain(%[[CTX]], %[[DOMAIN0]]#0 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT: ^bb0(%[[CTX1:.*]]: !hipsr.context, %[[ROOT_DATA1:.*]]: tensor<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT: %[[LHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[ROOT_DATA1]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[LHS:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[ROOT_DATA1]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[LHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[LHS_NORMAL_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[LHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[LHS_NORMAL:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[LHS]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[LHS_NORMAL_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[RHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[ROOT_SHAPE1]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[RHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[ROOT_DATA1]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[RHS:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[ROOT_DATA1]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[RHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[RHS_NORMAL_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[RHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[RHS_NORMAL:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[RHS]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[RHS_NORMAL_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[LHS_NORMAL_INIT]], %[[LHS_NORMAL]], %[[RHS_NORMAL_INIT]], %[[RHS_NORMAL]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 1 : i64}
-// CHECK-NEXT: %[[DOMAIN2:.*]]:2 = hipsr.pool_domain(%[[CTX]], %[[DOMAIN1]]#0, %[[DOMAIN1]]#1, %[[DOMAIN1]]#2, %[[DOMAIN1]]#3, %[[DOMAIN0]]#2, %[[DOMAIN0]]#3 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX2:.*]]: !hipsr.context, %[[LHS_SHAPE2:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[LHS_DATA2:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[RHS_SHAPE2:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[RHS_DATA2:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[INDEPENDENT_SHAPE2:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[INDEPENDENT_DATA2:.*]]: tensor<4xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[LHS_DEEP_INIT:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[LHS_SHAPE2]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[LHS_DEEP:.*]] = hipsr.cast(%[[CTX2]]) ins(%[[LHS_DATA2]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[LHS_DEEP_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[DEEP_JOIN_INIT:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[LHS_DEEP_INIT]], %[[RHS_SHAPE2]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[DEEP_JOIN:.*]] = hipsr.add(%[[CTX2]]) ins(%[[LHS_DEEP]], %[[RHS_DATA2]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) outs(%[[DEEP_JOIN_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.pool_domain_yield %[[LHS_NORMAL]], %[[RHS_NORMAL_INIT]], %[[RHS_NORMAL]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 1 : i64}
+// CHECK-NEXT: %[[DOMAIN2:.*]] = hipsr.pool_domain(%[[CTX]], %[[DOMAIN1]]#0, %[[DOMAIN1]]#1, %[[DOMAIN1]]#2, %[[DOMAIN0]]#1, %[[DOMAIN0]]#2 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT: ^bb0(%[[CTX2:.*]]: !hipsr.context, %[[LHS_NORMAL_DATA2:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[RHS_NORMAL_SHAPE2:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[RHS_NORMAL_DATA2:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[INDEPENDENT_SHAPE2:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[INDEPENDENT_DATA2:.*]]: tensor<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT: %[[LHS_DEEP_INIT:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[LHS_NORMAL_DATA2]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[LHS_DEEP:.*]] = hipsr.cast(%[[CTX2]]) ins(%[[LHS_NORMAL_DATA2]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[LHS_DEEP_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[DEEP_JOIN_INIT:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[LHS_DEEP_INIT]], %[[RHS_NORMAL_SHAPE2]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[DEEP_JOIN:.*]] = hipsr.add(%[[CTX2]]) ins(%[[LHS_DEEP]], %[[RHS_NORMAL_DATA2]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) outs(%[[DEEP_JOIN_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[JOIN_INIT:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[DEEP_JOIN_INIT]], %[[INDEPENDENT_SHAPE2]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[JOIN:.*]] = hipsr.add(%[[CTX2]]) ins(%[[DEEP_JOIN]], %[[INDEPENDENT_DATA2]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) outs(%[[JOIN_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[JOIN_INIT]], %[[JOIN]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 2 : i64}
-// CHECK-NEXT: %[[DOMAIN3:.*]] = hipsr.pool_domain(%[[CTX]], %[[DOMAIN2]]#0, %[[DOMAIN2]]#1 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX3:.*]]: !hipsr.context, %[[SHAPE_INPUT3:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[DATA_INPUT3:.*]]: tensor<4xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[RESULT_INIT:.*]] = hipsr.placeholder(%[[CTX3]]) ins(%[[SHAPE_INPUT3]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[RESULT:.*]] = hipsr.cast(%[[CTX3]]) ins(%[[DATA_INPUT3]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[RESULT_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.pool_domain_yield %[[JOIN]] : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>> {domain_id = 2 : i64}
+// CHECK-NEXT: %[[DOMAIN3:.*]] = hipsr.pool_domain(%[[CTX]], %[[DOMAIN2]] : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT: ^bb0(%[[CTX3:.*]]: !hipsr.context, %[[JOIN_DATA3:.*]]: tensor<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT: %[[RESULT_INIT:.*]] = hipsr.placeholder(%[[CTX3]]) ins(%[[JOIN_DATA3]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[RESULT:.*]] = hipsr.cast(%[[CTX3]]) ins(%[[JOIN_DATA3]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[RESULT_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: hipsr.pool_domain_yield %[[RESULT]] : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>> {domain_id = 3 : i64}
 // CHECK-NEXT: return %[[DOMAIN3]] : tensor<4xf16, #hipsr.mem<device>>
@@ -226,7 +227,8 @@ func.func @multi_branch(
 // -----
 
 // A barrier join puts the merge point one domain deeper than both parallel
-// arms. Shape and data values for both arms cross the second boundary.
+// arms. One value per arm crosses the second boundary, because the join reads
+// the same data its arms produced.
 //
 //                 root [N, D0]
 //                       |
@@ -242,23 +244,23 @@ func.func @multi_branch(
 //
 // CHECK-LABEL: func.func @diamond(
 // CHECK-SAME: %[[CTX:.*]]: !hipsr.context, %[[INPUT:.*]]: tensor<4xf32, #hipsr.mem<device>>) -> tensor<4xf16, #hipsr.mem<device>> {
-// CHECK-NEXT: %[[DOMAIN0:.*]]:2 = hipsr.pool_domain(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<4xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT: %[[DOMAIN0:.*]] = hipsr.pool_domain(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<4xf32, #hipsr.mem<device>>) {
 // CHECK-NEXT: ^bb0(%[[CTX0:.*]]: !hipsr.context, %[[INPUT0:.*]]: tensor<4xf32, #hipsr.mem<device>>):
 // CHECK-NEXT: %[[ROOT_INIT:.*]] = hipsr.placeholder(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[ROOT:.*]] = hipsr.cast(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[ROOT_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[ROOT_INIT]], %[[ROOT]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT: %[[DOMAIN1:.*]]:4 = hipsr.pool_domain(%[[CTX]], %[[DOMAIN0]]#0, %[[DOMAIN0]]#1 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX1:.*]]: !hipsr.context, %[[ROOT_SHAPE:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[ROOT_DATA:.*]]: tensor<4xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[LHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[ROOT_SHAPE]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.pool_domain_yield %[[ROOT]] : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT: %[[DOMAIN1:.*]]:2 = hipsr.pool_domain(%[[CTX]], %[[DOMAIN0]] : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT: ^bb0(%[[CTX1:.*]]: !hipsr.context, %[[ROOT_DATA:.*]]: tensor<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT: %[[LHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[ROOT_DATA]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[LHS:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[ROOT_DATA]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[LHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[RHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[ROOT_SHAPE]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[RHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[ROOT_DATA]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[RHS:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[ROOT_DATA]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[RHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[LHS_INIT]], %[[LHS]], %[[RHS_INIT]], %[[RHS]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 1 : i64}
-// CHECK-NEXT: %[[DOMAIN2:.*]] = hipsr.pool_domain(%[[CTX]], %[[DOMAIN1]]#0, %[[DOMAIN1]]#2, %[[DOMAIN1]]#1, %[[DOMAIN1]]#3 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX2:.*]]: !hipsr.context, %[[LHS_SHAPE:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[RHS_SHAPE:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[LHS_DATA:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[RHS_DATA:.*]]: tensor<4xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[JOIN_INIT:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[LHS_SHAPE]], %[[RHS_SHAPE]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.pool_domain_yield %[[LHS]], %[[RHS]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 1 : i64}
+// CHECK-NEXT: %[[DOMAIN2:.*]] = hipsr.pool_domain(%[[CTX]], %[[DOMAIN1]]#0, %[[DOMAIN1]]#1 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT: ^bb0(%[[CTX2:.*]]: !hipsr.context, %[[LHS_DATA:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[RHS_DATA:.*]]: tensor<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT: %[[JOIN_INIT:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[LHS_DATA]], %[[RHS_DATA]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[JOIN:.*]] = hipsr.add(%[[CTX2]]) ins(%[[LHS_DATA]], %[[RHS_DATA]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) outs(%[[JOIN_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: hipsr.pool_domain_yield %[[JOIN]] : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>> {domain_id = 2 : i64}
@@ -322,27 +324,27 @@ func.func @diamond(
 //
 // CHECK-LABEL: func.func @cascaded_diamonds(
 // CHECK-SAME: %[[CTX:.*]]: !hipsr.context, %[[INPUT:.*]]: tensor<4xf32, #hipsr.mem<device>>) -> tensor<4xf16, #hipsr.mem<device>> {
-// CHECK-NEXT: %[[DOMAIN0:.*]]:2 = hipsr.pool_domain(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<4xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT: %[[DOMAIN0:.*]] = hipsr.pool_domain(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<4xf32, #hipsr.mem<device>>) {
 // CHECK-NEXT: ^bb0(%[[CTX0:.*]]: !hipsr.context, %[[INPUT0:.*]]: tensor<4xf32, #hipsr.mem<device>>):
 // CHECK-NEXT: %[[ROOT_INIT:.*]] = hipsr.placeholder(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[ROOT:.*]] = hipsr.cast(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[ROOT_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[ROOT_INIT]], %[[ROOT]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT: %[[DOMAIN1:.*]]:2 = hipsr.pool_domain(%[[CTX]], %[[DOMAIN0]]#0, %[[DOMAIN0]]#1 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX1:.*]]: !hipsr.context, %[[ROOT_SHAPE:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[ROOT_DATA:.*]]: tensor<4xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[UPPER_LHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[ROOT_SHAPE]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.pool_domain_yield %[[ROOT]] : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT: %[[DOMAIN1:.*]] = hipsr.pool_domain(%[[CTX]], %[[DOMAIN0]] : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT: ^bb0(%[[CTX1:.*]]: !hipsr.context, %[[ROOT_DATA:.*]]: tensor<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT: %[[UPPER_LHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[ROOT_DATA]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[UPPER_LHS:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[ROOT_DATA]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[UPPER_LHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[UPPER_RHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[ROOT_SHAPE]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[UPPER_RHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[ROOT_DATA]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[UPPER_RHS:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[ROOT_DATA]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[UPPER_RHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[UPPER_JOIN_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[UPPER_LHS_INIT]], %[[UPPER_RHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[UPPER_JOIN:.*]] = hipsr.add(%[[CTX1]]) ins(%[[UPPER_LHS]], %[[UPPER_RHS]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) outs(%[[UPPER_JOIN_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[UPPER_JOIN_INIT]], %[[UPPER_JOIN]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 1 : i64}
-// CHECK-NEXT: %[[DOMAIN2:.*]] = hipsr.pool_domain(%[[CTX]], %[[DOMAIN1]]#0, %[[DOMAIN1]]#1 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX2:.*]]: !hipsr.context, %[[UPPER_SHAPE:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[UPPER_DATA:.*]]: tensor<4xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[LOWER_LHS_INIT:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[UPPER_SHAPE]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.pool_domain_yield %[[UPPER_JOIN]] : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>> {domain_id = 1 : i64}
+// CHECK-NEXT: %[[DOMAIN2:.*]] = hipsr.pool_domain(%[[CTX]], %[[DOMAIN1]] : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT: ^bb0(%[[CTX2:.*]]: !hipsr.context, %[[UPPER_DATA:.*]]: tensor<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT: %[[LOWER_LHS_INIT:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[UPPER_DATA]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[LOWER_LHS:.*]] = hipsr.cast(%[[CTX2]]) ins(%[[UPPER_DATA]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[LOWER_LHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[LOWER_RHS_INIT:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[UPPER_SHAPE]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[LOWER_RHS_INIT:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[UPPER_DATA]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[LOWER_RHS:.*]] = hipsr.cast(%[[CTX2]]) ins(%[[UPPER_DATA]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[LOWER_RHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[LOWER_JOIN_INIT:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[LOWER_LHS_INIT]], %[[LOWER_RHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[LOWER_JOIN:.*]] = hipsr.add(%[[CTX2]]) ins(%[[LOWER_LHS]], %[[LOWER_RHS]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) outs(%[[LOWER_JOIN_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
@@ -422,20 +424,20 @@ func.func @cascaded_diamonds(
 // CHECK-LABEL: func.func @multi_result_boundaries(
 // CHECK-SAME: %[[CTX:.*]]: !hipsr.context, %[[INPUT:.*]]: tensor<4xf16, #hipsr.mem<device>>)
 // CHECK-SAME: -> (tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: %[[DOMAIN0:.*]]:4 = hipsr.pool_domain(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT: %[[DOMAIN0:.*]]:2 = hipsr.pool_domain(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>) {
 // CHECK-NEXT: ^bb0(%[[CTX0:.*]]: !hipsr.context, %[[INPUT0:.*]]: tensor<4xf16, #hipsr.mem<device>>):
 // CHECK-NEXT: %[[ROOT_INITS:.*]]:2 = hipsr.placeholder(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[ROOT:.*]]:2 = hipsr.compute(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[ROOT_INITS]]#0, %[[ROOT_INITS]]#1 : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
 // CHECK-NEXT: ^bb0(%[[BODY_CTX:.*]]: !hipsr.context, %[[BODY_INPUT:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[LHS_DEST:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[RHS_DEST:.*]]: tensor<4xf16, #hipsr.mem<device>>):
 // CHECK-NEXT: hipsr.compute_yield %[[LHS_DEST]], %[[RHS_DEST]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: } : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[ROOT_INITS]]#0, %[[ROOT_INITS]]#1, %[[ROOT]]#0, %[[ROOT]]#1 : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT: %[[DOMAIN1:.*]]:2 = hipsr.pool_domain(%[[CTX]], %[[DOMAIN0]]#0, %[[DOMAIN0]]#2, %[[DOMAIN0]]#1, %[[DOMAIN0]]#3 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX1:.*]]: !hipsr.context, %[[LHS_SHAPE:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[LHS_INPUT:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[RHS_SHAPE:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[RHS_INPUT:.*]]: tensor<4xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[LHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[LHS_SHAPE]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.pool_domain_yield %[[ROOT]]#0, %[[ROOT]]#1 : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT: %[[DOMAIN1:.*]]:2 = hipsr.pool_domain(%[[CTX]], %[[DOMAIN0]]#0, %[[DOMAIN0]]#1 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT: ^bb0(%[[CTX1:.*]]: !hipsr.context, %[[LHS_INPUT:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[RHS_INPUT:.*]]: tensor<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT: %[[LHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[LHS_INPUT]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[LHS:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[LHS_INPUT]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[LHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[RHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[RHS_SHAPE]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[RHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[RHS_INPUT]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: %[[RHS:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[RHS_INPUT]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[RHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: hipsr.pool_domain_yield %[[LHS]], %[[RHS]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
 // CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 1 : i64}
@@ -467,6 +469,36 @@ func.func @multi_result_boundaries(
   %rhs = hipsr.cast(%ctx) ins(%root#1 : tensor<4xf16, #hipsr.mem<device>>)
       outs(%rhs_init : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
   return %lhs, %rhs : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
+}
+
+// -----
+
+// A barrier whose input is a block argument has no producer to wait on, so it
+// stays in domain zero and keeps that argument as its input.
+//
+//          input
+//            |
+//            v
+//    data [B, D0]
+//
+// CHECK-LABEL: func.func @root_barrier(
+// CHECK-SAME: %[[CTX:.*]]: !hipsr.context, %[[INPUT:.*]]: tensor<4xf32, #hipsr.mem<device>>) -> tensor<4xf16, #hipsr.mem<device>> {
+// CHECK-NEXT: %[[DOMAIN0:.*]] = hipsr.pool_domain(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<4xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT: ^bb0(%[[DOMAIN_CTX:.*]]: !hipsr.context, %[[DOMAIN_INPUT:.*]]: tensor<4xf32, #hipsr.mem<device>>):
+// CHECK-NEXT: %[[INIT:.*]] = hipsr.placeholder(%[[DOMAIN_CTX]]) ins(%[[DOMAIN_INPUT]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: %[[DATA:.*]] = hipsr.cast(%[[DOMAIN_CTX]]) ins(%[[DOMAIN_INPUT]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: hipsr.pool_domain_yield %[[DATA]] : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT: return %[[DOMAIN0]] : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT: }
+func.func @root_barrier(
+    %ctx: !hipsr.context, %input: tensor<4xf32, #hipsr.mem<device>>) -> tensor<4xf16, #hipsr.mem<device>> {
+  %init = hipsr.placeholder(%ctx)
+      ins(%input : tensor<4xf32, #hipsr.mem<device>>)
+      {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+  %data = hipsr.cast(%ctx) ins(%input : tensor<4xf32, #hipsr.mem<device>>)
+      outs(%init : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+  return %data : tensor<4xf16, #hipsr.mem<device>>
 }
 
 // -----


### PR DESCRIPTION
## Summary

A barrier placeholder marks a pool-domain boundary: it runs only after the values it reads have been computed. It was reading the destination buffer instead of the value, so the next domain read a buffer nothing had written.

## Related issue or design

None.

## Why

The conversion points every placeholder's inputs at each value's shape-graph counterpart, which names the destination the producer writes into. That is right for a normal placeholder, but a `hipsr.compute` result is a separate buffer from its destination, so waiting on the destination waits on nothing the body produced:

```mlir
%init = hipsr.placeholder(%ctx) ins(%in) {normal} : tensor<2xi64>
%data = hipsr.compute(%ctx) ins(%in) outs(%init) { ... } : tensor<2xi64>

// Before: waits on %init, a buffer the body never wrote
%wait = hipsr.placeholder(%ctx) ins(%init) {barrier} : tensor<2xi64>
// After
%wait = hipsr.placeholder(%ctx) ins(%data) {barrier} : tensor<2xi64>
```

`hipsr-partition-pool-domains` assigns operations to domains from what the barriers read, so the destination became a value the earlier domain had to yield. `sample_static` after bufferization, where domain 1 took its shape scalars out of the unwritten destination:

```mlir
// Before
%alloc_8 = memref.alloc() : memref<2xi64, #hipsr.mem<host>>
%compute_0 = hipsr.compute(%val_0) ins(%val_2) outs(%alloc_8) { ... }
hipsr.pool_domain_yield %alloc_7, %alloc_9, %alloc_8, %compute_0, %constant_1
// ... domain 1, where %val_9 is %alloc_8:
%load_2 = memref.load %val_9[%constant_7] : memref<2xi64, #hipsr.mem<host>>

// After
hipsr.pool_domain_yield %alloc_8, %compute_0, %constant_1
// ... domain 1, where %val_10 is %compute_0:
%load_2 = memref.load %val_10[%constant_7] : memref<2xi64, #hipsr.mem<host>>
```

## What

`hipsr-partition-pool-domains` now points each barrier's inputs back at the data values before it assigns operations to domains.

Undoing the rewiring there rather than in the conversion leaves the shape-graph input rule alone and keeps both verifiers as they are. Making a domain isolated turns the value into a captured block argument, which is already an allowed placeholder input, so a data result never reaches a placeholder's inputs at a pass boundary.

## Test plan

`ctest -C Release -R MorphizenMLIRLitTests` passes.

Five goldens are regenerated from actual pass output, now as strict `CHECK-NEXT` chains that verify the full IR:

| Golden | Allocations | Domain 0 results |
|---|---:|---:|
| `sample_static` | 18 -> 17 | 5 -> 3 |
| `sample_dynamic` | 19 -> 18 | 5 -> 3 |
| `embedding` | 50 -> 44 | 8 -> 5 |

The two `PartitionPoolDomains` goldens lose the placeholder results that only a barrier read.

## Notes for reviewers

This is a prerequisite for wiring `hipsr-pool-alloc` into the pipeline. That pass derives an allocation's lifetime from its first and last user and requires the first user to be a DPS destination, because a buffer read before anything writes it has no live range to pack. The unwritten destination's only user was `hipsr.pool_domain_yield`, which is not a DPS destination, so pool-alloc rejected `sample_static` with "buffer used before written".

AI assistance disclosure: Claude Opus 5 via Cursor was used for the investigation, the patch, and the golden regeneration. I reviewed the result, and validated it with the LIT suite and by reading the regenerated goldens.
