### PR TITLE
feat(hipsr): run hipsr-pool-alloc so each domain uses one buffer pool

### DIFF
--- a/lib/Dialect/Hipsr/Pipelines/Pipelines.cpp
+++ b/lib/Dialect/Hipsr/Pipelines/Pipelines.cpp
@@ -28,6 +28,7 @@
 //   --one-shot-bufferize
 //   --convert-linalg-to-loops
 //   --hipsr-use-output-allocator
+//   --hipsr-pool-alloc
 void mlir::hipsr::buildHipsrPipeline(OpPassManager &pm,
                                      const HipsrPipelineOptions & /*options*/) {
   pm.addPass(createAddContextArgPass());
@@ -58,6 +59,7 @@ void mlir::hipsr::buildHipsrPipeline(OpPassManager &pm,
   pm.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
 
   pm.addNestedPass<func::FuncOp>(createHipsrUseOutputAllocatorPass());
+  pm.addPass(createHipsrPoolAllocPass());
 }
 
 void mlir::hipsr::registerHipsrPipelines() {

--- a/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/HipsrPoolAllocPass.cpp
@@ -7,6 +7,7 @@
 
 #include "hip/Dialect/Hipsr/IR/HipsrDialect.h"
 #include "hip/Dialect/Hipsr/IR/HipsrOps.h"
+#include "hip/Dialect/Hipsr/IR/HipsrTypes.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/Transforms/BufferViewFlowAnalysis.h"
@@ -178,11 +179,27 @@ computeLiveness(PoolDomainOp domain) {
   };
 
   auto processAllocation =
-      [&aliases, &processUser, &blockLevelIndex](
+      [&aliases, &processUser, &blockLevelIndex,
+       domainOp = domain.getOperation()](
           memref::AllocOp allocOp) -> FailureOr<std::optional<Lifetime>> {
     Value buffer = allocOp.getResult();
     llvm::SmallVector<std::pair<Value, Operation *>> users;
     for (Value alias : aliases.resolve(buffer)) {
+      // pool_domain implements RegionBranchOpInterface, so the domain's result
+      // aliases the buffer the body yields:
+      //
+      //   %0 = hipsr.pool_domain(...) {   // domainOp; %0 is one `alias`
+      //     %a1 = memref.alloc()          // allocOp, so %a1 is `buffer`
+      //     hipsr.pool_domain_yield %a1
+      //   } -> memref<4xf16, #hipsr.mem<device>>
+      //   hipsr.pool_domain(%ctx, %0)     // only user of %0, outside the body
+      //
+      // processUser rejects a user outside the body with "allocation escapes
+      // IsolatedFromAbove domain". The yield already holds %a1 live to the end
+      // of the domain.
+      if (alias.getDefiningOp() == domainOp) {
+        continue;
+      }
       for (Operation *user : alias.getUsers()) {
         users.emplace_back(alias, user);
       }
@@ -204,6 +221,11 @@ computeLiveness(PoolDomainOp domain) {
   for (Operation &op : body) {
     auto allocOp = dyn_cast<memref::AllocOp>(&op);
     if (!allocOp) {
+      continue;
+    }
+    // The pool is device memory, so a host buffer keeps its own allocation.
+    if (!isDeviceMemRef(allocOp.getType())) {
+      LLVM_DEBUG(DBGS() << "  " << allocOp.getResult() << ": host memory\n");
       continue;
     }
     FailureOr<std::optional<Lifetime>> lifetimeOrErr =
@@ -440,16 +462,39 @@ emitPoolLayout(OpBuilder &builder, Location loc,
   return {offsets, poolSize};
 }
 
-void replaceAllocsWithViews(OpBuilder &builder, llvm::ArrayRef<Value> group,
-                            Value pool, Value offset) {
-  for (Value alloc : group) {
-    auto allocOp = alloc.getDefiningOp<memref::AllocOp>();
-    auto view =
-        memref::ViewOp::create(builder, allocOp.getLoc(), allocOp.getType(),
-                               pool, offset, allocOp.getDynamicSizes());
-    allocOp.getResult().replaceAllUsesWith(view.getResult());
+void replaceAllocsWithViews(OpBuilder &builder,
+                            llvm::ArrayRef<llvm::SmallVector<Value>> groups,
+                            llvm::ArrayRef<Value> offsets, Value pool) {
+  llvm::SmallVector<std::pair<memref::AllocOp, Value>> replacements;
+  for (auto [group, offset] : llvm::zip_equal(groups, offsets)) {
+    for (Value alloc : group) {
+      auto allocOp = alloc.getDefiningOp<memref::AllocOp>();
+      auto view =
+          memref::ViewOp::create(builder, allocOp.getLoc(), allocOp.getType(),
+                                 pool, offset, allocOp.getDynamicSizes());
+      replacements.emplace_back(allocOp, view.getResult());
+    }
+  }
+  for (auto [allocOp, view] : replacements) {
+    allocOp.getResult().replaceAllUsesWith(view);
     allocOp.erase();
   }
+}
+
+/// Reports the first device allocation left in the body of `domain`.
+///
+/// The pool replaces the body's device allocations, so one surviving there
+/// would call the device allocator on every inference. Allocations in nested
+/// regions are outside what the pass pools.
+LogicalResult verifyDeviceAllocsPooled(PoolDomainOp domain) {
+  for (Operation &op : domain.getBody().front()) {
+    auto allocOp = dyn_cast<memref::AllocOp>(&op);
+    if (allocOp && isDeviceMemRef(allocOp.getType())) {
+      return allocOp.emitError(
+          "hipsr-pool-alloc: device allocation is not backed by the pool");
+    }
+  }
+  return success();
 }
 
 struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
@@ -472,9 +517,10 @@ struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
       llvm::DenseMap<Value, Lifetime> lifetimes = std::move(*lifetimesOrErr);
       Operation *insertionPoint = findInsertionPoint(body, lifetimes);
       if (!insertionPoint) {
-        domain.emitError(
-            "hipsr-pool-alloc: pool_domain has no poolable allocation");
-        signalPassFailure();
+        LLVM_DEBUG(DBGS() << "  nothing poolable, domain left unchanged\n");
+        if (failed(verifyDeviceAllocsPooled(domain))) {
+          signalPassFailure();
+        }
         return;
       }
       LLVM_DEBUG({
@@ -515,8 +561,9 @@ struct HipsrPoolAllocPass : impl::HipsrPoolAllocPassBase<HipsrPoolAllocPass> {
           emitPoolLayout(builder, domain.getLoc(), groupSizes);
       Value pool = emitPool(builder, domain.getLoc(), ctx, poolSize,
                             domain.getDomainId());
-      for (auto [group, offset] : llvm::zip_equal(groups, offsets)) {
-        replaceAllocsWithViews(builder, group, pool, offset);
+      replaceAllocsWithViews(builder, groups, offsets, pool);
+      if (failed(verifyDeviceAllocsPooled(domain))) {
+        signalPassFailure();
       }
     });
   }

--- a/lib/Dialect/Hipsr/Transforms/MaterializeInitTensorsPass.cpp
+++ b/lib/Dialect/Hipsr/Transforms/MaterializeInitTensorsPass.cpp
@@ -23,14 +23,17 @@
 //   %d0 = shape.size_to_index (shape.get_extent %s, 0)
 //   %empty = tensor.empty(%d0) : tensor<?x4xf32>
 //   %0 = hipsr.cast(%ctx) ins(%a) outs(%empty) : tensor<?x4xf32>
-//   hipsr.preserve_shape %s, %0 : tensor<?x4xf32>
+//   hipsr.preserve_shape %s, %0 : !shape.shape, tensor<?x4xf32>
 //
-// The domain is rebuilt in a fresh block in five steps: constants, shape
-// computations, allocations, every other op, then one shape link per
-// allocation. hipsr-pool-alloc replaces the allocations in a domain with views
-// of one pool it emits after the last of them, so every allocation has to come
-// before the first op that reads one. A link names the result of the op that
-// fills the buffer, so it can only come after the data ops.
+// The domain is rebuilt in a fresh block in five steps:
+//
+//   1. constants
+//   2. shape computations
+//   3. allocations, all before the first op that reads one, because
+//      hipsr-pool-alloc acquires the pool in front of the first allocation
+//   4. every other op
+//   5. one shape link per allocation, which names the result of the op that
+//      fills the buffer and so has to follow the data ops
 //
 //===----------------------------------------------------------------------===//
 
@@ -131,7 +134,8 @@ ResultRange materializeShapeRegion(PlaceholderOp placeholder,
 }
 
 // Only dynamic dimensions come from the shape; a static extent is in the type.
-Value createInitTensor(Value result, Value resultShape, OpBuilder &builder) {
+SmallVector<Value> readDynamicSizes(Value result, Value resultShape,
+                                    OpBuilder &builder) {
   Location loc = result.getLoc();
   auto tensorType = cast<RankedTensorType>(result.getType());
   auto isDynamic = [tensorType](int64_t dimension) {
@@ -143,11 +147,10 @@ Value createInitTensor(Value result, Value resultShape, OpBuilder &builder) {
     return shape::SizeToIndexOp::create(builder, loc, extent);
   };
 
-  SmallVector<Value> dynamicSizes = llvm::map_to_vector(
+  return llvm::map_to_vector(
       llvm::make_filter_range(llvm::seq<int64_t>(tensorType.getRank()),
                               isDynamic),
       readExtent);
-  return tensor::EmptyOp::create(builder, loc, tensorType, dynamicSizes);
 }
 
 LogicalResult verifyMaterializable(ArrayRef<PlaceholderOp> placeholders) {
@@ -191,14 +194,30 @@ IRMapping createShapeComputations(ArrayRef<PlaceholderOp> placeholders,
 }
 
 // Each result maps to its tensor.empty, so ops cloned later use that buffer.
+//
+// Every extent comes before the first tensor.empty. hipsr-pool-alloc acquires
+// the pool in front of the first allocation and reads every extent there, so
+// each extent has to dominate that point.
+//
+//   %d0 = shape.size_to_index ...
+//   %d1 = shape.size_to_index ...
+//   %a0 = tensor.empty(%d0) : tensor<?x4xf32>
+//   %a1 = tensor.empty(%d1) : tensor<?x8xf32>
 void createAllocations(ArrayRef<PlaceholderOp> placeholders,
                        const IRMapping &shapes, IRMapping &cloned,
                        OpBuilder &builder) {
+  SmallVector<std::pair<OpResult, SmallVector<Value>>> allocations;
   for (PlaceholderOp placeholder : placeholders) {
     for (OpResult result : placeholder.getResults()) {
-      cloned.map(result,
-                 createInitTensor(result, shapes.lookup(result), builder));
+      allocations.emplace_back(
+          result, readDynamicSizes(result, shapes.lookup(result), builder));
     }
+  }
+  for (auto &[result, dynamicSizes] : allocations) {
+    cloned.map(result,
+               tensor::EmptyOp::create(builder, result.getLoc(),
+                                       cast<RankedTensorType>(result.getType()),
+                                       dynamicSizes));
   }
 }
 

--- a/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/embedding.mlir
@@ -119,293 +119,369 @@
 // CHECK-NEXT:        %[[ALLOC_8:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[DIM_3]], %[[ALLOC_8]]{{\[}}%[[CONSTANT_6]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[DIM_4]], %[[ALLOC_8]]{{\[}}%[[CONSTANT_5]]] : memref<2xindex>
-// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_7]]{{\[}}%[[CONSTANT_6]]] [%[[CONSTANT_6]]] [%[[CONSTANT_5]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_7]]{{\[}}%[[CONSTANT_5]]] [%[[CONSTANT_5]]] [%[[CONSTANT_5]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_7]]{{\[}}%[[CONSTANT_6]]] {{\[}}%[[CONSTANT_6]]] {{\[}}%[[CONSTANT_5]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_7]]{{\[}}%[[CONSTANT_5]]] {{\[}}%[[CONSTANT_5]]] {{\[}}%[[CONSTANT_5]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:        %[[ALLOC_9:.*]] = memref.alloc(%[[CONSTANT_1]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_9]]{{\[}}0] [%[[CONSTANT_6]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_9]][0] {{\[}}%[[CONSTANT_6]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        memref.copy %[[SUBVIEW_0]], %[[SUBVIEW_2]] : memref<?xindex, strided<[?], offset: ?>> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        %[[SUBVIEW_3:.*]] = memref.subview %[[ALLOC_9]]{{\[}}%[[CONSTANT_6]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_8]], %[[SUBVIEW_3]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        %[[ALLOC_10:.*]] = memref.alloc(%[[CONSTANT_7]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[ALLOC_10]]{{\[}}0] [%[[CONSTANT_1]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[ALLOC_10]][0] {{\[}}%[[CONSTANT_1]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_9]], %[[SUBVIEW_4]] : memref<?xindex> to memref<?xindex, strided<[1]>>
-// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_10]]{{\[}}%[[CONSTANT_1]]] [%[[CONSTANT_5]]] [1] : memref<?xindex> to memref<?xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_10]]{{\[}}%[[CONSTANT_1]]] {{\[}}%[[CONSTANT_5]]] [1] : memref<?xindex> to memref<?xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        memref.copy %[[SUBVIEW_1]], %[[SUBVIEW_5]] : memref<?xindex, strided<[?], offset: ?>> to memref<?xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        %[[LOAD_5:.*]] = memref.load %[[ALLOC_5]]{{\[}}%[[CONSTANT_6]]] : memref<?xindex>
 // CHECK-NEXT:        %[[LOAD_6:.*]] = memref.load %[[ALLOC_5]]{{\[}}%[[CONSTANT_5]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_11:.*]] = memref.alloc(%[[LOAD_5]], %[[LOAD_6]]) {alignment = 64 : i64} : memref<?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:        %[[LOAD_7:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[CONSTANT_6]]] : memref<?xindex>
 // CHECK-NEXT:        %[[LOAD_8:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[CONSTANT_5]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_12:.*]] = memref.alloc(%[[LOAD_7]], %[[LOAD_8]]) {alignment = 64 : i64} : memref<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_13:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[CONSTANT_8:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[MULI_1:.*]] = arith.muli %[[CONSTANT_8]], %[[LOAD_5]] : index
+// CHECK-NEXT:        %[[MULI_2:.*]] = arith.muli %[[MULI_1]], %[[LOAD_6]] : index
+// CHECK-NEXT:        %[[CONSTANT_9:.*]] = arith.constant 256 : index
+// CHECK-NEXT:        %[[CONSTANT_10:.*]] = arith.constant 255 : index
+// CHECK-NEXT:        %[[ADDI_0:.*]] = arith.addi %[[MULI_2]], %[[CONSTANT_10]] : index
+// CHECK-NEXT:        %[[DIVUI_0:.*]] = arith.divui %[[ADDI_0]], %[[CONSTANT_9]] : index
+// CHECK-NEXT:        %[[MULI_3:.*]] = arith.muli %[[DIVUI_0]], %[[CONSTANT_9]] : index
+// CHECK-NEXT:        %[[CONSTANT_11:.*]] = arith.constant 8192 : index
+// CHECK-NEXT:        %[[MULI_4:.*]] = arith.muli %[[CONSTANT_11]], %[[LOAD_7]] : index
+// CHECK-NEXT:        %[[MULI_5:.*]] = arith.muli %[[MULI_4]], %[[LOAD_8]] : index
+// CHECK-NEXT:        %[[CONSTANT_12:.*]] = arith.constant 256 : index
+// CHECK-NEXT:        %[[CONSTANT_13:.*]] = arith.constant 255 : index
+// CHECK-NEXT:        %[[ADDI_1:.*]] = arith.addi %[[MULI_5]], %[[CONSTANT_13]] : index
+// CHECK-NEXT:        %[[DIVUI_1:.*]] = arith.divui %[[ADDI_1]], %[[CONSTANT_12]] : index
+// CHECK-NEXT:        %[[MULI_6:.*]] = arith.muli %[[DIVUI_1]], %[[CONSTANT_12]] : index
+// CHECK-NEXT:        %[[CONSTANT_14:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[ADDI_2:.*]] = arith.addi %[[MULI_3]], %[[MULI_6]] : index
+// CHECK-NEXT:        %[[GET_POOL_0:.*]] = hipsr.get_pool(%[[VAL_0]], %[[ADDI_2]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[VIEW_0:.*]] = memref.view %[[GET_POOL_0]]{{\[}}%[[CONSTANT_14]]]{{\[}}%[[LOAD_5]], %[[LOAD_6]]] : memref<?xi8, #hipsr.mem<device>> to memref<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[VIEW_1:.*]] = memref.view %[[GET_POOL_0]]{{\[}}%[[MULI_3]]]{{\[}}%[[LOAD_7]], %[[LOAD_8]]] : memref<?xi8, #hipsr.mem<device>> to memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_11:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[COMPUTE_0:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[VAL_1]] : memref<?x4096xf16, #hipsr.mem<device>>) outs(%[[VAL_1]] : memref<?x4096xf16, #hipsr.mem<device>>) {
 // CHECK-NEXT:        ^bb0(%[[VAL_6:.*]]: !hipsr.context, %[[VAL_7:.*]]: memref<?x4096xf16, #hipsr.mem<device>>, %[[VAL_8:.*]]: memref<?x4096xf16, #hipsr.mem<device>>):
 // CHECK-NEXT:          %[[COLLAPSE_SHAPE_0:.*]] = memref.collapse_shape %[[VAL_7]] {{\[\[}}0, 1]] : memref<?x4096xf16, #hipsr.mem<device>> into memref<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT:          hipsr.compute_yield %[[COLLAPSE_SHAPE_0]] : memref<?xf16, #hipsr.mem<device>>
 // CHECK-NEXT:        } : memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.equal(%[[VAL_0]]) ins(%[[VAL_2]], %[[CONSTANT_3]] : memref<?x?xi64, #hipsr.mem<device>>, memref<i64, #hipsr.mem<device>>) outs(%[[ALLOC_11]] : memref<?x?xi1, #hipsr.mem<device>>)
-// CHECK-NEXT:        %[[COMPUTE_1:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[ALLOC_11]] : memref<?x?xi1, #hipsr.mem<device>>) outs(%[[ALLOC_11]] : memref<?x?xi1, #hipsr.mem<device>>) {
+// CHECK-NEXT:        hipsr.equal(%[[VAL_0]]) ins(%[[VAL_2]], %[[CONSTANT_3]] : memref<?x?xi64, #hipsr.mem<device>>, memref<i64, #hipsr.mem<device>>) outs(%[[VIEW_0]] : memref<?x?xi1, #hipsr.mem<device>>)
+// CHECK-NEXT:        %[[COMPUTE_1:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[VIEW_0]] : memref<?x?xi1, #hipsr.mem<device>>) outs(%[[VIEW_0]] : memref<?x?xi1, #hipsr.mem<device>>) {
 // CHECK-NEXT:        ^bb0(%[[VAL_9:.*]]: !hipsr.context, %[[VAL_10:.*]]: memref<?x?xi1, #hipsr.mem<device>>, %[[VAL_11:.*]]: memref<?x?xi1, #hipsr.mem<device>>):
-// CHECK-NEXT:          %[[CONSTANT_8:.*]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[CONSTANT_9:.*]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[DIM_5:.*]] = memref.dim %[[VAL_10]], %[[CONSTANT_9]] : memref<?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:          %[[DIM_6:.*]] = memref.dim %[[VAL_10]], %[[CONSTANT_8]] : memref<?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:          %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[VAL_10]] {{\[\[}}0], [1, 2]] output_shape [%[[DIM_5]], %[[DIM_6]], 1] : memref<?x?xi1, #hipsr.mem<device>> into memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[CONSTANT_15:.*]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[CONSTANT_16:.*]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[DIM_5:.*]] = memref.dim %[[VAL_10]], %[[CONSTANT_16]] : memref<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[DIM_6:.*]] = memref.dim %[[VAL_10]], %[[CONSTANT_15]] : memref<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[EXPAND_SHAPE_0:.*]] = memref.expand_shape %[[VAL_10]] {{\[\[}}0], [1, 2]] output_shape {{\[}}%[[DIM_5]], %[[DIM_6]], 1] : memref<?x?xi1, #hipsr.mem<device>> into memref<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT:          hipsr.compute_yield %[[EXPAND_SHAPE_0]] : memref<?x?x1xi1, #hipsr.mem<device>>
 // CHECK-NEXT:        } : memref<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.gather(%[[VAL_0]]) ins(%[[CONSTANT_4]], %[[VAL_2]] : memref<248320x4096xf16, #hipsr.mem<device>>, memref<?x?xi64, #hipsr.mem<device>>) outs(%[[ALLOC_12]] : memref<?x?x4096xf16, #hipsr.mem<device>>) {axis = 0 : i64}
-// CHECK-NEXT:        %[[COMPUTE_2:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[ALLOC_12]] : memref<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[ALLOC_13]] : memref<3xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        hipsr.gather(%[[VAL_0]]) ins(%[[CONSTANT_4]], %[[VAL_2]] : memref<248320x4096xf16, #hipsr.mem<device>>, memref<?x?xi64, #hipsr.mem<device>>) outs(%[[VIEW_1]] : memref<?x?x4096xf16, #hipsr.mem<device>>) {axis = 0 : i64}
+// CHECK-NEXT:        %[[COMPUTE_2:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[VIEW_1]] : memref<?x?x4096xf16, #hipsr.mem<device>>) outs(%[[ALLOC_11]] : memref<3xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:        ^bb0(%[[VAL_12:.*]]: !hipsr.context, %[[VAL_13:.*]]: memref<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_14:.*]]: memref<3xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:          %[[CONSTANT_10:.*]] = arith.constant 2 : index
-// CHECK-NEXT:          %[[CONSTANT_11:.*]] = arith.constant 4096 : i64
-// CHECK-NEXT:          %[[CONSTANT_12:.*]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[CONSTANT_13:.*]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[DIM_7:.*]] = memref.dim %[[VAL_13]], %[[CONSTANT_13]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[CONSTANT_17:.*]] = arith.constant 2 : index
+// CHECK-NEXT:          %[[CONSTANT_18:.*]] = arith.constant 4096 : i64
+// CHECK-NEXT:          %[[CONSTANT_19:.*]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[CONSTANT_20:.*]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[DIM_7:.*]] = memref.dim %[[VAL_13]], %[[CONSTANT_20]] : memref<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:          %[[INDEX_CAST_0:.*]] = arith.index_cast %[[DIM_7]] : index to i64
-// CHECK-NEXT:          memref.store %[[INDEX_CAST_0]], %[[VAL_14]]{{\[}}%[[CONSTANT_13]]] : memref<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:          %[[DIM_8:.*]] = memref.dim %[[VAL_13]], %[[CONSTANT_12]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:          memref.store %[[INDEX_CAST_0]], %[[VAL_14]]{{\[}}%[[CONSTANT_20]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          %[[DIM_8:.*]] = memref.dim %[[VAL_13]], %[[CONSTANT_19]] : memref<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:          %[[INDEX_CAST_1:.*]] = arith.index_cast %[[DIM_8]] : index to i64
-// CHECK-NEXT:          memref.store %[[INDEX_CAST_1]], %[[VAL_14]]{{\[}}%[[CONSTANT_12]]] : memref<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:          memref.store %[[CONSTANT_11]], %[[VAL_14]]{{\[}}%[[CONSTANT_10]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[INDEX_CAST_1]], %[[VAL_14]]{{\[}}%[[CONSTANT_19]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[CONSTANT_18]], %[[VAL_14]]{{\[}}%[[CONSTANT_17]]] : memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:          hipsr.compute_yield %[[VAL_14]] : memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        } : memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_2]], %[[COMPUTE_0]] : memref<1xindex>, memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_0]], %[[ALLOC_11]] : memref<2xindex>, memref<?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_0]], %[[VIEW_0]] : memref<2xindex>, memref<?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_6]], %[[COMPUTE_1]] : memref<3xindex>, memref<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_10]], %[[ALLOC_12]] : memref<?xindex>, memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_10]], %[[VIEW_1]] : memref<?xindex>, memref<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_0]], %[[COMPUTE_2]] : memref<1xindex>, memref<3xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.pool_domain_yield %[[COMPUTE_0]], %[[COMPUTE_1]], %[[ALLOC_12]], %[[ALLOC_12]], %[[COMPUTE_2]] : memref<?xf16, #hipsr.mem<device>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[COMPUTE_0]], %[[COMPUTE_1]], %[[VIEW_1]], %[[VIEW_1]], %[[COMPUTE_2]] : memref<?xf16, #hipsr.mem<device>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:      } -> memref<?xf16, #hipsr.mem<device>>, memref<?x?x1xi1, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>> {domain_id = 0 : i64}
-// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#1, %[[POOL_DOMAIN_0]]#4 : !hipsr.context, memref<?x?x1xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_15:.*]]: !hipsr.context, %[[VAL_16:.*]]: memref<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_17:.*]]: memref<3xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:        %[[CONSTANT_14:.*]] = arith.constant 3 : index
-// CHECK-NEXT:        %[[CONSTANT_15:.*]] = arith.constant 2 : index
-// CHECK-NEXT:        %[[CONSTANT_16:.*]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[CONSTANT_17:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[DIM_9:.*]] = memref.dim %[[VAL_16]], %[[CONSTANT_17]] : memref<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[DIM_10:.*]] = memref.dim %[[VAL_16]], %[[CONSTANT_16]] : memref<?x?x1xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_14:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[DIM_9]], %[[ALLOC_14]]{{\[}}%[[CONSTANT_17]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[DIM_10]], %[[ALLOC_14]]{{\[}}%[[CONSTANT_16]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_16]], %[[ALLOC_14]]{{\[}}%[[CONSTANT_15]]] : memref<3xindex>
-// CHECK-NEXT:        %[[LOAD_9:.*]] = memref.load %[[VAL_17]]{{\[}}%[[CONSTANT_17]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]] = hipsr.pool_domain(%[[ARG0]], %[[VAL_15:.*]]#1, %[[VAL_15]]#4 : !hipsr.context, memref<?x?x1xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_16:.*]]: !hipsr.context, %[[VAL_17:.*]]: memref<?x?x1xi1, #hipsr.mem<device>>, %[[VAL_18:.*]]: memref<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:        %[[CONSTANT_21:.*]] = arith.constant 3 : index
+// CHECK-NEXT:        %[[CONSTANT_22:.*]] = arith.constant 2 : index
+// CHECK-NEXT:        %[[CONSTANT_23:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[CONSTANT_24:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[DIM_9:.*]] = memref.dim %[[VAL_17]], %[[CONSTANT_24]] : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_10:.*]] = memref.dim %[[VAL_17]], %[[CONSTANT_23]] : memref<?x?x1xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_12:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_9]], %[[ALLOC_12]]{{\[}}%[[CONSTANT_24]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_10]], %[[ALLOC_12]]{{\[}}%[[CONSTANT_23]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_23]], %[[ALLOC_12]]{{\[}}%[[CONSTANT_22]]] : memref<3xindex>
+// CHECK-NEXT:        %[[LOAD_9:.*]] = memref.load %[[VAL_18]]{{\[}}%[[CONSTANT_24]]] : memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_2:.*]] = arith.index_cast %[[LOAD_9]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_10:.*]] = memref.load %[[VAL_17]]{{\[}}%[[CONSTANT_16]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_10:.*]] = memref.load %[[VAL_18]]{{\[}}%[[CONSTANT_23]]] : memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_3:.*]] = arith.index_cast %[[LOAD_10]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_11:.*]] = memref.load %[[VAL_17]]{{\[}}%[[CONSTANT_15]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_11:.*]] = memref.load %[[VAL_18]]{{\[}}%[[CONSTANT_22]]] : memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_4:.*]] = arith.index_cast %[[LOAD_11]] : i64 to index
-// CHECK-NEXT:        %[[ALLOC_15:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_2]], %[[ALLOC_15]]{{\[}}%[[CONSTANT_17]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_3]], %[[ALLOC_15]]{{\[}}%[[CONSTANT_16]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_4]], %[[ALLOC_15]]{{\[}}%[[CONSTANT_15]]] : memref<3xindex>
-// CHECK-NEXT:        %[[ALLOC_16:.*]] = memref.alloc(%[[CONSTANT_14]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_18:.*]] = %[[CONSTANT_17]] to %[[CONSTANT_14]] step %[[CONSTANT_16]] {
-// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_18]], %[[CONSTANT_17]] : index
+// CHECK-NEXT:        %[[ALLOC_13:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_2]], %[[ALLOC_13]]{{\[}}%[[CONSTANT_24]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_3]], %[[ALLOC_13]]{{\[}}%[[CONSTANT_23]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_4]], %[[ALLOC_13]]{{\[}}%[[CONSTANT_22]]] : memref<3xindex>
+// CHECK-NEXT:        %[[ALLOC_14:.*]] = memref.alloc(%[[CONSTANT_21]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        scf.for %[[VAL_19:.*]] = %[[CONSTANT_24]] to %[[CONSTANT_21]] step %[[CONSTANT_23]] {
+// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_19]], %[[CONSTANT_24]] : index
 // CHECK-NEXT:          %[[IF_2:.*]] = scf.if %[[CMPI_3]] -> (index) {
-// CHECK-NEXT:            scf.yield %[[CONSTANT_16]] : index
+// CHECK-NEXT:            scf.yield %[[CONSTANT_23]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_12:.*]] = memref.load %[[ALLOC_14]]{{\[}}%[[VAL_18]]] : memref<3xindex>
+// CHECK-NEXT:            %[[LOAD_12:.*]] = memref.load %[[ALLOC_12]]{{\[}}%[[VAL_19]]] : memref<3xindex>
 // CHECK-NEXT:            scf.yield %[[LOAD_12]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_18]], %[[CONSTANT_17]] : index
+// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_19]], %[[CONSTANT_24]] : index
 // CHECK-NEXT:          %[[IF_3:.*]] = scf.if %[[CMPI_4]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_2]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_13:.*]] = memref.load %[[ALLOC_15]]{{\[}}%[[VAL_18]]] : memref<3xindex>
-// CHECK-NEXT:            %[[CMPI_5:.*]] = arith.cmpi eq, %[[LOAD_13]], %[[CONSTANT_16]] : index
+// CHECK-NEXT:            %[[LOAD_13:.*]] = memref.load %[[ALLOC_13]]{{\[}}%[[VAL_19]]] : memref<3xindex>
+// CHECK-NEXT:            %[[CMPI_5:.*]] = arith.cmpi eq, %[[LOAD_13]], %[[CONSTANT_23]] : index
 // CHECK-NEXT:            %[[SELECT_1:.*]] = arith.select %[[CMPI_5]], %[[IF_2]], %[[LOAD_13]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_1]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_16]]{{\[}}%[[VAL_18]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_14]]{{\[}}%[[VAL_19]]] : memref<?xindex>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[CAST_1:.*]] = memref.cast %[[ALLOC_16]] : memref<?xindex> to memref<3xindex>
-// CHECK-NEXT:        %[[LOAD_14:.*]] = memref.load %[[ALLOC_16]]{{\[}}%[[CONSTANT_17]]] : memref<?xindex>
-// CHECK-NEXT:        %[[LOAD_15:.*]] = memref.load %[[ALLOC_16]]{{\[}}%[[CONSTANT_16]]] : memref<?xindex>
-// CHECK-NEXT:        %[[LOAD_16:.*]] = memref.load %[[ALLOC_16]]{{\[}}%[[CONSTANT_15]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_17:.*]] = memref.alloc(%[[LOAD_14]], %[[LOAD_15]], %[[LOAD_16]]) {alignment = 64 : i64} : memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.expand(%[[VAL_15]]) ins(%[[VAL_16]], %[[VAL_17]] : memref<?x?x1xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) outs(%[[ALLOC_17]] : memref<?x?x?xi1, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_1]], %[[ALLOC_17]] : memref<3xindex>, memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_17]] : memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_1:.*]] = memref.cast %[[ALLOC_14]] : memref<?xindex> to memref<3xindex>
+// CHECK-NEXT:        %[[LOAD_14:.*]] = memref.load %[[ALLOC_14]]{{\[}}%[[CONSTANT_24]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_15:.*]] = memref.load %[[ALLOC_14]]{{\[}}%[[CONSTANT_23]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_16:.*]] = memref.load %[[ALLOC_14]]{{\[}}%[[CONSTANT_22]]] : memref<?xindex>
+// CHECK-NEXT:        %[[CONSTANT_25:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[MULI_7:.*]] = arith.muli %[[CONSTANT_25]], %[[LOAD_14]] : index
+// CHECK-NEXT:        %[[MULI_8:.*]] = arith.muli %[[MULI_7]], %[[LOAD_15]] : index
+// CHECK-NEXT:        %[[MULI_9:.*]] = arith.muli %[[MULI_8]], %[[LOAD_16]] : index
+// CHECK-NEXT:        %[[CONSTANT_26:.*]] = arith.constant 256 : index
+// CHECK-NEXT:        %[[CONSTANT_27:.*]] = arith.constant 255 : index
+// CHECK-NEXT:        %[[ADDI_3:.*]] = arith.addi %[[MULI_9]], %[[CONSTANT_27]] : index
+// CHECK-NEXT:        %[[DIVUI_2:.*]] = arith.divui %[[ADDI_3]], %[[CONSTANT_26]] : index
+// CHECK-NEXT:        %[[MULI_10:.*]] = arith.muli %[[DIVUI_2]], %[[CONSTANT_26]] : index
+// CHECK-NEXT:        %[[CONSTANT_28:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[GET_POOL_1:.*]] = hipsr.get_pool(%[[VAL_16]], %[[MULI_10]]) {domain_id = 1 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[VIEW_2:.*]] = memref.view %[[GET_POOL_1]]{{\[}}%[[CONSTANT_28]]]{{\[}}%[[LOAD_14]], %[[LOAD_15]], %[[LOAD_16]]] : memref<?xi8, #hipsr.mem<device>> to memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.expand(%[[VAL_16]]) ins(%[[VAL_17]], %[[VAL_18]] : memref<?x?x1xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) outs(%[[VIEW_2]] : memref<?x?x?xi1, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_1]], %[[VIEW_2]] : memref<3xindex>, memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[VIEW_2]] : memref<?x?x?xi1, #hipsr.mem<device>>
 // CHECK-NEXT:      } -> memref<?x?x?xi1, #hipsr.mem<device>> {domain_id = 1 : i64}
-// CHECK-NEXT:      %[[POOL_DOMAIN_2:.*]]:2 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_1]], %[[POOL_DOMAIN_0]]#4 : !hipsr.context, memref<?x?x?xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_19:.*]]: !hipsr.context, %[[VAL_20:.*]]: memref<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_21:.*]]: memref<3xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:        %[[CONSTANT_18:.*]] = arith.constant 3 : index
-// CHECK-NEXT:        %[[CONSTANT_19:.*]] = arith.constant 2 : index
-// CHECK-NEXT:        %[[CONSTANT_20:.*]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[CONSTANT_21:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[ALLOC_18:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_20]], %[[ALLOC_18]]{{\[}}%[[CONSTANT_21]]] : memref<1xindex>
-// CHECK-NEXT:        %[[DIM_11:.*]] = memref.dim %[[VAL_20]], %[[CONSTANT_21]] : memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[DIM_12:.*]] = memref.dim %[[VAL_20]], %[[CONSTANT_20]] : memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[DIM_13:.*]] = memref.dim %[[VAL_20]], %[[CONSTANT_19]] : memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_19:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[DIM_11]], %[[ALLOC_19]]{{\[}}%[[CONSTANT_21]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[DIM_12]], %[[ALLOC_19]]{{\[}}%[[CONSTANT_20]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[DIM_13]], %[[ALLOC_19]]{{\[}}%[[CONSTANT_19]]] : memref<3xindex>
-// CHECK-NEXT:        %[[LOAD_17:.*]] = memref.load %[[VAL_21]]{{\[}}%[[CONSTANT_21]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      %[[POOL_DOMAIN_2:.*]]:2 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_1]], %[[VAL_20:.*]]#4 : !hipsr.context, memref<?x?x?xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_21:.*]]: !hipsr.context, %[[VAL_22:.*]]: memref<?x?x?xi1, #hipsr.mem<device>>, %[[VAL_23:.*]]: memref<3xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:        %[[CONSTANT_29:.*]] = arith.constant 3 : index
+// CHECK-NEXT:        %[[CONSTANT_30:.*]] = arith.constant 2 : index
+// CHECK-NEXT:        %[[CONSTANT_31:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[CONSTANT_32:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[ALLOC_15:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_31]], %[[ALLOC_15]]{{\[}}%[[CONSTANT_32]]] : memref<1xindex>
+// CHECK-NEXT:        %[[DIM_11:.*]] = memref.dim %[[VAL_22]], %[[CONSTANT_32]] : memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_12:.*]] = memref.dim %[[VAL_22]], %[[CONSTANT_31]] : memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_13:.*]] = memref.dim %[[VAL_22]], %[[CONSTANT_30]] : memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_16:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_11]], %[[ALLOC_16]]{{\[}}%[[CONSTANT_32]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_12]], %[[ALLOC_16]]{{\[}}%[[CONSTANT_31]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_13]], %[[ALLOC_16]]{{\[}}%[[CONSTANT_30]]] : memref<3xindex>
+// CHECK-NEXT:        %[[LOAD_17:.*]] = memref.load %[[VAL_23]]{{\[}}%[[CONSTANT_32]]] : memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_5:.*]] = arith.index_cast %[[LOAD_17]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_18:.*]] = memref.load %[[VAL_21]]{{\[}}%[[CONSTANT_20]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_18:.*]] = memref.load %[[VAL_23]]{{\[}}%[[CONSTANT_31]]] : memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_6:.*]] = arith.index_cast %[[LOAD_18]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_19:.*]] = memref.load %[[VAL_21]]{{\[}}%[[CONSTANT_19]]] : memref<3xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_19:.*]] = memref.load %[[VAL_23]]{{\[}}%[[CONSTANT_30]]] : memref<3xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_7:.*]] = arith.index_cast %[[LOAD_19]] : i64 to index
-// CHECK-NEXT:        %[[ALLOC_20:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_5]], %[[ALLOC_20]]{{\[}}%[[CONSTANT_21]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_6]], %[[ALLOC_20]]{{\[}}%[[CONSTANT_20]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_7]], %[[ALLOC_20]]{{\[}}%[[CONSTANT_19]]] : memref<3xindex>
-// CHECK-NEXT:        %[[ALLOC_21:.*]] = memref.alloc(%[[CONSTANT_18]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_22:.*]] = %[[CONSTANT_21]] to %[[CONSTANT_18]] step %[[CONSTANT_20]] {
-// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_22]], %[[CONSTANT_21]] : index
+// CHECK-NEXT:        %[[ALLOC_17:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_5]], %[[ALLOC_17]]{{\[}}%[[CONSTANT_32]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_6]], %[[ALLOC_17]]{{\[}}%[[CONSTANT_31]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_7]], %[[ALLOC_17]]{{\[}}%[[CONSTANT_30]]] : memref<3xindex>
+// CHECK-NEXT:        %[[ALLOC_18:.*]] = memref.alloc(%[[CONSTANT_29]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        scf.for %[[VAL_24:.*]] = %[[CONSTANT_32]] to %[[CONSTANT_29]] step %[[CONSTANT_31]] {
+// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_24]], %[[CONSTANT_32]] : index
 // CHECK-NEXT:          %[[IF_4:.*]] = scf.if %[[CMPI_6]] -> (index) {
-// CHECK-NEXT:            scf.yield %[[CONSTANT_20]] : index
+// CHECK-NEXT:            scf.yield %[[CONSTANT_31]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_20:.*]] = memref.load %[[ALLOC_19]]{{\[}}%[[VAL_22]]] : memref<3xindex>
+// CHECK-NEXT:            %[[LOAD_20:.*]] = memref.load %[[ALLOC_16]]{{\[}}%[[VAL_24]]] : memref<3xindex>
 // CHECK-NEXT:            scf.yield %[[LOAD_20]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_22]], %[[CONSTANT_21]] : index
+// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_24]], %[[CONSTANT_32]] : index
 // CHECK-NEXT:          %[[IF_5:.*]] = scf.if %[[CMPI_7]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_4]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_21:.*]] = memref.load %[[ALLOC_20]]{{\[}}%[[VAL_22]]] : memref<3xindex>
-// CHECK-NEXT:            %[[CMPI_8:.*]] = arith.cmpi eq, %[[LOAD_21]], %[[CONSTANT_20]] : index
+// CHECK-NEXT:            %[[LOAD_21:.*]] = memref.load %[[ALLOC_17]]{{\[}}%[[VAL_24]]] : memref<3xindex>
+// CHECK-NEXT:            %[[CMPI_8:.*]] = arith.cmpi eq, %[[LOAD_21]], %[[CONSTANT_31]] : index
 // CHECK-NEXT:            %[[SELECT_2:.*]] = arith.select %[[CMPI_8]], %[[IF_4]], %[[LOAD_21]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_2]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_21]]{{\[}}%[[VAL_22]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_18]]{{\[}}%[[VAL_24]]] : memref<?xindex>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[CAST_2:.*]] = memref.cast %[[ALLOC_21]] : memref<?xindex> to memref<3xindex>
-// CHECK-NEXT:        %[[FOR_1:.*]] = scf.for %[[VAL_23:.*]] = %[[CONSTANT_21]] to %[[CONSTANT_18]] step %[[CONSTANT_20]] iter_args(%[[VAL_24:.*]] = %[[CONSTANT_20]]) -> (index) {
-// CHECK-NEXT:          %[[LOAD_22:.*]] = memref.load %[[ALLOC_21]]{{\[}}%[[VAL_23]]] : memref<?xindex>
-// CHECK-NEXT:          %[[MULI_1:.*]] = arith.muli %[[LOAD_22]], %[[VAL_24]] : index
-// CHECK-NEXT:          scf.yield %[[MULI_1]] : index
+// CHECK-NEXT:        %[[CAST_2:.*]] = memref.cast %[[ALLOC_18]] : memref<?xindex> to memref<3xindex>
+// CHECK-NEXT:        %[[FOR_1:.*]] = scf.for %[[VAL_25:.*]] = %[[CONSTANT_32]] to %[[CONSTANT_29]] step %[[CONSTANT_31]] iter_args(%[[VAL_26:.*]] = %[[CONSTANT_31]]) -> (index) {
+// CHECK-NEXT:          %[[LOAD_22:.*]] = memref.load %[[ALLOC_18]]{{\[}}%[[VAL_25]]] : memref<?xindex>
+// CHECK-NEXT:          %[[MULI_11:.*]] = arith.muli %[[LOAD_22]], %[[VAL_26]] : index
+// CHECK-NEXT:          scf.yield %[[MULI_11]] : index
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[ALLOC_22:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_18]], %[[ALLOC_22]]{{\[}}%[[CONSTANT_21]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[FOR_1]], %[[ALLOC_22]]{{\[}}%[[CONSTANT_20]]] : memref<2xindex>
-// CHECK-NEXT:        %[[LOAD_23:.*]] = memref.load %[[ALLOC_21]]{{\[}}%[[CONSTANT_21]]] : memref<?xindex>
-// CHECK-NEXT:        %[[LOAD_24:.*]] = memref.load %[[ALLOC_21]]{{\[}}%[[CONSTANT_20]]] : memref<?xindex>
-// CHECK-NEXT:        %[[LOAD_25:.*]] = memref.load %[[ALLOC_21]]{{\[}}%[[CONSTANT_19]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_23:.*]] = memref.alloc(%[[LOAD_23]], %[[LOAD_24]], %[[LOAD_25]]) {alignment = 64 : i64} : memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[LOAD_26:.*]] = memref.load %[[ALLOC_22]]{{\[}}%[[CONSTANT_20]]] : memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_24:.*]] = memref.alloc(%[[LOAD_26]]) {alignment = 64 : i64} : memref<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_25:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_26:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.expand(%[[VAL_19]]) ins(%[[VAL_20]], %[[VAL_21]] : memref<?x?x?xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) outs(%[[ALLOC_23]] : memref<?x?x?xi1, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.nonzero(%[[VAL_19]]) ins(%[[ALLOC_23]] : memref<?x?x?xi1, #hipsr.mem<device>>) outs(%[[ALLOC_24]], %[[ALLOC_25]] : memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.copy_d2h(%[[VAL_19]]) ins(%[[ALLOC_25]] : memref<1xi64, #hipsr.mem<device>>) outs(%[[ALLOC_26]] : memref<1xi64, #hipsr.mem<host>>)
-// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_2]], %[[ALLOC_23]] : memref<3xindex>, memref<?x?x?xi1, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_22]], %[[ALLOC_24]] : memref<2xindex>, memref<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_18]], %[[ALLOC_25]] : memref<1xindex>, memref<1xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_18]], %[[ALLOC_26]] : memref<1xindex>, memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_24]], %[[ALLOC_26]] : memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[ALLOC_19:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_29]], %[[ALLOC_19]]{{\[}}%[[CONSTANT_32]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[FOR_1]], %[[ALLOC_19]]{{\[}}%[[CONSTANT_31]]] : memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_23:.*]] = memref.load %[[ALLOC_18]]{{\[}}%[[CONSTANT_32]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_24:.*]] = memref.load %[[ALLOC_18]]{{\[}}%[[CONSTANT_31]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_25:.*]] = memref.load %[[ALLOC_18]]{{\[}}%[[CONSTANT_30]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_26:.*]] = memref.load %[[ALLOC_19]]{{\[}}%[[CONSTANT_31]]] : memref<2xindex>
+// CHECK-NEXT:        %[[CONSTANT_33:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[MULI_12:.*]] = arith.muli %[[CONSTANT_33]], %[[LOAD_23]] : index
+// CHECK-NEXT:        %[[MULI_13:.*]] = arith.muli %[[MULI_12]], %[[LOAD_24]] : index
+// CHECK-NEXT:        %[[MULI_14:.*]] = arith.muli %[[MULI_13]], %[[LOAD_25]] : index
+// CHECK-NEXT:        %[[CONSTANT_34:.*]] = arith.constant 256 : index
+// CHECK-NEXT:        %[[CONSTANT_35:.*]] = arith.constant 255 : index
+// CHECK-NEXT:        %[[ADDI_4:.*]] = arith.addi %[[MULI_14]], %[[CONSTANT_35]] : index
+// CHECK-NEXT:        %[[DIVUI_3:.*]] = arith.divui %[[ADDI_4]], %[[CONSTANT_34]] : index
+// CHECK-NEXT:        %[[MULI_15:.*]] = arith.muli %[[DIVUI_3]], %[[CONSTANT_34]] : index
+// CHECK-NEXT:        %[[CONSTANT_36:.*]] = arith.constant 24 : index
+// CHECK-NEXT:        %[[MULI_16:.*]] = arith.muli %[[CONSTANT_36]], %[[LOAD_26]] : index
+// CHECK-NEXT:        %[[CONSTANT_37:.*]] = arith.constant 256 : index
+// CHECK-NEXT:        %[[CONSTANT_38:.*]] = arith.constant 255 : index
+// CHECK-NEXT:        %[[ADDI_5:.*]] = arith.addi %[[MULI_16]], %[[CONSTANT_38]] : index
+// CHECK-NEXT:        %[[DIVUI_4:.*]] = arith.divui %[[ADDI_5]], %[[CONSTANT_37]] : index
+// CHECK-NEXT:        %[[MULI_17:.*]] = arith.muli %[[DIVUI_4]], %[[CONSTANT_37]] : index
+// CHECK-NEXT:        %[[CONSTANT_39:.*]] = arith.constant 8 : index
+// CHECK-NEXT:        %[[CONSTANT_40:.*]] = arith.constant 256 : index
+// CHECK-NEXT:        %[[CONSTANT_41:.*]] = arith.constant 255 : index
+// CHECK-NEXT:        %[[ADDI_6:.*]] = arith.addi %[[CONSTANT_39]], %[[CONSTANT_41]] : index
+// CHECK-NEXT:        %[[DIVUI_5:.*]] = arith.divui %[[ADDI_6]], %[[CONSTANT_40]] : index
+// CHECK-NEXT:        %[[MULI_18:.*]] = arith.muli %[[DIVUI_5]], %[[CONSTANT_40]] : index
+// CHECK-NEXT:        %[[CONSTANT_42:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[ADDI_7:.*]] = arith.addi %[[MULI_15]], %[[MULI_17]] : index
+// CHECK-NEXT:        %[[ADDI_8:.*]] = arith.addi %[[ADDI_7]], %[[MULI_18]] : index
+// CHECK-NEXT:        %[[GET_POOL_2:.*]] = hipsr.get_pool(%[[VAL_21]], %[[ADDI_8]]) {domain_id = 2 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[VIEW_3:.*]] = memref.view %[[GET_POOL_2]]{{\[}}%[[CONSTANT_42]]]{{\[}}%[[LOAD_23]], %[[LOAD_24]], %[[LOAD_25]]] : memref<?xi8, #hipsr.mem<device>> to memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[VIEW_4:.*]] = memref.view %[[GET_POOL_2]]{{\[}}%[[MULI_15]]]{{\[}}%[[LOAD_26]]] : memref<?xi8, #hipsr.mem<device>> to memref<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[VIEW_5:.*]] = memref.view %[[GET_POOL_2]]{{\[}}%[[ADDI_7]]][] : memref<?xi8, #hipsr.mem<device>> to memref<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_20:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.expand(%[[VAL_21]]) ins(%[[VAL_22]], %[[VAL_23]] : memref<?x?x?xi1, #hipsr.mem<device>>, memref<3xi64, #hipsr.mem<host>>) outs(%[[VIEW_3]] : memref<?x?x?xi1, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.nonzero(%[[VAL_21]]) ins(%[[VIEW_3]] : memref<?x?x?xi1, #hipsr.mem<device>>) outs(%[[VIEW_4]], %[[VIEW_5]] : memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.copy_d2h(%[[VAL_21]]) ins(%[[VIEW_5]] : memref<1xi64, #hipsr.mem<device>>) outs(%[[ALLOC_20]] : memref<1xi64, #hipsr.mem<host>>)
+// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_2]], %[[VIEW_3]] : memref<3xindex>, memref<?x?x?xi1, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_19]], %[[VIEW_4]] : memref<2xindex>, memref<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_15]], %[[VIEW_5]] : memref<1xindex>, memref<1xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_15]], %[[ALLOC_20]] : memref<1xindex>, memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[VIEW_4]], %[[ALLOC_20]] : memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:      } -> memref<3x?xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>> {domain_id = 2 : i64}
-// CHECK-NEXT:      %[[POOL_DOMAIN_3:.*]]:3 = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_2]]#1, %[[POOL_DOMAIN_2]]#0 : !hipsr.context, memref<1xi64, #hipsr.mem<host>>, memref<3x?xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_25:.*]]: !hipsr.context, %[[VAL_26:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_27:.*]]: memref<3x?xi64, #hipsr.mem<device>>):
-// CHECK-NEXT:        %[[CONSTANT_22:.*]] = arith.constant 3 : index
-// CHECK-NEXT:        %[[CONSTANT_23:.*]] = arith.constant 2 : index
-// CHECK-NEXT:        %[[CONSTANT_24:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[CONSTANT_25:.*]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[ALLOC_27:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_25]], %[[ALLOC_27]]{{\[}}%[[CONSTANT_24]]] : memref<1xindex>
-// CHECK-NEXT:        %[[ALLOC_28:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_23]], %[[ALLOC_28]]{{\[}}%[[CONSTANT_24]]] : memref<1xindex>
-// CHECK-NEXT:        %[[ALLOC_29:.*]] = memref.alloc() {alignment = 64 : i64} : memref<0xindex>
-// CHECK-NEXT:        %[[LOAD_27:.*]] = memref.load %[[VAL_26]]{{\[}}%[[CONSTANT_24]]] : memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      %[[POOL_DOMAIN_3:.*]]:3 = hipsr.pool_domain(%[[ARG0]], %[[VAL_27:.*]]#1, %[[VAL_27]]#0 : !hipsr.context, memref<1xi64, #hipsr.mem<host>>, memref<3x?xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_28:.*]]: !hipsr.context, %[[VAL_29:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_30:.*]]: memref<3x?xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[CONSTANT_43:.*]] = arith.constant 3 : index
+// CHECK-NEXT:        %[[CONSTANT_44:.*]] = arith.constant 2 : index
+// CHECK-NEXT:        %[[CONSTANT_45:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[CONSTANT_46:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[ALLOC_21:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_46]], %[[ALLOC_21]]{{\[}}%[[CONSTANT_45]]] : memref<1xindex>
+// CHECK-NEXT:        %[[ALLOC_22:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_44]], %[[ALLOC_22]]{{\[}}%[[CONSTANT_45]]] : memref<1xindex>
+// CHECK-NEXT:        %[[ALLOC_23:.*]] = memref.alloc() {alignment = 64 : i64} : memref<0xindex>
+// CHECK-NEXT:        %[[LOAD_27:.*]] = memref.load %[[VAL_29]]{{\[}}%[[CONSTANT_45]]] : memref<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_8:.*]] = arith.index_cast %[[LOAD_27]] : i64 to index
-// CHECK-NEXT:        %[[ALLOC_30:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_22]], %[[ALLOC_30]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_8]], %[[ALLOC_30]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
-// CHECK-NEXT:        %[[LOAD_28:.*]] = memref.load %[[ALLOC_30]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
-// CHECK-NEXT:        %[[LOAD_29:.*]] = memref.load %[[ALLOC_30]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_31:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[LOAD_28]], %[[ALLOC_31]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[LOAD_29]], %[[ALLOC_31]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
-// CHECK-NEXT:        %[[LOAD_30:.*]] = memref.load %[[ALLOC_30]]{{\[}}%[[CONSTANT_25]]] : memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_32:.*]] = memref.alloc(%[[LOAD_30]]) {alignment = 64 : i64} : memref<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[LOAD_31:.*]] = memref.load %[[ALLOC_31]]{{\[}}%[[CONSTANT_24]]] : memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_33:.*]] = memref.alloc(%[[LOAD_31]]) {alignment = 64 : i64} : memref<?x3xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_34:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[ALLOC_35:.*]] = memref.alloc() {alignment = 64 : i64} : memref<i64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[COMPUTE_3:.*]] = hipsr.compute(%[[VAL_25]]) ins(%[[VAL_26]], %[[VAL_27]] : memref<1xi64, #hipsr.mem<host>>, memref<3x?xi64, #hipsr.mem<device>>) outs(%[[ALLOC_32]] : memref<3x?xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:        ^bb0(%[[VAL_28:.*]]: !hipsr.context, %[[VAL_29:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_30:.*]]: memref<3x?xi64, #hipsr.mem<device>>, %[[VAL_31:.*]]: memref<3x?xi64, #hipsr.mem<device>>):
-// CHECK-NEXT:          %[[CONSTANT_26:.*]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[DIM_14:.*]] = memref.dim %[[VAL_31]], %[[CONSTANT_26]] : memref<3x?xi64, #hipsr.mem<device>>
-// CHECK-NEXT:          %[[SUBVIEW_6:.*]] = memref.subview %[[VAL_30]]{{\[}}0, 0] [3, %[[DIM_14]]] [1, 1] : memref<3x?xi64, #hipsr.mem<device>> to memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_24:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_43]], %[[ALLOC_24]]{{\[}}%[[CONSTANT_45]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_8]], %[[ALLOC_24]]{{\[}}%[[CONSTANT_46]]] : memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_28:.*]] = memref.load %[[ALLOC_24]]{{\[}}%[[CONSTANT_46]]] : memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_29:.*]] = memref.load %[[ALLOC_24]]{{\[}}%[[CONSTANT_45]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_25:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[LOAD_28]], %[[ALLOC_25]]{{\[}}%[[CONSTANT_45]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[LOAD_29]], %[[ALLOC_25]]{{\[}}%[[CONSTANT_46]]] : memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_30:.*]] = memref.load %[[ALLOC_24]]{{\[}}%[[CONSTANT_46]]] : memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_31:.*]] = memref.load %[[ALLOC_25]]{{\[}}%[[CONSTANT_45]]] : memref<2xindex>
+// CHECK-NEXT:        %[[CONSTANT_47:.*]] = arith.constant 24 : index
+// CHECK-NEXT:        %[[MULI_19:.*]] = arith.muli %[[CONSTANT_47]], %[[LOAD_30]] : index
+// CHECK-NEXT:        %[[CONSTANT_48:.*]] = arith.constant 24 : index
+// CHECK-NEXT:        %[[MULI_20:.*]] = arith.muli %[[CONSTANT_48]], %[[LOAD_31]] : index
+// CHECK-NEXT:        %[[MAXUI_0:.*]] = arith.maxui %[[MULI_19]], %[[MULI_20]] : index
+// CHECK-NEXT:        %[[CONSTANT_49:.*]] = arith.constant 256 : index
+// CHECK-NEXT:        %[[CONSTANT_50:.*]] = arith.constant 255 : index
+// CHECK-NEXT:        %[[ADDI_9:.*]] = arith.addi %[[MAXUI_0]], %[[CONSTANT_50]] : index
+// CHECK-NEXT:        %[[DIVUI_6:.*]] = arith.divui %[[ADDI_9]], %[[CONSTANT_49]] : index
+// CHECK-NEXT:        %[[MULI_21:.*]] = arith.muli %[[DIVUI_6]], %[[CONSTANT_49]] : index
+// CHECK-NEXT:        %[[CONSTANT_51:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[GET_POOL_3:.*]] = hipsr.get_pool(%[[VAL_28]], %[[MULI_21]]) {domain_id = 3 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[VIEW_6:.*]] = memref.view %[[GET_POOL_3]]{{\[}}%[[CONSTANT_51]]]{{\[}}%[[LOAD_30]]] : memref<?xi8, #hipsr.mem<device>> to memref<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[VIEW_7:.*]] = memref.view %[[GET_POOL_3]]{{\[}}%[[CONSTANT_51]]]{{\[}}%[[LOAD_31]]] : memref<?xi8, #hipsr.mem<device>> to memref<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_26:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[ALLOC_27:.*]] = memref.alloc() {alignment = 64 : i64} : memref<i64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[COMPUTE_3:.*]] = hipsr.compute(%[[VAL_28]]) ins(%[[VAL_29]], %[[VAL_30]] : memref<1xi64, #hipsr.mem<host>>, memref<3x?xi64, #hipsr.mem<device>>) outs(%[[VIEW_6]] : memref<3x?xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_31:.*]]: !hipsr.context, %[[VAL_32:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_33:.*]]: memref<3x?xi64, #hipsr.mem<device>>, %[[VAL_34:.*]]: memref<3x?xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:          %[[CONSTANT_52:.*]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[DIM_14:.*]] = memref.dim %[[VAL_34]], %[[CONSTANT_52]] : memref<3x?xi64, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[SUBVIEW_6:.*]] = memref.subview %[[VAL_33]][0, 0] [3, %[[DIM_14]]] [1, 1] : memref<3x?xi64, #hipsr.mem<device>> to memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
 // CHECK-NEXT:          hipsr.compute_yield %[[SUBVIEW_6]] : memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
 // CHECK-NEXT:        } : memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.transpose(%[[VAL_25]]) ins(%[[COMPUTE_3]] : memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>) outs(%[[ALLOC_33]] : memref<?x3xi64, #hipsr.mem<device>>) {perm = array<i64: 1, 0>}
-// CHECK-NEXT:        %[[COMPUTE_4:.*]] = hipsr.compute(%[[VAL_25]]) ins(%[[ALLOC_33]] : memref<?x3xi64, #hipsr.mem<device>>) outs(%[[ALLOC_34]] : memref<2xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:        ^bb0(%[[VAL_32:.*]]: !hipsr.context, %[[VAL_33:.*]]: memref<?x3xi64, #hipsr.mem<device>>, %[[VAL_34:.*]]: memref<2xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:          %[[CONSTANT_27:.*]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[CONSTANT_28:.*]] = arith.constant 3 : i64
-// CHECK-NEXT:          %[[CONSTANT_29:.*]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[DIM_15:.*]] = memref.dim %[[VAL_33]], %[[CONSTANT_29]] : memref<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.transpose(%[[VAL_28]]) ins(%[[COMPUTE_3]] : memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>) outs(%[[VIEW_7]] : memref<?x3xi64, #hipsr.mem<device>>) {perm = array<i64: 1, 0>}
+// CHECK-NEXT:        %[[COMPUTE_4:.*]] = hipsr.compute(%[[VAL_28]]) ins(%[[VIEW_7]] : memref<?x3xi64, #hipsr.mem<device>>) outs(%[[ALLOC_26]] : memref<2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_35:.*]]: !hipsr.context, %[[VAL_36:.*]]: memref<?x3xi64, #hipsr.mem<device>>, %[[VAL_37:.*]]: memref<2xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:          %[[CONSTANT_53:.*]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[CONSTANT_54:.*]] = arith.constant 3 : i64
+// CHECK-NEXT:          %[[CONSTANT_55:.*]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[DIM_15:.*]] = memref.dim %[[VAL_36]], %[[CONSTANT_55]] : memref<?x3xi64, #hipsr.mem<device>>
 // CHECK-NEXT:          %[[INDEX_CAST_9:.*]] = arith.index_cast %[[DIM_15]] : index to i64
-// CHECK-NEXT:          memref.store %[[INDEX_CAST_9]], %[[VAL_34]]{{\[}}%[[CONSTANT_29]]] : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:          memref.store %[[CONSTANT_28]], %[[VAL_34]]{{\[}}%[[CONSTANT_27]]] : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:          hipsr.compute_yield %[[VAL_34]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[INDEX_CAST_9]], %[[VAL_37]]{{\[}}%[[CONSTANT_55]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[CONSTANT_54]], %[[VAL_37]]{{\[}}%[[CONSTANT_53]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          hipsr.compute_yield %[[VAL_37]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        } : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[COMPUTE_5:.*]] = hipsr.compute(%[[VAL_25]]) ins(%[[COMPUTE_4]] : memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_35]] : memref<i64, #hipsr.mem<host>>) {
-// CHECK-NEXT:        ^bb0(%[[VAL_35:.*]]: !hipsr.context, %[[VAL_36:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_37:.*]]: memref<i64, #hipsr.mem<host>>):
-// CHECK-NEXT:          %[[CONSTANT_30:.*]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[LOAD_32:.*]] = memref.load %[[VAL_36]]{{\[}}%[[CONSTANT_30]]] : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:          memref.store %[[LOAD_32]], %[[VAL_37]]{{\[}}] : memref<i64, #hipsr.mem<host>>
-// CHECK-NEXT:          hipsr.compute_yield %[[VAL_37]] : memref<i64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[COMPUTE_5:.*]] = hipsr.compute(%[[VAL_28]]) ins(%[[COMPUTE_4]] : memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_27]] : memref<i64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_38:.*]]: !hipsr.context, %[[VAL_39:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_40:.*]]: memref<i64, #hipsr.mem<host>>):
+// CHECK-NEXT:          %[[CONSTANT_56:.*]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[LOAD_32:.*]] = memref.load %[[VAL_39]]{{\[}}%[[CONSTANT_56]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[LOAD_32]], %[[VAL_40]][] : memref<i64, #hipsr.mem<host>>
+// CHECK-NEXT:          hipsr.compute_yield %[[VAL_40]] : memref<i64, #hipsr.mem<host>>
 // CHECK-NEXT:        } : memref<i64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[COMPUTE_6:.*]] = hipsr.compute(%[[VAL_25]]) ins(%[[COMPUTE_5]] : memref<i64, #hipsr.mem<host>>) outs(%[[COMPUTE_5]] : memref<i64, #hipsr.mem<host>>) {
-// CHECK-NEXT:        ^bb0(%[[VAL_38:.*]]: !hipsr.context, %[[VAL_39:.*]]: memref<i64, #hipsr.mem<host>>, %[[VAL_40:.*]]: memref<i64, #hipsr.mem<host>>):
-// CHECK-NEXT:          %[[EXPAND_SHAPE_1:.*]] = memref.expand_shape %[[VAL_39]] [] output_shape [1] : memref<i64, #hipsr.mem<host>> into memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[COMPUTE_6:.*]] = hipsr.compute(%[[VAL_28]]) ins(%[[COMPUTE_5]] : memref<i64, #hipsr.mem<host>>) outs(%[[COMPUTE_5]] : memref<i64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        ^bb0(%[[VAL_41:.*]]: !hipsr.context, %[[VAL_42:.*]]: memref<i64, #hipsr.mem<host>>, %[[VAL_43:.*]]: memref<i64, #hipsr.mem<host>>):
+// CHECK-NEXT:          %[[EXPAND_SHAPE_1:.*]] = memref.expand_shape %[[VAL_42]] [] output_shape [1] : memref<i64, #hipsr.mem<host>> into memref<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:          hipsr.compute_yield %[[EXPAND_SHAPE_1]] : memref<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        } : memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_30]], %[[COMPUTE_3]] : memref<2xindex>, memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_31]], %[[ALLOC_33]] : memref<2xindex>, memref<?x3xi64, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_28]], %[[COMPUTE_4]] : memref<1xindex>, memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_29]], %[[COMPUTE_5]] : memref<0xindex>, memref<i64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_27]], %[[COMPUTE_6]] : memref<1xindex>, memref<1xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_33]], %[[ALLOC_33]], %[[COMPUTE_6]] : memref<?x3xi64, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_24]], %[[COMPUTE_3]] : memref<2xindex>, memref<3x?xi64, strided<[?, 1]>, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_25]], %[[VIEW_7]] : memref<2xindex>, memref<?x3xi64, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_22]], %[[COMPUTE_4]] : memref<1xindex>, memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_23]], %[[COMPUTE_5]] : memref<0xindex>, memref<i64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_21]], %[[COMPUTE_6]] : memref<1xindex>, memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[VIEW_7]], %[[VIEW_7]], %[[COMPUTE_6]] : memref<?x3xi64, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:      } -> memref<?x3xi64, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>> {domain_id = 3 : i64}
-// CHECK-NEXT:      %[[POOL_DOMAIN_4:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#0, %[[POOL_DOMAIN_3]]#2, %[[POOL_DOMAIN_0]]#2, %[[POOL_DOMAIN_3]]#0, %[[POOL_DOMAIN_0]]#3, %[[POOL_DOMAIN_3]]#1 : !hipsr.context, memref<?xf16, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_41:.*]]: !hipsr.context, %[[VAL_42:.*]]: memref<?xf16, #hipsr.mem<device>>, %[[VAL_43:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_44:.*]]: memref<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_45:.*]]: memref<?x3xi64, #hipsr.mem<device>>, %[[VAL_46:.*]]: memref<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_47:.*]]: memref<?x3xi64, #hipsr.mem<device>>):
-// CHECK-NEXT:        %[[CONSTANT_31:.*]] = arith.constant 2 : index
-// CHECK-NEXT:        %[[CONSTANT_32:.*]] = arith.constant 4096 : index
-// CHECK-NEXT:        %[[CONSTANT_33:.*]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[CONSTANT_34:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[DIM_16:.*]] = memref.dim %[[VAL_42]], %[[CONSTANT_34]] : memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[LOAD_33:.*]] = memref.load %[[VAL_43]]{{\[}}%[[CONSTANT_34]]] : memref<1xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      %[[POOL_DOMAIN_4:.*]] = hipsr.pool_domain(%[[ARG0]], %[[VAL_44:.*]]#0, %[[VAL_45:.*]]#2, %[[VAL_44]]#2, %[[VAL_45]]#0, %[[VAL_44]]#3, %[[VAL_45]]#1 : !hipsr.context, memref<?xf16, #hipsr.mem<device>>, memref<1xi64, #hipsr.mem<host>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_46:.*]]: !hipsr.context, %[[VAL_47:.*]]: memref<?xf16, #hipsr.mem<device>>, %[[VAL_48:.*]]: memref<1xi64, #hipsr.mem<host>>, %[[VAL_49:.*]]: memref<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_50:.*]]: memref<?x3xi64, #hipsr.mem<device>>, %[[VAL_51:.*]]: memref<?x?x4096xf16, #hipsr.mem<device>>, %[[VAL_52:.*]]: memref<?x3xi64, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[CONSTANT_57:.*]] = arith.constant 2 : index
+// CHECK-NEXT:        %[[CONSTANT_58:.*]] = arith.constant 4096 : index
+// CHECK-NEXT:        %[[CONSTANT_59:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[CONSTANT_60:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[DIM_16:.*]] = memref.dim %[[VAL_47]], %[[CONSTANT_60]] : memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[LOAD_33:.*]] = memref.load %[[VAL_48]]{{\[}}%[[CONSTANT_60]]] : memref<1xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_10:.*]] = arith.index_cast %[[LOAD_33]] : i64 to index
-// CHECK-NEXT:        %[[CMPI_9:.*]] = arith.cmpi slt, %[[INDEX_CAST_10]], %[[CONSTANT_34]] : index
-// CHECK-NEXT:        %[[ADDI_0:.*]] = arith.addi %[[INDEX_CAST_10]], %[[DIM_16]] : index
-// CHECK-NEXT:        %[[SELECT_3:.*]] = arith.select %[[CMPI_9]], %[[ADDI_0]], %[[INDEX_CAST_10]] : index
-// CHECK-NEXT:        %[[MINSI_0:.*]] = arith.minsi %[[DIM_16]], %[[CONSTANT_34]] : index
-// CHECK-NEXT:        %[[MAXSI_0:.*]] = arith.maxsi %[[SELECT_3]], %[[CONSTANT_34]] : index
+// CHECK-NEXT:        %[[CMPI_9:.*]] = arith.cmpi slt, %[[INDEX_CAST_10]], %[[CONSTANT_60]] : index
+// CHECK-NEXT:        %[[ADDI_10:.*]] = arith.addi %[[INDEX_CAST_10]], %[[DIM_16]] : index
+// CHECK-NEXT:        %[[SELECT_3:.*]] = arith.select %[[CMPI_9]], %[[ADDI_10]], %[[INDEX_CAST_10]] : index
+// CHECK-NEXT:        %[[MINSI_0:.*]] = arith.minsi %[[DIM_16]], %[[CONSTANT_60]] : index
+// CHECK-NEXT:        %[[MAXSI_0:.*]] = arith.maxsi %[[SELECT_3]], %[[CONSTANT_60]] : index
 // CHECK-NEXT:        %[[MINSI_1:.*]] = arith.minsi %[[MAXSI_0]], %[[DIM_16]] : index
 // CHECK-NEXT:        %[[SUBI_1:.*]] = arith.subi %[[MINSI_1]], %[[MINSI_0]] : index
-// CHECK-NEXT:        %[[MAXSI_1:.*]] = arith.maxsi %[[SUBI_1]], %[[CONSTANT_34]] : index
-// CHECK-NEXT:        %[[ALLOC_36:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
-// CHECK-NEXT:        memref.store %[[MAXSI_1]], %[[ALLOC_36]]{{\[}}%[[CONSTANT_34]]] : memref<1xindex>
-// CHECK-NEXT:        %[[DIM_17:.*]] = memref.dim %[[VAL_44]], %[[CONSTANT_34]] : memref<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[DIM_18:.*]] = memref.dim %[[VAL_44]], %[[CONSTANT_33]] : memref<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_37:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[DIM_17]], %[[ALLOC_37]]{{\[}}%[[CONSTANT_34]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[DIM_18]], %[[ALLOC_37]]{{\[}}%[[CONSTANT_33]]] : memref<3xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_32]], %[[ALLOC_37]]{{\[}}%[[CONSTANT_31]]] : memref<3xindex>
-// CHECK-NEXT:        %[[LOAD_34:.*]] = memref.load %[[ALLOC_36]]{{\[}}%[[CONSTANT_34]]] : memref<1xindex>
-// CHECK-NEXT:        %[[ALLOC_38:.*]] = memref.alloc(%[[LOAD_34]]) {alignment = 64 : i64} : memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[DIM_19:.*]] = memref.dim %[[VAL_44]], %[[CONSTANT_34]] : memref<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[DIM_20:.*]] = memref.dim %[[VAL_44]], %[[CONSTANT_33]] : memref<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[CONSTANT_35:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[LOAD_35:.*]] = memref.load %[[ALLOC_37]]{{\[}}%[[CONSTANT_35]]] : memref<3xindex>
-// CHECK-NEXT:        %[[CONSTANT_36:.*]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[LOAD_36:.*]] = memref.load %[[ALLOC_37]]{{\[}}%[[CONSTANT_36]]] : memref<3xindex>
-// CHECK-NEXT:        %[[ALLOC_OUTPUT_0:.*]] = hipsr.alloc_output(%[[VAL_41]], %[[LOAD_35]], %[[LOAD_36]]) {out_idx = 0 : i64} : memref<?x?x4096xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.slice(%[[VAL_41]]) ins(%[[VAL_42]] : memref<?xf16, #hipsr.mem<device>>) ends(%[[VAL_43]] : memref<1xi64, #hipsr.mem<host>>) outs(%[[ALLOC_38]] : memref<?xf16, #hipsr.mem<device>>) {axes_attr = array<i64: 0>, starts_attr = array<i64: 0>, steps_attr = array<i64: 1>}
-// CHECK-NEXT:        hipsr.scatter_nd(%[[VAL_41]]) ins(%[[VAL_46]], %[[VAL_47]], %[[ALLOC_38]] : memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<?xf16, #hipsr.mem<device>>) outs(%[[ALLOC_OUTPUT_0]] : memref<?x?x4096xf16, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_36]], %[[ALLOC_38]] : memref<1xindex>, memref<?xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_37]], %[[ALLOC_OUTPUT_0]] : memref<3xindex>, memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[MAXSI_1:.*]] = arith.maxsi %[[SUBI_1]], %[[CONSTANT_60]] : index
+// CHECK-NEXT:        %[[ALLOC_28:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1xindex>
+// CHECK-NEXT:        memref.store %[[MAXSI_1]], %[[ALLOC_28]]{{\[}}%[[CONSTANT_60]]] : memref<1xindex>
+// CHECK-NEXT:        %[[DIM_17:.*]] = memref.dim %[[VAL_49]], %[[CONSTANT_60]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_18:.*]] = memref.dim %[[VAL_49]], %[[CONSTANT_59]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_29:.*]] = memref.alloc() {alignment = 64 : i64} : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_17]], %[[ALLOC_29]]{{\[}}%[[CONSTANT_60]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[DIM_18]], %[[ALLOC_29]]{{\[}}%[[CONSTANT_59]]] : memref<3xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_58]], %[[ALLOC_29]]{{\[}}%[[CONSTANT_57]]] : memref<3xindex>
+// CHECK-NEXT:        %[[LOAD_34:.*]] = memref.load %[[ALLOC_28]]{{\[}}%[[CONSTANT_60]]] : memref<1xindex>
+// CHECK-NEXT:        %[[DIM_19:.*]] = memref.dim %[[VAL_49]], %[[CONSTANT_60]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[DIM_20:.*]] = memref.dim %[[VAL_49]], %[[CONSTANT_59]] : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CONSTANT_61:.*]] = arith.constant 2 : index
+// CHECK-NEXT:        %[[MULI_22:.*]] = arith.muli %[[CONSTANT_61]], %[[LOAD_34]] : index
+// CHECK-NEXT:        %[[CONSTANT_62:.*]] = arith.constant 256 : index
+// CHECK-NEXT:        %[[CONSTANT_63:.*]] = arith.constant 255 : index
+// CHECK-NEXT:        %[[ADDI_11:.*]] = arith.addi %[[MULI_22]], %[[CONSTANT_63]] : index
+// CHECK-NEXT:        %[[DIVUI_7:.*]] = arith.divui %[[ADDI_11]], %[[CONSTANT_62]] : index
+// CHECK-NEXT:        %[[MULI_23:.*]] = arith.muli %[[DIVUI_7]], %[[CONSTANT_62]] : index
+// CHECK-NEXT:        %[[CONSTANT_64:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[GET_POOL_4:.*]] = hipsr.get_pool(%[[VAL_46]], %[[MULI_23]]) {domain_id = 4 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[VIEW_8:.*]] = memref.view %[[GET_POOL_4]]{{\[}}%[[CONSTANT_64]]]{{\[}}%[[LOAD_34]]] : memref<?xi8, #hipsr.mem<device>> to memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CONSTANT_65:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[LOAD_35:.*]] = memref.load %[[ALLOC_29]]{{\[}}%[[CONSTANT_65]]] : memref<3xindex>
+// CHECK-NEXT:        %[[CONSTANT_66:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[LOAD_36:.*]] = memref.load %[[ALLOC_29]]{{\[}}%[[CONSTANT_66]]] : memref<3xindex>
+// CHECK-NEXT:        %[[ALLOC_OUTPUT_0:.*]] = hipsr.alloc_output(%[[VAL_46]], %[[LOAD_35]], %[[LOAD_36]]) {out_idx = 0 : i64} : memref<?x?x4096xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.slice(%[[VAL_46]]) ins(%[[VAL_47]] : memref<?xf16, #hipsr.mem<device>>) ends(%[[VAL_48]] : memref<1xi64, #hipsr.mem<host>>) outs(%[[VIEW_8]] : memref<?xf16, #hipsr.mem<device>>) {axes_attr = array<i64: 0>, starts_attr = array<i64: 0>, steps_attr = array<i64: 1>}
+// CHECK-NEXT:        hipsr.scatter_nd(%[[VAL_46]]) ins(%[[VAL_51]], %[[VAL_52]], %[[VIEW_8]] : memref<?x?x4096xf16, #hipsr.mem<device>>, memref<?x3xi64, #hipsr.mem<device>>, memref<?xf16, #hipsr.mem<device>>) outs(%[[ALLOC_OUTPUT_0]] : memref<?x?x4096xf16, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_28]], %[[VIEW_8]] : memref<1xindex>, memref<?xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_29]], %[[ALLOC_OUTPUT_0]] : memref<3xindex>, memref<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_OUTPUT_0]] : memref<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:      } -> memref<?x?x4096xf16, #hipsr.mem<device>> {domain_id = 4 : i64}
 // CHECK-NEXT:      return %[[POOL_DOMAIN_4]] : memref<?x?x4096xf16, #hipsr.mem<device>>
 // CHECK-NEXT:    }
-// CHECK-NEXT:  }
 
 
 

--- a/test/lit/Dialect/Hipsr/Pipelines/sample_dynamic.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/sample_dynamic.mlir
@@ -29,8 +29,8 @@
 // CHECK-NEXT:        %[[ALLOC_2:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_0]], %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_3]], %[[ALLOC_2]]{{\[}}%[[CONSTANT_3]]] : memref<2xindex>
-// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_1]]{{\[}}%[[CONSTANT_4]]] [%[[CONSTANT_4]]] [%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] [%[[CONSTANT_4]]] [%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_1]]{{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:        %[[ALLOC_3:.*]] = memref.alloc(%[[CONSTANT_4]]) {alignment = 64 : i64} : memref<?xindex>
 // CHECK-NEXT:        scf.for %[[VAL_3:.*]] = %[[CONSTANT_4]] to %[[CONSTANT_4]] step %[[CONSTANT_3]] {
 // CHECK-NEXT:          %[[CMPI_0:.*]] = arith.cmpi ult, %[[VAL_3]], %[[CONSTANT_4]] : index
@@ -56,120 +56,145 @@
 // CHECK-NEXT:        memref.store %[[DIM_1]], %[[ALLOC_4]]{{\[}}%[[CONSTANT_4]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_3]], %[[ALLOC_4]]{{\[}}%[[CONSTANT_3]]] : memref<2xindex>
 // CHECK-NEXT:        %[[ALLOC_5:.*]] = memref.alloc(%[[CONSTANT_5]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_5]]{{\[}}0] [%[[CONSTANT_4]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_5]][0] {{\[}}%[[CONSTANT_4]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_3]], %[[SUBVIEW_2]] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        %[[SUBVIEW_3:.*]] = memref.subview %[[ALLOC_5]]{{\[}}%[[CONSTANT_4]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_4]], %[[SUBVIEW_3]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        %[[LOAD_2:.*]] = memref.load %[[ALLOC_5]]{{\[}}%[[CONSTANT_4]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_6:.*]] = memref.alloc(%[[LOAD_2]]) {alignment = 64 : i64} : memref<?x1xf16, #hipsr.mem<device>>
 // CHECK-NEXT:        %[[LOAD_3:.*]] = memref.load %[[ALLOC_5]]{{\[}}%[[CONSTANT_4]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_7:.*]] = memref.alloc(%[[LOAD_3]]) {alignment = 64 : i64} : memref<?x1xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_8:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.matmul(%[[VAL_0]]) ins(%[[VAL_1]], %[[CONSTANT_2]] : memref<?x3xf16, #hipsr.mem<device>>, memref<3x1xf16, #hipsr.mem<device>>) outs(%[[ALLOC_6]] : memref<?x1xf16, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.cast(%[[VAL_0]]) ins(%[[ALLOC_6]] : memref<?x1xf16, #hipsr.mem<device>>) outs(%[[ALLOC_7]] : memref<?x1xf32, #hipsr.mem<device>>)
-// CHECK-NEXT:        %[[COMPUTE_0:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[VAL_2]] : memref<?x4xf32, #hipsr.mem<device>>) outs(%[[ALLOC_8]] : memref<2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        %[[CONSTANT_6:.*]] = arith.constant 2 : index
+// CHECK-NEXT:        %[[MULI_0:.*]] = arith.muli %[[CONSTANT_6]], %[[LOAD_2]] : index
+// CHECK-NEXT:        %[[CONSTANT_7:.*]] = arith.constant 256 : index
+// CHECK-NEXT:        %[[CONSTANT_8:.*]] = arith.constant 255 : index
+// CHECK-NEXT:        %[[ADDI_0:.*]] = arith.addi %[[MULI_0]], %[[CONSTANT_8]] : index
+// CHECK-NEXT:        %[[DIVUI_0:.*]] = arith.divui %[[ADDI_0]], %[[CONSTANT_7]] : index
+// CHECK-NEXT:        %[[MULI_1:.*]] = arith.muli %[[DIVUI_0]], %[[CONSTANT_7]] : index
+// CHECK-NEXT:        %[[CONSTANT_9:.*]] = arith.constant 4 : index
+// CHECK-NEXT:        %[[MULI_2:.*]] = arith.muli %[[CONSTANT_9]], %[[LOAD_3]] : index
+// CHECK-NEXT:        %[[CONSTANT_10:.*]] = arith.constant 256 : index
+// CHECK-NEXT:        %[[CONSTANT_11:.*]] = arith.constant 255 : index
+// CHECK-NEXT:        %[[ADDI_1:.*]] = arith.addi %[[MULI_2]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:        %[[DIVUI_1:.*]] = arith.divui %[[ADDI_1]], %[[CONSTANT_10]] : index
+// CHECK-NEXT:        %[[MULI_3:.*]] = arith.muli %[[DIVUI_1]], %[[CONSTANT_10]] : index
+// CHECK-NEXT:        %[[CONSTANT_12:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[ADDI_2:.*]] = arith.addi %[[MULI_1]], %[[MULI_3]] : index
+// CHECK-NEXT:        %[[GET_POOL_0:.*]] = hipsr.get_pool(%[[VAL_0]], %[[ADDI_2]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[VIEW_0:.*]] = memref.view %[[GET_POOL_0]]{{\[}}%[[CONSTANT_12]]]{{\[}}%[[LOAD_2]]] : memref<?xi8, #hipsr.mem<device>> to memref<?x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[VIEW_1:.*]] = memref.view %[[GET_POOL_0]]{{\[}}%[[MULI_1]]]{{\[}}%[[LOAD_3]]] : memref<?xi8, #hipsr.mem<device>> to memref<?x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_6:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.matmul(%[[VAL_0]]) ins(%[[VAL_1]], %[[CONSTANT_2]] : memref<?x3xf16, #hipsr.mem<device>>, memref<3x1xf16, #hipsr.mem<device>>) outs(%[[VIEW_0]] : memref<?x1xf16, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.cast(%[[VAL_0]]) ins(%[[VIEW_0]] : memref<?x1xf16, #hipsr.mem<device>>) outs(%[[VIEW_1]] : memref<?x1xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        %[[COMPUTE_0:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[VAL_2]] : memref<?x4xf32, #hipsr.mem<device>>) outs(%[[ALLOC_6]] : memref<2xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:        ^bb0(%[[VAL_4:.*]]: !hipsr.context, %[[VAL_5:.*]]: memref<?x4xf32, #hipsr.mem<device>>, %[[VAL_6:.*]]: memref<2xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:          %[[CONSTANT_6:.*]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[CONSTANT_7:.*]] = arith.constant 4 : i64
-// CHECK-NEXT:          %[[CONSTANT_8:.*]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[DIM_2:.*]] = memref.dim %[[VAL_5]], %[[CONSTANT_8]] : memref<?x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:          %[[CONSTANT_13:.*]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[CONSTANT_14:.*]] = arith.constant 4 : i64
+// CHECK-NEXT:          %[[CONSTANT_15:.*]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[DIM_2:.*]] = memref.dim %[[VAL_5]], %[[CONSTANT_15]] : memref<?x4xf32, #hipsr.mem<device>>
 // CHECK-NEXT:          %[[INDEX_CAST_0:.*]] = arith.index_cast %[[DIM_2]] : index to i64
-// CHECK-NEXT:          memref.store %[[INDEX_CAST_0]], %[[VAL_6]]{{\[}}%[[CONSTANT_8]]] : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:          memref.store %[[CONSTANT_7]], %[[VAL_6]]{{\[}}%[[CONSTANT_6]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[INDEX_CAST_0]], %[[VAL_6]]{{\[}}%[[CONSTANT_15]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[CONSTANT_14]], %[[VAL_6]]{{\[}}%[[CONSTANT_13]]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:          hipsr.compute_yield %[[VAL_6]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        } : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_5]], %[[ALLOC_6]] : memref<?xindex>, memref<?x1xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_5]], %[[ALLOC_7]] : memref<?xindex>, memref<?x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_5]], %[[VIEW_0]] : memref<?xindex>, memref<?x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_5]], %[[VIEW_1]] : memref<?xindex>, memref<?x1xf32, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_0]], %[[COMPUTE_0]] : memref<1xindex>, memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_7]], %[[COMPUTE_0]], %[[CONSTANT_1]] : memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[VIEW_1]], %[[COMPUTE_0]], %[[CONSTANT_1]] : memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      } -> memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#0, %[[POOL_DOMAIN_0]]#1, %[[POOL_DOMAIN_0]]#2 : !hipsr.context, memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_7:.*]]: !hipsr.context, %[[VAL_8:.*]]: memref<?x1xf32, #hipsr.mem<device>>, %[[VAL_9:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_10:.*]]: memref<4x2xf32, #hipsr.mem<device>>):
-// CHECK-NEXT:        %[[CONSTANT_9:.*]] = arith.constant 2 : index
-// CHECK-NEXT:        %[[CONSTANT_10:.*]] = arith.constant 4 : index
-// CHECK-NEXT:        %[[CONSTANT_11:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[CONSTANT_12:.*]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[DIM_3:.*]] = memref.dim %[[VAL_8]], %[[CONSTANT_11]] : memref<?x1xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_9:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[DIM_3]], %[[ALLOC_9]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_12]], %[[ALLOC_9]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
-// CHECK-NEXT:        %[[LOAD_4:.*]] = memref.load %[[VAL_9]]{{\[}}%[[CONSTANT_11]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]] = hipsr.pool_domain(%[[ARG0]], %[[VAL_7:.*]]#0, %[[VAL_7]]#1, %[[VAL_7]]#2 : !hipsr.context, memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_8:.*]]: !hipsr.context, %[[VAL_9:.*]]: memref<?x1xf32, #hipsr.mem<device>>, %[[VAL_10:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_11:.*]]: memref<4x2xf32, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[CONSTANT_16:.*]] = arith.constant 2 : index
+// CHECK-NEXT:        %[[CONSTANT_17:.*]] = arith.constant 4 : index
+// CHECK-NEXT:        %[[CONSTANT_18:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[CONSTANT_19:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[DIM_3:.*]] = memref.dim %[[VAL_9]], %[[CONSTANT_18]] : memref<?x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_7:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[DIM_3]], %[[ALLOC_7]]{{\[}}%[[CONSTANT_18]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_19]], %[[ALLOC_7]]{{\[}}%[[CONSTANT_19]]] : memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_4:.*]] = memref.load %[[VAL_10]]{{\[}}%[[CONSTANT_18]]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_1:.*]] = arith.index_cast %[[LOAD_4]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_5:.*]] = memref.load %[[VAL_9]]{{\[}}%[[CONSTANT_12]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_5:.*]] = memref.load %[[VAL_10]]{{\[}}%[[CONSTANT_19]]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_2:.*]] = arith.index_cast %[[LOAD_5]] : i64 to index
-// CHECK-NEXT:        %[[ALLOC_10:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_1]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_2]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_11:.*]] = memref.alloc(%[[CONSTANT_9]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_11:.*]] = %[[CONSTANT_11]] to %[[CONSTANT_9]] step %[[CONSTANT_12]] {
-// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_11]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:        %[[ALLOC_8:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_1]], %[[ALLOC_8]]{{\[}}%[[CONSTANT_18]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_2]], %[[ALLOC_8]]{{\[}}%[[CONSTANT_19]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_9:.*]] = memref.alloc(%[[CONSTANT_16]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        scf.for %[[VAL_12:.*]] = %[[CONSTANT_18]] to %[[CONSTANT_16]] step %[[CONSTANT_19]] {
+// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_12]], %[[CONSTANT_18]] : index
 // CHECK-NEXT:          %[[IF_2:.*]] = scf.if %[[CMPI_3]] -> (index) {
-// CHECK-NEXT:            scf.yield %[[CONSTANT_12]] : index
+// CHECK-NEXT:            scf.yield %[[CONSTANT_19]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_6:.*]] = memref.load %[[ALLOC_9]]{{\[}}%[[VAL_11]]] : memref<2xindex>
+// CHECK-NEXT:            %[[LOAD_6:.*]] = memref.load %[[ALLOC_7]]{{\[}}%[[VAL_12]]] : memref<2xindex>
 // CHECK-NEXT:            scf.yield %[[LOAD_6]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_11]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_12]], %[[CONSTANT_18]] : index
 // CHECK-NEXT:          %[[IF_3:.*]] = scf.if %[[CMPI_4]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_2]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_7:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[VAL_11]]] : memref<2xindex>
-// CHECK-NEXT:            %[[CMPI_5:.*]] = arith.cmpi eq, %[[LOAD_7]], %[[CONSTANT_12]] : index
+// CHECK-NEXT:            %[[LOAD_7:.*]] = memref.load %[[ALLOC_8]]{{\[}}%[[VAL_12]]] : memref<2xindex>
+// CHECK-NEXT:            %[[CMPI_5:.*]] = arith.cmpi eq, %[[LOAD_7]], %[[CONSTANT_19]] : index
 // CHECK-NEXT:            %[[SELECT_1:.*]] = arith.select %[[CMPI_5]], %[[IF_2]], %[[LOAD_7]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_1]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_11]]{{\[}}%[[VAL_11]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_9]]{{\[}}%[[VAL_12]]] : memref<?xindex>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[CAST_0:.*]] = memref.cast %[[ALLOC_11]] : memref<?xindex> to memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_12:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_10]], %[[ALLOC_12]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_12]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
-// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[CAST_0]]{{\[}}%[[CONSTANT_11]]] [%[[CONSTANT_11]]] [%[[CONSTANT_12]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_12]]{{\[}}%[[CONSTANT_11]]] [%[[CONSTANT_11]]] [%[[CONSTANT_12]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[ALLOC_13:.*]] = memref.alloc(%[[CONSTANT_11]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_12:.*]] = %[[CONSTANT_11]] to %[[CONSTANT_11]] step %[[CONSTANT_12]] {
-// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_12]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:        %[[CAST_0:.*]] = memref.cast %[[ALLOC_9]] : memref<?xindex> to memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_10:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_17]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_18]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_16]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_19]]] : memref<2xindex>
+// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[CAST_0]]{{\[}}%[[CONSTANT_18]]] {{\[}}%[[CONSTANT_18]]] {{\[}}%[[CONSTANT_19]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_10]]{{\[}}%[[CONSTANT_18]]] {{\[}}%[[CONSTANT_18]]] {{\[}}%[[CONSTANT_19]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[ALLOC_11:.*]] = memref.alloc(%[[CONSTANT_18]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        scf.for %[[VAL_13:.*]] = %[[CONSTANT_18]] to %[[CONSTANT_18]] step %[[CONSTANT_19]] {
+// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_13]], %[[CONSTANT_18]] : index
 // CHECK-NEXT:          %[[IF_4:.*]] = scf.if %[[CMPI_6]] -> (index) {
-// CHECK-NEXT:            scf.yield %[[CONSTANT_12]] : index
+// CHECK-NEXT:            scf.yield %[[CONSTANT_19]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_8:.*]] = memref.load %[[SUBVIEW_4]]{{\[}}%[[VAL_12]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            %[[LOAD_8:.*]] = memref.load %[[SUBVIEW_4]]{{\[}}%[[VAL_13]]] : memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:            scf.yield %[[LOAD_8]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_12]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_13]], %[[CONSTANT_18]] : index
 // CHECK-NEXT:          %[[IF_5:.*]] = scf.if %[[CMPI_7]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_4]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_9:.*]] = memref.load %[[SUBVIEW_5]]{{\[}}%[[VAL_12]]] : memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:            %[[CMPI_8:.*]] = arith.cmpi eq, %[[LOAD_9]], %[[CONSTANT_12]] : index
+// CHECK-NEXT:            %[[LOAD_9:.*]] = memref.load %[[SUBVIEW_5]]{{\[}}%[[VAL_13]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            %[[CMPI_8:.*]] = arith.cmpi eq, %[[LOAD_9]], %[[CONSTANT_19]] : index
 // CHECK-NEXT:            %[[SELECT_2:.*]] = arith.select %[[CMPI_8]], %[[IF_4]], %[[LOAD_9]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_2]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_13]]{{\[}}%[[VAL_12]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_11]]{{\[}}%[[VAL_13]]] : memref<?xindex>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[LOAD_10:.*]] = memref.load %[[ALLOC_11]]{{\[}}%[[CONSTANT_11]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_14:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[LOAD_10]], %[[ALLOC_14]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_9]], %[[ALLOC_14]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_15:.*]] = memref.alloc(%[[CONSTANT_9]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_6:.*]] = memref.subview %[[ALLOC_15]]{{\[}}0] [%[[CONSTANT_11]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
-// CHECK-NEXT:        memref.copy %[[ALLOC_13]], %[[SUBVIEW_6]] : memref<?xindex> to memref<?xindex, strided<[1]>>
-// CHECK-NEXT:        %[[SUBVIEW_7:.*]] = memref.subview %[[ALLOC_15]]{{\[}}%[[CONSTANT_11]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
-// CHECK-NEXT:        memref.copy %[[ALLOC_14]], %[[SUBVIEW_7]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
-// CHECK-NEXT:        %[[LOAD_11:.*]] = memref.load %[[ALLOC_11]]{{\[}}%[[CONSTANT_11]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_16:.*]] = memref.alloc(%[[LOAD_11]]) {alignment = 64 : i64} : memref<?x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[LOAD_12:.*]] = memref.load %[[ALLOC_15]]{{\[}}%[[CONSTANT_11]]] : memref<?xindex>
-// CHECK-NEXT:        %[[CONSTANT_13:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[LOAD_13:.*]] = memref.load %[[ALLOC_15]]{{\[}}%[[CONSTANT_13]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_OUTPUT_0:.*]] = hipsr.alloc_output(%[[VAL_7]], %[[LOAD_13]]) {out_idx = 0 : i64} : memref<?x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.expand(%[[VAL_7]]) ins(%[[VAL_8]], %[[VAL_9]] : memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_16]] : memref<?x4xf32, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.matmul(%[[VAL_7]]) ins(%[[ALLOC_16]], %[[VAL_10]] : memref<?x4xf32, #hipsr.mem<device>>, memref<4x2xf32, #hipsr.mem<device>>) outs(%[[ALLOC_OUTPUT_0]] : memref<?x2xf32, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_0]], %[[ALLOC_16]] : memref<2xindex>, memref<?x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_15]], %[[ALLOC_OUTPUT_0]] : memref<?xindex>, memref<?x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[LOAD_10:.*]] = memref.load %[[ALLOC_9]]{{\[}}%[[CONSTANT_18]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_12:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[LOAD_10]], %[[ALLOC_12]]{{\[}}%[[CONSTANT_18]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_16]], %[[ALLOC_12]]{{\[}}%[[CONSTANT_19]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_13:.*]] = memref.alloc(%[[CONSTANT_16]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        %[[SUBVIEW_6:.*]] = memref.subview %[[ALLOC_13]][0] {{\[}}%[[CONSTANT_18]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        memref.copy %[[ALLOC_11]], %[[SUBVIEW_6]] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_7:.*]] = memref.subview %[[ALLOC_13]]{{\[}}%[[CONSTANT_18]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        memref.copy %[[ALLOC_12]], %[[SUBVIEW_7]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        %[[LOAD_11:.*]] = memref.load %[[ALLOC_9]]{{\[}}%[[CONSTANT_18]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOAD_12:.*]] = memref.load %[[ALLOC_13]]{{\[}}%[[CONSTANT_18]]] : memref<?xindex>
+// CHECK-NEXT:        %[[CONSTANT_20:.*]] = arith.constant 16 : index
+// CHECK-NEXT:        %[[MULI_4:.*]] = arith.muli %[[CONSTANT_20]], %[[LOAD_11]] : index
+// CHECK-NEXT:        %[[CONSTANT_21:.*]] = arith.constant 256 : index
+// CHECK-NEXT:        %[[CONSTANT_22:.*]] = arith.constant 255 : index
+// CHECK-NEXT:        %[[ADDI_3:.*]] = arith.addi %[[MULI_4]], %[[CONSTANT_22]] : index
+// CHECK-NEXT:        %[[DIVUI_2:.*]] = arith.divui %[[ADDI_3]], %[[CONSTANT_21]] : index
+// CHECK-NEXT:        %[[MULI_5:.*]] = arith.muli %[[DIVUI_2]], %[[CONSTANT_21]] : index
+// CHECK-NEXT:        %[[CONSTANT_23:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[GET_POOL_1:.*]] = hipsr.get_pool(%[[VAL_8]], %[[MULI_5]]) {domain_id = 1 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[VIEW_2:.*]] = memref.view %[[GET_POOL_1]]{{\[}}%[[CONSTANT_23]]]{{\[}}%[[LOAD_11]]] : memref<?xi8, #hipsr.mem<device>> to memref<?x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CONSTANT_24:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[LOAD_13:.*]] = memref.load %[[ALLOC_13]]{{\[}}%[[CONSTANT_24]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_OUTPUT_0:.*]] = hipsr.alloc_output(%[[VAL_8]], %[[LOAD_13]]) {out_idx = 0 : i64} : memref<?x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.expand(%[[VAL_8]]) ins(%[[VAL_9]], %[[VAL_10]] : memref<?x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>) outs(%[[VIEW_2]] : memref<?x4xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.matmul(%[[VAL_8]]) ins(%[[VIEW_2]], %[[VAL_11]] : memref<?x4xf32, #hipsr.mem<device>>, memref<4x2xf32, #hipsr.mem<device>>) outs(%[[ALLOC_OUTPUT_0]] : memref<?x2xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_0]], %[[VIEW_2]] : memref<2xindex>, memref<?x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_13]], %[[ALLOC_OUTPUT_0]] : memref<?xindex>, memref<?x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_OUTPUT_0]] : memref<?x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      } -> memref<?x2xf32, #hipsr.mem<device>> {domain_id = 1 : i64}
 // CHECK-NEXT:      return %[[POOL_DOMAIN_1]] : memref<?x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    }
-// CHECK-NEXT:  }
 
 
 

--- a/test/lit/Dialect/Hipsr/Pipelines/sample_static.mlir
+++ b/test/lit/Dialect/Hipsr/Pipelines/sample_static.mlir
@@ -27,8 +27,8 @@
 // CHECK-NEXT:        %[[ALLOC_2:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_0]], %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_3]], %[[ALLOC_2]]{{\[}}%[[CONSTANT_3]]] : memref<2xindex>
-// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_1]]{{\[}}%[[CONSTANT_4]]] [%[[CONSTANT_4]]] [%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] [%[[CONSTANT_4]]] [%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_0:.*]] = memref.subview %[[ALLOC_1]]{{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_1:.*]] = memref.subview %[[ALLOC_2]]{{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_4]]] {{\[}}%[[CONSTANT_3]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:        %[[ALLOC_3:.*]] = memref.alloc(%[[CONSTANT_4]]) {alignment = 64 : i64} : memref<?xindex>
 // CHECK-NEXT:        scf.for %[[VAL_3:.*]] = %[[CONSTANT_4]] to %[[CONSTANT_4]] step %[[CONSTANT_3]] {
 // CHECK-NEXT:          %[[CMPI_0:.*]] = arith.cmpi ult, %[[VAL_3]], %[[CONSTANT_4]] : index
@@ -53,112 +53,134 @@
 // CHECK-NEXT:        memref.store %[[CONSTANT_5]], %[[ALLOC_4]]{{\[}}%[[CONSTANT_4]]] : memref<2xindex>
 // CHECK-NEXT:        memref.store %[[CONSTANT_3]], %[[ALLOC_4]]{{\[}}%[[CONSTANT_3]]] : memref<2xindex>
 // CHECK-NEXT:        %[[ALLOC_5:.*]] = memref.alloc(%[[CONSTANT_5]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_5]]{{\[}}0] [%[[CONSTANT_4]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_2:.*]] = memref.subview %[[ALLOC_5]][0] {{\[}}%[[CONSTANT_4]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_3]], %[[SUBVIEW_2]] : memref<?xindex> to memref<?xindex, strided<[1]>>
 // CHECK-NEXT:        %[[SUBVIEW_3:.*]] = memref.subview %[[ALLOC_5]]{{\[}}%[[CONSTANT_4]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
 // CHECK-NEXT:        memref.copy %[[ALLOC_4]], %[[SUBVIEW_3]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
-// CHECK-NEXT:        %[[ALLOC_6:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2x1xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_7:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2x1xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_8:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.matmul(%[[VAL_0]]) ins(%[[VAL_1]], %[[CONSTANT_2]] : memref<2x3xf16, #hipsr.mem<device>>, memref<3x1xf16, #hipsr.mem<device>>) outs(%[[ALLOC_6]] : memref<2x1xf16, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.cast(%[[VAL_0]]) ins(%[[ALLOC_6]] : memref<2x1xf16, #hipsr.mem<device>>) outs(%[[ALLOC_7]] : memref<2x1xf32, #hipsr.mem<device>>)
-// CHECK-NEXT:        %[[COMPUTE_0:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[VAL_2]] : memref<2x4xf32, #hipsr.mem<device>>) outs(%[[ALLOC_8]] : memref<2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:        %[[CONSTANT_6:.*]] = arith.constant 4 : index
+// CHECK-NEXT:        %[[CONSTANT_7:.*]] = arith.constant 256 : index
+// CHECK-NEXT:        %[[CONSTANT_8:.*]] = arith.constant 255 : index
+// CHECK-NEXT:        %[[ADDI_0:.*]] = arith.addi %[[CONSTANT_6]], %[[CONSTANT_8]] : index
+// CHECK-NEXT:        %[[DIVUI_0:.*]] = arith.divui %[[ADDI_0]], %[[CONSTANT_7]] : index
+// CHECK-NEXT:        %[[MULI_0:.*]] = arith.muli %[[DIVUI_0]], %[[CONSTANT_7]] : index
+// CHECK-NEXT:        %[[CONSTANT_9:.*]] = arith.constant 8 : index
+// CHECK-NEXT:        %[[CONSTANT_10:.*]] = arith.constant 256 : index
+// CHECK-NEXT:        %[[CONSTANT_11:.*]] = arith.constant 255 : index
+// CHECK-NEXT:        %[[ADDI_1:.*]] = arith.addi %[[CONSTANT_9]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:        %[[DIVUI_1:.*]] = arith.divui %[[ADDI_1]], %[[CONSTANT_10]] : index
+// CHECK-NEXT:        %[[MULI_1:.*]] = arith.muli %[[DIVUI_1]], %[[CONSTANT_10]] : index
+// CHECK-NEXT:        %[[CONSTANT_12:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[ADDI_2:.*]] = arith.addi %[[MULI_0]], %[[MULI_1]] : index
+// CHECK-NEXT:        %[[GET_POOL_0:.*]] = hipsr.get_pool(%[[VAL_0]], %[[ADDI_2]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[VIEW_0:.*]] = memref.view %[[GET_POOL_0]]{{\[}}%[[CONSTANT_12]]][] : memref<?xi8, #hipsr.mem<device>> to memref<2x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[VIEW_1:.*]] = memref.view %[[GET_POOL_0]]{{\[}}%[[MULI_0]]][] : memref<?xi8, #hipsr.mem<device>> to memref<2x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_6:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        hipsr.matmul(%[[VAL_0]]) ins(%[[VAL_1]], %[[CONSTANT_2]] : memref<2x3xf16, #hipsr.mem<device>>, memref<3x1xf16, #hipsr.mem<device>>) outs(%[[VIEW_0]] : memref<2x1xf16, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.cast(%[[VAL_0]]) ins(%[[VIEW_0]] : memref<2x1xf16, #hipsr.mem<device>>) outs(%[[VIEW_1]] : memref<2x1xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        %[[COMPUTE_0:.*]] = hipsr.compute(%[[VAL_0]]) ins(%[[VAL_2]] : memref<2x4xf32, #hipsr.mem<device>>) outs(%[[ALLOC_6]] : memref<2xi64, #hipsr.mem<host>>) {
 // CHECK-NEXT:        ^bb0(%[[VAL_4:.*]]: !hipsr.context, %[[VAL_5:.*]]: memref<2x4xf32, #hipsr.mem<device>>, %[[VAL_6:.*]]: memref<2xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:          %[[CONSTANT_6:.*]] = arith.constant 1 : index
-// CHECK-NEXT:          %[[CONSTANT_7:.*]] = arith.constant 4 : i64
-// CHECK-NEXT:          %[[CONSTANT_8:.*]] = arith.constant 2 : i64
-// CHECK-NEXT:          %[[CONSTANT_9:.*]] = arith.constant 0 : index
-// CHECK-NEXT:          memref.store %[[CONSTANT_8]], %[[VAL_6]]{{\[}}%[[CONSTANT_9]]] : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:          memref.store %[[CONSTANT_7]], %[[VAL_6]]{{\[}}%[[CONSTANT_6]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          %[[CONSTANT_13:.*]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[CONSTANT_14:.*]] = arith.constant 4 : i64
+// CHECK-NEXT:          %[[CONSTANT_15:.*]] = arith.constant 2 : i64
+// CHECK-NEXT:          %[[CONSTANT_16:.*]] = arith.constant 0 : index
+// CHECK-NEXT:          memref.store %[[CONSTANT_15]], %[[VAL_6]]{{\[}}%[[CONSTANT_16]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          memref.store %[[CONSTANT_14]], %[[VAL_6]]{{\[}}%[[CONSTANT_13]]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:          hipsr.compute_yield %[[VAL_6]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        } : memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_5]], %[[ALLOC_6]] : memref<?xindex>, memref<2x1xf16, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_5]], %[[ALLOC_7]] : memref<?xindex>, memref<2x1xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_5]], %[[VIEW_0]] : memref<?xindex>, memref<2x1xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_5]], %[[VIEW_1]] : memref<?xindex>, memref<2x1xf32, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_0]], %[[COMPUTE_0]] : memref<1xindex>, memref<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_7]], %[[COMPUTE_0]], %[[CONSTANT_1]] : memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[VIEW_1]], %[[COMPUTE_0]], %[[CONSTANT_1]] : memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      } -> memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]] = hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]]#0, %[[POOL_DOMAIN_0]]#1, %[[POOL_DOMAIN_0]]#2 : !hipsr.context, memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>) {
-// CHECK-NEXT:      ^bb0(%[[VAL_7:.*]]: !hipsr.context, %[[VAL_8:.*]]: memref<2x1xf32, #hipsr.mem<device>>, %[[VAL_9:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_10:.*]]: memref<4x2xf32, #hipsr.mem<device>>):
-// CHECK-NEXT:        %[[CONSTANT_10:.*]] = arith.constant 4 : index
-// CHECK-NEXT:        %[[CONSTANT_11:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[CONSTANT_12:.*]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[CONSTANT_13:.*]] = arith.constant 2 : index
-// CHECK-NEXT:        %[[ALLOC_9:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_13]], %[[ALLOC_9]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_12]], %[[ALLOC_9]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
-// CHECK-NEXT:        %[[LOAD_2:.*]] = memref.load %[[VAL_9]]{{\[}}%[[CONSTANT_11]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:      %[[POOL_DOMAIN_1:.*]] = hipsr.pool_domain(%[[ARG0]], %[[VAL_7:.*]]#0, %[[VAL_7]]#1, %[[VAL_7]]#2 : !hipsr.context, memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>, memref<4x2xf32, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_8:.*]]: !hipsr.context, %[[VAL_9:.*]]: memref<2x1xf32, #hipsr.mem<device>>, %[[VAL_10:.*]]: memref<2xi64, #hipsr.mem<host>>, %[[VAL_11:.*]]: memref<4x2xf32, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[CONSTANT_17:.*]] = arith.constant 4 : index
+// CHECK-NEXT:        %[[CONSTANT_18:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[CONSTANT_19:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[CONSTANT_20:.*]] = arith.constant 2 : index
+// CHECK-NEXT:        %[[ALLOC_7:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_20]], %[[ALLOC_7]]{{\[}}%[[CONSTANT_18]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_19]], %[[ALLOC_7]]{{\[}}%[[CONSTANT_19]]] : memref<2xindex>
+// CHECK-NEXT:        %[[LOAD_2:.*]] = memref.load %[[VAL_10]]{{\[}}%[[CONSTANT_18]]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_0:.*]] = arith.index_cast %[[LOAD_2]] : i64 to index
-// CHECK-NEXT:        %[[LOAD_3:.*]] = memref.load %[[VAL_9]]{{\[}}%[[CONSTANT_12]]] : memref<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:        %[[LOAD_3:.*]] = memref.load %[[VAL_10]]{{\[}}%[[CONSTANT_19]]] : memref<2xi64, #hipsr.mem<host>>
 // CHECK-NEXT:        %[[INDEX_CAST_1:.*]] = arith.index_cast %[[LOAD_3]] : i64 to index
-// CHECK-NEXT:        %[[ALLOC_10:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_0]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[INDEX_CAST_1]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_11:.*]] = memref.alloc(%[[CONSTANT_13]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_11:.*]] = %[[CONSTANT_11]] to %[[CONSTANT_13]] step %[[CONSTANT_12]] {
-// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_11]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:        %[[ALLOC_8:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_0]], %[[ALLOC_8]]{{\[}}%[[CONSTANT_18]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[INDEX_CAST_1]], %[[ALLOC_8]]{{\[}}%[[CONSTANT_19]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_9:.*]] = memref.alloc(%[[CONSTANT_20]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        scf.for %[[VAL_12:.*]] = %[[CONSTANT_18]] to %[[CONSTANT_20]] step %[[CONSTANT_19]] {
+// CHECK-NEXT:          %[[CMPI_3:.*]] = arith.cmpi ult, %[[VAL_12]], %[[CONSTANT_18]] : index
 // CHECK-NEXT:          %[[IF_2:.*]] = scf.if %[[CMPI_3]] -> (index) {
-// CHECK-NEXT:            scf.yield %[[CONSTANT_12]] : index
+// CHECK-NEXT:            scf.yield %[[CONSTANT_19]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_4:.*]] = memref.load %[[ALLOC_9]]{{\[}}%[[VAL_11]]] : memref<2xindex>
+// CHECK-NEXT:            %[[LOAD_4:.*]] = memref.load %[[ALLOC_7]]{{\[}}%[[VAL_12]]] : memref<2xindex>
 // CHECK-NEXT:            scf.yield %[[LOAD_4]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_11]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:          %[[CMPI_4:.*]] = arith.cmpi ult, %[[VAL_12]], %[[CONSTANT_18]] : index
 // CHECK-NEXT:          %[[IF_3:.*]] = scf.if %[[CMPI_4]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_2]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_5:.*]] = memref.load %[[ALLOC_10]]{{\[}}%[[VAL_11]]] : memref<2xindex>
-// CHECK-NEXT:            %[[CMPI_5:.*]] = arith.cmpi eq, %[[LOAD_5]], %[[CONSTANT_12]] : index
+// CHECK-NEXT:            %[[LOAD_5:.*]] = memref.load %[[ALLOC_8]]{{\[}}%[[VAL_12]]] : memref<2xindex>
+// CHECK-NEXT:            %[[CMPI_5:.*]] = arith.cmpi eq, %[[LOAD_5]], %[[CONSTANT_19]] : index
 // CHECK-NEXT:            %[[SELECT_1:.*]] = arith.select %[[CMPI_5]], %[[IF_2]], %[[LOAD_5]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_1]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_11]]{{\[}}%[[VAL_11]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_3]], %[[ALLOC_9]]{{\[}}%[[VAL_12]]] : memref<?xindex>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[CAST_0:.*]] = memref.cast %[[ALLOC_11]] : memref<?xindex> to memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_12:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_10]], %[[ALLOC_12]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_13]], %[[ALLOC_12]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
-// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[CAST_0]]{{\[}}%[[CONSTANT_11]]] [%[[CONSTANT_11]]] [%[[CONSTANT_12]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_12]]{{\[}}%[[CONSTANT_11]]] [%[[CONSTANT_11]]] [%[[CONSTANT_12]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:        %[[ALLOC_13:.*]] = memref.alloc(%[[CONSTANT_11]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        scf.for %[[VAL_12:.*]] = %[[CONSTANT_11]] to %[[CONSTANT_11]] step %[[CONSTANT_12]] {
-// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_12]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:        %[[CAST_0:.*]] = memref.cast %[[ALLOC_9]] : memref<?xindex> to memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_10:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_17]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_18]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_20]], %[[ALLOC_10]]{{\[}}%[[CONSTANT_19]]] : memref<2xindex>
+// CHECK-NEXT:        %[[SUBVIEW_4:.*]] = memref.subview %[[CAST_0]]{{\[}}%[[CONSTANT_18]]] {{\[}}%[[CONSTANT_18]]] {{\[}}%[[CONSTANT_19]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[SUBVIEW_5:.*]] = memref.subview %[[ALLOC_10]]{{\[}}%[[CONSTANT_18]]] {{\[}}%[[CONSTANT_18]]] {{\[}}%[[CONSTANT_19]]] : memref<2xindex> to memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:        %[[ALLOC_11:.*]] = memref.alloc(%[[CONSTANT_18]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        scf.for %[[VAL_13:.*]] = %[[CONSTANT_18]] to %[[CONSTANT_18]] step %[[CONSTANT_19]] {
+// CHECK-NEXT:          %[[CMPI_6:.*]] = arith.cmpi ult, %[[VAL_13]], %[[CONSTANT_18]] : index
 // CHECK-NEXT:          %[[IF_4:.*]] = scf.if %[[CMPI_6]] -> (index) {
-// CHECK-NEXT:            scf.yield %[[CONSTANT_12]] : index
+// CHECK-NEXT:            scf.yield %[[CONSTANT_19]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_6:.*]] = memref.load %[[SUBVIEW_4]]{{\[}}%[[VAL_12]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            %[[LOAD_6:.*]] = memref.load %[[SUBVIEW_4]]{{\[}}%[[VAL_13]]] : memref<?xindex, strided<[?], offset: ?>>
 // CHECK-NEXT:            scf.yield %[[LOAD_6]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_12]], %[[CONSTANT_11]] : index
+// CHECK-NEXT:          %[[CMPI_7:.*]] = arith.cmpi ult, %[[VAL_13]], %[[CONSTANT_18]] : index
 // CHECK-NEXT:          %[[IF_5:.*]] = scf.if %[[CMPI_7]] -> (index) {
 // CHECK-NEXT:            scf.yield %[[IF_4]] : index
 // CHECK-NEXT:          } else {
-// CHECK-NEXT:            %[[LOAD_7:.*]] = memref.load %[[SUBVIEW_5]]{{\[}}%[[VAL_12]]] : memref<?xindex, strided<[?], offset: ?>>
-// CHECK-NEXT:            %[[CMPI_8:.*]] = arith.cmpi eq, %[[LOAD_7]], %[[CONSTANT_12]] : index
+// CHECK-NEXT:            %[[LOAD_7:.*]] = memref.load %[[SUBVIEW_5]]{{\[}}%[[VAL_13]]] : memref<?xindex, strided<[?], offset: ?>>
+// CHECK-NEXT:            %[[CMPI_8:.*]] = arith.cmpi eq, %[[LOAD_7]], %[[CONSTANT_19]] : index
 // CHECK-NEXT:            %[[SELECT_2:.*]] = arith.select %[[CMPI_8]], %[[IF_4]], %[[LOAD_7]] : index
 // CHECK-NEXT:            scf.yield %[[SELECT_2]] : index
 // CHECK-NEXT:          }
-// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_13]]{{\[}}%[[VAL_12]]] : memref<?xindex>
+// CHECK-NEXT:          memref.store %[[IF_5]], %[[ALLOC_11]]{{\[}}%[[VAL_13]]] : memref<?xindex>
 // CHECK-NEXT:        }
-// CHECK-NEXT:        %[[LOAD_8:.*]] = memref.load %[[ALLOC_11]]{{\[}}%[[CONSTANT_11]]] : memref<?xindex>
-// CHECK-NEXT:        %[[ALLOC_14:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[LOAD_8]], %[[ALLOC_14]]{{\[}}%[[CONSTANT_11]]] : memref<2xindex>
-// CHECK-NEXT:        memref.store %[[CONSTANT_13]], %[[ALLOC_14]]{{\[}}%[[CONSTANT_12]]] : memref<2xindex>
-// CHECK-NEXT:        %[[ALLOC_15:.*]] = memref.alloc(%[[CONSTANT_13]]) {alignment = 64 : i64} : memref<?xindex>
-// CHECK-NEXT:        %[[SUBVIEW_6:.*]] = memref.subview %[[ALLOC_15]]{{\[}}0] [%[[CONSTANT_11]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
-// CHECK-NEXT:        memref.copy %[[ALLOC_13]], %[[SUBVIEW_6]] : memref<?xindex> to memref<?xindex, strided<[1]>>
-// CHECK-NEXT:        %[[SUBVIEW_7:.*]] = memref.subview %[[ALLOC_15]]{{\[}}%[[CONSTANT_11]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
-// CHECK-NEXT:        memref.copy %[[ALLOC_14]], %[[SUBVIEW_7]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
-// CHECK-NEXT:        %[[ALLOC_16:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        %[[ALLOC_OUTPUT_0:.*]] = hipsr.alloc_output(%[[VAL_7]]) {out_idx = 0 : i64} : memref<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.expand(%[[VAL_7]]) ins(%[[VAL_8]], %[[VAL_9]] : memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>) outs(%[[ALLOC_16]] : memref<2x4xf32, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.matmul(%[[VAL_7]]) ins(%[[ALLOC_16]], %[[VAL_10]] : memref<2x4xf32, #hipsr.mem<device>>, memref<4x2xf32, #hipsr.mem<device>>) outs(%[[ALLOC_OUTPUT_0]] : memref<2x2xf32, #hipsr.mem<device>>)
-// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_0]], %[[ALLOC_16]] : memref<2xindex>, memref<2x4xf32, #hipsr.mem<device>>
-// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_15]], %[[ALLOC_OUTPUT_0]] : memref<?xindex>, memref<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[LOAD_8:.*]] = memref.load %[[ALLOC_9]]{{\[}}%[[CONSTANT_18]]] : memref<?xindex>
+// CHECK-NEXT:        %[[ALLOC_12:.*]] = memref.alloc() {alignment = 64 : i64} : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[LOAD_8]], %[[ALLOC_12]]{{\[}}%[[CONSTANT_18]]] : memref<2xindex>
+// CHECK-NEXT:        memref.store %[[CONSTANT_20]], %[[ALLOC_12]]{{\[}}%[[CONSTANT_19]]] : memref<2xindex>
+// CHECK-NEXT:        %[[ALLOC_13:.*]] = memref.alloc(%[[CONSTANT_20]]) {alignment = 64 : i64} : memref<?xindex>
+// CHECK-NEXT:        %[[SUBVIEW_6:.*]] = memref.subview %[[ALLOC_13]][0] {{\[}}%[[CONSTANT_18]]] [1] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        memref.copy %[[ALLOC_11]], %[[SUBVIEW_6]] : memref<?xindex> to memref<?xindex, strided<[1]>>
+// CHECK-NEXT:        %[[SUBVIEW_7:.*]] = memref.subview %[[ALLOC_13]]{{\[}}%[[CONSTANT_18]]] [2] [1] : memref<?xindex> to memref<2xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        memref.copy %[[ALLOC_12]], %[[SUBVIEW_7]] : memref<2xindex> to memref<2xindex, strided<[1], offset: ?>>
+// CHECK-NEXT:        %[[CONSTANT_21:.*]] = arith.constant 32 : index
+// CHECK-NEXT:        %[[CONSTANT_22:.*]] = arith.constant 256 : index
+// CHECK-NEXT:        %[[CONSTANT_23:.*]] = arith.constant 255 : index
+// CHECK-NEXT:        %[[ADDI_3:.*]] = arith.addi %[[CONSTANT_21]], %[[CONSTANT_23]] : index
+// CHECK-NEXT:        %[[DIVUI_2:.*]] = arith.divui %[[ADDI_3]], %[[CONSTANT_22]] : index
+// CHECK-NEXT:        %[[MULI_2:.*]] = arith.muli %[[DIVUI_2]], %[[CONSTANT_22]] : index
+// CHECK-NEXT:        %[[CONSTANT_24:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[GET_POOL_1:.*]] = hipsr.get_pool(%[[VAL_8]], %[[MULI_2]]) {domain_id = 1 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[VIEW_2:.*]] = memref.view %[[GET_POOL_1]]{{\[}}%[[CONSTANT_24]]][] : memref<?xi8, #hipsr.mem<device>> to memref<2x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ALLOC_OUTPUT_0:.*]] = hipsr.alloc_output(%[[VAL_8]]) {out_idx = 0 : i64} : memref<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.expand(%[[VAL_8]]) ins(%[[VAL_9]], %[[VAL_10]] : memref<2x1xf32, #hipsr.mem<device>>, memref<2xi64, #hipsr.mem<host>>) outs(%[[VIEW_2]] : memref<2x4xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.matmul(%[[VAL_8]]) ins(%[[VIEW_2]], %[[VAL_11]] : memref<2x4xf32, #hipsr.mem<device>>, memref<4x2xf32, #hipsr.mem<device>>) outs(%[[ALLOC_OUTPUT_0]] : memref<2x2xf32, #hipsr.mem<device>>)
+// CHECK-NEXT:        hipsr.preserve_shape %[[CAST_0]], %[[VIEW_2]] : memref<2xindex>, memref<2x4xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[ALLOC_13]], %[[ALLOC_OUTPUT_0]] : memref<?xindex>, memref<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:        hipsr.pool_domain_yield %[[ALLOC_OUTPUT_0]] : memref<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:      } -> memref<2x2xf32, #hipsr.mem<device>> {domain_id = 1 : i64}
 // CHECK-NEXT:      return %[[POOL_DOMAIN_1]] : memref<2x2xf32, #hipsr.mem<device>>
 // CHECK-NEXT:    }
-// CHECK-NEXT:  }
 
 
 

--- a/test/lit/Dialect/Hipsr/Transforms/MaterializeInitTensors/materialize-init-tensors.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/MaterializeInitTensors/materialize-init-tensors.mlir
@@ -26,33 +26,36 @@
 // inputs enter the domain as block arguments, so an earlier domain filled those
 // buffers and the region reads them as they are. That is the only form the pass
 // accepts; an input this domain allocates is the error case in invalid.mlir.
-// CHECK-LABEL: func.func @barrier_domain(
-// CHECK-SAME:      %[[CTX:.+]]: !hipsr.context, %[[IN:.+]]: tensor<?x1xf32, #hipsr.mem<device>>, %[[EXTENTS:.+]]: tensor<2xi64, #hipsr.mem<host>>) -> tensor<?x?xf32, #hipsr.mem<device>> {
-// CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[IN]], %[[EXTENTS]] : !hipsr.context, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) {
-// CHECK-NEXT:    ^bb0(%[[DCTX:.+]]: !hipsr.context, %[[DIN:.+]]: tensor<?x1xf32, #hipsr.mem<device>>, %[[DEXTENTS:.+]]: tensor<2xi64, #hipsr.mem<host>>):
-// CHECK-NEXT:      %[[SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[IN_SHAPE:.+]] = shape.shape_of %[[DIN]] : tensor<?x1xf32, #hipsr.mem<device>> -> tensor<2xindex>
-// CHECK-NEXT:        %[[ROW_INDEX:.+]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[ROWS:.+]] = tensor.extract %[[IN_SHAPE]]{{\[}}%[[ROW_INDEX]]] : tensor<2xindex>
-// CHECK-NEXT:        %[[COLUMN_INDEX:.+]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[COLUMN:.+]] = tensor.extract %[[DEXTENTS]]{{\[}}%[[COLUMN_INDEX]]] : tensor<2xi64, #hipsr.mem<host>>
-// CHECK-NEXT:        %[[COLUMNS:.+]] = arith.index_cast %[[COLUMN]] : i64 to index
-// CHECK-NEXT:        %[[RESULT_SHAPE:.+]] = shape.from_extents %[[ROWS]], %[[COLUMNS]] : index, index
-// CHECK-NEXT:        scf.yield %[[RESULT_SHAPE]] : !shape.shape
-// CHECK-NEXT:      }
-// CHECK-NEXT:      %[[D0_INDEX:.+]] = shape.const_size 0
-// CHECK-NEXT:      %[[D0_EXTENT:.+]] = shape.get_extent %[[SHAPE]], %[[D0_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:      %[[D0:.+]] = shape.size_to_index %[[D0_EXTENT]] : !shape.size
-// CHECK-NEXT:      %[[D1_INDEX:.+]] = shape.const_size 1
-// CHECK-NEXT:      %[[D1_EXTENT:.+]] = shape.get_extent %[[SHAPE]], %[[D1_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:      %[[D1:.+]] = shape.size_to_index %[[D1_EXTENT]] : !shape.size
-// CHECK-NEXT:      %[[INIT:.+]] = tensor.empty(%[[D0]], %[[D1]]) : tensor<?x?xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[EXPAND:.+]] = hipsr.expand(%[[DCTX]]) ins(%[[DIN]], %[[DEXTENTS]] : tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) outs(%[[INIT]] : tensor<?x?xf32, #hipsr.mem<device>>) : tensor<?x?xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[SHAPE]], %[[EXPAND]] : !shape.shape, tensor<?x?xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.pool_domain_yield %[[EXPAND]] : tensor<?x?xf32, #hipsr.mem<device>>
-// CHECK-NEXT:    } -> tensor<?x?xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x?xf32, #hipsr.mem<device>>
-// CHECK-NEXT:  }
+// CHECK-LABEL:   func.func @barrier_domain(
+// CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[ARG1:.*]]: tensor<?x1xf32, #hipsr.mem<device>>,
+// CHECK-SAME:      %[[ARG2:.*]]: tensor<2xi64, #hipsr.mem<host>>) -> tensor<?x?xf32, #hipsr.mem<device>> {
+// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]] = hipsr.pool_domain(%[[ARG0]], %[[ARG1]], %[[ARG2]] : !hipsr.context, tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: tensor<?x1xf32, #hipsr.mem<device>>, %[[VAL_2:.*]]: tensor<2xi64, #hipsr.mem<host>>):
+// CHECK-NEXT:        %[[EXECUTE_REGION_0:.*]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:          %[[SHAPE_OF_0:.*]] = shape.shape_of %[[VAL_1]] : tensor<?x1xf32, #hipsr.mem<device>> -> tensor<2xindex>
+// CHECK-NEXT:          %[[CONSTANT_0:.*]] = arith.constant 0 : index
+// CHECK-NEXT:          %[[EXTRACT_0:.*]] = tensor.extract %[[SHAPE_OF_0]]{{\[}}%[[CONSTANT_0]]] : tensor<2xindex>
+// CHECK-NEXT:          %[[CONSTANT_1:.*]] = arith.constant 1 : index
+// CHECK-NEXT:          %[[EXTRACT_1:.*]] = tensor.extract %[[VAL_2]]{{\[}}%[[CONSTANT_1]]] : tensor<2xi64, #hipsr.mem<host>>
+// CHECK-NEXT:          %[[INDEX_CAST_0:.*]] = arith.index_cast %[[EXTRACT_1]] : i64 to index
+// CHECK-NEXT:          %[[FROM_EXTENTS_0:.*]] = shape.from_extents %[[EXTRACT_0]], %[[INDEX_CAST_0]] : index, index
+// CHECK-NEXT:          scf.yield %[[FROM_EXTENTS_0]] : !shape.shape
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[CONST_SIZE_0:.*]] = shape.const_size 0
+// CHECK-NEXT:        %[[GET_EXTENT_0:.*]] = shape.get_extent %[[EXECUTE_REGION_0]], %[[CONST_SIZE_0]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:        %[[SIZE_TO_INDEX_0:.*]] = shape.size_to_index %[[GET_EXTENT_0]] : !shape.size
+// CHECK-NEXT:        %[[CONST_SIZE_1:.*]] = shape.const_size 1
+// CHECK-NEXT:        %[[GET_EXTENT_1:.*]] = shape.get_extent %[[EXECUTE_REGION_0]], %[[CONST_SIZE_1]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:        %[[SIZE_TO_INDEX_1:.*]] = shape.size_to_index %[[GET_EXTENT_1]] : !shape.size
+// CHECK-NEXT:        %[[EMPTY_0:.*]] = tensor.empty(%[[SIZE_TO_INDEX_0]], %[[SIZE_TO_INDEX_1]]) : tensor<?x?xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[EXPAND_0:.*]] = hipsr.expand(%[[VAL_0]]) ins(%[[VAL_1]], %[[VAL_2]] : tensor<?x1xf32, #hipsr.mem<device>>, tensor<2xi64, #hipsr.mem<host>>) outs(%[[EMPTY_0]] : tensor<?x?xf32, #hipsr.mem<device>>) : tensor<?x?xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[EXECUTE_REGION_0]], %[[EXPAND_0]] : !shape.shape, tensor<?x?xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[EXPAND_0]] : tensor<?x?xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> tensor<?x?xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT:      return %[[POOL_DOMAIN_0]] : tensor<?x?xf32, #hipsr.mem<device>>
+// CHECK-NEXT:    }
+
 func.func @barrier_domain(%ctx: !hipsr.context, %in: tensor<?x1xf32, #hipsr.mem<device>>,
                           %extents: tensor<2xi64, #hipsr.mem<host>>) -> tensor<?x?xf32, #hipsr.mem<device>> {
   %0 = hipsr.pool_domain(%ctx, %in, %extents
@@ -105,41 +108,45 @@ func.func @barrier_domain(%ctx: !hipsr.context, %in: tensor<?x1xf32, #hipsr.mem<
 // is what leaves the shape on the memref.alloc for -hip-use-output-allocator,
 // and naming the tensor.empty instead would keep it alive as an allocation of
 // its own for an op whose result is only a view of another buffer.
-// CHECK-LABEL: func.func @interleaved(
-// CHECK-SAME:      %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<?x256xf16, #hipsr.mem<device>>, %[[B:.+]]: tensor<256x512xf16, #hipsr.mem<device>>, %[[C:.+]]: tensor<?x512xf16, #hipsr.mem<device>>) -> tensor<?x512xf16, #hipsr.mem<device>> {
-// CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[A]], %[[B]], %[[C]] : !hipsr.context, tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>, tensor<?x512xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT:    ^bb0(%[[DCTX:.+]]: !hipsr.context, %[[DA:.+]]: tensor<?x256xf16, #hipsr.mem<device>>, %[[DB:.+]]: tensor<256x512xf16, #hipsr.mem<device>>, %[[DC:.+]]: tensor<?x512xf16, #hipsr.mem<device>>):
-// CHECK-NEXT:      %[[MATMUL_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[DA]] : tensor<?x256xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[B_SHAPE:.+]] = shape.shape_of %[[DB]] : tensor<256x512xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[M_INDEX:.+]] = shape.const_size 0
-// CHECK-NEXT:        %[[M:.+]] = shape.get_extent %[[A_SHAPE]], %[[M_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[N_INDEX:.+]] = shape.const_size 1
-// CHECK-NEXT:        %[[N:.+]] = shape.get_extent %[[B_SHAPE]], %[[N_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:        %[[FROM_EXTENTS:.+]] = shape.from_extents %[[M]], %[[N]] : !shape.size, !shape.size
-// CHECK-NEXT:        scf.yield %[[FROM_EXTENTS]] : !shape.shape
-// CHECK-NEXT:      }
-// CHECK-NEXT:      %[[ADD_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[C_SHAPE:.+]] = shape.shape_of %[[DC]] : tensor<?x512xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[BROADCAST:.+]] = shape.broadcast %[[MATMUL_SHAPE]], %[[C_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:        scf.yield %[[BROADCAST]] : !shape.shape
-// CHECK-NEXT:      }
-// CHECK-NEXT:      %[[MATMUL_D0_INDEX:.+]] = shape.const_size 0
-// CHECK-NEXT:      %[[MATMUL_D0_EXTENT:.+]] = shape.get_extent %[[MATMUL_SHAPE]], %[[MATMUL_D0_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:      %[[MATMUL_D0:.+]] = shape.size_to_index %[[MATMUL_D0_EXTENT]] : !shape.size
-// CHECK-NEXT:      %[[MATMUL_INIT:.+]] = tensor.empty(%[[MATMUL_D0]]) : tensor<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[ADD_D0_INDEX:.+]] = shape.const_size 0
-// CHECK-NEXT:      %[[ADD_D0_EXTENT:.+]] = shape.get_extent %[[ADD_SHAPE]], %[[ADD_D0_INDEX]] : !shape.shape, !shape.size -> !shape.size
-// CHECK-NEXT:      %[[ADD_D0:.+]] = shape.size_to_index %[[ADD_D0_EXTENT]] : !shape.size
-// CHECK-NEXT:      %[[ADD_INIT:.+]] = tensor.empty(%[[ADD_D0]]) : tensor<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[MATMUL:.+]] = hipsr.matmul(%[[DCTX]]) ins(%[[DA]], %[[DB]] : tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>) outs(%[[MATMUL_INIT]] : tensor<?x512xf16, #hipsr.mem<device>>) : tensor<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[ADD:.+]] = hipsr.add(%[[DCTX]]) ins(%[[MATMUL]], %[[DC]] : tensor<?x512xf16, #hipsr.mem<device>>, tensor<?x512xf16, #hipsr.mem<device>>) outs(%[[ADD_INIT]] : tensor<?x512xf16, #hipsr.mem<device>>) : tensor<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[MATMUL_SHAPE]], %[[MATMUL]] : !shape.shape, tensor<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[ADD_SHAPE]], %[[ADD]] : !shape.shape, tensor<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.pool_domain_yield %[[ADD]] : tensor<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:    } -> tensor<?x512xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT:    return %[[DOMAIN]] : tensor<?x512xf16, #hipsr.mem<device>>
-// CHECK-NEXT:  }
+// CHECK-LABEL:   func.func @interleaved(
+// CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[ARG1:.*]]: tensor<?x256xf16, #hipsr.mem<device>>,
+// CHECK-SAME:      %[[ARG2:.*]]: tensor<256x512xf16, #hipsr.mem<device>>,
+// CHECK-SAME:      %[[ARG3:.*]]: tensor<?x512xf16, #hipsr.mem<device>>) -> tensor<?x512xf16, #hipsr.mem<device>> {
+// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]] = hipsr.pool_domain(%[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]] : !hipsr.context, tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>, tensor<?x512xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: tensor<?x256xf16, #hipsr.mem<device>>, %[[VAL_2:.*]]: tensor<256x512xf16, #hipsr.mem<device>>, %[[VAL_3:.*]]: tensor<?x512xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[EXECUTE_REGION_0:.*]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:          %[[SHAPE_OF_0:.*]] = shape.shape_of %[[VAL_1]] : tensor<?x256xf16, #hipsr.mem<device>> -> !shape.shape
+// CHECK-NEXT:          %[[SHAPE_OF_1:.*]] = shape.shape_of %[[VAL_2]] : tensor<256x512xf16, #hipsr.mem<device>> -> !shape.shape
+// CHECK-NEXT:          %[[CONST_SIZE_0:.*]] = shape.const_size 0
+// CHECK-NEXT:          %[[GET_EXTENT_0:.*]] = shape.get_extent %[[SHAPE_OF_0]], %[[CONST_SIZE_0]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:          %[[CONST_SIZE_1:.*]] = shape.const_size 1
+// CHECK-NEXT:          %[[GET_EXTENT_1:.*]] = shape.get_extent %[[SHAPE_OF_1]], %[[CONST_SIZE_1]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:          %[[FROM_EXTENTS_0:.*]] = shape.from_extents %[[GET_EXTENT_0]], %[[GET_EXTENT_1]] : !shape.size, !shape.size
+// CHECK-NEXT:          scf.yield %[[FROM_EXTENTS_0]] : !shape.shape
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[EXECUTE_REGION_1:.*]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:          %[[SHAPE_OF_2:.*]] = shape.shape_of %[[VAL_3]] : tensor<?x512xf16, #hipsr.mem<device>> -> !shape.shape
+// CHECK-NEXT:          %[[BROADCAST_0:.*]] = shape.broadcast %[[EXECUTE_REGION_0]], %[[SHAPE_OF_2]] : !shape.shape, !shape.shape -> !shape.shape
+// CHECK-NEXT:          scf.yield %[[BROADCAST_0]] : !shape.shape
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[CONST_SIZE_2:.*]] = shape.const_size 0
+// CHECK-NEXT:        %[[GET_EXTENT_2:.*]] = shape.get_extent %[[EXECUTE_REGION_0]], %[[CONST_SIZE_2]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:        %[[SIZE_TO_INDEX_0:.*]] = shape.size_to_index %[[GET_EXTENT_2]] : !shape.size
+// CHECK-NEXT:        %[[CONST_SIZE_3:.*]] = shape.const_size 0
+// CHECK-NEXT:        %[[GET_EXTENT_3:.*]] = shape.get_extent %[[EXECUTE_REGION_1]], %[[CONST_SIZE_3]] : !shape.shape, !shape.size -> !shape.size
+// CHECK-NEXT:        %[[SIZE_TO_INDEX_1:.*]] = shape.size_to_index %[[GET_EXTENT_3]] : !shape.size
+// CHECK-NEXT:        %[[EMPTY_0:.*]] = tensor.empty(%[[SIZE_TO_INDEX_0]]) : tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[EMPTY_1:.*]] = tensor.empty(%[[SIZE_TO_INDEX_1]]) : tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[MATMUL_0:.*]] = hipsr.matmul(%[[VAL_0]]) ins(%[[VAL_1]], %[[VAL_2]] : tensor<?x256xf16, #hipsr.mem<device>>, tensor<256x512xf16, #hipsr.mem<device>>) outs(%[[EMPTY_0]] : tensor<?x512xf16, #hipsr.mem<device>>) : tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ADD_0:.*]] = hipsr.add(%[[VAL_0]]) ins(%[[MATMUL_0]], %[[VAL_3]] : tensor<?x512xf16, #hipsr.mem<device>>, tensor<?x512xf16, #hipsr.mem<device>>) outs(%[[EMPTY_1]] : tensor<?x512xf16, #hipsr.mem<device>>) : tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[EXECUTE_REGION_0]], %[[MATMUL_0]] : !shape.shape, tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[EXECUTE_REGION_1]], %[[ADD_0]] : !shape.shape, tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ADD_0]] : tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> tensor<?x512xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT:      return %[[POOL_DOMAIN_0]] : tensor<?x512xf16, #hipsr.mem<device>>
+// CHECK-NEXT:    }
+
 func.func @interleaved(%ctx: !hipsr.context, %a: tensor<?x256xf16, #hipsr.mem<device>>,
                        %b: tensor<256x512xf16, #hipsr.mem<device>>, %c: tensor<?x512xf16, #hipsr.mem<device>>)
     -> tensor<?x512xf16, #hipsr.mem<device>> {
@@ -190,30 +197,32 @@ func.func @interleaved(%ctx: !hipsr.context, %a: tensor<?x256xf16, #hipsr.mem<de
 // was, it would no longer dominate the read. Both results are fully static, so
 // neither allocation reads an extent; the only reader of a computed shape here
 // is the add region, which broadcasts the cast's.
-// CHECK-LABEL: func.func @constant_between_placeholders(
-// CHECK-SAME:      %[[CTX:.+]]: !hipsr.context, %[[A:.+]]: tensor<2x2xf16, #hipsr.mem<device>>) -> tensor<2x2xf32, #hipsr.mem<device>> {
-// CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[CTX]], %[[A]] : !hipsr.context, tensor<2x2xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT:    ^bb0(%[[DCTX:.+]]: !hipsr.context, %[[DA:.+]]: tensor<2x2xf16, #hipsr.mem<device>>):
-// CHECK-NEXT:      %[[WEIGHT:.+]] = hipsr.constant {value = dense<{{.*}}> : tensor<2x2xf32>} : tensor<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[CAST_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[A_SHAPE:.+]] = shape.shape_of %[[DA]] : tensor<2x2xf16, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        scf.yield %[[A_SHAPE]] : !shape.shape
-// CHECK-NEXT:      }
-// CHECK-NEXT:      %[[ADD_SHAPE:.+]] = scf.execute_region -> !shape.shape {
-// CHECK-NEXT:        %[[WEIGHT_SHAPE:.+]] = shape.shape_of %[[WEIGHT]] : tensor<2x2xf32, #hipsr.mem<device>> -> !shape.shape
-// CHECK-NEXT:        %[[BROADCAST:.+]] = shape.broadcast %[[CAST_SHAPE]], %[[WEIGHT_SHAPE]] : !shape.shape, !shape.shape -> !shape.shape
-// CHECK-NEXT:        scf.yield %[[BROADCAST]] : !shape.shape
-// CHECK-NEXT:      }
-// CHECK-NEXT:      %[[CAST_INIT:.+]] = tensor.empty() : tensor<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[ADD_INIT:.+]] = tensor.empty() : tensor<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[CAST:.+]] = hipsr.cast(%[[DCTX]]) ins(%[[DA]] : tensor<2x2xf16, #hipsr.mem<device>>) outs(%[[CAST_INIT]] : tensor<2x2xf32, #hipsr.mem<device>>) : tensor<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      %[[ADD:.+]] = hipsr.add(%[[DCTX]]) ins(%[[CAST]], %[[WEIGHT]] : tensor<2x2xf32, #hipsr.mem<device>>, tensor<2x2xf32, #hipsr.mem<device>>) outs(%[[ADD_INIT]] : tensor<2x2xf32, #hipsr.mem<device>>) : tensor<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[CAST_SHAPE]], %[[CAST]] : !shape.shape, tensor<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.preserve_shape %[[ADD_SHAPE]], %[[ADD]] : !shape.shape, tensor<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:      hipsr.pool_domain_yield %[[ADD]] : tensor<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:    } -> tensor<2x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
-// CHECK-NEXT:    return %[[DOMAIN]] : tensor<2x2xf32, #hipsr.mem<device>>
-// CHECK-NEXT:  }
+// CHECK-LABEL:   func.func @constant_between_placeholders(
+// CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[ARG1:.*]]: tensor<2x2xf16, #hipsr.mem<device>>) -> tensor<2x2xf32, #hipsr.mem<device>> {
+// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]] = hipsr.pool_domain(%[[ARG0]], %[[ARG1]] : !hipsr.context, tensor<2x2xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: tensor<2x2xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:        %[[CONSTANT_0:.*]] = hipsr.constant {value = dense<{{\[\[}}1.000000e+00, 2.000000e+00], [3.000000e+00, 4.000000e+00]]> : tensor<2x2xf32>} : tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[EXECUTE_REGION_0:.*]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:          %[[SHAPE_OF_0:.*]] = shape.shape_of %[[VAL_1]] : tensor<2x2xf16, #hipsr.mem<device>> -> !shape.shape
+// CHECK-NEXT:          scf.yield %[[SHAPE_OF_0]] : !shape.shape
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[EXECUTE_REGION_1:.*]] = scf.execute_region -> !shape.shape {
+// CHECK-NEXT:          %[[SHAPE_OF_1:.*]] = shape.shape_of %[[CONSTANT_0]] : tensor<2x2xf32, #hipsr.mem<device>> -> !shape.shape
+// CHECK-NEXT:          %[[BROADCAST_0:.*]] = shape.broadcast %[[EXECUTE_REGION_0]], %[[SHAPE_OF_1]] : !shape.shape, !shape.shape -> !shape.shape
+// CHECK-NEXT:          scf.yield %[[BROADCAST_0]] : !shape.shape
+// CHECK-NEXT:        }
+// CHECK-NEXT:        %[[EMPTY_0:.*]] = tensor.empty() : tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[EMPTY_1:.*]] = tensor.empty() : tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[CAST_0:.*]] = hipsr.cast(%[[VAL_0]]) ins(%[[VAL_1]] : tensor<2x2xf16, #hipsr.mem<device>>) outs(%[[EMPTY_0]] : tensor<2x2xf32, #hipsr.mem<device>>) : tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        %[[ADD_0:.*]] = hipsr.add(%[[VAL_0]]) ins(%[[CAST_0]], %[[CONSTANT_0]] : tensor<2x2xf32, #hipsr.mem<device>>, tensor<2x2xf32, #hipsr.mem<device>>) outs(%[[EMPTY_1]] : tensor<2x2xf32, #hipsr.mem<device>>) : tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[EXECUTE_REGION_0]], %[[CAST_0]] : !shape.shape, tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.preserve_shape %[[EXECUTE_REGION_1]], %[[ADD_0]] : !shape.shape, tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[ADD_0]] : tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:      } -> tensor<2x2xf32, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT:      return %[[POOL_DOMAIN_0]] : tensor<2x2xf32, #hipsr.mem<device>>
+// CHECK-NEXT:    }
+
 func.func @constant_between_placeholders(%ctx: !hipsr.context,
                                          %a: tensor<2x2xf16, #hipsr.mem<device>>)
     -> tensor<2x2xf32, #hipsr.mem<device>> {
@@ -253,17 +262,18 @@ func.func @constant_between_placeholders(%ctx: !hipsr.context,
 
 // A domain without placeholders is left alone. The tensor.empty here is the one
 // the input already had, not one the pass built.
-// CHECK-LABEL: func.func @no_placeholder(
-// CHECK-SAME:      %[[IN:.+]]: tensor<3x4xf32>) -> tensor<2x?xi64> {
-// CHECK-NEXT:    %[[DOMAIN:.+]] = hipsr.pool_domain(%[[IN]] : tensor<3x4xf32>) {
-// CHECK-NEXT:    ^bb0(%[[DIN:.+]]: tensor<3x4xf32>):
-// CHECK-NEXT:      %[[C1:.+]] = arith.constant 1 : index
-// CHECK-NEXT:      %[[DIM:.+]] = tensor.dim %[[DIN]], %[[C1]] : tensor<3x4xf32>
-// CHECK-NEXT:      %[[BUFFER:.+]] = tensor.empty(%[[DIM]]) : tensor<2x?xi64>
-// CHECK-NEXT:      hipsr.pool_domain_yield %[[BUFFER]] : tensor<2x?xi64>
-// CHECK-NEXT:    } -> tensor<2x?xi64> {domain_id = 0 : i64}
-// CHECK-NEXT:    return %[[DOMAIN]] : tensor<2x?xi64>
-// CHECK-NEXT:  }
+// CHECK-LABEL:   func.func @no_placeholder(
+// CHECK-SAME:      %[[ARG0:.*]]: tensor<3x4xf32>) -> tensor<2x?xi64> {
+// CHECK-NEXT:      %[[POOL_DOMAIN_0:.*]] = hipsr.pool_domain(%[[ARG0]] : tensor<3x4xf32>) {
+// CHECK-NEXT:      ^bb0(%[[VAL_0:.*]]: tensor<3x4xf32>):
+// CHECK-NEXT:        %[[CONSTANT_0:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[DIM_0:.*]] = tensor.dim %[[VAL_0]], %[[CONSTANT_0]] : tensor<3x4xf32>
+// CHECK-NEXT:        %[[EMPTY_0:.*]] = tensor.empty(%[[DIM_0]]) : tensor<2x?xi64>
+// CHECK-NEXT:        hipsr.pool_domain_yield %[[EMPTY_0]] : tensor<2x?xi64>
+// CHECK-NEXT:      } -> tensor<2x?xi64> {domain_id = 0 : i64}
+// CHECK-NEXT:      return %[[POOL_DOMAIN_0]] : tensor<2x?xi64>
+// CHECK-NEXT:    }
+
 func.func @no_placeholder(%in: tensor<3x4xf32>) -> tensor<2x?xi64> {
   %0 = hipsr.pool_domain(%in : tensor<3x4xf32>) {
   ^bb0(%domain_in: tensor<3x4xf32>):

--- a/test/lit/Dialect/Hipsr/Transforms/PoolAlloc/basic.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PoolAlloc/basic.mlir
@@ -74,42 +74,6 @@ func.func @sub_byte_element(%ctx: !hipsr.context,
 
 // -----
 
-// An allocation nothing reads keeps its memref.alloc. Only the live one is
-// sized into the pool, so the reserved bytes cover one buffer rather than two.
-// CHECK-LABEL:   func.func @dead_alloc_skipped(
-// CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
-// CHECK-SAME:      %[[ARG1:.*]]: memref<4x1024xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT:           hipsr.pool_domain(%[[ARG0]], %[[ARG1]] : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
-// CHECK-NEXT:           ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: memref<4x1024xf16, #hipsr.mem<device>>):
-// CHECK-NEXT:             %[[ALLOC_0:.*]] = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[CONSTANT_0:.*]] = arith.constant 8192 : index
-// CHECK-NEXT:             %[[CONSTANT_1:.*]] = arith.constant 256 : index
-// CHECK-NEXT:             %[[CONSTANT_2:.*]] = arith.constant 255 : index
-// CHECK-NEXT:             %[[ADDI_0:.*]] = arith.addi %[[CONSTANT_0]], %[[CONSTANT_2]] : index
-// CHECK-NEXT:             %[[DIVUI_0:.*]] = arith.divui %[[ADDI_0]], %[[CONSTANT_1]] : index
-// CHECK-NEXT:             %[[MULI_0:.*]] = arith.muli %[[DIVUI_0]], %[[CONSTANT_1]] : index
-// CHECK-NEXT:             %[[CONSTANT_3:.*]] = arith.constant 0 : index
-// CHECK-NEXT:             %[[GET_POOL_0:.*]] = hipsr.get_pool(%[[VAL_0]], %[[MULI_0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
-// CHECK-NEXT:             %[[VIEW_0:.*]] = memref.view %[[GET_POOL_0]]{{\[}}%[[CONSTANT_3]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
-// CHECK-NEXT:             hipsr.add(%[[VAL_0]]) ins(%[[VAL_1]], %[[VAL_1]] : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%[[VIEW_0]] : memref<4x1024xf16, #hipsr.mem<device>>)
-// CHECK-NEXT:           } {domain_id = 0 : i64}
-// CHECK-NEXT:           return
-// CHECK-NEXT:         }
-func.func @dead_alloc_skipped(%ctx: !hipsr.context,
-                              %in: memref<4x1024xf16, #hipsr.mem<device>>) {
-  hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
-  ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
-    %dead = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
-    %a1 = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
-    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>)
-               outs(%a1 : memref<4x1024xf16, #hipsr.mem<device>>)
-    hipsr.pool_domain_yield
-  } {domain_id = 0 : i64}
-  return
-}
-
-// -----
-
 // Buffers of different element types share one pool, so its size is the larger
 // of a static f32 buffer and a dynamic f16 one.
 // CHECK-LABEL:   func.func @mixed_dtypes(
@@ -267,5 +231,51 @@ func.func @two_domains(%ctx: !hipsr.context, %in: memref<4x1024xf16, #hipsr.mem<
     hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>, memref<4x1024xf16, #hipsr.mem<device>>) outs(%a2 : memref<4x1024xf16, #hipsr.mem<device>>)
     hipsr.pool_domain_yield
   } {domain_id = 7 : i64}
+  return
+}
+
+// -----
+
+// Domain 1 reads a buffer that domain 0 yields, so BufferViewFlowAnalysis
+// reports domain 0's result as an alias of %a1. That result is defined
+// outside the body, so the pass drops it; walking its users would instead
+// report %a1 as escaping the domain. The yield keeps %a1 live to the end of
+// domain 0 and hands out the pool view.
+// CHECK-LABEL:   func.func @yielded_buffer_read_by_next_domain(
+// CHECK-SAME:      %[[ARG0:.*]]: !hipsr.context,
+// CHECK-SAME:      %[[ARG1:.*]]: memref<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:           %[[POOL_DOMAIN_0:.*]] = hipsr.pool_domain(%[[ARG0]], %[[ARG1]] : !hipsr.context, memref<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:           ^bb0(%[[VAL_0:.*]]: !hipsr.context, %[[VAL_1:.*]]: memref<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:             %[[CONSTANT_0:.*]] = arith.constant 8 : index
+// CHECK-NEXT:             %[[CONSTANT_1:.*]] = arith.constant 256 : index
+// CHECK-NEXT:             %[[CONSTANT_2:.*]] = arith.constant 255 : index
+// CHECK-NEXT:             %[[ADDI_0:.*]] = arith.addi %[[CONSTANT_0]], %[[CONSTANT_2]] : index
+// CHECK-NEXT:             %[[DIVUI_0:.*]] = arith.divui %[[ADDI_0]], %[[CONSTANT_1]] : index
+// CHECK-NEXT:             %[[MULI_0:.*]] = arith.muli %[[DIVUI_0]], %[[CONSTANT_1]] : index
+// CHECK-NEXT:             %[[CONSTANT_3:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[GET_POOL_0:.*]] = hipsr.get_pool(%[[VAL_0]], %[[MULI_0]]) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
+// CHECK-NEXT:             %[[VIEW_0:.*]] = memref.view %[[GET_POOL_0]]{{\[}}%[[CONSTANT_3]]][] : memref<?xi8, #hipsr.mem<device>> to memref<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:             hipsr.add(%[[VAL_0]]) ins(%[[VAL_1]], %[[VAL_1]] : memref<4xf16, #hipsr.mem<device>>, memref<4xf16, #hipsr.mem<device>>) outs(%[[VIEW_0]] : memref<4xf16, #hipsr.mem<device>>)
+// CHECK-NEXT:             hipsr.pool_domain_yield %[[VIEW_0]] : memref<4xf16, #hipsr.mem<device>>
+// CHECK-NEXT:           } -> memref<4xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+// CHECK-NEXT:           hipsr.pool_domain(%[[ARG0]], %[[POOL_DOMAIN_0]], %[[ARG1]] : !hipsr.context, memref<4xf16, #hipsr.mem<device>>, memref<4xf16, #hipsr.mem<device>>) {
+// CHECK-NEXT:           ^bb0(%[[VAL_2:.*]]: !hipsr.context, %[[VAL_3:.*]]: memref<4xf16, #hipsr.mem<device>>, %[[VAL_4:.*]]: memref<4xf16, #hipsr.mem<device>>):
+// CHECK-NEXT:             hipsr.add(%[[VAL_2]]) ins(%[[VAL_3]], %[[VAL_3]] : memref<4xf16, #hipsr.mem<device>>, memref<4xf16, #hipsr.mem<device>>) outs(%[[VAL_4]] : memref<4xf16, #hipsr.mem<device>>)
+// CHECK-NEXT:           } {domain_id = 1 : i64}
+// CHECK-NEXT:           return
+// CHECK-NEXT:         }
+func.func @yielded_buffer_read_by_next_domain(%ctx: !hipsr.context,
+                                              %in: memref<4xf16, #hipsr.mem<device>>) {
+  %0 = hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context, %din: memref<4xf16, #hipsr.mem<device>>):
+    %a1 = memref.alloc() : memref<4xf16, #hipsr.mem<device>>
+    hipsr.add(%dctx) ins(%din, %din : memref<4xf16, #hipsr.mem<device>>, memref<4xf16, #hipsr.mem<device>>) outs(%a1 : memref<4xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield %a1 : memref<4xf16, #hipsr.mem<device>>
+  } -> memref<4xf16, #hipsr.mem<device>> {domain_id = 0 : i64}
+  hipsr.pool_domain(%ctx, %0, %in : !hipsr.context, memref<4xf16, #hipsr.mem<device>>, memref<4xf16, #hipsr.mem<device>>) {
+  ^bb0(%dctx: !hipsr.context, %dyielded: memref<4xf16, #hipsr.mem<device>>, %din: memref<4xf16, #hipsr.mem<device>>):
+    hipsr.add(%dctx) ins(%dyielded, %dyielded : memref<4xf16, #hipsr.mem<device>>, memref<4xf16, #hipsr.mem<device>>) outs(%din : memref<4xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  } {domain_id = 1 : i64}
   return
 }

--- a/test/lit/Dialect/Hipsr/Transforms/PoolAlloc/invalid.mlir
+++ b/test/lit/Dialect/Hipsr/Transforms/PoolAlloc/invalid.mlir
@@ -3,32 +3,6 @@
 
 // RUN: hip-mlir-opt %s -split-input-file -verify-diagnostics -hipsr-pool-alloc
 
-func.func @empty_domain() {
-  // expected-error@+1 {{hipsr-pool-alloc: pool_domain has no poolable allocation}}
-  hipsr.pool_domain() {
-    hipsr.pool_domain_yield
-  } {domain_id = 0 : i64}
-  return
-}
-
-// -----
-
-func.func @no_alloc(%ctx: !hipsr.context,
-                    %in: memref<4x1024xf16, #hipsr.mem<device>>) {
-  // expected-error@+1 {{hipsr-pool-alloc: pool_domain has no poolable allocation}}
-  hipsr.pool_domain(%ctx, %in
-      : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
-  ^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
-    hipsr.add(%dctx) ins(%din, %din : memref<4x1024xf16, #hipsr.mem<device>>,
-                                      memref<4x1024xf16, #hipsr.mem<device>>)
-               outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
-    hipsr.pool_domain_yield
-  } {domain_id = 0 : i64}
-  return
-}
-
-// -----
-
 func.func @alloc_without_dps_write(%ctx: !hipsr.context,
                                    %in: memref<4x1024xf16, #hipsr.mem<device>>) {
   hipsr.pool_domain(%ctx, %in
@@ -40,6 +14,22 @@ func.func @alloc_without_dps_write(%ctx: !hipsr.context,
                              : memref<4x1024xf16, #hipsr.mem<device>>,
                                memref<4x1024xf16, #hipsr.mem<device>>)
                outs(%din : memref<4x1024xf16, #hipsr.mem<device>>)
+    hipsr.pool_domain_yield
+  } {domain_id = 0 : i64}
+  return
+}
+
+// -----
+
+// The pool is the domain's only device allocation, so an allocation the pass
+// cannot pool must not survive it. Nothing reads this one, so it gets no live
+// range and stays a memref.alloc.
+func.func @dead_device_alloc(%ctx: !hipsr.context) {
+  hipsr.pool_domain(%ctx : !hipsr.context) {
+  ^bb0(%dctx: !hipsr.context):
+    // expected-warning@+2 {{allocation has no users}}
+    // expected-error@+1 {{device allocation is not backed by the pool}}
+    %dead = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
     hipsr.pool_domain_yield
   } {domain_id = 0 : i64}
   return


### PR DESCRIPTION
## Summary

This turns on `hipsr-pool-alloc` in the HIPSR pipeline, right after `hipsr-use-output-allocator`.

Every temporary buffer in a pool domain used to get its own `memref.alloc`. Now they are all views into one pool that the runtime hands out. All three pipeline goldens end with zero device allocations, so the graph no longer asks the device allocator for one buffer per temporary on every inference.

The pass already existed. This change makes it work on real pipeline output and switches it on.

## Before / after

Two temporaries in one domain, in the order the pipeline writes them: every allocation first, then the compute ops.

```mlir
hipsr.pool_domain(%ctx, %in : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
^bb0(%dctx: !hipsr.context, %din: memref<4x1024xf16, #hipsr.mem<device>>):
  %a = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
  %b = memref.alloc() : memref<4x1024xf16, #hipsr.mem<device>>
  hipsr.add(%dctx) ins(%din, %din) outs(%a)
  hipsr.add(%dctx) ins(%a, %a) outs(%b)
  hipsr.pool_domain_yield
} {domain_id = 0 : i64}
```

They become one pool and two views into it:

```mlir
hipsr.pool_domain(%arg0, %arg1 : !hipsr.context, memref<4x1024xf16, #hipsr.mem<device>>) {
^bb0(%arg2: !hipsr.context, %arg3: memref<4x1024xf16, #hipsr.mem<device>>):
  // ... each size rounded up to the 256-byte pool alignment ...
  %6 = arith.addi %2, %5 : index
  %7 = hipsr.get_pool(%arg2, %6) {domain_id = 0 : i64} : memref<?xi8, #hipsr.mem<device>>
  %view   = memref.view %7[%c0][] : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
  %view_3 = memref.view %7[%2][]  : memref<?xi8, #hipsr.mem<device>> to memref<4x1024xf16, #hipsr.mem<device>>
  hipsr.add(%arg2) ins(%arg3, %arg3) outs(%view)
  hipsr.add(%arg2) ins(%view, %view) outs(%view_3)
} {domain_id = 0 : i64}
```

Two buffers that are never live at the same time share an offset, so the pool is as big as the peak rather than the sum.

## Why

Hand-written test input has three properties that real pipeline output does not have. Each one used to make the pass fail.

**Not every buffer is device memory.** The pool lives on the device, so a `#hipsr.mem<host>` shape buffer cannot be carved out of it. It keeps its own allocation.

**The next domain can read a pooled buffer.** The partitioner splits a domain at a barrier and passes each domain's results to the next one, so this is normal. In `sample_static` the cast output crosses the split:

```mlir
%0:3 = hipsr.pool_domain(...) {                                   // domain 0
  %alloc_9 = memref.alloc() : memref<2x1xf32, #hipsr.mem<device>>
  hipsr.cast(%arg3) ins(%alloc_8) outs(%alloc_9)
  hipsr.pool_domain_yield %alloc_9, %4, %2
} -> memref<2x1xf32, #hipsr.mem<device>>, ... {domain_id = 0 : i64}
%1 = hipsr.pool_domain(%arg0, %0#0, %0#1, %0#2 : ...)             // domain 1 reads it
```

`hipsr.pool_domain` implements `RegionBranchOpInterface`, so `BufferViewFlowAnalysis` reports the domain result `%0#0` as an alias of `%alloc_9`. `%0#0` is defined outside the body, which means all of its users are outside the body too. That is not the allocation escaping, so the pass drops `%0#0` from the alias list. It only drops an alias defined by the domain op itself. The `hipsr.pool_domain_yield` inside the body is still a normal use, and that is what keeps the grouper from reusing the yielded buffer's offset.

**A domain can have nothing to pool.** It may only compute shapes on the host, or write straight into a graph output. That no longer fails.

The pass is stricter in one place. If a device allocation is still sitting at the top level of a domain body after the rewrite, the pass now fails. Leaving it there would quietly bring back the per-inference allocation this pass exists to remove.

## Notes for reviewers

- `hipsr-pool-alloc` has to run after `hipsr-use-output-allocator`, so graph outputs stay owned by the runtime and never land in the pool.
- Every view is created before any allocation is erased, so an erase cannot invalidate the builder's insertion point.
- `hipsr-materialize-init-tensors` now reads all the dynamic sizes first and creates the `tensor.empty` ops afterwards. It used to emit each init tensor as a unit, which left the second allocation's size reads after the first allocation. Bufferization turned that into a `memref.load` between two `memref.alloc`s, and the pool can no longer read those sizes at the point where it is taken. The new order also drops one duplicate `shape.get_extent` per allocation.
- The leftover-allocation check only looks at the top level of a domain body. The pass does not pool nested regions, and failing on them would turn a missing feature into a whole-model CPU fallback.
- No `hipdnn.pool_size`/`buffer_offsets`/`buffer_count` is emitted. Each `hipsr.get_pool` carries its own `domain_id` and a size computed in the IR. That is the runtime-managed path `generate-interface` already falls back to, and a dynamic size has no fixed offset to report.
- `PoolAlloc/basic.mlir` has a new case, `yielded_buffer_read_by_next_domain`, for the cross-domain read. Drop the alias filter and it fails with `allocation escapes IsolatedFromAbove domain`. The three pipeline goldens cover it too.

Full LIT suite: 484 passed, 12 unsupported (all already unsupported on `main`), 0 failed.

Prepared with AI assistance (Cursor, Claude), reviewed and validated locally.
