### PR TITLE
fix(onnx-to-hip): minor build fixes

### DIFF
--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -177,6 +177,13 @@ else()
   set(LLVM_ENABLE_RTTI ON CACHE BOOL "" FORCE)
   set(LLVM_ENABLE_ZLIB OFF CACHE BOOL "" FORCE)
   set(LLVM_ENABLE_ZSTD OFF CACHE BOOL "" FORCE)
+  # LLVM auto-enables DIA once it finds the DIA SDK, and DIASupport.h then pulls
+  # atlbase.h from the ATL headers. ATL reaches cl.exe differently per generator:
+  # MSBuild puts atlmfc/include on IncludePath itself, while Ninja takes it from
+  # INCLUDE in the invoking shell -- so the same machine builds from source under
+  # the Visual Studio generator and fails under Ninja. Nothing here reads PDBs,
+  # so drop the dependency rather than constrain how the build is launched.
+  set(LLVM_ENABLE_DIA_SDK OFF CACHE BOOL "" FORCE)
   set(LLVM_INCLUDE_TESTS OFF CACHE BOOL "" FORCE)
   set(LLVM_INCLUDE_EXAMPLES OFF CACHE BOOL "" FORCE)
   set(LLVM_INCLUDE_BENCHMARKS OFF CACHE BOOL "" FORCE)

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -6,23 +6,36 @@
 # ============================================================================
 # PDLL Pattern Compilation
 # ============================================================================
-# Locate mlir-pdll. LLVM_TOOLS_BINARY_DIR is exported by find_package(MLIR) and
-# covers both the prebuilt SDK and an installed LLVM; the _deps path covers an
-# LLVM built inside this project's FetchContent tree. Default search paths stay
-# enabled so a tool on PATH is still usable.
-find_program(MLIR_PDLL_EXE mlir-pdll
-    HINTS
-        "${CMAKE_BINARY_DIR}/_deps/llvm-project-build/bin"
-        "${LLVM_TOOLS_BINARY_DIR}"
-        "${LLVM_BINARY_DIR}/bin"
-)
+# Locate mlir-pdll. When LLVM/MLIR is built from source as a subproject the
+# `mlir-pdll` target exists but its .exe is not present at configure time, so
+# find_program cannot see it — use the target directly (the custom command
+# below then gains a build-time dependency on it). Fall back to find_program
+# for the prebuilt / installed-LLVM case: LLVM_TOOLS_BINARY_DIR is exported by
+# find_package(MLIR) and covers both the prebuilt SDK and an installed LLVM;
+# the _deps path covers a FetchContent tree that has already been built.
+# Default search paths stay enabled so a tool on PATH is still usable.
+if(TARGET mlir-pdll)
+    set(MLIR_PDLL_EXE mlir-pdll)
+    message(STATUS "OnnxToHip: using in-tree mlir-pdll target")
+else()
+    find_program(MLIR_PDLL_EXE NAMES mlir-pdll
+        HINTS
+            "${CMAKE_BINARY_DIR}/_deps/llvm-project-build/bin"
+            "${LLVM_TOOLS_BINARY_DIR}"
+            "${LLVM_BINARY_DIR}/bin"
+            "${MLIR_BINARY_DIR}/bin"
+    )
+endif()
 
 if(MLIR_PDLL_EXE)
