### PR TITLE
feat(qdq): fuse DQ+MatMul+Q into a new hip.qmatmul op

### DIFF
--- a/include/hip/Dialect/IR/HipBufferize.h
+++ b/include/hip/Dialect/IR/HipBufferize.h
@@ -210,6 +210,7 @@ registerHipBufferizableOpInterfaceModels(DialectRegistry &registry) {
     SizeOp::attachInterface<HipDstBufferizableModel<SizeOp>>(*ctx);
     LoopOp::attachInterface<HipDstBufferizableModel<LoopOp>>(*ctx);
     QAddOp::attachInterface<HipDstBufferizableModel<QAddOp>>(*ctx);
+    QMatMulOp::attachInterface<HipDstBufferizableModel<QMatMulOp>>(*ctx);
     // hip.if is a DPS control-flow op (getDpsInitsMutable, results alias
     // o_init) just like hip.loop. Without this model one-shot-bufferize aborts
     // with "op was not bufferized: hip.if" for any graph containing onnx.If,

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -4914,15 +4914,23 @@ def Hip_QMatMulOp : Hip_DpsOp<"qmatmul", /*traits=*/[],
     M = A_scale * B_scale / Y_scale   (folded at lowering time)
     ```
 
-    Shape contract matches `hip.matmul` without the transpose attributes:
+    Shape contract matches `hip.matmul`:
       A: [..., M, K], B: [..., K, N], Y: [broadcast(A.batch, B.batch), M, N].
+
+    Optional `transA` / `transB` (0/1) apply a last-dimension swap on the
+    corresponding operand before multiply, with the same meaning as on
+    `hip.matmul`: `transA` reads A as [..., K, M] and `transB` reads B as
+    [..., N, K]. They carry the compile-time fold of
+    `Transpose(perm=[..,r,r-2])` into MatMul, so a quantized attention
+    `Q @ K^T` still fuses. When unset they default to 0.
 
     Quantization is per-tensor, so every scale and zero point is an attribute.
     A, B and Y each carry their own quantized element type: real QDQ graphs
     commonly pair a `ui8` asymmetric activation with an `i8` symmetric weight.
     A and Y may be 8- or 16-bit, which is what makes A16W8 expressible; B is
     8-bit only, because the lowering's kernel keeps a 16-bit A exact by
-    splitting it into two bytes and that split needs an 8-bit other operand.
+    splitting it into two bytes and splits only A, leaving a wider B with no
+    path through it.
 
     Example:
     ```mlir
@@ -4944,7 +4952,9 @@ def Hip_QMatMulOp : Hip_DpsOp<"qmatmul", /*traits=*/[],
     F32Attr:$B_scale,
     I64Attr:$B_zero_point,
     F32Attr:$Y_scale,
-    I64Attr:$Y_zero_point
+    I64Attr:$Y_zero_point,
+    DefaultValuedAttr<I64Attr, "0">:$transA,
+    DefaultValuedAttr<I64Attr, "0">:$transB
   );
 
   let assemblyFormat = [{

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -4885,4 +4885,71 @@ def Hip_QAddOp : Hip_DpsOp_Broadcast<"qadd",
     attr-dict (`:` type($result_tensors)^)?
   }];
 }
+
+def Hip_QMatMulOp : Hip_DpsOp<"qmatmul", /*traits=*/[],
+                              /*outsAccessor=*/"Y",
+                              /*autoReify=*/0,
+                              /*autoInfer=*/1,
+                              /*declareInfer=*/1> {
+  let summary = "Quantized matrix multiplication with integrated QDQ";
+  let description = [{
+    Fuses DequantizeLinear x2 -> MatMul -> QuantizeLinear into a single
+    integer-domain batched GEMM.
+
+    ```
+    a = (A - A_zero_point) * A_scale
+    b = (B - B_zero_point) * B_scale
+    Y = saturate(round((a @ b) / Y_scale) + Y_zero_point)
+    ```
+
+    Expanded over the integer accumulator, with
+    `acc[m,n] = sum_k A[m,k]*B[k,n]`, `rowA[m] = sum_k A[m,k]` and
+    `colB[n] = sum_k B[k,n]`:
+
+    ```
+    Y[m,n] = saturate(round(M * (acc[m,n] - B_zero_point * rowA[m]
+                                          - A_zero_point * colB[n]
+                                          + K * A_zero_point * B_zero_point))
+                      + Y_zero_point)
+    M = A_scale * B_scale / Y_scale   (folded at lowering time)
+    ```
+
+    Shape contract matches `hip.matmul` without the transpose attributes:
+      A: [..., M, K], B: [..., K, N], Y: [broadcast(A.batch, B.batch), M, N].
+
+    Quantization is per-tensor, so every scale and zero point is an attribute.
+    A, B and Y each carry their own 8-bit element type: real QDQ graphs
+    commonly pair a `ui8` asymmetric activation with an `i8` symmetric weight.
+
+    Example:
+    ```mlir
+    hip.qmatmul(%ctx) ins(%A, %B : memref<64x128xi8, 1>, memref<128x32xi8, 1>)
+                      outs(%Y : memref<64x32xi8, 1>)
+                      {A_scale = 2.500000e-01 : f32, A_zero_point = -5 : i64,
+                       B_scale = 1.250000e-01 : f32, B_zero_point = 3 : i64,
+                       Y_scale = 5.000000e-01 : f32, Y_zero_point = 7 : i64}
+    ```
+  }];
+
+  let arguments = (ins
+    Hip_ContextType:$ctx,
+    Hip_TensorOrMemRef:$A,             // Left operand (quantized)
+    Hip_TensorOrMemRef:$B,             // Right operand (quantized)
+    Hip_TensorOrMemRef:$Y,             // Output buffer (quantized), DPS init
+    F32Attr:$A_scale,
+    I64Attr:$A_zero_point,
+    F32Attr:$B_scale,
+    I64Attr:$B_zero_point,
+    F32Attr:$Y_scale,
+    I64Attr:$Y_zero_point
+  );
+
+  let assemblyFormat = [{
+    `(` $ctx `)` `ins` `(` $A `,` $B `:` type($A) `,` type($B) `)`
+    `outs` `(` $Y `:` type($Y) `)`
+    attr-dict (`:` type($result_tensors)^)?
+  }];
+
+  let hasVerifier = 1;
+}
 #endif // HIP_OPS

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -4918,8 +4918,11 @@ def Hip_QMatMulOp : Hip_DpsOp<"qmatmul", /*traits=*/[],
       A: [..., M, K], B: [..., K, N], Y: [broadcast(A.batch, B.batch), M, N].
 
     Quantization is per-tensor, so every scale and zero point is an attribute.
-    A, B and Y each carry their own 8-bit element type: real QDQ graphs
+    A, B and Y each carry their own quantized element type: real QDQ graphs
     commonly pair a `ui8` asymmetric activation with an `i8` symmetric weight.
