### PR TITLE
test: exercise the per-chunk kv_span narrowing against a gemma4-capable OGA build (#933 + #599)

### DIFF
--- a/.github/workflows/windows-deps.yml
+++ b/.github/workflows/windows-deps.yml
@@ -587,6 +587,11 @@ jobs:
         if: steps.cache-oga.outputs.cache-hit != 'true'
         shell: bash
         run: |
+          # build.py imports tools/python/util, whose dependency_resolver
+          # imports requests at module scope. --ort_home means nothing is
+          # actually downloaded, but the import still has to resolve.
+          python -m pip install -q requests
+
           python "${{ github.workspace }}/source-oga/build.py" \
             --config Release \
             --cmake_generator Ninja \

--- a/.github/workflows/windows-deps.yml
+++ b/.github/workflows/windows-deps.yml
@@ -30,8 +30,14 @@ env:
   LLVM_TAG: llvmorg-22.1.0
   ONNXRUNTIME_VERSION: "1.27.0"
   ONNXRUNTIME_PR_PATCHES: ""
-  OGA_VERSION: "0.14.0"
-  OGA_PR_PATCHES: "2194"
+  # Fork branch carrying the AMDGPU MorphiZen integration (former PR 2194) plus
+  # sliding_window support, which upstream v0.14.0 does not have.
+  OGA_REPO: "amd-genmingz/onnxruntime-genai"
+  OGA_REF: "test_0_3"
+  # Optional space-separated microsoft/onnxruntime-genai PR numbers applied on
+  # top of the fork checkout via pull/<n>.patch + git am. Empty because the fork
+  # branch already carries the integration that 2194 used to supply.
+  OGA_PR_PATCHES: ""
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
   AMDGPU_EP_REF: "05eaa2a938f71e98b49bd1be3fb03720167be5cc"
   # Space-separated onnxruntime/onnxruntime-ep-amdgpu PR numbers applied on top
@@ -473,7 +479,7 @@ jobs:
       - name: Compute cache key
         id: key
         shell: bash
-        run: echo "value=oga-dml-mm2-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}" >> "$GITHUB_OUTPUT"
+        run: echo "value=oga-dml-mm3-${{ env.OGA_REPO }}-${{ env.OGA_REF }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}-2" >> "$GITHUB_OUTPUT"
 
       - name: Probe oga-artifacts
         id: cache-oga
@@ -525,8 +531,8 @@ jobs:
         if: steps.cache-oga.outputs.cache-hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: microsoft/onnxruntime-genai
-          ref: v${{ env.OGA_VERSION }}
+          repository: ${{ env.OGA_REPO }}
+          ref: ${{ env.OGA_REF }}
           path: source-oga
           submodules: true
           fetch-depth: 1


### PR DESCRIPTION
**Test PR — not for merge.** Base is `perf/gqa-chunk-kv-span`, so the diff here is only the CI change; #933 carries the kernel work.

## What this is

#933 narrows the decomposed prefill's key range per query chunk, and every measurement behind it is Gemma-4 26B-A4B at a 16K prefill on local hardware. CI cannot currently corroborate any of that: the shipped OGA build predates the gemma4-unified features, so the model that motivates the change is not the model CI exercises.

This stacks #599's workflow change (`.github/workflows/windows-deps.yml`, building OGA from the AMDGPU fork) on top of #933 so that the kernel change and a Gemma-4-capable runtime are in the same CI run.

The two commits are cherry-picked unmodified from `test/gemma4` — `.github/workflows/windows-deps.yml` here is byte-identical to #599's (blob `94b2308c`).

## How to read the result

A pass says the narrowing survives a Gemma-4 path built and run by CI rather than only on my machine. It does **not** reproduce the perf claim; TTFT and the SQTT extent checks in #933 are local measurements and stay that way.

## Disposition

Close this once #599 lands on `main` and #933 can be re-run against it directly. Nothing here should be merged: the workflow change belongs to #599, and the kernel change belongs to #933.
