### PR TITLE
feat: Swish, MatMulNBits fp16 zero-points, and signless IntegerAttr reads

### DIFF
--- a/docs/supported-operations.md
+++ b/docs/supported-operations.md
@@ -24,6 +24,7 @@ The conversion registrations in `lib/Conversion/OnnxToHip/OnnxToHip.cpp` and the
 | Tanh | Custom HIP kernel |
 | Softplus | Custom HIP kernel (f32/f16) |
 | Gelu | Custom HIP kernel |
+| Swish | Custom HIP kernel |
 | BiasGelu (`com.microsoft`) | Custom HIP kernel |
 | FastGelu (`com.microsoft`) | Custom HIP kernel |
 | Reciprocal | Custom HIP kernel |

--- a/include/hip/Dialect/IR/HipBufferize.h
+++ b/include/hip/Dialect/IR/HipBufferize.h
@@ -142,6 +142,7 @@ registerHipBufferizableOpInterfaceModels(DialectRegistry &registry) {
     BiasGeluOp::attachInterface<HipDstBufferizableModel<BiasGeluOp>>(*ctx);
     FastGeluOp::attachInterface<HipDstBufferizableModel<FastGeluOp>>(*ctx);
     LeakyReluOp::attachInterface<HipDstBufferizableModel<LeakyReluOp>>(*ctx);
+    SwishOp::attachInterface<HipDstBufferizableModel<SwishOp>>(*ctx);
     ResizeOp::attachInterface<HipDstBufferizableModel<ResizeOp>>(*ctx);
     GridSampleOp::attachInterface<HipDstBufferizableModel<GridSampleOp>>(*ctx);
     GlobalPoolOp::attachInterface<HipDstBufferizableModel<GlobalPoolOp>>(*ctx);

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -2307,6 +2307,36 @@ def Hip_LeakyReluOp : Hip_DpsOp<"leaky_relu"> {
   }];
 }
 
+def Hip_SwishOp : Hip_DpsOp<"swish"> {
+  let summary = "Swish activation: y = x * sigmoid(alpha * x)";
+  let description = [{
+    Applies the ONNX Swish activation element-wise.
+
+    Uses destination-passing style: the output buffer is provided as an
+    argument. The fused runtime kernel supports f16, f32, bf16, and f64.
+
+    Example:
+    ```mlir
+    hip.swish(%ctx) ins(%x : memref<3x4xf32, 1>)
+                    outs(%y : memref<3x4xf32, 1>)
+                    {alpha = 0.5 : f64}
+    ```
+  }];
+
+  let arguments = (ins
+    Hip_ContextType:$ctx,
+    Hip_TensorOrMemRef:$input,
+    Hip_TensorOrMemRef:$output,
+    DefaultValuedAttr<F64Attr, "1.0">:$alpha
+  );
+
+  let assemblyFormat = [{
+    `(` $ctx `)` `ins` `(` $input `:` type($input) `)`
+    `outs` `(` $output `:` type($output) `)`
+    attr-dict (`:` type($result_tensors)^)?
+  }];
+}
+
 def Hip_ReciprocalOp : Hip_DpsOp<"reciprocal", /*traits=*/[],
                                  /*outsAccessor=*/"Y",
                                  /*autoReify=*/1,

--- a/lib/Conversion/HipToLLVM/ActivationLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ActivationLowering.cpp
@@ -276,10 +276,9 @@ struct SwishOpLowering : public ConvertOpToLLVMPattern<SwishOp> {
     Value numElements = createI64Const(1);
     MemRefDescriptor outputDesc(adaptor.getOutput());
     for (auto dimIdx : llvm::seq<int64_t>(outputType.getRank())) {
-      Value dimSize =
-          outputType.isDynamicDim(dimIdx)
-              ? outputDesc.size(rewriter, loc, dimIdx)
-              : createI64Const(outputType.getDimSize(dimIdx));
+      Value dimSize = outputType.isDynamicDim(dimIdx)
+                          ? outputDesc.size(rewriter, loc, dimIdx)
+                          : createI64Const(outputType.getDimSize(dimIdx));
       numElements = LLVM::MulOp::create(rewriter, loc, numElements, dimSize);
     }
 
@@ -415,9 +414,9 @@ struct MiopenSoftmaxOpLowering
 
 void populateActivationLoweringPatterns(const LLVMTypeConverter &converter,
                                         RewritePatternSet &patterns) {
-  patterns
-      .add<SoftplusOpLowering, GeluOpLowering, LeakyReluOpLowering,
-           SwishOpLowering, SiluOpLowering, MiopenSoftmaxOpLowering>(converter);
+  patterns.add<SoftplusOpLowering, GeluOpLowering, LeakyReluOpLowering,
+               SwishOpLowering, SiluOpLowering, MiopenSoftmaxOpLowering>(
+      converter);
 }
 
 } // namespace hip

--- a/lib/Conversion/HipToLLVM/ActivationLowering.cpp
+++ b/lib/Conversion/HipToLLVM/ActivationLowering.cpp
@@ -245,6 +245,74 @@ struct LeakyReluOpLowering : public ConvertOpToLLVMPattern<LeakyReluOp> {
   }
 };
 
