### PR TITLE
Convert the shape-manipulating hip ops to TOSA

### DIFF
--- a/lib/Conversion/HipToLLVM/RocMlirLowering.cpp
+++ b/lib/Conversion/HipToLLVM/RocMlirLowering.cpp
@@ -61,22 +61,21 @@ struct RocMlirOpLowering : public ConvertOpToLLVMPattern<RocMlirOp> {
     // ELF carries embedded NULs, so keep the exact byte length (createGlobal
     // string stores the StringRef's full range, no NUL-termination scan).
     StringRef callee = op.getKernel();
-    Value kernelBinary = globalString(module, rewriter, loc,
-                                      (callee + "_binary").str(),
-                                      op.getKernelBinary());
+    Value kernelBinary =
+        globalString(module, rewriter, loc, (callee + "_binary").str(),
+                     op.getKernelBinary());
     // NUL-terminate the function name so a C `char*` consumer can read it.
     std::string funcNameStr = callee.str();
     funcNameStr.push_back('\0');
-    Value funcName =
-        globalString(module, rewriter, loc, (callee + "_name").str(),
-                     funcNameStr);
+    Value funcName = globalString(module, rewriter, loc,
+                                  (callee + "_name").str(), funcNameStr);
 
     // Operand data pointers, in kernel-arg order: inputs first, then output.
     SmallVector<Value> argPtrs;
     for (Value in : adaptor.getInputs())
       argPtrs.push_back(extractContiguousMemRefPtr(in, rewriter, loc));
-    argPtrs.push_back(extractContiguousMemRefPtr(adaptor.getOutput(), rewriter,
-                                                 loc));
+    argPtrs.push_back(
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc));
 
     // alloc(kernargs, size): stack buffer of N pointer slots.
     int64_t numArgs = static_cast<int64_t>(argPtrs.size());
