### PR TITLE
docs(hipsr): say what a placeholder's consumer is

### DIFF
--- a/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
+++ b/include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td
@@ -15,8 +15,10 @@ def Hipsr_PlaceholderOp : Hipsr_Op<
     [IsolatedFromAbove, SingleBlockImplicitTerminator<"ShapeYieldOp">]> {
   let summary = "Typed placeholder for hipsr `outs` operands";
   let description = [{
-    Supplies a hipsr op's `outs` values before its output shape is known. The
-    result type follows the consumer:
+    Supplies a hipsr op's `outs` values before its output shape is known. That
+    op is called the consumer throughout: it consumes the values this
+    placeholder supplies, and it writes those buffers rather than reading them.
+    The result type follows the consumer:
 
     - A DPS op ties each init to the result in the same position, so the
       placeholder carries the op's result types.


### PR DESCRIPTION
## Summary

Defines the term *consumer* once in the `hipsr.placeholder` op description. Documentation only; no code or behavior change.

## Related issue or design

Stacked on #943, which is where the term's awkwardness surfaced. This PR targets that branch so its own diff stays at three lines; GitHub will retarget it to `main` when #943 merges.

## Why

The op description, `Hipsr/Transforms/Passes.td`, `PopulateShapeRegionPass.cpp`, and the placeholder verifier all call a placeholder's `outs` user its *consumer*, about 65 times, but nothing states what the word covers.

Read with the usual MLIR producer/consumer meaning it points the wrong way. That operation *writes* the buffers the placeholder supplies and never reads them, so prose like "a destination has nothing to read until its consumer writes it" looks self-contradictory until you already know the term. The verifier compounds it by describing the same relationship a second way, reporting that a result must "initialize exactly one hipsr operation".

Renaming was considered and rejected as churn: the term is load-bearing in a public method (`getConsumer()`), in pass documentation, and in error strings pinned by four LIT files. One definition is enough to make every existing use read correctly.

## What

Three lines in `include/hip/Dialect/Hipsr/IR/HipsrPlaceholderOp.td`, at the point where the term first appears:

```
Supplies a hipsr op's `outs` values before its output shape is known. That
op is called the consumer throughout: it consumes the values this
placeholder supplies, and it writes those buffers rather than reading them.
The result type follows the consumer:
```

The two halves are both needed: the first says which operation the word picks out, the second heads off the backwards reading of the dataflow.

## Test plan

The change is inside a TableGen `description` field, which does not reach generated C++, so there is nothing to exercise behaviorally. I rebuilt and ran the LIT suite anyway to confirm nothing regressed:

```text
ctest -C Release -R MorphizenMLIRLitTests
Total Discovered Tests: 491
  Unsupported:  12 (2.44%)
  Passed     : 479 (97.56%)
```

`pre-commit run` is clean on the changed file.

## Notes for reviewers

If you would rather rename the term than define it, the mechanical change is contained: `getConsumer()`, 16 uses in `PopulateShapeRegionPass.cpp`, 2 in `Passes.td`, and error-message expectations in `placeholder.mlir`, `placeholder_compute.mlir`, `no-value.mlir`, and `PartitionPoolDomains/materialization.mlir`. `writer` and `initializedOp` were the candidates; the latter matches the dialect's existing "init" vocabulary but reads clumsily in sentences.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.

Substantial AI assistance: the audit of how the term is used and this wording were prepared with Cursor and Claude Opus 5, and validated with the LIT suite as described above. Commit trailers record the assistance.
