### PR TITLE
test: matmul_nbits K-padding zero-point fix on a gemma4-capable OGA build (#933 + #599)

### DIFF
--- a/.github/workflows/windows-deps.yml
+++ b/.github/workflows/windows-deps.yml
@@ -587,6 +587,11 @@ jobs:
         if: steps.cache-oga.outputs.cache-hit != 'true'
         shell: bash
         run: |
+          # build.py imports tools/python/util, whose dependency_resolver
+          # imports requests at module scope. --ort_home means nothing is
+          # actually downloaded, but the import still has to resolve.
+          python -m pip install -q requests
+
           python "${{ github.workspace }}/source-oga/build.py" \
             --config Release \
             --cmake_generator Ninja \

--- a/.github/workflows/windows-deps.yml
+++ b/.github/workflows/windows-deps.yml
@@ -30,8 +30,14 @@ env:
   LLVM_TAG: llvmorg-22.1.0
   ONNXRUNTIME_VERSION: "1.27.0"
   ONNXRUNTIME_PR_PATCHES: ""
-  OGA_VERSION: "0.14.0"
-  OGA_PR_PATCHES: "2194"
+  # Fork branch carrying the AMDGPU MorphiZen integration (former PR 2194) plus
+  # sliding_window support, which upstream v0.14.0 does not have.
+  OGA_REPO: "amd-genmingz/onnxruntime-genai"
+  OGA_REF: "test_0_3"
+  # Optional space-separated microsoft/onnxruntime-genai PR numbers applied on
+  # top of the fork checkout via pull/<n>.patch + git am. Empty because the fork
+  # branch already carries the integration that 2194 used to supply.
+  OGA_PR_PATCHES: ""
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
   AMDGPU_EP_REF: "05eaa2a938f71e98b49bd1be3fb03720167be5cc"
   # Space-separated onnxruntime/onnxruntime-ep-amdgpu PR numbers applied on top
@@ -473,7 +479,7 @@ jobs:
       - name: Compute cache key
         id: key
         shell: bash
-        run: echo "value=oga-dml-mm2-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}" >> "$GITHUB_OUTPUT"
+        run: echo "value=oga-dml-mm3-${{ env.OGA_REPO }}-${{ env.OGA_REF }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}-2" >> "$GITHUB_OUTPUT"
 
       - name: Probe oga-artifacts
         id: cache-oga
@@ -525,8 +531,8 @@ jobs:
         if: steps.cache-oga.outputs.cache-hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: microsoft/onnxruntime-genai
-          ref: v${{ env.OGA_VERSION }}
+          repository: ${{ env.OGA_REPO }}
+          ref: ${{ env.OGA_REF }}
           path: source-oga
           submodules: true
           fetch-depth: 1

--- a/lib/Runtime/Kernels/hip/autotune/matmul_nbits/tools/matmul_nbits_kpad_test.cpp
+++ b/lib/Runtime/Kernels/hip/autotune/matmul_nbits/tools/matmul_nbits_kpad_test.cpp
@@ -9,6 +9,14 @@
  * that path against a CPU reference, and a K%32==0 control shape to confirm the
  * ordinary WMMA path is unchanged.
  *
+ * Zero-point coverage matters as much as the shape here. The K-padding path
+ * reads zp_for_fp16_paths, which degrades to the packed-nibble zero_points when
+ * the caller supplies no pre-unpacked fp16 buffer. An earlier version of this
+ * test only ever passed zero_points=nullptr, so has_zp was false, the pointer
+ * was never dereferenced, and it reported the path correct while every real
+ * asymmetric model (gemma-4's SigLIP, K=4304) produced garbage. Every shape is
+ * now run in three zero-point modes -- see Zp below.
+ *
  * GPU required (runs the kernel). Build from the repo root, e.g.:
  *   flatc --cpp -o <gen> lib/Runtime/Kernels/hip/autotune/matmul_nbits/matmul_nbits_autotune.fbs
  *   clang++ -x hip --offload-arch=gfx1151 -O3 -std=c++17 -w \
@@ -58,12 +66,36 @@ static float h2f(uint16_t o) {
   return (float)h;
 }
 
+/* How the caller presents zero_points, mirroring what the runtime wrapper
+ * (lib/Runtime/real/matmul_nbits.cpp) hands the kernel:
+ *
+ *   Symmetric  - no zero_points at all; the kernel's implicit zp of 8.
+ *   AsymU8Only - packed nibbles + pre_unpacked_zp_u8, no fp16 buffer. This is
+ *                what the wrapper used to pass for K%32!=0, and the case the
+ *                K-padding path silently mis-read. The kernel must now decline
+ *                the fp16-zp paths and land on one that reads the uint8 buffer.
+ *   AsymFp16   - packed nibbles + both pre-unpacked buffers, i.e. what the
+ *                wrapper passes now. This is the case that must stay on WMMA.
+ *
+ * Both asym modes must agree with the same reference: which kernel serves the
+ * shape is a performance decision, never a numerical one. */
+enum class Zp { Symmetric, AsymU8Only, AsymFp16 };
+
+static const char* zpName(Zp z) {
+  switch (z) {
+    case Zp::Symmetric:  return "sym";
+    case Zp::AsymU8Only: return "asym u8-only";
+    default:             return "asym +fp16";
+  }
+}
+
 // One shape: row-major A[M,K] fp16, packed int4 B[N, ngk*(gs/2)], fp16
-// scales[N,ngk], symmetric (default zp=8). Returns max abs and max rel error
-// of hip_matmul_nbits against a CPU fp32 reference.
-static bool check(int M, int N, int K, int gs) {
+// scales[N,ngk], and zero-points per `mode`. Compares hip_matmul_nbits against
+// a CPU fp32 reference.
+static bool check(int M, int N, int K, int gs, Zp mode) {
   const int ngk = (K + gs - 1) / gs;
   const int row_bytes = ngk * (gs / 2);
+  const bool asym = (mode != Zp::Symmetric);
 
   std::vector<uint16_t> hA((size_t)M * K), hSc((size_t)N * ngk);
   std::vector<uint8_t> hB((size_t)N * row_bytes);
@@ -73,24 +105,57 @@ static bool check(int M, int N, int K, int gs) {
     hSc[i] = f2h(0.01f + 0.001f * float(i % 7));
   for (size_t i = 0; i < hB.size(); ++i) hB[i] = uint8_t(i * 31 + 7);
 
+  // Asymmetric zero-points, in all three layouts the kernel can be handed.
+  // Packed is [N, (ngk+1)/2] with the low nibble the even group and the high
+  // nibble the odd one; the u8 and fp16 forms are one value per group [N, ngk].
+  // Values deliberately stray from 8 so a path that ignores them, or reads the
+  // packed bytes as fp16, cannot accidentally match.
+  const int packed_cols = (ngk + 1) / 2;
+  std::vector<uint8_t> hZpPacked(asym ? (size_t)N * packed_cols : 0);
+  std::vector<uint8_t> hZpU8(asym ? (size_t)N * ngk : 0);
+  std::vector<uint16_t> hZpFp16(asym ? (size_t)N * ngk : 0);
+  auto zp_of = [&](int n, int g) -> int {
+    if (!asym) return 8;
+    return (int)hZpU8[(size_t)n * ngk + g];
+  };
+  if (asym) {
+    for (int n = 0; n < N; ++n)
+      for (int g = 0; g < ngk; ++g) {
+        const int v = (n * 7 + g * 5 + 1) % 16;
+        hZpU8[(size_t)n * ngk + g] = (uint8_t)v;
+        hZpFp16[(size_t)n * ngk + g] = f2h((float)v);
+        uint8_t& p = hZpPacked[(size_t)n * packed_cols + g / 2];
+        if (g % 2 == 0)
+          p = (uint8_t)((p & 0xF0) | v);
+        else
+          p = (uint8_t)((p & 0x0F) | (v << 4));
+      }
+  }
+
   auto wof = [&](int n, int k) -> int {
     const int g = k / gs, loc = k % gs;
     uint8_t p = hB[(size_t)n * row_bytes + (size_t)g * (gs / 2) + loc / 2];
     return (loc & 1) ? (p >> 4) : (p & 0xF);
   };
 
-  // CPU reference: out[m,n] = sum_k A[m,k] * (w-8) * scale[n, k/gs]
+  // CPU reference: out[m,n] = sum_k A[m,k] * (w - zp[n, k/gs]) * scale[n, k/gs].
+  // Dequantizing each B row once and reusing it across all M keeps this
+  // affordable at the full prefill M (the M=2268 case below is ~11e9 MACs).
   std::vector<float> ref((size_t)M * N, 0.0f);
-  for (int m = 0; m < M; ++m)
-    for (int n = 0; n < N; ++n) {
+  std::vector<float> brow((size_t)K);
+  for (int n = 0; n < N; ++n) {
+    for (int k = 0; k < K; ++k) {
+      const int g = k / gs;
+      brow[(size_t)k] =
+          (float(wof(n, k)) - float(zp_of(n, g))) * h2f(hSc[(size_t)n * ngk + g]);
+    }
+    for (int m = 0; m < M; ++m) {
+      const uint16_t* arow = &hA[(size_t)m * K];
       float acc = 0.0f;
-      for (int k = 0; k < K; ++k) {
-        float a = h2f(hA[(size_t)m * K + k]);
-        float sc = h2f(hSc[(size_t)n * ngk + k / gs]);
-        acc += a * (float(wof(n, k)) - 8.0f) * sc;
-      }
+      for (int k = 0; k < K; ++k) acc += h2f(arow[k]) * brow[(size_t)k];
       ref[(size_t)m * N + n] = acc;
     }
+  }
 
   void *dA, *dB, *dSc, *dOut;
   HIP_OK(hipMalloc(&dA, hA.size() * 2));
@@ -101,11 +166,26 @@ static bool check(int M, int N, int K, int gs) {
   HIP_OK(hipMemcpy(dB, hB.data(), hB.size(), hipMemcpyHostToDevice));
   HIP_OK(hipMemcpy(dSc, hSc.data(), hSc.size() * 2, hipMemcpyHostToDevice));
 
-  int rc = hip_matmul_nbits(nullptr, dA, dB, dSc, /*zp=*/nullptr, nullptr, dOut,
-                            M, N, K, 1, 4, gs, 2, 2, nullptr, nullptr);
+  void *dZpPacked = nullptr, *dZpU8 = nullptr, *dZpFp16 = nullptr;
+  if (asym) {
+    HIP_OK(hipMalloc(&dZpPacked, hZpPacked.size()));
+    HIP_OK(hipMemcpy(dZpPacked, hZpPacked.data(), hZpPacked.size(),
+                     hipMemcpyHostToDevice));
+    HIP_OK(hipMalloc(&dZpU8, hZpU8.size()));
+    HIP_OK(hipMemcpy(dZpU8, hZpU8.data(), hZpU8.size(), hipMemcpyHostToDevice));
+    if (mode == Zp::AsymFp16) {
+      HIP_OK(hipMalloc(&dZpFp16, hZpFp16.size() * 2));
+      HIP_OK(hipMemcpy(dZpFp16, hZpFp16.data(), hZpFp16.size() * 2,
+                       hipMemcpyHostToDevice));
+    }
+  }
+
+  int rc = hip_matmul_nbits(nullptr, dA, dB, dSc, dZpPacked, nullptr, dOut, M, N,
+                            K, 1, 4, gs, 2, asym ? 1 : 2, dZpU8, dZpFp16);
   HIP_OK(hipDeviceSynchronize());
   if (rc != 0) {
-    std::printf("  hip_matmul_nbits rc=%d\n", rc);
+    std::printf("  M=%-5d N=%-6d K=%-6d gs=%-3d %-13s hip_matmul_nbits rc=%d\n",
+                M, N, K, gs, zpName(mode), rc);
     return false;
   }
 
@@ -123,13 +203,28 @@ static bool check(int M, int N, int K, int gs) {
     max_ref = std::max(max_ref, std::fabs(ref[i]));
   }
   hipFree(dA); hipFree(dB); hipFree(dSc); hipFree(dOut);
+  if (dZpPacked) hipFree(dZpPacked);
+  if (dZpU8) hipFree(dZpU8);
+  if (dZpFp16) hipFree(dZpFp16);
 
   const float rel = max_abs / (max_ref + 1e-6f);
   const bool ok = rel < 0.02f;   // 2% of signal scale; fp16 tile-order rounding
-  std::printf("  M=%-5d N=%-6d K=%-6d gs=%-3d  max_abs=%.4f peak=%.3f "
+  std::printf("  M=%-5d N=%-6d K=%-6d gs=%-3d %-13s max_abs=%.4f peak=%.3f "
               "rel=%.4f  %s\n",
-              M, N, K, gs, max_abs, max_ref, rel, ok ? "OK" : "FAIL");
+              M, N, K, gs, zpName(mode), max_abs, max_ref, rel,
+              ok ? "OK" : "FAIL");
   return ok;
+}
+
+// Every shape in all three zero-point modes. The asym modes are the point:
+// AsymU8Only is the combination that used to reach the K-padding path with the
+// packed nibbles reinterpreted as fp16.
+static int checkAll(int M, int N, int K, int gs) {
+  int fails = 0;
+  fails += !check(M, N, K, gs, Zp::Symmetric);
+  fails += !check(M, N, K, gs, Zp::AsymU8Only);
+  fails += !check(M, N, K, gs, Zp::AsymFp16);
+  return fails;
 }
 
 int main() {
@@ -139,13 +234,20 @@ int main() {
 
   int fails = 0;
   std::printf("-- K%%32!=0 (new K-padding WMMA path) --\n");
-  fails += !check(32,  1152, 4304, 32);   // gemma-4 down_proj, prefill
-  fails += !check(128, 1152, 4304, 32);
-  fails += !check(17,  1152, 4304, 32);   // M not a multiple of the tile
+  fails += checkAll(32,  1152, 4304, 32);   // gemma-4 down_proj, prefill
+  fails += checkAll(128, 1152, 4304, 32);
+  fails += checkAll(17,  1152, 4304, 32);   // M not a multiple of the tile
+
+  // The shipped geometry: gemma-4's SigLIP down_proj at a 2268-token image
+  // prefill, the shape whose asym output was garbage. Slowest case here by far
+  // (the reference is ~11e9 MACs), and the one that actually reproduced the bug
+  // end to end.
+  std::printf("\n-- shipped SigLIP down_proj geometry --\n");
+  fails += checkAll(2268, 1152, 4304, 32);
 
   std::printf("\n-- K%%32==0 control (unchanged WMMA path) --\n");
-  fails += !check(32,  4096, 4096, 32);
-  fails += !check(128, 14336, 4096, 128);
+  fails += checkAll(32,  4096, 4096, 32);
+  fails += checkAll(128, 14336, 4096, 128);
 
   std::printf("\n%s\n", fails ? "FAILED" : "ALL PASSED");
   return fails ? 1 : 0;

--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -1162,6 +1162,123 @@ extern "C" int hip_gqa_add_attention_bias_f32(
   GQA_RETURN_LAUNCH_STATUS();
 }
 
+// Highest key position any query row in a chunk can attend, read off the
+// additive mask instead of assumed.
+//
+// The decomposed prefill tiles the query range into chunks and gives each its
+// own key extent. For a causal op that extent is the chunk's own last row,
+// which is exact and needs no mask inspection. A BIDIRECTIONAL op
+// (onnx.Attention is_causal=0) has no such bound in its attributes, so every
+// chunk scores every key -- and on Gemma-4's 5 global layers that is the
+// largest single block of wasted work in a 16K prefill, because their mask is
+// causal apart from a same-image-block leg reaching one image block above the
+// diagonal. AttentionWindowFold cannot supply the bound: the block extent is a
+// property of the input, not of the mask's structure.
+//
+// The mask itself already carries it, exactly, for one streaming read. An entry
+// whose additive bias is at or below -65504 -- the fp16 lower bound, and the
+// sentinel HF exports write for "not attended" -- cannot survive the softmax:
+// relative to any score the GEMM ahead of it can produce, exp() of it
+// underflows to exactly zero. That is the same property the mask relies on to
+// mask at all, and softmax_f32_to_out_kernel above already documents this
+// value for the same reason. So dropping those key positions from a chunk's
+// range is bit-exact rather than an approximation, and anything less negative
+// than the sentinel is treated as attended, which only narrows less.
+//
+// Only the region ABOVE the chunk's last row is scanned. Keys at or below it
+// are kept whatever the mask says, so the answer is max(diagonal, highest
+// attended key above it) and the work is half the mask rather than all of it.
+// The max is reduced over every bias batch/head plane as well as every row in
+// the chunk, so a broadcast plane and a per-head mask both yield a bound valid
+// for all of them.
+#define GQA_BIAS_EXTENT_THREADS 256
+
+// Additive bias at or below this cannot survive the softmax. Not a tolerance:
+// it is the fp16 lower bound, which is the sentinel itself.
+#define GQA_BIAS_MASKED_MAX (-65504.0f)
+
+template <typename TBias>
+__global__ void bias_key_extent_kernel(
+    const TBias* __restrict__ bias, int* __restrict__ out,
+    int bias_batch, int bias_heads, int bias_sq, int bias_total_seq,
+    int sq, int sq_chunk, int past_len) {
+  const int chunk = blockIdx.x;
+  const int q0 = chunk * sq_chunk;
+  if (q0 >= sq)
+    return;
+  const int c = min(sq_chunk, sq - q0);
+
+  // Absolute key position of the chunk's last query row. Keys at or below it
+  // are attended by the causal leg and are never dropped, so it is the floor.
+  const int diag = past_len + q0 + c - 1;
+  int best = diag;
+
+  const int scan_lo = diag + 1;
+  if (scan_lo < bias_total_seq) {
+    const size_t plane = static_cast<size_t>(bias_sq) * bias_total_seq;
+    const int planes = bias_batch * bias_heads;
+    for (int p = 0; p < planes; ++p) {
+      for (int r = 0; r < c; ++r) {
+        const size_t row_base = static_cast<size_t>(p) * plane +
+                                static_cast<size_t>(q0 + r) * bias_total_seq;
+        // `k > best` first: once this thread has seen a high hit, the lower
+        // columns cannot raise the answer and the load is skipped.
+        for (int k = scan_lo + threadIdx.x; k < bias_total_seq;
+             k += blockDim.x) {
+          if (k > best &&
+              static_cast<float>(bias[row_base + k]) > GQA_BIAS_MASKED_MAX)
+            best = k;
+        }
+      }
+    }
+  }
+
+  __shared__ int red[GQA_BIAS_EXTENT_THREADS];
+  red[threadIdx.x] = best;
+  __syncthreads();
+  for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+    if (threadIdx.x < s)
+      red[threadIdx.x] = max(red[threadIdx.x], red[threadIdx.x + s]);
+    __syncthreads();
+  }
+  if (threadIdx.x == 0)
+    out[chunk] = red[0];
+}
+
+extern "C" int hip_gqa_bias_key_extent(
+    void* stream_ptr, const void* bias, void* out_chunk_hi,
+    int bias_batch, int bias_heads, int bias_sq, int bias_total_seq,
+    int sq, int sq_chunk, int past_len, int num_chunks,
+    int bias_element_size_bytes) {
+  if (!bias || !out_chunk_hi || num_chunks <= 0 || sq_chunk <= 0 ||
+      bias_total_seq <= 0 || bias_sq <= 0)
+    return -1;
+  hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
+  if (bias_batch <= 0)
+    bias_batch = 1;
+  if (bias_heads <= 0)
+    bias_heads = 1;
+  (void)hipGetLastError();
+  if (bias_element_size_bytes == 2) {
+    bias_key_extent_kernel<__half>
+        <<<dim3(num_chunks), GQA_BIAS_EXTENT_THREADS, 0, stream>>>(
+            static_cast<const __half*>(bias), static_cast<int*>(out_chunk_hi),
+            bias_batch, bias_heads, bias_sq, bias_total_seq, sq, sq_chunk,
+            past_len);
+  } else if (bias_element_size_bytes == 4) {
+    bias_key_extent_kernel<float>
+        <<<dim3(num_chunks), GQA_BIAS_EXTENT_THREADS, 0, stream>>>(
+            static_cast<const float*>(bias), static_cast<int*>(out_chunk_hi),
+            bias_batch, bias_heads, bias_sq, bias_total_seq, sq, sq_chunk,
+            past_len);
+  } else {
+    fprintf(stderr, "hip_gqa_bias_key_extent: unsupported bias elem size %d\n",
+            bias_element_size_bytes);
+    return -1;
+  }
+  GQA_RETURN_LAUNCH_STATUS();
+}
+
 // Step 9b (fp32->fp16 variant): Softmax reading fp32 scores, writing fp16 output
 // Avoids inf-inf=NaN by operating entirely in fp32 before the final fp16 store.
 

--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -6754,9 +6754,18 @@ extern "C" int hip_matmul_nbits(
    * cropping, since only the contraction dim is padded. The weight rows are
    * already stored padded to full groups (num_groups_k*(group_size/2) bytes),
    * so B needs nothing. K%32==0 shapes never enter here and are byte-for-byte
-   * unaffected. Verified against the CPU reference for K=4304. */
+   * unaffected. Verified against the CPU reference for K=4304.
+   *
+   * fp16_zp_ready is load-bearing, not belt-and-braces: this branch reads
+   * zp_for_fp16_paths, which falls back to the packed-nibble zero_points when
+   * the wrapper did not pre-build an fp16 buffer. The wrapper's build gate used
+   * to be K%32==0 -- the exact complement of this predicate -- so every asym
+   * K%32!=0 prefill landed here and read nibbles as fp16, wrong values plus an
+   * over-read (packed is [N,(ngk+1)/2] bytes, this indexes [N,ngk] fp16). The
+   * wrapper now supplies the buffer; without it, fall through to the naive
+   * kernel's uint8 zp rather than compute silent garbage. */
   if ((batch_count == 1) && (K % 32 != 0) && M >= kWmmaMinM &&
-      !hipdnn_device_is_wave64()) {
+      fp16_zp_ready && !hipdnn_device_is_wave64()) {
     int iM = static_cast<int>(M);
     int iN = static_cast<int>(N);
     int iK = static_cast<int>(K);
@@ -6822,7 +6831,15 @@ extern "C" int hip_matmul_nbits(
   // M>=kWmmaMinM is instead served by the dequant-once + hipBLASLt path in
   // lib/Runtime/real/matmul_nbits.cpp, and any residual case falls through to
   // the correct GEMV/naive fallback below.
-  if (wmma_data_format && M >= kWmmaMinM && !hipdnn_device_is_wave64()) {
+  //
+  // fp16_zp_ready is redundant today -- the wrapper builds the fp16 zp for
+  // every batch==1, M>1 asym shape, which covers this predicate -- but it is
+  // stated rather than inferred: this branch reads zp_for_fp16_paths, and that
+  // pointer silently degrades to the packed nibbles when the buffer is absent.
+  // The K-padding branch above shipped that exact bug by leaning on a
+  // coincidence between the two gates.
+  if (wmma_data_format && M >= kWmmaMinM && fp16_zp_ready &&
+      !hipdnn_device_is_wave64()) {
     CUSTOM_KERNELS_DEBUG_LOG(
         "[custom_kernels] hip_matmul_nbits: WMMA fast path M=%lld N=%lld "
         "K=%lld bs=%lld zp=%s bias=%s\n",

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -816,6 +816,27 @@ HIP_KERNEL_API int hip_gqa_add_attention_bias_f32(
     int sq, int score_cols, int score_batch_stride, int bias_element_size_bytes,
     int bias_sq, int bias_row_offset, int bias_total_seq, int bias_col_offset);
 
+/* Highest key position each query chunk can attend, recovered from the additive
+ * mask. Writes one int per chunk to out_chunk_hi (device), as an ABSOLUTE key
+ * position, so the caller's per-chunk key range is [lo, out_chunk_hi[j] + 1).
+ *
+ * For a bidirectional op (onnx.Attention is_causal=0) the attributes carry no
+ * upper bound and every chunk otherwise scores every key. An entry whose bias
+ * is at or below -65504 -- the fp16 lower bound, the "not attended" sentinel --
+ * contributes exactly zero to the softmax, so excluding it is bit-exact.
+ * Anything less negative counts as attended, which only narrows less.
+ *
+ * Chunks are the caller's uniform tiling: chunk j covers query rows
+ * [j*sq_chunk, min((j+1)*sq_chunk, sq)). bias layout and the bias_batch /
+ * bias_heads broadcast follow hip_gqa_add_attention_bias_f32 above. past_len
+ * places query row 0 of the call at its absolute position. Only the region
+ * above each chunk's last row is read; the rest is kept regardless. */
+HIP_KERNEL_API int hip_gqa_bias_key_extent(
+    void* stream, const void* bias, void* out_chunk_hi,
+    int bias_batch, int bias_heads, int bias_sq, int bias_total_seq,
+    int sq, int sq_chunk, int past_len, int num_chunks,
+    int bias_element_size_bytes);
+
 /* Column-wise softmax in-place. One threadblock per (head, query).
  * Smooth softmax is activated when head_sink is non-null OR use_smooth_softmax
  * is set.  When head_sink is non-null, uses per-head sink factors:

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -1633,14 +1633,15 @@ static int gqa_forward_hipblaslt(
   //    above is derived from that identity, so without it kv_lo would be
   //    computed against the wrong absolute query position.
   //
-  //    With today's only producer of a window this pairing cannot actually
-  //    occur: the converter recovers a window from the additive mask, so a
-  //    window implies a mask, a mask means attention_bias is non-null, and
-  //    bidirectional_no_past is no_causal && !attention_bias. The guard is kept
-  //    anyway because that is a property of the converter rather than of this
-  //    function's contract -- a producer that stamps a window from a declared
-  //    attribute (opset 25's left_window_size) would not need a mask at all,
-  //    and would reach here with both set.
+  //    This pairing is reachable, and on the shape that matters most: #882
+  //    redefined bidirectional_no_past as no_causal && !past_key, so a windowed
+  //    Gemma-4 PREFILL now sets it (no_causal, and no past cache on the first
+  //    call) where the older no_causal && !attention_bias did not. It stays a
+  //    correct guard for the op-level bound below, which is taken at past_len
+  //    and is inert at a prefill anyway, but it is the wrong question to ask of
+  //    the per-chunk bound -- see chunk_narrow_ok below, which tests the
+  //    identity this restriction is really about instead of a flag that now
+  //    happens to imply more than it did.
   //  - Only with a present cache. kv_lo indexes key positions by their absolute
   //    position in a BNSD cache page; without present_key / present_value the
   //    GEMMs read the raw key / value operands, where a past_len derived from
@@ -1673,16 +1674,81 @@ static int gqa_forward_hipblaslt(
   // Number of key positions actually scored, and the first one. kv_span ==
   // total_seq and kv_lo == 0 whenever narrowing is inactive, which keeps every
   // downstream expression below identical to what it was.
+  //
+  // This is the OP-LEVEL range: the union over every query row in the call.
+  // The KV copy, the K/V expand and the score buffers are all sized against it,
+  // and copy_lo's write-skip invariant above is stated in terms of it, so it
+  // has to stay the union even though individual chunks below read less than
+  // it.
+  const bool kv_narrow_ok =
+      !bidirectional_no_past && present_key && present_value;
   int64_t kv_span = total_seq;
   int64_t kv_lo = 0;
-  if (local_window_size > 0 && !bidirectional_no_past && present_key &&
-      present_value) {
+  if (local_window_size > 0 && kv_narrow_ok) {
     const int64_t lo = past_len - local_window_size + 1;
     if (lo > 0) {
       kv_lo = lo;
       kv_span = total_seq - kv_lo;
     }
   }
+
+  // The bound above is taken at past_len, the absolute position of the FIRST
+  // query row of the call. That is why it does nothing at a fresh prefill:
+  // past_len is 0, so `lo` is negative and every chunk goes on scoring all
+  // total_seq keys even when the window is known. Narrowing per chunk instead,
+  // from the chunk's own query range, is what makes a recovered window pay at
+  // prefill rather than only at decode.
+  //
+  // Dropping keys ABOVE a chunk's last query row needs the op to be causal,
+  // and only the is_causal attribute establishes that. hip_gqa_causal_mask_f32
+  // below then masks exactly the entries being dropped, so narrowing is
+  // provably the same arithmetic. An additive mask cannot reinstate any of them
+  // either, since the causal mask is applied on top of it.
+  //
+  // A recovered window does NOT establish it. That is worth stating outright,
+  // because the shape of the match invites the opposite reading: the window
+  // comes from AttentionWindowFold matching `And(q >= k, q - k < W)`, whose
+  // first conjunct is the causal predicate. But the fold matches that as one
+  // DISJUNCT of the keep-condition, not as the whole of it. Gemma-4's windowed
+  // mask is `And(pad, Or(win, seg))`, and the fold accepts it because the
+  // same-image-block leg `seg` cannot reach further BACK than the window: 256
+  // soft tokens per image block against a window of 1024. That argument bounds
+  // the range below and says nothing about above. `seg` is bidirectional, so it
+  // reaches one image block ABOVE the diagonal, and it keeps those entries at a
+  // bias of 0 -- they are attended, and a diagonal bound would drop them. Text
+  // prompts hide this: `seg` is identically false with no image, which leaves
+  // the keep-condition causal after all and the diagonal bound exact.
+  //
+  // So no_causal takes its upper bound from the mask instead, whether or not a
+  // window was recovered -- see mask_chunk_hi below. That scan floors at the
+  // diagonal, so wherever nothing above it is attended it returns this same
+  // bound and nothing is given up. Whisper's encoder self-attention and decoder
+  // cross-attention have no mask to read and keep their full range, as before.
+  //
+  // The window still supplies the LOWER bound in chunkKeyRange, which is where
+  // the fold's reach-back argument actually applies.
+  const bool causal_narrow_ok = !no_causal;
+
+  // Whether a chunk's row range can be placed in absolute key coordinates at
+  // all. Every bound above is of the form past_len + q0, so it says exactly one
+  // thing: query row q0 of this call sits at absolute position past_len + q0,
+  // and therefore the last row of the call sits at total_seq - 1.
+  //
+  // That is stated as the identity rather than as !bidirectional_no_past, which
+  // is the flag the op-level bound uses. The two agreed until #882 redefined
+  // the flag from no_causal && !attention_bias to no_causal && !past_key, which
+  // set it on windowed Gemma-4 prefills -- shapes where sq == skv and past_len
+  // == 0, so the identity holds perfectly and narrowing is exact. Testing the
+  // flag there silently disabled the narrowing on the only shape that needs it
+  // while looking entirely correct.
+  //
+  // The identity is what actually fails on the shapes that must be excluded: a
+  // Whisper cross-attention has sq == 1 against skv == 1500, so past_len + q0
+  // addresses nothing, and a KV-cache-sharing decode re-reads a full history it
+  // did not produce. Both are caught, and both are also no_causal, so
+  // causal_narrow_ok already refuses them the diagonal bound.
+  const bool chunk_narrow_ok =
+      present_key && present_value && total_seq == past_len + sq;
 
   //===--------------------------------------------------------------------===//
   // Query-row chunking of the score matrix
@@ -1737,46 +1803,204 @@ static int gqa_forward_hipblaslt(
     }
   }
   const bool chunked = (sq_chunk < sq);
-  const int64_t sq_tail = chunked ? (sq % sq_chunk) : 0;
+
+  //===--------------------------------------------------------------------===//
+  // Per-chunk key bound recovered from the additive mask
+  //
+  // For a bidirectional op the diagonal bound above is unavailable, so this is
+  // the only thing that can bound a chunk from above -- and for a WINDOWED
+  // bidirectional op it is also what keeps the narrowing correct, since the
+  // diagonal would cut through the mask's same-image-block leg. Where such an
+  // op carries an additive mask, the mask already states which keys are
+  // attended, and the entries it rules out are exactly the ones a chunk can
+  // drop: an additive bias at or below -65504 contributes exactly zero to the
+  // softmax, so dropping it is bit-exact. That makes this a recovery of a bound
+  // the graph already contains rather than an assumption about the model, which
+  // is what the alternative would have been -- AttentionWindowFold cannot
+  // supply it, because the reach of Gemma-4's same-image-block leg is a
+  // property of the input, not of the mask's shape.
+  //
+  // Only worth doing when the op is actually chunked: a single chunk spans
+  // every query row, so its bound is the whole key range either way.
+  //
+  // One kernel over half the mask plus one D2H of a few ints per call, on each
+  // of Gemma-4's 30 layers: ~250 MB read apiece, against the ~6 GB of score
+  // traffic it removes on the 5 global ones and correctness on the 25 local
+  // ones. The mask is shared across layers of a kind, so a cache keyed on the
+  // bias pointer and this call's geometry would collapse the 30 scans to 2 and
+  // their stream syncs with them; that is left for later because the scan is
+  // already small against the score GEMMs it bounds, and because such a cache
+  // belongs on RuntimeState rather than in a file-static -- per-session, and so
+  // safe against a second session and against teardown. A failure anywhere here
+  // leaves the vector empty and the op scores its full range, which is exactly
+  // the old behaviour.
+  //===--------------------------------------------------------------------===//
+  std::vector<int32_t> mask_chunk_hi;
+  if (chunked && chunk_narrow_ok && !causal_narrow_ok && attention_bias &&
+      !use_no_expand) {
+    const int64_t nchunks = (sq + sq_chunk - 1) / sq_chunk;
+    // The scan's output lands at the front of the state workspace, which the
+    // layout below re-sizes and re-partitions for the score buffers. Both uses
+    // are safe together: the result is copied out and the stream synchronized
+    // before that happens, so the region is dead by the time it is reused, and
+    // ensure_workspace only ever grows. On a warm call the workspace already
+    // dwarfs the few hundred bytes wanted here and the request is a no-op; only
+    // a cold first inference pays an extra allocation for it.
+    const size_t hi_bytes = static_cast<size_t>(nchunks) * sizeof(int32_t);
+    int32_t *d_hi = nullptr;
+    if (hipdnn_ep_state_ensure_workspace(state, hi_bytes) == 0)
+      d_hi = static_cast<int32_t *>(hipdnn_ep_state_get_workspace(state));
+    if (d_hi &&
+        hip_gqa_bias_key_extent(
+            stream, attention_bias, d_hi, static_cast<int>(attn_bias_batch),
+            static_cast<int>(attn_bias_num_heads), static_cast<int>(sq),
+            static_cast<int>(total_seq), static_cast<int>(sq),
+            static_cast<int>(sq_chunk), static_cast<int>(past_len),
+            static_cast<int>(nchunks), static_cast<int>(elem_sz)) == 0) {
+      std::vector<int32_t> hi(static_cast<size_t>(nchunks), 0);
+      if (hipMemcpyAsync(hi.data(), d_hi, hi_bytes, hipMemcpyDeviceToHost,
+                         stream) == hipSuccess &&
+          hipStreamSynchronize(stream) == hipSuccess)
+        mask_chunk_hi = std::move(hi);
+    }
+    // Never expected: only a failed scratch allocation or a failed launch gets
+    // here, and both mean the prefill silently reverts to scoring every key.
+    if (mask_chunk_hi.empty())
+      fprintf(stderr,
+              "gqa_forward_hipblaslt: mask key-extent recovery failed; "
+              "scoring the full key range for sq=%lld total_seq=%lld\n",
+              (long long)sq, (long long)total_seq);
+  }
 
   // GEMM descriptor keys. The no-expand flavour uses explicit per-operand
-  // strides (non-zero stride fields); the expand flavour leaves them zero so
-  // queryOrCreateGemmState falls back to the dense packed-batch defaults.
+  // strides (non-zero stride fields); the expand flavour leaves them zero,
+  // so queryOrCreateGemmState falls back to the dense packed-batch defaults,
+  // except where a per-chunk key range makes a dense default wrong (strideA
+  // below).
   //
   // When chunking, the expand flavour must state Q's and O's strides
   // explicitly: n is the chunk length but those two operands still advance by
   // the full sq between heads. The score matrices are freshly packed per chunk,
   // so their strides stay at the dense default.
   //
-  // The key extent is kv_span, not total_seq: Kexp / Vexp are materialised over
-  // the narrowed range and the score matrices are sized to match, so stating
-  // total_seq here would have the GEMMs read and write past the regions
-  // allocated for them.
-  auto makeKeys = [&](int64_t n_rows, GqaGemmKey *score, GqaGemmKey *value) {
-    *score = {kv_span,
+  // The key extent is kv_ext, the chunk's own narrowed range, which is at most
+  // kv_span: Kexp / Vexp are materialised over the op-level narrowed range and
+  // the score matrices are sized to match, so stating total_seq here would have
+  // the GEMMs read and write past the regions allocated for them.
+  //
+  // strideA has to be stated explicitly the moment kv_ext differs from kv_span.
+  // Both keys otherwise leave it 0, which queryOrCreateGemmState resolves to
+  // the dense default m*k: kv_ext*d for the score GEMM and d*kv_ext for the
+  // value one, while Kexp / Vexp are packed at kv_span*d per head. Those agree
+  // only while the chunk reads the whole op-level range; once it reads a
+  // sub-range
+  // the dense default is short and every head after the first is mis-strided,
+  // silently, with no shape for hipBLASLt to reject. Keeping the 0 in the
+  // un-narrowed case is deliberate rather than tidy: it leaves the cache key
+  // bit-identical to what it was, so a shape that narrows nothing reuses
+  // exactly the descriptor it used before.
+  auto makeKeys = [&](int64_t n_rows, int64_t kv_ext, GqaGemmKey *score,
+                      GqaGemmKey *value) {
+    const int64_t strideA = (kv_ext != kv_span) ? kv_span * d : 0;
+    *score = {kv_ext,
               n_rows,
               d,
               B * H,
               true,
               /*outputFp32=*/true,
               gemm_fp32,
-              /*strideA=*/0,
+              strideA,
               /*strideB=*/chunked ? sq * d : 0,
               /*strideC=*/0};
     *value = {d,
               n_rows,
-              kv_span,
+              kv_ext,
               B * H,
               false,
               /*outputFp32=*/gemm_fp32,
               gemm_fp32,
-              /*strideA=*/0,
+              strideA,
               /*strideB=*/0,
               /*strideC=*/chunked ? sq * d : 0};
   };
 
-  GqaGemmKey scoreKey, valueKey;
+  //===--------------------------------------------------------------------===//
+  // Per-chunk key ranges
+  //
+  // One entry per iteration of the Steps 8-10 loop, resolved up front. Two
+  // things force that rather than deriving each chunk's shape inside the loop:
+  // the GEMM workspace region is sized once below and cannot grow afterwards,
+  // so every algorithm the loop will use has to be known before the allocation;
+  // and the score buffers need the widest chunk, which is not in general the
+  // first or the last one.
+  //
+  // A chunk is now its own GEMM shape, but far fewer distinct ones than that
+  // suggests. With a window the interior chunks all sit at the same extent
+  // (window + chunk rows, capped by the sequence), so at a 16K prefill with
+  // sq_chunk 640 and a 1024 window the 26 chunks collapse to four descriptors:
+  // the two leading partial ones, the interior extent, and the ragged tail.
+  // queryOrCreateGemmState is keyed on shape, so the duplicates cost a hash
+  // lookup and nothing else -- no extra hipblasLtMatmulAlgoGetHeuristic calls.
+  //===--------------------------------------------------------------------===//
+  struct GqaChunkPlan {
+    int64_t q0;     // first query row of the chunk
+    int64_t c;      // query rows in the chunk
+    int64_t kv_off; // first key read, RELATIVE to kv_lo
+    int64_t kv_ext; // key positions read
+    const GqaGemmCacheEntry *score;
+    const GqaGemmCacheEntry *value;
+  };
+  std::vector<GqaChunkPlan> chunks;
+
+  // Key range a chunk of query rows can attend, as [lo, hi) in absolute key
+  // positions. Clamped into the op-level [kv_lo, total_seq) so a chunk can only
+  // ever read a sub-range of what the expand actually materialised.
+  auto chunkKeyRange = [&](int64_t q0, int64_t c, int64_t *lo, int64_t *hi) {
+    int64_t k_lo = kv_lo;
+    int64_t k_hi = total_seq;
+    if (chunk_narrow_ok) {
+      if (causal_narrow_ok) {
+        // The chunk's last query row is at absolute position
+        // past_len + q0 + c - 1, so no key above it is attended.
+        const int64_t h = past_len + q0 + c;
+        if (h < k_hi)
+          k_hi = h;
+      } else if (!mask_chunk_hi.empty()) {
+        // Bidirectional op, windowed or not: no diagonal bound is available,
+        // but the mask stated one. The stored value is the highest key position
+        // any row in this chunk attends, so the exclusive end is one past it.
+        // It is floored at the diagonal, so this is never looser than the bound
+        // a causal op would take.
+        const size_t idx = static_cast<size_t>(q0 / sq_chunk);
+        if (idx < mask_chunk_hi.size()) {
+          const int64_t h = static_cast<int64_t>(mask_chunk_hi[idx]) + 1;
+          if (h < k_hi)
+            k_hi = h;
+        }
+      }
+      if (local_window_size > 0) {
+        // The chunk's first query row has the lowest lower bound in the chunk,
+        // so it covers every row in it.
+        const int64_t l = past_len + q0 - local_window_size + 1;
+        if (l > k_lo)
+          k_lo = l;
+      }
+    }
+    // A degenerate range would give the GEMMs a zero extent. It cannot arise
+    // from the arithmetic above (the chunk's own diagonal is always in range),
+    // but the GEMM descriptors must not be built from one if it ever did.
+    if (k_hi <= k_lo)
+      k_hi = k_lo + 1;
+    *lo = k_lo;
+    *hi = k_hi;
+  };
+
   if (use_no_expand) {
+    // No-expand is not chunked (see above), so it has exactly one iteration,
+    // spanning the whole query range and therefore the whole op-level key
+    // range: the per-chunk bound would reduce to kv_lo / kv_span anyway, and
+    // its operand layout is different enough that it keeps its own keys.
+    //
     // Score: C[kv_span, HPG*sq] = K^T[d,kv_span] * Q[d, HPG*sq] per (b, g)
     // pair. strideA steps over the buffer page (present_seq*d) even though only
     // kv_span tokens are read, keeping the descriptor stable across token
@@ -1784,59 +2008,65 @@ static int gqa_forward_hipblaslt(
     // the context passes the window, so the descriptor cache stops missing on
     // every token and the per-token hipblasLtMatmulAlgoGetHeuristic calls
     // collapse to one entry per shape.
-    scoreKey = {/*m=*/kv_span,
-                /*n=*/HPG * sq,
-                /*k=*/d,
-                /*batch=*/B * G,
-                /*transA=*/true,
-                /*outputFp32=*/true,
-                /*inputFp32=*/gemm_fp32,
-                /*strideA=*/present_seq * d,
-                /*strideB=*/HPG * sq * d,
-                /*strideC=*/HPG * sq * kv_span};
+    const GqaGemmKey scoreKey = {/*m=*/kv_span,
+                                 /*n=*/HPG * sq,
+                                 /*k=*/d,
+                                 /*batch=*/B * G,
+                                 /*transA=*/true,
+                                 /*outputFp32=*/true,
+                                 /*inputFp32=*/gemm_fp32,
+                                 /*strideA=*/present_seq * d,
+                                 /*strideB=*/HPG * sq * d,
+                                 /*strideC=*/HPG * sq * kv_span};
     // Value: C[d, HPG*sq] = V[d, kv_span] * S[kv_span, HPG*sq] per (b, g)
     // pair, writing into BNSD [B, G, HPG, sq, d] which at sq==1 coincides with
     // BSHD [B, 1, H, d].
-    valueKey = {/*m=*/d,
-                /*n=*/HPG * sq,
-                /*k=*/kv_span,
-                /*batch=*/B * G,
-                /*transA=*/false,
-                /*outputFp32=*/gemm_fp32,
-                /*inputFp32=*/gemm_fp32,
-                /*strideA=*/present_seq * d,
-                /*strideB=*/HPG * sq * kv_span,
-                /*strideC=*/HPG * sq * d};
+    const GqaGemmKey valueKey = {/*m=*/d,
+                                 /*n=*/HPG * sq,
+                                 /*k=*/kv_span,
+                                 /*batch=*/B * G,
+                                 /*transA=*/false,
+                                 /*outputFp32=*/gemm_fp32,
+                                 /*inputFp32=*/gemm_fp32,
+                                 /*strideA=*/present_seq * d,
+                                 /*strideB=*/HPG * sq * kv_span,
+                                 /*strideC=*/HPG * sq * d};
+    const GqaGemmCacheEntry *sSt =
+        queryOrCreateGemmState(state, ltHandle, scoreKey, op_state_slot);
+    if (!sSt)
+      return -1;
+    const GqaGemmCacheEntry *vSt =
+        queryOrCreateGemmState(state, ltHandle, valueKey, op_state_slot);
+    if (!vSt)
+      return -1;
+    chunks.push_back({0, sq, 0, kv_span, sSt, vSt});
   } else {
-    makeKeys(sq_chunk, &scoreKey, &valueKey);
+    for (int64_t q0 = 0; q0 < sq; q0 += sq_chunk) {
+      const int64_t c = std::min<int64_t>(sq_chunk, sq - q0);
+      int64_t lo, hi;
+      chunkKeyRange(q0, c, &lo, &hi);
+      const int64_t ext = hi - lo;
+
+      GqaGemmKey sKey, vKey;
+      makeKeys(c, ext, &sKey, &vKey);
+      const GqaGemmCacheEntry *sSt =
+          queryOrCreateGemmState(state, ltHandle, sKey, op_state_slot);
+      if (!sSt)
+        return -1;
+      const GqaGemmCacheEntry *vSt =
+          queryOrCreateGemmState(state, ltHandle, vKey, op_state_slot);
+      if (!vSt)
+        return -1;
+      chunks.push_back({q0, c, lo - kv_lo, ext, sSt, vSt});
+    }
   }
 
-  const GqaGemmCacheEntry *scoreState =
-      queryOrCreateGemmState(state, ltHandle, scoreKey, op_state_slot);
-  if (!scoreState)
-    return -1;
-  const GqaGemmCacheEntry *valueState =
-      queryOrCreateGemmState(state, ltHandle, valueKey, op_state_slot);
-  if (!valueState)
-    return -1;
-
-  // A ragged final chunk is a different n and so a different descriptor. Both
-  // shapes are resolved before sizing the workspace because the GEMM workspace
-  // region has to cover whichever algorithm asks for more.
-  const GqaGemmCacheEntry *scoreTailState = nullptr;
-  const GqaGemmCacheEntry *valueTailState = nullptr;
-  if (sq_tail > 0) {
-    GqaGemmKey scoreTailKey, valueTailKey;
-    makeKeys(sq_tail, &scoreTailKey, &valueTailKey);
-    scoreTailState =
-        queryOrCreateGemmState(state, ltHandle, scoreTailKey, op_state_slot);
-    if (!scoreTailState)
-      return -1;
-    valueTailState =
-        queryOrCreateGemmState(state, ltHandle, valueTailKey, op_state_slot);
-    if (!valueTailState)
-      return -1;
-  }
+  // The widest chunk, which is what the two score buffers have to hold. This is
+  // at most sq_chunk * kv_span (the size they had before any per-chunk
+  // narrowing) and usually far less, so the allocation only ever shrinks.
+  int64_t max_chunk_score_elems = 0;
+  for (const GqaChunkPlan &cp : chunks)
+    max_chunk_score_elems = std::max(max_chunk_score_elems, cp.c * cp.kv_ext);
 
   // ---- Workspace layout ----
   // All temp buffers are packed contiguously into the shared workspace,
@@ -1861,15 +2091,18 @@ static int gqa_forward_hipblaslt(
   size_t Kexp_bytes =
       use_no_expand ? 0 : static_cast<size_t>(B) * H * kv_span * d * elem_sz;
   size_t Vexp_bytes = Kexp_bytes;
-  // Both score buffers span kv_span keys, not total_seq: they hold exactly what
-  // the Score GEMM writes. These offsets chain into off_S_fp16, off_O, temp_end
-  // and the GEMM workspace, so kv_span has to appear in both or the region
-  // boundaries disagree with the GEMM extents and it is a silent heap
-  // overwrite rather than a crash.
+  // Both score buffers are sized to the widest chunk, not to
+  // sq_chunk * total_seq: they hold exactly what the Score GEMM writes on the
+  // heaviest iteration. These offsets chain into off_S_fp16, off_O, temp_end
+  // and the GEMM workspace, so the same extent has to appear in both or the
+  // region boundaries disagree with the GEMM extents and it is a silent heap
+  // overwrite rather than a crash. It must be the max over chunks and not the
+  // current chunk's own extent for the same reason: the offsets are fixed for
+  // the whole call while the extent varies per iteration.
   size_t S_f32_bytes =
-      static_cast<size_t>(B) * H * sq_chunk * kv_span * sizeof(float);
+      static_cast<size_t>(B) * H * max_chunk_score_elems * sizeof(float);
   size_t S_fp16_bytes =
-      static_cast<size_t>(B) * H * sq_chunk * kv_span * elem_sz;
+      static_cast<size_t>(B) * H * max_chunk_score_elems * elem_sz;
   size_t O_bytes =
       need_transpose ? static_cast<size_t>(B) * H * sq * d * elem_sz : 0;
 
@@ -1909,12 +2142,13 @@ static int gqa_forward_hipblaslt(
 
   // Single workspace allocation: temp buffers + GEMM workspace.
   {
-    size_t gemm_ws =
-        std::max(scoreState->workspace_size, valueState->workspace_size);
-    if (scoreTailState)
-      gemm_ws = std::max(gemm_ws, scoreTailState->workspace_size);
-    if (valueTailState)
-      gemm_ws = std::max(gemm_ws, valueTailState->workspace_size);
+    // Over every chunk's pair of algorithms, since the region is allocated once
+    // and the loop below cannot grow it.
+    size_t gemm_ws = 0;
+    for (const GqaChunkPlan &cp : chunks) {
+      gemm_ws = std::max(gemm_ws, cp.score->workspace_size);
+      gemm_ws = std::max(gemm_ws, cp.value->workspace_size);
+    }
     size_t total_needed = temp_end + gemm_ws;
     HIP_CHECK(hipdnn_ep_state_ensure_workspace(state, total_needed));
   }
@@ -2089,11 +2323,17 @@ static int gqa_forward_hipblaslt(
     float beta = 0.0f;
     float valAlpha = 1.0f;
 
-    for (int64_t q0 = 0; q0 < sq; q0 += sq_chunk) {
-      const int64_t c = std::min<int64_t>(sq_chunk, sq - q0);
-      const bool is_tail = (c != sq_chunk);
-      const GqaGemmCacheEntry *sSt = is_tail ? scoreTailState : scoreState;
-      const GqaGemmCacheEntry *vSt = is_tail ? valueTailState : valueState;
+    for (const GqaChunkPlan &cp : chunks) {
+      const int64_t q0 = cp.q0;
+      const int64_t c = cp.c;
+      // Key positions this chunk actually scores, and where they start.
+      // chunk_kv_lo is absolute (it indexes the bias and drives the mask's
+      // shift); cp.kv_off is the same position relative to kv_lo, which is what
+      // indexes the K / V operands because the expand packed them from kv_lo.
+      const int64_t kv_ext = cp.kv_ext;
+      const int64_t chunk_kv_lo = kv_lo + cp.kv_off;
+      const GqaGemmCacheEntry *sSt = cp.score;
+      const GqaGemmCacheEntry *vSt = cp.value;
 
       // Q and O keep their full-sq batch strides (stated in the GEMM key), so
       // selecting a chunk is a plain offset into the query axis of each.
@@ -2101,9 +2341,17 @@ static int gqa_forward_hipblaslt(
                            static_cast<size_t>(q0) * d * elem_sz;
       void *valueC = static_cast<char *>(valueCBase) +
                      static_cast<size_t>(q0) * d * elem_sz;
+      // The chunk's key range is selected the same way the op-level one is: by
+      // advancing the K / V base pointers. The cache and the expand destination
+      // are both BNSD with d fastest, so a key offset is a contiguous byte
+      // offset, and the per-head batch stride stated in the GEMM key keeps
+      // describing the whole buffer rather than the slice.
+      const size_t chunkKvOff = static_cast<size_t>(cp.kv_off) * d * elem_sz;
+      const void *scoreAc = static_cast<const char *>(scoreA) + chunkKvOff;
+      const void *valueAc = static_cast<const char *>(valueA) + chunkKvOff;
       // The score buffers are re-packed per chunk, so their per-head stride is
       // the chunk's own row count over the key range actually scored.
-      const int scoreBatchStride = static_cast<int>(c * kv_span);
+      const int scoreBatchStride = static_cast<int>(c * kv_ext);
 
       // ---- Step 8: Score GEMM (fp16/fp32 in, fp32 out) ----
       // A = K: no-expand reads present_key directly, expand reads d_Kexp.
@@ -2111,7 +2359,7 @@ static int gqa_forward_hipblaslt(
       // (BSHD==BNSD@sq=1).
       hipblasLtMatmulAlgo_t sAlgo = sSt->algo;
       HIPBLAS_CHECK(hipblasLtMatmul(
-          ltHandle, sSt->desc, &scoreAlpha, scoreA, sSt->layA, scoreB,
+          ltHandle, sSt->desc, &scoreAlpha, scoreAc, sSt->layA, scoreB,
           sSt->layB, &beta, d_S_f32, sSt->layC, d_S_f32, sSt->layD, &sAlgo,
           gemm_ws_ptr, gemm_ws_bytes, stream));
 
@@ -2149,9 +2397,9 @@ static int gqa_forward_hipblaslt(
       // so the kernel then writes nothing -- correct, just redundant.)
       if ((sq > 1 || local_window_size > 0) && !no_causal) {
         HIP_CHECK(hip_gqa_causal_mask_f32(
-            stream, d_S_f32, static_cast<int>(B * H), static_cast<int>(kv_span),
+            stream, d_S_f32, static_cast<int>(B * H), static_cast<int>(kv_ext),
             static_cast<int>(c), scoreBatchStride,
-            static_cast<int>(past_len + q0 - kv_lo),
+            static_cast<int>(past_len + q0 - chunk_kv_lo),
             static_cast<int>(local_window_size)));
       }
       // fp16 GQA: softmax writes fp16 probabilities for the fp16 Value GEMM.
@@ -2175,24 +2423,24 @@ static int gqa_forward_hipblaslt(
       if (attention_bias) {
         HIP_CHECK(hip_gqa_softmax_f32_to_out_biased(
             stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * c),
-            static_cast<int>(kv_span), static_cast<int>(c), scoreBatchStride,
+            static_cast<int>(kv_ext), static_cast<int>(c), scoreBatchStride,
             scoreBatchStride, head_sink, static_cast<int>(H),
             static_cast<int>(use_smooth_softmax), attention_bias,
             static_cast<int>(attn_bias_batch),
             static_cast<int>(attn_bias_num_heads), static_cast<int>(elem_sz),
             static_cast<int>(gemm_fp32), static_cast<int>(sq),
             static_cast<int>(q0), static_cast<int>(total_seq),
-            static_cast<int>(kv_lo)));
+            static_cast<int>(chunk_kv_lo)));
       } else if (gemm_fp32) {
         HIP_CHECK(hip_gqa_softmax_f32_to_f32(
             stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * c),
-            static_cast<int>(kv_span), static_cast<int>(c), scoreBatchStride,
+            static_cast<int>(kv_ext), static_cast<int>(c), scoreBatchStride,
             scoreBatchStride, head_sink, static_cast<int>(H),
             static_cast<int>(use_smooth_softmax)));
       } else {
         HIP_CHECK(hip_gqa_softmax_f32_to_f16(
             stream, d_S_f32, d_S_fp16, static_cast<int>(B * H * c),
-            static_cast<int>(kv_span), static_cast<int>(c), scoreBatchStride,
+            static_cast<int>(kv_ext), static_cast<int>(c), scoreBatchStride,
             scoreBatchStride, head_sink, static_cast<int>(H),
             static_cast<int>(use_smooth_softmax)));
       }
@@ -2203,7 +2451,7 @@ static int gqa_forward_hipblaslt(
       //        GEMM writes straight to output (BSHD==BNSD).
       hipblasLtMatmulAlgo_t vAlgo = vSt->algo;
       HIPBLAS_CHECK(hipblasLtMatmul(
-          ltHandle, vSt->desc, &valAlpha, valueA, vSt->layA, d_S_fp16,
+          ltHandle, vSt->desc, &valAlpha, valueAc, vSt->layA, d_S_fp16,
           vSt->layB, &beta, valueC, vSt->layC, valueC, vSt->layD, &vAlgo,
           gemm_ws_ptr, gemm_ws_bytes, stream));
     }
@@ -2224,15 +2472,28 @@ static int gqa_forward_hipblaslt(
     // exporting its cache in place takes the append branch and the copy_lo
     // below is inert, which is otherwise indistinguishable from the narrowing
     // failing to engage.
+    // The per-chunk key extents are summarised as their range and their sum
+    // rather than listed: the sum against sq*kv_span is the whole point of the
+    // narrowing (it is the score-matrix area actually computed), and chunks is
+    // what says how many descriptors the loop cycled through.
+    int64_t kv_ext_min = chunks.empty() ? 0 : chunks.front().kv_ext;
+    int64_t kv_ext_max = 0, score_elems = 0;
+    for (const GqaChunkPlan &cp : chunks) {
+      kv_ext_min = std::min(kv_ext_min, cp.kv_ext);
+      kv_ext_max = std::max(kv_ext_max, cp.kv_ext);
+      score_elems += cp.c * cp.kv_ext;
+    }
     RUNTIME_DEBUG_LOG(
         "[REAL] GQA hipBLASLt: B=%lld sq=%lld sq_chunk=%lld total_seq=%lld "
-        "kv_lo=%lld kv_span=%lld H=%lld G=%lld d=%lld no_expand=%d "
+        "kv_lo=%lld kv_span=%lld chunks=%zu kv_ext=[%lld,%lld] "
+        "score_elems=%lld/%lld H=%lld G=%lld d=%lld no_expand=%d "
         "transpose=%d kv_inplace=%d past_len=%lld past_buf_seq=%lld "
         "present_seq=%lld\n",
         (long long)B, (long long)sq, (long long)sq_chunk, (long long)total_seq,
-        (long long)kv_lo, (long long)kv_span, (long long)H, (long long)G,
-        (long long)d, static_cast<int>(use_no_expand),
-        static_cast<int>(need_transpose),
+        (long long)kv_lo, (long long)kv_span, chunks.size(),
+        (long long)kv_ext_min, (long long)kv_ext_max, (long long)score_elems,
+        (long long)(sq * kv_span), (long long)H, (long long)G, (long long)d,
+        static_cast<int>(use_no_expand), static_cast<int>(need_transpose),
         static_cast<int>(past_key != nullptr && past_key == present_key),
         (long long)past_len, (long long)past_buf_seq, (long long)present_seq);
   }

--- a/lib/Runtime/real/matmul_nbits.cpp
+++ b/lib/Runtime/real/matmul_nbits.cpp
@@ -602,14 +602,22 @@ int wrap_matmul_nbits(RuntimeState *state, int op_state_slot, const void *A,
                   mst->zp, stream, zero_points, static_cast<int>(N), ngk);
     if (!pre_zp_u8)
       return -1;
-    // The fp16 buffer is consumed only by the bits=4 WMMA (batch==1 &&
-    // K%32==0 && M>=16) and col-major GEMV M>1 fallback (same predicate on K,
-    // M>1). Build it eagerly when those preconditions are met — the cache
-    // makes the cost a one-time hit per zero_points pointer. The u2 WMMA path
-    // consumes uint8 zp directly, so bits=2 never needs the fp16 buffer (and
-    // the converter is nibble-specific anyway).
-    bool wmma_data_format = (batch_count == 1) && (K % 32 == 0);
-    if (bits == 4 && wmma_data_format && M > 1) {
+    // The fp16 buffer is consumed by the bits=4 WMMA prefill and by the
+    // col-major GEMV M>1 fallback. Build it eagerly when those preconditions
+    // are met — the cache makes the cost a one-time hit per zero_points
+    // pointer. The u2 WMMA path consumes uint8 zp directly, so bits=2 never
+    // needs the fp16 buffer (and the converter is nibble-specific anyway).
+    //
+    // Deliberately NOT gated on K%32==0. The WMMA prefill has two entries: the
+    // K%32==0 path and the K-padding path, which zero-pads K up to a multiple
+    // of 32 and runs the same kernel (see hip_matmul_nbits). Both read
+    // zp_for_fp16_paths. A K%32==0 gate here is the exact complement of the
+    // K-padding path's predicate, so every asym K%32!=0 prefill reached that
+    // path with zp_for_fp16_paths still pointing at the packed nibbles and
+    // silently computed against them reinterpreted as fp16 (gemma-4's SigLIP
+    // down_proj, K=4304). The kernel now also refuses that combination, but
+    // supplying the buffer is what keeps the shape on the fast path.
+    if (bits == 4 && batch_count == 1 && M > 1) {
       pre_zp_fp16 = hipdnn_ep_real::lookup_or_convert_zp_fp16(
           mst->zp, stream, zero_points, static_cast<int>(N), ngk);
       if (!pre_zp_fp16)


### PR DESCRIPTION
**Test PR — not for merge.** Base is `perf/gqa-chunk-kv-span`, so the diff here is #599's workflow change plus the matmul_nbits fix; #933 carries the GQA kernel work and reaches CI through the base.

## What this stacks

| Component | Source | In the diff? |
|---|---|---|
| `perf(gqa)`: per-chunk key-range narrowing | #933, via base branch | no (base) |
| `ci(windows)`: gemma4-capable OGA build | #599, cherry-picked | yes |
| `fix(matmul_nbits)`: K-padding zero-points | new here | yes |

#599's two commits are cherry-picked unmodified with authorship intact; the resulting `.github/workflows/windows-deps.yml` is byte-identical to #599's — both are blob `94b2308c`. It repoints the OGA checkout from `microsoft/onnxruntime-genai@v0.14.0` to `amd-genmingz/onnxruntime-genai@test_0_3`, which carries the AMDGPU MorphiZen integration plus sliding-window support.

## The matmul_nbits fix

The nightly VLM run has been emitting fluent nonsense (`-y own-y own…`) on gemma-4-26B-A4B QMoE at every prefill length. That is not #933 and not #719. Bisected against CI's own `gpu-test-package` artifacts, vision session on the EP:

| build | date | output |
|---|---|---|
| `aaff3f91` | Sep 2 08:01 | correct, TTFT 16,120 ms |
| `1723fd36` | Sep 3 16:31 | correct, TTFT 26,216 ms |
| `13f44fb8` (#903) | Sep 4 08:10 | **garbage**, TTFT 1,595 ms |

`1723fd36` is `13f44fb8`'s direct parent, so it is that one commit — #903, "offline autotune LUT, WMMA/GEMV tuning, and K-padding". It made GPU vision ~20x faster and numerically wrong at the same time.

#903 added a WMMA branch for `K % 32 != 0` int4 prefill that zero-pads K and runs the ordinary kernel. That branch reads `zp_for_fp16_paths`, but the wrapper only built the unpacked fp16 zero-point buffer when `K % 32 == 0` — the exact complement of the new branch's predicate. So every asymmetric `K % 32 != 0` prefill reached it with `zp_for_fp16_paths` still pointing at the nibble-packed `zero_points` and read those bytes as fp16: wrong values, plus a read past the end (packed is `[N,(ngk+1)/2]` bytes, the branch indexes `[N,ngk]` fp16 — 78,336 against 311,040 at N=1152, ngk=135).

SigLIP-So400m's MLP is 1152→4304→1152, and `4304` is the only ragged dimension anywhere in this model: `4304 % 32 == 16`. The `down_proj` (M=2268 N=1152 K=4304, group_size 32) is therefore the single qualifying matmul, and every decoder matmul has `K % 32 == 0`. That is why the decoder stayed correct while the vision encoder garbled, deterministically, on every image.

Two changes:

- Build the fp16 zero-points for any `bits=4, batch==1, M>1` shape rather than only `K % 32 == 0`. This keeps K=4304 on the fast path instead of reverting to the naive kernel it used before #903.
- Gate both WMMA branches on `fp16_zp_ready`, the flag already guarding the col-major GEMV path. Absent the buffer they now decline and fall through to a kernel that reads the uint8 zero-points, rather than computing silently wrong results. The K-padding branch shipped this bug by inferring the buffer's presence from a coincidence between two gates instead of checking.

`mn_kpad_test` covered K=4304 and passed, because it only ever ran symmetric (`zero_points=nullptr`), so `has_zp` was false and the bad pointer was never dereferenced. It now runs every shape in three zero-point modes — symmetric, asym with only the uint8 buffer, asym with both — and adds the shipped M=2268 geometry. It remains a standalone dev tool, not wired into CMake.

## What this run will and will not show

**The matmul fix is directly observable here.** The `Run VLM benchmark` job iterates the persisted `amdgpu-vlm-models` directory with `dog.jpg`, and the publish step captures the generated text into the `Output` column of the `VLM Benchmark Results` comment. That column is where the `-y own-y own…` came from, so it is also where the fix shows up. Local result on gfx1151 with the CI config unchanged — vision session still on the EP with `profile: hip` and `disable_cpu_ep_fallback: 1`:

| prefill tokens | TTFT | output |
|---|---|---|
| 274 | 907 ms | coherent caption |
| 412 | 1,000 ms | coherent caption |
| 2,303 | 2,446 ms | coherent caption |
| 16,399 | 13,822 ms | coherent caption |

Under `HIPDNN_EP_DEBUG=1` the `down_proj` takes the K-pad path 27 times, once per SigLIP layer, with zero naive fallbacks — so the fast path is retained, not traded away for correctness. The vision-on-CPU arm is unchanged at 5,462 ms, confirming `K % 32 == 0` shapes were untouched.

**#933's perf claim is still not corroborated.** The VLM job runs at `--max_length 4096` and the default prompt, so roughly a 274-token prefill. #933's win is a 16K prefill: −50.5% TTFT (35,327.3 → 17,502.6 ms, interleaved and order-reversed against `main`), measured locally on gfx1151. Nothing in CI times a prefill at that length, and the mask-derived upper bound #933 fixes only matters where an image block straddles a query chunk boundary, which needs a long enough context to force small chunks. A green run here says nothing regressed; the numbers in #933 rest on the local measurements recorded there.

Note this corrects the earlier revision of this description, which claimed CI could not load the model at all. That was wrong: `.github` contains no literal `gemma` reference, but the VLM and OGA jobs iterate model directories staged on the GPU runner, which is precisely how the nightly hit this bug.

## Disposition

Nothing here should be merged. The workflow change belongs to #599 and the GQA kernel change to #933. The matmul_nbits fix is the one piece with no home yet — #903 is broken on `main` today, so any model whose intermediate size is not a multiple of 32 will garble on the vision path. Worth splitting into its own PR against `main` once this run confirms it.

Supersedes #941.
