### PR TITLE
feat(runtime): add OP_PROFILE to the qmatmul, qadd, and qmul wrappers

### DIFF
--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -51,6 +51,17 @@ static inline const char *hipdnn_ep_tensor_op_name(int64_t op) {
   }
 }
 
+static inline const char *hipdnn_ep_qelementwise_kind_name(int64_t kind) {
+  switch (kind) {
+  case HIPDNN_EP_QELEMENTWISE_ADD:
+    return "qadd";
+  case HIPDNN_EP_QELEMENTWISE_MUL:
+    return "qmul";
+  default:
+    return "qelementwise_unknown";
+  }
+}
+
 static inline int64_t hipdnn_ep_datatype_size(int64_t data_type) {
   switch (data_type) {
   case HIPDNN_EP_DATATYPE_FLOAT:

--- a/lib/Runtime/real/qelementwise.cpp
+++ b/lib/Runtime/real/qelementwise.cpp
@@ -18,6 +18,7 @@
 // OUT = saturate(round(M * (A - z_a) * (B - z_b)) + z_out)
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
 #include "hip_custom_kernels.h"
 
 #include <cstdio>
@@ -48,6 +49,23 @@ int wrap_qelementwise(RuntimeState *state, void *lhs, void *rhs, void *output,
                       const int64_t *out_shape, int64_t out_rank,
                       int64_t data_type, float M_a, int64_t lhs_zp, float M_b,
                       int64_t rhs_zp, int64_t output_zp) {
+  // Kind-specific OP_PROFILE label so PERF rows separate qadd / qmul.
+  OP_PROFILE(
+      hipdnn_ep_qelementwise_kind_name(kind),
+      [&] {
+        char b[96];
+        int n =
+            snprintf(b, sizeof(b), "%s:", hipdnn_ep_datatype_name(data_type));
+        for (int64_t i = 0; out_shape && i < out_rank; ++i) {
+          if (n <= 0 || n >= static_cast<int>(sizeof(b)))
+            break;
+          n += snprintf(b + n, sizeof(b) - n, "%s%lld", i ? "x" : "",
+                        (long long)out_shape[i]);
+        }
+        return std::string(b);
+      },
+      state);
+
   if (!state || !lhs || !rhs || !output) {
     fprintf(stderr, "wrap_qelementwise: null tensor argument\n");
     return -1;

--- a/lib/Runtime/real/qmatmul.cpp
+++ b/lib/Runtime/real/qmatmul.cpp
@@ -26,6 +26,7 @@
 // byte; see lib/Runtime/Kernels/hip/qmatmul_kernel.hip for the derivation.
 #include "../debug_log.h"
 #include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
 #include "hip_custom_kernels.h"
 
 #include <cstdint>
@@ -69,6 +70,19 @@ int wrap_qmatmul(RuntimeState *state, const void *A, const void *B, void *Y,
                  int64_t a_data_type, int64_t b_data_type, int64_t y_data_type,
                  float M_scale, int64_t A_zero_point, int64_t B_zero_point,
                  int64_t Y_zero_point) {
+  OP_PROFILE(
+      "qmatmul",
+      [&] {
+        char b[96];
+        snprintf(b, sizeof(b), "m=%lld,n=%lld,k=%lld,b=%lld:%s/%s->%s",
+                 (long long)M, (long long)N, (long long)K,
+                 (long long)batch_count, hipdnn_ep_datatype_name(a_data_type),
+                 hipdnn_ep_datatype_name(b_data_type),
+                 hipdnn_ep_datatype_name(y_data_type));
+        return std::string(b);
+      },
+      state);
+
   if (!state || !A || !B || !Y) {
     fprintf(stderr, "wrap_qmatmul: null tensor argument\n");
     return -1;


### PR DESCRIPTION
## Summary

Adds an `OP_PROFILE` scope to the three quantized-fusion runtime wrappers that
were missing one, so `HIPDNN_EP_PERF=1` reports `qmatmul`, `qadd`, and `qmul` as
their own rows in the `[PERF]` table and in the Chrome trace. No behavior change
when profiling is off.

## Related issue or design

- Design: `docs/design/per-op-profiling.md`
- Ops instrumented here: #921 (`hip.qmatmul`), #916 (`hip.qmul`), #907 (`hip.qadd`)

## Why

Per-op GPU time is derived by differencing consecutive markers on the in-order
stream (`op_profile_resolve_and_print`: `gpuMs = cumMs - tlPrevMs`). An op
without a marker is therefore not merely unreported — its GPU time is absorbed
into the next instrumented op's duration. On QDQ models the quantized
MatMul/Add/Mul sit on the hot path, so their cost was being silently attributed
to neighbouring ops, which is misleading exactly where the recent fusion work
needs measurement.

## What

- `wrap_qmatmul`: label `qmatmul`, shape tag `m=..,n=..,k=..,b=..:<a>/<b>-><y>`.
  The dtypes are part of the tag because A16W8 and A8W8 take different kernel
  paths and should not share a row.
- `wrap_qelementwise`: `hip.qadd` and `hip.qmul` share this single wrapper, so a
  fixed label would merge them into one row. The label is derived from the
  `kind` argument, the same way `global_pool.cpp` labels by mode. Shape tag is
  `<dtype>:<out dims joined by x>`, bounded by the buffer size and null-safe on
  `out_shape`.
- `hipdnn_ep_runtime.h`: new `hipdnn_ep_qelementwise_kind_name()` placed next to
  the existing `hipdnn_ep_tensor_op_name()`, matching the pool / global-pool
  naming helpers.

No CMake change is required: `op_profile.h` is already in the bitcode `DEPENDS`
list, and both `.cpp` files are already registered in `compile_to_bitcode` and
`RUNTIME_BC_MODULES`.

## AI Assistance

The code was developed collaboratively with Cursor, and all code has been reviewed.