### PR TITLE
fix(hipsr): keep barrier placeholders on the data values

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
@@ -24,15 +24,16 @@ def Hipsr_PlaceholderOp : Hipsr_Op<
       body writes into, so the placeholder carries that destination's shape,
       which may differ from the result held there.
 
-    Inputs feed the shape graph and must be block arguments or results of
-    `hipsr.placeholder`, `arith.constant`, or `hipsr.constant` — never data
-    results, which keeps the shape graph parallel to the data graph.
-    `placeholder_type` is `normal` or `barrier`.
+    A `normal` placeholder's inputs feed the shape graph and must be block
+    arguments or results of `hipsr.placeholder`, `arith.constant`, or
+    `hipsr.constant` — never data results, which keeps the shape graph parallel
+    to the data graph. A `barrier`'s inputs are the data values themselves,
+    because its region reads their contents rather than only their shapes.
 
-    A placeholder and its consumer read the same values, the placeholder on the
-    shape-graph side and the consumer on the data side, even when one of them
-    ignores a value. Matching the two lists is what keeps the pair in one pool
-    domain. Values with no placeholder behind them, such as block arguments and
+    A placeholder and its consumer read the same values, a `normal` placeholder
+    through their shape-graph counterparts, even when one of them ignores a
+    value. Matching the two lists is what keeps the pair in one pool domain.
+    Values with no placeholder behind them, such as block arguments and
     constants, are outside the rule.
 
     The optional `shape_region` computes the result shapes and ends with