+    A and Y may be 8- or 16-bit, which is what makes A16W8 expressible; B is
+    8-bit only, because the lowering's kernel keeps a 16-bit A exact by
+    splitting it into two bytes and that split needs an 8-bit other operand.
 
     Example:
     ```mlir

--- a/lib/Conversion/HipToLLVM/CMakeLists.txt
+++ b/lib/Conversion/HipToLLVM/CMakeLists.txt
@@ -63,6 +63,7 @@ add_library(HipToLLVM STATIC
   GridSampleLowering.cpp
   GlobalPoolLowering.cpp
   QElementwiseLowering.cpp
+  QMatMulLowering.cpp
 )
 
 add_dependencies(HipToLLVM

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -289,6 +289,7 @@ void ConvertHipToLLVMPass::runOnOperation() {
   populateGridSampleLoweringPatterns(typeConverter, patterns);
   populateGlobalPoolLoweringPatterns(typeConverter, patterns);
   populateQElementwiseLoweringPatterns(typeConverter, patterns);
+  populateQMatMulLoweringPatterns(typeConverter, patterns);
 
   // Standard dialect lowerings
   // Bundle func/memref/arith/cf lowering with HIP lowering to minimize

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -140,6 +140,7 @@ inline constexpr const char *kWrapScatterND = "wrap_scatter_nd";
 inline constexpr const char *kWrapNonZero = "wrap_nonzero";
 inline constexpr const char *kWrapSize = "wrap_size";
 inline constexpr const char *kWrapQElementwise = "wrap_qelementwise";
+inline constexpr const char *kWrapQMatMul = "wrap_qmatmul";
 // Synchronize the stream and read a device i32 scalar back to the host
 // (used by hip.readback_dim to materialise a data-dependent dynamic dim).
 inline constexpr const char *kHipReadbackI32 = "hipdnn_ep_readback_i32";
@@ -524,6 +525,8 @@ void populateGlobalPoolLoweringPatterns(const LLVMTypeConverter &converter,
                                         RewritePatternSet &patterns);
 void populateQElementwiseLoweringPatterns(const LLVMTypeConverter &converter,
                                           RewritePatternSet &patterns);
+void populateQMatMulLoweringPatterns(const LLVMTypeConverter &converter,
+                                     RewritePatternSet &patterns);
 } // namespace hip
 } // namespace mlir
 

--- a/lib/Conversion/HipToLLVM/QMatMulLowering.cpp
+++ b/lib/Conversion/HipToLLVM/QMatMulLowering.cpp
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "HipToLLVMUtils.h"
+
+namespace mlir {
+namespace hip {
+namespace {
+
+// hip.qmatmul -> wrap_qmatmul(..., M_scale, A_zp, B_zp, Y_zp)
+//
+// The fused chain is DQ(A) @ DQ(B) -> Q, which over the integer accumulator
+// `acc[m,n] = sum_k A[m,k]*B[k,n]` is
+//
+//   Y = saturate(round(M * (acc - z_b*rowA - z_a*colB + K*z_a*z_b)) + z_y)
+//
+// with M = s_a * s_b / s_y. Only M is compile-time foldable, and folding it
+// here is what keeps the kernel down to one float multiply and one round per
+// output element instead of three dequant/requant divisions. The zero-point
+// correction terms depend on the operand data, so they stay in the kernel.
+struct QMatMulOpLowering : public ConvertOpToLLVMPattern<QMatMulOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(QMatMulOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+    Type ptrType = getPtrType();
+    Type i32Type = rewriter.getI32Type();
+    Type i64Type = rewriter.getI64Type();
+    Type f32Type = rewriter.getF32Type();
+
+    auto createI64Const = [&](int64_t value) -> Value {
+      return LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                      rewriter.getI64IntegerAttr(value));
+    };
+
+    auto AType = cast<MemRefType>(op.getA().getType());
+    auto BType = cast<MemRefType>(op.getB().getType());
+    auto YType = cast<MemRefType>(op.getY().getType());
+
+    // A and Y may be 8- or 16-bit; B must be 8-bit. The kernel handles a 16-bit
+    // A by splitting it into two bytes and running one 8-bit dot per byte, and
+    // only A is split, so a wider B has no path through it. PDL fusion already
+    // refuses to build such a hip.qmatmul, so this is the backstop for
+    // hand-written IR.
+    for (Type elemType : {AType.getElementType(), YType.getElementType()}) {
+      if (!elemType.isInteger(8) && !elemType.isInteger(16))
+        return rewriter.notifyMatchFailure(
+            op, "expected 8- or 16-bit A and Y element types");
+    }
+    if (!BType.getElementType().isInteger(8))
+      return rewriter.notifyMatchFailure(op, "expected an 8-bit B element type");
+    int64_t aDataType = getHipdnnDataType(AType.getElementType());
+    int64_t bDataType = getHipdnnDataType(BType.getElementType());
+    int64_t yDataType = getHipdnnDataType(YType.getElementType());
+
+    float yScale = op.getYScale().convertToFloat();
+    if (yScale == 0.0f)
+      return rewriter.notifyMatchFailure(op, "Y_scale must be non-zero");
+    // Accumulate the product in double so the single narrowing to f32 is the
+    // only rounding the folded coefficient carries.
+    double mScale = (static_cast<double>(op.getAScale().convertToFloat()) *
+                     static_cast<double>(op.getBScale().convertToFloat())) /
+                    static_cast<double>(yScale);
+    Value mScaleValue = LLVM::ConstantOp::create(
+        rewriter, loc, f32Type,
+        rewriter.getF32FloatAttr(static_cast<float>(mScale)));
+
+    int64_t ARank = AType.getRank();
+    int64_t BRank = BType.getRank();
+    int64_t transA = op.getTransA();
+    int64_t transB = op.getTransB();
+    MemRefDescriptor ADesc(adaptor.getA());
+    MemRefDescriptor BDesc(adaptor.getB());
+
+    // A: [..., M, K] or [..., K, M] when transA; B: [..., K, N] or [..., N, K]
+    // when transB. M/N/K are the logical extents either way, and the kernel
+    // gets the flags so it can pick the matching load stride.
+    Value M = (ARank >= 2) ? (transA ? ADesc.size(rewriter, loc, ARank - 1)
+                                     : ADesc.size(rewriter, loc, ARank - 2))
+                           : createI64Const(1);
+    Value K = transA ? ADesc.size(rewriter, loc, ARank - 2)
+                     : ADesc.size(rewriter, loc, ARank - 1);
+    Value N = transB ? BDesc.size(rewriter, loc, BRank - 2)
+                     : BDesc.size(rewriter, loc, BRank - 1);
+
+    Value batchCount;
+    if (ARank == 2) {
+      batchCount = createI64Const(1);
+    } else {
+      batchCount = ADesc.size(rewriter, loc, 0);
+      for (int64_t i : llvm::seq<int64_t>(1, ARank - 2)) {
+        Value dim = ADesc.size(rewriter, loc, i);
+        batchCount = LLVM::MulOp::create(rewriter, loc, batchCount, dim);
+      }
+    }
+
+    // b_batch_stride: per-batch element stride into B. Three shapes reach here
+    // with batch_count > 1 and need different strides:
+    //   * rank-2 weight                              -> one matrix -> 0
+    //   * rank-N weight whose leading dims multiply   -> K * N
+    //   * rank-N weight whose leading dims are all 1  -> still one matrix -> 0
+    // transB only swaps the trailing two extents, so the per-matrix element
+    // count stays K * N either way.
+    // The leading-one case ([1, K, N]) is why this is not simply
+    // `BRank > 2 ? K*N : 0`: treating it as per-batch reads K*N elements past
+    // the end of the weight on every batch after the first.
+    Value bBatchStride;
+    if (BRank == 2) {
+      bBatchStride = createI64Const(0);
+    } else {
+      bool allLeadingStatic = true;
+      int64_t staticLeadingProduct = 1;
+      for (int64_t i : llvm::seq<int64_t>(0, BRank - 2)) {
+        if (BType.isDynamicDim(i)) {
+          allLeadingStatic = false;
+          break;
+        }
+        staticLeadingProduct *= BType.getDimSize(i);
+      }
+      if (allLeadingStatic) {
+        bBatchStride = (staticLeadingProduct <= 1)
+                           ? createI64Const(0)
+                           : LLVM::MulOp::create(rewriter, loc, K, N).getRes();
+      } else {
+        Value one = createI64Const(1);
+        Value zero = createI64Const(0);
+        Value leadingProduct = one;
+        for (int64_t i : llvm::seq<int64_t>(0, BRank - 2)) {
+          Value dim = BDesc.size(rewriter, loc, i);
+          leadingProduct =
+              LLVM::MulOp::create(rewriter, loc, leadingProduct, dim).getRes();
+        }
+        Value isBroadcast = LLVM::ICmpOp::create(
+            rewriter, loc, LLVM::ICmpPredicate::sle, leadingProduct, one);
+        Value kn = LLVM::MulOp::create(rewriter, loc, K, N).getRes();
+        bBatchStride =
+            LLVM::SelectOp::create(rewriter, loc, isBroadcast, zero, kn)
+                .getRes();
+      }
+    }
+
+    // Runtime signature:
+    // int wrap_qmatmul(RuntimeState* state,
+    //                  const void* A, const void* B, void* Y,
+    //                  int64_t M, int64_t N, int64_t K,
+    //                  int64_t batch_count, int64_t b_batch_stride,
+    //                  int64_t trans_a, int64_t trans_b,
+    //                  int64_t a_data_type, int64_t b_data_type,
+    //                  int64_t y_data_type, float M_scale,
+    //                  int64_t A_zero_point, int64_t B_zero_point,
+    //                  int64_t Y_zero_point)
+    SmallVector<Type, 18> paramTypes = {
+        ptrType, // state
+        ptrType, // A
+        ptrType, // B
+        ptrType, // Y
+        i64Type, // M
+        i64Type, // N
+        i64Type, // K
+        i64Type, // batch_count
+        i64Type, // b_batch_stride
+        i64Type, // trans_a
+        i64Type, // trans_b
+        i64Type, // a_data_type
+        i64Type, // b_data_type
+        i64Type, // y_data_type
+        f32Type, // M_scale
+        i64Type, // A_zero_point
+        i64Type, // B_zero_point
+        i64Type  // Y_zero_point
+    };
+
+    FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
+        rewriter, module, kWrapQMatMul, paramTypes, i32Type);
+    if (failed(funcOp))
+      return failure();
+
+    SmallVector<Value, 18> args = {
+        adaptor.getCtx(),
+        extractContiguousMemRefPtr(adaptor.getA(), rewriter, loc),
+        extractContiguousMemRefPtr(adaptor.getB(), rewriter, loc),
+        extractContiguousMemRefPtr(adaptor.getY(), rewriter, loc),
+        M,
+        N,
+        K,
+        batchCount,
+        bBatchStride,
+        createI64Const(transA),
+        createI64Const(transB),
+        createI64Const(aDataType),
+        createI64Const(bDataType),
+        createI64Const(yDataType),
+        mScaleValue,
+        createI64Const(op.getAZeroPoint()),
+        createI64Const(op.getBZeroPoint()),
+        createI64Const(op.getYZeroPoint())};
+
+    LLVM::CallOp::create(rewriter, loc, *funcOp, args);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+} // namespace
+
+void populateQMatMulLoweringPatterns(const LLVMTypeConverter &converter,
+                                     RewritePatternSet &patterns) {
+  patterns.add<QMatMulOpLowering>(converter);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/HipToLLVM/QMatMulLowering.cpp
+++ b/lib/Conversion/HipToLLVM/QMatMulLowering.cpp
@@ -53,7 +53,8 @@ struct QMatMulOpLowering : public ConvertOpToLLVMPattern<QMatMulOp> {
             op, "expected 8- or 16-bit A and Y element types");
     }
     if (!BType.getElementType().isInteger(8))
-      return rewriter.notifyMatchFailure(op, "expected an 8-bit B element type");
+      return rewriter.notifyMatchFailure(op,
+                                         "expected an 8-bit B element type");
     int64_t aDataType = getHipdnnDataType(AType.getElementType());
     int64_t bDataType = getHipdnnDataType(BType.getElementType());
     int64_t yDataType = getHipdnnDataType(YType.getElementType());

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -23,25 +23,24 @@ if(MLIR_PDLL_EXE)
     # once and emits one PDL module. Every .pdll is still globbed as a
     # dependency, otherwise editing an included pattern would not rebuild it.
     set(PDL_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/pdl")
-    set(PDL_ENTRY "${PDL_SOURCE_DIR}/HipFusionPatterns.pdll")
     file(GLOB PDL_SOURCES CONFIGURE_DEPENDS "${PDL_SOURCE_DIR}/*.pdll")
-    set(PDL_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/pdl")
-    file(MAKE_DIRECTORY "${PDL_BUILD_DIR}")
-    set(PDL_OUTPUT "${PDL_BUILD_DIR}/HipFusionPatterns.pdl.mlir")
-    set(PDL_RUNTIME_OUTPUT "${CMAKE_BINARY_DIR}/bin/HipFusionPatterns.pdl.mlir")
-    add_custom_command(OUTPUT "${PDL_OUTPUT}" "${PDL_RUNTIME_OUTPUT}"
+    set(PDL_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/HipFusionPatterns.pdl.mlir")
+    # ConvertOnnxToHipPass loads the patterns from the EP library's own
+    # directory, which multi-config generators put under a per-config
+    # subdirectory of CMAKE_RUNTIME_OUTPUT_DIRECTORY.
+    get_property(_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+    set(PDL_STAGED
+        "${CMAKE_BINARY_DIR}/bin/$<$<BOOL:${_multi_config}>:$<CONFIG>/>HipFusionPatterns.pdl.mlir")
+    add_custom_command(OUTPUT "${PDL_OUTPUT}" "${PDL_STAGED}"
         COMMAND "${MLIR_PDLL_EXE}" -x mlir "-I${PDL_SOURCE_DIR}"
-                "${PDL_ENTRY}" -o "${PDL_OUTPUT}"
-        COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_BINARY_DIR}/bin"
-        COMMAND "${CMAKE_COMMAND}" -E copy_if_different
-                "${PDL_OUTPUT}" "${PDL_RUNTIME_OUTPUT}"
+                "${PDL_SOURCE_DIR}/HipFusionPatterns.pdll" -o "${PDL_OUTPUT}"
+        COMMAND "${CMAKE_COMMAND}" -E copy "${PDL_OUTPUT}" "${PDL_STAGED}"
         DEPENDS ${PDL_SOURCES}
-        COMMENT "Compiling PDLL patterns: HipFusionPatterns.pdll -> HipFusionPatterns.pdl.mlir (+ bin copy)"
+        COMMENT "Compiling PDLL patterns -> HipFusionPatterns.pdl.mlir"
         VERBATIM)
-    add_custom_target(HipPdllPatterns DEPENDS "${PDL_OUTPUT}" "${PDL_RUNTIME_OUTPUT}")
+    add_custom_target(HipPdllPatterns DEPENDS "${PDL_OUTPUT}" "${PDL_STAGED}")
     install(FILES "${PDL_OUTPUT}" DESTINATION bin)
-    # ConvertOnnxToHipPass resolves the patterns next to the loaded EP module,
-    # so every packaging path (install tree, wheel, staged test package) has to
+    # Every packaging path (install tree, wheel, staged test package) has to
     # ship this file beside the EP library. Export it for those consumers.
     set(HIP_PDL_FUSION_PATTERNS "${PDL_OUTPUT}" CACHE INTERNAL
         "Compiled PDL fusion patterns that must ship beside the EP library")

--- a/lib/Conversion/OnnxToHip/pdl/HipFusionPatterns.pdll
+++ b/lib/Conversion/OnnxToHip/pdl/HipFusionPatterns.pdll
@@ -20,10 +20,15 @@
 Constraint HasContextArg(op: Op);
 Constraint IsSplatConstantValue(val: Value);
 Constraint HasExtractableZeropoint(op: Op, index: Attr);
+Constraint IsEightBitQuantized(op: Op);
+Constraint IsEightOrSixteenBitQuantized(op: Op);
+Constraint HasStaticShapedResults(op: Op);
 
 Rewrite GetContextArg(op: Op) -> Value;
 Rewrite ExtractScaleValue(val: Value) -> Attr;
 Rewrite ExtractZeropointValue(op: Op, index: Attr, defaultValue: Attr) -> Attr;
+Rewrite ExtractAttrInt64(op: Op, name: Attr, defaultValue: Attr) -> Attr;
 
 #include "QDQAddFusion.pdll"
 #include "QDQMulFusion.pdll"
+#include "QDQMatMulFusion.pdll"

--- a/lib/Conversion/OnnxToHip/pdl/QDQMatMulFusion.pdll
+++ b/lib/Conversion/OnnxToHip/pdl/QDQMatMulFusion.pdll
@@ -1,0 +1,72 @@
+//===- QDQMatMulFusion.pdll -----------------------------------------------===//
+//
+// PDLL pattern for QDQ MatMul fusion - pure PDLL approach.
+//
+// Included by HipFusionPatterns.pdll, which declares the native constraints
+// used below. Not compilable on its own.
+//===----------------------------------------------------------------------===//
+
+Pattern QDQMatMul with benefit(10) {
+  // Match the QDQ chain:
+  //   DequantizeLinear, DequantizeLinear -> MatMul -> QuantizeLinear
+  //
+  // ONNX makes zero_point optional on both Q and DQ, so a trailing ValueRange
+  // absorbs the 2-operand and 3-operand forms with one pattern.
+  let dq_a = op<onnx.DequantizeLinear>(a: Value, a_scale: Value, a_tail: ValueRange);
+  let dq_b = op<onnx.DequantizeLinear>(b: Value, b_scale: Value, b_tail: ValueRange);
+
+  // Currently, we support A16W8 and A8W8. A16W16 requires a higher-bit-width
+  // accumulator and therefore an additional kernel implementation, so we will
+  // not add support for it for now.
+  IsEightOrSixteenBitQuantized(dq_a);
+  IsEightBitQuantized(dq_b);
+
+  let matmul = op<onnx.MatMul>(dq_a.0, dq_b.0);
+
+  let quant = op<onnx.QuantizeLinear>(matmul.0, y_scale: Value, y_tail: ValueRange) -> (y_type: Type);
+  IsEightOrSixteenBitQuantized(quant);
+
+  // The rewrite below builds its DPS init with a bare `tensor.empty`, which
+  // only verifies for a static result type.
+  HasStaticShapedResults(quant);
+
+  // Fusability only: every scale must be a per-tensor splat constant and every
+  // zero point must be readable (or absent, which means zero).
+  HasContextArg(quant);
+  IsSplatConstantValue(a_scale);
+  IsSplatConstantValue(b_scale);
+  IsSplatConstantValue(y_scale);
+  HasExtractableZeropoint(dq_a, attr<"2 : i64">);
+  HasExtractableZeropoint(dq_b, attr<"2 : i64">);
+  HasExtractableZeropoint(quant, attr<"2 : i64">);
+
+  // Root on the chain tail so the output type is available for tensor.empty.
+  rewrite quant with {
+    let ctx = GetContextArg(quant);
+    let a_scale_attr = ExtractScaleValue(a_scale);
+    let b_scale_attr = ExtractScaleValue(b_scale);
+    let y_scale_attr = ExtractScaleValue(y_scale);
+    let a_zeropoint_attr = ExtractZeropointValue(dq_a, attr<"2 : i64">, attr<"0 : i64">);
+    let b_zeropoint_attr = ExtractZeropointValue(dq_b, attr<"2 : i64">, attr<"0 : i64">);
+    let y_zeropoint_attr = ExtractZeropointValue(quant, attr<"2 : i64">, attr<"0 : i64">);
+
+    // TransposeMatMulFold stamps hipdnn.transA / hipdnn.transB onto
+    // onnx.MatMul, so hip.qmatmul carries them through even though nothing
+    // reaches this pattern with a non-zero stamp today.
+    let trans_a_attr = ExtractAttrInt64(matmul, attr<"\"hipdnn.transA\"">, attr<"0 : i64">);
+    let trans_b_attr = ExtractAttrInt64(matmul, attr<"\"hipdnn.transB\"">, attr<"0 : i64">);
+
+    let empty = op<tensor.empty> -> (y_type);
+    let qmatmul = op<hip.qmatmul>(ctx, a, b, empty.0) {
+      A_scale = a_scale_attr,
+      A_zero_point = a_zeropoint_attr,
+      B_scale = b_scale_attr,
+      B_zero_point = b_zeropoint_attr,
+      Y_scale = y_scale_attr,
+      Y_zero_point = y_zeropoint_attr,
+      transA = trans_a_attr,
+      transB = trans_b_attr
+    } -> (y_type);
+    replace quant with qmatmul;
+  };
+}

--- a/lib/Conversion/OnnxToHip/pdl/qdq_fusion_pass.hpp
+++ b/lib/Conversion/OnnxToHip/pdl/qdq_fusion_pass.hpp
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-// qdq_fusion_pass.hpp — PDL fusion pass for QDQ MatMul patterns
+// qdq_fusion_pass.hpp — PDL fusion pass for QDQ patterns
 
 #pragma once
 
@@ -122,6 +122,52 @@ hasExtractableZeropoint(mlir::PatternRewriter &, mlir::PDLResultList &,
                            .has_value());
 }
 
+// Restrict a Q/DQ op to an 8-bit quantized side.
+inline mlir::LogicalResult
+isEightBitQuantized(mlir::PatternRewriter &, mlir::PDLResultList &,
+                    llvm::ArrayRef<mlir::PDLValue> args) {
+  if (args.size() != 1)
+    return mlir::failure();
+  auto *op = args[0].dyn_cast<mlir::Operation *>();
+  if (!op)
+    return mlir::failure();
+  auto quantType = getQuantizedElementType(op);
+  return mlir::success(quantType && quantType.getWidth() == 8);
+}
+
+// Restrict a Q/DQ op to an 8- or 16-bit quantized side.
+inline mlir::LogicalResult
+isEightOrSixteenBitQuantized(mlir::PatternRewriter &, mlir::PDLResultList &,
+                             llvm::ArrayRef<mlir::PDLValue> args) {
+  if (args.size() != 1)
+    return mlir::failure();
+  auto *op = args[0].dyn_cast<mlir::Operation *>();
+  if (!op)
+    return mlir::failure();
+  auto quantType = getQuantizedElementType(op);
+  if (!quantType)
+    return mlir::failure();
+  unsigned width = quantType.getWidth();
+  return mlir::success(width == 8 || width == 16);
+}
+
+// Require every result of `op` to have a static shape.
+inline mlir::LogicalResult
+hasStaticShapedResults(mlir::PatternRewriter &, mlir::PDLResultList &,
+                       llvm::ArrayRef<mlir::PDLValue> args) {
+  if (args.size() != 1)
+    return mlir::failure();
+  auto *op = args[0].dyn_cast<mlir::Operation *>();
+  if (!op || op->getNumResults() == 0)
+    return mlir::failure();
+  for (mlir::Value result : op->getResults()) {
+    auto shaped = mlir::dyn_cast<mlir::ShapedType>(result.getType());
+    if (!shaped || !shaped.hasStaticShape())
+      return mlir::failure();
+  }
+  return mlir::success();
+}
+
 //===----------------------------------------------------------------------===//
 // Rewrite functions -- reached only after the constraints above accepted.
 //===----------------------------------------------------------------------===//
@@ -171,6 +217,33 @@ extractZeropointValue(mlir::PatternRewriter &rewriter,
   return mlir::success();
 }
 
+// args[0] = op, args[1] = attribute name, args[2] = value to use when absent.
+// Return failure if the attribute is not an i64 integer attribute.
+inline mlir::LogicalResult
+extractAttrInt64(mlir::PatternRewriter &rewriter,
+                 mlir::PDLResultList &results,
+                 llvm::ArrayRef<mlir::PDLValue> args) {
+  if (args.size() != 3)
+    return mlir::failure();
+
+  auto *op = args[0].dyn_cast<mlir::Operation *>();
+  auto nameAttr = mlir::dyn_cast_or_null<mlir::StringAttr>(
+      args[1].dyn_cast<mlir::Attribute>());
+  auto defaultValue = mlir::dyn_cast_or_null<mlir::IntegerAttr>(
+      args[2].dyn_cast<mlir::Attribute>());
+
+  if (!op || !nameAttr || !defaultValue)
+    return mlir::failure();
+
+  auto attr = op->getAttrOfType<mlir::IntegerAttr>(nameAttr.getValue());
+
+  if (attr && !attr.getType().isInteger(64))
+    return mlir::failure();
+
+  results.push_back(attr ? attr : defaultValue);
+  return mlir::success();
+}
+
 // Apply PDL patterns
 inline bool run(mlir::ModuleOp mlirModule, llvm::StringRef pdlBytecodeFile) {
   if (pdlBytecodeFile.empty())
@@ -192,10 +265,17 @@ inline bool run(mlir::ModuleOp mlirModule, llvm::StringRef pdlBytecodeFile) {
                                          isSplatConstantValue);
   pdlPatterns.registerConstraintFunction("HasExtractableZeropoint",
                                          hasExtractableZeropoint);
+  pdlPatterns.registerConstraintFunction("IsEightBitQuantized",
+                                         isEightBitQuantized);
+  pdlPatterns.registerConstraintFunction("IsEightOrSixteenBitQuantized",
+                                         isEightOrSixteenBitQuantized);
+  pdlPatterns.registerConstraintFunction("HasStaticShapedResults",
+                                         hasStaticShapedResults);
   pdlPatterns.registerRewriteFunction("GetContextArg", getContextArg);
   pdlPatterns.registerRewriteFunction("ExtractScaleValue", extractScaleValue);
   pdlPatterns.registerRewriteFunction("ExtractZeropointValue",
                                       extractZeropointValue);
+  pdlPatterns.registerRewriteFunction("ExtractAttrInt64", extractAttrInt64);
 
   mlir::RewritePatternSet patterns(ctx);
   patterns.add(std::move(pdlPatterns));

--- a/lib/Conversion/OnnxToHip/pdl/qdq_fusion_pass.hpp
+++ b/lib/Conversion/OnnxToHip/pdl/qdq_fusion_pass.hpp
@@ -221,8 +221,7 @@ extractZeropointValue(mlir::PatternRewriter &rewriter,
 // args[0] = op, args[1] = attribute name, args[2] = value to use when absent.
 // Return failure if the attribute is not an i64 integer attribute.
 inline mlir::LogicalResult
-extractAttrInt64(mlir::PatternRewriter &rewriter,
-                 mlir::PDLResultList &results,
+extractAttrInt64(mlir::PatternRewriter &rewriter, mlir::PDLResultList &results,
                  llvm::ArrayRef<mlir::PDLValue> args) {
   if (args.size() != 3)
     return mlir::failure();

--- a/lib/Conversion/OnnxToHip/pdl/qdq_fusion_pass.hpp
+++ b/lib/Conversion/OnnxToHip/pdl/qdq_fusion_pass.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "mlir/Dialect/PDL/IR/PDL.h"
+#include "mlir/Dialect/PDL/IR/PDLOps.h"
 #include "mlir/Dialect/PDLInterp/IR/PDLInterp.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/PatternMatch.h"
@@ -256,6 +257,13 @@ inline bool run(mlir::ModuleOp mlirModule, llvm::StringRef pdlBytecodeFile) {
       mlir::parseSourceFile<mlir::ModuleOp>(pdlBytecodeFile, parseConfig);
   if (!pdlModule)
     return false;
+
+  // FrozenRewritePatternSet skips the PDL-to-PDLInterp lowering for a module
+  // holding no pdl.pattern, then still asks the bytecode generator for the
+  // @matcher function that lowering would have produced. Bail out first so a
+  // pattern set that is empty (every pattern disabled) stays a no-op.
+  if (pdlModule->getOps<mlir::pdl::PatternOp>().empty())
+    return true;
 
   mlir::PDLPatternModule pdlPatterns(std::move(pdlModule));
 

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -733,8 +733,7 @@ LogicalResult QMatMulOp::verify() {
       *this, [&]() -> SmallVector<SmallVector<int64_t>> {
         SmallVector<int64_t> outShape = mlir::hip::inferMatmulShape(
             getShapeOf(getA()), getShapeOf(getB()),
-            [&]() { return this->emitOpError(); }, /*transA=*/0,
-            /*transB=*/0);
+            [&]() { return this->emitOpError(); }, getTransA(), getTransB());
         if (outShape.empty())
           return {};
         return {std::move(outShape)};

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -712,6 +712,39 @@ LogicalResult MatmulOp::verify() {
 // that file and `docs/design/hip-shape-inference.md` for the rationale.
 
 //===----------------------------------------------------------------------===//
+// QMatMulOp: ins(A, B), outs(Y)
+// Quantized matrix multiplication with integrated QDQ scales and zero points
+//===----------------------------------------------------------------------===//
+
+MutableOperandRange QMatMulOp::getDpsInitsMutable() { return getYMutable(); }
+
+void QMatMulOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
+}
+
+LogicalResult QMatMulOp::verify() {
+  if (failed(verifyDpsComputeOp(*this, {getA(), getB(), getY()},
+                                /*numInits=*/1)))
+    return failure();
+
+  return mlir::hip::verifyHipOpShape(
+      *this, [&]() -> SmallVector<SmallVector<int64_t>> {
+        SmallVector<int64_t> outShape = mlir::hip::inferMatmulShape(
+            getShapeOf(getA()), getShapeOf(getB()),
+            [&]() { return this->emitOpError(); }, /*transA=*/0,
+            /*transB=*/0);
+        if (outShape.empty())
+          return {};
+        return {std::move(outShape)};
+      });
+}
+
+// `QMatMulOp::reifyResultShapes` lives in
+// `lib/Dialect/IR/HipReifyResultShapesImpl.cpp`.
+
+//===----------------------------------------------------------------------===//
 // RmsNormOp: ins(input, scale), outs(output)
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
+++ b/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
@@ -39,7 +39,6 @@ ArrayRef<int64_t> getShapeOf(Value v) {
   return {};
 }
 
-
 LogicalResult reifyMatmulLikeShape(Operation *op, OpBuilder &b, Value A,
                                    Value B, int64_t transA, int64_t transB,
                                    ReifiedRankedShapedTypeDims &reified) {

--- a/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
+++ b/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
@@ -39,49 +39,28 @@ ArrayRef<int64_t> getShapeOf(Value v) {
   return {};
 }
 
-} // namespace
 
-//===----------------------------------------------------------------------===//
-// MatmulOp
-//
-// Reify recomputes the result shape via `inferMatmulShape`, then lifts
-// each dim to an OpFoldResult: static dims become `IndexAttr`; dynamic
-// dims become `tensor.dim` of whichever operand contributes the runtime
-// size — M from A[-2], N from B[-1], batch from the broadcast-canonical
-// side.
-//
-// Before:
-//   %m = hip.matmul ins(%a, %b : tensor<?x4096xf16>, tensor<4096x4096xf16>)
-//                   outs(%out : tensor<?x4096xf16>) -> tensor<?x4096xf16>
-// After (reified result shape):
-//   dim 0 (dynamic M) -> %d0 = tensor.dim %a, %c0
-//   dim 1 (static N)  -> 4096 : index
-//===----------------------------------------------------------------------===//
-
-LogicalResult
-MatmulOp::reifyResultShapes(OpBuilder &b,
-                            ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+LogicalResult reifyMatmulLikeShape(Operation *op, OpBuilder &b, Value A,
+                                   Value B, int64_t transA, int64_t transB,
+                                   ReifiedRankedShapedTypeDims &reified) {
   // memref-mode has no SSA results; reify is only called on tensor mode
   // per interface contract, but bail defensively if invoked anyway.
-  if (getNumResults() == 0)
+  if (op->getNumResults() == 0)
     return failure();
 
-  ArrayRef<int64_t> aShape = getShapeOf(getA());
-  ArrayRef<int64_t> bShape = getShapeOf(getB());
+  ArrayRef<int64_t> aShape = getShapeOf(A);
+  ArrayRef<int64_t> bShape = getShapeOf(B);
   if (aShape.empty() || bShape.empty())
     return failure();
 
   // Re-run the matmul-shape helper. verify() has already passed by reify
   // time, but bail on empty() in case a pre-verify call sneaks in.
   SmallVector<int64_t> outShape = mlir::hip::inferMatmulShape(
-      aShape, bShape, [&]() { return this->emitOpError(); }, getTransA(),
-      getTransB());
+      aShape, bShape, [&]() { return op->emitOpError(); }, transA, transB);
   if (outShape.empty())
     return failure();
 
-  Location loc = getLoc();
-  Value A = getA();
-  Value B = getB();
+  Location loc = op->getLoc();
   size_t outRank = outShape.size();
   size_t aRank = aShape.size();
   size_t bRank = bShape.size();
@@ -96,14 +75,14 @@ MatmulOp::reifyResultShapes(OpBuilder &b,
   for (size_t i : llvm::seq<size_t>(0, outRank)) {
     // M dim: A[-2], or A[-1] when transA.
     if (i + 2 == outRank) {
-      size_t aDim = getTransA() ? aRank - 1 : aRank - 2;
+      size_t aDim = transA ? aRank - 1 : aRank - 2;
       dims.push_back(
           mlir::hip::reifyDimOrConstant(b, loc, outShape[i], A, aDim));
       continue;
     }
     // N dim: B[-1], or B[-2] when transB.
     if (i + 1 == outRank) {
-      size_t bDim = getTransB() ? bRank - 2 : bRank - 1;
+      size_t bDim = transB ? bRank - 2 : bRank - 1;
       dims.push_back(
           mlir::hip::reifyDimOrConstant(b, loc, outShape[i], B, bDim));
       continue;
@@ -120,8 +99,33 @@ MatmulOp::reifyResultShapes(OpBuilder &b,
     dims.push_back(
         mlir::hip::reifyDimOrConstant(b, loc, outShape[i], src, srcDim));
   }
-  reifiedReturnShapes.assign({std::move(dims)});
+  reified.assign({std::move(dims)});
   return success();
+}
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// MatmulOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+MatmulOp::reifyResultShapes(OpBuilder &b,
+                            ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+  return reifyMatmulLikeShape(getOperation(), b, getA(), getB(), getTransA(),
+                              getTransB(), reifiedReturnShapes);
+}
+
+//===----------------------------------------------------------------------===//
+// QMatMulOp
+//
+//===----------------------------------------------------------------------===//
+
+LogicalResult
+QMatMulOp::reifyResultShapes(OpBuilder &b,
+                             ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+  return reifyMatmulLikeShape(getOperation(), b, getA(), getB(), /*transA=*/0,
+                              /*transB=*/0, reifiedReturnShapes);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
+++ b/lib/Dialect/IR/HipReifyResultShapesImpl.cpp
@@ -124,8 +124,8 @@ MatmulOp::reifyResultShapes(OpBuilder &b,
 LogicalResult
 QMatMulOp::reifyResultShapes(OpBuilder &b,
                              ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
-  return reifyMatmulLikeShape(getOperation(), b, getA(), getB(), /*transA=*/0,
-                              /*transB=*/0, reifiedReturnShapes);
+  return reifyMatmulLikeShape(getOperation(), b, getA(), getB(), getTransA(),
+                              getTransB(), reifiedReturnShapes);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -387,6 +387,7 @@ if(NOT BUILD_MOCK_RUNTIME)
     compile_to_bitcode(real/grid_sample.cpp runtime_grid_sample.bc)
     compile_to_bitcode(real/global_pool.cpp runtime_global_pool.bc)
     compile_to_bitcode(real/qelementwise.cpp runtime_qelementwise.bc)
+    compile_to_bitcode(real/qmatmul.cpp runtime_qmatmul.bc)
 
     # GQA offline-autotune LUT, embedded into runtime.bc so the JIT'd runtime
     # always has it: it ships with the project build (inside runtime.bc), not
@@ -515,6 +516,7 @@ if(NOT BUILD_MOCK_RUNTIME)
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_gather_block_quantized.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_qdq.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_qelementwise.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_qmatmul.bc
     )
     # Vendor-symbol stubs (see the compile_to_bitcode above) join runtime.bc only
     # when the vendor BLAS/DNN backends are disabled.

--- a/lib/Runtime/Kernels/CMakeLists.txt
+++ b/lib/Runtime/Kernels/CMakeLists.txt
@@ -50,6 +50,7 @@ set(_kernel_sources
     hip/softplus_kernel.hip
     hip/elementwise_where_kernel.hip
     hip/qelementwise_kernel.hip
+    hip/qmatmul_kernel.hip
     hip/elementwise_unary_kernel.hip
     hip/elementwise_binary_kernel.hip  # Mul/Add/Min/Max/Div/Mod/Equal/Less
     hip/tile_kernel.hip

--- a/lib/Runtime/Kernels/hip/qmatmul_kernel.hip
+++ b/lib/Runtime/Kernels/hip/qmatmul_kernel.hip
@@ -1,0 +1,574 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+// FusedOp(A,B) = Q(DQ(A) @ DQ(B))
+//
+// a = (A - z_a) * s_a
+// b = (B - z_b) * s_b
+// Y = saturate(round((a @ b) / s_y) + z_y)
+//
+// (a @ b)[m,n] = s_a*s_b * sum_k (A[m,k] - z_a) * (B[k,n] - z_b)
+//              = s_a*s_b * (acc[m,n] - z_b*rowA[m] - z_a*colB[n] + K*z_a*z_b)
+//   acc[m,n] = sum_k A[m,k]*B[k,n]
+//   rowA[m]  = sum_k A[m,k]
+//   colB[n]  = sum_k B[k,n]
+// --->
+// let M = s_a * s_b / s_y   (folded by lowering)
+// Y = saturate(round(M * (acc - z_b*rowA - z_a*colB + K*z_a*z_b)) + z_y)
+//
+// A - z_a does not fit back into 8 bits, so the zero points cannot be folded
+// into the operands; they are carried as the rowA / colB correction terms
+// instead. Each term is only accumulated when its zero point is non-zero, so
+// the symmetric weights that dominate real QDQ graphs cost nothing extra.
+//
+// 16-bit activations (A16W8)
+// --------------------------
+// A may be 16-bit while B stays 8-bit. Two things break at that width: the
+// int32 accumulator overflows at K around 256 (a single u16*u8 product already
+// reaches 1.7e7), and hipdnn_dot4 is a 4x8-bit instruction that cannot see a
+// 16-bit operand at all.
+//
+// Both are solved by splitting A into its two bytes. With
+//
+//   A = hi * 256 + lo,   hi = A >> 8,   lo = A & 0xFF
+//
+// (an arithmetic shift for int16 and a logical one for uint16, so hi carries
+// A's signedness and lo is always unsigned), the dot product separates into
+// two 8-bit dot products:
+//
+//   acc  = sum_k A[k]*B[k] = 256 * sum_k hi[k]*B[k] + sum_k lo[k]*B[k]
+//   rowA = sum_k A[k]      = 256 * sum_k hi[k]      + sum_k lo[k]
+//
+// Each half runs on dot4 with its own int32 accumulator -- |lo*B| <= 255*128
+// keeps K under 65792, far past any real shape -- and the two halves are
+// combined in int64 at the epilogue. The result is exact, and the cost is two
+// dot4 instructions per term instead of one rather than the 4x-plus slowdown a
+// scalar int64 inner loop would bring.
+//
+// The GEMV path (M == 1) is bandwidth-bound and does not use dot4, so it just
+// accumulates in int64 directly instead of splitting.
+
+#include "debug_log.h"
+#include "hip_arch_compat.h"
+#include "hip_custom_kernels.h"
+
+#include <hip/hip_runtime.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+
+namespace {
+
+// All-ones byte vector: dot4(x, kOnes4) sums the four bytes of x, which is how
+// rowA / colB ride along on the same integer dot pipeline as the products.
+constexpr int kOnes4 = 0x01010101;
+
+template <typename T> struct QMatMulTraits;
+
+template <> struct QMatMulTraits<int8_t> {
+  static constexpr bool kSigned = true;
+  __device__ static float lowest() { return static_cast<float>(INT8_MIN); }
+  __device__ static float highest() { return static_cast<float>(INT8_MAX); }
+};
+
+template <> struct QMatMulTraits<uint8_t> {
+  static constexpr bool kSigned = false;
+  __device__ static float lowest() { return 0.0f; }
+  __device__ static float highest() { return static_cast<float>(UINT8_MAX); }
+};
+
+template <> struct QMatMulTraits<int16_t> {
+  static constexpr bool kSigned = true;
+  __device__ static float lowest() { return static_cast<float>(INT16_MIN); }
+  __device__ static float highest() { return static_cast<float>(INT16_MAX); }
+};
+
+template <> struct QMatMulTraits<uint16_t> {
+  static constexpr bool kSigned = false;
+  __device__ static float lowest() { return 0.0f; }
+  __device__ static float highest() { return static_cast<float>(UINT16_MAX); }
+};
+
+// The HIP compile flags include `-Xclang -fno-cuda-host-device-constexpr`
+// (see lib/Runtime/Kernels/cmake/hip_utils.cmake), which makes
+// `std::numeric_limits<T>` members host-only, hence the explicit bounds above.
+template <typename T> __device__ inline T q_saturate(float v) {
+  return static_cast<T>(
+      fminf(QMatMulTraits<T>::highest(), fmaxf(QMatMulTraits<T>::lowest(), v)));
+}
+
+// Requantize one accumulated output element.
+//
+// Everything is combined in int64: with a 16-bit A the four terms reach ~1e12
+// between them, and even at 8 bits their sum outgrows int32 for large K. The
+// narrowing to float afterwards is safe because m_scale immediately brings the
+// value back into the output's quantized range, so float's ~6e-8 relative
+// error stays two orders of magnitude below one LSB of a 16-bit output.
+template <typename TY>
+__device__ inline TY
+qmatmul_epilogue(int64_t acc, int64_t row_a, int64_t col_b, int64_t k_zazb,
+                 int32_t a_zp, int32_t b_zp, float m_scale, int32_t y_zp) {
+  const int64_t corrected = acc - static_cast<int64_t>(b_zp) * row_a -
+                            static_cast<int64_t>(a_zp) * col_b + k_zazb;
+  const float scaled = m_scale * static_cast<float>(corrected);
+  return q_saturate<TY>(rintf(scaled) + static_cast<float>(y_zp));
+}
+
+//===----------------------------------------------------------------------===//
+// Tiled GEMM (M > 1)
+//===----------------------------------------------------------------------===//
+
+constexpr int kTileM = 64;
+constexpr int kTileN = 64;
+constexpr int kTileK = 16;
+constexpr int kThreadM = 4;
+constexpr int kThreadN = 4;
+constexpr int kTiledBlock = (kTileM / kThreadM) * (kTileN / kThreadN); // 256
+// Rows of the transposed B tile that one pass over the block can stage.
+constexpr int kBStageRows = kTiledBlock / kTileN; // 4
+
+// The LDS tiles hold raw bytes: hipdnn_dot4's template flags decide how each
+// operand's bytes are interpreted, so staging never has to know the signedness.
+using QMatMulByte = uint8_t;
+
+// A 16-bit A is staged as two byte planes (hi, lo); an 8-bit one needs a single
+// plane holding the value itself. Indices into the plane dimension:
+constexpr int kPlaneHi = 0;
+constexpr int kPlaneLo = 1;
+
+template <typename TA> struct QMatMulAPlanes {
+  static constexpr bool kWide = sizeof(TA) == 2;
+  static constexpr int kCount = kWide ? 2 : 1;
+};
+
+// Reads 4 k-consecutive bytes of an LDS tile row as one dot4 operand. The tile
+// rows are kTileK bytes wide and the array is 16-byte aligned, so every
+// multiple-of-4 offset is a legal aligned int load.
+__device__ inline int lds_pack4(const QMatMulByte *row, int k) {
+  return *reinterpret_cast<const int *>(row + k);
+}
+
+// Y[b, m, n] = requantize(sum_k A[b, m, k] * B[b, k, n])
+//
+// Grid: (ceil(N/kTileN), ceil(M/kTileM), batch_count). Each block stages a
+// [kTileM x kTileK] slab of A and a [kTileN x kTileK] transposed slab of B into
+// LDS, then each thread reduces a kThreadM x kThreadN micro-tile over K.
+//
+// Both LDS tiles are k-major because dot4 needs four k-consecutive bytes in one
+// register. For a [K, N] B that means staging it transposed; for a [N, K] one
+// (trans_b) the tile is already in that order and staging is a straight copy.
+//
+// trans_a / trans_b are runtime flags rather than template parameters: they
+// only pick a load stride during staging, which is block-uniform and off the
+// dot4 inner loop, and templating them would quadruple the 32 instantiations
+// the dtype triple already costs.
+//
+// A 16-bit A is staged as two byte planes and every dot4 runs twice, once per
+// plane; see the byte-split derivation in the file header.
+template <typename TA, typename TB, typename TY>
+__global__ __launch_bounds__(kTiledBlock) void qmatmul_tiled_kernel(
+    const TA *__restrict__ A, const TB *__restrict__ B, TY *__restrict__ Y,
+    int64_t M, int64_t N, int64_t K, int64_t b_batch_stride, float m_scale,
+    int32_t a_zp, int32_t b_zp, int32_t y_zp, int64_t k_zazb, bool need_row_a,
+    bool need_col_b, bool trans_a, bool trans_b) {
+  constexpr bool kAWide = QMatMulAPlanes<TA>::kWide;
+  constexpr int kAPlanes = QMatMulAPlanes<TA>::kCount;
+  constexpr bool kASigned = QMatMulTraits<TA>::kSigned;
+  constexpr bool kBSigned = QMatMulTraits<TB>::kSigned;
+
+  __shared__ __align__(16) QMatMulByte a_lds[kAPlanes][kTileM][kTileK];
+  __shared__ __align__(16) QMatMulByte b_lds[kTileN][kTileK];
+
+  const int64_t batch = blockIdx.z;
+  A += batch * M * K;
+  B += batch * b_batch_stride;
+  Y += batch * M * N;
+
+  const int64_t m_base = static_cast<int64_t>(blockIdx.y) * kTileM;
+  const int64_t n_base = static_cast<int64_t>(blockIdx.x) * kTileN;
+  const int tid = threadIdx.x;
+
+  // Micro-tile origin of this thread inside the block tile.
+  const int thread_m = (tid / (kTileN / kThreadN)) * kThreadM;
+  const int thread_n = (tid % (kTileN / kThreadN)) * kThreadN;
+
+  // Per-plane accumulators. |lo * B| <= 255*128 bounds the widest plane, so
+  // int32 holds K up to 65792 -- past any shape the runtime admits.
+  int32_t acc[kAPlanes][kThreadM][kThreadN] = {};
+  int32_t row_a[kAPlanes][kThreadM] = {};
+  int32_t col_b[kThreadN] = {};
+
+  // Staging maps, each coalescing the reads of the layout it serves.
+  //
+  // `row4_*` walks a tile row-major, one 4-byte run per thread, which is what
+  // A wants and also what a [N, K] B wants since its k-runs are contiguous.
+  // kTileM == kTileN, so the one map covers both tiles.
+  //
+  // `b_*` walks a [K, N] B, where the k stride is N: one byte per thread per
+  // k, so the 64 threads sharing a k cover a contiguous 64-byte run.
+  static_assert(kTileM == kTileN, "row4 staging map is shared by A and B");
+  const int row4_r = (tid * 4) / kTileK;
+  const int row4_c = (tid * 4) % kTileK;
+  const int b_n = tid % kTileN;
+  const int b_k_base = tid / kTileN;
+
+  for (int64_t k0 = 0; k0 < K; k0 += kTileK) {
+    // Out-of-range elements are staged as 0. Zeros are the identity for all
+    // three sums (acc, rowA, colB), so no separate tail handling is needed.
+    const int64_t a_row = m_base + row4_r;
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {
+      const int64_t k = k0 + row4_c + i;
+      const bool in_range = a_row < M && k < K;
+      // A [K, M] costs a strided read here, unlike the contiguous [M, K] one.
+      // Left as is: TransposeMatMulFold folds Transpose into whichever operand
+      // the graph transposes, and attention's Q @ K^T only ever stamps transB.
+      const int64_t a_idx = trans_a ? k * M + a_row : a_row * K + k;
+      if constexpr (kAWide) {
+        // Promoting to int first makes `>> 8` arithmetic for int16 and logical
+        // for uint16, so hi inherits A's signedness while lo stays an unsigned
+        // byte -- exactly the split A = hi*256 + lo needs.
+        const int v = in_range ? static_cast<int>(A[a_idx]) : 0;
+        a_lds[kPlaneHi][row4_r][row4_c + i] = static_cast<QMatMulByte>(v >> 8);
+        a_lds[kPlaneLo][row4_r][row4_c + i] =
+            static_cast<QMatMulByte>(v & 0xFF);
+      } else {
+        a_lds[kPlaneHi][row4_r][row4_c + i] =
+            in_range ? static_cast<QMatMulByte>(A[a_idx]) : QMatMulByte{0};
+      }
+    }
+
+    if (trans_b) {
+      const int64_t b_row = n_base + row4_r;
+#pragma unroll
+      for (int i = 0; i < 4; ++i) {
+        const int64_t k = k0 + row4_c + i;
+        b_lds[row4_r][row4_c + i] =
+            (b_row < N && k < K) ? static_cast<QMatMulByte>(B[b_row * K + k])
+                                 : QMatMulByte{0};
+      }
+    } else {
+      const int64_t b_col = n_base + b_n;
+#pragma unroll
+      for (int rep = 0; rep < kTileK / kBStageRows; ++rep) {
+        const int b_k = b_k_base + rep * kBStageRows;
+        const int64_t k = k0 + b_k;
+        b_lds[b_n][b_k] = (b_col < N && k < K)
+                              ? static_cast<QMatMulByte>(B[k * N + b_col])
+                              : QMatMulByte{0};
+      }
+    }
+
+    __syncthreads();
+
+#pragma unroll
+    for (int kk = 0; kk < kTileK; kk += 4) {
+      int a_frag[kAPlanes][kThreadM];
+      int b_frag[kThreadN];
+#pragma unroll
+      for (int p = 0; p < kAPlanes; ++p) {
+#pragma unroll
+        for (int i = 0; i < kThreadM; ++i)
+          a_frag[p][i] = lds_pack4(a_lds[p][thread_m + i], kk);
+      }
+#pragma unroll
+      for (int j = 0; j < kThreadN; ++j)
+        b_frag[j] = lds_pack4(b_lds[thread_n + j], kk);
+
+#pragma unroll
+      for (int i = 0; i < kThreadM; ++i) {
+#pragma unroll
+        for (int j = 0; j < kThreadN; ++j) {
+          acc[kPlaneHi][i][j] = hipdnn_dot4<kASigned, kBSigned>(
+              a_frag[kPlaneHi][i], b_frag[j], acc[kPlaneHi][i][j]);
+          if constexpr (kAWide)
+            acc[kPlaneLo][i][j] = hipdnn_dot4<false, kBSigned>(
+                a_frag[kPlaneLo][i], b_frag[j], acc[kPlaneLo][i][j]);
+        }
+      }
+
+      // Block-uniform branches: the whole grid agrees on them, so the skipped
+      // dots cost nothing when the corresponding zero point is 0.
+      if (need_row_a) {
+#pragma unroll
+        for (int i = 0; i < kThreadM; ++i) {
+          row_a[kPlaneHi][i] = hipdnn_dot4<kASigned, false>(
+              a_frag[kPlaneHi][i], kOnes4, row_a[kPlaneHi][i]);
+          if constexpr (kAWide)
+            row_a[kPlaneLo][i] = hipdnn_dot4<false, false>(
+                a_frag[kPlaneLo][i], kOnes4, row_a[kPlaneLo][i]);
+        }
+      }
+      if (need_col_b) {
+#pragma unroll
+        for (int j = 0; j < kThreadN; ++j)
+          col_b[j] = hipdnn_dot4<kBSigned, false>(b_frag[j], kOnes4, col_b[j]);
+      }
+    }
+
+    __syncthreads();
+  }
+
+#pragma unroll
+  for (int i = 0; i < kThreadM; ++i) {
+    const int64_t m = m_base + thread_m + i;
+    if (m >= M)
+      continue;
+    int64_t row_a64;
+    if constexpr (kAWide)
+      row_a64 = int64_t{256} * row_a[kPlaneHi][i] + row_a[kPlaneLo][i];
+    else
+      row_a64 = row_a[kPlaneHi][i];
+#pragma unroll
+    for (int j = 0; j < kThreadN; ++j) {
+      const int64_t n = n_base + thread_n + j;
+      if (n >= N)
+        continue;
+      int64_t acc64;
+      if constexpr (kAWide)
+        acc64 = int64_t{256} * acc[kPlaneHi][i][j] + acc[kPlaneLo][i][j];
+      else
+        acc64 = acc[kPlaneHi][i][j];
+      Y[m * N + n] = qmatmul_epilogue<TY>(acc64, row_a64, col_b[j], k_zazb,
+                                          a_zp, b_zp, m_scale, y_zp);
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// GEMV (M == 1, the LLM decode shape)
+//===----------------------------------------------------------------------===//
+
+constexpr int kGemvBlock = 256;
+constexpr int kGemvTileK = 256;
+
+// Y[b, 0, n] = requantize(sum_k A[b, 0, k] * B[b, k, n])
+//
+// One thread per output column so that, for a fixed k, the block's global reads
+// of B are contiguous. A is identical across threads, so it is staged in LDS
+// once per k-tile instead of being re-read per column.
+//
+// A tiled GEMM degenerates badly at M == 1 (63 of 64 rows in each block tile
+// are padding), and this shape dominates LLM decode, so it gets its own path.
+//
+// The accumulators are int64 rather than the tiled path's split int32 planes:
+// this kernel is bandwidth-bound and does not use dot4, so the wider adds are
+// free here and the byte-split machinery would only add work.
+//
+// There is no trans_a flag: at M == 1 both layouts of A are the same K-element
+// vector, so the index is unchanged. trans_b costs the coalescing of the B
+// reads, since a [N, K] B puts each thread's column on its own row.
+template <typename TA, typename TB, typename TY>
+__global__ __launch_bounds__(kGemvBlock) void qmatmul_gemv_kernel(
+    const TA *__restrict__ A, const TB *__restrict__ B, TY *__restrict__ Y,
+    int64_t N, int64_t K, int64_t b_batch_stride, float m_scale, int32_t a_zp,
+    int32_t b_zp, int32_t y_zp, int64_t k_zazb, bool need_row_a,
+    bool need_col_b, bool trans_b) {
+  __shared__ int32_t a_lds[kGemvTileK];
+
+  const int64_t batch = blockIdx.y;
+  A += batch * K;
+  B += batch * b_batch_stride;
+  Y += batch * N;
+
+  const int64_t n = static_cast<int64_t>(blockIdx.x) * kGemvBlock + threadIdx.x;
+  const bool active = n < N;
+
+  int64_t acc = 0;
+  int64_t row_a = 0;
+  int64_t col_b = 0;
+
+  for (int64_t k0 = 0; k0 < K; k0 += kGemvTileK) {
+    const int64_t remaining = K - k0;
+    const int tile =
+        static_cast<int>(remaining < kGemvTileK ? remaining : kGemvTileK);
+    for (int t = threadIdx.x; t < tile; t += kGemvBlock)
+      a_lds[t] = static_cast<int32_t>(A[k0 + t]);
+    __syncthreads();
+
+    if (active) {
+      for (int t = 0; t < tile; ++t) {
+        const int64_t k = k0 + t;
+        const int32_t b_val =
+            static_cast<int32_t>(trans_b ? B[n * K + k] : B[k * N + n]);
+        acc += a_lds[t] * b_val;
+        if (need_col_b)
+          col_b += b_val;
+      }
+      // rowA does not depend on n; every thread recomputes it from LDS rather
+      // than paying a second reduction and broadcast.
+      if (need_row_a) {
+        for (int t = 0; t < tile; ++t)
+          row_a += a_lds[t];
+      }
+    }
+    __syncthreads();
+  }
+
+  if (active)
+    Y[n] = qmatmul_epilogue<TY>(acc, row_a, col_b, k_zazb, a_zp, b_zp, m_scale,
+                                y_zp);
+}
+
+//===----------------------------------------------------------------------===//
+// Dispatch
+//===----------------------------------------------------------------------===//
+
+// Bundled so the three dispatch levels below stay readable: A has 4 element
+// types, B has 2 and Y has 4, and threading a dozen scalars through 32 switch
+// arms by hand buries the one thing each arm actually says.
+struct QMatMulArgs {
+  hipStream_t stream;
+  const void *A;
+  const void *B;
+  void *Y;
+  int64_t M;
+  int64_t N;
+  int64_t K;
+  int64_t batch_count;
+  int64_t b_batch_stride;
+  bool trans_a;
+  bool trans_b;
+  float m_scale;
+  int32_t a_zp;
+  int32_t b_zp;
+  int32_t y_zp;
+};
+
+template <typename TA, typename TB, typename TY>
+int launch_qmatmul(const QMatMulArgs &g) {
+  const int64_t k_zazb = static_cast<int64_t>(g.K) * g.a_zp * g.b_zp;
+  const bool need_row_a = g.b_zp != 0;
+  const bool need_col_b = g.a_zp != 0;
+
+  const auto *a_ptr = static_cast<const TA *>(g.A);
+  const auto *b_ptr = static_cast<const TB *>(g.B);
+  auto *y_ptr = static_cast<TY *>(g.Y);
+
+  (void)hipGetLastError();
+  if (g.M == 1) {
+    dim3 grid(static_cast<unsigned>((g.N + kGemvBlock - 1) / kGemvBlock),
+              static_cast<unsigned>(g.batch_count));
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(qmatmul_gemv_kernel<TA, TB, TY>), grid,
+                       dim3(kGemvBlock), 0, g.stream, a_ptr, b_ptr, y_ptr, g.N,
+                       g.K, g.b_batch_stride, g.m_scale, g.a_zp, g.b_zp, g.y_zp,
+                       k_zazb, need_row_a, need_col_b, g.trans_b);
+  } else {
+    dim3 grid(static_cast<unsigned>((g.N + kTileN - 1) / kTileN),
+              static_cast<unsigned>((g.M + kTileM - 1) / kTileM),
+              static_cast<unsigned>(g.batch_count));
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(qmatmul_tiled_kernel<TA, TB, TY>), grid,
+                       dim3(kTiledBlock), 0, g.stream, a_ptr, b_ptr, y_ptr, g.M,
+                       g.N, g.K, g.b_batch_stride, g.m_scale, g.a_zp, g.b_zp,
+                       g.y_zp, k_zazb, need_row_a, need_col_b, g.trans_a,
+                       g.trans_b);
+  }
+  return 0;
+}
+
+// Y is 8- or 16-bit: a 16-bit activation is usually requantized back to 16-bit
+// to keep the precision it was chosen for, but an 8-bit output is legal too.
+template <typename TA, typename TB>
+int dispatch_y(int y_dtype, const QMatMulArgs &args) {
+  switch (y_dtype) {
+  case HIP_DTYPE_INT8:
+    return launch_qmatmul<TA, TB, int8_t>(args);
+  case HIP_DTYPE_UINT8:
+    return launch_qmatmul<TA, TB, uint8_t>(args);
+  case HIP_DTYPE_INT16:
+    return launch_qmatmul<TA, TB, int16_t>(args);
+  case HIP_DTYPE_UINT16:
+    return launch_qmatmul<TA, TB, uint16_t>(args);
+  default:
+    return -1;
+  }
+}
+
+// B stays 8-bit because only A is byte-split, leaving a 16-bit weight no path
+// through the dot4 pipeline. Splitting B the same way would work -- four
+// plane products instead of two, with the widest still bounded by 255*255 --
+// but is not implemented: 16-bit integer weights save neither space nor
+// bandwidth over fp16, which has hardware matrix instructions.
+template <typename TA>
+int dispatch_b(int b_dtype, int y_dtype, const QMatMulArgs &args) {
+  switch (b_dtype) {
+  case HIP_DTYPE_INT8:
+    return dispatch_y<TA, int8_t>(y_dtype, args);
+  case HIP_DTYPE_UINT8:
+    return dispatch_y<TA, uint8_t>(y_dtype, args);
+  default:
+    return -1;
+  }
+}
+
+int dispatch_a(int a_dtype, int b_dtype, int y_dtype, const QMatMulArgs &args) {
+  switch (a_dtype) {
+  case HIP_DTYPE_INT8:
+    return dispatch_b<int8_t>(b_dtype, y_dtype, args);
+  case HIP_DTYPE_UINT8:
+    return dispatch_b<uint8_t>(b_dtype, y_dtype, args);
+  case HIP_DTYPE_INT16:
+    return dispatch_b<int16_t>(b_dtype, y_dtype, args);
+  case HIP_DTYPE_UINT16:
+    return dispatch_b<uint16_t>(b_dtype, y_dtype, args);
+  default:
+    return -1;
+  }
+}
+
+} // namespace
+
+extern "C" int hip_qmatmul(void *stream, const void *A, const void *B, void *Y,
+                           int64_t M, int64_t N, int64_t K, int64_t batch_count,
+                           int64_t b_batch_stride, int trans_a, int trans_b,
+                           int a_dtype, int b_dtype, int y_dtype, float M_scale,
+                           int64_t a_zp, int64_t b_zp, int64_t y_zp) {
+  if (!A || !B || !Y) {
+    fprintf(stderr, "[custom_kernels] hip_qmatmul: null tensor argument\n");
+    return -1;
+  }
+  if (M <= 0 || N <= 0 || K <= 0 || batch_count <= 0)
+    return 0;
+
+  CUSTOM_KERNELS_DEBUG_LOG(
+      "[custom_kernels] hip_qmatmul: M=%lld N=%lld K=%lld batch=%lld "
+      "b_batch_stride=%lld trans=(%d,%d) dtypes=(%d,%d,%d) M_scale=%g "
+      "zp=(%lld,%lld,%lld)\n",
+      (long long)M, (long long)N, (long long)K, (long long)batch_count,
+      (long long)b_batch_stride, trans_a, trans_b, a_dtype, b_dtype, y_dtype,
+      (double)M_scale, (long long)a_zp, (long long)b_zp, (long long)y_zp);
+
+  const QMatMulArgs args{static_cast<hipStream_t>(stream),
+                         A,
+                         B,
+                         Y,
+                         M,
+                         N,
+                         K,
+                         batch_count,
+                         b_batch_stride,
+                         trans_a != 0,
+                         trans_b != 0,
+                         M_scale,
+                         static_cast<int32_t>(a_zp),
+                         static_cast<int32_t>(b_zp),
+                         static_cast<int32_t>(y_zp)};
+  const int rc = dispatch_a(a_dtype, b_dtype, y_dtype, args);
+
+  if (rc != 0) {
+    fprintf(stderr,
+            "[custom_kernels] hip_qmatmul: unsupported dtype triple "
+            "(a=%d, b=%d, y=%d)\n",
+            a_dtype, b_dtype, y_dtype);
+    return rc;
+  }
+
+  hipError_t err = hipGetLastError();
+  if (err != hipSuccess) {
+    fprintf(stderr, "[custom_kernels] hip_qmatmul launch failed: %s\n",
+            hipGetErrorString(err));
+  }
+  return static_cast<int>(err);
+}

--- a/lib/Runtime/Kernels/include/hip_arch_compat.h
+++ b/lib/Runtime/Kernels/include/hip_arch_compat.h
@@ -153,6 +153,50 @@ __device__ static inline int hipdnn_sudot4(int a, int b, int acc) {
 }
 #endif  /* __HIPCC__ */
 
+/* Portable 4x8-bit integer dot-product with i32 accumulate where BOTH operand
+ * signednesses are chosen by the caller. hipdnn_sudot4 above hard-codes
+ * "signed a, non-negative b", which does not cover an i8 x i8 or ui8 x ui8
+ * quantized GEMM.
+ *
+ * The intrinsic's sign flags must be compile-time constants, hence template
+ * parameters rather than runtime bools.
+ *
+ * RDNA3/RDNA4 (gfx11xx/gfx12xx) take both flags directly on the mixed-sign
+ * v_dot4_i32_iu8. CDNA (gfx9xx) has only the uniformly-signed v_dot4_i32_i8 and
+ * uniformly-unsigned v_dot4_i32_u8, so a mixed-sign pair there falls through to
+ * the scalar branch. The scalar branch also keeps the host pass (and any arch
+ * without dot instructions) compilable. Only defined in a HIP translation
+ * unit. */
+#if defined(__HIPCC__)
+template <bool ASigned, bool BSigned>
+__device__ static inline int hipdnn_dot4(int a, int b, int acc) {
+#if defined(__HIP_DEVICE_COMPILE__) && (defined(__GFX11__) || defined(__GFX12__))
+  return __builtin_amdgcn_sudot4(ASigned, a, BSigned, b, acc, false);
+#else
+#if defined(__HIP_DEVICE_COMPILE__) && defined(__GFX9__)
+  if constexpr (ASigned && BSigned)
+    return __builtin_amdgcn_sdot4(a, b, acc, false);
+  else if constexpr (!ASigned && !BSigned)
+    return static_cast<int>(__builtin_amdgcn_udot4(
+        static_cast<unsigned>(a), static_cast<unsigned>(b),
+        static_cast<unsigned>(acc), false));
+#endif
+  int r = acc;
+#pragma unroll
+  for (int i = 0; i < 4; ++i) {
+    const int a_byte = (a >> (i * 8)) & 0xFF;
+    const int b_byte = (b >> (i * 8)) & 0xFF;
+    const int av =
+        ASigned ? static_cast<int>(static_cast<signed char>(a_byte)) : a_byte;
+    const int bv =
+        BSigned ? static_cast<int>(static_cast<signed char>(b_byte)) : b_byte;
+    r += av * bv;
+  }
+  return r;
+#endif
+}
+#endif  /* __HIPCC__ */
+
 /* Host-side runtime probe for the wavefront size of the *currently selected*
  * device. Used by the host dispatch to avoid launching WMMA kernels on CDNA
  * (where they compile to a trap) and to size blocks as whole waves.

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -172,6 +172,38 @@ HIP_KERNEL_API int hip_qelementwise(
     int64_t output_zp);
 
 /* =========================================================================
+ * Quantized batched matmul (Q(DQ(A) @ DQ(B)))
+ * =========================================================================
+ *
+ * A: [batch_count x M x K], B: [K x N] when b_batch_stride == 0 or
+ * [batch_count x K x N] when b_batch_stride == K*N, Y: [batch_count x M x N].
+ * All row-major and contiguous.
+ *
+ * trans_a / trans_b swap the trailing two extents of the corresponding operand
+ * in memory -- A stored as [batch_count x K x M], B as [N x K] -- while M, N, K
+ * stay the logical extents and b_batch_stride stays K*N. Only the load stride
+ * changes; Y is never transposed.
+ *
+ * Supported hip_dtype, independently per edge:
+ *   a: HIP_DTYPE_INT8, HIP_DTYPE_UINT8, HIP_DTYPE_INT16, HIP_DTYPE_UINT16
+ *   b: HIP_DTYPE_INT8, HIP_DTYPE_UINT8
+ *   y: HIP_DTYPE_INT8, HIP_DTYPE_UINT8, HIP_DTYPE_INT16, HIP_DTYPE_UINT16
+ *
+ */
+HIP_KERNEL_API int hip_qmatmul(
+    void* stream,
+    const void* A,
+    const void* B,
+    void* Y,
+    int64_t M, int64_t N, int64_t K,
+    int64_t batch_count,
+    int64_t b_batch_stride,
+    int trans_a, int trans_b,
+    int a_dtype, int b_dtype, int y_dtype,
+    float M_scale,
+    int64_t a_zp, int64_t b_zp, int64_t y_zp);
+
+/* =========================================================================
  * Elementwise Unary (Neg / Sign / Cos / Sin / Not)
  * =========================================================================
  *

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -922,6 +922,24 @@ int wrap_qelementwise(RuntimeState *state, void *lhs, void *rhs, void *output,
                       int64_t data_type, float M_a, int64_t lhs_zp, float M_b,
                       int64_t rhs_zp, int64_t output_zp);
 
+// Quantized batched matmul wrapper: the integer-domain form of the fused
+// DequantizeLinear x2 -> MatMul -> QuantizeLinear chain.
+//
+//   A: [batch_count x M x K], B: [K x N] (broadcast when b_batch_stride == 0)
+//      or [batch_count x K x N], Y: [batch_count x M x N], all row-major.
+//
+// With acc[m,n] = sum_k A[m,k]*B[k,n], rowA[m] = sum_k A[m,k] and
+// colB[n] = sum_k B[k,n], all exact in int32:
+//
+//   Y = saturate(round(M_scale * (acc - B_zp*rowA - A_zp*colB + K*A_zp*B_zp))
+//                + Y_zp)
+int wrap_qmatmul(RuntimeState *state, const void *A, const void *B, void *Y,
+                 int64_t M, int64_t N, int64_t K, int64_t batch_count,
+                 int64_t b_batch_stride, int64_t trans_a, int64_t trans_b,
+                 int64_t a_data_type, int64_t b_data_type, int64_t y_data_type,
+                 float M_scale, int64_t A_zero_point, int64_t B_zero_point,
+                 int64_t Y_zero_point);
+
 // Element-wise Where wrapper (NumPy-style multidirectional broadcasting,
 // arbitrary rank). Computes output[i] = condition[i] ? x[i] : y[i] with
 // per-operand broadcasting.

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -1592,6 +1592,31 @@ int wrap_qelementwise(RuntimeState *state, void *lhs, void *rhs, void *output,
   return 0;
 }
 
+int wrap_qmatmul(RuntimeState *state, const void *A, const void *B, void *Y,
+                 int64_t M, int64_t N, int64_t K, int64_t batch_count,
+                 int64_t b_batch_stride, int64_t trans_a, int64_t trans_b,
+                 int64_t a_data_type, int64_t b_data_type, int64_t y_data_type,
+                 float M_scale, int64_t A_zero_point, int64_t B_zero_point,
+                 int64_t Y_zero_point) {
+  (void)A;
+  (void)B;
+  (void)Y;
+  (void)b_batch_stride;
+  (void)a_data_type;
+  (void)b_data_type;
+  (void)y_data_type;
+  (void)A_zero_point;
+  (void)B_zero_point;
+  (void)Y_zero_point;
+  if (!state)
+    return -1;
+  MOCK_PRINT("[MOCK] wrap_qmatmul(M=%lld, N=%lld, K=%lld, batch=%lld, "
+             "trans=(%lld,%lld), M_scale=%g)",
+             (long long)M, (long long)N, (long long)K, (long long)batch_count,
+             (long long)trans_a, (long long)trans_b, (double)M_scale);
+  return 0;
+}
+
 int wrap_and(RuntimeState *state, void *a, void *b, void *output, int64_t a_n,
              int64_t a_c, int64_t a_h, int64_t a_w, int64_t b_n, int64_t b_c,
              int64_t b_h, int64_t b_w, int64_t out_n, int64_t out_c,

--- a/lib/Runtime/real/qmatmul.cpp
+++ b/lib/Runtime/real/qmatmul.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+// FusedOp(A,B) = Q(DQ(A) @ DQ(B))
+//
+// a = (A - z_a) * s_a
+// b = (B - z_b) * s_b
+// Y = saturate(round((a @ b) / s_y) + z_y)
+//
+// (a @ b)[m,n] = s_a*s_b * sum_k (A[m,k] - z_a) * (B[k,n] - z_b)
+//              = s_a*s_b * (acc[m,n] - z_b*rowA[m] - z_a*colB[n] + K*z_a*z_b)
+//   acc[m,n] = sum_k A[m,k]*B[k,n]
+//   rowA[m]  = sum_k A[m,k]
+//   colB[n]  = sum_k B[k,n]
+// --->
+// let M = s_a * s_b / s_y
+// Y = saturate(round(M * (acc - z_b*rowA - z_a*colB + K*z_a*z_b)) + z_y)
+//
+// acc, rowA and colB are exact integers, so the only rounding is the single
+// multiply by M and the final round -- strictly less error than the unfused
+// path, which accumulates K products in f32.
+//
+// A may be 16-bit (A16W8) while B stays 8-bit. The kernel keeps that exact by
+// splitting A into two bytes, A = hi*256 + lo, and running one 8-bit dot per
+// byte; see lib/Runtime/Kernels/hip/qmatmul_kernel.hip for the derivation.
+#include "../debug_log.h"
+#include "../hipdnn_ep_runtime.h"
+#include "hip_custom_kernels.h"
+
+#include <cstdint>
+#include <cstdio>
+
+// Maps the quantized types qmatmul accepts; which width each edge may use is
+// the caller's rule.
+static int hipdnn_to_hip_dtype_qmatmul(int64_t hipdnn_type) {
+  switch (hipdnn_type) {
+  case HIPDNN_EP_DATATYPE_INT8:
+    return HIP_DTYPE_INT8;
+  case HIPDNN_EP_DATATYPE_UINT8:
+    return HIP_DTYPE_UINT8;
+  case HIPDNN_EP_DATATYPE_INT16:
+    return HIP_DTYPE_INT16;
+  case HIPDNN_EP_DATATYPE_UINT16:
+    return HIP_DTYPE_UINT16;
+  default:
+    return -1;
+  }
+}
+
+// Largest K that cannot overflow the int32 accumulator for the widest product
+// each dtype pair can produce. Unsigned operands are the tighter case: 255*255
+// per term against 127*128 for signed.
+//
+// A 16-bit A contributes 255 as well, because what the accumulator actually
+// sees is its low byte -- the wider `hi` plane is bounded by 128 (int16) or 255
+// (uint16) and never sets the limit. The GEMV path (M == 1) accumulates in
+// int64 and is not bound by this at all, but the limit is applied uniformly so
+// that a shape's validity does not depend on its batch size.
+static int64_t max_safe_k(int a_dtype, int b_dtype) {
+  const int64_t a_mag = (a_dtype == HIP_DTYPE_INT8) ? 128 : 255;
+  const int64_t b_mag = (b_dtype == HIP_DTYPE_UINT8) ? 255 : 128;
+  return INT32_MAX / (a_mag * b_mag);
+}
+
+int wrap_qmatmul(RuntimeState *state, const void *A, const void *B, void *Y,
+                 int64_t M, int64_t N, int64_t K, int64_t batch_count,
+                 int64_t b_batch_stride, int64_t trans_a, int64_t trans_b,
+                 int64_t a_data_type, int64_t b_data_type, int64_t y_data_type,
+                 float M_scale, int64_t A_zero_point, int64_t B_zero_point,
+                 int64_t Y_zero_point) {
+  if (!state || !A || !B || !Y) {
+    fprintf(stderr, "wrap_qmatmul: null tensor argument\n");
+    return -1;
+  }
+  if (M <= 0 || N <= 0 || K <= 0 || batch_count <= 0) {
+    fprintf(stderr,
+            "wrap_qmatmul: invalid dims M=%lld N=%lld K=%lld batch=%lld\n",
+            (long long)M, (long long)N, (long long)K, (long long)batch_count);
+    return -1;
+  }
+
+  const int a_dtype = hipdnn_to_hip_dtype_qmatmul(a_data_type);
+  const int b_dtype = hipdnn_to_hip_dtype_qmatmul(b_data_type);
+  const int y_dtype = hipdnn_to_hip_dtype_qmatmul(y_data_type);
+  // Only A has a 16-bit path: the kernel splits it into two byte planes and
+  // runs one 8-bit dot per plane, which leaves a wider B with nothing to use.
+  bool isW8 = b_dtype == HIP_DTYPE_INT8 || b_dtype == HIP_DTYPE_UINT8;
+  if (a_dtype < 0 || b_dtype < 0 || y_dtype < 0 || !isW8) {
+    fprintf(stderr,
+            "[REAL] wrap_qmatmul: unsupported data types A=%s(%lld) "
+            "B=%s(%lld) Y=%s(%lld); A and Y must be 8- or 16-bit quantized "
+            "and B must be 8-bit\n",
+            hipdnn_ep_datatype_name(a_data_type), (long long)a_data_type,
+            hipdnn_ep_datatype_name(b_data_type), (long long)b_data_type,
+            hipdnn_ep_datatype_name(y_data_type), (long long)y_data_type);
+    return -1;
+  }
+
+  const int64_t k_limit = max_safe_k(a_dtype, b_dtype);
+  // Splitting a 16-bit A into two bytes is what keeps it on the 8-bit dot4
+  // pipeline, and the price is an int32 accumulator, which is what bounds K.
+  // Even the tightest dtype pairing still allows K = 33025, far past the
+  // reduction widths real graphs use, so this rarely fires.
+  if (K > k_limit) {
+    fprintf(stderr,
+            "[REAL] wrap_qmatmul: K=%lld exceeds the int32 accumulator limit "
+            "%lld for this dtype pair\n",
+            (long long)K, (long long)k_limit);
+    return -1;
+  }
+
+  void *stream = hipdnn_ep_state_get_stream(state);
+
+  if (hipdnn_ep_debug_enabled()) {
+    fprintf(stderr,
+            "[REAL] wrap_qmatmul: M=%lld N=%lld K=%lld batch=%lld "
+            "b_batch_stride=%lld trans=(%lld,%lld) dtypes=(%s,%s,%s) "
+            "M_scale=%g zp=(%lld,%lld,%lld)\n",
+            (long long)M, (long long)N, (long long)K, (long long)batch_count,
+            (long long)b_batch_stride, (long long)trans_a, (long long)trans_b,
+            hipdnn_ep_datatype_name(a_data_type),
+            hipdnn_ep_datatype_name(b_data_type),
+            hipdnn_ep_datatype_name(y_data_type), (double)M_scale,
+            (long long)A_zero_point, (long long)B_zero_point,
+            (long long)Y_zero_point);
+  }
+
+  return hip_qmatmul(stream, A, B, Y, M, N, K, batch_count, b_batch_stride,
+                     trans_a != 0, trans_b != 0, a_dtype, b_dtype, y_dtype,
+                     M_scale, A_zero_point, B_zero_point, Y_zero_point);
+}

--- a/test/lit/Conversion/hip-to-llvm/test_qmatmul.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_qmatmul.mlir
@@ -1,0 +1,72 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST: hip.qmatmul -> llvm.call @wrap_qmatmul
+//
+// One case carries every non-trivial part of the lowering at once:
+//   * A16W8 (ui16 / i8 / ui16) -> the three data-type codes are passed
+//     independently, so a wider A must not drag B's code along.
+//   * transB -> N comes from B's second-to-last extent, K still from A's last.
+//   * rank-3 per-batch B -> batch_count from A's leading dim and a
+//     b_batch_stride of K*N rather than the broadcast 0.
+//   * Asymmetric zero points, with 32768 proving a ui16 zero point survives
+//     instead of wrapping to -32768.
+//
+// The scales are chosen so the folded coefficient is exact in f32 and readable:
+//   M = A_scale * B_scale / Y_scale = 0.25 * 0.125 / 0.5 = 0.0625 = 2^-4
+// Anything the kernel could recompute from A_scale/B_scale/Y_scale at runtime
+// would cost a float divide per output element, so the fold has to land here.
+//
+// Extents are read back from the descriptors even though they are static here,
+// so the checks bind SSA values instead of matching shape constants.
+//
+// RUN: hip-mlir-opt %s --convert-hip-to-llvm | FileCheck %s
+// ============================================================================
+
+module {
+  // Binding every argument lets the final CHECK pin the whole 18-parameter ABI
+  // in order, matching wrap_qmatmul in lib/Runtime/hipdnn_ep_runtime.h:
+  //   4 ptr : state, A, B, Y
+  //   5 i64 : M, N, K, batch_count, b_batch_stride
+  //   2 i64 : trans_a, trans_b
+  //   3 i64 : a_data_type, b_data_type, y_data_type
+  //   1 f32 : M_scale
+  //   3 i64 : A_zero_point, B_zero_point, Y_zero_point
+  //
+  // CHECK-LABEL: llvm.func @test_qmatmul(
+  // CHECK:      %[[MSCALE:.*]] = llvm.mlir.constant(6.250000e-02 : f32) : f32
+  // CHECK-NEXT: %[[M:.*]] = llvm.extractvalue %[[ADESC:.*]][3, 1]
+  // CHECK-NEXT: %[[K:.*]] = llvm.extractvalue %[[ADESC]][3, 2]
+  // CHECK-NEXT: %[[N:.*]] = llvm.extractvalue %[[BDESC:.*]][3, 1]
+  // CHECK-NEXT: %[[BATCH:.*]] = llvm.extractvalue %[[ADESC]][3, 0]
+  // CHECK-NEXT: %[[STRIDE:.*]] = llvm.mul %[[K]], %[[N]] : i64
+  // CHECK-NEXT: llvm.extractvalue %[[ADESC]][1]
+  // CHECK-NEXT: %[[APTR:.*]] = llvm.addrspacecast
+  // CHECK-NEXT: llvm.extractvalue %[[BDESC]][1]
+  // CHECK-NEXT: %[[BPTR:.*]] = llvm.addrspacecast
+  // CHECK-NEXT: llvm.extractvalue %[[YDESC:.*]][1]
+  // CHECK-NEXT: %[[YPTR:.*]] = llvm.addrspacecast
+  // CHECK-NEXT: %[[TRANSA:.*]] = llvm.mlir.constant(0 : i64) : i64
+  // CHECK-NEXT: %[[TRANSB:.*]] = llvm.mlir.constant(1 : i64) : i64
+  // CHECK-NEXT: %[[ADT:.*]] = llvm.mlir.constant(9 : i64) : i64
+  // CHECK-NEXT: %[[BDT:.*]] = llvm.mlir.constant(5 : i64) : i64
+  // CHECK-NEXT: %[[YDT:.*]] = llvm.mlir.constant(9 : i64) : i64
+  // CHECK-NEXT: %[[AZP:.*]] = llvm.mlir.constant(32768 : i64) : i64
+  // CHECK-NEXT: %[[BZP:.*]] = llvm.mlir.constant(3 : i64) : i64
+  // CHECK-NEXT: %[[YZP:.*]] = llvm.mlir.constant(32768 : i64) : i64
+  // CHECK-NEXT: llvm.call @wrap_qmatmul(%{{.*}}, %[[APTR]], %[[BPTR]], %[[YPTR]], %[[M]], %[[N]], %[[K]], %[[BATCH]], %[[STRIDE]], %[[TRANSA]], %[[TRANSB]], %[[ADT]], %[[BDT]], %[[YDT]], %[[MSCALE]], %[[AZP]], %[[BZP]], %[[YZP]]) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, f32, i64, i64, i64) -> i32
+  func.func @test_qmatmul(%ctx: !hip.context,
+                          %A: memref<2x64x128xui16, 1>,
+                          %B: memref<2x32x128xi8, 1>,
+                          %Y: memref<2x64x32xui16, 1>) {
+    hip.qmatmul(%ctx)
+        ins(%A, %B : memref<2x64x128xui16, 1>, memref<2x32x128xi8, 1>)
+        outs(%Y : memref<2x64x32xui16, 1>)
+        {A_scale = 2.500000e-01 : f32, A_zero_point = 32768 : i64,
+         B_scale = 1.250000e-01 : f32, B_zero_point = 3 : i64,
+         Y_scale = 5.000000e-01 : f32, Y_zero_point = 32768 : i64,
+         transA = 0 : i64, transB = 1 : i64}
+    return
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_qmatmul.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_qmatmul.mlir
@@ -1,0 +1,61 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST: QDQ MatMul Fusion Pattern (Pure PDLL approach)
+//
+// Pattern fuses:
+//   onnx.DequantizeLinear, onnx.DequantizeLinear
+//     -> onnx.MatMul -> onnx.QuantizeLinear
+// into:
+//   hip.qmatmul
+//
+// Zero points are deliberately non-zero (asymmetric quantization) so the
+// checks prove the extracted values reach the attributes with their sign
+// intact, rather than matching an incidental zero.
+//
+// PDL fusion runs before lowerOnnxConstants and folds scale/zp into hip.qmatmul
+// attributes, so the onnx.Constant carriers are dead and get DCE'd — no
+// hip.constant survivors in the output IR.
+//
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+// ============================================================================
+
+module {
+  // ===== Fused: 2D, all i8, asymmetric zero points =====
+  // CHECK-LABEL: func.func @main_graph
+  // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[A:.*]]: tensor<64x128xi8>, %[[B:.*]]: tensor<128x32xi8>) -> tensor<64x32xi8> {
+  // CHECK-NEXT:   %[[EMPTY:.*]] = tensor.empty() : tensor<64x32xi8>
+  // CHECK-NEXT:   %[[QMM:.*]] = hip.qmatmul(%[[CTX]]) ins(%[[A]], %[[B]] : tensor<64x128xi8>, tensor<128x32xi8>) outs(%[[EMPTY]] : tensor<64x32xi8>) {A_scale = 2.500000e-01 : f32, A_zero_point = -5 : i64, B_scale = 1.250000e-01 : f32, B_zero_point = 3 : i64, Y_scale = 5.000000e-01 : f32, Y_zero_point = 7 : i64} : tensor<64x32xi8>
+  // CHECK-NEXT:   return %[[QMM]] : tensor<64x32xi8>
+  // CHECK-NEXT: }
+
+  // Nothing of the fused chain survives: no onnx QDQ ops and no hip.constant
+  // scale/zp carriers anywhere in the output.
+  // CHECK-NOT: onnx.DequantizeLinear
+  // CHECK-NOT: onnx.MatMul
+  // CHECK-NOT: onnx.QuantizeLinear
+  // CHECK-NOT: hip.constant
+  func.func @main_graph(%A: tensor<64x128xi8>,
+                        %B: tensor<128x32xi8>) -> tensor<64x32xi8> {
+    %a_scale = "onnx.Constant"() {value = dense<0.25> : tensor<f32>} : () -> tensor<f32>
+    %a_zp = "onnx.Constant"() {value = dense<-5> : tensor<i8>} : () -> tensor<i8>
+    %b_scale = "onnx.Constant"() {value = dense<0.125> : tensor<f32>} : () -> tensor<f32>
+    %b_zp = "onnx.Constant"() {value = dense<3> : tensor<i8>} : () -> tensor<i8>
+    %y_scale = "onnx.Constant"() {value = dense<0.5> : tensor<f32>} : () -> tensor<f32>
+    %y_zp = "onnx.Constant"() {value = dense<7> : tensor<i8>} : () -> tensor<i8>
+
+    %a_dq = "onnx.DequantizeLinear"(%A, %a_scale, %a_zp)
+            : (tensor<64x128xi8>, tensor<f32>, tensor<i8>) -> tensor<64x128xf32>
+    %b_dq = "onnx.DequantizeLinear"(%B, %b_scale, %b_zp)
+            : (tensor<128x32xi8>, tensor<f32>, tensor<i8>) -> tensor<128x32xf32>
+
+    %prod = "onnx.MatMul"(%a_dq, %b_dq)
+            : (tensor<64x128xf32>, tensor<128x32xf32>) -> tensor<64x32xf32>
+
+    %result = "onnx.QuantizeLinear"(%prod, %y_scale, %y_zp)
+              : (tensor<64x32xf32>, tensor<f32>, tensor<i8>) -> tensor<64x32xi8>
+
+    return %result : tensor<64x32xi8>
+  }
+}


### PR DESCRIPTION
## Summary

Adds `hip.qmatmul` and a PDL pattern that collapses
`DequantizeLinear, DequantizeLinear -> MatMul -> QuantizeLinear` into it,
executed by a new integer-accumulating HIP kernel. Covers A8W8 and A16W8 with
per-tensor scales.

## Related issue or design

None. Follows the existing QDQ Add/Mul fusion structure in
`lib/Conversion/OnnxToHip/pdl/`.

## Why

A QDQ MatMul chain runs three kernels and materializes an f32 intermediate the
size of the product. Accumulating in integers removes that buffer and is also
more accurate than the f32 reduction it replaces: the accumulation is exact, and
only the final rescale rounds.

## What

- **Dialect**: `hip.qmatmul` with per-tensor scale/zero-point attributes and
  `transA`/`transB`. Verification and shape reification share
  `reifyMatmulLikeShape` with `hip.matmul` instead of duplicating it.
- **Fusion**: `QDQMatMulFusion.pdll` requires splat scales, readable zero
  points, static result shapes, an 8- or 16-bit A and Y, and an 8-bit B. Adds
  native helpers `IsEightBitQuantized`, `IsEightOrSixteenBitQuantized`,
  `HasStaticShapedResults`, and a generic `ExtractAttrInt64`.
- **Lowering**: folds `M = A_scale * B_scale / Y_scale` at compile time and
  computes `b_batch_stride` — `K*N` for a per-batch weight, 0 for a broadcast
  one — with a runtime path for unknown leading dims.
- **Runtime/kernel**: `wrap_qmatmul` over a tiled kernel (64x64x16, dot4
  fragments) plus a GEMV path for `M == 1`. A 16-bit A is byte-split into hi/lo
  planes so the 8-bit dot instructions still apply; the zero-point corrections
  ride the same dot pipeline and are applied in the epilogue.
- **Portability**: templated `hipdnn_dot4<ASigned, BSigned>` covers all four
  sign combinations — `v_dot4_i32_iu8` on RDNA3/4, scalar fallback for
  mixed signs on CDNA.
- **Build**: the compiled `HipFusionPatterns.pdl.mlir` is staged per config so
  it tracks source edits, and an empty pattern module is now a no-op rather than
  an abort.

## Test plan

- [x] `test/lit/Conversion/onnx-to-hip/test_qmatmul.mlir` — the chain fuses into
      one `hip.qmatmul` carrying the folded attributes.
- [x] `test/lit/Conversion/hip-to-llvm/test_qmatmul.mlir` — argument order and
      sources for the A16W8 + `transB` + rank-3 per-batch case.
- [x] End-to-end accuracy on gfx1151 vs the ORT CPU EP, 12 fixtures covering the
      A8W8/A16W8 sign combinations, both kernel paths, per-batch and broadcast
      weights, non-tile-aligned extents, and omitted zero points. HIP matches an
      exact int64 numpy golden **bit-for-bit in all 12**. Each graph is only the
      fusion pattern and runs under `HIPDNN_EP_STRICT=1` with CPU fallback
      disabled, so a compile failure would fail session creation; every log
      shows exactly one `wrap_qmatmul` and no leftover Q/DQ runtime calls.
- [x] Accumulator bound: K = 32768, 99.2% of the runtime's uint8 x uint8 limit,
      with `|corrected|` peaking at 76% of the int32 range — still exact.
- [x] Verify the functionality using a real model; the logs show that `wrap_qmatmul` 
       is being called.

## Notes for reviewers

- `transA`/`transB` are plumbed through but are always 0 from an ONNX graph
  today: `TransposeMatMulFold` stamps them inside the pre-lowering loop, while
  this pattern runs once at module level before it. They are in place for when
  that ordering changes. Consequently the kernel's transposed paths have LIT
  coverage only, not runtime coverage.
- B must be 8-bit. A16W16 would need a wider accumulator and a second kernel.
- The int32 accumulator bounds K (33025 for uint8 x uint8, 131071 for
  int8 x int8); the runtime rejects a larger K rather than silently overflowing.
- On CDNA a mixed-sign pair — the common uint8 activation x int8 weight — takes
  the scalar fallback in `hipdnn_dot4`. Only RDNA3/4 was measured.
- At 22 files / ~1.5k lines this will trip the `large-pr` label. It is a
  vertical slice (dialect, fusion, lowering, runtime, kernel) committed layer by
  layer; splitting it horizontally would leave an op with no lowering, or a
  kernel nothing reaches.

## AI Assistance

The code was developed collaboratively with Cursor, and all code has been
reviewed.