### PR TITLE
test: build OGA from the AMDGPU fork so gemma4-unified features are exercised

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -49,11 +49,14 @@ jobs:
       # editing this list auto-invalidates the cached ORT install prefix.
       # Remove a PR number once its fix is in the pinned ONNXRUNTIME_VERSION.
       ONNXRUNTIME_PR_PATCHES: ""
-      OGA_VERSION: "0.14.0"
-      # Space-separated microsoft/onnxruntime-genai PR numbers fetched from
-      # pull/<n>.patch and `git apply` on top of v<OGA_VERSION>. Part of the OGA
-      # cache key. Remove a PR once it lands in the pinned OGA release.
-      OGA_PR_PATCHES: "2194"
+      # Fork branch carrying the AMDGPU MorphiZen integration (former PR 2194) plus
+      # sliding_window support, which upstream v0.14.0 does not have.
+      OGA_REPO: "amd-genmingz/onnxruntime-genai"
+      OGA_REF: "test_0_3"
+      # Optional space-separated microsoft/onnxruntime-genai PR numbers applied on
+      # top of the fork checkout via pull/<n>.patch + git am. Empty because the fork
+      # branch already carries the integration that 2194 used to supply.
+      OGA_PR_PATCHES: ""
       # ilammy/msvc-dev-cmd and mozilla-actions/sccache-action have no
       # Node.js 24 releases yet; allow Node.js 20 until they are updated.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
@@ -370,20 +373,20 @@ jobs:
           # OGA is built against the patched ort-install, so the key folds in
           # both OGA's own PR list and ONNXRUNTIME_PR_PATCHES; editing either
           # forces a rebuild. The mm<N> token bumps when the OGA artifact set
-          # changes shape, or when a PR's branch content changes under the same
-          # number (mm2: PR 2194 now carries the AMDGPU OGA integration).
-          key: oga-dml-mm2-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}
+          # changes shape, or when a ref's content changes under the same name
+          # (mm3: the fork branch replaces upstream v0.14.0 + PR 2194). The fork
+          # branch is mutable, so the trailing -<n> forces a rebuild by hand.
+          key: oga-dml-mm3-${{ env.OGA_REPO }}-${{ env.OGA_REF }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}-2
 
-      # OGA is built from upstream microsoft/onnxruntime-genai + PR patches
-      # (OGA_PR_PATCHES). PR 2194 (the dynamic-shape-morphizen branch) now also
-      # carries the AMDGPU umbrella integration, so the patched upstream build
-      # is the AMDGPU-targeted OGA -- no fork checkout needed.
+      # OGA is built from the AMDGPU fork branch, which already carries the
+      # MorphiZen integration that PR 2194 used to supply plus sliding_window
+      # support. OGA_PR_PATCHES stays available for patches on top.
       - name: Checkout OGA
         if: steps.cache-oga.outputs.cache-hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: microsoft/onnxruntime-genai
-          ref: v${{ env.OGA_VERSION }}
+          repository: ${{ env.OGA_REPO }}
+          ref: ${{ env.OGA_REF }}
           path: source-oga
           submodules: true
           fetch-depth: 1
@@ -442,6 +445,11 @@ jobs:
         if: steps.cache-oga.outputs.cache-hit != 'true'
         shell: bash
         run: |
+          # build.py imports tools/python/util, whose dependency_resolver
+          # imports requests at module scope. --ort_home means nothing is
+          # actually downloaded, but the import still has to resolve.
+          python -m pip install -q requests
+
           python "${{ github.workspace }}/source-oga/build.py" \
             --config Release \
             --cmake_generator Ninja \

--- a/backend-mlir-compiler/custom-op-mlir/CMakeLists.txt
+++ b/backend-mlir-compiler/custom-op-mlir/CMakeLists.txt
@@ -77,9 +77,18 @@ endif()
 # Define MORPHIZEN_CUSTOM_OP for conditional compilation
 target_compile_definitions(${LIB_NAME} PRIVATE MORPHIZEN_CUSTOM_OP=1)
 