--- a/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
+++ b/lib/Conversion/OnnxToHipsr/OnnxToHipsr.cpp
@@ -53,8 +53,14 @@ void eraseDeadNoValue(ModuleOp module) {
 
 // Placeholder inputs form the shape graph, not the data graph.
 // PlaceholderOp::verify reports any input this cannot fix.
+//
+// A barrier is the exception: its region reads the inputs themselves, not just
+// their shapes, so it stays on the data values.
 void rewirePlaceholderInputs(ModuleOp module) {
   module.walk([](PlaceholderOp placeholder) {
+    if (placeholder.getPlaceholderType() == PlaceholderType::Barrier) {
+      return;
+    }
     SmallVector<Value> resolvedInputs =
         llvm::map_to_vector(placeholder.getInputs(), getShapeGraphCounterpart);
     placeholder.getInputsMutable().assign(resolvedInputs);

--- a/lib/Dialect/Hipsr/IR/HipsrPlaceholderOp.cpp
+++ b/lib/Dialect/Hipsr/IR/HipsrPlaceholderOp.cpp
@@ -16,7 +16,11 @@ using namespace mlir::hipsr;
 namespace {
 
 // Keep the shape graph apart from the data graph: no data results as inputs.
+// A barrier is exempt, because its region reads the values themselves.
 LogicalResult verifyShapeGraphInputs(PlaceholderOp op) {
+  if (op.getPlaceholderType() == PlaceholderType::Barrier) {
+    return success();
+  }
   for (auto [index, input] : llvm::enumerate(op.getInputs())) {
     if (!PlaceholderOp::isAllowedShapeGraphInput(input)) {
       return op.emitOpError("input ")
@@ -67,6 +71,16 @@ LogicalResult verifyResultUses(PlaceholderOp op) {
 LogicalResult verifyConsumerTopology(PlaceholderOp op) {
   Operation *consumer = op.getConsumer();
   if (!consumer) {
+    return success();
+  }
+
+  // A barrier reads the data values themselves, so it names exactly what its
+  // consumer names.
+  if (op.getPlaceholderType() == PlaceholderType::Barrier) {
+    if (!llvm::equal(op.getInputs(), getHipsrInputOperands(consumer))) {
+      return op.emitOpError("inputs must match the operands of its consumer '")
+             << consumer->getName() << "'";
+    }
     return success();
   }
 

--- a/lib/Dialect/Hipsr/Transforms/MaterializeInitTensorsPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/MaterializeInitTensorsPass.cpp
@@ -157,8 +157,10 @@ LogicalResult verifyMaterializable(ArrayRef<PlaceholderOp> placeholders) {
           "shape region must be populated by -hipsr-populate-shape-region");
     }
     if (placeholder.getPlaceholderType() == PlaceholderType::Barrier &&
-        llvm::any_of(placeholder.getInputs(), [](Value input) {
-          return isa_and_nonnull<PlaceholderOp>(input.getDefiningOp());
+        llvm::any_of(placeholder.getInputs(), [&](Value input) {
+          Operation *definingOp = input.getDefiningOp();
+          return definingOp &&
+                 definingOp->getBlock() == placeholder->getBlock();
         })) {
       return placeholder.emitOpError(
           "barrier input must be allocated outside this pool domain");

--- a/test/lit/Conversion/onnx-to-hipsr/nonzero.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/nonzero.mlir
@@ -24,7 +24,7 @@
 // CHECK-NEXT:      hipsr.shape_yield %[[COUNT_SHAPE]] : !shape.shape
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %[[HOST_COUNT:.+]] = hipsr.copy_d2h(%[[CTX]]) ins(%[[SEARCH]]#1 : tensor<1xi64, #hipsr.mem<device>>) outs(%[[HOST_INIT]] : tensor<1xi64, #hipsr.mem<host>>) : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[HOST_INIT]], %[[INITS]]#0 : tensor<1xi64, #hipsr.mem<host>>, tensor<2x?xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<2x?xi64, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[HOST_COUNT]], %[[SEARCH]]#0 : tensor<1xi64, #hipsr.mem<host>>, tensor<2x?xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<2x?xi64, #hipsr.mem<device>> shape_region {
 // CHECK-NEXT:    ^bb0(%{{.+}}: !hipsr.context, %[[COUNT:.+]]: tensor<1xi64, #hipsr.mem<host>>, %{{.+}}: tensor<2x?xi64, #hipsr.mem<device>>):
 // CHECK-NEXT:      %[[ZERO:.+]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[FOUND:.+]] = tensor.extract %[[COUNT]]{{\[}}%[[ZERO]]] : tensor<1xi64, #hipsr.mem<host>>
@@ -65,7 +65,7 @@ func.func @nonzero_mask(%ctx: !hipsr.context,
 // CHECK-NEXT:      hipsr.shape_yield %[[COUNT_SHAPE]] : !shape.shape
 // CHECK-NEXT:    }
 // CHECK-NEXT:    %[[HOST_COUNT:.+]] = hipsr.copy_d2h(%[[CTX]]) ins(%[[SEARCH]]#1 : tensor<1xi64, #hipsr.mem<device>>) outs(%[[HOST_INIT]] : tensor<1xi64, #hipsr.mem<host>>) : tensor<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[HOST_INIT]], %[[INITS]]#0 : tensor<1xi64, #hipsr.mem<host>>, tensor<1x12xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<1x?xi64, #hipsr.mem<device>> shape_region {
+// CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[HOST_COUNT]], %[[SEARCH]]#0 : tensor<1xi64, #hipsr.mem<host>>, tensor<1x12xi64, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<1x?xi64, #hipsr.mem<device>> shape_region {
 // CHECK-NEXT:    ^bb0(%{{.+}}: !hipsr.context, %[[COUNT:.+]]: tensor<1xi64, #hipsr.mem<host>>, %{{.+}}: tensor<1x12xi64, #hipsr.mem<device>>):
 // CHECK-NEXT:      %[[ZERO:.+]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[FOUND:.+]] = tensor.extract %[[COUNT]]{{\[}}%[[ZERO]]] : tensor<1xi64, #hipsr.mem<host>>

--- a/test/lit/Conversion/onnx-to-hipsr/shape.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/shape.mlir
@@ -256,7 +256,7 @@ func.func @result_names_no_space(%ctx: !hipsr.context,
 // CHECK-NEXT:        %[[EXTENTS1:.*]] = tensor.insert %[[EXT1]] into %[[EXTENTS0]]{{\[}}%[[C1]]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        hipsr.compute_yield %[[EXTENTS1]] : tensor<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:      } : tensor<2xi64, #hipsr.mem<host>>{{$}}
-// CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]], %[[EXTENTS_INIT]] : tensor<?x3xf16, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      %[[INIT:.*]] = hipsr.placeholder(%[[CTX]]) ins(%[[INPUT]], %[[RESULT]] : tensor<?x3xf16, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x?xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      %[[EXPANDED:.*]] = hipsr.expand(%[[CTX]]) ins(%[[INPUT]], %[[RESULT]] : tensor<?x3xf16, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) outs(%[[INIT]] : tensor<?x?xf16, #hipsr.mem<device>>) : tensor<?x?xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      return %[[EXPANDED]] : tensor<?x?xf16, #hipsr.mem<device>>
 // CHECK-NEXT:    }

--- a/test/lit/Conversion/onnx-to-hipsr/slice.mlir
+++ b/test/lit/Conversion/onnx-to-hipsr/slice.mlir
@@ -41,9 +41,10 @@ func.func @strided_window(%ctx: !hipsr.context,
 
 // A bound the graph computes stays an operand and leaves the sliced axis
 // dynamic, so the init is a barrier placeholder holding the data and that one
-// operand for its region to read. The barrier takes the destination the compute
-// writes into, the same as an expand's shape operand. `axes` and `steps` arrive
-// as onnx.NoValue and get ONNX's defaults, the leading axis and a unit step.
+// operand for its region to read. The barrier names the value the compute
+// wrote, not the destination it was given, because its region reads the bound
+// itself. `axes` and `steps` arrive as onnx.NoValue and get ONNX's defaults,
+// the leading axis and a unit step.
 // CHECK-LABEL: func.func @computed_bound(
 // CHECK-SAME:    %[[CTX:.+]]: !hipsr.context,
 // CHECK-SAME:    %[[DATA:.+]]: tensor<8xf16, #hipsr.mem<device>>,
@@ -64,7 +65,7 @@ func.func @strided_window(%ctx: !hipsr.context,
 // CHECK-NEXT:      hipsr.compute_yield %[[BOUND_VECTOR]] : tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:    } : tensor<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:    %{{.+}} = hipsr.constant {value = dense<0> : tensor<1xi64>} : tensor<1xi64, #hipsr.mem<device>>
-// CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[DATA]], %[[ENDS_INIT]] : tensor<8xf16, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    %[[INIT:.+]] = hipsr.placeholder(%[[CTX]]) ins(%[[DATA]], %[[ENDS]] : tensor<8xf16, #hipsr.mem<device>>, tensor<1xi64, #hipsr.mem<host>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT:    %[[RESULT:.+]] = hipsr.slice(%[[CTX]]) ins(%[[DATA]] : tensor<8xf16, #hipsr.mem<device>>) ends(%[[ENDS]] : tensor<1xi64, #hipsr.mem<host>>) outs(%[[INIT]] : tensor<?xf16, #hipsr.mem<device>>) {axes_attr = array<i64: 0>, starts_attr = array<i64: 0>, steps_attr = array<i64: 1>} : tensor<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT:    return %[[RESULT]] : tensor<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT:  }

--- a/test/lit/Dialect/Hipsr/IR/placeholder.mlir
+++ b/test/lit/Dialect/Hipsr/IR/placeholder.mlir
@@ -256,3 +256,19 @@ func.func @input_missing_from_consumer(
       outs(%result_init : tensor<4x8xf32, #hipsr.mem<device>>) : tensor<4x8xf32, #hipsr.mem<device>>
   return %result : tensor<4x8xf32, #hipsr.mem<device>>
 }
+
+// -----
+// A barrier region reads its inputs by position, so the two lists must agree on
+// order as well as content.
+func.func @barrier_inputs_out_of_order(
+    %ctx: !hipsr.context, %lhs: tensor<4x8xf32, #hipsr.mem<device>>,
+    %rhs: tensor<4x8xf32, #hipsr.mem<device>>) -> tensor<4x8xf32, #hipsr.mem<device>> {
+  // expected-error @+1 {{inputs must match the operands of its consumer 'hipsr.add'}}
+  %sum_init = hipsr.placeholder(%ctx)
+      ins(%rhs, %lhs : tensor<4x8xf32, #hipsr.mem<device>>, tensor<4x8xf32, #hipsr.mem<device>>)
+      {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4x8xf32, #hipsr.mem<device>>
+  %sum = hipsr.add(%ctx)
+      ins(%lhs, %rhs : tensor<4x8xf32, #hipsr.mem<device>>, tensor<4x8xf32, #hipsr.mem<device>>)
+      outs(%sum_init : tensor<4x8xf32, #hipsr.mem<device>>) : tensor<4x8xf32, #hipsr.mem<device>>
+  return %sum : tensor<4x8xf32, #hipsr.mem<device>>
+}

--- a/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
@@ -54,7 +54,7 @@
 // CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
 // CHECK-SAME:      %[[ARG1:.*]]: memref<?x?xi64, #hipsr.mem<device>> {onnx.name = "input_ids"},
 // CHECK-SAME:      %[[ARG2:.*]]: memref<?x4096xf16, #hipsr.mem<device>> {onnx.name = "image_features"}) -> (memref<?x?x4096xf16, #hipsr.mem<device>> {onnx.name = "inputs_embeds"}) attributes {onnx.graph.name = "main_graph"} {
-// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]]:8 = hipsr.pool_domain(%[[ARG0]], %[[ARG2]], %[[ARG1]] : !hipsr.context, memref<?x4096xf16, #hipsr.mem<device>>, memref<?x?xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]]:5 = hipsr.pool_domain(%[[ARG0]], %[[ARG2]], %[[ARG1]] : !hipsr.context, memref<?x4096xf16, #hipsr.mem<device>>, memref<?x?xi64, #hipsr.mem<device>>) {
 // CHECK-NEXT:      ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: memref<?x4096xf16, #hipsr.mem<device>>, %[[VAL_2:.*]]: memref<?x?xi64, #hipsr.mem<device>>):
 // CHECK-NEXT:        %[[CONSTANT_0:.*]] = arith.constant 248320 : index
 // CHECK-NEXT:        %[[CONSTANT_1:.*]] = arith.constant 2 : index
@@ -119,47 +119,42 @@
 // CHECK-NEXT:        %[[ALLOC_8:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[DIM_3]], %[[ALLOC_8]]{{\[}}%[[CONSTANT_6]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[DIM_4]], %[[ALLOC_8]]{{\[}}%[[CONSTANT_5]]] : memref<2xindex>
-// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_7]]{{\[}}%[[CONSTANT_6]]] {{\[}}%[[CONSTANT_6]]] {{\[}}%[[CONSTANT_5]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_7]]{{\[}}%[[CONSTANT_5]]] {{\[}}%[[CONSTANT_5]]] {{\[}}%[[CONSTANT_5]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_7]]{{\[}}%[[CONSTANT_6]]] [%[[CONSTANT_6]]] [%[[CONSTANT_5]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_7]]{{\[}}%[[CONSTANT_5]]] [%[[CONSTANT_5]]] [%[[CONSTANT_5]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:        %[[ALLOC_9:.*]] = memref.alloc(%[[CONSTANT_1]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_9]][0] {{\[}}%[[CONSTANT_6]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_9]]{{\[}}0] [%[[CONSTANT_6]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        memref.copy %[[SUBVIEW_0]], %[[SUBVIEW_2]] : memref<?xindex, strided<[?], offset: ?>> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        %[[SUBVIEW_3:.*]] = memref.subview %[[ALLOC_9]]{{\[}}%[[CONSTANT_6]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_8]], %[[SUBVIEW_3]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        %[[ALLOC_10:.*]] = memref.alloc(%[[CONSTANT_7]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[ALLOC_10]][0] {{\[}}%[[CONSTANT_1]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[ALLOC_10]]{{\[}}0] [%[[CONSTANT_1]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_9]], %[[SUBVIEW_4]] : memref<?xindex> to memref<?xindex, strided<[1]>>
-// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_10]]{{\[}}%[[CONSTANT_1]]] {{\[}}%[[CONSTANT_5]]] [1] : memref<?xindex> to memref<?xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_10]]{{\[}}%[[CONSTANT_1]]] [%[[CONSTANT_5]]] [1] : memref<?xindex> to memref<?xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        memref.copy %[[SUBVIEW_1]], %[[SUBVIEW_5]] : memref<?xindex, strided<[?], offset: ?>> to memref<?xindex, strided<[1], offset: ?>>
-// CHECK-NEXT:        %[[LOAD_5:.*]] = memref.load %[[ALLOC_2]]{{\[}}%[[CONSTANT_6]]] : memref<1xindex>
-// CHECK-NEXT:        %[[ALLOC_11:.*]] = memref.alloc(%[[LOAD_5]]) {alignment = 64 : i64} : memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[LOAD_6:.*]] = memref.load %[[ALLOC_5]]{{\[}}%[[CONSTANT_6]]] : memref<?xindex>
-// CHECK-NEXT:        %[[LOAD_7:.*]] = memref.load %[[ALLOC_5]]{{\[}}%[[CONSTANT_5]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_12:.*]] = memref.alloc(%[[LOAD_6]], %[[LOAD_7]]) {alignment = 64 : i64} : memref<?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[LOAD_8:.*]] = memref.load %[[ALLOC_6]]{{\[}}%[[CONSTANT_6]]] : memref<3xindex>
-// CHECK-NEXT:        %[[LOAD_9:.*]] = memref.load %[[ALLOC_6]]{{\[}}%[[CONSTANT_5]]] : memref<3xindex>
-// CHECK-NEXT:        %[[ALLOC_13:.*]] = memref.alloc(%[[LOAD_8]], %[[LOAD_9]]) {alignment = 64 : i64} : memref<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[LOAD_10:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[CONSTANT_6]]] : memref<?xindex>
-// CHECK-NEXT:        %[[LOAD_11:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[CONSTANT_5]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_14:.*]] = memref.alloc(%[[LOAD_10]], %[[LOAD_11]]) {alignment = 64 : i64} : memref<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_15:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_5:.*]] = memref.load %[[ALLOC_5]]{{\[}}%[[CONSTANT_6]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_6:.*]] = memref.load %[[ALLOC_5]]{{\[}}%[[CONSTANT_5]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_11:.*]] = memref.alloc(%[[LOAD_5]], %[[LOAD_6]]) {alignment = 64 : i64} : memref<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[LOAD_7:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[CONSTANT_6]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_8:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[CONSTANT_5]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_12:.*]] = memref.alloc(%[[LOAD_7]], %[[LOAD_8]]) {alignment = 64 : i64} : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_13:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[COMPUTE_0:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[VAL_1]] : memref<?x4096xf16, #hipsr.mem<device>>) outs(%[[VAL_1]] : memref<?x4096xf16, #hipsr.mem<device>>) {
 // CHECK-NEXT:        ^bb0(%[[VAL_6:.*]]: !hipsr.context, %[[VAL_7:.*]]: memref<?x4096xf16, #hipsr.mem<device>>, %[[VAL_8:.*]]: memref<?x4096xf16, #hipsr.mem<device>>):
 // CHECK-NEXT:          %[[COLLAPSE_SHAPE_0:.*]] = memref.collapse_shape %[[VAL_7]] {{\[\[}}0, 1]] : memref<?x4096xf16, #hipsr.mem<device>> into memref<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT:          hipsr.compute_yield %[[COLLAPSE_SHAPE_0]] : memref<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT:        } : memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.equal(%[[VAL_0]]) ins(%[[VAL_2]], %[[CONSTANT_3]] : memref<?x?xi64, #hipsr.mem<device>>, memref<i64, #hipsr.mem<device>>) outs(%[[ALLOC_12]] : memref<?x?xi1, #hipsr.mem<device>>)
-// CHECK-NEXT:        %[[COMPUTE_1:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[ALLOC_12]] : memref<?x?xi1, #hipsr.mem<device>>) outs(%[[ALLOC_12]] : memref<?x?xi1, #hipsr.mem<device>>) {
+// CHECK-NEXT:        hipsr.equal(%[[VAL_0]]) ins(%[[VAL_2]], %[[CONSTANT_3]] : memref<?x?xi64, #hipsr.mem<device>>, memref<i64, #hipsr.mem<device>>) outs(%[[ALLOC_11]] : memref<?x?xi1, #hipsr.mem<device>>)
+// CHECK-NEXT:        %[[COMPUTE_1:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[ALLOC_11]] : memref<?x?xi1, #hipsr.mem<device>>) outs(%[[ALLOC_11]] : memref<?x?xi1, #hipsr.mem<device>>) {
 // CHECK-NEXT:        ^bb0(%[[VAL_9:.*]]: !hipsr.context, %[[VAL_10:.*]]: memref<?x?xi1, #hipsr.mem<device>>, %[[VAL_11:.*]]: memref<?x?xi1, #hipsr.mem<device>>):
 // CHECK-NEXT:          %[[CONSTANT_8:.*]] = arith.constant 1 : index
 // CHECK-NEXT:          %[[CONSTANT_9:.*]] = arith.constant 0 : index
 // CHECK-NEXT:          %[[DIM_5:.*]] = memref.dim %[[VAL_10]], %[[CONSTANT_9]] : memref<?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:          %[[DIM_6:.*]] = memref.dim %[[VAL_10]], %[[CONSTANT_8]] : memref<?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:          %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[VAL_10]] {{\[\[}}0], [1, 2]] output_shape {{\[}}%[[DIM_5]], %[[DIM_6]], 1] : memref<?x?xi1, #hipsr.mem<device>> into memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[VAL_10]] {{\[\[}}0], [1, 2]] output_shape [%[[DIM_5]], %[[DIM_6]], 1] : memref<?x?xi1, #hipsr.mem<device>> into memref<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT:          hipsr.compute_yield %[[EXPAND_SHAPE_0]] : memref<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT:        } : memref<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.gather(%[[VAL_0]]) ins(%[[CONSTANT_4]], %[[VAL_2]] : memref<248320x4096xf16, #hipsr.mem<device>>, memref<?x?xi64, #hipsr.mem<device>>) outs(%[[ALLOC_14]] : memref<?x?x4096xf16, #hipsr.mem<device>>) {axis = 0 : i64}
-// CHECK-NEXT:        %[[COMPUTE_2:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[ALLOC_14]] : memref<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[ALLOC_15]] : memref<3xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        hipsr.gather(%[[VAL_0]]) ins(%[[CONSTANT_4]], %[[VAL_2]] : memref<248320x4096xf16, #hipsr.mem<device>>, memref<?x?xi64, #hipsr.mem<device>>) outs(%[[ALLOC_12]] : memref<?x?x4096xf16, #hipsr.mem<device>>) {axis = 0 : i64}
+// CHECK-NEXT:        %[[COMPUTE_2:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[ALLOC_12]] : memref<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[ALLOC_13]] : memref<3xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:        ^bb0(%[[VAL_12:.*]]: !hipsr.context, %[[VAL_13:.*]]: memref<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_14:.*]]: memref<3xi64, #hipsr.mem<host>>):
 // CHECK-NEXT:          %[[CONSTANT_10:.*]] = arith.constant 2 : index
 // CHECK-NEXT:          %[[CONSTANT_11:.*]] = arith.constant 4096 : i64
@@ -175,209 +170,208 @@
 // CHECK-NEXT:          hipsr.compute_yield %[[VAL_14]] : memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        } : memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_2]], %[[COMPUTE_0]] : memref<1xindex>, memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_0]], %[[ALLOC_12]] : memref<2xindex>, memref<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_0]], %[[ALLOC_11]] : memref<2xindex>, memref<?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_6]], %[[COMPUTE_1]] : memref<3xindex>, memref<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_10]], %[[ALLOC_14]] : memref<?xindex>, memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_10]], %[[ALLOC_12]] : memref<?xindex>, memref<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_0]], %[[COMPUTE_2]] : memref<1xindex>, memref<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_11]], %[[COMPUTE_0]], %[[ALLOC_13]], %[[COMPUTE_1]], %[[ALLOC_14]], %[[ALLOC_14]], %[[ALLOC_15]], %[[COMPUTE_2]] : memref<?xf16, #hipsr.mem<device>>, memref<?xf16, #hipsr.mem<device>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>, memref<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:      } -> memref<?xf16, #hipsr.mem<device>>, memref<?xf16, #hipsr.mem<device>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>, memref<3xi64, #hipsr.mem<host>> {domain_id = 0 : i64}
-// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]]:2 = hipsr.pool_domain(%[[ARG0]], %[[VAL_15:.*]]#2, %[[VAL_15]]#6, %[[VAL_15]]#3, %[[VAL_15]]#7 : !hipsr.context, memref<?x?x1xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_16:.*]]: !hipsr.context, %[[VAL_17:.*]]: memref<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_18:.*]]: memref<3xi64, #hipsr.mem<host>>, %[[VAL_19:.*]]: memref<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_20:.*]]: memref<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[COMPUTE_0]], %[[COMPUTE_1]], %[[ALLOC_12]], %[[ALLOC_12]], %[[COMPUTE_2]] : memref<?xf16, #hipsr.mem<device>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      } -> memref<?xf16, #hipsr.mem<device>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>> {domain_id = 0 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#1, %[[POOL_DOMAIN_0]]#4 : !hipsr.context, memref<?x?x1xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_15:.*]]: !hipsr.context, %[[VAL_16:.*]]: memref<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_17:.*]]: memref<3xi64, #hipsr.mem<host>>):
 // CHECK-NEXT:        %[[CONSTANT_14:.*]] = arith.constant 3 : index
 // CHECK-NEXT:        %[[CONSTANT_15:.*]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[CONSTANT_16:.*]] = arith.constant 1 : index
 // CHECK-NEXT:        %[[CONSTANT_17:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[DIM_9:.*]] = memref.dim %[[VAL_17]], %[[CONSTANT_17]] : memref<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[DIM_10:.*]] = memref.dim %[[VAL_17]], %[[CONSTANT_16]] : memref<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_16:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[DIM_9]], %[[ALLOC_16]]{{\[}}%[[CONSTANT_17]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[DIM_10]], %[[ALLOC_16]]{{\[}}%[[CONSTANT_16]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_16]], %[[ALLOC_16]]{{\[}}%[[CONSTANT_15]]] : memref<3xindex>
-// CHECK-NEXT:        %[[LOAD_12:.*]] = memref.load %[[VAL_18]]{{\[}}%[[CONSTANT_17]]] : memref<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[INDEX_CAST_2:.*]] = arith.index_cast %[[LOAD_12]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_13:.*]] = memref.load %[[VAL_18]]{{\[}}%[[CONSTANT_16]]] : memref<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[INDEX_CAST_3:.*]] = arith.index_cast %[[LOAD_13]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_14:.*]] = memref.load %[[VAL_18]]{{\[}}%[[CONSTANT_15]]] : memref<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[INDEX_CAST_4:.*]] = arith.index_cast %[[LOAD_14]] : i64 to index
-// CHECK-NEXT:        %[[ALLOC_17:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_2]], %[[ALLOC_17]]{{\[}}%[[CONSTANT_17]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_3]], %[[ALLOC_17]]{{\[}}%[[CONSTANT_16]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_4]], %[[ALLOC_17]]{{\[}}%[[CONSTANT_15]]] : memref<3xindex>
-// CHECK-NEXT:        %[[ALLOC_18:.*]] = memref.alloc(%[[CONSTANT_14]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_21:.*]] = %[[CONSTANT_17]] to %[[CONSTANT_14]] step %[[CONSTANT_16]] {
-// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_21]], %[[CONSTANT_17]] : index
+// CHECK-NEXT:        %[[DIM_9:.*]] = memref.dim %[[VAL_16]], %[[CONSTANT_17]] : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_10:.*]] = memref.dim %[[VAL_16]], %[[CONSTANT_16]] : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_14:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_9]], %[[ALLOC_14]]{{\[}}%[[CONSTANT_17]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_10]], %[[ALLOC_14]]{{\[}}%[[CONSTANT_16]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_16]], %[[ALLOC_14]]{{\[}}%[[CONSTANT_15]]] : memref<3xindex>
+// CHECK-NEXT:        %[[LOAD_9:.*]] = memref.load %[[VAL_17]]{{\[}}%[[CONSTANT_17]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_2:.*]] = arith.index_cast %[[LOAD_9]] : i64 to index
+// CHECK-NEXT:        %[[LOAD_10:.*]] = memref.load %[[VAL_17]]{{\[}}%[[CONSTANT_16]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_3:.*]] = arith.index_cast %[[LOAD_10]] : i64 to index
+// CHECK-NEXT:        %[[LOAD_11:.*]] = memref.load %[[VAL_17]]{{\[}}%[[CONSTANT_15]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_4:.*]] = arith.index_cast %[[LOAD_11]] : i64 to index
+// CHECK-NEXT:        %[[ALLOC_15:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_2]], %[[ALLOC_15]]{{\[}}%[[CONSTANT_17]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_3]], %[[ALLOC_15]]{{\[}}%[[CONSTANT_16]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_4]], %[[ALLOC_15]]{{\[}}%[[CONSTANT_15]]] : memref<3xindex>
+// CHECK-NEXT:        %[[ALLOC_16:.*]] = memref.alloc(%[[CONSTANT_14]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        scf.for %[[VAL_18:.*]] = %[[CONSTANT_17]] to %[[CONSTANT_14]] step %[[CONSTANT_16]] {
+// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_18]], %[[CONSTANT_17]] : index
 // CHECK-NEXT:          %[[IF_2:.*]] = scf.if %[[CMPI_3]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[CONSTANT_16]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_15:.*]] = memref.load %[[ALLOC_16]]{{\[}}%[[VAL_21]]] : memref<3xindex>
-// CHECK-NEXT:            scf.yield %[[LOAD_15]] : index
+// CHECK-NEXT:            %[[LOAD_12:.*]] = memref.load %[[ALLOC_14]]{{\[}}%[[VAL_18]]] : memref<3xindex>
+// CHECK-NEXT:            scf.yield %[[LOAD_12]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_21]], %[[CONSTANT_17]] : index
+// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_18]], %[[CONSTANT_17]] : index
 // CHECK-NEXT:          %[[IF_3:.*]] = scf.if %[[CMPI_4]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_2]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_16:.*]] = memref.load %[[ALLOC_17]]{{\[}}%[[VAL_21]]] : memref<3xindex>
-// CHECK-NEXT:            %[[CMPI_5:.*]] = arith.cmpi eq, %[[LOAD_16]], %[[CONSTANT_16]] : index
-// CHECK-NEXT:            %[[SELECT_1:.*]] = arith.select %[[CMPI_5]], %[[IF_2]], %[[LOAD_16]] : index
+// CHECK-NEXT:            %[[LOAD_13:.*]] = memref.load %[[ALLOC_15]]{{\[}}%[[VAL_18]]] : memref<3xindex>
+// CHECK-NEXT:            %[[CMPI_5:.*]] = arith.cmpi eq, %[[LOAD_13]], %[[CONSTANT_16]] : index
+// CHECK-NEXT:            %[[SELECT_1:.*]] = arith.select %[[CMPI_5]], %[[IF_2]], %[[LOAD_13]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_1]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_18]]{{\[}}%[[VAL_21]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_16]]{{\[}}%[[VAL_18]]] : memref<?xindex>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[CAST_1:.*]] = memref.cast %[[ALLOC_18]] : memref<?xindex> to memref<3xindex>
-// CHECK-NEXT:        %[[LOAD_17:.*]] = memref.load %[[ALLOC_18]]{{\[}}%[[CONSTANT_17]]] : memref<?xindex>
-// CHECK-NEXT:        %[[LOAD_18:.*]] = memref.load %[[ALLOC_18]]{{\[}}%[[CONSTANT_16]]] : memref<?xindex>
-// CHECK-NEXT:        %[[LOAD_19:.*]] = memref.load %[[ALLOC_18]]{{\[}}%[[CONSTANT_15]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_19:.*]] = memref.alloc(%[[LOAD_17]], %[[LOAD_18]], %[[LOAD_19]]) {alignment = 64 : i64} : memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.expand(%[[VAL_16]]) ins(%[[VAL_19]], %[[VAL_20]] : memref<?x?x1xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) outs(%[[ALLOC_19]] : memref<?x?x?xi1, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_1]], %[[ALLOC_19]] : memref<3xindex>, memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_19]], %[[ALLOC_19]] : memref<?x?x?xi1, #hipsr.mem<device>>, memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:      } -> memref<?x?x?xi1, #hipsr.mem<device>>, memref<?x?x?xi1, #hipsr.mem<device>> {domain_id = 1 : i64}
-// CHECK-NEXT:      %[[POOL_DOMAIN_2:.*]]:4 = hipsr.pool_domain(%[[ARG0]], %[[VAL_22:.*]]#0, %[[VAL_23:.*]]#6, %[[VAL_22]]#1, %[[VAL_23]]#7 : !hipsr.context, memref<?x?x?xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>, memref<?x?x?xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_24:.*]]: !hipsr.context, %[[VAL_25:.*]]: memref<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_26:.*]]: memref<3xi64, #hipsr.mem<host>>, %[[VAL_27:.*]]: memref<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_28:.*]]: memref<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:        %[[CAST_1:.*]] = memref.cast %[[ALLOC_16]] : memref<?xindex> to memref<3xindex>
+// CHECK-NEXT:        %[[LOAD_14:.*]] = memref.load %[[ALLOC_16]]{{\[}}%[[CONSTANT_17]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_15:.*]] = memref.load %[[ALLOC_16]]{{\[}}%[[CONSTANT_16]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_16:.*]] = memref.load %[[ALLOC_16]]{{\[}}%[[CONSTANT_15]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_17:.*]] = memref.alloc(%[[LOAD_14]], %[[LOAD_15]], %[[LOAD_16]]) {alignment = 64 : i64} : memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.expand(%[[VAL_15]]) ins(%[[VAL_16]], %[[VAL_17]] : memref<?x?x1xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) outs(%[[ALLOC_17]] : memref<?x?x?xi1, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_1]], %[[ALLOC_17]] : memref<3xindex>, memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_17]] : memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> memref<?x?x?xi1, #hipsr.mem<device>> {domain_id = 1 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_2:.*]]:2 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_1]], %[[POOL_DOMAIN_0]]#4 : !hipsr.context, memref<?x?x?xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_19:.*]]: !hipsr.context, %[[VAL_20:.*]]: memref<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_21:.*]]: memref<3xi64, #hipsr.mem<host>>):
 // CHECK-NEXT:        %[[CONSTANT_18:.*]] = arith.constant 3 : index
 // CHECK-NEXT:        %[[CONSTANT_19:.*]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[CONSTANT_20:.*]] = arith.constant 1 : index
 // CHECK-NEXT:        %[[CONSTANT_21:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[ALLOC_20:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_20]], %[[ALLOC_20]]{{\[}}%[[CONSTANT_21]]] : memref<1xindex>
-// CHECK-NEXT:        %[[DIM_11:.*]] = memref.dim %[[VAL_25]], %[[CONSTANT_21]] : memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[DIM_12:.*]] = memref.dim %[[VAL_25]], %[[CONSTANT_20]] : memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[DIM_13:.*]] = memref.dim %[[VAL_25]], %[[CONSTANT_19]] : memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_21:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[DIM_11]], %[[ALLOC_21]]{{\[}}%[[CONSTANT_21]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[DIM_12]], %[[ALLOC_21]]{{\[}}%[[CONSTANT_20]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[DIM_13]], %[[ALLOC_21]]{{\[}}%[[CONSTANT_19]]] : memref<3xindex>
-// CHECK-NEXT:        %[[LOAD_20:.*]] = memref.load %[[VAL_26]]{{\[}}%[[CONSTANT_21]]] : memref<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[INDEX_CAST_5:.*]] = arith.index_cast %[[LOAD_20]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_21:.*]] = memref.load %[[VAL_26]]{{\[}}%[[CONSTANT_20]]] : memref<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[INDEX_CAST_6:.*]] = arith.index_cast %[[LOAD_21]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_22:.*]] = memref.load %[[VAL_26]]{{\[}}%[[CONSTANT_19]]] : memref<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[INDEX_CAST_7:.*]] = arith.index_cast %[[LOAD_22]] : i64 to index
-// CHECK-NEXT:        %[[ALLOC_22:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_5]], %[[ALLOC_22]]{{\[}}%[[CONSTANT_21]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_6]], %[[ALLOC_22]]{{\[}}%[[CONSTANT_20]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_7]], %[[ALLOC_22]]{{\[}}%[[CONSTANT_19]]] : memref<3xindex>
-// CHECK-NEXT:        %[[ALLOC_23:.*]] = memref.alloc(%[[CONSTANT_18]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_29:.*]] = %[[CONSTANT_21]] to %[[CONSTANT_18]] step %[[CONSTANT_20]] {
-// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_29]], %[[CONSTANT_21]] : index
+// CHECK-NEXT:        %[[ALLOC_18:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_20]], %[[ALLOC_18]]{{\[}}%[[CONSTANT_21]]] : memref<1xindex>
+// CHECK-NEXT:        %[[DIM_11:.*]] = memref.dim %[[VAL_20]], %[[CONSTANT_21]] : memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_12:.*]] = memref.dim %[[VAL_20]], %[[CONSTANT_20]] : memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_13:.*]] = memref.dim %[[VAL_20]], %[[CONSTANT_19]] : memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_19:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_11]], %[[ALLOC_19]]{{\[}}%[[CONSTANT_21]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_12]], %[[ALLOC_19]]{{\[}}%[[CONSTANT_20]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_13]], %[[ALLOC_19]]{{\[}}%[[CONSTANT_19]]] : memref<3xindex>
+// CHECK-NEXT:        %[[LOAD_17:.*]] = memref.load %[[VAL_21]]{{\[}}%[[CONSTANT_21]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_5:.*]] = arith.index_cast %[[LOAD_17]] : i64 to index
+// CHECK-NEXT:        %[[LOAD_18:.*]] = memref.load %[[VAL_21]]{{\[}}%[[CONSTANT_20]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_6:.*]] = arith.index_cast %[[LOAD_18]] : i64 to index
+// CHECK-NEXT:        %[[LOAD_19:.*]] = memref.load %[[VAL_21]]{{\[}}%[[CONSTANT_19]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_7:.*]] = arith.index_cast %[[LOAD_19]] : i64 to index
+// CHECK-NEXT:        %[[ALLOC_20:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_5]], %[[ALLOC_20]]{{\[}}%[[CONSTANT_21]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_6]], %[[ALLOC_20]]{{\[}}%[[CONSTANT_20]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_7]], %[[ALLOC_20]]{{\[}}%[[CONSTANT_19]]] : memref<3xindex>
+// CHECK-NEXT:        %[[ALLOC_21:.*]] = memref.alloc(%[[CONSTANT_18]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        scf.for %[[VAL_22:.*]] = %[[CONSTANT_21]] to %[[CONSTANT_18]] step %[[CONSTANT_20]] {
+// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_22]], %[[CONSTANT_21]] : index
 // CHECK-NEXT:          %[[IF_4:.*]] = scf.if %[[CMPI_6]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[CONSTANT_20]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_23:.*]] = memref.load %[[ALLOC_21]]{{\[}}%[[VAL_29]]] : memref<3xindex>
-// CHECK-NEXT:            scf.yield %[[LOAD_23]] : index
+// CHECK-NEXT:            %[[LOAD_20:.*]] = memref.load %[[ALLOC_19]]{{\[}}%[[VAL_22]]] : memref<3xindex>
+// CHECK-NEXT:            scf.yield %[[LOAD_20]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_29]], %[[CONSTANT_21]] : index
+// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_22]], %[[CONSTANT_21]] : index
 // CHECK-NEXT:          %[[IF_5:.*]] = scf.if %[[CMPI_7]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_4]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_24:.*]] = memref.load %[[ALLOC_22]]{{\[}}%[[VAL_29]]] : memref<3xindex>
-// CHECK-NEXT:            %[[CMPI_8:.*]] = arith.cmpi eq, %[[LOAD_24]], %[[CONSTANT_20]] : index
-// CHECK-NEXT:            %[[SELECT_2:.*]] = arith.select %[[CMPI_8]], %[[IF_4]], %[[LOAD_24]] : index
+// CHECK-NEXT:            %[[LOAD_21:.*]] = memref.load %[[ALLOC_20]]{{\[}}%[[VAL_22]]] : memref<3xindex>
+// CHECK-NEXT:            %[[CMPI_8:.*]] = arith.cmpi eq, %[[LOAD_21]], %[[CONSTANT_20]] : index
+// CHECK-NEXT:            %[[SELECT_2:.*]] = arith.select %[[CMPI_8]], %[[IF_4]], %[[LOAD_21]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_2]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_23]]{{\[}}%[[VAL_29]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_21]]{{\[}}%[[VAL_22]]] : memref<?xindex>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[CAST_2:.*]] = memref.cast %[[ALLOC_23]] : memref<?xindex> to memref<3xindex>
-// CHECK-NEXT:        %[[FOR_1:.*]] = scf.for %[[VAL_30:.*]] = %[[CONSTANT_21]] to %[[CONSTANT_18]] step %[[CONSTANT_20]] iter_args(%[[VAL_31:.*]] = %[[CONSTANT_20]]) -> (index) {
-// CHECK-NEXT:          %[[LOAD_25:.*]] = memref.load %[[ALLOC_23]]{{\[}}%[[VAL_30]]] : memref<?xindex>
-// CHECK-NEXT:          %[[MULI_1:.*]] = arith.muli %[[LOAD_25]], %[[VAL_31]] : index
+// CHECK-NEXT:        %[[CAST_2:.*]] = memref.cast %[[ALLOC_21]] : memref<?xindex> to memref<3xindex>
+// CHECK-NEXT:        %[[FOR_1:.*]] = scf.for %[[VAL_23:.*]] = %[[CONSTANT_21]] to %[[CONSTANT_18]] step %[[CONSTANT_20]] iter_args(%[[VAL_24:.*]] = %[[CONSTANT_20]]) -> (index) {
+// CHECK-NEXT:          %[[LOAD_22:.*]] = memref.load %[[ALLOC_21]]{{\[}}%[[VAL_23]]] : memref<?xindex>
+// CHECK-NEXT:          %[[MULI_1:.*]] = arith.muli %[[LOAD_22]], %[[VAL_24]] : index
 // CHECK-NEXT:          scf.yield %[[MULI_1]] : index
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[ALLOC_24:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_18]], %[[ALLOC_24]]{{\[}}%[[CONSTANT_21]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[FOR_1]], %[[ALLOC_24]]{{\[}}%[[CONSTANT_20]]] : memref<2xindex>
-// CHECK-NEXT:        %[[LOAD_26:.*]] = memref.load %[[ALLOC_23]]{{\[}}%[[CONSTANT_21]]] : memref<?xindex>
-// CHECK-NEXT:        %[[LOAD_27:.*]] = memref.load %[[ALLOC_23]]{{\[}}%[[CONSTANT_20]]] : memref<?xindex>
-// CHECK-NEXT:        %[[LOAD_28:.*]] = memref.load %[[ALLOC_23]]{{\[}}%[[CONSTANT_19]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_25:.*]] = memref.alloc(%[[LOAD_26]], %[[LOAD_27]], %[[LOAD_28]]) {alignment = 64 : i64} : memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[LOAD_29:.*]] = memref.load %[[ALLOC_24]]{{\[}}%[[CONSTANT_20]]] : memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_26:.*]] = memref.alloc(%[[LOAD_29]]) {alignment = 64 : i64} : memref<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_27:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_28:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.expand(%[[VAL_24]]) ins(%[[VAL_27]], %[[VAL_28]] : memref<?x?x?xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) outs(%[[ALLOC_25]] : memref<?x?x?xi1, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.nonzero(%[[VAL_24]]) ins(%[[ALLOC_25]] : memref<?x?x?xi1, #hipsr.mem<device>>) outs(%[[ALLOC_26]], %[[ALLOC_27]] : memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.copy_d2h(%[[VAL_24]]) ins(%[[ALLOC_27]] : memref<1xi64, #hipsr.mem<device>>) outs(%[[ALLOC_28]] : memref<1xi64, #hipsr.mem<host>>)
-// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_2]], %[[ALLOC_25]] : memref<3xindex>, memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_24]], %[[ALLOC_26]] : memref<2xindex>, memref<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_20]], %[[ALLOC_27]] : memref<1xindex>, memref<1xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_20]], %[[ALLOC_28]] : memref<1xindex>, memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_26]], %[[ALLOC_26]], %[[ALLOC_28]], %[[ALLOC_28]] : memref<3x?xi64, #hipsr.mem<device>>, memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:      } -> memref<3x?xi64, #hipsr.mem<device>>, memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<1xi64, #hipsr.mem<host>> {domain_id = 2 : i64}
-// CHECK-NEXT:      %[[POOL_DOMAIN_3:.*]]:4 = hipsr.pool_domain(%[[ARG0]], %[[VAL_32:.*]]#2, %[[VAL_32]]#0, %[[VAL_32]]#3, %[[VAL_32]]#1 : !hipsr.context, memref<1xi64, #hipsr.mem<host>>, memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<3x?xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_33:.*]]: !hipsr.context, %[[VAL_34:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_35:.*]]: memref<3x?xi64, #hipsr.mem<device>>, %[[VAL_36:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_37:.*]]: memref<3x?xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[ALLOC_22:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_18]], %[[ALLOC_22]]{{\[}}%[[CONSTANT_21]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[FOR_1]], %[[ALLOC_22]]{{\[}}%[[CONSTANT_20]]] : memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_23:.*]] = memref.load %[[ALLOC_21]]{{\[}}%[[CONSTANT_21]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_24:.*]] = memref.load %[[ALLOC_21]]{{\[}}%[[CONSTANT_20]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_25:.*]] = memref.load %[[ALLOC_21]]{{\[}}%[[CONSTANT_19]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_23:.*]] = memref.alloc(%[[LOAD_23]], %[[LOAD_24]], %[[LOAD_25]]) {alignment = 64 : i64} : memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[LOAD_26:.*]] = memref.load %[[ALLOC_22]]{{\[}}%[[CONSTANT_20]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_24:.*]] = memref.alloc(%[[LOAD_26]]) {alignment = 64 : i64} : memref<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_25:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_26:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.expand(%[[VAL_19]]) ins(%[[VAL_20]], %[[VAL_21]] : memref<?x?x?xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) outs(%[[ALLOC_23]] : memref<?x?x?xi1, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.nonzero(%[[VAL_19]]) ins(%[[ALLOC_23]] : memref<?x?x?xi1, #hipsr.mem<device>>) outs(%[[ALLOC_24]], %[[ALLOC_25]] : memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.copy_d2h(%[[VAL_19]]) ins(%[[ALLOC_25]] : memref<1xi64, #hipsr.mem<device>>) outs(%[[ALLOC_26]] : memref<1xi64, #hipsr.mem<host>>)
+// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_2]], %[[ALLOC_23]] : memref<3xindex>, memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_22]], %[[ALLOC_24]] : memref<2xindex>, memref<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_18]], %[[ALLOC_25]] : memref<1xindex>, memref<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_18]], %[[ALLOC_26]] : memref<1xindex>, memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_24]], %[[ALLOC_26]] : memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      } -> memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>> {domain_id = 2 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_3:.*]]:3 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_2]]#1, %[[POOL_DOMAIN_2]]#0 : !hipsr.context, memref<1xi64, #hipsr.mem<host>>, memref<3x?xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_25:.*]]: !hipsr.context, %[[VAL_26:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_27:.*]]: memref<3x?xi64, #hipsr.mem<device>>):
 // CHECK-NEXT:        %[[CONSTANT_22:.*]] = arith.constant 3 : index
 // CHECK-NEXT:        %[[CONSTANT_23:.*]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[CONSTANT_24:.*]] = arith.constant 0 : index
 // CHECK-NEXT:        %[[CONSTANT_25:.*]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[ALLOC_29:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_25]], %[[ALLOC_29]]{{\[}}%[[CONSTANT_24]]] : memref<1xindex>
-// CHECK-NEXT:        %[[ALLOC_30:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_23]], %[[ALLOC_30]]{{\[}}%[[CONSTANT_24]]] : memref<1xindex>
-// CHECK-NEXT:        %[[ALLOC_31:.*]] = memref.alloc() {alignment = 64 : i64} : memref<0xindex>
-// CHECK-NEXT:        %[[LOAD_30:.*]] = memref.load %[[VAL_34]]{{\[}}%[[CONSTANT_24]]] : memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[INDEX_CAST_8:.*]] = arith.index_cast %[[LOAD_30]] : i64 to index
-// CHECK-NEXT:        %[[ALLOC_32:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_22]], %[[ALLOC_32]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_8]], %[[ALLOC_32]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
-// CHECK-NEXT:        %[[LOAD_31:.*]] = memref.load %[[ALLOC_32]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
-// CHECK-NEXT:        %[[LOAD_32:.*]] = memref.load %[[ALLOC_32]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_33:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[LOAD_31]], %[[ALLOC_33]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[LOAD_32]], %[[ALLOC_33]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
-// CHECK-NEXT:        %[[LOAD_33:.*]] = memref.load %[[ALLOC_32]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_34:.*]] = memref.alloc(%[[LOAD_33]]) {alignment = 64 : i64} : memref<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[LOAD_34:.*]] = memref.load %[[ALLOC_33]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_35:.*]] = memref.alloc(%[[LOAD_34]]) {alignment = 64 : i64} : memref<?x3xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_36:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[ALLOC_37:.*]] = memref.alloc() {alignment = 64 : i64} : memref<i64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[ALLOC_38:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[COMPUTE_3:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[VAL_36]], %[[VAL_37]] : memref<1xi64, #hipsr.mem<host>>, memref<3x?xi64, #hipsr.mem<device>>) outs(%[[ALLOC_34]] : memref<3x?xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:        ^bb0(%[[VAL_38:.*]]: !hipsr.context, %[[VAL_39:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_40:.*]]: memref<3x?xi64, #hipsr.mem<device>>, %[[VAL_41:.*]]: memref<3x?xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[ALLOC_27:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_25]], %[[ALLOC_27]]{{\[}}%[[CONSTANT_24]]] : memref<1xindex>
+// CHECK-NEXT:        %[[ALLOC_28:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_23]], %[[ALLOC_28]]{{\[}}%[[CONSTANT_24]]] : memref<1xindex>
+// CHECK-NEXT:        %[[ALLOC_29:.*]] = memref.alloc() {alignment = 64 : i64} : memref<0xindex>
+// CHECK-NEXT:        %[[LOAD_27:.*]] = memref.load %[[VAL_26]]{{\[}}%[[CONSTANT_24]]] : memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_8:.*]] = arith.index_cast %[[LOAD_27]] : i64 to index
+// CHECK-NEXT:        %[[ALLOC_30:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_22]], %[[ALLOC_30]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_8]], %[[ALLOC_30]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_28:.*]] = memref.load %[[ALLOC_30]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_29:.*]] = memref.load %[[ALLOC_30]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_31:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[LOAD_28]], %[[ALLOC_31]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[LOAD_29]], %[[ALLOC_31]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_30:.*]] = memref.load %[[ALLOC_30]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_32:.*]] = memref.alloc(%[[LOAD_30]]) {alignment = 64 : i64} : memref<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[LOAD_31:.*]] = memref.load %[[ALLOC_31]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_33:.*]] = memref.alloc(%[[LOAD_31]]) {alignment = 64 : i64} : memref<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_34:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[ALLOC_35:.*]] = memref.alloc() {alignment = 64 : i64} : memref<i64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[COMPUTE_3:.*]] = hipsr.compute(%[[VAL_25]]) ins(%[[VAL_26]], %[[VAL_27]] : memref<1xi64, #hipsr.mem<host>>, memref<3x?xi64, #hipsr.mem<device>>) outs(%[[ALLOC_32]] : memref<3x?xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_28:.*]]: !hipsr.context, %[[VAL_29:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_30:.*]]: memref<3x?xi64, #hipsr.mem<device>>, %[[VAL_31:.*]]: memref<3x?xi64, #hipsr.mem<device>>):
 // CHECK-NEXT:          %[[CONSTANT_26:.*]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[DIM_14:.*]] = memref.dim %[[VAL_41]], %[[CONSTANT_26]] : memref<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:          %[[SUBVIEW_6:.*]] = memref.subview %[[VAL_40]][0, 0] [3, %[[DIM_14]]] [1, 1] : memref<3x?xi64, #hipsr.mem<device>> to memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[DIM_14:.*]] = memref.dim %[[VAL_31]], %[[CONSTANT_26]] : memref<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[SUBVIEW_6:.*]] = memref.subview %[[VAL_30]]{{\[}}0, 0] [3, %[[DIM_14]]] [1, 1] : memref<3x?xi64, #hipsr.mem<device>> to memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
 // CHECK-NEXT:          hipsr.compute_yield %[[SUBVIEW_6]] : memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
 // CHECK-NEXT:        } : memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.transpose(%[[VAL_33]]) ins(%[[COMPUTE_3]] : memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>) outs(%[[ALLOC_35]] : memref<?x3xi64, #hipsr.mem<device>>) {perm = array<i64: 1, 0>}
-// CHECK-NEXT:        %[[COMPUTE_4:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[ALLOC_35]] : memref<?x3xi64, #hipsr.mem<device>>) outs(%[[ALLOC_36]] : memref<2xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:        ^bb0(%[[VAL_42:.*]]: !hipsr.context, %[[VAL_43:.*]]: memref<?x3xi64, #hipsr.mem<device>>, %[[VAL_44:.*]]: memref<2xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:        hipsr.transpose(%[[VAL_25]]) ins(%[[COMPUTE_3]] : memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>) outs(%[[ALLOC_33]] : memref<?x3xi64, #hipsr.mem<device>>) {perm = array<i64: 1, 0>}
+// CHECK-NEXT:        %[[COMPUTE_4:.*]] = hipsr.compute(%[[VAL_25]]) ins(%[[ALLOC_33]] : memref<?x3xi64, #hipsr.mem<device>>) outs(%[[ALLOC_34]] : memref<2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_32:.*]]: !hipsr.context, %[[VAL_33:.*]]: memref<?x3xi64, #hipsr.mem<device>>, %[[VAL_34:.*]]: memref<2xi64, #hipsr.mem<host>>):
 // CHECK-NEXT:          %[[CONSTANT_27:.*]] = arith.constant 1 : index
 // CHECK-NEXT:          %[[CONSTANT_28:.*]] = arith.constant 3 : i64
 // CHECK-NEXT:          %[[CONSTANT_29:.*]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[DIM_15:.*]] = memref.dim %[[VAL_43]], %[[CONSTANT_29]] : memref<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[DIM_15:.*]] = memref.dim %[[VAL_33]], %[[CONSTANT_29]] : memref<?x3xi64, #hipsr.mem<device>>
 // CHECK-NEXT:          %[[INDEX_CAST_9:.*]] = arith.index_cast %[[DIM_15]] : index to i64
-// CHECK-NEXT:          memref.store %[[INDEX_CAST_9]], %[[VAL_44]]{{\[}}%[[CONSTANT_29]]] : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:          memref.store %[[CONSTANT_28]], %[[VAL_44]]{{\[}}%[[CONSTANT_27]]] : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:          hipsr.compute_yield %[[VAL_44]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[INDEX_CAST_9]], %[[VAL_34]]{{\[}}%[[CONSTANT_29]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[CONSTANT_28]], %[[VAL_34]]{{\[}}%[[CONSTANT_27]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          hipsr.compute_yield %[[VAL_34]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        } : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[COMPUTE_5:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[COMPUTE_4]] : memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_37]] : memref<i64, #hipsr.mem<host>>) {
-// CHECK-NEXT:        ^bb0(%[[VAL_45:.*]]: !hipsr.context, %[[VAL_46:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_47:.*]]: memref<i64, #hipsr.mem<host>>):
+// CHECK-NEXT:        %[[COMPUTE_5:.*]] = hipsr.compute(%[[VAL_25]]) ins(%[[COMPUTE_4]] : memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_35]] : memref<i64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_35:.*]]: !hipsr.context, %[[VAL_36:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_37:.*]]: memref<i64, #hipsr.mem<host>>):
 // CHECK-NEXT:          %[[CONSTANT_30:.*]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[LOAD_35:.*]] = memref.load %[[VAL_46]]{{\[}}%[[CONSTANT_30]]] : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:          memref.store %[[LOAD_35]], %[[VAL_47]][] : memref<i64, #hipsr.mem<host>>
-// CHECK-NEXT:          hipsr.compute_yield %[[VAL_47]] : memref<i64, #hipsr.mem<host>>
+// CHECK-NEXT:          %[[LOAD_32:.*]] = memref.load %[[VAL_36]]{{\[}}%[[CONSTANT_30]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[LOAD_32]], %[[VAL_37]]{{\[}}] : memref<i64, #hipsr.mem<host>>
+// CHECK-NEXT:          hipsr.compute_yield %[[VAL_37]] : memref<i64, #hipsr.mem<host>>
 // CHECK-NEXT:        } : memref<i64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[COMPUTE_6:.*]] = hipsr.compute(%[[VAL_33]]) ins(%[[COMPUTE_5]] : memref<i64, #hipsr.mem<host>>) outs(%[[COMPUTE_5]] : memref<i64, #hipsr.mem<host>>) {
-// CHECK-NEXT:        ^bb0(%[[VAL_48:.*]]: !hipsr.context, %[[VAL_49:.*]]: memref<i64, #hipsr.mem<host>>, %[[VAL_50:.*]]: memref<i64, #hipsr.mem<host>>):
-// CHECK-NEXT:          %[[EXPAND_SHAPE_1:.*]] = memref.expand_shape %[[VAL_49]] [] output_shape [1] : memref<i64, #hipsr.mem<host>> into memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[COMPUTE_6:.*]] = hipsr.compute(%[[VAL_25]]) ins(%[[COMPUTE_5]] : memref<i64, #hipsr.mem<host>>) outs(%[[COMPUTE_5]] : memref<i64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_38:.*]]: !hipsr.context, %[[VAL_39:.*]]: memref<i64, #hipsr.mem<host>>, %[[VAL_40:.*]]: memref<i64, #hipsr.mem<host>>):
+// CHECK-NEXT:          %[[EXPAND_SHAPE_1:.*]] = memref.expand_shape %[[VAL_39]] [] output_shape [1] : memref<i64, #hipsr.mem<host>> into memref<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:          hipsr.compute_yield %[[EXPAND_SHAPE_1]] : memref<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        } : memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_32]], %[[COMPUTE_3]] : memref<2xindex>, memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_33]], %[[ALLOC_35]] : memref<2xindex>, memref<?x3xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_30]], %[[COMPUTE_4]] : memref<1xindex>, memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_31]], %[[COMPUTE_5]] : memref<0xindex>, memref<i64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_29]], %[[COMPUTE_6]] : memref<1xindex>, memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_35]], %[[ALLOC_35]], %[[ALLOC_38]], %[[COMPUTE_6]] : memref<?x3xi64, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:      } -> memref<?x3xi64, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<1xi64, #hipsr.mem<host>> {domain_id = 3 : i64}
-// CHECK-NEXT:      %[[POOL_DOMAIN_4:.*]] = hipsr.pool_domain(%[[ARG0]], %[[VAL_51:.*]]#0, %[[VAL_52:.*]]#2, %[[VAL_51]]#1, %[[VAL_52]]#3, %[[VAL_51]]#4, %[[VAL_52]]#0, %[[VAL_51]]#5, %[[VAL_52]]#1 : !hipsr.context, memref<?xf16, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<?xf16, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_53:.*]]: !hipsr.context, %[[VAL_54:.*]]: memref<?xf16, #hipsr.mem<device>>, %[[VAL_55:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_56:.*]]: memref<?xf16, #hipsr.mem<device>>, %[[VAL_57:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_58:.*]]: memref<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_59:.*]]: memref<?x3xi64, #hipsr.mem<device>>, %[[VAL_60:.*]]: memref<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_61:.*]]: memref<?x3xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_30]], %[[COMPUTE_3]] : memref<2xindex>, memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_31]], %[[ALLOC_33]] : memref<2xindex>, memref<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_28]], %[[COMPUTE_4]] : memref<1xindex>, memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_29]], %[[COMPUTE_5]] : memref<0xindex>, memref<i64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_27]], %[[COMPUTE_6]] : memref<1xindex>, memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_33]], %[[ALLOC_33]], %[[COMPUTE_6]] : memref<?x3xi64, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      } -> memref<?x3xi64, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>> {domain_id = 3 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_4:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#0, %[[POOL_DOMAIN_3]]#2, %[[POOL_DOMAIN_0]]#2, %[[POOL_DOMAIN_3]]#0, %[[POOL_DOMAIN_0]]#3, %[[POOL_DOMAIN_3]]#1 : !hipsr.context, memref<?xf16, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_41:.*]]: !hipsr.context, %[[VAL_42:.*]]: memref<?xf16, #hipsr.mem<device>>, %[[VAL_43:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_44:.*]]: memref<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_45:.*]]: memref<?x3xi64, #hipsr.mem<device>>, %[[VAL_46:.*]]: memref<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_47:.*]]: memref<?x3xi64, #hipsr.mem<device>>):
 // CHECK-NEXT:        %[[CONSTANT_31:.*]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[CONSTANT_32:.*]] = arith.constant 4096 : index
 // CHECK-NEXT:        %[[CONSTANT_33:.*]] = arith.constant 1 : index
 // CHECK-NEXT:        %[[CONSTANT_34:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[DIM_16:.*]] = memref.dim %[[VAL_54]], %[[CONSTANT_34]] : memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[LOAD_36:.*]] = memref.load %[[VAL_55]]{{\[}}%[[CONSTANT_34]]] : memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[INDEX_CAST_10:.*]] = arith.index_cast %[[LOAD_36]] : i64 to index
+// CHECK-NEXT:        %[[DIM_16:.*]] = memref.dim %[[VAL_42]], %[[CONSTANT_34]] : memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[LOAD_33:.*]] = memref.load %[[VAL_43]]{{\[}}%[[CONSTANT_34]]] : memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[INDEX_CAST_10:.*]] = arith.index_cast %[[LOAD_33]] : i64 to index
 // CHECK-NEXT:        %[[CMPI_9:.*]] = arith.cmpi slt, %[[INDEX_CAST_10]], %[[CONSTANT_34]] : index
 // CHECK-NEXT:        %[[ADDI_0:.*]] = arith.addi %[[INDEX_CAST_10]], %[[DIM_16]] : index
 // CHECK-NEXT:        %[[SELECT_3:.*]] = arith.select %[[CMPI_9]], %[[ADDI_0]], %[[INDEX_CAST_10]] : index
@@ -386,31 +380,32 @@
 // CHECK-NEXT:        %[[MINSI_1:.*]] = arith.minsi %[[MAXSI_0]], %[[DIM_16]] : index
 // CHECK-NEXT:        %[[SUBI_1:.*]] = arith.subi %[[MINSI_1]], %[[MINSI_0]] : index
 // CHECK-NEXT:        %[[MAXSI_1:.*]] = arith.maxsi %[[SUBI_1]], %[[CONSTANT_34]] : index
-// CHECK-NEXT:        %[[ALLOC_39:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
-// CHECK-NEXT:        memref.store %[[MAXSI_1]], %[[ALLOC_39]]{{\[}}%[[CONSTANT_34]]] : memref<1xindex>
-// CHECK-NEXT:        %[[DIM_17:.*]] = memref.dim %[[VAL_58]], %[[CONSTANT_34]] : memref<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[DIM_18:.*]] = memref.dim %[[VAL_58]], %[[CONSTANT_33]] : memref<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_40:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[DIM_17]], %[[ALLOC_40]]{{\[}}%[[CONSTANT_34]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[DIM_18]], %[[ALLOC_40]]{{\[}}%[[CONSTANT_33]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_32]], %[[ALLOC_40]]{{\[}}%[[CONSTANT_31]]] : memref<3xindex>
-// CHECK-NEXT:        %[[LOAD_37:.*]] = memref.load %[[ALLOC_39]]{{\[}}%[[CONSTANT_34]]] : memref<1xindex>
-// CHECK-NEXT:        %[[ALLOC_41:.*]] = memref.alloc(%[[LOAD_37]]) {alignment = 64 : i64} : memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[DIM_19:.*]] = memref.dim %[[VAL_58]], %[[CONSTANT_34]] : memref<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[DIM_20:.*]] = memref.dim %[[VAL_58]], %[[CONSTANT_33]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_36:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
+// CHECK-NEXT:        memref.store %[[MAXSI_1]], %[[ALLOC_36]]{{\[}}%[[CONSTANT_34]]] : memref<1xindex>
+// CHECK-NEXT:        %[[DIM_17:.*]] = memref.dim %[[VAL_44]], %[[CONSTANT_34]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_18:.*]] = memref.dim %[[VAL_44]], %[[CONSTANT_33]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_37:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_17]], %[[ALLOC_37]]{{\[}}%[[CONSTANT_34]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_18]], %[[ALLOC_37]]{{\[}}%[[CONSTANT_33]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_32]], %[[ALLOC_37]]{{\[}}%[[CONSTANT_31]]] : memref<3xindex>
+// CHECK-NEXT:        %[[LOAD_34:.*]] = memref.load %[[ALLOC_36]]{{\[}}%[[CONSTANT_34]]] : memref<1xindex>
+// CHECK-NEXT:        %[[ALLOC_38:.*]] = memref.alloc(%[[LOAD_34]]) {alignment = 64 : i64} : memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_19:.*]] = memref.dim %[[VAL_44]], %[[CONSTANT_34]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_20:.*]] = memref.dim %[[VAL_44]], %[[CONSTANT_33]] : memref<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:        %[[CONSTANT_35:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[LOAD_38:.*]] = memref.load %[[ALLOC_40]]{{\[}}%[[CONSTANT_35]]] : memref<3xindex>
+// CHECK-NEXT:        %[[LOAD_35:.*]] = memref.load %[[ALLOC_37]]{{\[}}%[[CONSTANT_35]]] : memref<3xindex>
 // CHECK-NEXT:        %[[CONSTANT_36:.*]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[LOAD_39:.*]] = memref.load %[[ALLOC_40]]{{\[}}%[[CONSTANT_36]]] : memref<3xindex>
-// CHECK-NEXT:        %[[ALLOC_OUTPUT_0:.*]] = hipsr.alloc_output(%[[VAL_53]], %[[LOAD_38]], %[[LOAD_39]]) {out_idx = 0 : i64} : memref<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.slice(%[[VAL_53]]) ins(%[[VAL_56]] : memref<?xf16, #hipsr.mem<device>>) ends(%[[VAL_57]] : memref<1xi64, #hipsr.mem<host>>) outs(%[[ALLOC_41]] : memref<?xf16, #hipsr.mem<device>>) {axes_attr = array<i64: 0>, starts_attr = array<i64: 0>, steps_attr = array<i64: 1>}
-// CHECK-NEXT:        hipsr.scatter_nd(%[[VAL_53]]) ins(%[[VAL_60]], %[[VAL_61]], %[[ALLOC_41]] : memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<?xf16, #hipsr.mem<device>>) outs(%[[ALLOC_OUTPUT_0]] : memref<?x?x4096xf16, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_39]], %[[ALLOC_41]] : memref<1xindex>, memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_40]], %[[ALLOC_OUTPUT_0]] : memref<3xindex>, memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[LOAD_36:.*]] = memref.load %[[ALLOC_37]]{{\[}}%[[CONSTANT_36]]] : memref<3xindex>
+// CHECK-NEXT:        %[[ALLOC_OUTPUT_0:.*]] = hipsr.alloc_output(%[[VAL_41]], %[[LOAD_35]], %[[LOAD_36]]) {out_idx = 0 : i64} : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.slice(%[[VAL_41]]) ins(%[[VAL_42]] : memref<?xf16, #hipsr.mem<device>>) ends(%[[VAL_43]] : memref<1xi64, #hipsr.mem<host>>) outs(%[[ALLOC_38]] : memref<?xf16, #hipsr.mem<device>>) {axes_attr = array<i64: 0>, starts_attr = array<i64: 0>, steps_attr = array<i64: 1>}
+// CHECK-NEXT:        hipsr.scatter_nd(%[[VAL_41]]) ins(%[[VAL_46]], %[[VAL_47]], %[[ALLOC_38]] : memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<?xf16, #hipsr.mem<device>>) outs(%[[ALLOC_OUTPUT_0]] : memref<?x?x4096xf16, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_36]], %[[ALLOC_38]] : memref<1xindex>, memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_37]], %[[ALLOC_OUTPUT_0]] : memref<3xindex>, memref<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_OUTPUT_0]] : memref<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      } -> memref<?x?x4096xf16, #hipsr.mem<device>> {domain_id = 4 : i64}
 // CHECK-NEXT:      return %[[POOL_DOMAIN_4]] : memref<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:    }
+// CHECK-NEXT:  }
 
 
 

--- a/test/lit/Dialect/Hipsr/Pipelines/sample_dynamic.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/sample_dynamic.mlir
@@ -12,7 +12,7 @@
 // CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
 // CHECK-SAME:      %[[ARG1:.*]]: memref<?x3xf16, #hipsr.mem<device>> {onnx.name = "a"},
 // CHECK-SAME:      %[[ARG2:.*]]: memref<?x4xf32, #hipsr.mem<device>> {onnx.name = "b"}) -> (memref<?x2xf32, #hipsr.mem<device>> {onnx.name = "y"}) attributes {onnx.graph.name = "main_graph"} {
-// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]]:5 = hipsr.pool_domain(%[[ARG0]], %[[ARG1]], %[[ARG2]] : !hipsr.context, memref<?x3xf16, #hipsr.mem<device>>, memref<?x4xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]]:3 = hipsr.pool_domain(%[[ARG0]], %[[ARG1]], %[[ARG2]] : !hipsr.context, memref<?x3xf16, #hipsr.mem<device>>, memref<?x4xf32, #hipsr.mem<device>>) {
 // CHECK-NEXT:      ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: memref<?x3xf16, #hipsr.mem<device>>, %[[VAL_2:.*]]: memref<?x4xf32, #hipsr.mem<device>>):
 // CHECK-NEXT:        %[[CONSTANT_0:.*]] = arith.constant 3 : index
 // CHECK-NEXT:        %[[CONSTANT_1:.*]] = hipsr.constant {value = dense<{{\[\[}}1.000000e+00, 2.000000e+00], [3.000000e+00, 4.000000e+00], [5.000000e+00, 6.000000e+00], [7.000000e+00, 8.000000e+00]]> : tensor<4x2xf32>} : memref<4x2xf32, #hipsr.mem<device>>
@@ -29,8 +29,8 @@
 // CHECK-NEXT:        %[[ALLOC_2:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_0]], %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_3]], %[[ALLOC_2]]{{\[}}%[[CONSTANT_3]]] : memref<2xindex>
-// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_1]]{{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_1]]{{\[}}%[[CONSTANT_4]]] [%[[CONSTANT_4]]] [%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] [%[[CONSTANT_4]]] [%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:        %[[ALLOC_3:.*]] = memref.alloc(%[[CONSTANT_4]]) {alignment = 64 : i64} : memref<?xindex>
 // CHECK-NEXT:        scf.for %[[VAL_3:.*]] = %[[CONSTANT_4]] to %[[CONSTANT_4]] step %[[CONSTANT_3]] {
 // CHECK-NEXT:          %[[CMPI_0:.*]] = arith.cmpi ult, %[[VAL_3]], %[[CONSTANT_4]] : index
@@ -56,7 +56,7 @@
 // CHECK-NEXT:        memref.store %[[DIM_1]], %[[ALLOC_4]]{{\[}}%[[CONSTANT_4]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_3]], %[[ALLOC_4]]{{\[}}%[[CONSTANT_3]]] : memref<2xindex>
 // CHECK-NEXT:        %[[ALLOC_5:.*]] = memref.alloc(%[[CONSTANT_5]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_5]][0] {{\[}}%[[CONSTANT_4]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_5]]{{\[}}0] [%[[CONSTANT_4]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_3]], %[[SUBVIEW_2]] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        %[[SUBVIEW_3:.*]] = memref.subview %[[ALLOC_5]]{{\[}}%[[CONSTANT_4]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_4]], %[[SUBVIEW_3]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
@@ -81,77 +81,77 @@
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_5]], %[[ALLOC_6]] : memref<?xindex>, memref<?x1xf16, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_5]], %[[ALLOC_7]] : memref<?xindex>, memref<?x1xf32, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_0]], %[[COMPUTE_0]] : memref<1xindex>, memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_7]], %[[ALLOC_7]], %[[ALLOC_8]], %[[COMPUTE_0]], %[[CONSTANT_1]] : memref<?x1xf32, #hipsr.mem<device>>, memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      } -> memref<?x1xf32, #hipsr.mem<device>>, memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]] = hipsr.pool_domain(%[[ARG0]], %[[VAL_7:.*]]#0, %[[VAL_7]]#2, %[[VAL_7]]#1, %[[VAL_7]]#3, %[[VAL_7]]#4 : !hipsr.context, memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_8:.*]]: !hipsr.context, %[[VAL_9:.*]]: memref<?x1xf32, #hipsr.mem<device>>, %[[VAL_10:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_11:.*]]: memref<?x1xf32, #hipsr.mem<device>>, %[[VAL_12:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_13:.*]]: memref<4x2xf32, #hipsr.mem<device>>):
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_7]], %[[COMPUTE_0]], %[[CONSTANT_1]] : memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#0, %[[POOL_DOMAIN_0]]#1, %[[POOL_DOMAIN_0]]#2 : !hipsr.context, memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_7:.*]]: !hipsr.context, %[[VAL_8:.*]]: memref<?x1xf32, #hipsr.mem<device>>, %[[VAL_9:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_10:.*]]: memref<4x2xf32, #hipsr.mem<device>>):
 // CHECK-NEXT:        %[[CONSTANT_9:.*]] = arith.constant 2 : index
 // CHECK-NEXT:        %[[CONSTANT_10:.*]] = arith.constant 4 : index
 // CHECK-NEXT:        %[[CONSTANT_11:.*]] = arith.constant 0 : index
 // CHECK-NEXT:        %[[CONSTANT_12:.*]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[DIM_3:.*]] = memref.dim %[[VAL_9]], %[[CONSTANT_11]] : memref<?x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_3:.*]] = memref.dim %[[VAL_8]], %[[CONSTANT_11]] : memref<?x1xf32, #hipsr.mem<device>>
 // CHECK-NEXT:        %[[ALLOC_9:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[DIM_3]], %[[ALLOC_9]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_12]], %[[ALLOC_9]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
-// CHECK-NEXT:        %[[LOAD_4:.*]] = memref.load %[[VAL_10]]{{\[}}%[[CONSTANT_11]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_4:.*]] = memref.load %[[VAL_9]]{{\[}}%[[CONSTANT_11]]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_1:.*]] = arith.index_cast %[[LOAD_4]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_5:.*]] = memref.load %[[VAL_10]]{{\[}}%[[CONSTANT_12]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_5:.*]] = memref.load %[[VAL_9]]{{\[}}%[[CONSTANT_12]]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_2:.*]] = arith.index_cast %[[LOAD_5]] : i64 to index
 // CHECK-NEXT:        %[[ALLOC_10:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[INDEX_CAST_1]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[INDEX_CAST_2]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
 // CHECK-NEXT:        %[[ALLOC_11:.*]] = memref.alloc(%[[CONSTANT_9]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_14:.*]] = %[[CONSTANT_11]] to %[[CONSTANT_9]] step %[[CONSTANT_12]] {
-// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_14]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:        scf.for %[[VAL_11:.*]] = %[[CONSTANT_11]] to %[[CONSTANT_9]] step %[[CONSTANT_12]] {
+// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_11]], %[[CONSTANT_11]] : index
 // CHECK-NEXT:          %[[IF_2:.*]] = scf.if %[[CMPI_3]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[CONSTANT_12]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_6:.*]] = memref.load %[[ALLOC_9]]{{\[}}%[[VAL_14]]] : memref<2xindex>
+// CHECK-NEXT:            %[[LOAD_6:.*]] = memref.load %[[ALLOC_9]]{{\[}}%[[VAL_11]]] : memref<2xindex>
 // CHECK-NEXT:            scf.yield %[[LOAD_6]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_14]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_11]], %[[CONSTANT_11]] : index
 // CHECK-NEXT:          %[[IF_3:.*]] = scf.if %[[CMPI_4]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_2]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_7:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[VAL_14]]] : memref<2xindex>
+// CHECK-NEXT:            %[[LOAD_7:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[VAL_11]]] : memref<2xindex>
 // CHECK-NEXT:            %[[CMPI_5:.*]] = arith.cmpi eq, %[[LOAD_7]], %[[CONSTANT_12]] : index
 // CHECK-NEXT:            %[[SELECT_1:.*]] = arith.select %[[CMPI_5]], %[[IF_2]], %[[LOAD_7]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_1]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_11]]{{\[}}%[[VAL_14]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_11]]{{\[}}%[[VAL_11]]] : memref<?xindex>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %[[CAST_0:.*]] = memref.cast %[[ALLOC_11]] : memref<?xindex> to memref<2xindex>
 // CHECK-NEXT:        %[[ALLOC_12:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_10]], %[[ALLOC_12]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_12]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
-// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[CAST_0]]{{\[}}%[[CONSTANT_11]]] {{\[}}%[[CONSTANT_11]]] {{\[}}%[[CONSTANT_12]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_12]]{{\[}}%[[CONSTANT_11]]] {{\[}}%[[CONSTANT_11]]] {{\[}}%[[CONSTANT_12]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[CAST_0]]{{\[}}%[[CONSTANT_11]]] [%[[CONSTANT_11]]] [%[[CONSTANT_12]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_12]]{{\[}}%[[CONSTANT_11]]] [%[[CONSTANT_11]]] [%[[CONSTANT_12]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:        %[[ALLOC_13:.*]] = memref.alloc(%[[CONSTANT_11]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_15:.*]] = %[[CONSTANT_11]] to %[[CONSTANT_11]] step %[[CONSTANT_12]] {
-// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_15]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:        scf.for %[[VAL_12:.*]] = %[[CONSTANT_11]] to %[[CONSTANT_11]] step %[[CONSTANT_12]] {
+// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_12]], %[[CONSTANT_11]] : index
 // CHECK-NEXT:          %[[IF_4:.*]] = scf.if %[[CMPI_6]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[CONSTANT_12]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_8:.*]] = memref.load %[[SUBVIEW_4]]{{\[}}%[[VAL_15]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            %[[LOAD_8:.*]] = memref.load %[[SUBVIEW_4]]{{\[}}%[[VAL_12]]] : memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:            scf.yield %[[LOAD_8]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_15]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_12]], %[[CONSTANT_11]] : index
 // CHECK-NEXT:          %[[IF_5:.*]] = scf.if %[[CMPI_7]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_4]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_9:.*]] = memref.load %[[SUBVIEW_5]]{{\[}}%[[VAL_15]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            %[[LOAD_9:.*]] = memref.load %[[SUBVIEW_5]]{{\[}}%[[VAL_12]]] : memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:            %[[CMPI_8:.*]] = arith.cmpi eq, %[[LOAD_9]], %[[CONSTANT_12]] : index
 // CHECK-NEXT:            %[[SELECT_2:.*]] = arith.select %[[CMPI_8]], %[[IF_4]], %[[LOAD_9]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_2]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_13]]{{\[}}%[[VAL_15]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_13]]{{\[}}%[[VAL_12]]] : memref<?xindex>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %[[LOAD_10:.*]] = memref.load %[[ALLOC_11]]{{\[}}%[[CONSTANT_11]]] : memref<?xindex>
 // CHECK-NEXT:        %[[ALLOC_14:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[LOAD_10]], %[[ALLOC_14]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_14]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
 // CHECK-NEXT:        %[[ALLOC_15:.*]] = memref.alloc(%[[CONSTANT_9]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_6:.*]] = memref.subview %[[ALLOC_15]][0] {{\[}}%[[CONSTANT_11]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_6:.*]] = memref.subview %[[ALLOC_15]]{{\[}}0] [%[[CONSTANT_11]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_13]], %[[SUBVIEW_6]] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        %[[SUBVIEW_7:.*]] = memref.subview %[[ALLOC_15]]{{\[}}%[[CONSTANT_11]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_14]], %[[SUBVIEW_7]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
@@ -160,15 +160,16 @@
 // CHECK-NEXT:        %[[LOAD_12:.*]] = memref.load %[[ALLOC_15]]{{\[}}%[[CONSTANT_11]]] : memref<?xindex>
 // CHECK-NEXT:        %[[CONSTANT_13:.*]] = arith.constant 0 : index
 // CHECK-NEXT:        %[[LOAD_13:.*]] = memref.load %[[ALLOC_15]]{{\[}}%[[CONSTANT_13]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_OUTPUT_0:.*]] = hipsr.alloc_output(%[[VAL_8]], %[[LOAD_13]]) {out_idx = 0 : i64} : memref<?x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.expand(%[[VAL_8]]) ins(%[[VAL_11]], %[[VAL_12]] : memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_16]] : memref<?x4xf32, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.matmul(%[[VAL_8]]) ins(%[[ALLOC_16]], %[[VAL_13]] : memref<?x4xf32, #hipsr.mem<device>>, memref<4x2xf32, #hipsr.mem<device>>) outs(%[[ALLOC_OUTPUT_0]] : memref<?x2xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        %[[ALLOC_OUTPUT_0:.*]] = hipsr.alloc_output(%[[VAL_7]], %[[LOAD_13]]) {out_idx = 0 : i64} : memref<?x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.expand(%[[VAL_7]]) ins(%[[VAL_8]], %[[VAL_9]] : memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_16]] : memref<?x4xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.matmul(%[[VAL_7]]) ins(%[[ALLOC_16]], %[[VAL_10]] : memref<?x4xf32, #hipsr.mem<device>>, memref<4x2xf32, #hipsr.mem<device>>) outs(%[[ALLOC_OUTPUT_0]] : memref<?x2xf32, #hipsr.mem<device>>)
 // CHECK-NEXT:        hipsr.preserve_shape %[[CAST_0]], %[[ALLOC_16]] : memref<2xindex>, memref<?x4xf32, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_15]], %[[ALLOC_OUTPUT_0]] : memref<?xindex>, memref<?x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_OUTPUT_0]] : memref<?x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      } -> memref<?x2xf32, #hipsr.mem<device>> {domain_id = 1 : i64}
 // CHECK-NEXT:      return %[[POOL_DOMAIN_1]] : memref<?x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    }
+// CHECK-NEXT:  }
 
 
 

--- a/test/lit/Dialect/Hipsr/Pipelines/sample_static.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/sample_static.mlir
@@ -11,7 +11,7 @@
 // CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
 // CHECK-SAME:      %[[ARG1:.*]]: memref<2x3xf16, #hipsr.mem<device>> {onnx.name = "a"},
 // CHECK-SAME:      %[[ARG2:.*]]: memref<2x4xf32, #hipsr.mem<device>> {onnx.name = "b"}) -> (memref<2x2xf32, #hipsr.mem<device>> {onnx.name = "y"}) attributes {onnx.graph.name = "main_graph"} {
-// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]]:5 = hipsr.pool_domain(%[[ARG0]], %[[ARG1]], %[[ARG2]] : !hipsr.context, memref<2x3xf16, #hipsr.mem<device>>, memref<2x4xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]]:3 = hipsr.pool_domain(%[[ARG0]], %[[ARG1]], %[[ARG2]] : !hipsr.context, memref<2x3xf16, #hipsr.mem<device>>, memref<2x4xf32, #hipsr.mem<device>>) {
 // CHECK-NEXT:      ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: memref<2x3xf16, #hipsr.mem<device>>, %[[VAL_2:.*]]: memref<2x4xf32, #hipsr.mem<device>>):
 // CHECK-NEXT:        %[[CONSTANT_0:.*]] = arith.constant 3 : index
 // CHECK-NEXT:        %[[CONSTANT_1:.*]] = hipsr.constant {value = dense<{{\[\[}}1.000000e+00, 2.000000e+00], [3.000000e+00, 4.000000e+00], [5.000000e+00, 6.000000e+00], [7.000000e+00, 8.000000e+00]]> : tensor<4x2xf32>} : memref<4x2xf32, #hipsr.mem<device>>
@@ -27,8 +27,8 @@
 // CHECK-NEXT:        %[[ALLOC_2:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_0]], %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_3]], %[[ALLOC_2]]{{\[}}%[[CONSTANT_3]]] : memref<2xindex>
-// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_1]]{{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_1]]{{\[}}%[[CONSTANT_4]]] [%[[CONSTANT_4]]] [%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] [%[[CONSTANT_4]]] [%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:        %[[ALLOC_3:.*]] = memref.alloc(%[[CONSTANT_4]]) {alignment = 64 : i64} : memref<?xindex>
 // CHECK-NEXT:        scf.for %[[VAL_3:.*]] = %[[CONSTANT_4]] to %[[CONSTANT_4]] step %[[CONSTANT_3]] {
 // CHECK-NEXT:          %[[CMPI_0:.*]] = arith.cmpi ult, %[[VAL_3]], %[[CONSTANT_4]] : index
@@ -53,7 +53,7 @@
 // CHECK-NEXT:        memref.store %[[CONSTANT_5]], %[[ALLOC_4]]{{\[}}%[[CONSTANT_4]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_3]], %[[ALLOC_4]]{{\[}}%[[CONSTANT_3]]] : memref<2xindex>
 // CHECK-NEXT:        %[[ALLOC_5:.*]] = memref.alloc(%[[CONSTANT_5]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_5]][0] {{\[}}%[[CONSTANT_4]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_5]]{{\[}}0] [%[[CONSTANT_4]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_3]], %[[SUBVIEW_2]] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        %[[SUBVIEW_3:.*]] = memref.subview %[[ALLOC_5]]{{\[}}%[[CONSTANT_4]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_4]], %[[SUBVIEW_3]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
@@ -75,10 +75,10 @@
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_5]], %[[ALLOC_6]] : memref<?xindex>, memref<2x1xf16, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_5]], %[[ALLOC_7]] : memref<?xindex>, memref<2x1xf32, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_0]], %[[COMPUTE_0]] : memref<1xindex>, memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_7]], %[[ALLOC_7]], %[[ALLOC_8]], %[[COMPUTE_0]], %[[CONSTANT_1]] : memref<2x1xf32, #hipsr.mem<device>>, memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      } -> memref<2x1xf32, #hipsr.mem<device>>, memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]] = hipsr.pool_domain(%[[ARG0]], %[[VAL_7:.*]]#0, %[[VAL_7]]#2, %[[VAL_7]]#1, %[[VAL_7]]#3, %[[VAL_7]]#4 : !hipsr.context, memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_8:.*]]: !hipsr.context, %[[VAL_9:.*]]: memref<2x1xf32, #hipsr.mem<device>>, %[[VAL_10:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_11:.*]]: memref<2x1xf32, #hipsr.mem<device>>, %[[VAL_12:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_13:.*]]: memref<4x2xf32, #hipsr.mem<device>>):
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_7]], %[[COMPUTE_0]], %[[CONSTANT_1]] : memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#0, %[[POOL_DOMAIN_0]]#1, %[[POOL_DOMAIN_0]]#2 : !hipsr.context, memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_7:.*]]: !hipsr.context, %[[VAL_8:.*]]: memref<2x1xf32, #hipsr.mem<device>>, %[[VAL_9:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_10:.*]]: memref<4x2xf32, #hipsr.mem<device>>):
 // CHECK-NEXT:        %[[CONSTANT_10:.*]] = arith.constant 4 : index
 // CHECK-NEXT:        %[[CONSTANT_11:.*]] = arith.constant 0 : index
 // CHECK-NEXT:        %[[CONSTANT_12:.*]] = arith.constant 1 : index
@@ -86,78 +86,79 @@
 // CHECK-NEXT:        %[[ALLOC_9:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_13]], %[[ALLOC_9]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_12]], %[[ALLOC_9]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
-// CHECK-NEXT:        %[[LOAD_2:.*]] = memref.load %[[VAL_10]]{{\[}}%[[CONSTANT_11]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_2:.*]] = memref.load %[[VAL_9]]{{\[}}%[[CONSTANT_11]]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_0:.*]] = arith.index_cast %[[LOAD_2]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_3:.*]] = memref.load %[[VAL_10]]{{\[}}%[[CONSTANT_12]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_3:.*]] = memref.load %[[VAL_9]]{{\[}}%[[CONSTANT_12]]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_1:.*]] = arith.index_cast %[[LOAD_3]] : i64 to index
 // CHECK-NEXT:        %[[ALLOC_10:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[INDEX_CAST_0]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[INDEX_CAST_1]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
 // CHECK-NEXT:        %[[ALLOC_11:.*]] = memref.alloc(%[[CONSTANT_13]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_14:.*]] = %[[CONSTANT_11]] to %[[CONSTANT_13]] step %[[CONSTANT_12]] {
-// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_14]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:        scf.for %[[VAL_11:.*]] = %[[CONSTANT_11]] to %[[CONSTANT_13]] step %[[CONSTANT_12]] {
+// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_11]], %[[CONSTANT_11]] : index
 // CHECK-NEXT:          %[[IF_2:.*]] = scf.if %[[CMPI_3]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[CONSTANT_12]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_4:.*]] = memref.load %[[ALLOC_9]]{{\[}}%[[VAL_14]]] : memref<2xindex>
+// CHECK-NEXT:            %[[LOAD_4:.*]] = memref.load %[[ALLOC_9]]{{\[}}%[[VAL_11]]] : memref<2xindex>
 // CHECK-NEXT:            scf.yield %[[LOAD_4]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_14]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_11]], %[[CONSTANT_11]] : index
 // CHECK-NEXT:          %[[IF_3:.*]] = scf.if %[[CMPI_4]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_2]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_5:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[VAL_14]]] : memref<2xindex>
+// CHECK-NEXT:            %[[LOAD_5:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[VAL_11]]] : memref<2xindex>
 // CHECK-NEXT:            %[[CMPI_5:.*]] = arith.cmpi eq, %[[LOAD_5]], %[[CONSTANT_12]] : index
 // CHECK-NEXT:            %[[SELECT_1:.*]] = arith.select %[[CMPI_5]], %[[IF_2]], %[[LOAD_5]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_1]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_11]]{{\[}}%[[VAL_14]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_11]]{{\[}}%[[VAL_11]]] : memref<?xindex>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %[[CAST_0:.*]] = memref.cast %[[ALLOC_11]] : memref<?xindex> to memref<2xindex>
 // CHECK-NEXT:        %[[ALLOC_12:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_10]], %[[ALLOC_12]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_13]], %[[ALLOC_12]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
-// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[CAST_0]]{{\[}}%[[CONSTANT_11]]] {{\[}}%[[CONSTANT_11]]] {{\[}}%[[CONSTANT_12]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_12]]{{\[}}%[[CONSTANT_11]]] {{\[}}%[[CONSTANT_11]]] {{\[}}%[[CONSTANT_12]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[CAST_0]]{{\[}}%[[CONSTANT_11]]] [%[[CONSTANT_11]]] [%[[CONSTANT_12]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_12]]{{\[}}%[[CONSTANT_11]]] [%[[CONSTANT_11]]] [%[[CONSTANT_12]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:        %[[ALLOC_13:.*]] = memref.alloc(%[[CONSTANT_11]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_15:.*]] = %[[CONSTANT_11]] to %[[CONSTANT_11]] step %[[CONSTANT_12]] {
-// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_15]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:        scf.for %[[VAL_12:.*]] = %[[CONSTANT_11]] to %[[CONSTANT_11]] step %[[CONSTANT_12]] {
+// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_12]], %[[CONSTANT_11]] : index
 // CHECK-NEXT:          %[[IF_4:.*]] = scf.if %[[CMPI_6]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[CONSTANT_12]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_6:.*]] = memref.load %[[SUBVIEW_4]]{{\[}}%[[VAL_15]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            %[[LOAD_6:.*]] = memref.load %[[SUBVIEW_4]]{{\[}}%[[VAL_12]]] : memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:            scf.yield %[[LOAD_6]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_15]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_12]], %[[CONSTANT_11]] : index
 // CHECK-NEXT:          %[[IF_5:.*]] = scf.if %[[CMPI_7]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_4]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_7:.*]] = memref.load %[[SUBVIEW_5]]{{\[}}%[[VAL_15]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            %[[LOAD_7:.*]] = memref.load %[[SUBVIEW_5]]{{\[}}%[[VAL_12]]] : memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:            %[[CMPI_8:.*]] = arith.cmpi eq, %[[LOAD_7]], %[[CONSTANT_12]] : index
 // CHECK-NEXT:            %[[SELECT_2:.*]] = arith.select %[[CMPI_8]], %[[IF_4]], %[[LOAD_7]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_2]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_13]]{{\[}}%[[VAL_15]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_13]]{{\[}}%[[VAL_12]]] : memref<?xindex>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        %[[LOAD_8:.*]] = memref.load %[[ALLOC_11]]{{\[}}%[[CONSTANT_11]]] : memref<?xindex>
 // CHECK-NEXT:        %[[ALLOC_14:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[LOAD_8]], %[[ALLOC_14]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_13]], %[[ALLOC_14]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
 // CHECK-NEXT:        %[[ALLOC_15:.*]] = memref.alloc(%[[CONSTANT_13]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_6:.*]] = memref.subview %[[ALLOC_15]][0] {{\[}}%[[CONSTANT_11]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_6:.*]] = memref.subview %[[ALLOC_15]]{{\[}}0] [%[[CONSTANT_11]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_13]], %[[SUBVIEW_6]] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        %[[SUBVIEW_7:.*]] = memref.subview %[[ALLOC_15]]{{\[}}%[[CONSTANT_11]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_14]], %[[SUBVIEW_7]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        %[[ALLOC_16:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_OUTPUT_0:.*]] = hipsr.alloc_output(%[[VAL_8]]) {out_idx = 0 : i64} : memref<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.expand(%[[VAL_8]]) ins(%[[VAL_11]], %[[VAL_12]] : memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_16]] : memref<2x4xf32, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.matmul(%[[VAL_8]]) ins(%[[ALLOC_16]], %[[VAL_13]] : memref<2x4xf32, #hipsr.mem<device>>, memref<4x2xf32, #hipsr.mem<device>>) outs(%[[ALLOC_OUTPUT_0]] : memref<2x2xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        %[[ALLOC_OUTPUT_0:.*]] = hipsr.alloc_output(%[[VAL_7]]) {out_idx = 0 : i64} : memref<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.expand(%[[VAL_7]]) ins(%[[VAL_8]], %[[VAL_9]] : memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_16]] : memref<2x4xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.matmul(%[[VAL_7]]) ins(%[[ALLOC_16]], %[[VAL_10]] : memref<2x4xf32, #hipsr.mem<device>>, memref<4x2xf32, #hipsr.mem<device>>) outs(%[[ALLOC_OUTPUT_0]] : memref<2x2xf32, #hipsr.mem<device>>)
 // CHECK-NEXT:        hipsr.preserve_shape %[[CAST_0]], %[[ALLOC_16]] : memref<2xindex>, memref<2x4xf32, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_15]], %[[ALLOC_OUTPUT_0]] : memref<?xindex>, memref<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_OUTPUT_0]] : memref<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      } -> memref<2x2xf32, #hipsr.mem<device>> {domain_id = 1 : i64}
 // CHECK-NEXT:      return %[[POOL_DOMAIN_1]] : memref<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    }
+// CHECK-NEXT:  }
 
 
 

--- a/test/lit/Dialect/Hipsr/Transforms/MaterializeInitTensors/invalid.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/MaterializeInitTensors/invalid.mlir
@@ -34,11 +34,11 @@ func.func @unpopulated_shape_region(%ctx: !hipsr.context, %a: tensor<?x256xf16, 
 // -----
 
 // A barrier reads its inputs as buffers, and the pool hands a buffer out only
-// after the last allocation in the domain, so an input allocated here has no
-// value to name yet. The placeholder verifier allows the edge, because a
-// placeholder result is a legal shape-graph input, and
-// -hipsr-partition-pool-domains never builds it, because it starts a barrier one
-// domain past every input. That leaves the pass to reject it.
+// after the last allocation in the domain, so an input produced here is not
+// ready yet. The placeholder verifier allows the edge, because a barrier names
+// the data value its consumer reads, and -hipsr-partition-pool-domains never
+// builds one, because it starts a barrier one domain past every input. That
+// leaves this pass to reject it.
 func.func @barrier_over_placeholder(%ctx: !hipsr.context, %in: tensor<?x1xf16, #hipsr.mem<device>>)
     -> tensor<?x1xf16, #hipsr.mem<device>> {
   %0 = hipsr.pool_domain(%ctx, %in
@@ -56,7 +56,7 @@ func.func @barrier_over_placeholder(%ctx: !hipsr.context, %in: tensor<?x1xf16, #
         outs(%cast_init : tensor<?x1xf32, #hipsr.mem<device>>) : tensor<?x1xf32, #hipsr.mem<device>>
     // expected-error@+1 {{barrier input must be allocated outside this pool domain}}
     %barrier_init = hipsr.placeholder(%domain_ctx)
-        ins(%cast_init : tensor<?x1xf32, #hipsr.mem<device>>)
+        ins(%cast : tensor<?x1xf32, #hipsr.mem<device>>)
         {placeholder_type = #hipsr.placeholder_type<barrier>}
         : tensor<?x1xf16, #hipsr.mem<device>> shape_region {
     ^bb0(%region_ctx: !hipsr.context, %region_cast: tensor<?x1xf32, #hipsr.mem<device>>):

--- a/test/lit/Dialect/Hipsr/Transforms/PartitionPoolDomains/analysis_report.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PartitionPoolDomains/analysis_report.mlir
@@ -9,7 +9,7 @@
 // expected-remark@+1 {{hipsr-partition-pool-domains: operation domains [0->0,1->0,2->1,3->1,4->1,5->1,6->1,7->1]}}
 func.func @parallel_barriers(
     %ctx: !hipsr.context, %input: tensor<?x8xf16, #hipsr.mem<device>>) -> tensor<?x8xf16, #hipsr.mem<device>> {
-  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 0 ops [0=hipsr.placeholder,1=hipsr.cast] results [0#0,1#0]}}
+  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 0 ops [0=hipsr.placeholder,1=hipsr.cast] results [1#0]}}
   %root_init = hipsr.placeholder(%ctx)
       ins(%input : tensor<?x8xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16, #hipsr.mem<device>>
@@ -18,13 +18,13 @@ func.func @parallel_barriers(
 
   // expected-remark@+1 {{hipsr-partition-pool-domains: domain 1 ops [2=hipsr.placeholder,3=hipsr.cast,4=hipsr.placeholder,5=hipsr.cast,6=hipsr.placeholder,7=hipsr.add] results [7#0]}}
   %lhs_init = hipsr.placeholder(%ctx)
-      ins(%root_init : tensor<?x8xf16, #hipsr.mem<device>>)
+      ins(%root : tensor<?x8xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x8xf16, #hipsr.mem<device>>
   %lhs = hipsr.cast(%ctx) ins(%root : tensor<?x8xf16, #hipsr.mem<device>>)
       outs(%lhs_init : tensor<?x8xf16, #hipsr.mem<device>>) : tensor<?x8xf16, #hipsr.mem<device>>
 
   %rhs_init = hipsr.placeholder(%ctx)
-      ins(%root_init : tensor<?x8xf16, #hipsr.mem<device>>)
+      ins(%root : tensor<?x8xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x8xf16, #hipsr.mem<device>>
   %rhs = hipsr.cast(%ctx) ins(%root : tensor<?x8xf16, #hipsr.mem<device>>)
       outs(%rhs_init : tensor<?x8xf16, #hipsr.mem<device>>) : tensor<?x8xf16, #hipsr.mem<device>>
@@ -59,7 +59,7 @@ func.func @root_barrier(
 // expected-remark@+1 {{hipsr-partition-pool-domains: operation domains [0->0,1->0,2->1,3->1,4->1,5->1,6->1,7->1]}}
 func.func @normal_after_barrier(
     %ctx: !hipsr.context, %input: tensor<?x8xf16, #hipsr.mem<device>>) -> tensor<?x8xf16, #hipsr.mem<device>> {
-  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 0 ops [0=hipsr.placeholder,1=hipsr.cast] results [0#0,1#0]}}
+  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 0 ops [0=hipsr.placeholder,1=hipsr.cast] results [1#0]}}
   %root_init = hipsr.placeholder(%ctx)
       ins(%input : tensor<?x8xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16, #hipsr.mem<device>>
@@ -68,7 +68,7 @@ func.func @normal_after_barrier(
 
   // expected-remark@+1 {{hipsr-partition-pool-domains: domain 1 ops [2=hipsr.placeholder,3=hipsr.cast,4=hipsr.placeholder,5=hipsr.cast,6=hipsr.placeholder,7=hipsr.cast] results [7#0]}}
   %barrier_init = hipsr.placeholder(%ctx)
-      ins(%root_init : tensor<?x8xf16, #hipsr.mem<device>>)
+      ins(%root : tensor<?x8xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x8xf16, #hipsr.mem<device>>
   %barrier = hipsr.cast(%ctx) ins(%root : tensor<?x8xf16, #hipsr.mem<device>>)
       outs(%barrier_init : tensor<?x8xf16, #hipsr.mem<device>>) : tensor<?x8xf16, #hipsr.mem<device>>
@@ -94,23 +94,23 @@ func.func @normal_after_barrier(
 // expected-remark@+1 {{hipsr-partition-pool-domains: operation domains [0->0,1->0,2->1,3->1,4->2,5->2,6->1,7->1,8->0,9->0,10->1,11->1,12->3,13->3]}}
 func.func @mixed_depth_branches(
     %ctx: !hipsr.context, %input: tensor<?x8xf16, #hipsr.mem<device>>) -> tensor<?x8xf16, #hipsr.mem<device>> {
-  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 0 ops [0=hipsr.placeholder,1=hipsr.cast,8=hipsr.placeholder,9=hipsr.cast] results [0#0,1#0,8#0,9#0]}}
+  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 0 ops [0=hipsr.placeholder,1=hipsr.cast,8=hipsr.placeholder,9=hipsr.cast] results [1#0,8#0,9#0]}}
   %root_init = hipsr.placeholder(%ctx)
       ins(%input : tensor<?x8xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<?x8xf16, #hipsr.mem<device>>
   %root = hipsr.cast(%ctx) ins(%input : tensor<?x8xf16, #hipsr.mem<device>>)
       outs(%root_init : tensor<?x8xf16, #hipsr.mem<device>>) : tensor<?x8xf16, #hipsr.mem<device>>
 
-  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 1 ops [2=hipsr.placeholder,3=hipsr.cast,6=hipsr.placeholder,7=hipsr.cast,10=hipsr.placeholder,11=hipsr.add] results [2#0,3#0,10#0,11#0]}}
+  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 1 ops [2=hipsr.placeholder,3=hipsr.cast,6=hipsr.placeholder,7=hipsr.cast,10=hipsr.placeholder,11=hipsr.add] results [3#0,11#0]}}
   %deep1_init = hipsr.placeholder(%ctx)
-      ins(%root_init : tensor<?x8xf16, #hipsr.mem<device>>)
+      ins(%root : tensor<?x8xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x8xf16, #hipsr.mem<device>>
   %deep1 = hipsr.cast(%ctx) ins(%root : tensor<?x8xf16, #hipsr.mem<device>>)
       outs(%deep1_init : tensor<?x8xf16, #hipsr.mem<device>>) : tensor<?x8xf16, #hipsr.mem<device>>
 
-  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 2 ops [4=hipsr.placeholder,5=hipsr.cast] results [4#0,5#0]}}
+  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 2 ops [4=hipsr.placeholder,5=hipsr.cast] results [5#0]}}
   %deep2_init = hipsr.placeholder(%ctx)
-      ins(%deep1_init : tensor<?x8xf16, #hipsr.mem<device>>)
+      ins(%deep1 : tensor<?x8xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x8xf16, #hipsr.mem<device>>
   %deep2 = hipsr.cast(%ctx) ins(%deep1 : tensor<?x8xf16, #hipsr.mem<device>>)
       outs(%deep2_init : tensor<?x8xf16, #hipsr.mem<device>>) : tensor<?x8xf16, #hipsr.mem<device>>
@@ -136,7 +136,7 @@ func.func @mixed_depth_branches(
 
   // expected-remark@+1 {{hipsr-partition-pool-domains: domain 3 ops [12=hipsr.placeholder,13=hipsr.add] results [13#0]}}
   %result_init = hipsr.placeholder(%ctx)
-      ins(%deep2_init, %middle_shallow_init
+      ins(%deep2, %middle_shallow
           : tensor<?x8xf16, #hipsr.mem<device>>, tensor<?x8xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x8xf16, #hipsr.mem<device>>
   %result = hipsr.add(%ctx)
@@ -152,7 +152,7 @@ func.func @mixed_depth_branches(
 func.func @multi_result_domain_results(
     %ctx: !hipsr.context, %input: tensor<?x8xf16, #hipsr.mem<device>>)
     -> (tensor<?x8xf16, #hipsr.mem<device>>, tensor<?x8xf16, #hipsr.mem<device>>) {
-  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 0 ops [0=hipsr.placeholder,1=hipsr.compute] results [0#0,0#1,1#0,1#1]}}
+  // expected-remark@+1 {{hipsr-partition-pool-domains: domain 0 ops [0=hipsr.placeholder,1=hipsr.compute] results [1#0,1#1]}}
   %root_inits:2 = hipsr.placeholder(%ctx)
       ins(%input : tensor<?x8xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<normal>}
@@ -168,13 +168,13 @@ func.func @multi_result_domain_results(
 
   // expected-remark@+1 {{hipsr-partition-pool-domains: domain 1 ops [2=hipsr.placeholder,3=hipsr.cast,4=hipsr.placeholder,5=hipsr.cast] results [3#0,5#0]}}
   %lhs_init = hipsr.placeholder(%ctx)
-      ins(%root_inits#0 : tensor<?x8xf16, #hipsr.mem<device>>)
+      ins(%root#0 : tensor<?x8xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x8xf16, #hipsr.mem<device>>
   %lhs = hipsr.cast(%ctx) ins(%root#0 : tensor<?x8xf16, #hipsr.mem<device>>)
       outs(%lhs_init : tensor<?x8xf16, #hipsr.mem<device>>) : tensor<?x8xf16, #hipsr.mem<device>>
 
   %rhs_init = hipsr.placeholder(%ctx)
-      ins(%root_inits#1 : tensor<?x8xf16, #hipsr.mem<device>>)
+      ins(%root#1 : tensor<?x8xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?x8xf16, #hipsr.mem<device>>
   %rhs = hipsr.cast(%ctx) ins(%root#1 : tensor<?x8xf16, #hipsr.mem<device>>)
       outs(%rhs_init : tensor<?x8xf16, #hipsr.mem<device>>) : tensor<?x8xf16, #hipsr.mem<device>>

--- a/test/lit/Dialect/Hipsr/Transforms/PartitionPoolDomains/materialization.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PartitionPoolDomains/materialization.mlir
@@ -29,32 +29,34 @@
 //            v
 //   data4 [N, D2]
 //
-// CHECK-LABEL: func.func @mixed_chain(
-// CHECK-SAME: %[[CTX:.*]]: !hipsr.context, %[[INPUT:.*]]: tensor<4xf32, #hipsr.mem<device>>) -> tensor<4xf16, #hipsr.mem<device>> {
-// CHECK-NEXT: %[[DOMAIN0:.*]]:2 = hipsr.pool_domain(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<4xf32, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX0:.*]]: !hipsr.context, %[[INPUT0:.*]]: tensor<4xf32, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[INIT0:.*]] = hipsr.placeholder(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[DATA0:.*]] = hipsr.cast(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[INIT0]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[INIT0]], %[[DATA0]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT: %[[DOMAIN1:.*]]:2 = hipsr.pool_domain(%[[CTX]], %[[DOMAIN0]]#0, %[[DOMAIN0]]#1 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX1:.*]]: !hipsr.context, %[[SHAPE_INPUT1:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[DATA_INPUT1:.*]]: tensor<4xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[INIT1:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[SHAPE_INPUT1]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf32, #hipsr.mem<device>>
-// CHECK-NEXT: %[[DATA1:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[DATA_INPUT1]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[INIT1]] : tensor<4xf32, #hipsr.mem<device>>) : tensor<4xf32, #hipsr.mem<device>>
-// CHECK-NEXT: %[[INIT2:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[INIT1]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[DATA2:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[DATA1]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[INIT2]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[INIT2]], %[[DATA2]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 1 : i64}
-// CHECK-NEXT: %[[DOMAIN2:.*]] = hipsr.pool_domain(%[[CTX]], %[[DOMAIN1]]#0, %[[DOMAIN1]]#1 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX2:.*]]: !hipsr.context, %[[SHAPE_INPUT2:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[DATA_INPUT2:.*]]: tensor<4xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[INIT3:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[SHAPE_INPUT2]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf32, #hipsr.mem<device>>
-// CHECK-NEXT: %[[DATA3:.*]] = hipsr.cast(%[[CTX2]]) ins(%[[DATA_INPUT2]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[INIT3]] : tensor<4xf32, #hipsr.mem<device>>) : tensor<4xf32, #hipsr.mem<device>>
-// CHECK-NEXT: %[[INIT4:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[INIT3]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[DATA4:.*]] = hipsr.cast(%[[CTX2]]) ins(%[[DATA3]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[INIT4]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[DATA4]] : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>> {domain_id = 2 : i64}
-// CHECK-NEXT: return %[[DOMAIN2]] : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: }
+// CHECK-LABEL:   func.func @mixed_chain(
+// CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[ARG1:.*]]: tensor<4xf32, #hipsr.mem<device>>) -> tensor<4xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]] = hipsr.pool_domain(%[[ARG0]], %[[ARG1]] : !hipsr.context, tensor<4xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: tensor<4xf32, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[PLACEHOLDER_0:.*]] = hipsr.placeholder(%[[VAL_0]]) ins(%[[VAL_1]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_0:.*]] = hipsr.cast(%[[VAL_0]]) ins(%[[VAL_1]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_0]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[CAST_0]] : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> tensor<4xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]] : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_2:.*]]: !hipsr.context, %[[VAL_3:.*]]: tensor<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[PLACEHOLDER_1:.*]] = hipsr.placeholder(%[[VAL_2]]) ins(%[[VAL_3]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_1:.*]] = hipsr.cast(%[[VAL_2]]) ins(%[[VAL_3]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_1]] : tensor<4xf32, #hipsr.mem<device>>) : tensor<4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[PLACEHOLDER_2:.*]] = hipsr.placeholder(%[[VAL_2]]) ins(%[[PLACEHOLDER_1]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_2:.*]] = hipsr.cast(%[[VAL_2]]) ins(%[[CAST_1]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_2]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[CAST_2]] : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> tensor<4xf16, #hipsr.mem<device>> {domain_id = 1 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_2:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_1]] : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_4:.*]]: !hipsr.context, %[[VAL_5:.*]]: tensor<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[PLACEHOLDER_3:.*]] = hipsr.placeholder(%[[VAL_4]]) ins(%[[VAL_5]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_3:.*]] = hipsr.cast(%[[VAL_4]]) ins(%[[VAL_5]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_3]] : tensor<4xf32, #hipsr.mem<device>>) : tensor<4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[PLACEHOLDER_4:.*]] = hipsr.placeholder(%[[VAL_4]]) ins(%[[PLACEHOLDER_3]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_4:.*]] = hipsr.cast(%[[VAL_4]]) ins(%[[CAST_3]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_4]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[CAST_4]] : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> tensor<4xf16, #hipsr.mem<device>> {domain_id = 2 : i64}
+// CHECK-NEXT:      return %[[POOL_DOMAIN_2]] : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    }
+
 func.func @mixed_chain(
     %ctx: !hipsr.context, %input: tensor<4xf32, #hipsr.mem<device>>) -> tensor<4xf16, #hipsr.mem<device>> {
   %init0 = hipsr.placeholder(%ctx)
@@ -63,7 +65,7 @@ func.func @mixed_chain(
   %data0 = hipsr.cast(%ctx) ins(%input : tensor<4xf32, #hipsr.mem<device>>)
       outs(%init0 : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
   %init1 = hipsr.placeholder(%ctx)
-      ins(%init0 : tensor<4xf16, #hipsr.mem<device>>)
+      ins(%data0 : tensor<4xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf32, #hipsr.mem<device>>
   %data1 = hipsr.cast(%ctx) ins(%data0 : tensor<4xf16, #hipsr.mem<device>>)
       outs(%init1 : tensor<4xf32, #hipsr.mem<device>>) : tensor<4xf32, #hipsr.mem<device>>
@@ -73,7 +75,7 @@ func.func @mixed_chain(
   %data2 = hipsr.cast(%ctx) ins(%data1 : tensor<4xf32, #hipsr.mem<device>>)
       outs(%init2 : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
   %init3 = hipsr.placeholder(%ctx)
-      ins(%init2 : tensor<4xf16, #hipsr.mem<device>>)
+      ins(%data2 : tensor<4xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf32, #hipsr.mem<device>>
   %data3 = hipsr.cast(%ctx) ins(%data2 : tensor<4xf16, #hipsr.mem<device>>)
       outs(%init3 : tensor<4xf32, #hipsr.mem<device>>) : tensor<4xf32, #hipsr.mem<device>>
@@ -125,46 +127,48 @@ func.func @mixed_chain(
 //                               v
 //                       result [B, D3]
 //
-// CHECK-LABEL: func.func @multi_branch(
-// CHECK-SAME: %[[CTX:.*]]: !hipsr.context, %[[INPUT:.*]]: tensor<4xf32, #hipsr.mem<device>>) -> tensor<4xf16, #hipsr.mem<device>> {
-// CHECK-NEXT: %[[DOMAIN0:.*]]:4 = hipsr.pool_domain(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<4xf32, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX0:.*]]: !hipsr.context, %[[INPUT0:.*]]: tensor<4xf32, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[ROOT_INIT:.*]] = hipsr.placeholder(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[ROOT:.*]] = hipsr.cast(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[ROOT_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[INDEPENDENT_INIT:.*]] = hipsr.placeholder(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[INDEPENDENT:.*]] = hipsr.cast(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[INDEPENDENT_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[ROOT_INIT]], %[[ROOT]], %[[INDEPENDENT_INIT]], %[[INDEPENDENT]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT: %[[DOMAIN1:.*]]:4 = hipsr.pool_domain(%[[CTX]], %[[DOMAIN0]]#0, %[[DOMAIN0]]#1 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX1:.*]]: !hipsr.context, %[[ROOT_SHAPE1:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[ROOT_DATA1:.*]]: tensor<4xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[LHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[ROOT_SHAPE1]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[LHS:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[ROOT_DATA1]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[LHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[LHS_NORMAL_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[LHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[LHS_NORMAL:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[LHS]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[LHS_NORMAL_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[RHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[ROOT_SHAPE1]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[RHS:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[ROOT_DATA1]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[RHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[RHS_NORMAL_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[RHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[RHS_NORMAL:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[RHS]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[RHS_NORMAL_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[LHS_NORMAL_INIT]], %[[LHS_NORMAL]], %[[RHS_NORMAL_INIT]], %[[RHS_NORMAL]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 1 : i64}
-// CHECK-NEXT: %[[DOMAIN2:.*]]:2 = hipsr.pool_domain(%[[CTX]], %[[DOMAIN1]]#0, %[[DOMAIN1]]#1, %[[DOMAIN1]]#2, %[[DOMAIN1]]#3, %[[DOMAIN0]]#2, %[[DOMAIN0]]#3 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX2:.*]]: !hipsr.context, %[[LHS_SHAPE2:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[LHS_DATA2:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[RHS_SHAPE2:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[RHS_DATA2:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[INDEPENDENT_SHAPE2:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[INDEPENDENT_DATA2:.*]]: tensor<4xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[LHS_DEEP_INIT:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[LHS_SHAPE2]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[LHS_DEEP:.*]] = hipsr.cast(%[[CTX2]]) ins(%[[LHS_DATA2]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[LHS_DEEP_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[DEEP_JOIN_INIT:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[LHS_DEEP_INIT]], %[[RHS_SHAPE2]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[DEEP_JOIN:.*]] = hipsr.add(%[[CTX2]]) ins(%[[LHS_DEEP]], %[[RHS_DATA2]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) outs(%[[DEEP_JOIN_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[JOIN_INIT:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[DEEP_JOIN_INIT]], %[[INDEPENDENT_SHAPE2]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[JOIN:.*]] = hipsr.add(%[[CTX2]]) ins(%[[DEEP_JOIN]], %[[INDEPENDENT_DATA2]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) outs(%[[JOIN_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[JOIN_INIT]], %[[JOIN]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 2 : i64}
-// CHECK-NEXT: %[[DOMAIN3:.*]] = hipsr.pool_domain(%[[CTX]], %[[DOMAIN2]]#0, %[[DOMAIN2]]#1 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX3:.*]]: !hipsr.context, %[[SHAPE_INPUT3:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[DATA_INPUT3:.*]]: tensor<4xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[RESULT_INIT:.*]] = hipsr.placeholder(%[[CTX3]]) ins(%[[SHAPE_INPUT3]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[RESULT:.*]] = hipsr.cast(%[[CTX3]]) ins(%[[DATA_INPUT3]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[RESULT_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[RESULT]] : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>> {domain_id = 3 : i64}
-// CHECK-NEXT: return %[[DOMAIN3]] : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: }
+// CHECK-LABEL:   func.func @multi_branch(
+// CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[ARG1:.*]]: tensor<4xf32, #hipsr.mem<device>>) -> tensor<4xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]]:3 = hipsr.pool_domain(%[[ARG0]], %[[ARG1]] : !hipsr.context, tensor<4xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: tensor<4xf32, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[PLACEHOLDER_0:.*]] = hipsr.placeholder(%[[VAL_0]]) ins(%[[VAL_1]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_0:.*]] = hipsr.cast(%[[VAL_0]]) ins(%[[VAL_1]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_0]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[PLACEHOLDER_1:.*]] = hipsr.placeholder(%[[VAL_0]]) ins(%[[VAL_1]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_1:.*]] = hipsr.cast(%[[VAL_0]]) ins(%[[VAL_1]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_1]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[CAST_0]], %[[PLACEHOLDER_1]], %[[CAST_1]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]]:3 = hipsr.pool_domain(%[[ARG0]], %[[VAL_2:.*]]#0 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_3:.*]]: !hipsr.context, %[[VAL_4:.*]]: tensor<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[PLACEHOLDER_2:.*]] = hipsr.placeholder(%[[VAL_3]]) ins(%[[VAL_4]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_2:.*]] = hipsr.cast(%[[VAL_3]]) ins(%[[VAL_4]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_2]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[PLACEHOLDER_3:.*]] = hipsr.placeholder(%[[VAL_3]]) ins(%[[PLACEHOLDER_2]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_3:.*]] = hipsr.cast(%[[VAL_3]]) ins(%[[CAST_2]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_3]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[PLACEHOLDER_4:.*]] = hipsr.placeholder(%[[VAL_3]]) ins(%[[VAL_4]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_4:.*]] = hipsr.cast(%[[VAL_3]]) ins(%[[VAL_4]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_4]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[PLACEHOLDER_5:.*]] = hipsr.placeholder(%[[VAL_3]]) ins(%[[PLACEHOLDER_4]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_5:.*]] = hipsr.cast(%[[VAL_3]]) ins(%[[CAST_4]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_5]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[CAST_3]], %[[PLACEHOLDER_5]], %[[CAST_5]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 1 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_2:.*]] = hipsr.pool_domain(%[[ARG0]], %[[VAL_5:.*]]#0, %[[VAL_5]]#1, %[[VAL_5]]#2, %[[VAL_6:.*]]#1, %[[VAL_6]]#2 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_7:.*]]: !hipsr.context, %[[VAL_8:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[VAL_9:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[VAL_10:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[VAL_11:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[VAL_12:.*]]: tensor<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[PLACEHOLDER_6:.*]] = hipsr.placeholder(%[[VAL_7]]) ins(%[[VAL_8]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_6:.*]] = hipsr.cast(%[[VAL_7]]) ins(%[[VAL_8]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_6]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[PLACEHOLDER_7:.*]] = hipsr.placeholder(%[[VAL_7]]) ins(%[[PLACEHOLDER_6]], %[[VAL_9]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ADD_0:.*]] = hipsr.add(%[[VAL_7]]) ins(%[[CAST_6]], %[[VAL_10]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_7]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[PLACEHOLDER_8:.*]] = hipsr.placeholder(%[[VAL_7]]) ins(%[[PLACEHOLDER_7]], %[[VAL_11]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ADD_1:.*]] = hipsr.add(%[[VAL_7]]) ins(%[[ADD_0]], %[[VAL_12]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_8]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ADD_1]] : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> tensor<4xf16, #hipsr.mem<device>> {domain_id = 2 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_3:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_2]] : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_13:.*]]: !hipsr.context, %[[VAL_14:.*]]: tensor<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[PLACEHOLDER_9:.*]] = hipsr.placeholder(%[[VAL_13]]) ins(%[[VAL_14]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_7:.*]] = hipsr.cast(%[[VAL_13]]) ins(%[[VAL_14]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_9]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[CAST_7]] : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> tensor<4xf16, #hipsr.mem<device>> {domain_id = 3 : i64}
+// CHECK-NEXT:      return %[[POOL_DOMAIN_3]] : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    }
+
 func.func @multi_branch(
     %ctx: !hipsr.context, %input: tensor<4xf32, #hipsr.mem<device>>) -> tensor<4xf16, #hipsr.mem<device>> {
   %root_init = hipsr.placeholder(%ctx)
@@ -173,7 +177,7 @@ func.func @multi_branch(
   %root = hipsr.cast(%ctx) ins(%input : tensor<4xf32, #hipsr.mem<device>>)
       outs(%root_init : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
   %lhs_init = hipsr.placeholder(%ctx)
-      ins(%root_init : tensor<4xf16, #hipsr.mem<device>>)
+      ins(%root : tensor<4xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
   %lhs = hipsr.cast(%ctx) ins(%root : tensor<4xf16, #hipsr.mem<device>>)
       outs(%lhs_init : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
@@ -183,12 +187,12 @@ func.func @multi_branch(
   %lhs_normal = hipsr.cast(%ctx) ins(%lhs : tensor<4xf16, #hipsr.mem<device>>)
       outs(%lhs_normal_init : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
   %lhs_deep_init = hipsr.placeholder(%ctx)
-      ins(%lhs_normal_init : tensor<4xf16, #hipsr.mem<device>>)
+      ins(%lhs_normal : tensor<4xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
   %lhs_deep = hipsr.cast(%ctx) ins(%lhs_normal : tensor<4xf16, #hipsr.mem<device>>)
       outs(%lhs_deep_init : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
   %rhs_init = hipsr.placeholder(%ctx)
-      ins(%root_init : tensor<4xf16, #hipsr.mem<device>>)
+      ins(%root : tensor<4xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
   %rhs = hipsr.cast(%ctx) ins(%root : tensor<4xf16, #hipsr.mem<device>>)
       outs(%rhs_init : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
@@ -216,7 +220,7 @@ func.func @multi_branch(
       ins(%deep_join, %independent : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>)
       outs(%join_init : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
   %result_init = hipsr.placeholder(%ctx)
-      ins(%join_init : tensor<4xf16, #hipsr.mem<device>>)
+      ins(%join : tensor<4xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
   %result = hipsr.cast(%ctx) ins(%join : tensor<4xf16, #hipsr.mem<device>>)
       outs(%result_init : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
@@ -240,30 +244,32 @@ func.func @multi_branch(
 //                       v
 //                join [B, D2]
 //
-// CHECK-LABEL: func.func @diamond(
-// CHECK-SAME: %[[CTX:.*]]: !hipsr.context, %[[INPUT:.*]]: tensor<4xf32, #hipsr.mem<device>>) -> tensor<4xf16, #hipsr.mem<device>> {
-// CHECK-NEXT: %[[DOMAIN0:.*]]:2 = hipsr.pool_domain(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<4xf32, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX0:.*]]: !hipsr.context, %[[INPUT0:.*]]: tensor<4xf32, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[ROOT_INIT:.*]] = hipsr.placeholder(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[ROOT:.*]] = hipsr.cast(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[ROOT_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[ROOT_INIT]], %[[ROOT]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT: %[[DOMAIN1:.*]]:4 = hipsr.pool_domain(%[[CTX]], %[[DOMAIN0]]#0, %[[DOMAIN0]]#1 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX1:.*]]: !hipsr.context, %[[ROOT_SHAPE:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[ROOT_DATA:.*]]: tensor<4xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[LHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[ROOT_SHAPE]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[LHS:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[ROOT_DATA]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[LHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[RHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[ROOT_SHAPE]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[RHS:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[ROOT_DATA]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[RHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[LHS_INIT]], %[[LHS]], %[[RHS_INIT]], %[[RHS]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 1 : i64}
-// CHECK-NEXT: %[[DOMAIN2:.*]] = hipsr.pool_domain(%[[CTX]], %[[DOMAIN1]]#0, %[[DOMAIN1]]#2, %[[DOMAIN1]]#1, %[[DOMAIN1]]#3 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX2:.*]]: !hipsr.context, %[[LHS_SHAPE:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[RHS_SHAPE:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[LHS_DATA:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[RHS_DATA:.*]]: tensor<4xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[JOIN_INIT:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[LHS_SHAPE]], %[[RHS_SHAPE]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[JOIN:.*]] = hipsr.add(%[[CTX2]]) ins(%[[LHS_DATA]], %[[RHS_DATA]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) outs(%[[JOIN_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[JOIN]] : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>> {domain_id = 2 : i64}
-// CHECK-NEXT: return %[[DOMAIN2]] : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: }
+// CHECK-LABEL:   func.func @diamond(
+// CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[ARG1:.*]]: tensor<4xf32, #hipsr.mem<device>>) -> tensor<4xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]] = hipsr.pool_domain(%[[ARG0]], %[[ARG1]] : !hipsr.context, tensor<4xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: tensor<4xf32, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[PLACEHOLDER_0:.*]] = hipsr.placeholder(%[[VAL_0]]) ins(%[[VAL_1]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_0:.*]] = hipsr.cast(%[[VAL_0]]) ins(%[[VAL_1]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_0]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[CAST_0]] : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> tensor<4xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]]:2 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]] : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_2:.*]]: !hipsr.context, %[[VAL_3:.*]]: tensor<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[PLACEHOLDER_1:.*]] = hipsr.placeholder(%[[VAL_2]]) ins(%[[VAL_3]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_1:.*]] = hipsr.cast(%[[VAL_2]]) ins(%[[VAL_3]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_1]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[PLACEHOLDER_2:.*]] = hipsr.placeholder(%[[VAL_2]]) ins(%[[VAL_3]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_2:.*]] = hipsr.cast(%[[VAL_2]]) ins(%[[VAL_3]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_2]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[CAST_1]], %[[CAST_2]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 1 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_2:.*]] = hipsr.pool_domain(%[[ARG0]], %[[VAL_4:.*]]#0, %[[VAL_4]]#1 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_5:.*]]: !hipsr.context, %[[VAL_6:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[VAL_7:.*]]: tensor<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[PLACEHOLDER_3:.*]] = hipsr.placeholder(%[[VAL_5]]) ins(%[[VAL_6]], %[[VAL_7]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ADD_0:.*]] = hipsr.add(%[[VAL_5]]) ins(%[[VAL_6]], %[[VAL_7]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_3]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ADD_0]] : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> tensor<4xf16, #hipsr.mem<device>> {domain_id = 2 : i64}
+// CHECK-NEXT:      return %[[POOL_DOMAIN_2]] : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    }
+
 func.func @diamond(
     %ctx: !hipsr.context, %input: tensor<4xf32, #hipsr.mem<device>>) -> tensor<4xf16, #hipsr.mem<device>> {
   %root_init = hipsr.placeholder(%ctx)
@@ -273,19 +279,19 @@ func.func @diamond(
       outs(%root_init : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
 
   %lhs_init = hipsr.placeholder(%ctx)
-      ins(%root_init : tensor<4xf16, #hipsr.mem<device>>)
+      ins(%root : tensor<4xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
   %lhs = hipsr.cast(%ctx) ins(%root : tensor<4xf16, #hipsr.mem<device>>)
       outs(%lhs_init : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
 
   %rhs_init = hipsr.placeholder(%ctx)
-      ins(%root_init : tensor<4xf16, #hipsr.mem<device>>)
+      ins(%root : tensor<4xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
   %rhs = hipsr.cast(%ctx) ins(%root : tensor<4xf16, #hipsr.mem<device>>)
       outs(%rhs_init : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
 
   %join_init = hipsr.placeholder(%ctx)
-      ins(%lhs_init, %rhs_init : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>)
+      ins(%lhs, %rhs : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
   %join = hipsr.add(%ctx)
       ins(%lhs, %rhs : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>)
@@ -320,36 +326,38 @@ func.func @diamond(
 //                               v
 //                    lower_join [N, D2]
 //
-// CHECK-LABEL: func.func @cascaded_diamonds(
-// CHECK-SAME: %[[CTX:.*]]: !hipsr.context, %[[INPUT:.*]]: tensor<4xf32, #hipsr.mem<device>>) -> tensor<4xf16, #hipsr.mem<device>> {
-// CHECK-NEXT: %[[DOMAIN0:.*]]:2 = hipsr.pool_domain(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<4xf32, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX0:.*]]: !hipsr.context, %[[INPUT0:.*]]: tensor<4xf32, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[ROOT_INIT:.*]] = hipsr.placeholder(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[ROOT:.*]] = hipsr.cast(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[ROOT_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[ROOT_INIT]], %[[ROOT]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT: %[[DOMAIN1:.*]]:2 = hipsr.pool_domain(%[[CTX]], %[[DOMAIN0]]#0, %[[DOMAIN0]]#1 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX1:.*]]: !hipsr.context, %[[ROOT_SHAPE:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[ROOT_DATA:.*]]: tensor<4xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[UPPER_LHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[ROOT_SHAPE]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[UPPER_LHS:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[ROOT_DATA]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[UPPER_LHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[UPPER_RHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[ROOT_SHAPE]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[UPPER_RHS:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[ROOT_DATA]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[UPPER_RHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[UPPER_JOIN_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[UPPER_LHS_INIT]], %[[UPPER_RHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[UPPER_JOIN:.*]] = hipsr.add(%[[CTX1]]) ins(%[[UPPER_LHS]], %[[UPPER_RHS]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) outs(%[[UPPER_JOIN_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[UPPER_JOIN_INIT]], %[[UPPER_JOIN]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 1 : i64}
-// CHECK-NEXT: %[[DOMAIN2:.*]] = hipsr.pool_domain(%[[CTX]], %[[DOMAIN1]]#0, %[[DOMAIN1]]#1 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX2:.*]]: !hipsr.context, %[[UPPER_SHAPE:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[UPPER_DATA:.*]]: tensor<4xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[LOWER_LHS_INIT:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[UPPER_SHAPE]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[LOWER_LHS:.*]] = hipsr.cast(%[[CTX2]]) ins(%[[UPPER_DATA]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[LOWER_LHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[LOWER_RHS_INIT:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[UPPER_SHAPE]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[LOWER_RHS:.*]] = hipsr.cast(%[[CTX2]]) ins(%[[UPPER_DATA]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[LOWER_RHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[LOWER_JOIN_INIT:.*]] = hipsr.placeholder(%[[CTX2]]) ins(%[[LOWER_LHS_INIT]], %[[LOWER_RHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[LOWER_JOIN:.*]] = hipsr.add(%[[CTX2]]) ins(%[[LOWER_LHS]], %[[LOWER_RHS]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) outs(%[[LOWER_JOIN_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[LOWER_JOIN]] : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>> {domain_id = 2 : i64}
-// CHECK-NEXT: return %[[DOMAIN2]] : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: }
+// CHECK-LABEL:   func.func @cascaded_diamonds(
+// CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[ARG1:.*]]: tensor<4xf32, #hipsr.mem<device>>) -> tensor<4xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]] = hipsr.pool_domain(%[[ARG0]], %[[ARG1]] : !hipsr.context, tensor<4xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: tensor<4xf32, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[PLACEHOLDER_0:.*]] = hipsr.placeholder(%[[VAL_0]]) ins(%[[VAL_1]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_0:.*]] = hipsr.cast(%[[VAL_0]]) ins(%[[VAL_1]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_0]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[CAST_0]] : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> tensor<4xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]] : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_2:.*]]: !hipsr.context, %[[VAL_3:.*]]: tensor<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[PLACEHOLDER_1:.*]] = hipsr.placeholder(%[[VAL_2]]) ins(%[[VAL_3]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_1:.*]] = hipsr.cast(%[[VAL_2]]) ins(%[[VAL_3]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_1]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[PLACEHOLDER_2:.*]] = hipsr.placeholder(%[[VAL_2]]) ins(%[[VAL_3]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_2:.*]] = hipsr.cast(%[[VAL_2]]) ins(%[[VAL_3]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_2]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[PLACEHOLDER_3:.*]] = hipsr.placeholder(%[[VAL_2]]) ins(%[[PLACEHOLDER_1]], %[[PLACEHOLDER_2]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ADD_0:.*]] = hipsr.add(%[[VAL_2]]) ins(%[[CAST_1]], %[[CAST_2]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_3]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ADD_0]] : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> tensor<4xf16, #hipsr.mem<device>> {domain_id = 1 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_2:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_1]] : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_4:.*]]: !hipsr.context, %[[VAL_5:.*]]: tensor<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[PLACEHOLDER_4:.*]] = hipsr.placeholder(%[[VAL_4]]) ins(%[[VAL_5]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_3:.*]] = hipsr.cast(%[[VAL_4]]) ins(%[[VAL_5]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_4]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[PLACEHOLDER_5:.*]] = hipsr.placeholder(%[[VAL_4]]) ins(%[[VAL_5]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_4:.*]] = hipsr.cast(%[[VAL_4]]) ins(%[[VAL_5]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_5]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[PLACEHOLDER_6:.*]] = hipsr.placeholder(%[[VAL_4]]) ins(%[[PLACEHOLDER_4]], %[[PLACEHOLDER_5]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ADD_1:.*]] = hipsr.add(%[[VAL_4]]) ins(%[[CAST_3]], %[[CAST_4]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_6]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ADD_1]] : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> tensor<4xf16, #hipsr.mem<device>> {domain_id = 2 : i64}
+// CHECK-NEXT:      return %[[POOL_DOMAIN_2]] : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    }
+
 func.func @cascaded_diamonds(
     %ctx: !hipsr.context, %input: tensor<4xf32, #hipsr.mem<device>>) -> tensor<4xf16, #hipsr.mem<device>> {
   %root_init = hipsr.placeholder(%ctx)
@@ -359,13 +367,13 @@ func.func @cascaded_diamonds(
       outs(%root_init : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
 
   %upper_lhs_init = hipsr.placeholder(%ctx)
-      ins(%root_init : tensor<4xf16, #hipsr.mem<device>>)
+      ins(%root : tensor<4xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
   %upper_lhs = hipsr.cast(%ctx) ins(%root : tensor<4xf16, #hipsr.mem<device>>)
       outs(%upper_lhs_init : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
 
   %upper_rhs_init = hipsr.placeholder(%ctx)
-      ins(%root_init : tensor<4xf16, #hipsr.mem<device>>)
+      ins(%root : tensor<4xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
   %upper_rhs = hipsr.cast(%ctx) ins(%root : tensor<4xf16, #hipsr.mem<device>>)
       outs(%upper_rhs_init : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
@@ -378,13 +386,13 @@ func.func @cascaded_diamonds(
       outs(%upper_join_init : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
 
   %lower_lhs_init = hipsr.placeholder(%ctx)
-      ins(%upper_join_init : tensor<4xf16, #hipsr.mem<device>>)
+      ins(%upper_join : tensor<4xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
   %lower_lhs = hipsr.cast(%ctx) ins(%upper_join : tensor<4xf16, #hipsr.mem<device>>)
       outs(%lower_lhs_init : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
 
   %lower_rhs_init = hipsr.placeholder(%ctx)
-      ins(%upper_join_init : tensor<4xf16, #hipsr.mem<device>>)
+      ins(%upper_join : tensor<4xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
   %lower_rhs = hipsr.cast(%ctx) ins(%upper_join : tensor<4xf16, #hipsr.mem<device>>)
       outs(%lower_rhs_init : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
@@ -419,28 +427,29 @@ func.func @cascaded_diamonds(
 //                             v
 //                     return (lhs, rhs)
 //
-// CHECK-LABEL: func.func @multi_result_boundaries(
-// CHECK-SAME: %[[CTX:.*]]: !hipsr.context, %[[INPUT:.*]]: tensor<4xf16, #hipsr.mem<device>>)
-// CHECK-SAME: -> (tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: %[[DOMAIN0:.*]]:4 = hipsr.pool_domain(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX0:.*]]: !hipsr.context, %[[INPUT0:.*]]: tensor<4xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[ROOT_INITS:.*]]:2 = hipsr.placeholder(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[ROOT:.*]]:2 = hipsr.compute(%[[CTX0]]) ins(%[[INPUT0]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[ROOT_INITS]]#0, %[[ROOT_INITS]]#1 : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[BODY_CTX:.*]]: !hipsr.context, %[[BODY_INPUT:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[LHS_DEST:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[RHS_DEST:.*]]: tensor<4xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: hipsr.compute_yield %[[LHS_DEST]], %[[RHS_DEST]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[ROOT_INITS]]#0, %[[ROOT_INITS]]#1, %[[ROOT]]#0, %[[ROOT]]#1 : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT: %[[DOMAIN1:.*]]:2 = hipsr.pool_domain(%[[CTX]], %[[DOMAIN0]]#0, %[[DOMAIN0]]#2, %[[DOMAIN0]]#1, %[[DOMAIN0]]#3 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[CTX1:.*]]: !hipsr.context, %[[LHS_SHAPE:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[LHS_INPUT:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[RHS_SHAPE:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[RHS_INPUT:.*]]: tensor<4xf16, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[LHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[LHS_SHAPE]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[LHS:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[LHS_INPUT]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[LHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[RHS_INIT:.*]] = hipsr.placeholder(%[[CTX1]]) ins(%[[RHS_SHAPE]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[RHS:.*]] = hipsr.cast(%[[CTX1]]) ins(%[[RHS_INPUT]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[RHS_INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: hipsr.pool_domain_yield %[[LHS]], %[[RHS]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 1 : i64}
-// CHECK-NEXT: return %[[DOMAIN1]]#0, %[[DOMAIN1]]#1 : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: }
+// CHECK-LABEL:   func.func @multi_result_boundaries(
+// CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[ARG1:.*]]: tensor<4xf16, #hipsr.mem<device>>) -> (tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]]:2 = hipsr.pool_domain(%[[ARG0]], %[[ARG1]] : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: tensor<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[PLACEHOLDER_0:.*]]:2 = hipsr.placeholder(%[[VAL_0]]) ins(%[[VAL_1]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[COMPUTE_0:.*]]:2 = hipsr.compute(%[[VAL_0]]) ins(%[[VAL_1]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_0]]#0, %[[PLACEHOLDER_0]]#1 : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_2:.*]]: !hipsr.context, %[[VAL_3:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[VAL_4:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[VAL_5:.*]]: tensor<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:          hipsr.compute_yield %[[VAL_4]], %[[VAL_5]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        } : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[VAL_6:.*]]#0, %[[VAL_6]]#1 : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]]:2 = hipsr.pool_domain(%[[ARG0]], %[[VAL_7:.*]]#0, %[[VAL_7]]#1 : !hipsr.context, tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_8:.*]]: !hipsr.context, %[[VAL_9:.*]]: tensor<4xf16, #hipsr.mem<device>>, %[[VAL_10:.*]]: tensor<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[PLACEHOLDER_1:.*]] = hipsr.placeholder(%[[VAL_8]]) ins(%[[VAL_9]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_0:.*]] = hipsr.cast(%[[VAL_8]]) ins(%[[VAL_9]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_1]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[PLACEHOLDER_2:.*]] = hipsr.placeholder(%[[VAL_8]]) ins(%[[VAL_10]] : tensor<4xf16, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_1:.*]] = hipsr.cast(%[[VAL_8]]) ins(%[[VAL_10]] : tensor<4xf16, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_2]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[CAST_0]], %[[CAST_1]] : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>> {domain_id = 1 : i64}
+// CHECK-NEXT:      return %[[VAL_11:.*]]#0, %[[VAL_11]]#1 : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    }
+
 func.func @multi_result_boundaries(
     %ctx: !hipsr.context, %input: tensor<4xf16, #hipsr.mem<device>>)
     -> (tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>) {
@@ -457,12 +466,12 @@ func.func @multi_result_boundaries(
         : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
   } : tensor<4xf16, #hipsr.mem<device>>, tensor<4xf16, #hipsr.mem<device>>
   %lhs_init = hipsr.placeholder(%ctx)
-      ins(%root_inits#0 : tensor<4xf16, #hipsr.mem<device>>)
+      ins(%root#0 : tensor<4xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
   %lhs = hipsr.cast(%ctx) ins(%root#0 : tensor<4xf16, #hipsr.mem<device>>)
       outs(%lhs_init : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
   %rhs_init = hipsr.placeholder(%ctx)
-      ins(%root_inits#1 : tensor<4xf16, #hipsr.mem<device>>)
+      ins(%root#1 : tensor<4xf16, #hipsr.mem<device>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<4xf16, #hipsr.mem<device>>
   %rhs = hipsr.cast(%ctx) ins(%root#1 : tensor<4xf16, #hipsr.mem<device>>)
       outs(%rhs_init : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
@@ -483,16 +492,17 @@ func.func @multi_result_boundaries(
 //
 //   return (no operands)
 //
-// CHECK-LABEL: func.func @no_result_domain(
-// CHECK-SAME: %[[CTX:.*]]: !hipsr.context, %[[INPUT:.*]]: tensor<4xf32, #hipsr.mem<device>>) {
-// CHECK-NEXT: hipsr.pool_domain(%[[CTX]], %[[INPUT]] : !hipsr.context, tensor<4xf32, #hipsr.mem<device>>) {
-// CHECK-NEXT: ^bb0(%[[DOMAIN_CTX:.*]]: !hipsr.context, %[[DOMAIN_INPUT:.*]]: tensor<4xf32, #hipsr.mem<device>>):
-// CHECK-NEXT: %[[INIT:.*]] = hipsr.placeholder(%[[DOMAIN_CTX]]) ins(%[[DOMAIN_INPUT]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NEXT: %[[UNUSED:.*]] = hipsr.cast(%[[DOMAIN_CTX]]) ins(%[[DOMAIN_INPUT]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[INIT]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
-// CHECK-NOT: hipsr.pool_domain_yield
-// CHECK-NEXT: } {domain_id = 0 : i64}
-// CHECK-NEXT: return
-// CHECK-NEXT: }
+// CHECK-LABEL:   func.func @no_result_domain(
+// CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[ARG1:.*]]: tensor<4xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT:      hipsr.pool_domain(%[[ARG0]], %[[ARG1]] : !hipsr.context, tensor<4xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: tensor<4xf32, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[PLACEHOLDER_0:.*]] = hipsr.placeholder(%[[VAL_0]]) ins(%[[VAL_1]] : tensor<4xf32, #hipsr.mem<device>>) {placeholder_type = #hipsr.placeholder_type<normal>} : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_0:.*]] = hipsr.cast(%[[VAL_0]]) ins(%[[VAL_1]] : tensor<4xf32, #hipsr.mem<device>>) outs(%[[PLACEHOLDER_0]] : tensor<4xf16, #hipsr.mem<device>>) : tensor<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      } {domain_id = 0 : i64}
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
 func.func @no_result_domain(
     %ctx: !hipsr.context, %input: tensor<4xf32, #hipsr.mem<device>>) {
   %init = hipsr.placeholder(%ctx)
@@ -513,9 +523,11 @@ func.func @no_result_domain(
 //             return
 //   pool domains: none
 //
-// CHECK-LABEL: func.func @empty(%{{.*}}: !hipsr.context) {
-// CHECK-NEXT: return
-// CHECK-NEXT: }
+// CHECK-LABEL:   func.func @empty(
+// CHECK-SAME:                     %[[ARG0:.*]]: !hipsr.context) {
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
 func.func @empty(%ctx: !hipsr.context) {
   return
 }
@@ -533,5 +545,6 @@ func.func @empty(%ctx: !hipsr.context) {
 //         i32 result
 //   pool domains: none
 //
-// CHECK-LABEL: func.func private @declaration(i32) -> i32
+// CHECK-LABEL:   func.func private @declaration(i32) -> i32
+
 func.func private @declaration(i32) -> i32

--- a/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/slice.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PopulateShapeRegion/slice.mlir
@@ -49,10 +49,11 @@ func.func @slice_constant_window(%ctx: !hipsr.context,
 // -----
 
 // A bound the graph computes, in the shape a shape computation leaves behind: a
-// hipsr.compute writes it into a host destination and the barrier holds that
-// destination. The region reads the bound off the operand the barrier hands
-// over and clamps it against the data's own size. The start is in an attribute,
-// so it needs no read, and folding drops the branch it cannot take.
+// hipsr.compute writes it into a host destination and the barrier names what
+// the compute wrote, because its region reads the bound rather than its shape.
+// The region reads that operand and clamps it against the data's own size. The
+// start is in an attribute, so it needs no read, and folding drops the branch
+// it cannot take.
 // CHECK-LABEL: func.func @slice_runtime_bound(
 // CHECK:      placeholder_type = #hipsr.placeholder_type<barrier>} : tensor<?xf16, #hipsr.mem<device>> shape_region {
 // CHECK-NEXT: ^bb0(%{{.+}}: !hipsr.context, %[[DATA:.+]]: tensor<?xf16, #hipsr.mem<device>>, %[[ENDS:.+]]: tensor<1xi64, #hipsr.mem<host>>):
@@ -93,8 +94,8 @@ func.func @slice_runtime_bound(%ctx: !hipsr.context,
     hipsr.compute_yield %entries : tensor<1xi64, #hipsr.mem<host>>
   } : tensor<1xi64, #hipsr.mem<host>>
   %init = hipsr.placeholder(%ctx)
-      ins(%data, %ends_init : tensor<?xf16, #hipsr.mem<device>>,
-                              tensor<1xi64, #hipsr.mem<host>>)
+      ins(%data, %ends : tensor<?xf16, #hipsr.mem<device>>,
+                         tensor<1xi64, #hipsr.mem<host>>)
       {placeholder_type = #hipsr.placeholder_type<barrier>}
       : tensor<?xf16, #hipsr.mem<device>>
   %result = hipsr.slice(%ctx)


### PR DESCRIPTION
## Summary

A barrier placeholder's region reads the *contents* of its inputs, not just their shapes. The conversion post-process rewired every placeholder input to its shape-graph counterpart, which pointed barriers at a destination buffer rather than at the value written into it. Barriers now keep the data values.

## Why

`hipsr.producer` and `hipsr.consumer` below stand in for any hipsr op; types and regions are elided.

```mlir
// A producer is handed a destination and yields the value written into it.
%dest  = hipsr.placeholder(%ctx) ins(%src) {normal}
%value = hipsr.producer(%ctx) ins(%src) outs(%dest)

// Before: the barrier named %dest, while its own consumer named %value.
%init  = hipsr.placeholder(%ctx) ins(%dest) {barrier}
%out   = hipsr.consumer(%ctx) ins(%value) outs(%init)

// After: both name %value.
%init  = hipsr.placeholder(%ctx) ins(%value) {barrier}
%out   = hipsr.consumer(%ctx) ins(%value) outs(%init)
```

One-Shot Bufferize runs the producer in place on `%src`, so nothing ever writes `%dest`. The barrier's region read it anyway and computed a shape out of uninitialized memory.

## What

- `OnnxToHipsr.cpp`: skip barriers when rewiring placeholder inputs into the shape graph.
- `HipsrPlaceholderOp.cpp`: a barrier may name data results, and its inputs must equal its consumer's operands. This also rejects a permuted list, which the region would have read positionally.
- `MaterializeInitTensorsPass.cpp`: still reject a barrier input allocated inside the same pool domain, now tested by block rather than by defining operation.
- Goldens regenerated. Most of the diff is `Pipelines/embedding.mlir` and `PartitionPoolDomains/materialization.mlir`; the substantive change is about 25 lines.

LIT: 480 passed, 12 unsupported. Prepared with Cursor and Claude Opus 5, and reviewed; commit trailers record the assistance.
