### PR TITLE
build: compress HIP fatbins in custom kernel libraries

### DIFF
--- a/lib/Runtime/Kernels/cmake/hip_utils.cmake
+++ b/lib/Runtime/Kernels/cmake/hip_utils.cmake
@@ -192,6 +192,9 @@ endfunction()
 #------------------------------------------------------------------------------
 function(_hip_compile_sources TARGET_NAME HIP_SOURCES INCLUDE_DIRS COMPILE_OPTS ARCH_LIST OUTPUT_OBJS)
     _hip_get_arch_flags("${ARCH_LIST}" arch_flags)
+    # Compress the embedded HIP fatbin (clang-offload-bundler -compress).
+    # Decompressed once by the HIP runtime at load; clang default is off.
+    list(APPEND arch_flags "--offload-compress")
 
     # Build include flags
     # NOTE: -I and path are separate list items to handle paths with spaces
@@ -422,8 +425,10 @@ function(hip_add_executable TARGET_NAME)
             )
         endif()
 
-        # Warning suppression flags
-        target_compile_options(${TARGET_NAME} PRIVATE $<$<COMPILE_LANGUAGE:HIP>:-Wno-ignored-attributes>)
+        target_compile_options(${TARGET_NAME} PRIVATE
+            $<$<COMPILE_LANGUAGE:HIP>:-Wno-ignored-attributes>
+            $<$<COMPILE_LANGUAGE:HIP>:--offload-compress>
+        )
     endif()
 
     # Link HIP runtime
@@ -519,8 +524,10 @@ function(hip_add_library TARGET_NAME)
             )
         endif()
 
-        # Warning suppression flags
-        target_compile_options(${TARGET_NAME} PRIVATE $<$<COMPILE_LANGUAGE:HIP>:-Wno-ignored-attributes>)
+        target_compile_options(${TARGET_NAME} PRIVATE
+            $<$<COMPILE_LANGUAGE:HIP>:-Wno-ignored-attributes>
+            $<$<COMPILE_LANGUAGE:HIP>:--offload-compress>
+        )
     endif()
 
     # Propagate HIP settings to dependents


### PR DESCRIPTION
## Summary

Pass --offload-compress so hipcc/clang shrinks the embedded device bundle at compile time. Saves space for the .dll (11 MB -> 3 MB), but requires decompression on first use.

Draft PR for now to let CI assess the impact.

## Related issue or design

<!-- Link the issue/design discussion, use "Fixes #123", or write "None". -->

## Why

<!-- Explain the problem and rationale when the design choice is not obvious. -->

## What

<!-- Optional for small changes. List concrete implementation details. -->

## Test plan

<!-- List commands run and results, or explain why testing was not needed. -->

## Notes for reviewers

<!-- Optional: limitations, follow-ups, important assumptions, or ordering constraints. -->

<!--
Optional sections: remove this comment and keep the sections that apply.

## Compiler IR

<details>
<summary>Before / after</summary>

```mlir
// Before
```

```mlir
// After
```

</details>

## Performance

| Metric | Before | After |
|---|---:|---:|
| | | |

Hardware, workload, build configuration, and measurement method:
-->

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [ ] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.

Used Cursor to draft the change. Change is reviewed and understood.