-find_package(hipblaslt CONFIG REQUIRED)
+# LlvmIrJit dlopens hipBLASLt by name, and that base name has moved across ROCm
+# releases, so take it from the imported target when there is one. REQUIRED here
+# breaks the mock build, which configures this target but has no ROCm installed
+# and never loads the library at runtime.
+find_package(hipblaslt CONFIG QUIET)
+if(TARGET roc::hipblaslt)
+  set(HIPBLASLT_DLL_NAME "$<TARGET_FILE_BASE_NAME:roc::hipblaslt>")
+else()
+  set(HIPBLASLT_DLL_NAME "libhipblaslt")
+endif()
 target_compile_definitions(${LIB_NAME} PRIVATE
-    HIPDNN_HIPBLASLT_DLL="$<TARGET_FILE_BASE_NAME:roc::hipblaslt>")
+    HIPDNN_HIPBLASLT_DLL="${HIPBLASLT_DLL_NAME}")
 
 if(HIPDNN_EP_LINK_HIP_HOST)
   target_compile_definitions(${LIB_NAME} PRIVATE HIPDNN_EP_LINK_HIP_HOST=1)


### PR DESCRIPTION
Port of #599 onto `gpuep/releases/gpuep-rel-2610`.

#599 targets `.github/workflows/windows-deps.yml`, which does not exist on this
release branch: it was cut before the dependency build was split out of
`windows-build.yml`, and the OGA section still lives inline there. The change is
therefore ported rather than cherry-picked, but it is the same four edits against
the same steps.

## What it does

Upstream `microsoft/onnxruntime-genai` v0.14.0 plus PR 2194 does not carry
`sliding_window` support, which gemma4-unified needs. OGA is now built from
`amd-genmingz/onnxruntime-genai@test_0_3`, the fork branch that already carries
the AMDGPU MorphiZen integration PR 2194 used to supply, so `OGA_PR_PATCHES` goes
empty while staying available for patches on top.

- `OGA_VERSION` / `OGA_PR_PATCHES: "2194"` become `OGA_REPO` / `OGA_REF` with an
  empty patch list.
- The `Checkout OGA` step points at the fork.
- The OGA cache key folds in the repo and ref in place of the version, bumps
  `mm2` to `mm3`, and carries a trailing manual suffix: a branch is mutable where
  a tag is not, so a rebuild sometimes has to be forced by hand.
- `python -m pip install -q requests` runs before `build.py`. `build.py` imports
  `tools/python/util`, whose `dependency_resolver` imports `requests` at module
  scope; `--ort_home` means nothing is actually downloaded, but the import still
  has to resolve.

## Differences from #599

Only the location. On `main` the four hunks land in `windows-deps.yml` at
top-level `env` and in a `Compute cache key` step that echoes into
`$GITHUB_OUTPUT`; here they land in `windows-build.yml` under the
`build-windows` job's `env` and in the `key:` field of the `actions/cache` step
directly. The env indentation shifts from 2 to 6 spaces accordingly. Two
neighbouring comments that described the old upstream-plus-2194 arrangement were
updated, since the workflow now does check out a fork.

`linux-build.yml` on this branch has its own OGA pin and is left alone, matching
#599, which only touched the Windows path.

## Verification

`check yaml` and the rest of pre-commit pass on the edited file, and the workflow
parses with the `build-windows` job resolving to
`OGA_REPO=amd-genmingz/onnxruntime-genai`, `OGA_REF=test_0_3`,
`OGA_PR_PATCHES=""`. Not otherwise exercised locally: this is a CI-only change,
so the real check is the build on this PR.

Draft, and a test PR like its parent: it pins CI to a personal fork branch, which
is not something to merge into a release branch as-is.

---

## Second commit: unrelated pre-existing mock-build failure

Windows Build (Mock) was already failing on this branch before this PR, on every
push since 27 Aug, at CMake configure time:

```
CMake Error at backend-mlir-compiler/custom-op-mlir/CMakeLists.txt:80
  Could not find a package configuration file provided by "hipblaslt"
```

The mock runner has no ROCm installed and the mock runtime never loads hipBLASLt,
but the lookup was `REQUIRED`, so configure aborted before any build step. The
package is wanted only for the DLL base name that `LlvmIrJit` hands to
`DynamicLibrarySearchGenerator::Load`, which has moved across ROCm releases.

The lookup is now `QUIET`, still reading the name off `roc::hipblaslt` when
that target exists and falling back to `libhipblaslt` when it does not. Builds
that do find hipBLASLt expand to the same generator expression as before, so
nothing changes for them. `main` has already dropped this `find_package`
outright along with the code that used the macro; this is the smaller change that
suits a release branch.

It is folded in here so this PR's CI can go green rather than sitting on a red
check that has nothing to do with the OGA switch.