+// hip.swish(ctx, input, output)
+//   -> wrap_swish(state, input, output, num_elements, data_type, alpha)
+// Supports static and dynamic shapes and the complete ONNX Swish type set.
+struct SwishOpLowering : public ConvertOpToLLVMPattern<SwishOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(SwishOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+    Type ptrType = LLVM::LLVMPointerType::get(rewriter.getContext(), 0);
+    Type i32Type = rewriter.getI32Type();
+    Type i64Type = rewriter.getI64Type();
+    Type f64Type = rewriter.getF64Type();
+
+    auto createI64Const = [&](int64_t value) -> Value {
+      return LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                      rewriter.getI64IntegerAttr(value));
+    };
+
+    Value statePtr = adaptor.getCtx();
+    Value inputPtr =
+        extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value outputPtr =
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
+
+    auto outputType = cast<MemRefType>(op.getOutput().getType());
+    Value numElements = createI64Const(1);
+    MemRefDescriptor outputDesc(adaptor.getOutput());
+    for (auto dimIdx : llvm::seq<int64_t>(outputType.getRank())) {
+      Value dimSize =
+          outputType.isDynamicDim(dimIdx)
+              ? outputDesc.size(rewriter, loc, dimIdx)
+              : createI64Const(outputType.getDimSize(dimIdx));
+      numElements = LLVM::MulOp::create(rewriter, loc, numElements, dimSize);
+    }
+
+    Type elemType = outputType.getElementType();
+    int64_t dataType = getHipdnnDataType(elemType);
+    if (dataType < 0 || (dataType > 2 && dataType != 6)) {
+      std::string errorMsg;
+      llvm::raw_string_ostream os(errorMsg);
+      os << "unsupported element type '" << elemType
+         << "' for Swish. Only f32, f16, bf16, and f64 are supported";
+      return rewriter.notifyMatchFailure(op, os.str());
+    }
+
+    Value dataTypeVal = createI64Const(dataType);
+    Value alphaConst = LLVM::ConstantOp::create(
+        rewriter, loc, f64Type,
+        rewriter.getF64FloatAttr(op.getAlpha().convertToDouble()));
+
+    SmallVector<Type, 6> paramTypes = {ptrType, ptrType, ptrType,
+                                       i64Type, i64Type, f64Type};
+    FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
+        rewriter, module, kWrapSwish, paramTypes, i32Type);
+    if (failed(funcOp))
+      return failure();
+
+    SmallVector<Value, 6> args = {statePtr,    inputPtr,    outputPtr,
+                                  numElements, dataTypeVal, alphaConst};
+    LLVM::CallOp::create(rewriter, loc, *funcOp, args);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 // hip.silu(handle, input, output)
 struct SiluOpLowering : public ConvertOpToLLVMPattern<SiluOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
@@ -347,8 +415,9 @@ struct MiopenSoftmaxOpLowering
 
 void populateActivationLoweringPatterns(const LLVMTypeConverter &converter,
                                         RewritePatternSet &patterns) {
-  patterns.add<SoftplusOpLowering, GeluOpLowering, LeakyReluOpLowering,
-               SiluOpLowering, MiopenSoftmaxOpLowering>(converter);
+  patterns
+      .add<SoftplusOpLowering, GeluOpLowering, LeakyReluOpLowering,
+           SwishOpLowering, SiluOpLowering, MiopenSoftmaxOpLowering>(converter);
 }
 
 } // namespace hip

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -74,6 +74,7 @@ inline constexpr const char *kWrapBiasGelu = "wrap_bias_gelu"; // hip.bias_gelu
 inline constexpr const char *kWrapFastGelu = "wrap_fast_gelu"; // hip.fast_gelu
 inline constexpr const char *kWrapLeakyRelu =
     "wrap_leaky_relu";                                        // hip.leaky_relu
+inline constexpr const char *kWrapSwish = "wrap_swish";       // hip.swish
 inline constexpr const char *kWrapSoftplus = "wrap_softplus"; // hip.softplus
 inline constexpr const char *kWrapElementwiseSub = "wrap_elementwise_sub";
 inline constexpr const char *kWrapRotaryEmbedding = "wrap_rotary_embedding";

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -154,6 +154,7 @@ add_library(OnnxToHip STATIC
   IfOutline.cpp
   ReluConversion.cpp
   LeakyReluConversion.cpp
+  SwishConversion.cpp
   ClipConversion.cpp
 )
 

