### PR TITLE
ci(windows): build OGA from the AMDGPU fork branch to exercise #719 on Gemma-4

### DIFF
--- a/.github/workflows/windows-deps.yml
+++ b/.github/workflows/windows-deps.yml
@@ -30,8 +30,14 @@ env:
   LLVM_TAG: llvmorg-22.1.0
   ONNXRUNTIME_VERSION: "1.27.0"
   ONNXRUNTIME_PR_PATCHES: ""
-  OGA_VERSION: "0.14.0"
-  OGA_PR_PATCHES: "2194"
+  # Fork branch carrying the AMDGPU MorphiZen integration (former PR 2194) plus
+  # sliding_window support, which upstream v0.14.0 does not have.
+  OGA_REPO: "amd-genmingz/onnxruntime-genai"
+  OGA_REF: "test_0_3"
+  # Optional space-separated microsoft/onnxruntime-genai PR numbers applied on
+  # top of the fork checkout via pull/<n>.patch + git am. Empty because the fork
+  # branch already carries the integration that 2194 used to supply.
+  OGA_PR_PATCHES: ""
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
   AMDGPU_EP_REF: "05eaa2a938f71e98b49bd1be3fb03720167be5cc"
 
@@ -442,7 +448,7 @@ jobs:
       - name: Compute cache key
         id: key
         shell: bash
-        run: echo "value=oga-dml-mm2-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}" >> "$GITHUB_OUTPUT"
+        run: echo "value=oga-dml-mm3-${{ env.OGA_REPO }}-${{ env.OGA_REF }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}-2" >> "$GITHUB_OUTPUT"
 
       - name: Probe oga-artifacts
         id: cache-oga
@@ -494,8 +500,8 @@ jobs:
         if: steps.cache-oga.outputs.cache-hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: microsoft/onnxruntime-genai
-          ref: v${{ env.OGA_VERSION }}
+          repository: ${{ env.OGA_REPO }}
+          ref: ${{ env.OGA_REF }}
           path: source-oga
           submodules: true
           fetch-depth: 1
@@ -550,6 +556,11 @@ jobs:
         if: steps.cache-oga.outputs.cache-hit != 'true'
         shell: bash
         run: |
+          # build.py imports tools/python/util, whose dependency_resolver
+          # imports requests at module scope. --ort_home means nothing is
+          # actually downloaded, but the import still has to resolve.
+          python -m pip install -q requests
+
           python "${{ github.workspace }}/source-oga/build.py" \
             --config Release \
             --cmake_generator Ninja \