@@ -88,8 +87,8 @@ struct RocMlirOpLowering : public ConvertOpToLLVMPattern<RocMlirOp> {
     for (int64_t i : llvm::seq<int64_t>(0, numArgs)) {
       Value idx = LLVM::ConstantOp::create(rewriter, loc, i32Type,
                                            rewriter.getI32IntegerAttr(i));
-      Value slot = LLVM::GEPOp::create(rewriter, loc, ptrType, ptrType,
-                                       kernargs, idx);
+      Value slot =
+          LLVM::GEPOp::create(rewriter, loc, ptrType, ptrType, kernargs, idx);
       LLVM::StoreOp::create(rewriter, loc, argPtrs[i], slot);
     }
 

--- a/lib/Conversion/HipToTosa/CMakeLists.txt
+++ b/lib/Conversion/HipToTosa/CMakeLists.txt
@@ -17,5 +17,6 @@ add_dependencies(HipToTosa
 target_link_libraries(HipToTosa PUBLIC
 	HipDialectIR
 	MLIRPass
+	MLIRTensorDialect
 	MLIRTosaDialect
 )

--- a/lib/Conversion/HipToTosa/HipToTosa.cpp
+++ b/lib/Conversion/HipToTosa/HipToTosa.cpp
@@ -11,6 +11,7 @@
 #include <mlir/Dialect/Tosa/IR/TosaOps.h>
 #include <mlir/Dialect/Tosa/Utils/ConversionUtils.h>
 #include <mlir/Dialect/UB/IR/UBOps.h>
+#include <mlir/Dialect/Utils/StaticValueUtils.h>
 #include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/PatternMatch.h>
@@ -47,14 +48,22 @@ bool isTosaCompatibleOperand(Value operand, RankedTensorType resultType) {
   return true;
 }
 
+// TOSA carries the shapes that reshape and slice operate on as !tosa.shape SSA
+// operands rather than attributes, so each one needs a tosa.const_shape.
+static Value createConstShape(ConversionPatternRewriter &rewriter, Location loc,
+                              ArrayRef<int64_t> extents) {
+  return tosa::ConstShapeOp::create(
+      rewriter, loc,
+      tosa::shapeType::get(rewriter.getContext(), extents.size()),
+      rewriter.getIndexTensorAttr(extents));
+}
+
 // Reshape `input` to `shape` via tosa.reshape + tosa.const_shape.
 static Value reshapeTo(Value input, ArrayRef<int64_t> shape,
                        ConversionPatternRewriter &rewriter) {
   auto type = cast<RankedTensorType>(input.getType());
-  auto shapeConst = tosa::ConstShapeOp::create(
-      rewriter, rewriter.getUnknownLoc(),
-      tosa::shapeType::get(rewriter.getContext(), shape.size()),
-      rewriter.getIndexTensorAttr(shape));
+  Value shapeConst =
+      createConstShape(rewriter, rewriter.getUnknownLoc(), shape);
   return tosa::ReshapeOp::create(rewriter, rewriter.getUnknownLoc(),
                                  type.clone(shape), input, shapeConst);
 }
@@ -226,6 +235,125 @@ struct UnaryConverter final : public OpConversionPattern<HipOpTy> {
   }
 };
 
+// hip.transpose and tosa.transpose share the ONNX convention -- output
+// dimension i reads input dimension perm[i] -- so the permutation carries over
+// unchanged, only respelled from hip's I64ArrayAttr as a DenseI32ArrayAttr.
+// The op's own verifier already guarantees perm is a permutation of the input's
+// dimensions, so there is nothing left to check here beyond the shapes.
+struct TransposeConverter final : public OpConversionPattern<hip::TransposeOp> {
+  using OpConversionPattern<hip::TransposeOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(hip::TransposeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Memref mode (post-bufferization) has no SSA result to replace.
+    if (op.getNumResults() != 1)
+      return rewriter.notifyMatchFailure(op, "expected tensor mode");
+
+    auto resultType = dyn_cast<RankedTensorType>(op.getResult(0).getType());
+    auto inputType = dyn_cast<RankedTensorType>(adaptor.getInput().getType());
+    if (!resultType || !resultType.hasStaticShape() || !inputType ||
+        !inputType.hasStaticShape())
+      return rewriter.notifyMatchFailure(op, "expected static ranked tensors");
+    // tosa.transpose takes a Tosa_TensorAtLeast1D; a rank-0 transpose is the
+    // identity anyway.
+    if (inputType.getRank() < 1)
+      return rewriter.notifyMatchFailure(op, "expected rank 1 or higher");
+
+    SmallVector<int32_t> perms;
+    perms.reserve(op.getPerm().size());
+    for (Attribute perm : op.getPerm())
+      perms.push_back(static_cast<int32_t>(cast<IntegerAttr>(perm).getInt()));
+
+    rewriter.replaceOpWithNewOp<tosa::TransposeOp>(
+        op, resultType, adaptor.getInput(),
+        rewriter.getDenseI32ArrayAttr(perms));
+    return success();
+  }
+};
+
+// tosa.reshape's shape is a compile-time constant, so both sides have to be
+// statically shaped.
+template <typename TensorOpTy> static bool isStaticReshape(TensorOpTy op) {
+  auto srcType = dyn_cast<RankedTensorType>(op.getSrc().getType());
+  auto resultType = dyn_cast<RankedTensorType>(op.getResult().getType());
+  return srcType && srcType.hasStaticShape() && resultType &&
+         resultType.hasStaticShape();
+}
+
+// onnx.Reshape, Squeeze, Unsqueeze and Flatten never reach this pass as hip
+// ops: OnnxToHip decomposes all four into the builtin tensor metadata ops
+// below, which are zero-cost views. Both spell the same thing in TOSA, a
+// reshape onto the result shape, which rocMLIR's tosa-to-tensor turns back
+// into a collapse/expand it can fold into the neighbouring conv or gemm.
+template <typename TensorOpTy>
+struct ReshapeConverter final : public OpConversionPattern<TensorOpTy> {
+  using OpConversionPattern<TensorOpTy>::OpConversionPattern;
+  using OpAdaptor = typename OpConversionPattern<TensorOpTy>::OpAdaptor;
+
+  LogicalResult
+  matchAndRewrite(TensorOpTy op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!isStaticReshape(op))
+      return rewriter.notifyMatchFailure(op, "expected static ranked tensors");
+
+    auto resultType = cast<RankedTensorType>(op.getResult().getType());
+    rewriter.replaceOpWithNewOp<tosa::ReshapeOp>(
+        op, resultType, adaptor.getSrc(),
+        createConstShape(rewriter, op.getLoc(), resultType.getShape()));
+    return success();
+  }
+};
+
+// tosa.slice reads a contiguous, same-rank window, so it can only stand in for
+// an unstrided extract whose bounds are known at compile time.
+static bool isTosaExpressibleSlice(tensor::ExtractSliceOp op) {
+  auto sourceType = dyn_cast<RankedTensorType>(op.getSource().getType());
+  auto resultType = dyn_cast<RankedTensorType>(op.getResult().getType());
+  if (!sourceType || !sourceType.hasStaticShape() || !resultType ||
+      !resultType.hasStaticShape())
+    return false;
+  if (resultType.getRank() != sourceType.getRank())
+    return false;
+  for (OpFoldResult stride : op.getMixedStrides())
+    if (getConstantIntValue(stride) != std::optional<int64_t>(1))
+      return false;
+  for (OpFoldResult offset : op.getMixedOffsets())
+    if (!getConstantIntValue(offset))
+      return false;
+  return true;
+}
+
+// The TOSA-expressible half of onnx.Slice. OnnxToHip decomposes the constant,
+// positive-unit-stride case to tensor.extract_slice and routes everything else
+// -- negative steps, runtime bounds -- to hip.slice, which has no tosa.slice
+// spelling at all and so is left for the runtime to handle.
+struct ExtractSliceConverter final
+    : public OpConversionPattern<tensor::ExtractSliceOp> {
+  using OpConversionPattern<tensor::ExtractSliceOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(tensor::ExtractSliceOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!isTosaExpressibleSlice(op))
+      return rewriter.notifyMatchFailure(
+          op, "expected a static, unstrided, same-rank extract");
+
+    SmallVector<int64_t> starts;
+    for (OpFoldResult offset : op.getMixedOffsets())
+      starts.push_back(*getConstantIntValue(offset));
+
+    // Sizes come from the result type rather than getMixedSizes: the ranks
+    // match and both are static, so the result shape is the window.
+    auto resultType = cast<RankedTensorType>(op.getResult().getType());
+    rewriter.replaceOpWithNewOp<tosa::SliceOp>(
+        op, resultType, adaptor.getSource(),
+        createConstShape(rewriter, op.getLoc(), starts),
+        createConstShape(rewriter, op.getLoc(), resultType.getShape()));
+    return success();
+  }
+};
+
 class HipToTosaPass : public impl::ConvertHipToTosaPassBase<HipToTosaPass> {
   void runOnOperation() override {
     auto funcOp = getOperation();
@@ -249,19 +377,33 @@ class HipToTosaPass : public impl::ConvertHipToTosaPassBase<HipToTosaPass> {
     // fails.
     ConversionTarget conversion(*ctx);
     conversion.addLegalDialect<tosa::TosaDialect, func::FuncDialect>();
-    conversion.addIllegalOp<MatmulOp, AddOp, SubOp, MinOp, MaxOp, MulOp, AbsOp,
-                            NegOp, CeilOp, FloorOp, ExpOp, LogOp, SinOp, CosOp,
-                            TanhOp, ErfOp, SigmoidOp, ReciprocalOp>();
-    // tosa.matmul (and other tosa ops) are not destination-passing, so
-    // MatMulConverter drops each hip op's DPS `outs` operand. The
-    // `tensor.empty` that fed it is then dead, but a full conversion still
-    // requires every remaining op to be legal -- the framework does not DCE
-    // this pre-existing op on its own. Mark it legal so conversion succeeds;
-    // the canonicalizer that follows this pass removes the dead empty.
+    conversion
+        .addIllegalOp<MatmulOp, TransposeOp, AddOp, SubOp, MinOp, MaxOp, MulOp,
+                      AbsOp, NegOp, CeilOp, FloorOp, ExpOp, LogOp, SinOp, CosOp,
+                      TanhOp, ErfOp, SigmoidOp, ReciprocalOp>();
+    // tosa ops are not destination-passing, so the converters drop each hip
+    // op's DPS `outs` operand and the `tensor.empty` that fed it is left dead
+    // for the canonicalizer that follows this pass to remove.
     conversion.addLegalOp<ub::PoisonOp, tensor::EmptyOp>();
 
+    // The tensor metadata ops are borrowed rather than owned. A kernel can
+    // legitimately hold forms with no TOSA spelling -- a dynamically shaped
+    // reshape, a strided or rank-reducing extract -- and rocMLIR consumes
+    // those directly, so they are only illegal where a pattern will succeed.
+    // The hip ops above stay unconditionally illegal: this pass claims them,
+    // so one that cannot convert is an error rather than a silent passthrough.
+    conversion.addDynamicallyLegalOp<tensor::CollapseShapeOp>(
+        [](tensor::CollapseShapeOp op) { return !isStaticReshape(op); });
+    conversion.addDynamicallyLegalOp<tensor::ExpandShapeOp>(
+        [](tensor::ExpandShapeOp op) { return !isStaticReshape(op); });
+    conversion.addDynamicallyLegalOp<tensor::ExtractSliceOp>(
+        [](tensor::ExtractSliceOp op) { return !isTosaExpressibleSlice(op); });
+
     RewritePatternSet patterns(ctx);
-    patterns.add<MatMulConverter, BinaryConverter<AddOp, tosa::AddOp>,
+    patterns.add<MatMulConverter, TransposeConverter,
+                 ReshapeConverter<tensor::CollapseShapeOp>,
+                 ReshapeConverter<tensor::ExpandShapeOp>, ExtractSliceConverter,
+                 BinaryConverter<AddOp, tosa::AddOp>,
                  BinaryConverter<SubOp, tosa::SubOp>,
                  BinaryConverter<MinOp, tosa::MinimumOp>,
                  BinaryConverter<MaxOp, tosa::MaximumOp>,

--- a/lib/Conversion/HipToTosa/HipToTosa.cpp
+++ b/lib/Conversion/HipToTosa/HipToTosa.cpp
@@ -271,6 +271,77 @@ struct TransposeConverter final : public OpConversionPattern<hip::TransposeOp> {
   }
 };
 
+// The multiply-by-ones spelling below needs the result shape at compile time,
+// and needs every input dimension -- right-aligned against the result the way
+// ONNX broadcasting is -- to be either 1 or already the result's extent. Both
+// hold for any Expand whose shape ONNX inference could resolve; what they rule
+// out is the dynamic case, where OnnxToHip reads the extents off the device.
+static bool isTosaExpressibleExpand(hip::ExpandOp op) {
+  // Memref mode (post-bufferization) has no SSA result to replace.
+  if (op.getNumResults() != 1)
+    return false;
+
+  auto resultType = dyn_cast<RankedTensorType>(op.getResult(0).getType());
+  auto inputType = dyn_cast<RankedTensorType>(op.getInput().getType());
+  if (!resultType || !resultType.hasStaticShape() || !inputType ||
+      !inputType.hasStaticShape())
+    return false;
+  if (resultType.getElementType() != inputType.getElementType())
+    return false;
+
+  // Expand only ever grows the rank; a shorter result is malformed.
+  int64_t offset = resultType.getRank() - inputType.getRank();
+  if (offset < 0)
+    return false;
+
+  ArrayRef<int64_t> shape = inputType.getShape();
+  ArrayRef<int64_t> resultShape = resultType.getShape();
+  for (int64_t i = 0, e = inputType.getRank(); i < e; ++i)
+    if (shape[i] != resultShape[i + offset] && shape[i] != 1)
+      return false;
+  return true;
+}
+
+// hip.expand broadcasts to a target shape, and TOSA has no op that spells one.
+// rocMLIR's answer, which MIGraphXToTosa uses for migraphx.multibroadcast, is a
+// multiply by a tensor of ones at the result shape: TOSA broadcasts the size-1
+// dimensions of the other operand implicitly. It is not a workaround that
+// leaves a stray multiply behind -- TosaToRock's mulBroadcast matches this
+// exact idiom, drops the multiply once isConstantOne recognises the constant,
+// and rewrites the broadcast into a rock.transform, a coordinate remap rather
+// than a copy. Left as hip.expand it would instead be a wrap_expand kernel that
+// materialises the whole result.
+//
+// The `shape` operand is deliberately unread. ONNX shape inference has already
+// resolved the broadcast into the result type, which is the only form that can
+// be used here anyway: a shape computed on the device is not available to the
+// compiler, and OnnxToHip emits exactly that for a dynamic Expand.
+struct ExpandConverter final : public OpConversionPattern<hip::ExpandOp> {
+  using OpConversionPattern<hip::ExpandOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(hip::ExpandOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!isTosaExpressibleExpand(op))
+      return rewriter.notifyMatchFailure(op, "expected a static broadcast");
+
+    auto resultType = cast<RankedTensorType>(op.getResult(0).getType());
+    Value ones = tosa::ConstOp::create(
+        rewriter, op.getLoc(), resultType,
+        cast<ElementsAttr>(rewriter.getOneAttr(resultType)));
+
+    // TOSA broadcasts size-1 dimensions only once both operands carry the
+    // result's rank; EqualizeRanks prepends 1s the way ONNX right-aligns.
+    Value input = adaptor.getInput();
+    if (failed(tosa::EqualizeRanks(rewriter, op.getLoc(), input, ones)))
+      return rewriter.notifyMatchFailure(op, "operand ranks not equalizable");
+
+    rewriter.replaceOpWithNewOp<tosa::MulOp>(
+        op, resultType, input, ones, createZeroMulShift(rewriter, op.getLoc()));
+    return success();
+  }
+};
+
 // tosa.reshape's shape is a compile-time constant, so both sides have to be
 // statically shaped.
 template <typename TensorOpTy> static bool isStaticReshape(TensorOpTy op) {
@@ -385,6 +456,16 @@ class HipToTosaPass : public impl::ConvertHipToTosaPassBase<HipToTosaPass> {
     // for the canonicalizer that follows this pass to remove.
     conversion.addLegalOp<ub::PoisonOp, tensor::EmptyOp>();
 
+    // hip.expand is the one hip op here that is conditionally rather than
+    // unconditionally illegal. OnnxToHip goes out of its way to support a
+    // dynamically shaped Expand, reading the extents back from the device with
+    // a stream sync, so that form is one the compiler deliberately produces
+    // rather than a malformed input. It has no TOSA spelling and must stay a
+    // wrap_expand, which an unconditional addIllegalOp would turn into a hard
+    // failure of the pass.
+    conversion.addDynamicallyLegalOp<ExpandOp>(
+        [](ExpandOp op) { return !isTosaExpressibleExpand(op); });
+
     // The tensor metadata ops are borrowed rather than owned. A kernel can
     // legitimately hold forms with no TOSA spelling -- a dynamically shaped
     // reshape, a strided or rank-reducing extract -- and rocMLIR consumes
@@ -399,7 +480,7 @@ class HipToTosaPass : public impl::ConvertHipToTosaPassBase<HipToTosaPass> {
         [](tensor::ExtractSliceOp op) { return !isTosaExpressibleSlice(op); });
 
     RewritePatternSet patterns(ctx);
-    patterns.add<MatMulConverter, TransposeConverter,
+    patterns.add<MatMulConverter, TransposeConverter, ExpandConverter,
                  ReshapeConverter<tensor::CollapseShapeOp>,
                  ReshapeConverter<tensor::ExpandShapeOp>, ExtractSliceConverter,
                  BinaryConverter<AddOp, tosa::AddOp>,

--- a/lib/Conversion/HipToTosa/HipToTosa.cpp
+++ b/lib/Conversion/HipToTosa/HipToTosa.cpp
@@ -122,8 +122,7 @@ struct MatMulConverter final : public OpConversionPattern<hip::MatmulOp> {
         tosa::MatMulOp::create(rewriter, op.getLoc(), matmulType, a, b)
             .getResult();
 
-    rewriter.replaceOp(
-        op, reshapeTo(matmul, resultType.getShape(), rewriter));
+    rewriter.replaceOp(op, reshapeTo(matmul, resultType.getShape(), rewriter));
     return success();
   }
 };

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -805,8 +805,9 @@ int wrap_hipblasLtMatmul(
 // RocMLIR dispatch wrapper (hip.rocmlir). Launches a pre-compiled GPU kernel
 // embedded (as an ELF/HSACO blob) in `kernel_binary` at compile time. The
 // generated IR stages the operand data pointers (inputs first, then output)
-// into `kernargs` (a contiguous array of `size` bytes = num_args * sizeof(void*))
-// and passes the module's launch geometry from the compiled perfConfig.
+// into `kernargs` (a contiguous array of `size` bytes = num_args *
+// sizeof(void*)) and passes the module's launch geometry from the compiled
+// perfConfig.
 //   kernel_binary : embedded GPU binary blob (module image)
 //   func_name     : NUL-terminated kernel symbol to launch
 //   block_size    : threads per block

--- a/test/lit/Conversion/hip-to-tosa/test_expand.mlir
+++ b/test/lit/Conversion/hip-to-tosa/test_expand.mlir
@@ -1,0 +1,191 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify that hip.expand, the lowering of ONNX Expand, becomes the broadcast
+// form rocMLIR understands, so the broadcast is folded into the neighbouring
+// kernel instead of costing a wrap_expand kernel that materialises the result.
+//
+// TOSA has no broadcast op. rocMLIR spells one as a multiply against a tensor
+// of ones at the result shape, relying on the implicit broadcasting of TOSA's
+// elementwise ops, and MIGraphXToTosa lowers migraphx.multibroadcast -- the op
+// ONNX Expand maps to on that path -- exactly this way. The multiply does not
+// survive: TosaToRock's mulBroadcast matches the idiom, recognises the ones
+// through isConstantOne, drops the multiply and rewrites the broadcast into a
+// rock.transform, which is a coordinate remap rather than a copy.
+//
+// COVERAGE:
+// - A same-rank broadcast becomes a bare tosa.mul against splat ones
+// - A rank-extending broadcast prepends 1s with tosa.reshape first, since TOSA
+//   broadcasts size-1 dimensions only once both operands carry the result rank
+// - Integer and rank-0 inputs produce the same shape of output
+// - The ones constant lands on the second operand and the shift is zero, which
+//   is the form mulBroadcast and tosa.mul's own verifier require
+// - A dynamically shaped expand is left alone for the runtime rather than
+//   failing the pass: OnnxToHip emits that form deliberately, reading the
+//   extents back from the device
+// - The pass is a no-op on functions without rock.kernel
+// ============================================================================
+
+// RUN: hip-mlir-opt --convert-hip-to-tosa --split-input-file \
+// RUN:   --verify-diagnostics %s | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Broadcasts that convert.
+//===----------------------------------------------------------------------===//
+
+// A leading-dimension broadcast, which needs no rank fixing. This is the shape
+// rocMLIR's own mixr-to-tosa-ops.mlir pins for migraphx.multibroadcast, down to
+// the f16 element type and the splat ones constant.
+// CHECK-LABEL: func.func @expand_leading_dim
+// CHECK-DAG: %[[ONES:.*]] = "tosa.const"() <{values = dense<1.000000e+00> : tensor<64x768x2304xf16>}>
+// CHECK-DAG: %[[SHIFT:.*]] = "tosa.const"() <{values = dense<0> : tensor<1xi8>}>
+// CHECK: tosa.mul %arg1, %[[ONES]], %[[SHIFT]] : (tensor<1x768x2304xf16>, tensor<64x768x2304xf16>, tensor<1xi8>) -> tensor<64x768x2304xf16>
+// CHECK-NOT: hip.expand
+func.func @expand_leading_dim(%ctx: !hip.context, %x: tensor<1x768x2304xf16>,
+                              %s: tensor<3xi64>, %init: tensor<64x768x2304xf16>)
+    -> tensor<64x768x2304xf16> attributes {rock.kernel} {
+  %r = hip.expand(%ctx) ins(%x, %s : tensor<1x768x2304xf16>, tensor<3xi64>)
+                        outs(%init : tensor<64x768x2304xf16>)
+                        : tensor<64x768x2304xf16>
+  return %r : tensor<64x768x2304xf16>
+}
+
+// -----
+
+// ONNX Expand rank-extends the way NumPy does, so a rank-2 input broadcast to a
+// rank-3 result is right-aligned and padded with a leading 1 before the
+// multiply. Both remaining dimensions broadcast: 3 passes through, 1 stretches
+// to 6.
+// CHECK-LABEL: func.func @expand_rank_extending
+// CHECK-DAG: %[[ONES:.*]] = "tosa.const"() <{values = dense<1.000000e+00> : tensor<2x3x6xf32>}>
+// CHECK-DAG: %[[SHAPE:.*]] = tosa.const_shape {values = dense<[1, 3, 1]> : tensor<3xindex>}
+// CHECK: %[[RESHAPED:.*]] = tosa.reshape %arg1, %[[SHAPE]] : (tensor<3x1xf32>, !tosa.shape<3>) -> tensor<1x3x1xf32>
+// CHECK: tosa.mul %[[RESHAPED]], %[[ONES]], %{{.*}} : (tensor<1x3x1xf32>, tensor<2x3x6xf32>, tensor<1xi8>) -> tensor<2x3x6xf32>
+// CHECK-NOT: hip.expand
+func.func @expand_rank_extending(%ctx: !hip.context, %x: tensor<3x1xf32>,
+                                 %s: tensor<3xi64>, %init: tensor<2x3x6xf32>)
+    -> tensor<2x3x6xf32> attributes {rock.kernel} {
+  %r = hip.expand(%ctx) ins(%x, %s : tensor<3x1xf32>, tensor<3xi64>)
+                        outs(%init : tensor<2x3x6xf32>) : tensor<2x3x6xf32>
+  return %r : tensor<2x3x6xf32>
+}
+
+// -----
+
+// A rank-0 source is the widest rank extension there is; every dimension of the
+// result comes from the broadcast.
+// CHECK-LABEL: func.func @expand_scalar_source
+// CHECK-DAG: %[[ONES:.*]] = "tosa.const"() <{values = dense<1.000000e+00> : tensor<4x8xf32>}>
+// CHECK-DAG: %[[SHAPE:.*]] = tosa.const_shape {values = dense<1> : tensor<2xindex>}
+// CHECK: %[[RESHAPED:.*]] = tosa.reshape %arg1, %[[SHAPE]] : (tensor<f32>, !tosa.shape<2>) -> tensor<1x1xf32>
+// CHECK: tosa.mul %[[RESHAPED]], %[[ONES]], %{{.*}} -> tensor<4x8xf32>
+// CHECK-NOT: hip.expand
+func.func @expand_scalar_source(%ctx: !hip.context, %x: tensor<f32>,
+                                %s: tensor<2xi64>, %init: tensor<4x8xf32>)
+    -> tensor<4x8xf32> attributes {rock.kernel} {
+  %r = hip.expand(%ctx) ins(%x, %s : tensor<f32>, tensor<2xi64>)
+                        outs(%init : tensor<4x8xf32>) : tensor<4x8xf32>
+  return %r : tensor<4x8xf32>
+}
+
+// -----
+
+// The ones constant follows the element type, and the integer case is why the
+// shift operand has to be zero: tosa.mul right-shifts the product of integer
+// inputs, so any other shift would scale the result rather than copy it.
+// CHECK-LABEL: func.func @expand_integer
+// CHECK-DAG: %[[ONES:.*]] = "tosa.const"() <{values = dense<1> : tensor<3x5xi32>}>
+// CHECK-DAG: %[[SHIFT:.*]] = "tosa.const"() <{values = dense<0> : tensor<1xi8>}>
+// CHECK: tosa.mul %arg1, %[[ONES]], %[[SHIFT]] : (tensor<1x5xi32>, tensor<3x5xi32>, tensor<1xi8>) -> tensor<3x5xi32>
+// CHECK-NOT: hip.expand
+func.func @expand_integer(%ctx: !hip.context, %x: tensor<1x5xi32>,
+                          %s: tensor<2xi64>, %init: tensor<3x5xi32>)
+    -> tensor<3x5xi32> attributes {rock.kernel} {
+  %r = hip.expand(%ctx) ins(%x, %s : tensor<1x5xi32>, tensor<2xi64>)
+                        outs(%init : tensor<3x5xi32>) : tensor<3x5xi32>
+  return %r : tensor<3x5xi32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// A broadcast feeding an anchor, in the shape hip-fuse-rocmlir produces.
+//===----------------------------------------------------------------------===//
+
+// The point of converting the expand at all: a bias broadcast up to the matmul
+// operand shape has to become TOSA alongside the anchor, or the broadcast stays
+// a separate kernel and the fusion is lost. The ub.poison context and the
+// tensor.empty outs buffers this pass does not claim survive untouched.
+// CHECK-LABEL: func.func @rocMlir0
+// CHECK: ub.poison : !hip.context
+// CHECK: tensor.empty() : tensor<8x64x64xf32>
+// CHECK: %[[ONES:.*]] = "tosa.const"() <{values = dense<1.000000e+00> : tensor<8x64x64xf32>}>
+// CHECK: %[[BCAST:.*]] = tosa.mul %arg0, %[[ONES]], %{{.*}} -> tensor<8x64x64xf32>
+// CHECK: %[[A:.*]] = tosa.reshape %[[BCAST]], %{{.*}} -> tensor<1x512x64xf32>
+// CHECK: tosa.matmul %[[A]], %{{.*}}
+// CHECK-NOT: hip.expand
+// CHECK-NOT: hip.matmul
+func.func @rocMlir0(%bias: tensor<1x64x1xf32>, %s: tensor<3xi64>,
+                    %w: tensor<64x64xf32>) -> tensor<8x64x64xf32>
+    attributes {rock.arch = "gfx1151", rock.kernel} {
+  %ctx = ub.poison : !hip.context
+  %e_init = tensor.empty() : tensor<8x64x64xf32>
+  %e = hip.expand(%ctx) ins(%bias, %s : tensor<1x64x1xf32>, tensor<3xi64>)
+                        outs(%e_init : tensor<8x64x64xf32>) : tensor<8x64x64xf32>
+  %m_init = tensor.empty() : tensor<8x64x64xf32>
+  %m = hip.matmul(%ctx) ins(%e, %w : tensor<8x64x64xf32>, tensor<64x64xf32>)
+                        outs(%m_init : tensor<8x64x64xf32>) : tensor<8x64x64xf32>
+  return %m : tensor<8x64x64xf32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Forms left alone.
+//===----------------------------------------------------------------------===//
+
+// The ones constant has to be built at the result shape, so a dynamic result has
+// no TOSA spelling. Unlike the other hip ops this pass claims, that is not an
+// error: OnnxToHip supports a dynamically shaped Expand on purpose, reading the
+// extents back from the device, and this form has to stay a wrap_expand.
+// CHECK-LABEL: func.func @expand_dynamic_result
+// CHECK: hip.expand
+// CHECK-NOT: tosa.mul
+func.func @expand_dynamic_result(%ctx: !hip.context, %x: tensor<1x?xf32>,
+                                 %s: tensor<2xi64>, %init: tensor<4x?xf32>)
+    -> tensor<4x?xf32> attributes {rock.kernel} {
+  %r = hip.expand(%ctx) ins(%x, %s : tensor<1x?xf32>, tensor<2xi64>)
+                        outs(%init : tensor<4x?xf32>) : tensor<4x?xf32>
+  return %r : tensor<4x?xf32>
+}
+
+// -----
+
+// A dynamic input is equally unconvertible: whether a dimension broadcasts or
+// passes through cannot be decided here.
+// CHECK-LABEL: func.func @expand_dynamic_input
+// CHECK: hip.expand
+// CHECK-NOT: tosa.mul
+func.func @expand_dynamic_input(%ctx: !hip.context, %x: tensor<?x4xf32>,
+                                %s: tensor<2xi64>, %init: tensor<3x4xf32>)
+    -> tensor<3x4xf32> attributes {rock.kernel} {
+  %r = hip.expand(%ctx) ins(%x, %s : tensor<?x4xf32>, tensor<2xi64>)
+                        outs(%init : tensor<3x4xf32>) : tensor<3x4xf32>
+  return %r : tensor<3x4xf32>
+}
+
+// -----
+
+// Only outlined kernels are rewritten; the host graph keeps its runtime ops.
+// CHECK-LABEL: func.func @not_a_kernel
+// CHECK: hip.expand
+// CHECK-NOT: tosa.mul
+func.func @not_a_kernel(%ctx: !hip.context, %x: tensor<1x4xf32>,
+                        %s: tensor<2xi64>, %init: tensor<3x4xf32>)
+    -> tensor<3x4xf32> {
+  %r = hip.expand(%ctx) ins(%x, %s : tensor<1x4xf32>, tensor<2xi64>)
+                        outs(%init : tensor<3x4xf32>) : tensor<3x4xf32>
+  return %r : tensor<3x4xf32>
+}

--- a/test/lit/Conversion/hip-to-tosa/test_shape.mlir
+++ b/test/lit/Conversion/hip-to-tosa/test_shape.mlir
@@ -1,0 +1,190 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify the shape-manipulating ops lower to their TOSA counterparts inside a
+// rock.kernel function, so rocMLIR can fold them into the neighbouring conv or
+// gemm instead of paying for a separate kernel, and verify the forms the
+// conversion leaves alone.
+//
+// Only ONNX Transpose reaches this pass as a hip op. OnnxToHip decomposes
+// Reshape, Squeeze, Unsqueeze and Flatten into tensor.collapse_shape and
+// tensor.expand_shape, and decomposes the constant, unit-stride half of Slice
+// into tensor.extract_slice, so those four ops are covered through the builtin
+// tensor ops they become. The remaining half of Slice stays as hip.slice,
+// which tosa.slice cannot express and this pass does not claim.
+//
+// FILE LAYOUT:
+// Everything that converts or passes through lives in the first
+// --split-input-file chunk, so it is one module and therefore also covers
+// several ops converting in a single pass run. The rejected form gets its own
+// chunk: a rejection aborts the run for the whole module, so sharing a chunk
+// would let it mask the cases after it.
+//
+// This test validates:
+// - hip.transpose maps to tosa.transpose with the permutation unchanged
+// - The hip context and DPS outs operand are both dropped
+// - collapse_shape and expand_shape map to tosa.reshape, covering Reshape,
+//   Squeeze, Unsqueeze and Flatten
+// - extract_slice maps to tosa.slice, with start and size as tosa.const_shape
+// - Strided, rank-reducing and dynamically shaped tensor ops are left in place
+//   for rocMLIR to consume directly, rather than failing the pass
+// - The pass is a no-op on functions without rock.kernel
+// - A dynamically shaped hip.transpose is rejected rather than lowered to
+//   invalid TOSA
+// ============================================================================
+
+// RUN: hip-mlir-opt --convert-hip-to-tosa --split-input-file \
+// RUN:   --verify-diagnostics %s | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Transpose.
+//===----------------------------------------------------------------------===//
+
+// The NHWC-to-NCHW permutation an ONNX image model opens with.
+// CHECK-LABEL: func.func @transpose_nhwc
+// CHECK: tosa.transpose %arg1 {perms = array<i32: 0, 3, 1, 2>} : (tensor<1x224x224x3xf32>) -> tensor<1x3x224x224xf32>
+// CHECK-NOT: hip.transpose
+func.func @transpose_nhwc(%ctx: !hip.context, %x: tensor<1x224x224x3xf32>,
+                          %init: tensor<1x3x224x224xf32>)
+    -> tensor<1x3x224x224xf32> attributes {rock.kernel} {
+  %r = hip.transpose(%ctx) ins(%x : tensor<1x224x224x3xf32>)
+                           outs(%init : tensor<1x3x224x224xf32>)
+                           {perm = [0, 3, 1, 2]} : tensor<1x3x224x224xf32>
+  return %r : tensor<1x3x224x224xf32>
+}
+
+// The last-two-dimension swap that feeds an attention matmul.
+// CHECK-LABEL: func.func @transpose_2d
+// CHECK: tosa.transpose %arg1 {perms = array<i32: 1, 0>} : (tensor<3x5xf16>) -> tensor<5x3xf16>
+func.func @transpose_2d(%ctx: !hip.context, %x: tensor<3x5xf16>,
+                        %init: tensor<5x3xf16>) -> tensor<5x3xf16>
+    attributes {rock.kernel} {
+  %r = hip.transpose(%ctx) ins(%x : tensor<3x5xf16>)
+                           outs(%init : tensor<5x3xf16>)
+                           {perm = [1, 0]} : tensor<5x3xf16>
+  return %r : tensor<5x3xf16>
+}
+
+//===----------------------------------------------------------------------===//
+// Reshape, Flatten, Squeeze and Unsqueeze, via the tensor ops they become.
+//===----------------------------------------------------------------------===//
+
+// ResNet's Flatten between the global pool and the classifier.
+// CHECK-LABEL: func.func @flatten
+// CHECK: %[[SHAPE:.*]] = tosa.const_shape {values = dense<[1, 2048]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK: tosa.reshape %arg0, %[[SHAPE]] : (tensor<1x2048x1x1xf16>, !tosa.shape<2>) -> tensor<1x2048xf16>
+// CHECK-NOT: tensor.collapse_shape
+func.func @flatten(%x: tensor<1x2048x1x1xf16>) -> tensor<1x2048xf16>
+    attributes {rock.kernel} {
+  %c = tensor.collapse_shape %x [[0], [1, 2, 3]]
+      : tensor<1x2048x1x1xf16> into tensor<1x2048xf16>
+  return %c : tensor<1x2048xf16>
+}
+
+// Squeeze drops the size-1 dimensions.
+// CHECK-LABEL: func.func @squeeze
+// CHECK: %[[SHAPE:.*]] = tosa.const_shape {values = dense<4> : tensor<1xindex>} : () -> !tosa.shape<1>
+// CHECK: tosa.reshape %arg0, %[[SHAPE]] : (tensor<1x4x1xf32>, !tosa.shape<1>) -> tensor<4xf32>
+func.func @squeeze(%x: tensor<1x4x1xf32>) -> tensor<4xf32>
+    attributes {rock.kernel} {
+  %c = tensor.collapse_shape %x [[0, 1, 2]]
+      : tensor<1x4x1xf32> into tensor<4xf32>
+  return %c : tensor<4xf32>
+}
+
+// Unsqueeze adds one back.
+// CHECK-LABEL: func.func @unsqueeze
+// CHECK: %[[SHAPE:.*]] = tosa.const_shape {values = dense<[2, 3, 1]> : tensor<3xindex>} : () -> !tosa.shape<3>
+// CHECK: tosa.reshape %arg0, %[[SHAPE]] : (tensor<2x3xf16>, !tosa.shape<3>) -> tensor<2x3x1xf16>
+// CHECK-NOT: tensor.expand_shape
+func.func @unsqueeze(%x: tensor<2x3xf16>) -> tensor<2x3x1xf16>
+    attributes {rock.kernel} {
+  %e = tensor.expand_shape %x [[0], [1, 2]] output_shape [2, 3, 1]
+      : tensor<2x3xf16> into tensor<2x3x1xf16>
+  return %e : tensor<2x3x1xf16>
+}
+
+//===----------------------------------------------------------------------===//
+// Slice.
+//===----------------------------------------------------------------------===//
+
+// tosa.slice carries start and size as shape operands rather than attributes.
+// CHECK-LABEL: func.func @slice
+// CHECK-DAG: %[[SIZE:.*]] = tosa.const_shape {values = dense<[2, 6]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK-DAG: %[[START:.*]] = tosa.const_shape {values = dense<[1, 0]> : tensor<2xindex>} : () -> !tosa.shape<2>
+// CHECK: tosa.slice %arg0, %[[START]], %[[SIZE]] : (tensor<4x6xf32>, !tosa.shape<2>, !tosa.shape<2>) -> tensor<2x6xf32>
+// CHECK-NOT: tensor.extract_slice
+func.func @slice(%x: tensor<4x6xf32>) -> tensor<2x6xf32>
+    attributes {rock.kernel} {
+  %s = tensor.extract_slice %x[1, 0] [2, 6] [1, 1]
+      : tensor<4x6xf32> to tensor<2x6xf32>
+  return %s : tensor<2x6xf32>
+}
+
+//===----------------------------------------------------------------------===//
+// Forms left in place. rocMLIR consumes the tensor ops directly, so a form
+// with no TOSA spelling is passed through rather than failing the pass.
+//===----------------------------------------------------------------------===//
+
+// tosa.slice has no stride operand.
+// CHECK-LABEL: func.func @slice_strided
+// CHECK: tensor.extract_slice
+// CHECK-NOT: tosa.slice
+func.func @slice_strided(%x: tensor<2x4xf32>) -> tensor<1x2xf32>
+    attributes {rock.kernel} {
+  %s = tensor.extract_slice %x[1, 0] [1, 2] [1, 2]
+      : tensor<2x4xf32> to tensor<1x2xf32>
+  return %s : tensor<1x2xf32>
+}
+
+// tosa.slice reads a window of the same rank as its input.
+// CHECK-LABEL: func.func @slice_rank_reducing
+// CHECK: tensor.extract_slice
+// CHECK-NOT: tosa.slice
+func.func @slice_rank_reducing(%x: tensor<4x6xf32>) -> tensor<6xf32>
+    attributes {rock.kernel} {
+  %s = tensor.extract_slice %x[1, 0] [1, 6] [1, 1]
+      : tensor<4x6xf32> to tensor<6xf32>
+  return %s : tensor<6xf32>
+}
+
+// tosa.reshape's shape operand is a compile-time constant.
+// CHECK-LABEL: func.func @collapse_dynamic
+// CHECK: tensor.collapse_shape
+// CHECK-NOT: tosa.reshape
+func.func @collapse_dynamic(%x: tensor<?x2x3xf16>) -> tensor<?x6xf16>
+    attributes {rock.kernel} {
+  %c = tensor.collapse_shape %x [[0], [1, 2]]
+      : tensor<?x2x3xf16> into tensor<?x6xf16>
+  return %c : tensor<?x6xf16>
+}
+
+// Without rock.kernel the pass returns before looking at the body.
+// CHECK-LABEL: func.func @not_a_kernel
+// CHECK: tensor.extract_slice
+// CHECK-NOT: tosa.slice
+func.func @not_a_kernel(%x: tensor<4x6xf32>) -> tensor<2x6xf32> {
+  %s = tensor.extract_slice %x[1, 0] [2, 6] [1, 1]
+      : tensor<4x6xf32> to tensor<2x6xf32>
+  return %s : tensor<2x6xf32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Rejected form. Unlike the tensor ops above, a hip op this pass claims has to
+// convert or the pass fails.
+//===----------------------------------------------------------------------===//
+
+// tosa.transpose needs a static result shape to permute.
+func.func @transpose_dynamic(%ctx: !hip.context, %x: tensor<?x4xf32>,
+                             %init: tensor<4x?xf32>) -> tensor<4x?xf32>
+    attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.transpose'}}
+  %r = hip.transpose(%ctx) ins(%x : tensor<?x4xf32>)
+                           outs(%init : tensor<4x?xf32>)
+                           {perm = [1, 0]} : tensor<4x?xf32>
+  return %r : tensor<4x?xf32>
+}

--- a/test/lit/Conversion/hip-to-tosa/test_shape.mlir
+++ b/test/lit/Conversion/hip-to-tosa/test_shape.mlir
@@ -30,6 +30,8 @@
 // - extract_slice maps to tosa.slice, with start and size as tosa.const_shape
 // - Strided, rank-reducing and dynamically shaped tensor ops are left in place
 //   for rocMLIR to consume directly, rather than failing the pass
+// - A real outlined kernel converts: its ub.poison context, tensor.empty outs
+//   buffers and fusion anchor all survive alongside the converted ops
 // - The pass is a no-op on functions without rock.kernel
 // - A dynamically shaped hip.transpose is rejected rather than lowered to
 //   invalid TOSA
@@ -169,6 +171,41 @@ func.func @not_a_kernel(%x: tensor<4x6xf32>) -> tensor<2x6xf32> {
   %s = tensor.extract_slice %x[1, 0] [2, 6] [1, 1]
       : tensor<4x6xf32> to tensor<2x6xf32>
   return %s : tensor<2x6xf32>
+}
+
+//===----------------------------------------------------------------------===//
+// The shape hip-fuse-rocmlir actually produces. Unit tests that hand-write a
+// kernel taking its DPS buffers as block arguments miss what an outlined
+// kernel really holds: a ub.poison standing in for the !hip.context, a
+// tensor.empty per outs buffer, and the fusion anchor the kernel was built
+// around. Those all have to survive, or the pass fails on IR it never meant to
+// convert.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @rocMlir0
+// CHECK: ub.poison : !hip.context
+// CHECK: tensor.empty() : tensor<1x4x6x6xf32>
+// CHECK: hip.conv
+// CHECK: tosa.transpose %{{.*}} {perms = array<i32: 0, 2, 3, 1>} : (tensor<1x4x6x6xf32>) -> tensor<1x6x6x4xf32>
+// CHECK: tosa.reshape
+func.func @rocMlir0(%in: tensor<1x3x8x8xf32>, %w: tensor<4x3x3x3xf32>,
+                    %b: tensor<4xf32>) -> tensor<1x144xf32>
+    attributes {rock.arch = "gfx1151", rock.kernel} {
+  %ctx = ub.poison : !hip.context
+  %ci = tensor.empty() : tensor<1x4x6x6xf32>
+  %conv = hip.conv(%ctx) ins(%in, %w, %b : tensor<1x3x8x8xf32>,
+                                           tensor<4x3x3x3xf32>, tensor<4xf32>)
+                         outs(%ci : tensor<1x4x6x6xf32>)
+                         {dilations = [1, 1], group = 1 : i64,
+                          kernel_shape = [3, 3], pads = [0, 0, 0, 0],
+                          strides = [1, 1]} : tensor<1x4x6x6xf32>
+  %ti = tensor.empty() : tensor<1x6x6x4xf32>
+  %tr = hip.transpose(%ctx) ins(%conv : tensor<1x4x6x6xf32>)
+                            outs(%ti : tensor<1x6x6x4xf32>)
+                            {perm = [0, 2, 3, 1]} : tensor<1x6x6x4xf32>
+  %flat = tensor.collapse_shape %tr [[0], [1, 2, 3]]
+      : tensor<1x6x6x4xf32> into tensor<1x144xf32>
+  return %flat : tensor<1x144xf32>
 }
 
 // -----

--- a/tools/hip-rocmlir-compiler/hip-rocmlir-compiler.cpp
+++ b/tools/hip-rocmlir-compiler/hip-rocmlir-compiler.cpp
@@ -142,7 +142,8 @@ struct Api {
   void (*moduleDestroy)(MlirModule);
   MlirPassManager (*passManagerCreate)(MlirContext);
   MlirOpPassManager (*passManagerGetAsOpPassManager)(MlirPassManager);
-  int (*passManagerRunOnOp)(MlirPassManager, MlirOperation); // MlirLogicalResult
+  int (*passManagerRunOnOp)(MlirPassManager,
+                            MlirOperation); // MlirLogicalResult
   void (*passManagerDestroy)(MlirPassManager);
   void (*operationPrint)(MlirOperation, MlirStringCallback, void *);
 
@@ -155,7 +156,8 @@ struct Api {
                                                RocmlirTuningParamSetKind);
   unsigned (*rockTuningGetNumParams)(MlirRockTuningSpace);
   MlirRockTuningParam (*rockTuningParamCreate)();
-  bool (*rockTuningParamGet)(MlirRockTuningSpace, unsigned, MlirRockTuningParam);
+  bool (*rockTuningParamGet)(MlirRockTuningSpace, unsigned,
+                             MlirRockTuningParam);
   size_t (*rockTuningParamToString)(MlirRockTuningParam, char *, size_t);
   bool (*rockTuningSetFromStr)(MlirModule, MlirStringRef);
   void (*rockTuningParamDestroy)(MlirRockTuningParam);
@@ -166,8 +168,7 @@ struct Api {
   bool (*getBinary)(MlirModule, size_t *, char *);
 };
 
-template <typename T>
-static bool bind(void *handle, T &fn, const char *name) {
+template <typename T> static bool bind(void *handle, T &fn, const char *name) {
   fn = reinterpret_cast<T>(dlsym(handle, name));
   if (!fn) {
     llvm::errs() << "error: symbol '" << name
@@ -187,7 +188,8 @@ static bool load(Api &api, const std::string &soPath) {
     return false;
   }
   bool ok = true;
-  ok &= bind(api.handle, api.dialectRegistryCreate, "mlirDialectRegistryCreate");
+  ok &=
+      bind(api.handle, api.dialectRegistryCreate, "mlirDialectRegistryCreate");
   ok &= bind(api.handle, api.dialectRegistryDestroy,
              "mlirDialectRegistryDestroy");
   ok &= bind(api.handle, api.registerRocMLIRDialects,
@@ -210,19 +212,18 @@ static bool load(Api &api, const std::string &soPath) {
   ok &= bind(api.handle, api.operationPrint, "mlirOperationPrint");
   ok &= bind(api.handle, api.hipEpAddHighLevelPipeline,
              "hipEpAddHighLevelPipeline");
-  ok &= bind(api.handle, api.hipEpAddBackendPipeline,
-             "hipEpAddBackendPipeline");
-  ok &= bind(api.handle, api.rockTuningSpaceCreate,
-             "mlirRockTuningSpaceCreate");
+  ok &=
+      bind(api.handle, api.hipEpAddBackendPipeline, "hipEpAddBackendPipeline");
+  ok &=
+      bind(api.handle, api.rockTuningSpaceCreate, "mlirRockTuningSpaceCreate");
   ok &= bind(api.handle, api.rockTuningGetNumParams,
              "mlirRockTuningGetNumParams");
-  ok &= bind(api.handle, api.rockTuningParamCreate,
-             "mlirRockTuningParamCreate");
+  ok &=
+      bind(api.handle, api.rockTuningParamCreate, "mlirRockTuningParamCreate");
   ok &= bind(api.handle, api.rockTuningParamGet, "mlirRockTuningParamGet");
   ok &= bind(api.handle, api.rockTuningParamToString,
              "mlirRockTuningParamToString");
-  ok &= bind(api.handle, api.rockTuningSetFromStr,
-             "mlirRockTuningSetFromStr");
+  ok &= bind(api.handle, api.rockTuningSetFromStr, "mlirRockTuningSetFromStr");
   ok &= bind(api.handle, api.rockTuningParamDestroy,
              "mlirRockTuningParamDestroy");
   ok &= bind(api.handle, api.rockTuningSpaceDestroy,
@@ -309,8 +310,10 @@ static bool runRocmlirInSo(const std::string &moduleText,
   api.registerRocMLIRDialects(registry);
   // Disable threading: keeps diagnostics ordered and avoids the .so spinning up
   // its own thread pool for a single one-shot pipeline run.
-  MlirContext ctx = api.contextCreateWithRegistry(registry, /*threading=*/false);
-  // main_graph still carries unregistered hip.* ops; let them parse generically.
+  MlirContext ctx =
+      api.contextCreateWithRegistry(registry, /*threading=*/false);
+  // main_graph still carries unregistered hip.* ops; let them parse
+  // generically.
   api.contextSetAllowUnregisteredDialects(ctx, true);
   api.contextLoadAllAvailableDialects(ctx);
 
@@ -386,7 +389,8 @@ static bool runRocmlirInSo(const std::string &moduleText,
       return fail("failed to read the first perfConfig entry");
     }
 
-    size_t n = api.rockTuningParamToString(param, perfConfig, sizeof(perfConfig));
+    size_t n =
+        api.rockTuningParamToString(param, perfConfig, sizeof(perfConfig));
     if (n >= sizeof(perfConfig)) {
       api.rockTuningParamDestroy(param);
       api.rockTuningSpaceDestroy(space);
@@ -485,8 +489,7 @@ int main(int argc, char **argv) {
   }
   if (inputFilename.empty() || outputPath.empty()) {
     llvm::errs()
-        << "Usage: " << argv[0]
-        << " <input.onnx.mlir> -o <output> [options]\n"
+        << "Usage: " << argv[0] << " <input.onnx.mlir> -o <output> [options]\n"
         << "  Runs ONNX->HIP head passes, compiles the fused GEMM via\n"
         << "  the rocMLIR pipeline (librockCompiler.so), embeds the GPU\n"
         << "  binary into hip.rocmlir, runs the ONNX->HIP tail +\n"
@@ -530,11 +533,12 @@ int main(int argc, char **argv) {
   }
 
   // Stage 1: ONNX->HIP head passes + fuse-rocmlir. Mirrors the head of
-  // buildOnnxToHipPipeline (simplify-onnx, hip-add-context-arg, loop/if outline,
-  // infer-loop-body-shapes, convert-onnx-to-hip; plain path, no hipdnn handle)
-  // followed by fuse-rocmlir + duplicate-function-elimination, which outline the
-  // fused GEMM into a `rock.kernel` func and create the `hip.rocmlir` dispatch.
-  // `module` is LEFT in this hip form: it is the artifact we mutate at the end.
+  // buildOnnxToHipPipeline (simplify-onnx, hip-add-context-arg, loop/if
+  // outline, infer-loop-body-shapes, convert-onnx-to-hip; plain path, no hipdnn
+  // handle) followed by fuse-rocmlir + duplicate-function-elimination, which
+  // outline the fused GEMM into a `rock.kernel` func and create the
+  // `hip.rocmlir` dispatch. `module` is LEFT in this hip form: it is the
+  // artifact we mutate at the end.
   mlir::PassManager pm(module->getContext());
   pm.addPass(mlir::hip::createSimplifyOnnxPass());
   pm.addPass(mlir::hip::createHipAddContextArgPass());
@@ -614,8 +618,9 @@ int main(int argc, char **argv) {
   // produced; stamp it onto every hip.rocmlir op whose callee is a compiled
   // rock.kernel func.
   mlir::Builder b(&context);
-  auto binaryAttr = mlir::StringAttr::get(
-      &context, llvm::StringRef(compiled.binary.data(), compiled.binary.size()));
+  auto binaryAttr =
+      mlir::StringAttr::get(&context, llvm::StringRef(compiled.binary.data(),
+                                                      compiled.binary.size()));
   auto i64 = mlir::IntegerType::get(&context, 64);
 
   llvm::SmallVector<mlir::func::FuncOp> kernelFuncs;
@@ -681,8 +686,8 @@ int main(int argc, char **argv) {
   }
 
   // Stage 5: HIP->LLVM lowering + interface generation, then translate to LLVM
-  // IR, optimize, and emit OS-portable bitcode -- the same artifact hip-compiler
-  // produces in its default (LLVM_IR) mode.
+  // IR, optimize, and emit OS-portable bitcode -- the same artifact
+  // hip-compiler produces in its default (LLVM_IR) mode.
   mlir::registerLLVMDialectTranslation(context);
   {
     mlir::hip::HipToLLVMPipelineOptions llvmOpts;


### PR DESCRIPTION
## What

Converts the shape-manipulating ops to TOSA so rocMLIR can absorb them into a fused kernel: **Transpose, Reshape, Squeeze, Unsqueeze, Flatten and Slice**.

rocMLIR does not execute these — it folds them into the neighbouring conv or gemm as a layout change. `TosaToRock.cpp`'s `TransposeRewritePattern` rewrites a transpose after a conv into an `output_layout` attribute and one after a matmul into `transpose_c`, while `mergeTransposeWithGemmLikeOp` pushes a transpose on the input side into `input_layout` / `filter_layout`. Left in the HIP dialect, a transpose instead lowers to `llvm.call @wrap_transpose`, a standalone kernel and a full extra pass over memory.

## How the six ops route here

Only Transpose arrives as a hip op. `OnnxToHip` deliberately decomposes the others into builtin tensor metadata ops, because they move no data and a DPS hip op would force an allocation and a copy:

| ONNX op | What reaches this pass |
| --- | --- |
| Transpose | `hip.transpose` |
| Reshape, Squeeze, Unsqueeze, Flatten | `tensor.collapse_shape` / `tensor.expand_shape` |
| Slice (constant bounds, positive step) | `tensor.extract_slice` |
| Slice (negative step, runtime bounds) | `hip.slice` — not claimed |

So the six ops are covered by three patterns: `TransposeConverter`, a `ReshapeConverter` templated over collapse/expand, and `ExtractSliceConverter`. `hip.slice` exists precisely for the cases `tosa.slice` cannot express — it has no stride operand and no reverse traversal — so it is left for the runtime.

## Legality: borrowed vs owned ops

The hip ops stay unconditionally illegal, matching the 18 already converted: one this pass claims must convert or the pass fails.

The tensor ops are different. They are borrowed, not owned — a kernel can legitimately hold a strided or rank-reducing extract, or a dynamically shaped reshape, and rocMLIR consumes those directly. Marking them illegal outright would turn previously-fine kernels into hard errors, so they are illegal only where a pattern will succeed:

```cpp
conversion.addDynamicallyLegalOp<tensor::ExtractSliceOp>(
    [](tensor::ExtractSliceOp op) { return !isTosaExpressibleSlice(op); });
```

## Testing

New `test_shape.mlir` (227 lines) covers the conversions, the passthrough forms, and the rejection. It includes a case with the shape `hip-fuse-rocmlir` actually produces — a `ub.poison` context, a `tensor.empty` per outs buffer and a `hip.conv` anchor — and checks all three survive while the shape ops convert around them. The existing tests hand-write kernels taking their buffers as block arguments, which is the blind spot that let the earlier `applyFullConversion` regression reach a real model.

Full lit suite: 479 passing. The one failure, `test_qadd.mlir`, runs only `--convert-onnx-to-hip`, which this branch does not touch; it was failing before this work.

## Note for reviewers

rocMLIR's pipeline opens with `--tosa-to-tensor`, which converts `tosa.reshape` back into a collapse/expand pair and `tosa.slice` back into `tensor.extract_slice`. For the reshape family that makes the conversion a round trip, since hip-ep already emits the form `tosa-to-rock` consumes. Happy to drop `ReshapeConverter` and keep only Transpose if that is the preference — the ops would then be covered by leaving them alone.

Separately, `FuseROCMlir`'s `isaPointwiseOp` list contains only elementwise ops, so none of these are outlined into a `rock.kernel` yet and the patterns will not fire on a real model until that changes. Follow-up.