-    message(STATUS "OnnxToHip: mlir-pdll found: ${MLIR_PDLL_EXE}")
+    if(NOT TARGET mlir-pdll)
+        message(STATUS "OnnxToHip: mlir-pdll found: ${MLIR_PDLL_EXE}")
+    endif()
     # HipFusionPatterns.pdll #includes every pattern file, so mlir-pdll runs
     # once and emits one PDL module. Every .pdll is still globbed as a
     # dependency, otherwise editing an included pattern would not rebuild it.
     set(PDL_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/pdl")
+    set(PDL_ENTRY "${PDL_SOURCE_DIR}/HipFusionPatterns.pdll")
     file(GLOB PDL_SOURCES CONFIGURE_DEPENDS "${PDL_SOURCE_DIR}/*.pdll")
     set(PDL_OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/HipFusionPatterns.pdl.mlir")
     # ConvertOnnxToHipPass loads the patterns from the EP library's own
@@ -31,11 +44,18 @@ if(MLIR_PDLL_EXE)
     get_property(_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
     set(PDL_STAGED
         "${CMAKE_BINARY_DIR}/bin/$<$<BOOL:${_multi_config}>:$<CONFIG>/>HipFusionPatterns.pdl.mlir")
+    if(TARGET mlir-pdll)
+        set(MLIR_PDLL_COMMAND "$<TARGET_FILE:mlir-pdll>")
+        set(MLIR_PDLL_DEPENDS mlir-pdll)
+    else()
+        set(MLIR_PDLL_COMMAND "${MLIR_PDLL_EXE}")
+        set(MLIR_PDLL_DEPENDS "${MLIR_PDLL_EXE}")
+    endif()
     add_custom_command(OUTPUT "${PDL_OUTPUT}" "${PDL_STAGED}"
-        COMMAND "${MLIR_PDLL_EXE}" -x mlir "-I${PDL_SOURCE_DIR}"
-                "${PDL_SOURCE_DIR}/HipFusionPatterns.pdll" -o "${PDL_OUTPUT}"
+        COMMAND "${MLIR_PDLL_COMMAND}" -x mlir "-I${PDL_SOURCE_DIR}"
+                "${PDL_ENTRY}" -o "${PDL_OUTPUT}"
         COMMAND "${CMAKE_COMMAND}" -E copy "${PDL_OUTPUT}" "${PDL_STAGED}"
-        DEPENDS ${PDL_SOURCES}
+        DEPENDS ${PDL_SOURCES} ${MLIR_PDLL_DEPENDS}
         COMMENT "Compiling PDLL patterns -> HipFusionPatterns.pdl.mlir"
         VERBATIM)
     add_custom_target(HipPdllPatterns DEPENDS "${PDL_OUTPUT}" "${PDL_STAGED}")
@@ -46,7 +66,23 @@ if(MLIR_PDLL_EXE)
         "Compiled PDL fusion patterns that must ship beside the EP library")
     message(STATUS "OnnxToHip: PDLL fusion enabled — patterns: ${PDL_OUTPUT}")
 else()
-    message(WARNING "OnnxToHip: mlir-pdll not found — PDLL fusion disabled")
+    message(FATAL_ERROR
+        "OnnxToHip: mlir-pdll not found. ConvertOnnxToHipPass requires the "
+        "compiled HipFusionPatterns.pdl.mlir next to the EP library.\n"
+        "\n"
+        "To fix:\n"
+        "  - From-source LLVM: ensure mlir is in LLVM_ENABLE_PROJECTS "
+        "(cmake/deps.cmake already does this) and reconfigure after LLVM is "
+        "in the build tree.\n"
+        "  - Prebuilt LLVM: install the MLIR tools (mlir-pdll) into the same "
+        "prefix as find_package(MLIR), or put mlir-pdll on PATH.\n"
+        "\n"
+        "Searched in:\n"
+        "  - ${CMAKE_BINARY_DIR}/_deps/llvm-project-build/bin\n"
+        "  - ${LLVM_TOOLS_BINARY_DIR}\n"
+        "  - ${LLVM_BINARY_DIR}/bin\n"
+        "  - ${MLIR_BINARY_DIR}/bin\n"
+        "  - System PATH")
 endif()
 
 # ============================================================================

--- a/lib/Conversion/OnnxToHip/CMakeLists.txt
+++ b/lib/Conversion/OnnxToHip/CMakeLists.txt
@@ -66,7 +66,7 @@ if(MLIR_PDLL_EXE)
         "Compiled PDL fusion patterns that must ship beside the EP library")
     message(STATUS "OnnxToHip: PDLL fusion enabled — patterns: ${PDL_OUTPUT}")
 else()
-    message(FATAL_ERROR
+    message(WARNING
         "OnnxToHip: mlir-pdll not found. ConvertOnnxToHipPass requires the "
         "compiled HipFusionPatterns.pdl.mlir next to the EP library.\n"
         "\n"


### PR DESCRIPTION
## Summary

find_program cannot see mlir-pdll until the FetchContent LLVM build produces the binary, which disabled PDL fusion on from-source trees.

The same pattern is already used for lib/Runtime, for example.

Also disable DIA to prevent issues with ATL dependency.

## Related issue or design

None

## Test plan

Local build was failing before (since a recent commit caused `python/` to error out during build when mlir-pdll is n/a). With the change, it passes.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [ ] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.

Debugged and resolved with assistance of Cursor. The code changes have been reviewed and understood.