--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -1168,16 +1168,65 @@ extern "C" int hip_gqa_add_attention_bias_f32(
 // Output-type-templated: reads fp32 scores, writes TOut ∈ {__half, float}.
 // fp16 output (TOut=__half) feeds the fp16 Value GEMM; fp32 output (TOut=float)
 // feeds the fp32 Value GEMM on the Whisper no_causal fp32 decomposed path.
-template <typename TOut>
+//
+// HAS_BIAS folds the external additive mask in here instead of running
+// add_attention_bias_kernel first. That kernel was a full read-modify-write
+// over the score buffer -- 2.14 GB per head at a 16K prompt -- purely to hand
+// this kernel a value it is about to read anyway. A block owns one query row,
+// and the bias runs along the key axis in the same order the reduction below
+// does, so the fold is one extra contiguous stream to read. The three passes
+// re-read it, but a row is 32-64 KB and stays resident across them, so the cost
+// is one stream from memory against the two the separate pass spent on the
+// scores alone.
+//
+// The bias is indexed on its own full extents rather than through a bumped
+// pointer, for the reason add_attention_bias_kernel gives at length: `input`
+// can be a sub-block of the logical [bias_sq, bias_total_seq] matrix -- `cols`
+// query rows from bias_row_offset when the caller tiles the prefill, and `rows`
+// key columns from bias_col_offset when it narrows to a sliding window -- while
+// the bias always describes the whole thing. Folding either offset into the
+// pointer would mis-stride every batch/head plane after the first.
+//
+// The bias is added to the score BEFORE the max is taken, which is required
+// rather than incidental: taking the max of unbiased scores and then adding the
+// bias could leave a masked entry (bias -65504) as the column max and put every
+// exponent off scale.
+template <typename TOut, bool HAS_BIAS = false, typename TBias = __half>
 __global__ void softmax_f32_to_out_kernel(
     const float* input, TOut* output,
     int rows, int cols, int input_batch_stride, int output_batch_stride,
-    const __half* head_sink, int num_heads, int use_smooth_softmax) {
+    const __half* head_sink, int num_heads, int use_smooth_softmax,
+    const TBias* __restrict__ bias, int bias_batch, int bias_heads,
+    int bias_sq, int bias_row_offset, int bias_total_seq, int bias_col_offset) {
   const int linear = __builtin_amdgcn_readfirstlane(blockIdx.x);
   const int head = __builtin_amdgcn_readfirstlane(linear / cols);
   const int col  = __builtin_amdgcn_readfirstlane(linear % cols);
   const float* in_col = input + (size_t)head * input_batch_stride + (size_t)col * rows;
   TOut* out_col = output + (size_t)head * output_batch_stride + (size_t)col * rows;
+
+  // Start of this query row inside the bias, resolved exactly as
+  // add_attention_bias_kernel resolves it. `col` is the query row (this kernel
+  // reduces along `rows`, the key axis), so it indexes the bias's row axis.
+  const TBias* bias_row = nullptr;
+  if (HAS_BIAS) {
+    const int b = head / num_heads;
+    const int h = head % num_heads;
+    const int bias_b = (bias_batch == 1) ? 0 : b;
+    const int bias_h = (bias_heads == 1) ? 0 : h;
+    const size_t bias_plane = (size_t)bias_sq * bias_total_seq;
+    bias_row = bias + (size_t)bias_b * bias_heads * bias_plane +
+               (size_t)bias_h * bias_plane +
+               (size_t)(bias_row_offset + col) * bias_total_seq +
+               bias_col_offset;
+  }
+
+  // Score with the bias already folded in, or the raw score when there is none.
+  auto score_at = [&](int i) -> float {
+    float s = in_col[i];
+    if (HAS_BIAS)
+      s += static_cast<float>(bias_row[i]);
+    return s;
+  };
 
   const int tid = threadIdx.x;
   const int wave_id = tid / WAVE_SIZE;
@@ -1188,7 +1237,7 @@ __global__ void softmax_f32_to_out_kernel(
   // Pass 1: find max (fp32, no overflow risk)
   float local_max = -INFINITY;
   for (int i = tid; i < rows; i += blockDim.x)
-    local_max = fmaxf(local_max, in_col[i]);
+    local_max = fmaxf(local_max, score_at(i));
 
   local_max = warp_reduce_max(local_max);
   if (tid % WAVE_SIZE == 0)
@@ -1206,7 +1255,7 @@ __global__ void softmax_f32_to_out_kernel(
   // Pass 2: exp2f + sum (fp32 throughout, values recomputed in Pass 3)
   float local_sum = 0.0f;
   for (int i = tid; i < rows; i += blockDim.x)
-    local_sum += exp2f((in_col[i] - max_val) * LOG2E);
+    local_sum += exp2f((score_at(i) - max_val) * LOG2E);
 
   local_sum = warp_reduce_sum(local_sum);
   if (tid % WAVE_SIZE == 0)
@@ -1232,17 +1281,19 @@ __global__ void softmax_f32_to_out_kernel(
   // Pass 3: normalize and write output (fp16 or fp32 per TOut).
   float inv_sum = 1.0f / sum_val;
   for (int i = tid; i < rows; i += blockDim.x) {
-    float e = exp2f((in_col[i] - max_val) * LOG2E);
+    float e = exp2f((score_at(i) - max_val) * LOG2E);
     out_col[i] = gqa_from_float<TOut>(e * inv_sum);
   }
 }
 
-template <typename TOut>
+template <typename TOut, bool HAS_BIAS, typename TBias>
 static void launch_softmax_f32_to_out(
     hipStream_t stream, const void* input_f32, void* output,
     int total_head_queries, int rows, int cols,
     int input_batch_stride, int output_batch_stride,
-    const void* head_sink, int num_heads, int use_smooth_softmax) {
+    const void* head_sink, int num_heads, int use_smooth_softmax,
+    const void* bias, int bias_batch, int bias_heads,
+    int bias_sq, int bias_row_offset, int bias_total_seq, int bias_col_offset) {
   // The block must be a whole multiple of the hardware wave, else the tail of a
   // partial wave is inactive and the __shfl_xor reduction folds in its lanes.
   // The floor is therefore the device wave size: 32 on wave32 (RDNA, unchanged
@@ -1254,11 +1305,27 @@ static void launch_softmax_f32_to_out(
   while (threads < std::min(rows, 256)) threads *= 2;
   if (threads > 256) threads = 256;
   int num_waves = threads / wave;
-  softmax_f32_to_out_kernel<TOut><<<total_head_queries, threads,
-                                    num_waves * sizeof(float), stream>>>(
-      static_cast<const float*>(input_f32), static_cast<TOut*>(output),
-      rows, cols, input_batch_stride, output_batch_stride,
-      static_cast<const __half*>(head_sink), num_heads, use_smooth_softmax);
+  softmax_f32_to_out_kernel<TOut, HAS_BIAS, TBias>
+      <<<total_head_queries, threads, num_waves * sizeof(float), stream>>>(
+          static_cast<const float*>(input_f32), static_cast<TOut*>(output),
+          rows, cols, input_batch_stride, output_batch_stride,
+          static_cast<const __half*>(head_sink), num_heads, use_smooth_softmax,
+          static_cast<const TBias*>(bias), bias_batch, bias_heads, bias_sq,
+          bias_row_offset, bias_total_seq, bias_col_offset);
+}
+
+// Selects the no-bias instantiation, so the existing callers stay on exactly
+// the code they had.
+template <typename TOut>
+static void launch_softmax_f32_to_out(
+    hipStream_t stream, const void* input_f32, void* output,
+    int total_head_queries, int rows, int cols,
+    int input_batch_stride, int output_batch_stride,
+    const void* head_sink, int num_heads, int use_smooth_softmax) {
+  launch_softmax_f32_to_out<TOut, false, __half>(
+      stream, input_f32, output, total_head_queries, rows, cols,
+      input_batch_stride, output_batch_stride, head_sink, num_heads,
+      use_smooth_softmax, nullptr, 1, 1, 0, 0, 0, 0);
 }
 
 extern "C" int hip_gqa_softmax_f32_to_f16(
@@ -1289,6 +1356,58 @@ extern "C" int hip_gqa_softmax_f32_to_f32(
       stream, input_f32, output_f32, total_head_queries, rows, cols,
       input_batch_stride, output_batch_stride, head_sink, num_heads,
       use_smooth_softmax);
+  GQA_RETURN_LAUNCH_STATUS();
+}
+
+// Bias-folding variant: adds the external additive mask while reading the score
+// column, replacing a separate hip_gqa_add_attention_bias_f32 pass over the
+// same buffer. bias_element_size_bytes selects the mask dtype (2 = fp16, the
+// usual ONNX Attention export; 4 = fp32). output_fp32 picks the probability
+// dtype, matching the two entries above. The bias extents follow
+// hip_gqa_add_attention_bias_f32, including its convention that a
+// non-positive bias_sq / bias_total_seq means the bias covers exactly the block
+// passed in; note this kernel's `cols` is the query count and `rows` the key
+// extent, the transpose of the names that entry uses.
+extern "C" int hip_gqa_softmax_f32_to_out_biased(
+    void* stream_ptr, const void* input_f32, void* output,
+    int total_head_queries, int rows, int cols,
+    int input_batch_stride, int output_batch_stride,
+    const void* head_sink, int num_heads, int use_smooth_softmax,
+    const void* bias, int bias_batch, int bias_heads,
+    int bias_element_size_bytes, int output_fp32,
+    int bias_sq, int bias_row_offset, int bias_total_seq, int bias_col_offset) {
+  if (!bias)
+    return -1;
+  hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
+  (void)hipGetLastError();  // clear stale error for correct attribution
+  if (bias_element_size_bytes != 2 && bias_element_size_bytes != 4) {
+    fprintf(stderr,
+            "hip_gqa_softmax_f32_to_out_biased: unsupported bias elem size %d\n",
+            bias_element_size_bytes);
+    return -1;
+  }
+  if (bias_sq <= 0)
+    bias_sq = cols;
+  if (bias_total_seq <= 0)
+    bias_total_seq = rows;
+#define GQA_SOFTMAX_BIASED(TOUT, TBIAS)                                        \
+  launch_softmax_f32_to_out<TOUT, true, TBIAS>(                                \
+      stream, input_f32, output, total_head_queries, rows, cols,               \
+      input_batch_stride, output_batch_stride, head_sink, num_heads,           \
+      use_smooth_softmax, bias, bias_batch, bias_heads, bias_sq,               \
+      bias_row_offset, bias_total_seq, bias_col_offset)
+  if (output_fp32) {
+    if (bias_element_size_bytes == 2)
+      GQA_SOFTMAX_BIASED(float, __half);
+    else
+      GQA_SOFTMAX_BIASED(float, float);
+  } else {
+    if (bias_element_size_bytes == 2)
+      GQA_SOFTMAX_BIASED(__half, __half);
+    else
+      GQA_SOFTMAX_BIASED(__half, float);
+  }
+#undef GQA_SOFTMAX_BIASED
   GQA_RETURN_LAUNCH_STATUS();
 }
 

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -805,6 +805,29 @@ HIP_KERNEL_API int hip_gqa_softmax_f32_to_f32(
     int input_batch_stride, int output_batch_stride,
     const void* head_sink, int num_heads, int use_smooth_softmax);
 
+/* Same as hip_gqa_softmax_f32_to_f32 / _f16, with the external additive mask
+ * folded into the score read so a preceding hip_gqa_add_attention_bias_f32 pass
+ * over the same buffer is not needed. output_fp32 picks the probability dtype
+ * (0 = fp16, feeding the fp16 Value GEMM; 1 = fp32) and
+ * bias_element_size_bytes the mask dtype (2 = fp16, 4 = fp32). The bias is
+ * added before the column max is taken.
+ *
+ * The bias is indexed on its own full extents, exactly as
+ * hip_gqa_add_attention_bias_f32 does, because the score buffer can be a
+ * sub-block of the logical [bias_sq, bias_total_seq] matrix: `cols` query rows
+ * starting at bias_row_offset, and `rows` key columns starting at
+ * bias_col_offset. Mind the axis names -- this kernel reduces along `rows`, so
+ * its `rows` is the key extent and its `cols` the query count, which is the
+ * transpose of the naming hip_gqa_add_attention_bias_f32 uses. */
+HIP_KERNEL_API int hip_gqa_softmax_f32_to_out_biased(
+    void* stream, const void* input_f32, void* output,
+    int total_head_queries, int rows, int cols,
+    int input_batch_stride, int output_batch_stride,
+    const void* head_sink, int num_heads, int use_smooth_softmax,
+    const void* bias, int bias_batch, int bias_heads,
+    int bias_element_size_bytes, int output_fp32,
+    int bias_sq, int bias_row_offset, int bias_total_seq, int bias_col_offset);
+
 /* Legacy fast-path decode kernel (folded into gqa_kernel.hip with a legacy_*
  * device kernel). The production decode path uses hip_gqa_flash_decode above
  * for EVERY fp16 causal GQA/MHA decode (window + sink folded in, split count

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -2088,22 +2088,11 @@ static int gqa_forward_hipblaslt(
           sSt->layB, &beta, d_S_f32, sSt->layC, d_S_f32, sSt->layD, &sAlgo,
           gemm_ws_ptr, gemm_ws_bytes, stream));
 
-      // ---- Step 8b: Add external attention bias (onnx.Attention attn_mask) --
-      // The bias is indexed over the full query and key ranges, so the chunk's
-      // row offset and the window's key offset are passed through rather than
-      // folded into the pointer: with bias_batch or bias_heads > 1 the plane
-      // stride still spans all sq rows and all total_seq columns.
-      if (attention_bias) {
-        HIP_CHECK(hip_gqa_add_attention_bias_f32(
-            stream, d_S_f32, const_cast<void *>(attention_bias),
-            static_cast<int>(B * H), static_cast<int>(H),
-            static_cast<int>(attn_bias_batch),
-            static_cast<int>(attn_bias_num_heads), static_cast<int>(c),
-            static_cast<int>(kv_span), scoreBatchStride,
-            static_cast<int>(elem_sz), static_cast<int>(sq),
-            static_cast<int>(q0), static_cast<int>(total_seq),
-            static_cast<int>(kv_lo)));
-      }
+      // ---- Step 8b: external attention bias (onnx.Attention attn_mask) ----
+      // Folded into the softmax's own score read below rather than added by a
+      // pass of its own. hip_gqa_add_attention_bias_f32 was a full
+      // read-modify-write over this buffer -- 2.14 GB per head at a 16K prompt
+      // -- to deliver a value the softmax was about to read anyway.
 
       // ---- Step 9: Causal Mask (fp32) + Softmax (fp32 -> fp16/fp32) ----
       // S is treated as [B*H, c, kv_span] (head stride c*kv_span) by both
@@ -2143,7 +2132,31 @@ static int gqa_forward_hipblaslt(
       // fp32 Value GEMM. d_S_fp16 is the probabilities buffer either way (sized
       // by elem_sz above), so the name is fp16-specific but holds fp32 when
       // gemm_fp32.
-      if (gemm_fp32) {
+      //
+      // With a bias, the biased entry folds it in while reading the score. It
+      // takes the bias's own extents and the chunk's / window's offsets into
+      // them, for the same reason hip_gqa_add_attention_bias_f32 did: the score
+      // block is a sub-block of the logical [sq, total_seq] matrix, and with
+      // attn_bias_batch or attn_bias_num_heads > 1 a bumped pointer would
+      // mis-stride every plane after the first.
+      //
+      // Folding here applies the bias AFTER the causal triangle above, which
+      // inverts the order documented at Step 8b. That is safe only because the
+      // triangle writes -INFINITY: adding any finite bias to it leaves
+      // -INFINITY, and where the triangle wrote nothing the sum is the same
+      // either way.
+      if (attention_bias) {
+        HIP_CHECK(hip_gqa_softmax_f32_to_out_biased(
+            stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * c),
+            static_cast<int>(kv_span), static_cast<int>(c), scoreBatchStride,
+            scoreBatchStride, head_sink, static_cast<int>(H),
+            static_cast<int>(use_smooth_softmax), attention_bias,
+            static_cast<int>(attn_bias_batch),
+            static_cast<int>(attn_bias_num_heads), static_cast<int>(elem_sz),
+            static_cast<int>(gemm_fp32), static_cast<int>(sq),
+            static_cast<int>(q0), static_cast<int>(total_seq),
+            static_cast<int>(kv_lo)));
+      } else if (gemm_fp32) {
         HIP_CHECK(hip_gqa_softmax_f32_to_f32(
             stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * c),
             static_cast<int>(kv_span), static_cast<int>(c), scoreBatchStride,


### PR DESCRIPTION
## What

Stacked on top of #719 (`perf/gqa-fuse-bias-softmax`) so CI builds and tests that branch's GQA change against an OGA that can load Gemma-4. This PR adds exactly one commit; the rest of the diff is #719 and should be reviewed there.

The change is the `windows-deps.yml` half of #599, re-applied rather than cherry-picked so this branch stays one reviewable commit:

- OGA is checked out from `amd-genmingz/onnxruntime-genai @ test_0_3` instead of `microsoft/onnxruntime-genai @ v0.14.0`. The fork branch carries the AMDGPU MorphiZen integration that `OGA_PR_PATCHES: "2194"` used to supply **plus sliding_window support, which upstream v0.14.0 does not have**. `OGA_PR_PATCHES` is emptied accordingly.
- The OGA cache key is rev'd `mm2` -> `mm3` and now contains the repo and ref rather than a version string, so the old version-keyed artifact set cannot be silently reused.
- `requests` is pip-installed before `build.py`, whose `tools/python/util` dependency resolver imports it at module scope even though `--ort_home` means nothing is downloaded.

Authored by @amd-genmingz in #599. Only the Windows deps workflow is touched; `linux-build.yml` still pins the upstream `OGA_VERSION`, matching #599.

## Why

#719 is a Gemma-4 optimisation and its numbers were taken locally, so it is worth putting it through the CI GPU suite. `windows-build.yml` chains `prebuild` (this workflow) -> `build_real` -> `gpu_test` on the StrixHalo runner and has no draft gate, so opening this as a draft is enough to run the full chain.

Separately, this is the first chance to see the fork OGA on CI hardware. Gemma-4 currently does not run through genai locally on any commit tested: `vlm_benchmark.py` aborts in the EP's output-allocator callback before reaching a single GQA dispatch, because with `past_present_share_buffer: true` genai binds `present` to the same fixed-capacity buffer as `past` while the EP reports `past_buf + new`:

```
output allocator callback failed for out_idx 1: ... output 'present.0.key'
has shape {1,8,1024,256} but the computed output shape for this run is {1,8,3264,256}
```

That reproduces on `main`, `e2a8f041`, `8b86c388`, `e1735368` and `bf15cac1`, so it is pre-existing and unrelated to #719. Whether the fork's sliding_window support changes that behaviour is the open question.

## What this does and does not prove

**Read this before treating a green run as validation.** There is no Gemma-4 test in CI -- `.github/` contains no reference to the model at all. So a green run here shows:

- the fork OGA branch builds on the Windows CI toolchain, and
- the existing GPU suite still passes with it, and with #719's kernel change underneath.

It does **not** show that Gemma-4 loads or that the `present.0.key` mismatch is resolved, because nothing in the suite exercises that path. Confirming the blocker needs a Gemma-4 case added to the GPU test, which is deliberately not in this PR.

## Notes for reviewers

- This targets `perf/gqa-fuse-bias-softmax`, not `main`, so the diff stays reviewable. It should not be merged before #719; if #719 lands first, this reduces to the single `windows-deps.yml` commit and can be retargeted at `main`.
- The cache-key bump means the first run pays a full OGA build rather than a cache hit, so expect the `prebuild` job to be slow once.
- #599 also mentions an onnxruntime-extensions bump to PR 1091 in its description, which is **not** in its diff and therefore not here either.

Made with [Cursor](https://cursor.com)