--- a/lib/Conversion/OnnxToHip/MatMulConversion.cpp
+++ b/lib/Conversion/OnnxToHip/MatMulConversion.cpp
@@ -35,10 +35,12 @@ MatMulToHip::matchAndRewrite(mlir::Operation *op,
 
   int64_t transA = 0;
   int64_t transB = 0;
+  // TransposeMatMulFold stamps these with getI64IntegerAttr, i.e. signless i64,
+  // so read through getValue(); getSInt() asserts on a non-signed type.
   if (auto attr = op->getAttrOfType<mlir::IntegerAttr>("hipdnn.transA"))
-    transA = attr.getSInt();
+    transA = attr.getValue().getSExtValue();
   if (auto attr = op->getAttrOfType<mlir::IntegerAttr>("hipdnn.transB"))
-    transB = attr.getSInt();
+    transB = attr.getValue().getSExtValue();
 
   // MatMul: result[..., M, N] = A[..., M, K] @ B[..., K, N].
   // Batch and M dims come from A; N comes from B's last dim.

--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -331,6 +331,7 @@ static mlir::LogicalResult convertComputeOps(mlir::func::FuncOp funcOp,
   populateConcatConversionPatterns(patterns, ctx);
   populateReluConversionPatterns(patterns, ctx);
   populateLeakyReluConversionPatterns(patterns, ctx);
+  populateSwishConversionPatterns(patterns, ctx);
   populateClipConversionPatterns(patterns, ctx);
   populatePoolConversionPatterns(patterns, ctx);
   populateResizeConversionPatterns(patterns, ctx);

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -452,6 +452,8 @@ void populateReluConversionPatterns(RewritePatternSet &patterns,
                                     MLIRContext *ctx);
 void populateLeakyReluConversionPatterns(RewritePatternSet &patterns,
                                          MLIRContext *ctx);
+void populateSwishConversionPatterns(RewritePatternSet &patterns,
+                                     MLIRContext *ctx);
 void populateClipConversionPatterns(RewritePatternSet &patterns,
                                     MLIRContext *ctx);
 void populatePoolConversionPatterns(RewritePatternSet &patterns,

--- a/lib/Conversion/OnnxToHip/SwishConversion.cpp
+++ b/lib/Conversion/OnnxToHip/SwishConversion.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+//===- SwishConversion.cpp - onnx.Swish -> hip.swish ---------------------===//
+//
+// Lowers ONNX Swish to one fused HIP operation:
+//
+//   y = x * sigmoid(alpha * x)
+//
+// Keeping this fused avoids two or three kernel launches from decomposing the
+// ONNX function body into Mul/Sigmoid/Mul. It also preserves the full ONNX
+// type set: f16, f32, bf16, and f64.
+//
+//===----------------------------------------------------------------------===//
+
+#include "OnnxToHipUtils.h"
+
+namespace mlir {
+namespace hip {
+namespace {
+
+struct SwishToHip : public mlir::RewritePattern {
+  SwishToHip(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Swish", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    if (op->getNumOperands() != 1 || op->getNumResults() != 1)
+      return rewriter.notifyMatchFailure(
+          op, "onnx.Swish expects 1 operand and 1 result");
+
+    mlir::Value input = op->getOperand(0);
+    auto inputType = mlir::dyn_cast<mlir::RankedTensorType>(input.getType());
+    auto resultType =
+        mlir::dyn_cast<mlir::RankedTensorType>(op->getResult(0).getType());
+    if (!inputType || !resultType)
+      return rewriter.notifyMatchFailure(
+          op, "onnx.Swish requires ranked tensor input and result");
+
+    mlir::Type elemType = inputType.getElementType();
+    if (!elemType.isF16() && !elemType.isF32() && !elemType.isBF16() &&
+        !elemType.isF64())
+      return rewriter.notifyMatchFailure(
+          op, "onnx.Swish supports only f16, f32, bf16, and f64");
+    if (inputType != resultType)
+      return rewriter.notifyMatchFailure(
+          op, "onnx.Swish input and result types must match");
+
+    auto ctxOrFailure = getContextArg(op, rewriter);
+    if (mlir::failed(ctxOrFailure))
+      return mlir::failure();
+
+    double alpha = 1.0;
+    if (auto attr = op->getAttrOfType<mlir::FloatAttr>("alpha"))
+      alpha = attr.getValueAsDouble();
+
+    mlir::Location loc = op->getLoc();
+    mlir::Value init =
+        createEmptyTensor(rewriter, loc, resultType, input);
+    auto swish = mlir::hip::SwishOp::create(
+        rewriter, loc, resultType, *ctxOrFailure, input, init,
+        rewriter.getF64FloatAttr(alpha));
+    rewriter.replaceOp(op, swish->getResult(0));
+    return mlir::success();
+  }
+};
+
+} // namespace
+
+void populateSwishConversionPatterns(RewritePatternSet &patterns,
+                                     MLIRContext *ctx) {
+  patterns.add<SwishToHip>(ctx);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/OnnxToHip/SwishConversion.cpp
+++ b/lib/Conversion/OnnxToHip/SwishConversion.cpp
@@ -57,11 +57,10 @@ struct SwishToHip : public mlir::RewritePattern {
       alpha = attr.getValueAsDouble();
 
     mlir::Location loc = op->getLoc();
-    mlir::Value init =
-        createEmptyTensor(rewriter, loc, resultType, input);
-    auto swish = mlir::hip::SwishOp::create(
-        rewriter, loc, resultType, *ctxOrFailure, input, init,
-        rewriter.getF64FloatAttr(alpha));
+    mlir::Value init = createEmptyTensor(rewriter, loc, resultType, input);
+    auto swish = mlir::hip::SwishOp::create(rewriter, loc, resultType,
+                                            *ctxOrFailure, input, init,
+                                            rewriter.getF64FloatAttr(alpha));
     rewriter.replaceOp(op, swish->getResult(0));
     return mlir::success();
   }

--- a/lib/Conversion/OnnxToHip/TransposeMatMulFold.cpp
+++ b/lib/Conversion/OnnxToHip/TransposeMatMulFold.cpp
@@ -65,8 +65,9 @@ getExplicitTransposePerm(mlir::Operation *transposeOp) {
       auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(elem);
       if (!intAttr)
         return std::nullopt;
-      // getValue(), not getSInt(): an ArrayAttr written as `perm = [0, 1, 3, 2]`
-      // holds signless i64 elements, and getSInt() asserts on a signless type.
+      // getValue(), not getSInt(): an ArrayAttr written as `perm = [0, 1, 3,
+      // 2]` holds signless i64 elements, and getSInt() asserts on a signless
+      // type.
       perm.push_back(intAttr.getValue().getSExtValue());
     }
     return perm;

--- a/lib/Conversion/OnnxToHip/TransposeMatMulFold.cpp
+++ b/lib/Conversion/OnnxToHip/TransposeMatMulFold.cpp
@@ -65,7 +65,9 @@ getExplicitTransposePerm(mlir::Operation *transposeOp) {
       auto intAttr = mlir::dyn_cast<mlir::IntegerAttr>(elem);
       if (!intAttr)
         return std::nullopt;
-      perm.push_back(intAttr.getSInt());
+      // getValue(), not getSInt(): an ArrayAttr written as `perm = [0, 1, 3, 2]`
+      // holds signless i64 elements, and getSInt() asserts on a signless type.
+      perm.push_back(intAttr.getValue().getSExtValue());
     }
     return perm;
   }

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -1224,9 +1224,7 @@ void LeakyReluOp::getEffects(
 // SwishOp: ins(input), outs(output)
 //===----------------------------------------------------------------------===//
 
-MutableOperandRange SwishOp::getDpsInitsMutable() {
-  return getOutputMutable();
-}
+MutableOperandRange SwishOp::getDpsInitsMutable() { return getOutputMutable(); }
 
 void SwishOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -1221,6 +1221,20 @@ void LeakyReluOp::getEffects(
 }
 
 //===----------------------------------------------------------------------===//
+// SwishOp: ins(input), outs(output)
+//===----------------------------------------------------------------------===//
+
+MutableOperandRange SwishOp::getDpsInitsMutable() {
+  return getOutputMutable();
+}
+
+void SwishOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
+}
+
+//===----------------------------------------------------------------------===//
 // PoolOp: ins(input), outs([output] or [output, indices])
 //===----------------------------------------------------------------------===//
 

--- a/lib/Runtime/Kernels/CMakeLists.txt
+++ b/lib/Runtime/Kernels/CMakeLists.txt
@@ -47,6 +47,7 @@ set(_kernel_sources
     hip/bias_gelu_kernel.hip
     hip/fast_gelu_kernel.hip
     hip/leaky_relu_kernel.hip
+    hip/swish_kernel.hip
     hip/softplus_kernel.hip
     hip/elementwise_where_kernel.hip
     hip/qelementwise_kernel.hip

--- a/lib/Runtime/Kernels/hip/swish_kernel.hip
+++ b/lib/Runtime/Kernels/hip/swish_kernel.hip
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "hip_custom_kernels.h"
+#include "debug_log.h"
+
+#include <hip/hip_bf16.h>
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+#include <cstdint>
+#include <cstdio>
+
+template <typename T> struct SwishTraits;
+
+template <> struct SwishTraits<float> {
+  using ComputeType = float;
+  __device__ static ComputeType load(float value) { return value; }
+  __device__ static float store(ComputeType value) { return value; }
+  __device__ static ComputeType expFn(ComputeType value) {
+    return expf(value);
+  }
+};
+
+template <> struct SwishTraits<__half> {
+  using ComputeType = float;
+  __device__ static ComputeType load(__half value) {
+    return __half2float(value);
+  }
+  __device__ static __half store(ComputeType value) {
+    return __float2half(value);
+  }
+  __device__ static ComputeType expFn(ComputeType value) {
+    return expf(value);
+  }
+};
+
+template <> struct SwishTraits<__hip_bfloat16> {
+  using ComputeType = float;
+  __device__ static ComputeType load(__hip_bfloat16 value) {
+    return __bfloat162float(value);
+  }
+  __device__ static __hip_bfloat16 store(ComputeType value) {
+    return __float2bfloat16(value);
+  }
+  __device__ static ComputeType expFn(ComputeType value) {
+    return expf(value);
+  }
+};
+
+template <> struct SwishTraits<double> {
+  using ComputeType = double;
+  __device__ static ComputeType load(double value) { return value; }
+  __device__ static double store(ComputeType value) { return value; }
+  __device__ static ComputeType expFn(ComputeType value) {
+    return exp(value);
+  }
+};
+
+template <typename T>
+__device__ __forceinline__ T computeSwish(T input, double alpha) {
+  using Traits = SwishTraits<T>;
+  using ComputeType = typename Traits::ComputeType;
+
+  ComputeType x = Traits::load(input);
+
+  // ONNX defines Swish as a function of CastLike, Mul, Sigmoid, and Mul.
+  // Round each intermediate back to T so low-precision behavior matches that
+  // function body rather than an unconstrained higher-precision fusion.
+  ComputeType typedAlpha =
+      Traits::load(Traits::store(static_cast<ComputeType>(alpha)));
+  ComputeType scaled = Traits::load(Traits::store(typedAlpha * x));
+  ComputeType sigmoid = ComputeType(1) /
+                        (ComputeType(1) + Traits::expFn(-scaled));
+  sigmoid = Traits::load(Traits::store(sigmoid));
+  return Traits::store(x * sigmoid);
+}
+
+template <typename T>
+__global__ void swishKernel(const T *__restrict__ input,
+                            T *__restrict__ output, int64_t numElements,
+                            double alpha) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx < numElements)
+    output[idx] = computeSwish<T>(input[idx], alpha);
+}
+
+extern "C" int hip_swish(void *stream, const void *input, void *output,
+                         int64_t numElements, int hipDtype, double alpha) {
+  if (numElements <= 0)
+    return 0;
+
+  hipStream_t hipStream = static_cast<hipStream_t>(stream);
+  constexpr int kBlockSize = 256;
+  int gridSize =
+      static_cast<int>((numElements + kBlockSize - 1) / kBlockSize);
+
+  // Clear a stale launch error so the status below belongs to this kernel.
+  (void)hipGetLastError();
+  switch (hipDtype) {
+  case HIP_DTYPE_FLOAT16:
+    hipLaunchKernelGGL(swishKernel<__half>, dim3(gridSize), dim3(kBlockSize), 0,
+                       hipStream, static_cast<const __half *>(input),
+                       static_cast<__half *>(output), numElements, alpha);
+    break;
+  case HIP_DTYPE_FLOAT32:
+    hipLaunchKernelGGL(swishKernel<float>, dim3(gridSize), dim3(kBlockSize), 0,
+                       hipStream, static_cast<const float *>(input),
+                       static_cast<float *>(output), numElements, alpha);
+    break;
+  case HIP_DTYPE_BFLOAT16:
+    hipLaunchKernelGGL(
+        swishKernel<__hip_bfloat16>, dim3(gridSize), dim3(kBlockSize), 0,
+        hipStream, static_cast<const __hip_bfloat16 *>(input),
+        static_cast<__hip_bfloat16 *>(output), numElements, alpha);
+    break;
+  case HIP_DTYPE_FLOAT64:
+    hipLaunchKernelGGL(swishKernel<double>, dim3(gridSize), dim3(kBlockSize), 0,
+                       hipStream, static_cast<const double *>(input),
+                       static_cast<double *>(output), numElements, alpha);
+    break;
+  default:
+    fprintf(stderr, "[custom_kernels] hip_swish: unsupported dtype=%d\n",
+            hipDtype);
+    return -1;
+  }
+
+  CUSTOM_KERNELS_DEBUG_LOG(
+      "[custom_kernels] hip_swish: dtype=%d, alpha=%f, num=%lld\n", hipDtype,
+      alpha, (long long)numElements);
+  hipError_t error = hipGetLastError();
+  if (error != hipSuccess)
+    fprintf(stderr, "[custom_kernels] hip_swish launch failed: %s\n",
+            hipGetErrorString(error));
+  return static_cast<int>(error);
+}

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -531,6 +531,19 @@ HIP_KERNEL_API int hip_leaky_relu(
     double alpha);
 
 /* =========================================================================
+ * Swish Activation
+ * =========================================================================
+ *
+ * Applies Swish element-wise: y = x * sigmoid(alpha * x).
+ * Supports HIP_DTYPE_FLOAT16, HIP_DTYPE_FLOAT32, HIP_DTYPE_BFLOAT16, and
+ * HIP_DTYPE_FLOAT64.
+ *
+ * Returns: 0 on success (hipSuccess), non-zero hipError_t on failure.
+ */
+HIP_KERNEL_API int hip_swish(void *stream, const void *input, void *output,
+                             int64_t num_elements, int hip_dtype, double alpha);
+
+/* =========================================================================
  * Softplus activation
  * =========================================================================
  *

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -1107,6 +1107,12 @@ int wrap_fast_gelu(RuntimeState *state, void *input, void *bias, void *output,
 int wrap_leaky_relu(RuntimeState *state, void *input, void *output,
                     int64_t num_elements, int64_t data_type, double alpha);
 
+// Swish activation wrapper (uses custom HIP kernel).
+// data_type: HIPDNN_EP_DATATYPE_* (supports FLOAT, HALF, BFLOAT16, DOUBLE)
+// alpha: sigmoid input scale (default 1.0 per ONNX spec)
+int wrap_swish(RuntimeState *state, void *input, void *output,
+               int64_t num_elements, int64_t data_type, double alpha);
+
 // Window-pool wrapper (uses custom HIP kernel).
 // Generic ONNX MaxPool / AveragePool / LpPool over (N, C, D_1[, D_2[, D_3]])
 // input with row-major output layout.  `pool_mode` (HIPDNN_EP_POOL_*) selects

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -1131,6 +1131,20 @@ int wrap_leaky_relu(RuntimeState *state, void *input, void *output,
   return 0;
 }
 
+int wrap_swish(RuntimeState *state, void *input, void *output,
+               int64_t num_elements, int64_t data_type, double alpha) {
+  if (!state) {
+    fprintf(stderr, "Invalid state in wrap_swish\n");
+    return -1;
+  }
+
+  MOCK_PRINT("[MOCK] wrap_swish(num_elements=%lld, data_type=%s(%lld), "
+             "alpha=%f)\n",
+             (long long)num_elements, hipdnn_ep_datatype_name(data_type),
+             (long long)data_type, alpha);
+  return 0;
+}
+
 // Mock impl of the runtime symbol referenced by the hip.miopen.softmax
 // lowering. Signature must match lib/Runtime/real/activation.cpp.
 extern "C" int hip_miopen_softmax(RuntimeState *state, const void *input,

--- a/lib/Runtime/real/activation.cpp
+++ b/lib/Runtime/real/activation.cpp
@@ -251,3 +251,42 @@ int wrap_leaky_relu(RuntimeState *state, void *input, void *output,
   RUNTIME_DEBUG_LOG("[REAL] wrap_leaky_relu: completed successfully\n");
   return 0;
 }
+
+int wrap_swish(RuntimeState *state, void *input, void *output,
+               int64_t num_elements, int64_t data_type, double alpha) {
+  OP_PROFILE(
+      "swish",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "n=%lld", (long long)num_elements);
+        return std::string(b);
+      },
+      state);
+  if (!state || !input || !output) {
+    fprintf(stderr, "[REAL] wrap_swish: null argument\n");
+    return -1;
+  }
+
+  int hip_dtype = hipdnn_ep_to_hip_dtype_elementwise_unary(data_type);
+  if (hip_dtype < 0) {
+    fprintf(stderr, "[REAL] wrap_swish: unsupported data_type %lld\n",
+            (long long)data_type);
+    return -1;
+  }
+
+  void *stream = hipdnn_ep_state_get_stream(state);
+  RUNTIME_DEBUG_LOG("[REAL] wrap_swish: num_elements=%lld, "
+                    "data_type=%s(%lld), alpha=%f\n",
+                    (long long)num_elements, hipdnn_ep_datatype_name(data_type),
+                    (long long)data_type, alpha);
+
+  int result =
+      hip_swish(stream, input, output, num_elements, hip_dtype, alpha);
+  if (result != 0) {
+    fprintf(stderr, "[REAL] wrap_swish: kernel launch failed (%d)\n", result);
+    return -1;
+  }
+
+  RUNTIME_DEBUG_LOG("[REAL] wrap_swish: completed successfully\n");
+  return 0;
+}

--- a/lib/Runtime/real/activation.cpp
+++ b/lib/Runtime/real/activation.cpp
@@ -280,8 +280,7 @@ int wrap_swish(RuntimeState *state, void *input, void *output,
                     (long long)num_elements, hipdnn_ep_datatype_name(data_type),
                     (long long)data_type, alpha);
 
-  int result =
-      hip_swish(stream, input, output, num_elements, hip_dtype, alpha);
+  int result = hip_swish(stream, input, output, num_elements, hip_dtype, alpha);
   if (result != 0) {
     fprintf(stderr, "[REAL] wrap_swish: kernel launch failed (%d)\n", result);
     return -1;

--- a/test/lit/Conversion/hip-to-llvm/test_swish.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_swish.mlir
@@ -1,0 +1,46 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s --convert-hip-to-llvm | FileCheck %s
+
+module {
+  func.func @swish_static(
+      %ctx: !hip.context,
+      %input: memref<2x3xf32, 1>,
+      %output: memref<2x3xf32, 1>) {
+    // CHECK-LABEL: llvm.func @swish_static
+    // CHECK: llvm.mlir.constant(5.000000e-01 : f64) : f64
+    // CHECK: llvm.call @wrap_swish({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, f64) -> i32
+    hip.swish(%ctx) ins(%input : memref<2x3xf32, 1>)
+                    outs(%output : memref<2x3xf32, 1>)
+                    {alpha = 0.5 : f64}
+    return
+  }
+
+  func.func @swish_dynamic_bf16(
+      %ctx: !hip.context,
+      %input: memref<?x?x16xbf16, 1>,
+      %output: memref<?x?x16xbf16, 1>) {
+    // CHECK-LABEL: llvm.func @swish_dynamic_bf16
+    // CHECK-DAG: llvm.extractvalue %{{.*}}[3, 0]
+    // CHECK-DAG: llvm.extractvalue %{{.*}}[3, 1]
+    // CHECK-DAG: llvm.mlir.constant(16 : i64) : i64
+    // CHECK-DAG: llvm.mlir.constant(2 : i64) : i64
+    // CHECK: llvm.call @wrap_swish({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, f64) -> i32
+    hip.swish(%ctx) ins(%input : memref<?x?x16xbf16, 1>)
+                    outs(%output : memref<?x?x16xbf16, 1>)
+    return
+  }
+
+  func.func @swish_f64(
+      %ctx: !hip.context,
+      %input: memref<8xf64, 1>,
+      %output: memref<8xf64, 1>) {
+    // CHECK-LABEL: llvm.func @swish_f64
+    // CHECK-DAG: llvm.mlir.constant(6 : i64) : i64
+    // CHECK: llvm.call @wrap_swish({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, f64) -> i32
+    hip.swish(%ctx) ins(%input : memref<8xf64, 1>)
+                    outs(%output : memref<8xf64, 1>)
+    return
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_swish.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_swish.mlir
@@ -1,0 +1,56 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+
+module {
+  func.func @main_graph(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+    return %arg0 : tensor<4xf32>
+  }
+
+  func.func @swish_default(%x: tensor<3x4xf32>) -> tensor<3x4xf32> {
+    %y = "onnx.Swish"(%x) : (tensor<3x4xf32>) -> tensor<3x4xf32>
+    return %y : tensor<3x4xf32>
+  }
+
+  // CHECK-LABEL: func.func @swish_default
+  // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[X:.*]]: tensor<3x4xf32>)
+  // CHECK-NOT: onnx.Swish
+  // CHECK: hip.swish(%[[CTX]]) ins(%[[X]] : tensor<3x4xf32>)
+  // CHECK-NOT: alpha
+  // CHECK-SAME: : tensor<3x4xf32>
+
+  func.func @swish_alpha_f16(%x: tensor<2x3xf16>) -> tensor<2x3xf16> {
+    %y = "onnx.Swish"(%x) {alpha = 0.5 : f32}
+        : (tensor<2x3xf16>) -> tensor<2x3xf16>
+    return %y : tensor<2x3xf16>
+  }
+
+  // CHECK-LABEL: func.func @swish_alpha_f16
+  // CHECK-NOT: onnx.Swish
+  // CHECK: hip.swish
+  // CHECK-SAME: {alpha = 5.000000e-01 : f64}
+
+  func.func @swish_bf16(%x: tensor<2x5xbf16>) -> tensor<2x5xbf16> {
+    %y = "onnx.Swish"(%x) {alpha = 2.0 : f32}
+        : (tensor<2x5xbf16>) -> tensor<2x5xbf16>
+    return %y : tensor<2x5xbf16>
+  }
+
+  // CHECK-LABEL: func.func @swish_bf16
+  // CHECK-NOT: onnx.Swish
+  // CHECK: hip.swish
+
+  func.func @swish_dynamic_f64(%x: tensor<?x?xf64>) -> tensor<?x?xf64> {
+    %y = "onnx.Swish"(%x) {alpha = -0.25 : f32}
+        : (tensor<?x?xf64>) -> tensor<?x?xf64>
+    return %y : tensor<?x?xf64>
+  }
+
+  // CHECK-LABEL: func.func @swish_dynamic_f64
+  // CHECK-SAME: (%[[CTX2:.*]]: !hip.context, %[[X2:.*]]: tensor<?x?xf64>)
+  // CHECK-NOT: onnx.Swish
+  // CHECK: tensor.dim
+  // CHECK: hip.swish(%[[CTX2]])
+  // CHECK-SAME: {alpha = -2.500000e-01 : f64}
+}

--- a/test/lit/e2e/test_swish_model.mlir
+++ b/test/lit/e2e/test_swish_model.mlir
@@ -1,0 +1,21 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s --hipdnn-pipeline | FileCheck %s
+
+// CHECK: module attributes {
+// CHECK-SAME: hipdnn.input_count = 1
+// CHECK-SAME: hipdnn.output_count = 1
+// CHECK: llvm.func @wrap_swish
+// CHECK: llvm.func @inference_init
+// CHECK: llvm.func @inference_compute
+// CHECK: llvm.func @inference_cleanup
+// CHECK: llvm.func @inference_get_metadata_json
+// CHECK-NOT: onnx.Swish
+module {
+  func.func @main_graph(%arg0: tensor<3x4xf32> {onnx.name = "x"}) -> (tensor<3x4xf32> {onnx.name = "y"}) {
+    %0 = "onnx.Swish"(%arg0) {alpha = 0.5 : f32, onnx_node_name = "swish_node"} : (tensor<3x4xf32>) -> tensor<3x4xf32>
+    "onnx.Return"(%0) : (tensor<3x4xf32>) -> ()
+  }
+  "onnx.EntryPoint"() {func = @main_graph} : () -> ()
+}

--- a/test/numeric/tests/test_activation.py
+++ b/test/numeric/tests/test_activation.py
@@ -24,9 +24,7 @@ CHUNK_OPT_HEADS = 16
 CHUNK_OPT_GATE_CH = 32
 
 
-def _make_unary_model(
-    op_type: str, dtype, shape: list[int], opset: int = 17, **attrs
-):
+def _make_unary_model(op_type: str, dtype, shape: list[int], opset: int = 17, **attrs):
     """Build a single-input unary ONNX model."""
     tp = np_to_onnx_type(dtype)
     X = helper.make_tensor_value_info("X", tp, shape)

--- a/test/numeric/tests/test_activation.py
+++ b/test/numeric/tests/test_activation.py
@@ -4,7 +4,7 @@
 #
 
 """Tests for activation / unary operations: Sigmoid, Tanh, Sqrt, Reciprocal,
-Softplus."""
+Softplus, Swish."""
 
 import numpy as np
 import pytest
@@ -24,13 +24,15 @@ CHUNK_OPT_HEADS = 16
 CHUNK_OPT_GATE_CH = 32
 
 
-def _make_unary_model(op_type: str, dtype, shape: list[int], **attrs):
+def _make_unary_model(
+    op_type: str, dtype, shape: list[int], opset: int = 17, **attrs
+):
     """Build a single-input unary ONNX model."""
     tp = np_to_onnx_type(dtype)
     X = helper.make_tensor_value_info("X", tp, shape)
     Y = helper.make_tensor_value_info("Y", tp, shape)
     node = helper.make_node(op_type, ["X"], ["Y"], **attrs)
-    return make_model_from_nodes([node], [X], [Y])
+    return make_model_from_nodes([node], [X], [Y], opset=opset)
 
 
 class TestSigmoid:
@@ -200,3 +202,26 @@ class TestSoftplus:
 
         actual, expected = model_runner.run_sample(model, [x])
         compare_outputs(actual, expected, atol=1e-4)
+
+
+class TestSwish:
+    """Swish(x) = x * sigmoid(alpha * x), introduced in ONNX opset 24."""
+
+    @pytest.mark.parametrize(
+        "dtype,alpha,atol,rtol",
+        [
+            (np.float16, None, 2e-3, 2e-3),
+            (np.float16, 0.5, 2e-3, 2e-3),
+            (np.float32, -0.25, 1e-5, 1e-5),
+            (np.float64, 2.0, 1e-12, 1e-12),
+        ],
+    )
+    def test_swish(self, model_runner, dtype, alpha, atol, rtol):
+        attrs = {} if alpha is None else {"alpha": alpha}
+        model = _make_unary_model("Swish", dtype, [4, 17], opset=24, **attrs)
+
+        rng = np.random.default_rng(29)
+        x = rng.uniform(-8, 8, [4, 17]).astype(dtype)
+
+        actual, expected = model_runner.run_sample(model, [x])
+        compare_outputs(actual, expected, atol=atol, rtol=rtol)


### PR DESCRIPTION
## Summary

This PR lands three related pieces needed to compile and run graphs such as Hy-MT 1.8B 2-bit fp16 ONNX on hipgpu: native Swish, bits=2 **fp16** MatMulNBits zero-points, and two `getSInt()` aborts on signless i64 (`BuiltinAttributes.cpp:371`).

### 1. Native `onnx.Swish` (`da9ef389`)

These graphs import Swish as a real ONNX op rather than `Mul(x, Sigmoid(x))`. This adds the full path, not only conversion:

- `hip.swish` dialect op, ONNX-to-HIP conversion, HIP-to-LLVM lowering
- Custom HIP kernel + real/mock runtime (`f16` / `f32` / `bf16` / `f64`)
- LIT (onnx-to-hip, hip-to-llvm, e2e), numeric activation tests, `docs/supported-operations.md`

### 2. MatMulNBits bits=2 fp16 zero-points (`bcf6c22b`) ====>  this step is removed because PR 931 did same thing.

Some quantized graphs store per-group zero-points as **fp16 1.5**, matching codebook `{-1.5, -0.5, +0.5, +1.5}`. Rounding those values to uint8 (`rintf(1.5) -> 2`) dequantizes every weight against the wrong offset and poisons GEMV/prefill.

- u2 GEMV and naive kernels are templated on zp type (`__half` vs `uint8_t`)
- Packed uint8 zp (`zp_elem_size==1`) is unchanged
- u2 WMMA still assumes integer zp, so it is **disabled when zp is fp16** (falls back to GEMV/naive)
- Numeric coverage: `test_matmul_nbits_2bit_fp16_fractional_zero_point` (seq 1 and 16)

### 3. `getSInt()` abort at `BuiltinAttributes.cpp:371` (both commits)

`IntegerAttr::getSInt()` asserts if the storage type is **signless** i64. Two attributes written with `getI64IntegerAttr` / ArrayAttr `[0, 1, 3, 2]` hit that:

| Site | Commit | Attribute |
|---|---|---|
| `TransposeMatMulFold.cpp` | `da9ef389` | Transpose `perm` ArrayAttr |
| `MatMulConversion.cpp` | `bcf6c22b` | `hipdnn.transA` / `hipdnn.transB` stamped by the fold |

Both now use `getValue().getSExtValue()`. Without the first fix, last-two-dim Transpose-into-MatMul fold aborted; without the second, folded MatMul conversion aborted later (and under `HIPDNN_EP_STRICT=1` looked like leftover unbufferized ops).

## Test plan

- [ ] LIT: `test/lit/Conversion/onnx-to-hip/test_swish.mlir`, `hip-to-llvm/test_swish.mlir`, `e2e/test_swish_model.mlir`
- [ ] Numeric: Swish cases in `test/numeric/tests/test_activation.py`
- [ ] Numeric: `test_matmul_nbits_2bit_fp16_fractional_zero_point`
- [ ] GPU: Hy-MT 1.8B 2-bit fp16 ONNX with `HIPDNN_EP_STRICT=1` (Swish + MatMulNBits fp16 zp + Transpose fold)

## AI assistance

Substantial compiler/runtime and test changes were drafted with Cursor. Validated via LIT/numeric paths and a Hy-MT CPU-vs-hipgpu token comparison after clearing the model cache.