### PR TITLE
Lower where, leaky-relu, softmax, reduce, sqrt, cast, and QDQ to TOSA

### DIFF
--- a/lib/Conversion/HipToTosa/HipToTosa.cpp
+++ b/lib/Conversion/HipToTosa/HipToTosa.cpp
@@ -66,7 +66,8 @@ bool isTosaCompatibleOperand(Value operand, RankedTensorType resultType) {
 static Value createConstShape(ConversionPatternRewriter &rewriter, Location loc,
                               ArrayRef<int64_t> extents) {
   return tosa::ConstShapeOp::create(
-      rewriter, loc, tosa::shapeType::get(rewriter.getContext(), extents.size()),
+      rewriter, loc,
+      tosa::shapeType::get(rewriter.getContext(), extents.size()),
       rewriter.getIndexTensorAttr(extents));
 }
 
@@ -133,8 +134,7 @@ struct MatMulConverter final : public OpConversionPattern<hip::MatmulOp> {
         tosa::MatMulOp::create(rewriter, op.getLoc(), matmulType, a, b)
             .getResult();
 
-    rewriter.replaceOp(
-        op, reshapeTo(matmul, resultType.getShape(), rewriter));
+    rewriter.replaceOp(op, reshapeTo(matmul, resultType.getShape(), rewriter));
     return success();
   }
 };
@@ -761,8 +761,7 @@ LogicalResult reshapeQdqParam(ConversionPatternRewriter &rewriter, Location loc,
     // TOSA elementwise ops need matching rank. ONNX per-tensor scale/ZP is
     // sometimes tensor<1xT>; fold that to a rank-0 scalar.
     if (paramType.getRank() == 1 && paramType.getDimSize(0) == 1) {
-      auto scalarType =
-          RankedTensorType::get({}, paramType.getElementType());
+      auto scalarType = RankedTensorType::get({}, paramType.getElementType());
       Value shape = tosa::getTosaConstShape(rewriter, loc, ArrayRef<int64_t>{});
       param = tosa::ReshapeOp::create(rewriter, loc, scalarType, param, shape);
       return success();

--- a/lib/Conversion/HipToTosa/HipToTosa.cpp
+++ b/lib/Conversion/HipToTosa/HipToTosa.cpp
@@ -6,7 +6,6 @@
 #include "hip/Dialect/IR/HipDialect.h"
 #include "hip/Dialect/Transforms/Passes.h"
 
-#include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/Tensor/IR/Tensor.h>
 #include <mlir/Dialect/Tosa/IR/TosaOps.h>
@@ -876,7 +875,7 @@ class HipToTosaPass : public impl::ConvertHipToTosaPassBase<HipToTosaPass> {
     // requires every remaining op to be legal -- the framework does not DCE
     // this pre-existing op on its own. Mark it legal so conversion succeeds;
     // the canonicalizer that follows this pass removes the dead empty.
-    conversion.addLegalOp<ub::PoisonOp, tensor::EmptyOp, arith::ConstantOp>();
+    conversion.addLegalOp<ub::PoisonOp, tensor::EmptyOp>();
 
     RewritePatternSet patterns(ctx);
     patterns.add<MatMulConverter, BinaryConverter<AddOp, tosa::AddOp>,

--- a/lib/Conversion/HipToTosa/HipToTosa.cpp
+++ b/lib/Conversion/HipToTosa/HipToTosa.cpp
@@ -6,17 +6,25 @@
 #include "hip/Dialect/IR/HipDialect.h"
 #include "hip/Dialect/Transforms/Passes.h"
 
+#include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/Dialect/Func/IR/FuncOps.h>
 #include <mlir/Dialect/Tensor/IR/Tensor.h>
 #include <mlir/Dialect/Tosa/IR/TosaOps.h>
 #include <mlir/Dialect/Tosa/Utils/ConversionUtils.h>
 #include <mlir/Dialect/UB/IR/UBOps.h>
+#include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/BuiltinTypes.h>
+#include <mlir/IR/Matchers.h>
 #include <mlir/IR/MLIRContext.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/Pass/Pass.h>
 #include <mlir/Transforms/DialectConversion.h>
 #include <mlir/Transforms/GreedyPatternRewriteDriver.h>
+
+#include <llvm/ADT/APFloat.h>
+#include <llvm/ADT/APInt.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/StringRef.h>
 
 #include <type_traits>
 
@@ -30,11 +38,9 @@ namespace {
 // TOSA broadcasts size-1 dimensions only and requires every operand to carry
 // the result's rank, so hip's ONNX/NumPy rank-extending broadcast does not
 // always survive a 1-1 mapping.
-bool isTosaCompatibleOperand(Value operand, RankedTensorType resultType) {
-  auto operandType = dyn_cast<RankedTensorType>(operand.getType());
-  if (!operandType || !operandType.hasStaticShape())
-    return false;
-  if (operandType.getElementType() != resultType.getElementType())
+bool isTosaBroadcastableShape(RankedTensorType operandType,
+                               RankedTensorType resultType) {
+  if (!operandType.hasStaticShape())
     return false;
   if (operandType.getRank() != resultType.getRank())
     return false;
@@ -45,6 +51,15 @@ bool isTosaCompatibleOperand(Value operand, RankedTensorType resultType) {
     if (shape[i] != resultShape[i] && shape[i] != 1)
       return false;
   return true;
+}
+
+bool isTosaCompatibleOperand(Value operand, RankedTensorType resultType) {
+  auto operandType = dyn_cast<RankedTensorType>(operand.getType());
+  if (!operandType)
+    return false;
+  if (operandType.getElementType() != resultType.getElementType())
+    return false;
+  return isTosaBroadcastableShape(operandType, resultType);
 }
 
 // Reshape `input` to `shape` via tosa.reshape + tosa.const_shape.
@@ -131,6 +146,20 @@ Value createZeroMulShift(ConversionPatternRewriter &rewriter, Location loc) {
       rewriter, loc, shiftType,
       DenseElementsAttr::get(shiftType,
                              rewriter.getIntegerAttr(rewriter.getI8Type(), 0)));
+}
+
+// Splat a float scalar across `type`, matching rock::tosa::getZeroTensor's
+// tosa.const shape (the result tensor, not a rank-0 scalar).
+Value createSplatFloat(ConversionPatternRewriter &rewriter, Location loc,
+                       RankedTensorType type, double value) {
+  auto elemType = cast<FloatType>(type.getElementType());
+  APFloat ap(value);
+  bool losesInfo = false;
+  ap.convert(elemType.getFloatSemantics(), APFloat::rmNearestTiesToEven,
+             &losesInfo);
+  return tosa::ConstOp::create(
+      rewriter, loc, type,
+      DenseElementsAttr::get(type, rewriter.getFloatAttr(elemType, ap)));
 }
 
 // Covers the hip ops whose operands are (ctx, lhs, rhs, output) and whose TOSA
@@ -226,6 +255,592 @@ struct UnaryConverter final : public OpConversionPattern<HipOpTy> {
   }
 };
 
+// TOSA has no sqrt. Emit tosa.reciprocal(tosa.rsqrt(x)), which
+// RockTosaToElementwise folds back into a single math.sqrt.
+struct SqrtConverter final : public OpConversionPattern<SqrtOp> {
+  using OpConversionPattern<SqrtOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(SqrtOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (op.getNumResults() != 1)
+      return rewriter.notifyMatchFailure(op, "expected tensor mode");
+
+    auto resultType = dyn_cast<RankedTensorType>(op.getResult(0).getType());
+    if (!resultType || !resultType.hasStaticShape())
+      return rewriter.notifyMatchFailure(op, "expected a static ranked tensor");
+    if (adaptor.getX().getType() != resultType)
+      return rewriter.notifyMatchFailure(
+          op, "operand and result types must match exactly");
+    if (!isa<FloatType>(resultType.getElementType()))
+      return rewriter.notifyMatchFailure(op, "tosa op requires a float tensor");
+
+    auto rsqrt = tosa::RsqrtOp::create(rewriter, op.getLoc(), resultType,
+                                        adaptor.getX());
+    rewriter.replaceOpWithNewOp<tosa::ReciprocalOp>(op, resultType, rsqrt);
+    return success();
+  }
+};
+
+// hip.where is ternary (cond, x, y). tosa.select is the 1-1 mapping; it cannot
+// use BinaryConverter because the predicate is i1 while the result is not.
+// EqualizeRanks is pairwise, so the three operands are equalized the same way
+// CreateOpAndInferShape does for Select.
+struct WhereConverter final : public OpConversionPattern<WhereOp> {
+  using OpConversionPattern<WhereOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(WhereOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (op.getNumResults() != 1)
+      return rewriter.notifyMatchFailure(op, "expected tensor mode");
+
+    auto resultType = dyn_cast<RankedTensorType>(op.getResult(0).getType());
+    if (!resultType || !resultType.hasStaticShape())
+      return rewriter.notifyMatchFailure(op, "expected a static ranked tensor");
+
+    Value cond = adaptor.getCondition();
+    Value x = adaptor.getX();
+    Value y = adaptor.getY();
+    Location loc = op.getLoc();
+    if (failed(tosa::EqualizeRanks(rewriter, loc, cond, x)) ||
+        failed(tosa::EqualizeRanks(rewriter, loc, cond, y)) ||
+        failed(tosa::EqualizeRanks(rewriter, loc, x, y)))
+      return rewriter.notifyMatchFailure(op, "operand ranks not equalizable");
+
+    auto condType = dyn_cast<RankedTensorType>(cond.getType());
+    if (!condType || !condType.getElementType().isInteger(1) ||
+        !isTosaBroadcastableShape(condType, resultType))
+      return rewriter.notifyMatchFailure(
+          op, "condition is not a tosa-broadcastable i1 tensor");
+    if (!isTosaCompatibleOperand(x, resultType) ||
+        !isTosaCompatibleOperand(y, resultType))
+      return rewriter.notifyMatchFailure(op, "operands not tosa-broadcastable");
+
+    rewriter.replaceOpWithNewOp<tosa::SelectOp>(op, resultType, cond, x, y);
+    return success();
+  }
+};
+
+// hip.leaky_relu is unary plus an `alpha` attribute; TOSA has no matching op.
+// For alpha in [0, 1] it lowers as:
+//   tosa.maximum(x, tosa.mul(x, splat(alpha))).
+struct LeakyReluConverter final : public OpConversionPattern<LeakyReluOp> {
+  using OpConversionPattern<LeakyReluOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(LeakyReluOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (op.getNumResults() != 1)
+      return rewriter.notifyMatchFailure(op, "expected tensor mode");
+
+    auto resultType = dyn_cast<RankedTensorType>(op.getResult(0).getType());
+    if (!resultType || !resultType.hasStaticShape())
+      return rewriter.notifyMatchFailure(op, "expected a static ranked tensor");
+    Value x = adaptor.getInput();
+    if (x.getType() != resultType)
+      return rewriter.notifyMatchFailure(
+          op, "operand and result types must match exactly");
+    if (!isa<FloatType>(resultType.getElementType()))
+      return rewriter.notifyMatchFailure(op, "tosa op requires a float tensor");
+
+    Location loc = op.getLoc();
+    Value alpha = createSplatFloat(rewriter, loc, resultType,
+                                   op.getAlpha().convertToDouble());
+    Value scaled = tosa::MulOp::create(rewriter, loc, resultType, x, alpha,
+                                       createZeroMulShift(rewriter, loc));
+    rewriter.replaceOpWithNewOp<tosa::MaximumOp>(
+        op, resultType, x, scaled, tosa::NanPropagationMode::IGNORE);
+    return success();
+  }
+};
+
+bool extractConstantInts(Value v, SmallVectorImpl<int64_t> &out) {
+  out.clear();
+  IntegerAttr intAttr;
+  DenseIntElementsAttr denseAttr;
+  if (matchPattern(v, m_Constant(&intAttr))) {
+    out.push_back(intAttr.getInt());
+    return true;
+  }
+  if (matchPattern(v, m_Constant(&denseAttr))) {
+    for (APInt e : denseAttr.getValues<APInt>())
+      out.push_back(e.getSExtValue());
+    return true;
+  }
+  return false;
+}
+
+// TOSA reduce ops take one i32 axis and always leave that dim as size 1.
+// hip.reduce_* carry ONNX axes as a tensor plus keepdims / noop_with_empty_axes.
+FailureOr<int32_t> matchSingleReduceAxis(Value axes, int64_t rank,
+                                         int64_t noopWithEmptyAxes,
+                                         ConversionPatternRewriter &rewriter,
+                                         Operation *op) {
+  SmallVector<int64_t, 4> axesVals;
+  if (!extractConstantInts(axes, axesVals)) {
+    (void)rewriter.notifyMatchFailure(op, "axes must be a constant");
+    return failure();
+  }
+  if (axesVals.empty()) {
+    (void)rewriter.notifyMatchFailure(
+        op, noopWithEmptyAxes ? "empty axes identity"
+                              : "empty axes reduce-all is not a single tosa "
+                                "reduce");
+    return failure();
+  }
+  if (axesVals.size() != 1) {
+    (void)rewriter.notifyMatchFailure(op, "tosa reduce supports a single axis");
+    return failure();
+  }
+
+  int64_t axis = axesVals[0];
+  if (axis < 0)
+    axis += rank;
+  if (axis < 0 || axis >= rank) {
+    (void)rewriter.notifyMatchFailure(op, "axis out of range");
+    return failure();
+  }
+  return static_cast<int32_t>(axis);
+}
+
+RankedTensorType keepdimsReduceType(RankedTensorType dataType, int32_t axis) {
+  SmallVector<int64_t> shape(dataType.getShape().begin(),
+                             dataType.getShape().end());
+  shape[axis] = 1;
+  return RankedTensorType::get(shape, dataType.getElementType());
+}
+
+// hip.miopen.softmax is last-dim softmax. TOSA has no softmax op; expand to
+// reduce_max/sub/exp/reduce_sum/reciprocal/mul, which TosaToRock attention
+// matching expects.
+struct SoftmaxConverter final : public OpConversionPattern<MiopenSoftmaxOp> {
+  using OpConversionPattern<MiopenSoftmaxOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(MiopenSoftmaxOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (op.getNumResults() != 1)
+      return rewriter.notifyMatchFailure(op, "expected tensor mode");
+
+    auto resultType = dyn_cast<RankedTensorType>(op.getResult(0).getType());
+    if (!resultType || !resultType.hasStaticShape())
+      return rewriter.notifyMatchFailure(op, "expected a static ranked tensor");
+    Value input = adaptor.getInput();
+    if (input.getType() != resultType)
+      return rewriter.notifyMatchFailure(
+          op, "operand and result types must match exactly");
+    if (resultType.getRank() < 1)
+      return rewriter.notifyMatchFailure(op, "tosa reduce requires rank >= 1");
+    if (!isa<FloatType>(resultType.getElementType()))
+      return rewriter.notifyMatchFailure(
+          op, "tosa softmax requires a float tensor");
+
+    int32_t axis = static_cast<int32_t>(resultType.getRank() - 1);
+    auto reducedTy = keepdimsReduceType(resultType, axis);
+    Location loc = op.getLoc();
+    IntegerAttr axisAttr = rewriter.getI32IntegerAttr(axis);
+    auto rmax =
+        tosa::ReduceMaxOp::create(rewriter, loc, reducedTy, input, axisAttr);
+    auto sub = tosa::SubOp::create(rewriter, loc, resultType, input, rmax);
+    auto exp = tosa::ExpOp::create(rewriter, loc, resultType, sub);
+    auto rsum =
+        tosa::ReduceSumOp::create(rewriter, loc, reducedTy, exp, axisAttr);
+    auto rec = tosa::ReciprocalOp::create(rewriter, loc, reducedTy, rsum);
+    rewriter.replaceOpWithNewOp<tosa::MulOp>(
+        op, resultType, exp, rec, createZeroMulShift(rewriter, loc));
+    return success();
+  }
+};
+
+void replaceWithTosaReduce(Operation *op, Value reduced,
+                            RankedTensorType resultType, bool keepdims,
+                            ConversionPatternRewriter &rewriter) {
+  if (keepdims) {
+    rewriter.replaceOp(op, reduced);
+    return;
+  }
+  Value shape =
+      tosa::getTosaConstShape(rewriter, op->getLoc(), resultType.getShape());
+  rewriter.replaceOpWithNewOp<tosa::ReshapeOp>(op, resultType, reduced, shape);
+}
+
+LogicalResult matchHipReduce(Operation *op, Value data, Value axes,
+                               int64_t keepdims, int64_t noopWithEmptyAxes,
+                               ConversionPatternRewriter &rewriter,
+                               RankedTensorType &resultType, Value &dataOut,
+                               int32_t &axis, bool &keepdimsOut,
+                               bool &identity) {
+  identity = false;
+  if (op->getNumResults() != 1)
+    return rewriter.notifyMatchFailure(op, "expected tensor mode");
+  resultType = dyn_cast<RankedTensorType>(op->getResult(0).getType());
+  if (!resultType || !resultType.hasStaticShape())
+    return rewriter.notifyMatchFailure(op, "expected a static ranked tensor");
+  auto dataType = dyn_cast<RankedTensorType>(data.getType());
+  if (!dataType || !dataType.hasStaticShape())
+    return rewriter.notifyMatchFailure(op, "expected static ranked data");
+  if (dataType.getRank() < 1)
+    return rewriter.notifyMatchFailure(op, "tosa reduce requires rank >= 1");
+
+  SmallVector<int64_t, 4> axesVals;
+  if (!extractConstantInts(axes, axesVals))
+    return rewriter.notifyMatchFailure(op, "axes must be a constant");
+  if (axesVals.empty() && noopWithEmptyAxes) {
+    if (data.getType() != resultType)
+      return rewriter.notifyMatchFailure(op, "identity type mismatch");
+    identity = true;
+    dataOut = data;
+    keepdimsOut = keepdims != 0;
+    return success();
+  }
+
+  FailureOr<int32_t> axisOr = matchSingleReduceAxis(
+      axes, dataType.getRank(), noopWithEmptyAxes, rewriter, op);
+  if (failed(axisOr))
+    return failure();
+  axis = *axisOr;
+  keepdimsOut = keepdims != 0;
+  dataOut = data;
+  identity = false;
+  auto reducedTy = keepdimsReduceType(dataType, axis);
+  if (keepdimsOut && resultType != reducedTy)
+    return rewriter.notifyMatchFailure(op, "keepdims result type mismatch");
+  if (!keepdimsOut && resultType.getRank() != dataType.getRank() - 1)
+    return rewriter.notifyMatchFailure(op, "keepdims=0 rank mismatch");
+  return success();
+}
+
+// hip.reduce_sum -> tosa.reduce_sum. One constant axis, TOSA keepdims=1,
+// optional reshape.
+struct ReduceSumConverter final : public OpConversionPattern<ReduceSumOp> {
+  using OpConversionPattern<ReduceSumOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ReduceSumOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    RankedTensorType resultType;
+    Value data;
+    int32_t axis = 0;
+    bool keepdims = true;
+    bool identity = false;
+    if (failed(matchHipReduce(op, adaptor.getData(), adaptor.getAxes(),
+                              op.getKeepdims(), op.getNoopWithEmptyAxes(),
+                              rewriter, resultType, data, axis, keepdims,
+                              identity)))
+      return failure();
+    if (identity) {
+      rewriter.replaceOp(op, data);
+      return success();
+    }
+    auto reducedTy =
+        keepdimsReduceType(cast<RankedTensorType>(data.getType()), axis);
+    auto reduced = tosa::ReduceSumOp::create(
+        rewriter, op.getLoc(), reducedTy, data,
+        rewriter.getI32IntegerAttr(axis));
+    replaceWithTosaReduce(op, reduced, resultType, keepdims, rewriter);
+    return success();
+  }
+};
+
+// TOSA has no reduce_mean. Scale by 1/N then reduce_sum.
+struct ReduceMeanConverter final : public OpConversionPattern<ReduceMeanOp> {
+  using OpConversionPattern<ReduceMeanOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ReduceMeanOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    RankedTensorType resultType;
+    Value data;
+    int32_t axis = 0;
+    bool keepdims = true;
+    bool identity = false;
+    if (failed(matchHipReduce(op, adaptor.getData(), adaptor.getAxes(),
+                              op.getKeepdims(), op.getNoopWithEmptyAxes(),
+                              rewriter, resultType, data, axis, keepdims,
+                              identity)))
+      return failure();
+    if (identity) {
+      rewriter.replaceOp(op, data);
+      return success();
+    }
+    auto dataType = cast<RankedTensorType>(data.getType());
+    if (!isa<FloatType>(dataType.getElementType()))
+      return rewriter.notifyMatchFailure(
+          op, "tosa reduce_mean lowering requires a float tensor");
+    int64_t n = dataType.getDimSize(axis);
+    if (n <= 0)
+      return rewriter.notifyMatchFailure(op, "reduce axis extent must be > 0");
+
+    Location loc = op.getLoc();
+    Type elemType = dataType.getElementType();
+    auto oneType = RankedTensorType::get({1}, elemType);
+    Value nConst =
+        createSplatFloat(rewriter, loc, oneType, static_cast<double>(n));
+    auto inv = tosa::ReciprocalOp::create(rewriter, loc, oneType, nConst);
+    SmallVector<int64_t> ones(dataType.getRank(), 1);
+    Value onesShape = tosa::getTosaConstShape(rewriter, loc, ones);
+    auto invTy = RankedTensorType::get(ones, elemType);
+    Value invShaped =
+        tosa::ReshapeOp::create(rewriter, loc, invTy, inv, onesShape);
+    Value scaled = tosa::MulOp::create(rewriter, loc, dataType, data, invShaped,
+                                        createZeroMulShift(rewriter, loc));
+    auto reducedTy = keepdimsReduceType(dataType, axis);
+    auto reduced = tosa::ReduceSumOp::create(
+        rewriter, loc, reducedTy, scaled, rewriter.getI32IntegerAttr(axis));
+    replaceWithTosaReduce(op, reduced, resultType, keepdims, rewriter);
+    return success();
+  }
+};
+
+// rocMLIR's rock-tosa-to-elementwise lowers these tosa.custom names; a plain
+// tosa.cast float->int is illegal there.
+constexpr StringLiteral kRockCustomOpDomain = "rocmlir";
+constexpr StringLiteral kRockUnsignedCast = "unsigned_cast";
+constexpr StringLiteral kRockFpToIntCast = "fp_to_int_cast";
+
+Value emitTosaCast(ConversionPatternRewriter &rewriter, Location loc,
+                    Value input, Type resElemType) {
+  auto inType = cast<RankedTensorType>(input.getType());
+  Type inElem = inType.getElementType();
+  auto outType = RankedTensorType::get(inType.getShape(), resElemType);
+  if (inElem == resElemType)
+    return input;
+  if (inElem.isUnsignedInteger() || resElemType.isUnsignedInteger()) {
+    return tosa::CustomOp::create(rewriter, loc, outType, kRockUnsignedCast,
+                                  kRockCustomOpDomain, "", input)
+        .getResult(0);
+  }
+  if (isa<FloatType>(inElem) && isa<IntegerType>(resElemType)) {
+    return tosa::CustomOp::create(rewriter, loc, outType, kRockFpToIntCast,
+                                  kRockCustomOpDomain, "", input)
+        .getResult(0);
+  }
+  return tosa::CastOp::create(rewriter, loc, outType, input);
+}
+
+Value emitTosaMul(ConversionPatternRewriter &rewriter, Location loc, Value lhs,
+                  Value rhs, RankedTensorType resultType) {
+  return tosa::MulOp::create(rewriter, loc, resultType, lhs, rhs,
+                             createZeroMulShift(rewriter, loc));
+}
+
+// ONNX QDQ scale/ZP is a scalar, a 1-D per-axis vector, or already ranked
+// like the data. TOSA only broadcasts size-1 dims at matching rank, so a
+// 1-D vector on `axis` has to be reshaped to [1, ..., C, ..., 1] first.
+LogicalResult reshapeQdqParam(ConversionPatternRewriter &rewriter, Location loc,
+                               Value &param, RankedTensorType dataType,
+                               int64_t axis, Operation *op) {
+  auto paramType = dyn_cast<RankedTensorType>(param.getType());
+  if (!paramType || !paramType.hasStaticShape())
+    return rewriter.notifyMatchFailure(op, "qdq param must be a static tensor");
+
+  int64_t rank = dataType.getRank();
+  if (rank == 0) {
+    if (paramType.getRank() != 0 &&
+        !(paramType.getRank() == 1 && paramType.getDimSize(0) == 1))
+      return rewriter.notifyMatchFailure(op, "rank-0 qdq expects a scalar");
+    return success();
+  }
+
+  if (axis < 0)
+    axis += rank;
+  if (axis < 0 || axis >= rank)
+    return rewriter.notifyMatchFailure(op, "qdq axis out of range");
+
+  if (paramType.getRank() == rank) {
+    auto asDataRank =
+        RankedTensorType::get(dataType.getShape(), paramType.getElementType());
+    if (!isTosaBroadcastableShape(paramType, asDataRank))
+      return rewriter.notifyMatchFailure(op, "qdq param not broadcastable");
+    return success();
+  }
+
+  SmallVector<int64_t> targetShape(rank, 1);
+  if (paramType.getRank() == 0) {
+    // per-tensor scalar: all-ones shape of the data rank
+  } else if (paramType.getRank() == 1) {
+    int64_t n = paramType.getDimSize(0);
+    int64_t axisExtent = dataType.getDimSize(axis);
+    if (n != 1 && n != axisExtent)
+      return rewriter.notifyMatchFailure(
+          op, "1-d qdq param length must match the quantized axis");
+    targetShape[axis] = n;
+  } else {
+    return rewriter.notifyMatchFailure(op, "unsupported qdq param rank");
+  }
+
+  auto newType = RankedTensorType::get(targetShape, paramType.getElementType());
+  if (paramType == newType)
+    return success();
+  Value shape = tosa::getTosaConstShape(rewriter, loc, targetShape);
+  param = tosa::ReshapeOp::create(rewriter, loc, newType, param, shape);
+  return success();
+}
+
+LogicalResult matchQdqCommon(Operation *op, Value input, Value scale,
+                              Value zeroPoint, int64_t axis, int64_t blockSize,
+                              ConversionPatternRewriter &rewriter,
+                              RankedTensorType &resultType, Value &inputOut,
+                              Value &scaleOut, Value &zpOut) {
+  if (op->getNumResults() != 1)
+    return rewriter.notifyMatchFailure(op, "expected tensor mode");
+  resultType = dyn_cast<RankedTensorType>(op->getResult(0).getType());
+  if (!resultType || !resultType.hasStaticShape())
+    return rewriter.notifyMatchFailure(op, "expected a static ranked tensor");
+  auto inputType = dyn_cast<RankedTensorType>(input.getType());
+  if (!inputType || !inputType.hasStaticShape())
+    return rewriter.notifyMatchFailure(op, "expected static ranked input");
+  if (inputType.getShape() != resultType.getShape())
+    return rewriter.notifyMatchFailure(op, "qdq cannot change the shape");
+  if (blockSize != 0)
+    return rewriter.notifyMatchFailure(op, "blocked qdq is not a tosa mul");
+  if (op->hasAttr("packed_int4"))
+    return rewriter.notifyMatchFailure(op, "packed_int4 is not tosa");
+
+  Location loc = op->getLoc();
+  scaleOut = scale;
+  if (failed(reshapeQdqParam(rewriter, loc, scaleOut, inputType, axis, op)))
+    return failure();
+  zpOut = zeroPoint;
+  if (zpOut &&
+      failed(reshapeQdqParam(rewriter, loc, zpOut, inputType, axis, op)))
+    return failure();
+  inputOut = input;
+  return success();
+}
+
+// hip.cast is 1-1 with tosa.cast when both endpoints are signed or float.
+// Float->int and any unsigned endpoint go through rocMLIR tosa.custom, because
+// rock-tosa-to-elementwise rejects tosa.cast float->int.
+struct CastConverter final : public OpConversionPattern<CastOp> {
+  using OpConversionPattern<CastOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(CastOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (op.getNumResults() != 1)
+      return rewriter.notifyMatchFailure(op, "expected tensor mode");
+
+    auto resultType = dyn_cast<RankedTensorType>(op.getResult(0).getType());
+    if (!resultType || !resultType.hasStaticShape())
+      return rewriter.notifyMatchFailure(op, "expected a static ranked tensor");
+    auto inputType = dyn_cast<RankedTensorType>(adaptor.getInput().getType());
+    if (!inputType || !inputType.hasStaticShape())
+      return rewriter.notifyMatchFailure(op, "expected static ranked input");
+    if (inputType.getShape() != resultType.getShape())
+      return rewriter.notifyMatchFailure(op, "cast cannot change the shape");
+
+    Type inElem = inputType.getElementType();
+    Type outElem = resultType.getElementType();
+    if (!isa<FloatType, IntegerType>(inElem) ||
+        !isa<FloatType, IntegerType>(outElem))
+      return rewriter.notifyMatchFailure(op, "unsupported cast element type");
+
+    rewriter.replaceOp(
+        op, emitTosaCast(rewriter, op.getLoc(), adaptor.getInput(), outElem));
+    return success();
+  }
+};
+
+// y = (x - zp) * scale.
+struct DequantizeLinearConverter final
+    : public OpConversionPattern<DequantizeLinearOp> {
+  using OpConversionPattern<DequantizeLinearOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(DequantizeLinearOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    RankedTensorType resultType;
+    Value input, scale, zp;
+    if (failed(matchQdqCommon(op, adaptor.getInput(), adaptor.getScale(),
+                              adaptor.getZeroPoint(), op.getAxis(),
+                              op.getBlockSize(), rewriter, resultType, input,
+                              scale, zp)))
+      return failure();
+    if (!isa<FloatType>(resultType.getElementType()))
+      return rewriter.notifyMatchFailure(op, "dequant result must be float");
+    auto scaleType = cast<RankedTensorType>(scale.getType());
+    if (scaleType.getElementType() != resultType.getElementType())
+      return rewriter.notifyMatchFailure(op, "scale type must match result");
+
+    Location loc = op.getLoc();
+    Value shifted =
+        emitTosaCast(rewriter, loc, input, resultType.getElementType());
+    if (zp) {
+      Value zpCast =
+          emitTosaCast(rewriter, loc, zp, resultType.getElementType());
+      shifted = tosa::SubOp::create(rewriter, loc, resultType, shifted, zpCast);
+    }
+    rewriter.replaceOp(op,
+                        emitTosaMul(rewriter, loc, shifted, scale, resultType));
+    return success();
+  }
+};
+
+// y = saturate(x / scale + zp).
+struct QuantizeLinearConverter final
+    : public OpConversionPattern<QuantizeLinearOp> {
+  using OpConversionPattern<QuantizeLinearOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(QuantizeLinearOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (op.getSaturate() == 0)
+      return rewriter.notifyMatchFailure(
+          op, "saturate=0 wrap is not a tosa.clamp");
+
+    RankedTensorType resultType;
+    Value input, scale, zp;
+    if (failed(matchQdqCommon(op, adaptor.getInput(), adaptor.getScale(),
+                              adaptor.getZeroPoint(), op.getAxis(),
+                              op.getBlockSize(), rewriter, resultType, input,
+                              scale, zp)))
+      return failure();
+    auto inputType = cast<RankedTensorType>(input.getType());
+    Type inElem = inputType.getElementType();
+    Type outElem = resultType.getElementType();
+    if (!isa<FloatType>(inElem) || !isa<IntegerType>(outElem))
+      return rewriter.notifyMatchFailure(
+          op, "quantize expects float input and integer output");
+    auto scaleType = cast<RankedTensorType>(scale.getType());
+    if (scaleType.getElementType() != inElem)
+      return rewriter.notifyMatchFailure(op, "scale type must match input");
+
+    Location loc = op.getLoc();
+    auto inv = tosa::ReciprocalOp::create(rewriter, loc, scaleType, scale);
+    Value scaled = emitTosaMul(rewriter, loc, input, inv, inputType);
+
+    if (!zp) {
+      rewriter.replaceOp(op, emitTosaCast(rewriter, loc, scaled, outElem));
+      return success();
+    }
+
+    Type biasElem = rewriter.getI32Type();
+    auto i32Type = RankedTensorType::get(resultType.getShape(), biasElem);
+    Value asI32 = emitTosaCast(rewriter, loc, scaled, biasElem);
+    Value zpI32 = emitTosaCast(rewriter, loc, zp, biasElem);
+    Value biased = tosa::AddOp::create(rewriter, loc, i32Type, asI32, zpI32);
+
+    unsigned width = outElem.getIntOrFloatBitWidth();
+    APInt minI = outElem.isUnsignedInteger() ? APInt::getMinValue(width)
+                                           : APInt::getSignedMinValue(width);
+    APInt maxI = outElem.isUnsignedInteger() ? APInt::getMaxValue(width)
+                                           : APInt::getSignedMaxValue(width);
+    int64_t minValI = outElem.isUnsignedInteger() ? minI.getZExtValue()
+                                               : minI.getSExtValue();
+    int64_t maxValI = outElem.isUnsignedInteger() ? maxI.getZExtValue()
+                                               : maxI.getSExtValue();
+    Attribute minVal = rewriter.getIntegerAttr(biasElem, minValI);
+    Attribute maxVal = rewriter.getIntegerAttr(biasElem, maxValI);
+    Value clamped = tosa::ClampOp::create(
+        rewriter, loc, i32Type, biased, minVal, maxVal,
+        tosa::NanPropagationMode::PROPAGATE);
+    rewriter.replaceOp(op, emitTosaCast(rewriter, loc, clamped, outElem));
+    return success();
+  }
+};
+
 class HipToTosaPass : public impl::ConvertHipToTosaPassBase<HipToTosaPass> {
   void runOnOperation() override {
     auto funcOp = getOperation();
@@ -251,14 +866,17 @@ class HipToTosaPass : public impl::ConvertHipToTosaPassBase<HipToTosaPass> {
     conversion.addLegalDialect<tosa::TosaDialect, func::FuncDialect>();
     conversion.addIllegalOp<MatmulOp, AddOp, SubOp, MinOp, MaxOp, MulOp, AbsOp,
                             NegOp, CeilOp, FloorOp, ExpOp, LogOp, SinOp, CosOp,
-                            TanhOp, ErfOp, SigmoidOp, ReciprocalOp>();
+                            TanhOp, ErfOp, SigmoidOp, ReciprocalOp, SqrtOp,
+                            WhereOp, LeakyReluOp, MiopenSoftmaxOp, ReduceSumOp,
+                            ReduceMeanOp, CastOp, QuantizeLinearOp,
+                            DequantizeLinearOp>();
     // tosa.matmul (and other tosa ops) are not destination-passing, so
     // MatMulConverter drops each hip op's DPS `outs` operand. The
     // `tensor.empty` that fed it is then dead, but a full conversion still
     // requires every remaining op to be legal -- the framework does not DCE
     // this pre-existing op on its own. Mark it legal so conversion succeeds;
     // the canonicalizer that follows this pass removes the dead empty.
-    conversion.addLegalOp<ub::PoisonOp, tensor::EmptyOp>();
+    conversion.addLegalOp<ub::PoisonOp, tensor::EmptyOp, arith::ConstantOp>();
 
     RewritePatternSet patterns(ctx);
     patterns.add<MatMulConverter, BinaryConverter<AddOp, tosa::AddOp>,
@@ -278,7 +896,11 @@ class HipToTosaPass : public impl::ConvertHipToTosaPassBase<HipToTosaPass> {
                  UnaryConverter<ErfOp, tosa::ErfOp, /*FloatOnly=*/true>,
                  UnaryConverter<SigmoidOp, tosa::SigmoidOp, /*FloatOnly=*/true>,
                  UnaryConverter<ReciprocalOp, tosa::ReciprocalOp,
-                                /*FloatOnly=*/true>>(ctx);
+                                /*FloatOnly=*/true>,
+                 SqrtConverter, WhereConverter, LeakyReluConverter,
+                 SoftmaxConverter, ReduceSumConverter, ReduceMeanConverter,
+                 CastConverter, DequantizeLinearConverter,
+                 QuantizeLinearConverter>(ctx);
 
     if (failed(applyPartialConversion(funcOp, conversion, std::move(patterns))))
       signalPassFailure();

--- a/lib/Conversion/HipToTosa/HipToTosa.cpp
+++ b/lib/Conversion/HipToTosa/HipToTosa.cpp
@@ -322,8 +322,9 @@ struct WhereConverter final : public OpConversionPattern<WhereOp> {
 };
 
 // hip.leaky_relu is unary plus an `alpha` attribute; TOSA has no matching op.
-// For alpha in [0, 1] it lowers as:
+// y = x >= 0 ? x : alpha * x. For alpha in [0, 1] that is
 //   tosa.maximum(x, tosa.mul(x, splat(alpha))).
+// Otherwise emit tosa.select(tosa.greater(x, 0), x, scaled).
 struct LeakyReluConverter final : public OpConversionPattern<LeakyReluOp> {
   using OpConversionPattern<LeakyReluOp>::OpConversionPattern;
 
@@ -344,12 +345,22 @@ struct LeakyReluConverter final : public OpConversionPattern<LeakyReluOp> {
       return rewriter.notifyMatchFailure(op, "tosa op requires a float tensor");
 
     Location loc = op.getLoc();
-    Value alpha = createSplatFloat(rewriter, loc, resultType,
-                                   op.getAlpha().convertToDouble());
+    double alphaVal = op.getAlpha().convertToDouble();
+    Value alpha = createSplatFloat(rewriter, loc, resultType, alphaVal);
     Value scaled = tosa::MulOp::create(rewriter, loc, resultType, x, alpha,
                                        createZeroMulShift(rewriter, loc));
-    rewriter.replaceOpWithNewOp<tosa::MaximumOp>(
-        op, resultType, x, scaled, tosa::NanPropagationMode::IGNORE);
+    if (alphaVal >= 0.0 && alphaVal <= 1.0) {
+      rewriter.replaceOpWithNewOp<tosa::MaximumOp>(
+          op, resultType, x, scaled, tosa::NanPropagationMode::IGNORE);
+      return success();
+    }
+
+    Value zero = createSplatFloat(rewriter, loc, resultType, 0.0);
+    auto predType =
+        RankedTensorType::get(resultType.getShape(), rewriter.getI1Type());
+    Value pred = tosa::GreaterOp::create(rewriter, loc, predType, x, zero);
+    rewriter.replaceOpWithNewOp<tosa::SelectOp>(op, resultType, pred, x,
+                                                scaled);
     return success();
   }
 };
@@ -636,8 +647,16 @@ LogicalResult reshapeQdqParam(ConversionPatternRewriter &rewriter, Location loc,
 
   int64_t rank = dataType.getRank();
   if (rank == 0) {
-    if (paramType.getRank() != 0 &&
-        !(paramType.getRank() == 1 && paramType.getDimSize(0) == 1))
+    // TOSA elementwise ops need matching rank. ONNX per-tensor scale/ZP is
+    // sometimes tensor<1xT>; fold that to a rank-0 scalar.
+    if (paramType.getRank() == 1 && paramType.getDimSize(0) == 1) {
+      auto scalarType =
+          RankedTensorType::get({}, paramType.getElementType());
+      Value shape = tosa::getTosaConstShape(rewriter, loc, ArrayRef<int64_t>{});
+      param = tosa::ReshapeOp::create(rewriter, loc, scalarType, param, shape);
+      return success();
+    }
+    if (paramType.getRank() != 0)
       return rewriter.notifyMatchFailure(op, "rank-0 qdq expects a scalar");
     return success();
   }

--- a/lib/Conversion/HipToTosa/HipToTosa.cpp
+++ b/lib/Conversion/HipToTosa/HipToTosa.cpp
@@ -13,8 +13,8 @@
 #include <mlir/Dialect/UB/IR/UBOps.h>
 #include <mlir/IR/BuiltinAttributes.h>
 #include <mlir/IR/BuiltinTypes.h>
-#include <mlir/IR/Matchers.h>
 #include <mlir/IR/MLIRContext.h>
+#include <mlir/IR/Matchers.h>
 #include <mlir/IR/PatternMatch.h>
 #include <mlir/Pass/Pass.h>
 #include <mlir/Transforms/DialectConversion.h>
@@ -38,7 +38,7 @@ namespace {
 // the result's rank, so hip's ONNX/NumPy rank-extending broadcast does not
 // always survive a 1-1 mapping.
 bool isTosaBroadcastableShape(RankedTensorType operandType,
-                               RankedTensorType resultType) {
+                              RankedTensorType resultType) {
   if (!operandType.hasStaticShape())
     return false;
   if (operandType.getRank() != resultType.getRank())
@@ -275,7 +275,7 @@ struct SqrtConverter final : public OpConversionPattern<SqrtOp> {
       return rewriter.notifyMatchFailure(op, "tosa op requires a float tensor");
 
     auto rsqrt = tosa::RsqrtOp::create(rewriter, op.getLoc(), resultType,
-                                        adaptor.getX());
+                                       adaptor.getX());
     rewriter.replaceOpWithNewOp<tosa::ReciprocalOp>(op, resultType, rsqrt);
     return success();
   }
@@ -371,7 +371,8 @@ bool extractConstantInts(Value v, SmallVectorImpl<int64_t> &out) {
 }
 
 // TOSA reduce ops take one i32 axis and always leave that dim as size 1.
-// hip.reduce_* carry ONNX axes as a tensor plus keepdims / noop_with_empty_axes.
+// hip.reduce_* carry ONNX axes as a tensor plus keepdims /
+// noop_with_empty_axes.
 FailureOr<int32_t> matchSingleReduceAxis(Value axes, int64_t rank,
                                          int64_t noopWithEmptyAxes,
                                          ConversionPatternRewriter &rewriter,
@@ -446,15 +447,15 @@ struct SoftmaxConverter final : public OpConversionPattern<MiopenSoftmaxOp> {
     auto rsum =
         tosa::ReduceSumOp::create(rewriter, loc, reducedTy, exp, axisAttr);
     auto rec = tosa::ReciprocalOp::create(rewriter, loc, reducedTy, rsum);
-    rewriter.replaceOpWithNewOp<tosa::MulOp>(
-        op, resultType, exp, rec, createZeroMulShift(rewriter, loc));
+    rewriter.replaceOpWithNewOp<tosa::MulOp>(op, resultType, exp, rec,
+                                             createZeroMulShift(rewriter, loc));
     return success();
   }
 };
 
 void replaceWithTosaReduce(Operation *op, Value reduced,
-                            RankedTensorType resultType, bool keepdims,
-                            ConversionPatternRewriter &rewriter) {
+                           RankedTensorType resultType, bool keepdims,
+                           ConversionPatternRewriter &rewriter) {
   if (keepdims) {
     rewriter.replaceOp(op, reduced);
     return;
@@ -465,11 +466,10 @@ void replaceWithTosaReduce(Operation *op, Value reduced,
 }
 
 LogicalResult matchHipReduce(Operation *op, Value data, Value axes,
-                               int64_t keepdims, int64_t noopWithEmptyAxes,
-                               ConversionPatternRewriter &rewriter,
-                               RankedTensorType &resultType, Value &dataOut,
-                               int32_t &axis, bool &keepdimsOut,
-                               bool &identity) {
+                             int64_t keepdims, int64_t noopWithEmptyAxes,
+                             ConversionPatternRewriter &rewriter,
+                             RankedTensorType &resultType, Value &dataOut,
+                             int32_t &axis, bool &keepdimsOut, bool &identity) {
   identity = false;
   if (op->getNumResults() != 1)
     return rewriter.notifyMatchFailure(op, "expected tensor mode");
@@ -534,9 +534,9 @@ struct ReduceSumConverter final : public OpConversionPattern<ReduceSumOp> {
     }
     auto reducedTy =
         keepdimsReduceType(cast<RankedTensorType>(data.getType()), axis);
-    auto reduced = tosa::ReduceSumOp::create(
-        rewriter, op.getLoc(), reducedTy, data,
-        rewriter.getI32IntegerAttr(axis));
+    auto reduced =
+        tosa::ReduceSumOp::create(rewriter, op.getLoc(), reducedTy, data,
+                                  rewriter.getI32IntegerAttr(axis));
     replaceWithTosaReduce(op, reduced, resultType, keepdims, rewriter);
     return success();
   }
@@ -583,10 +583,10 @@ struct ReduceMeanConverter final : public OpConversionPattern<ReduceMeanOp> {
     Value invShaped =
         tosa::ReshapeOp::create(rewriter, loc, invTy, inv, onesShape);
     Value scaled = tosa::MulOp::create(rewriter, loc, dataType, data, invShaped,
-                                        createZeroMulShift(rewriter, loc));
+                                       createZeroMulShift(rewriter, loc));
     auto reducedTy = keepdimsReduceType(dataType, axis);
-    auto reduced = tosa::ReduceSumOp::create(
-        rewriter, loc, reducedTy, scaled, rewriter.getI32IntegerAttr(axis));
+    auto reduced = tosa::ReduceSumOp::create(rewriter, loc, reducedTy, scaled,
+                                             rewriter.getI32IntegerAttr(axis));
     replaceWithTosaReduce(op, reduced, resultType, keepdims, rewriter);
     return success();
   }
@@ -599,7 +599,7 @@ constexpr StringLiteral kRockUnsignedCast = "unsigned_cast";
 constexpr StringLiteral kRockFpToIntCast = "fp_to_int_cast";
 
 Value emitTosaCast(ConversionPatternRewriter &rewriter, Location loc,
-                    Value input, Type resElemType) {
+                   Value input, Type resElemType) {
   auto inType = cast<RankedTensorType>(input.getType());
   Type inElem = inType.getElementType();
   auto outType = RankedTensorType::get(inType.getShape(), resElemType);
@@ -628,8 +628,8 @@ Value emitTosaMul(ConversionPatternRewriter &rewriter, Location loc, Value lhs,
 // like the data. TOSA only broadcasts size-1 dims at matching rank, so a
 // 1-D vector on `axis` has to be reshaped to [1, ..., C, ..., 1] first.
 LogicalResult reshapeQdqParam(ConversionPatternRewriter &rewriter, Location loc,
-                               Value &param, RankedTensorType dataType,
-                               int64_t axis, Operation *op) {
+                              Value &param, RankedTensorType dataType,
+                              int64_t axis, Operation *op) {
   auto paramType = dyn_cast<RankedTensorType>(param.getType());
   if (!paramType || !paramType.hasStaticShape())
     return rewriter.notifyMatchFailure(op, "qdq param must be a static tensor");
@@ -678,10 +678,10 @@ LogicalResult reshapeQdqParam(ConversionPatternRewriter &rewriter, Location loc,
 }
 
 LogicalResult matchQdqCommon(Operation *op, Value input, Value scale,
-                              Value zeroPoint, int64_t axis, int64_t blockSize,
-                              ConversionPatternRewriter &rewriter,
-                              RankedTensorType &resultType, Value &inputOut,
-                              Value &scaleOut, Value &zpOut) {
+                             Value zeroPoint, int64_t axis, int64_t blockSize,
+                             ConversionPatternRewriter &rewriter,
+                             RankedTensorType &resultType, Value &inputOut,
+                             Value &scaleOut, Value &zpOut) {
   if (op->getNumResults() != 1)
     return rewriter.notifyMatchFailure(op, "expected tensor mode");
   resultType = dyn_cast<RankedTensorType>(op->getResult(0).getType());
@@ -772,7 +772,7 @@ struct DequantizeLinearConverter final
       shifted = tosa::SubOp::create(rewriter, loc, resultType, shifted, zpCast);
     }
     rewriter.replaceOp(op,
-                        emitTosaMul(rewriter, loc, shifted, scale, resultType));
+                       emitTosaMul(rewriter, loc, shifted, scale, resultType));
     return success();
   }
 };
@@ -786,8 +786,8 @@ struct QuantizeLinearConverter final
   matchAndRewrite(QuantizeLinearOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (op.getSaturate() == 0)
-      return rewriter.notifyMatchFailure(
-          op, "saturate=0 wrap is not a tosa.clamp");
+      return rewriter.notifyMatchFailure(op,
+                                         "saturate=0 wrap is not a tosa.clamp");
 
     RankedTensorType resultType;
     Value input, scale, zp;
@@ -823,18 +823,18 @@ struct QuantizeLinearConverter final
 
     unsigned width = outElem.getIntOrFloatBitWidth();
     APInt minI = outElem.isUnsignedInteger() ? APInt::getMinValue(width)
-                                           : APInt::getSignedMinValue(width);
+                                             : APInt::getSignedMinValue(width);
     APInt maxI = outElem.isUnsignedInteger() ? APInt::getMaxValue(width)
-                                           : APInt::getSignedMaxValue(width);
-    int64_t minValI = outElem.isUnsignedInteger() ? minI.getZExtValue()
-                                               : minI.getSExtValue();
-    int64_t maxValI = outElem.isUnsignedInteger() ? maxI.getZExtValue()
-                                               : maxI.getSExtValue();
+                                             : APInt::getSignedMaxValue(width);
+    int64_t minValI =
+        outElem.isUnsignedInteger() ? minI.getZExtValue() : minI.getSExtValue();
+    int64_t maxValI =
+        outElem.isUnsignedInteger() ? maxI.getZExtValue() : maxI.getSExtValue();
     Attribute minVal = rewriter.getIntegerAttr(biasElem, minValI);
     Attribute maxVal = rewriter.getIntegerAttr(biasElem, maxValI);
-    Value clamped = tosa::ClampOp::create(
-        rewriter, loc, i32Type, biased, minVal, maxVal,
-        tosa::NanPropagationMode::PROPAGATE);
+    Value clamped =
+        tosa::ClampOp::create(rewriter, loc, i32Type, biased, minVal, maxVal,
+                              tosa::NanPropagationMode::PROPAGATE);
     rewriter.replaceOp(op, emitTosaCast(rewriter, loc, clamped, outElem));
     return success();
   }
@@ -863,12 +863,12 @@ class HipToTosaPass : public impl::ConvertHipToTosaPassBase<HipToTosaPass> {
     // fails.
     ConversionTarget conversion(*ctx);
     conversion.addLegalDialect<tosa::TosaDialect, func::FuncDialect>();
-    conversion.addIllegalOp<MatmulOp, AddOp, SubOp, MinOp, MaxOp, MulOp, AbsOp,
-                            NegOp, CeilOp, FloorOp, ExpOp, LogOp, SinOp, CosOp,
-                            TanhOp, ErfOp, SigmoidOp, ReciprocalOp, SqrtOp,
-                            WhereOp, LeakyReluOp, MiopenSoftmaxOp, ReduceSumOp,
-                            ReduceMeanOp, CastOp, QuantizeLinearOp,
-                            DequantizeLinearOp>();
+    conversion
+        .addIllegalOp<MatmulOp, AddOp, SubOp, MinOp, MaxOp, MulOp, AbsOp, NegOp,
+                      CeilOp, FloorOp, ExpOp, LogOp, SinOp, CosOp, TanhOp,
+                      ErfOp, SigmoidOp, ReciprocalOp, SqrtOp, WhereOp,
+                      LeakyReluOp, MiopenSoftmaxOp, ReduceSumOp, ReduceMeanOp,
+                      CastOp, QuantizeLinearOp, DequantizeLinearOp>();
     // tosa.matmul (and other tosa ops) are not destination-passing, so
     // MatMulConverter drops each hip op's DPS `outs` operand. The
     // `tensor.empty` that fed it is then dead, but a full conversion still
@@ -878,28 +878,27 @@ class HipToTosaPass : public impl::ConvertHipToTosaPassBase<HipToTosaPass> {
     conversion.addLegalOp<ub::PoisonOp, tensor::EmptyOp>();
 
     RewritePatternSet patterns(ctx);
-    patterns.add<MatMulConverter, BinaryConverter<AddOp, tosa::AddOp>,
-                 BinaryConverter<SubOp, tosa::SubOp>,
-                 BinaryConverter<MinOp, tosa::MinimumOp>,
-                 BinaryConverter<MaxOp, tosa::MaximumOp>,
-                 BinaryConverter<MulOp, tosa::MulOp>,
-                 UnaryConverter<AbsOp, tosa::AbsOp>,
-                 UnaryConverter<NegOp, tosa::NegateOp>,
-                 UnaryConverter<CeilOp, tosa::CeilOp, /*FloatOnly=*/true>,
-                 UnaryConverter<FloorOp, tosa::FloorOp, /*FloatOnly=*/true>,
-                 UnaryConverter<ExpOp, tosa::ExpOp, /*FloatOnly=*/true>,
-                 UnaryConverter<LogOp, tosa::LogOp, /*FloatOnly=*/true>,
-                 UnaryConverter<SinOp, tosa::SinOp, /*FloatOnly=*/true>,
-                 UnaryConverter<CosOp, tosa::CosOp, /*FloatOnly=*/true>,
-                 UnaryConverter<TanhOp, tosa::TanhOp, /*FloatOnly=*/true>,
-                 UnaryConverter<ErfOp, tosa::ErfOp, /*FloatOnly=*/true>,
-                 UnaryConverter<SigmoidOp, tosa::SigmoidOp, /*FloatOnly=*/true>,
-                 UnaryConverter<ReciprocalOp, tosa::ReciprocalOp,
-                                /*FloatOnly=*/true>,
-                 SqrtConverter, WhereConverter, LeakyReluConverter,
-                 SoftmaxConverter, ReduceSumConverter, ReduceMeanConverter,
-                 CastConverter, DequantizeLinearConverter,
-                 QuantizeLinearConverter>(ctx);
+    patterns.add<
+        MatMulConverter, BinaryConverter<AddOp, tosa::AddOp>,
+        BinaryConverter<SubOp, tosa::SubOp>,
+        BinaryConverter<MinOp, tosa::MinimumOp>,
+        BinaryConverter<MaxOp, tosa::MaximumOp>,
+        BinaryConverter<MulOp, tosa::MulOp>, UnaryConverter<AbsOp, tosa::AbsOp>,
+        UnaryConverter<NegOp, tosa::NegateOp>,
+        UnaryConverter<CeilOp, tosa::CeilOp, /*FloatOnly=*/true>,
+        UnaryConverter<FloorOp, tosa::FloorOp, /*FloatOnly=*/true>,
+        UnaryConverter<ExpOp, tosa::ExpOp, /*FloatOnly=*/true>,
+        UnaryConverter<LogOp, tosa::LogOp, /*FloatOnly=*/true>,
+        UnaryConverter<SinOp, tosa::SinOp, /*FloatOnly=*/true>,
+        UnaryConverter<CosOp, tosa::CosOp, /*FloatOnly=*/true>,
+        UnaryConverter<TanhOp, tosa::TanhOp, /*FloatOnly=*/true>,
+        UnaryConverter<ErfOp, tosa::ErfOp, /*FloatOnly=*/true>,
+        UnaryConverter<SigmoidOp, tosa::SigmoidOp, /*FloatOnly=*/true>,
+        UnaryConverter<ReciprocalOp, tosa::ReciprocalOp,
+                       /*FloatOnly=*/true>,
+        SqrtConverter, WhereConverter, LeakyReluConverter, SoftmaxConverter,
+        ReduceSumConverter, ReduceMeanConverter, CastConverter,
+        DequantizeLinearConverter, QuantizeLinearConverter>(ctx);
 
     if (failed(applyPartialConversion(funcOp, conversion, std::move(patterns))))
       signalPassFailure();

--- a/lib/Dialect/Transforms/FuseROCMlir.cpp
+++ b/lib/Dialect/Transforms/FuseROCMlir.cpp
@@ -121,7 +121,9 @@ public:
                            LeakyReluOp, ReciprocalOp, SqrtOp, DivOp, EqualOp,
                            AndOp, OrOp, NotOp, CosOp, ErfOp, SinOp, CeilOp,
                            RoundOp, AtanOp, FloorOp, ExpOp, LogOp, AbsOp, NegOp,
-                           SubOp, CastOp, LessOp, SignOp, ModOp>(op);
+                           SubOp, CastOp, LessOp, SignOp, ModOp, WhereOp,
+                           MiopenSoftmaxOp, QuantizeLinearOp,
+                           DequantizeLinearOp>(op);
   }
 
 private:

--- a/lib/Dialect/Transforms/FuseROCMlir.cpp
+++ b/lib/Dialect/Transforms/FuseROCMlir.cpp
@@ -116,12 +116,12 @@ public:
   }
 
   bool isaPointwiseOp(Operation *op) const {
-    return isa_and_present<
-        MulOp, AddOp, MinOp, MaxOp, SiluOp, SigmoidOp, TanhOp, SoftplusOp,
-        GeluOp, BiasGeluOp, FastGeluOp, LeakyReluOp, ReciprocalOp, SqrtOp,
-        DivOp, EqualOp, AndOp, OrOp, NotOp, CosOp, ErfOp, SinOp, CeilOp,
-        RoundOp, AtanOp, FloorOp, ExpOp, LogOp, AbsOp, NegOp, SubOp, CastOp,
-        LessOp, SignOp, ModOp, WhereOp>(op);
+    return isa_and_present<MulOp, AddOp, MinOp, MaxOp, SiluOp, SigmoidOp,
+                           TanhOp, SoftplusOp, GeluOp, BiasGeluOp, FastGeluOp,
+                           LeakyReluOp, ReciprocalOp, SqrtOp, DivOp, EqualOp,
+                           AndOp, OrOp, NotOp, CosOp, ErfOp, SinOp, CeilOp,
+                           RoundOp, AtanOp, FloorOp, ExpOp, LogOp, AbsOp, NegOp,
+                           SubOp, CastOp, LessOp, SignOp, ModOp, WhereOp>(op);
   }
 
 private:

--- a/lib/Dialect/Transforms/FuseROCMlir.cpp
+++ b/lib/Dialect/Transforms/FuseROCMlir.cpp
@@ -121,8 +121,7 @@ public:
         GeluOp, BiasGeluOp, FastGeluOp, LeakyReluOp, ReciprocalOp, SqrtOp,
         DivOp, EqualOp, AndOp, OrOp, NotOp, CosOp, ErfOp, SinOp, CeilOp,
         RoundOp, AtanOp, FloorOp, ExpOp, LogOp, AbsOp, NegOp, SubOp, CastOp,
-        LessOp, SignOp, ModOp, WhereOp, MiopenSoftmaxOp, QuantizeLinearOp,
-        DequantizeLinearOp>(op);
+        LessOp, SignOp, ModOp, WhereOp>(op);
   }
 
 private:

--- a/lib/Dialect/Transforms/FuseROCMlir.cpp
+++ b/lib/Dialect/Transforms/FuseROCMlir.cpp
@@ -116,14 +116,13 @@ public:
   }
 
   bool isaPointwiseOp(Operation *op) const {
-    return isa_and_present<MulOp, AddOp, MinOp, MaxOp, SiluOp, SigmoidOp,
-                           TanhOp, SoftplusOp, GeluOp, BiasGeluOp, FastGeluOp,
-                           LeakyReluOp, ReciprocalOp, SqrtOp, DivOp, EqualOp,
-                           AndOp, OrOp, NotOp, CosOp, ErfOp, SinOp, CeilOp,
-                           RoundOp, AtanOp, FloorOp, ExpOp, LogOp, AbsOp, NegOp,
-                           SubOp, CastOp, LessOp, SignOp, ModOp, WhereOp,
-                           MiopenSoftmaxOp, QuantizeLinearOp,
-                           DequantizeLinearOp>(op);
+    return isa_and_present<
+        MulOp, AddOp, MinOp, MaxOp, SiluOp, SigmoidOp, TanhOp, SoftplusOp,
+        GeluOp, BiasGeluOp, FastGeluOp, LeakyReluOp, ReciprocalOp, SqrtOp,
+        DivOp, EqualOp, AndOp, OrOp, NotOp, CosOp, ErfOp, SinOp, CeilOp,
+        RoundOp, AtanOp, FloorOp, ExpOp, LogOp, AbsOp, NegOp, SubOp, CastOp,
+        LessOp, SignOp, ModOp, WhereOp, MiopenSoftmaxOp, QuantizeLinearOp,
+        DequantizeLinearOp>(op);
   }
 
 private:

--- a/test/lit/Conversion/hip-to-tosa/test_decompose.mlir
+++ b/test/lit/Conversion/hip-to-tosa/test_decompose.mlir
@@ -1,0 +1,256 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify hip ops that decompose to more than one TOSA op inside a
+// rock.kernel function, so rocMLIR can absorb them into a fused kernel, and
+// verify the forms the conversion rejects.
+//
+// hip.leaky_relu is not a BinaryConverter/UnaryConverter mapping: TOSA has no
+// leaky-relu op. The lowering is tosa.maximum(x, tosa.mul(x, splat(alpha)))
+// with nan_mode = IGNORE.
+//
+// hip.miopen.softmax is last-dim softmax. TOSA has no softmax op; the
+// lowering is reduce_max/sub/exp/reduce_sum/reciprocal/mul, which TosaToRock
+// attention matching expects.
+//
+// hip.sqrt has no TOSA sqrt; the lowering is tosa.reciprocal(tosa.rsqrt(x)).
+// rocMLIR folds that pair back to math.sqrt.
+//
+// FILE LAYOUT:
+// Everything that converts lives in the first --split-input-file chunk, so
+// it is one module and therefore also covers several ops converting in a
+// single pass run. Each rejected form then gets its own chunk: full
+// conversion turns a rejection into a pass failure that aborts the run for
+// the whole module, so sharing a chunk would let one rejection mask the cases
+// after it. A failing chunk contributes no output, while the chunks that
+// convert still print for FileCheck.
+// ============================================================================
+
+// RUN: hip-mlir-opt --convert-hip-to-tosa --split-input-file \
+// RUN:   --verify-diagnostics %s | FileCheck %s
+
+// CHECK-LABEL: func.func @leaky_relu
+// CHECK: %[[ALPHA:.*]] = "tosa.const"{{.*}}tensor<2x8xf16>
+// CHECK: %[[SHIFT:.*]] = "tosa.const"{{.*}}dense<0> : tensor<1xi8>
+// CHECK: %[[SCALED:.*]] = tosa.mul %arg1, %[[ALPHA]], %[[SHIFT]]
+// CHECK: tosa.maximum %arg1, %[[SCALED]] {{.*}}nan_mode = IGNORE
+// CHECK-NOT: hip.leaky_relu
+func.func @leaky_relu(%ctx: !hip.context, %x: tensor<2x8xf16>,
+                      %init: tensor<2x8xf16>) -> tensor<2x8xf16>
+    attributes {rock.kernel} {
+  %r = hip.leaky_relu(%ctx) ins(%x : tensor<2x8xf16>)
+                            outs(%init : tensor<2x8xf16>) : tensor<2x8xf16>
+  return %r : tensor<2x8xf16>
+}
+
+// CHECK-LABEL: func.func @leaky_relu_alpha
+// CHECK: tosa.mul
+// CHECK: tosa.maximum {{.*}}nan_mode = IGNORE
+// CHECK-NOT: hip.leaky_relu
+func.func @leaky_relu_alpha(%ctx: !hip.context, %x: tensor<4xf32>,
+                           %init: tensor<4xf32>) -> tensor<4xf32>
+    attributes {rock.kernel} {
+  %r = hip.leaky_relu(%ctx) ins(%x : tensor<4xf32>)
+                            outs(%init : tensor<4xf32>)
+                            {alpha = 0.2 : f64} : tensor<4xf32>
+  return %r : tensor<4xf32>
+}
+
+// The shape hip-fuse-rocmlir actually produces: the !hip.context is a
+// ub.poison materialized inside the outlined kernel rather than a block
+// argument.
+// CHECK-LABEL: func.func @leaky_relu_outlined_kernel
+// CHECK: tosa.maximum {{.*}}nan_mode = IGNORE
+// CHECK-NOT: hip.leaky_relu
+func.func @leaky_relu_outlined_kernel(%x: tensor<2x8xf16>,
+                                     %init: tensor<2x8xf16>)
+    -> tensor<2x8xf16> attributes {rock.kernel} {
+  %ctx = ub.poison : !hip.context
+  %r = hip.leaky_relu(%ctx) ins(%x : tensor<2x8xf16>)
+                            outs(%init : tensor<2x8xf16>) : tensor<2x8xf16>
+  return %r : tensor<2x8xf16>
+}
+
+// The pass early-returns unless the function is an outlined kernel.
+// CHECK-LABEL: func.func @leaky_relu_not_a_kernel
+// CHECK: hip.leaky_relu
+// CHECK-NOT: tosa.maximum
+func.func @leaky_relu_not_a_kernel(%ctx: !hip.context, %x: tensor<2x8xf16>,
+                                   %init: tensor<2x8xf16>) -> tensor<2x8xf16> {
+  %r = hip.leaky_relu(%ctx) ins(%x : tensor<2x8xf16>)
+                            outs(%init : tensor<2x8xf16>) : tensor<2x8xf16>
+  return %r : tensor<2x8xf16>
+}
+
+// CHECK-LABEL: func.func @softmax
+// CHECK: tosa.reduce_max %arg1 {axis = 1 : i32}
+// CHECK: tosa.sub
+// CHECK: tosa.exp
+// CHECK: tosa.reduce_sum {{.*}}{axis = 1 : i32}
+// CHECK: tosa.reciprocal
+// CHECK: tosa.mul
+// CHECK-NOT: hip.miopen.softmax
+func.func @softmax(%ctx: !hip.context, %x: tensor<2x8xf16>,
+                   %init: tensor<2x8xf16>) -> tensor<2x8xf16>
+    attributes {rock.kernel} {
+  %r = hip.miopen.softmax(%ctx) ins(%x : tensor<2x8xf16>)
+                                 outs(%init : tensor<2x8xf16>)
+                                 -> tensor<2x8xf16>
+  return %r : tensor<2x8xf16>
+}
+
+// 3D [B,S,D] softmax is over the last dim (axis = 2).
+// CHECK-LABEL: func.func @softmax_3d
+// CHECK: tosa.reduce_max %arg1 {axis = 2 : i32}
+// CHECK: tosa.reduce_sum {{.*}}{axis = 2 : i32}
+// CHECK-NOT: hip.miopen.softmax
+func.func @softmax_3d(%ctx: !hip.context, %x: tensor<2x4x8xf16>,
+                      %init: tensor<2x4x8xf16>) -> tensor<2x4x8xf16>
+    attributes {rock.kernel} {
+  %r = hip.miopen.softmax(%ctx) ins(%x : tensor<2x4x8xf16>)
+                                 outs(%init : tensor<2x4x8xf16>)
+                                 -> tensor<2x4x8xf16>
+  return %r : tensor<2x4x8xf16>
+}
+
+// CHECK-LABEL: func.func @softmax_outlined_kernel
+// CHECK: tosa.reduce_max %arg0 {axis = 1 : i32}
+// CHECK-NOT: hip.miopen.softmax
+func.func @softmax_outlined_kernel(%x: tensor<2x8xf16>,
+                                   %init: tensor<2x8xf16>)
+    -> tensor<2x8xf16> attributes {rock.kernel} {
+  %ctx = ub.poison : !hip.context
+  %r = hip.miopen.softmax(%ctx) ins(%x : tensor<2x8xf16>)
+                                 outs(%init : tensor<2x8xf16>)
+                                 -> tensor<2x8xf16>
+  return %r : tensor<2x8xf16>
+}
+
+// CHECK-LABEL: func.func @softmax_not_a_kernel
+// CHECK: hip.miopen.softmax
+// CHECK-NOT: tosa.reduce_max
+func.func @softmax_not_a_kernel(%ctx: !hip.context, %x: tensor<2x8xf16>,
+                                %init: tensor<2x8xf16>) -> tensor<2x8xf16> {
+  %r = hip.miopen.softmax(%ctx) ins(%x : tensor<2x8xf16>)
+                                 outs(%init : tensor<2x8xf16>)
+                                 -> tensor<2x8xf16>
+  return %r : tensor<2x8xf16>
+}
+
+// CHECK-LABEL: func.func @sqrt
+// CHECK: %[[RSQRT:.*]] = tosa.rsqrt %arg1
+// CHECK: tosa.reciprocal %[[RSQRT]]
+// CHECK-NOT: hip.sqrt
+func.func @sqrt(%ctx: !hip.context, %x: tensor<2x8xf16>,
+                %init: tensor<2x8xf16>) -> tensor<2x8xf16>
+    attributes {rock.kernel} {
+  %r = hip.sqrt(%ctx) ins(%x : tensor<2x8xf16>)
+                      outs(%init : tensor<2x8xf16>) : tensor<2x8xf16>
+  return %r : tensor<2x8xf16>
+}
+
+// CHECK-LABEL: func.func @sqrt_outlined_kernel
+// CHECK: tosa.rsqrt
+// CHECK: tosa.reciprocal
+// CHECK-NOT: hip.sqrt
+func.func @sqrt_outlined_kernel(%x: tensor<2x8xf16>, %init: tensor<2x8xf16>)
+    -> tensor<2x8xf16> attributes {rock.kernel} {
+  %ctx = ub.poison : !hip.context
+  %r = hip.sqrt(%ctx) ins(%x : tensor<2x8xf16>)
+                      outs(%init : tensor<2x8xf16>) : tensor<2x8xf16>
+  return %r : tensor<2x8xf16>
+}
+
+// CHECK-LABEL: func.func @sqrt_not_a_kernel
+// CHECK: hip.sqrt
+// CHECK-NOT: tosa.rsqrt
+func.func @sqrt_not_a_kernel(%ctx: !hip.context, %x: tensor<2x8xf16>,
+                               %init: tensor<2x8xf16>) -> tensor<2x8xf16> {
+  %r = hip.sqrt(%ctx) ins(%x : tensor<2x8xf16>)
+                      outs(%init : tensor<2x8xf16>) : tensor<2x8xf16>
+  return %r : tensor<2x8xf16>
+}
+
+// -----
+
+// Dynamic shapes give the pattern no static shape to reason about.
+func.func @dynamic_shape(%ctx: !hip.context, %x: tensor<?x8xf16>,
+                         %init: tensor<?x8xf16>) -> tensor<?x8xf16>
+    attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.leaky_relu'}}
+  %r = hip.leaky_relu(%ctx) ins(%x : tensor<?x8xf16>)
+                            outs(%init : tensor<?x8xf16>) : tensor<?x8xf16>
+  return %r : tensor<?x8xf16>
+}
+
+// -----
+
+// Integer operands are not a valid ONNX LeakyRelu and would have no TOSA
+// float-profile lowering for the mul/maximum pair.
+func.func @integer_operand(%ctx: !hip.context, %x: tensor<4xi32>,
+                           %init: tensor<4xi32>) -> tensor<4xi32>
+    attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.leaky_relu'}}
+  %r = hip.leaky_relu(%ctx) ins(%x : tensor<4xi32>)
+                            outs(%init : tensor<4xi32>) : tensor<4xi32>
+  return %r : tensor<4xi32>
+}
+
+// -----
+
+func.func @softmax_dynamic_shape(%ctx: !hip.context, %x: tensor<?x8xf16>,
+                                  %init: tensor<?x8xf16>) -> tensor<?x8xf16>
+    attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.miopen.softmax'}}
+  %r = hip.miopen.softmax(%ctx) ins(%x : tensor<?x8xf16>)
+                                 outs(%init : tensor<?x8xf16>)
+                                 -> tensor<?x8xf16>
+  return %r : tensor<?x8xf16>
+}
+
+// -----
+
+func.func @softmax_integer_operand(%ctx: !hip.context, %x: tensor<4xi32>,
+                                  %init: tensor<4xi32>) -> tensor<4xi32>
+    attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.miopen.softmax'}}
+  %r = hip.miopen.softmax(%ctx) ins(%x : tensor<4xi32>)
+                                 outs(%init : tensor<4xi32>)
+                                 -> tensor<4xi32>
+  return %r : tensor<4xi32>
+}
+
+// -----
+
+func.func @softmax_rank0(%ctx: !hip.context, %x: tensor<f16>,
+                          %init: tensor<f16>) -> tensor<f16>
+    attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.miopen.softmax'}}
+  %r = hip.miopen.softmax(%ctx) ins(%x : tensor<f16>)
+                                 outs(%init : tensor<f16>) -> tensor<f16>
+  return %r : tensor<f16>
+}
+
+// -----
+
+func.func @sqrt_dynamic_shape(%ctx: !hip.context, %x: tensor<?x8xf16>,
+                               %init: tensor<?x8xf16>) -> tensor<?x8xf16>
+    attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.sqrt'}}
+  %r = hip.sqrt(%ctx) ins(%x : tensor<?x8xf16>)
+                      outs(%init : tensor<?x8xf16>) : tensor<?x8xf16>
+  return %r : tensor<?x8xf16>
+}
+
+// -----
+
+func.func @sqrt_integer_operand(%ctx: !hip.context, %x: tensor<4xi32>,
+                                 %init: tensor<4xi32>) -> tensor<4xi32>
+    attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.sqrt'}}
+  %r = hip.sqrt(%ctx) ins(%x : tensor<4xi32>)
+                      outs(%init : tensor<4xi32>) : tensor<4xi32>
+  return %r : tensor<4xi32>
+}

--- a/test/lit/Conversion/hip-to-tosa/test_decompose.mlir
+++ b/test/lit/Conversion/hip-to-tosa/test_decompose.mlir
@@ -8,8 +8,9 @@
 // verify the forms the conversion rejects.
 //
 // hip.leaky_relu is not a BinaryConverter/UnaryConverter mapping: TOSA has no
-// leaky-relu op. The lowering is tosa.maximum(x, tosa.mul(x, splat(alpha)))
-// with nan_mode = IGNORE.
+// leaky-relu op. For alpha in [0, 1] the lowering is
+// tosa.maximum(x, tosa.mul(x, splat(alpha))) with nan_mode = IGNORE. Outside
+// that range it is tosa.select(tosa.greater(x, 0), x, scaled).
 //
 // hip.miopen.softmax is last-dim softmax. TOSA has no softmax op; the
 // lowering is reduce_max/sub/exp/reduce_sum/reciprocal/mul, which TosaToRock
@@ -71,6 +72,38 @@ func.func @leaky_relu_outlined_kernel(%x: tensor<2x8xf16>,
   %r = hip.leaky_relu(%ctx) ins(%x : tensor<2x8xf16>)
                             outs(%init : tensor<2x8xf16>) : tensor<2x8xf16>
   return %r : tensor<2x8xf16>
+}
+
+// alpha > 1 is not max(x, alpha*x); keep the ONNX select.
+// CHECK-LABEL: func.func @leaky_relu_alpha_gt1
+// CHECK: tosa.mul
+// CHECK: tosa.greater
+// CHECK: tosa.select
+// CHECK-NOT: tosa.maximum
+// CHECK-NOT: hip.leaky_relu
+func.func @leaky_relu_alpha_gt1(%ctx: !hip.context, %x: tensor<4xf32>,
+                                %init: tensor<4xf32>) -> tensor<4xf32>
+    attributes {rock.kernel} {
+  %r = hip.leaky_relu(%ctx) ins(%x : tensor<4xf32>)
+                            outs(%init : tensor<4xf32>)
+                            {alpha = 1.1 : f64} : tensor<4xf32>
+  return %r : tensor<4xf32>
+}
+
+// Negative alpha is the same select path, not maximum.
+// CHECK-LABEL: func.func @leaky_relu_alpha_neg
+// CHECK: tosa.mul
+// CHECK: tosa.greater
+// CHECK: tosa.select
+// CHECK-NOT: tosa.maximum
+// CHECK-NOT: hip.leaky_relu
+func.func @leaky_relu_alpha_neg(%ctx: !hip.context, %x: tensor<4xf32>,
+                                %init: tensor<4xf32>) -> tensor<4xf32>
+    attributes {rock.kernel} {
+  %r = hip.leaky_relu(%ctx) ins(%x : tensor<4xf32>)
+                            outs(%init : tensor<4xf32>)
+                            {alpha = -1.000000e-01 : f64} : tensor<4xf32>
+  return %r : tensor<4xf32>
 }
 
 // CHECK-LABEL: func.func @softmax

--- a/test/lit/Conversion/hip-to-tosa/test_decompose.mlir
+++ b/test/lit/Conversion/hip-to-tosa/test_decompose.mlir
@@ -73,17 +73,6 @@ func.func @leaky_relu_outlined_kernel(%x: tensor<2x8xf16>,
   return %r : tensor<2x8xf16>
 }
 
-// The pass early-returns unless the function is an outlined kernel.
-// CHECK-LABEL: func.func @leaky_relu_not_a_kernel
-// CHECK: hip.leaky_relu
-// CHECK-NOT: tosa.maximum
-func.func @leaky_relu_not_a_kernel(%ctx: !hip.context, %x: tensor<2x8xf16>,
-                                   %init: tensor<2x8xf16>) -> tensor<2x8xf16> {
-  %r = hip.leaky_relu(%ctx) ins(%x : tensor<2x8xf16>)
-                            outs(%init : tensor<2x8xf16>) : tensor<2x8xf16>
-  return %r : tensor<2x8xf16>
-}
-
 // CHECK-LABEL: func.func @softmax
 // CHECK: tosa.reduce_max %arg1 {axis = 1 : i32}
 // CHECK: tosa.sub
@@ -128,17 +117,6 @@ func.func @softmax_outlined_kernel(%x: tensor<2x8xf16>,
   return %r : tensor<2x8xf16>
 }
 
-// CHECK-LABEL: func.func @softmax_not_a_kernel
-// CHECK: hip.miopen.softmax
-// CHECK-NOT: tosa.reduce_max
-func.func @softmax_not_a_kernel(%ctx: !hip.context, %x: tensor<2x8xf16>,
-                                %init: tensor<2x8xf16>) -> tensor<2x8xf16> {
-  %r = hip.miopen.softmax(%ctx) ins(%x : tensor<2x8xf16>)
-                                 outs(%init : tensor<2x8xf16>)
-                                 -> tensor<2x8xf16>
-  return %r : tensor<2x8xf16>
-}
-
 // CHECK-LABEL: func.func @sqrt
 // CHECK: %[[RSQRT:.*]] = tosa.rsqrt %arg1
 // CHECK: tosa.reciprocal %[[RSQRT]]
@@ -158,16 +136,6 @@ func.func @sqrt(%ctx: !hip.context, %x: tensor<2x8xf16>,
 func.func @sqrt_outlined_kernel(%x: tensor<2x8xf16>, %init: tensor<2x8xf16>)
     -> tensor<2x8xf16> attributes {rock.kernel} {
   %ctx = ub.poison : !hip.context
-  %r = hip.sqrt(%ctx) ins(%x : tensor<2x8xf16>)
-                      outs(%init : tensor<2x8xf16>) : tensor<2x8xf16>
-  return %r : tensor<2x8xf16>
-}
-
-// CHECK-LABEL: func.func @sqrt_not_a_kernel
-// CHECK: hip.sqrt
-// CHECK-NOT: tosa.rsqrt
-func.func @sqrt_not_a_kernel(%ctx: !hip.context, %x: tensor<2x8xf16>,
-                               %init: tensor<2x8xf16>) -> tensor<2x8xf16> {
   %r = hip.sqrt(%ctx) ins(%x : tensor<2x8xf16>)
                       outs(%init : tensor<2x8xf16>) : tensor<2x8xf16>
   return %r : tensor<2x8xf16>

--- a/test/lit/Conversion/hip-to-tosa/test_qdq.mlir
+++ b/test/lit/Conversion/hip-to-tosa/test_qdq.mlir
@@ -108,6 +108,23 @@ func.func @dequantize_outlined_kernel(%x: tensor<2x8xi8>, %scale: tensor<f32>,
   return %r : tensor<2x8xf32>
 }
 
+// Rank-0 data with a length-1 vector scale: reshape the scale to a scalar
+// so tosa.mul has matching ranks.
+// CHECK-LABEL: func.func @dequantize_rank0_scale1
+// CHECK: tosa.reshape %arg2
+// CHECK: tosa.mul
+// CHECK-NOT: hip.dequantize_linear
+func.func @dequantize_rank0_scale1(%ctx: !hip.context, %x: tensor<i8>,
+                                     %scale: tensor<1xf32>,
+                                     %init: tensor<f32>) -> tensor<f32>
+    attributes {rock.kernel} {
+  %r = hip.dequantize_linear(%ctx)
+         ins(%x, %scale : tensor<i8>, tensor<1xf32>)
+         outs(%init : tensor<f32>)
+         {axis = 0 : i64, block_size = 0 : i64} : tensor<f32>
+  return %r : tensor<f32>
+}
+
 // -----
 
 func.func @dequantize_dynamic(%ctx: !hip.context, %x: tensor<?x8xi8>,

--- a/test/lit/Conversion/hip-to-tosa/test_qdq.mlir
+++ b/test/lit/Conversion/hip-to-tosa/test_qdq.mlir
@@ -108,20 +108,6 @@ func.func @dequantize_outlined_kernel(%x: tensor<2x8xi8>, %scale: tensor<f32>,
   return %r : tensor<2x8xf32>
 }
 
-// CHECK-LABEL: func.func @dequantize_not_a_kernel
-// CHECK: hip.dequantize_linear
-// CHECK-NOT: tosa.mul
-func.func @dequantize_not_a_kernel(%ctx: !hip.context, %x: tensor<2x8xi8>,
-                                    %scale: tensor<f32>,
-                                    %init: tensor<2x8xf32>)
-    -> tensor<2x8xf32> {
-  %r = hip.dequantize_linear(%ctx)
-         ins(%x, %scale : tensor<2x8xi8>, tensor<f32>)
-         outs(%init : tensor<2x8xf32>)
-         {axis = 1 : i64, block_size = 0 : i64} : tensor<2x8xf32>
-  return %r : tensor<2x8xf32>
-}
-
 // -----
 
 func.func @dequantize_dynamic(%ctx: !hip.context, %x: tensor<?x8xi8>,

--- a/test/lit/Conversion/hip-to-tosa/test_qdq.mlir
+++ b/test/lit/Conversion/hip-to-tosa/test_qdq.mlir
@@ -1,0 +1,178 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify hip.quantize_linear / hip.dequantize_linear decompose to TOSA
+// arithmetic inside a rock.kernel function, so rocMLIR can absorb them into a
+// fused kernel.
+//
+// Dequantize: (cast(x) - cast(zp)) * scale
+// Quantize:   saturate(x * reciprocal(scale) + zp), with float->int via
+//             tosa.custom fp_to_int_cast (plain tosa.cast is illegal in
+//             rock-tosa-to-elementwise).
+//
+// FILE LAYOUT:
+// Converting cases in the first --split-input-file chunk; each rejection
+// in its own chunk.
+// ============================================================================
+
+// RUN: hip-mlir-opt --convert-hip-to-tosa --split-input-file \
+// RUN:   --verify-diagnostics %s | FileCheck %s
+
+// Per-tensor dequant, no zero_point: cast then mul.
+// CHECK-LABEL: func.func @dequantize_no_zp
+// CHECK: %[[CAST:.*]] = tosa.cast %arg1 : (tensor<2x8xi8>) -> tensor<2x8xf32>
+// CHECK: tosa.mul %[[CAST]]
+// CHECK-NOT: hip.dequantize_linear
+func.func @dequantize_no_zp(%ctx: !hip.context, %x: tensor<2x8xi8>,
+                             %scale: tensor<f32>, %init: tensor<2x8xf32>)
+    -> tensor<2x8xf32> attributes {rock.kernel} {
+  %r = hip.dequantize_linear(%ctx)
+         ins(%x, %scale : tensor<2x8xi8>, tensor<f32>)
+         outs(%init : tensor<2x8xf32>)
+         {axis = 1 : i64, block_size = 0 : i64} : tensor<2x8xf32>
+  return %r : tensor<2x8xf32>
+}
+
+// Per-axis dequant: 1-D scale/zp reshape onto axis 1 before sub/mul.
+// CHECK-LABEL: func.func @dequantize_per_axis
+// CHECK: tosa.reshape %arg2
+// CHECK: tosa.reshape %arg3
+// CHECK: tosa.cast %arg1
+// CHECK: tosa.sub
+// CHECK: tosa.mul
+// CHECK-NOT: hip.dequantize_linear
+func.func @dequantize_per_axis(%ctx: !hip.context, %x: tensor<1x64x32xi8>,
+                                %scale: tensor<64xf32>, %zp: tensor<64xi8>,
+                                %init: tensor<1x64x32xf32>)
+    -> tensor<1x64x32xf32> attributes {rock.kernel} {
+  %r = hip.dequantize_linear(%ctx)
+         ins(%x, %scale : tensor<1x64x32xi8>, tensor<64xf32>)
+         zero_point(%zp : tensor<64xi8>)
+         outs(%init : tensor<1x64x32xf32>)
+         {axis = 1 : i64, block_size = 0 : i64} : tensor<1x64x32xf32>
+  return %r : tensor<1x64x32xf32>
+}
+
+// Quantize without zp: reciprocal, mul, fp_to_int_cast.
+// CHECK-LABEL: func.func @quantize_no_zp
+// CHECK: tosa.reciprocal
+// CHECK: tosa.mul
+// CHECK: tosa.custom {{.*}}operator_name = "fp_to_int_cast"
+// CHECK-NOT: hip.quantize_linear
+func.func @quantize_no_zp(%ctx: !hip.context, %x: tensor<2x8xf32>,
+                            %scale: tensor<f32>, %init: tensor<2x8xi8>)
+    -> tensor<2x8xi8> attributes {rock.kernel} {
+  %r = hip.quantize_linear(%ctx)
+         ins(%x, %scale : tensor<2x8xf32>, tensor<f32>)
+         outs(%init : tensor<2x8xi8>)
+         {axis = 1 : i64, block_size = 0 : i64, precision = 0 : i64,
+          saturate = 1 : i64} : tensor<2x8xi8>
+  return %r : tensor<2x8xi8>
+}
+
+// Quantize with zp: widen to i32, add, clamp, custom-cast to i8.
+// CHECK-LABEL: func.func @quantize_with_zp
+// CHECK: tosa.reciprocal
+// CHECK: tosa.mul
+// CHECK: tosa.custom {{.*}}operator_name = "fp_to_int_cast"
+// CHECK: tosa.add
+// CHECK: tosa.clamp
+// CHECK: tosa.cast
+// CHECK-NOT: hip.quantize_linear
+func.func @quantize_with_zp(%ctx: !hip.context, %x: tensor<2x8xf32>,
+                            %scale: tensor<f32>, %zp: tensor<i8>,
+                            %init: tensor<2x8xi8>) -> tensor<2x8xi8>
+    attributes {rock.kernel} {
+  %r = hip.quantize_linear(%ctx)
+         ins(%x, %scale : tensor<2x8xf32>, tensor<f32>)
+         zero_point(%zp : tensor<i8>)
+         outs(%init : tensor<2x8xi8>)
+         {axis = 1 : i64, block_size = 0 : i64, precision = 0 : i64,
+          saturate = 1 : i64} : tensor<2x8xi8>
+  return %r : tensor<2x8xi8>
+}
+
+// CHECK-LABEL: func.func @dequantize_outlined_kernel
+// CHECK: tosa.mul
+// CHECK-NOT: hip.dequantize_linear
+func.func @dequantize_outlined_kernel(%x: tensor<2x8xi8>, %scale: tensor<f32>,
+                                     %init: tensor<2x8xf32>)
+    -> tensor<2x8xf32> attributes {rock.kernel} {
+  %ctx = ub.poison : !hip.context
+  %r = hip.dequantize_linear(%ctx)
+         ins(%x, %scale : tensor<2x8xi8>, tensor<f32>)
+         outs(%init : tensor<2x8xf32>)
+         {axis = 1 : i64, block_size = 0 : i64} : tensor<2x8xf32>
+  return %r : tensor<2x8xf32>
+}
+
+// CHECK-LABEL: func.func @dequantize_not_a_kernel
+// CHECK: hip.dequantize_linear
+// CHECK-NOT: tosa.mul
+func.func @dequantize_not_a_kernel(%ctx: !hip.context, %x: tensor<2x8xi8>,
+                                    %scale: tensor<f32>,
+                                    %init: tensor<2x8xf32>)
+    -> tensor<2x8xf32> {
+  %r = hip.dequantize_linear(%ctx)
+         ins(%x, %scale : tensor<2x8xi8>, tensor<f32>)
+         outs(%init : tensor<2x8xf32>)
+         {axis = 1 : i64, block_size = 0 : i64} : tensor<2x8xf32>
+  return %r : tensor<2x8xf32>
+}
+
+// -----
+
+func.func @dequantize_dynamic(%ctx: !hip.context, %x: tensor<?x8xi8>,
+                              %scale: tensor<f32>, %init: tensor<?x8xf32>)
+    -> tensor<?x8xf32> attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.dequantize_linear'}}
+  %r = hip.dequantize_linear(%ctx)
+         ins(%x, %scale : tensor<?x8xi8>, tensor<f32>)
+         outs(%init : tensor<?x8xf32>)
+         {axis = 1 : i64, block_size = 0 : i64} : tensor<?x8xf32>
+  return %r : tensor<?x8xf32>
+}
+
+// -----
+
+func.func @dequantize_packed_int4(%ctx: !hip.context, %x: tensor<2x8xi8>,
+                                   %scale: tensor<f32>, %init: tensor<2x8xf32>)
+    -> tensor<2x8xf32> attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.dequantize_linear'}}
+  %r = hip.dequantize_linear(%ctx)
+         ins(%x, %scale : tensor<2x8xi8>, tensor<f32>)
+         outs(%init : tensor<2x8xf32>)
+         {axis = 1 : i64, block_size = 0 : i64, packed_int4}
+         : tensor<2x8xf32>
+  return %r : tensor<2x8xf32>
+}
+
+// -----
+
+func.func @quantize_blocked(%ctx: !hip.context, %x: tensor<128x4xf16>,
+                              %scale: tensor<4x4xf16>, %init: tensor<128x4xi8>)
+    -> tensor<128x4xi8> attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.quantize_linear'}}
+  %r = hip.quantize_linear(%ctx)
+         ins(%x, %scale : tensor<128x4xf16>, tensor<4x4xf16>)
+         outs(%init : tensor<128x4xi8>)
+         {axis = 0 : i64, block_size = 32 : i64, precision = 0 : i64,
+          saturate = 1 : i64} : tensor<128x4xi8>
+  return %r : tensor<128x4xi8>
+}
+
+// -----
+
+func.func @quantize_no_saturate(%ctx: !hip.context, %x: tensor<2x8xf32>,
+                                 %scale: tensor<f32>, %init: tensor<2x8xi8>)
+    -> tensor<2x8xi8> attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.quantize_linear'}}
+  %r = hip.quantize_linear(%ctx)
+         ins(%x, %scale : tensor<2x8xf32>, tensor<f32>)
+         outs(%init : tensor<2x8xi8>)
+         {axis = 1 : i64, block_size = 0 : i64, precision = 0 : i64,
+          saturate = 0 : i64} : tensor<2x8xi8>
+  return %r : tensor<2x8xi8>
+}

--- a/test/lit/Conversion/hip-to-tosa/test_reduce.mlir
+++ b/test/lit/Conversion/hip-to-tosa/test_reduce.mlir
@@ -1,0 +1,177 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify hip.reduce_sum / hip.reduce_mean lower inside a rock.kernel
+// function. TOSA reduce ops take one i32 axis and always keepdims=1;
+// keepdims=0 is a reshape afterward. Mean is scale-by-1/N then reduce_sum.
+//
+// FILE LAYOUT:
+// Converting cases in the first chunk; each rejection in its own chunk.
+// ============================================================================
+
+// RUN: hip-mlir-opt --convert-hip-to-tosa --split-input-file \
+// RUN:   --verify-diagnostics %s | FileCheck %s
+
+// CHECK-LABEL: func.func @reduce_sum
+// CHECK: tosa.reduce_sum %arg1 {axis = 1 : i32}
+// CHECK-NOT: hip.reduce_sum
+func.func @reduce_sum(%ctx: !hip.context, %data: tensor<2x8xf16>,
+                      %init: tensor<2x1xf16>) -> tensor<2x1xf16>
+    attributes {rock.kernel} {
+  %axes = arith.constant dense<[1]> : tensor<1xi64>
+  %r = hip.reduce_sum(%ctx)
+         ins(%data, %axes : tensor<2x8xf16>, tensor<1xi64>)
+         outs(%init : tensor<2x1xf16>) : tensor<2x1xf16>
+  return %r : tensor<2x1xf16>
+}
+
+// CHECK-LABEL: func.func @reduce_sum_keepdims0
+// CHECK: tosa.reduce_sum %arg1 {axis = 1 : i32}
+// CHECK: tosa.reshape
+// CHECK-NOT: hip.reduce_sum
+func.func @reduce_sum_keepdims0(%ctx: !hip.context, %data: tensor<2x8xf16>,
+                                %init: tensor<2xf16>) -> tensor<2xf16>
+    attributes {rock.kernel} {
+  %axes = arith.constant dense<[1]> : tensor<1xi64>
+  %r = hip.reduce_sum(%ctx)
+         ins(%data, %axes : tensor<2x8xf16>, tensor<1xi64>)
+         outs(%init : tensor<2xf16>)
+         {keepdims = 0 : i64} : tensor<2xf16>
+  return %r : tensor<2xf16>
+}
+
+// CHECK-LABEL: func.func @reduce_sum_neg_axis
+// CHECK: tosa.reduce_sum %arg1 {axis = 1 : i32}
+// CHECK-NOT: hip.reduce_sum
+func.func @reduce_sum_neg_axis(%ctx: !hip.context, %data: tensor<2x8xf16>,
+                               %init: tensor<2x1xf16>) -> tensor<2x1xf16>
+    attributes {rock.kernel} {
+  %axes = arith.constant dense<[-1]> : tensor<1xi64>
+  %r = hip.reduce_sum(%ctx)
+         ins(%data, %axes : tensor<2x8xf16>, tensor<1xi64>)
+         outs(%init : tensor<2x1xf16>) : tensor<2x1xf16>
+  return %r : tensor<2x1xf16>
+}
+
+// CHECK-LABEL: func.func @reduce_sum_i32
+// CHECK: tosa.reduce_sum %arg1 {axis = 0 : i32}
+// CHECK-NOT: hip.reduce_sum
+func.func @reduce_sum_i32(%ctx: !hip.context, %data: tensor<4x8xi32>,
+                          %init: tensor<1x8xi32>) -> tensor<1x8xi32>
+    attributes {rock.kernel} {
+  %axes = arith.constant dense<[0]> : tensor<1xi64>
+  %r = hip.reduce_sum(%ctx)
+         ins(%data, %axes : tensor<4x8xi32>, tensor<1xi64>)
+         outs(%init : tensor<1x8xi32>) : tensor<1x8xi32>
+  return %r : tensor<1x8xi32>
+}
+
+// Empty axes + noop_with_empty_axes is an ONNX identity.
+// CHECK-LABEL: func.func @reduce_sum_noop
+// CHECK-NOT: tosa.reduce_sum
+// CHECK-NOT: hip.reduce_sum
+func.func @reduce_sum_noop(%ctx: !hip.context, %data: tensor<2x8xf16>,
+                           %init: tensor<2x8xf16>) -> tensor<2x8xf16>
+    attributes {rock.kernel} {
+  %axes = arith.constant dense<[]> : tensor<0xi64>
+  %r = hip.reduce_sum(%ctx)
+         ins(%data, %axes : tensor<2x8xf16>, tensor<0xi64>)
+         outs(%init : tensor<2x8xf16>)
+         {noop_with_empty_axes = 1 : i64} : tensor<2x8xf16>
+  return %r : tensor<2x8xf16>
+}
+
+// CHECK-LABEL: func.func @reduce_mean
+// CHECK: tosa.reciprocal
+// CHECK: tosa.reshape
+// CHECK: tosa.mul
+// CHECK: tosa.reduce_sum {{.*}}{axis = 1 : i32}
+// CHECK-NOT: hip.reduce_mean
+func.func @reduce_mean(%ctx: !hip.context, %data: tensor<2x8xf16>,
+                       %init: tensor<2x1xf16>) -> tensor<2x1xf16>
+    attributes {rock.kernel} {
+  %axes = arith.constant dense<[1]> : tensor<1xi64>
+  %r = hip.reduce_mean(%ctx)
+         ins(%data, %axes : tensor<2x8xf16>, tensor<1xi64>)
+         outs(%init : tensor<2x1xf16>) : tensor<2x1xf16>
+  return %r : tensor<2x1xf16>
+}
+
+// CHECK-LABEL: func.func @reduce_mean_outlined_kernel
+// CHECK: tosa.reduce_sum {{.*}}{axis = 1 : i32}
+// CHECK-NOT: hip.reduce_mean
+func.func @reduce_mean_outlined_kernel(%data: tensor<2x8xf16>,
+                                       %init: tensor<2x1xf16>)
+    -> tensor<2x1xf16> attributes {rock.kernel} {
+  %ctx = ub.poison : !hip.context
+  %axes = arith.constant dense<[1]> : tensor<1xi64>
+  %r = hip.reduce_mean(%ctx)
+         ins(%data, %axes : tensor<2x8xf16>, tensor<1xi64>)
+         outs(%init : tensor<2x1xf16>) : tensor<2x1xf16>
+  return %r : tensor<2x1xf16>
+}
+
+// CHECK-LABEL: func.func @reduce_sum_not_a_kernel
+// CHECK: hip.reduce_sum
+// CHECK-NOT: tosa.reduce_sum
+func.func @reduce_sum_not_a_kernel(%ctx: !hip.context, %data: tensor<2x8xf16>,
+                                   %init: tensor<2x1xf16>) -> tensor<2x1xf16> {
+  %axes = arith.constant dense<[1]> : tensor<1xi64>
+  %r = hip.reduce_sum(%ctx)
+         ins(%data, %axes : tensor<2x8xf16>, tensor<1xi64>)
+         outs(%init : tensor<2x1xf16>) : tensor<2x1xf16>
+  return %r : tensor<2x1xf16>
+}
+
+// -----
+
+func.func @dynamic_shape(%ctx: !hip.context, %data: tensor<?x8xf16>,
+                         %init: tensor<?x1xf16>) -> tensor<?x1xf16>
+    attributes {rock.kernel} {
+  %axes = arith.constant dense<[1]> : tensor<1xi64>
+  // expected-error @+1 {{failed to legalize operation 'hip.reduce_sum'}}
+  %r = hip.reduce_sum(%ctx)
+         ins(%data, %axes : tensor<?x8xf16>, tensor<1xi64>)
+         outs(%init : tensor<?x1xf16>) : tensor<?x1xf16>
+  return %r : tensor<?x1xf16>
+}
+
+// -----
+
+func.func @non_constant_axes(%ctx: !hip.context, %data: tensor<2x8xf16>,
+                             %axes: tensor<1xi64>, %init: tensor<2x1xf16>)
+    -> tensor<2x1xf16> attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.reduce_sum'}}
+  %r = hip.reduce_sum(%ctx)
+         ins(%data, %axes : tensor<2x8xf16>, tensor<1xi64>)
+         outs(%init : tensor<2x1xf16>) : tensor<2x1xf16>
+  return %r : tensor<2x1xf16>
+}
+
+// -----
+
+func.func @multi_axis(%ctx: !hip.context, %data: tensor<2x8xf16>,
+                      %init: tensor<1x1xf16>) -> tensor<1x1xf16>
+    attributes {rock.kernel} {
+  %axes = arith.constant dense<[0, 1]> : tensor<2xi64>
+  // expected-error @+1 {{failed to legalize operation 'hip.reduce_sum'}}
+  %r = hip.reduce_sum(%ctx)
+         ins(%data, %axes : tensor<2x8xf16>, tensor<2xi64>)
+         outs(%init : tensor<1x1xf16>) : tensor<1x1xf16>
+  return %r : tensor<1x1xf16>
+}
+
+// -----
+
+func.func @integer_mean(%ctx: !hip.context, %data: tensor<2x8xi32>,
+                        %init: tensor<2x1xi32>) -> tensor<2x1xi32>
+    attributes {rock.kernel} {
+  %axes = arith.constant dense<[1]> : tensor<1xi64>
+  // expected-error @+1 {{failed to legalize operation 'hip.reduce_mean'}}
+  %r = hip.reduce_mean(%ctx)
+         ins(%data, %axes : tensor<2x8xi32>, tensor<1xi64>)
+         outs(%init : tensor<2x1xi32>) : tensor<2x1xi32>
+  return %r : tensor<2x1xi32>
+}

--- a/test/lit/Conversion/hip-to-tosa/test_reduce.mlir
+++ b/test/lit/Conversion/hip-to-tosa/test_reduce.mlir
@@ -113,18 +113,6 @@ func.func @reduce_mean_outlined_kernel(%data: tensor<2x8xf16>,
   return %r : tensor<2x1xf16>
 }
 
-// CHECK-LABEL: func.func @reduce_sum_not_a_kernel
-// CHECK: hip.reduce_sum
-// CHECK-NOT: tosa.reduce_sum
-func.func @reduce_sum_not_a_kernel(%ctx: !hip.context, %data: tensor<2x8xf16>,
-                                   %init: tensor<2x1xf16>) -> tensor<2x1xf16> {
-  %axes = arith.constant dense<[1]> : tensor<1xi64>
-  %r = hip.reduce_sum(%ctx)
-         ins(%data, %axes : tensor<2x8xf16>, tensor<1xi64>)
-         outs(%init : tensor<2x1xf16>) : tensor<2x1xf16>
-  return %r : tensor<2x1xf16>
-}
-
 // -----
 
 func.func @dynamic_shape(%ctx: !hip.context, %data: tensor<?x8xf16>,

--- a/test/lit/Conversion/hip-to-tosa/test_ternary.mlir
+++ b/test/lit/Conversion/hip-to-tosa/test_ternary.mlir
@@ -1,0 +1,128 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify hip.where lowers to tosa.select inside a rock.kernel function, so
+// rocMLIR can absorb it into a fused kernel, and verify the forms the
+// conversion rejects.
+//
+// hip.where is ternary (cond, x, y) and cannot use BinaryConverter: the
+// predicate is i1 while the result is not. Rank equalization is the same
+// pairwise EqualizeRanks used for the binary ops, applied to all three
+// operands.
+//
+// FILE LAYOUT:
+// Converting cases in the first chunk; each rejection in its own chunk.
+// ============================================================================
+
+// RUN: hip-mlir-opt --convert-hip-to-tosa --split-input-file \
+// RUN:   --verify-diagnostics %s | FileCheck %s
+
+// CHECK-LABEL: func.func @where
+// CHECK: tosa.select %arg1, %arg2, %arg3
+// CHECK-NOT: hip.where
+func.func @where(%ctx: !hip.context, %cond: tensor<2x8xi1>,
+                 %x: tensor<2x8xf16>, %y: tensor<2x8xf16>,
+                 %init: tensor<2x8xf16>) -> tensor<2x8xf16>
+    attributes {rock.kernel} {
+  %r = hip.where(%ctx) ins(%cond, %x, %y :
+                           tensor<2x8xi1>, tensor<2x8xf16>, tensor<2x8xf16>)
+                       outs(%init : tensor<2x8xf16>) : tensor<2x8xf16>
+  return %r : tensor<2x8xf16>
+}
+
+// Size-1 condition relies on TOSA's implicit broadcast after ranks match.
+// CHECK-LABEL: func.func @where_size1_cond
+// CHECK: tosa.select
+// CHECK-NOT: hip.where
+func.func @where_size1_cond(%ctx: !hip.context, %cond: tensor<2x1xi1>,
+                             %x: tensor<2x8xf16>, %y: tensor<2x8xf16>,
+                             %init: tensor<2x8xf16>) -> tensor<2x8xf16>
+    attributes {rock.kernel} {
+  %r = hip.where(%ctx) ins(%cond, %x, %y :
+                           tensor<2x1xi1>, tensor<2x8xf16>, tensor<2x8xf16>)
+                       outs(%init : tensor<2x8xf16>) : tensor<2x8xf16>
+  return %r : tensor<2x8xf16>
+}
+
+// A lower-rank true-value is reshaped with leading 1s first.
+// CHECK-LABEL: func.func @where_rank_extend
+// CHECK: tosa.reshape
+// CHECK: tosa.select
+// CHECK-NOT: hip.where
+func.func @where_rank_extend(%ctx: !hip.context, %cond: tensor<2x8xi1>,
+                             %x: tensor<8xf16>, %y: tensor<2x8xf16>,
+                             %init: tensor<2x8xf16>) -> tensor<2x8xf16>
+    attributes {rock.kernel} {
+  %r = hip.where(%ctx) ins(%cond, %x, %y :
+                           tensor<2x8xi1>, tensor<8xf16>, tensor<2x8xf16>)
+                       outs(%init : tensor<2x8xf16>) : tensor<2x8xf16>
+  return %r : tensor<2x8xf16>
+}
+
+// The shape hip-fuse-rocmlir actually produces.
+// CHECK-LABEL: func.func @where_outlined_kernel
+// CHECK: tosa.select
+// CHECK-NOT: hip.where
+func.func @where_outlined_kernel(%cond: tensor<2x8xi1>, %x: tensor<2x8xf16>,
+                                 %y: tensor<2x8xf16>, %init: tensor<2x8xf16>)
+    -> tensor<2x8xf16> attributes {rock.kernel} {
+  %ctx = ub.poison : !hip.context
+  %r = hip.where(%ctx) ins(%cond, %x, %y :
+                           tensor<2x8xi1>, tensor<2x8xf16>, tensor<2x8xf16>)
+                       outs(%init : tensor<2x8xf16>) : tensor<2x8xf16>
+  return %r : tensor<2x8xf16>
+}
+
+// CHECK-LABEL: func.func @where_not_a_kernel
+// CHECK: hip.where
+// CHECK-NOT: tosa.select
+func.func @where_not_a_kernel(%ctx: !hip.context, %cond: tensor<2x8xi1>,
+                              %x: tensor<2x8xf16>, %y: tensor<2x8xf16>,
+                              %init: tensor<2x8xf16>) -> tensor<2x8xf16> {
+  %r = hip.where(%ctx) ins(%cond, %x, %y :
+                           tensor<2x8xi1>, tensor<2x8xf16>, tensor<2x8xf16>)
+                       outs(%init : tensor<2x8xf16>) : tensor<2x8xf16>
+  return %r : tensor<2x8xf16>
+}
+
+// -----
+
+func.func @dynamic_shape(%ctx: !hip.context, %cond: tensor<?x8xi1>,
+                          %x: tensor<?x8xf16>, %y: tensor<?x8xf16>,
+                          %init: tensor<?x8xf16>) -> tensor<?x8xf16>
+    attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.where'}}
+  %r = hip.where(%ctx) ins(%cond, %x, %y :
+                           tensor<?x8xi1>, tensor<?x8xf16>, tensor<?x8xf16>)
+                       outs(%init : tensor<?x8xf16>) : tensor<?x8xf16>
+  return %r : tensor<?x8xf16>
+}
+
+// -----
+
+// hip.where requires an i1 condition; an i32 mask is not tosa.select.
+func.func @cond_not_i1(%ctx: !hip.context, %cond: tensor<2x8xi32>,
+                        %x: tensor<2x8xf16>, %y: tensor<2x8xf16>,
+                        %init: tensor<2x8xf16>) -> tensor<2x8xf16>
+    attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.where'}}
+  %r = hip.where(%ctx) ins(%cond, %x, %y :
+                           tensor<2x8xi32>, tensor<2x8xf16>, tensor<2x8xf16>)
+                       outs(%init : tensor<2x8xf16>) : tensor<2x8xf16>
+  return %r : tensor<2x8xf16>
+}
+
+// -----
+
+func.func @incompatible_broadcast(%ctx: !hip.context, %cond: tensor<2x8xi1>,
+                                  %x: tensor<2x8xf16>, %y: tensor<4xf16>,
+                                  %init: tensor<2x8xf16>) -> tensor<2x8xf16>
+    attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.where'}}
+  %r = hip.where(%ctx) ins(%cond, %x, %y :
+                           tensor<2x8xi1>, tensor<2x8xf16>, tensor<4xf16>)
+                       outs(%init : tensor<2x8xf16>) : tensor<2x8xf16>
+  return %r : tensor<2x8xf16>
+}

--- a/test/lit/Conversion/hip-to-tosa/test_ternary.mlir
+++ b/test/lit/Conversion/hip-to-tosa/test_ternary.mlir
@@ -75,18 +75,6 @@ func.func @where_outlined_kernel(%cond: tensor<2x8xi1>, %x: tensor<2x8xf16>,
   return %r : tensor<2x8xf16>
 }
 
-// CHECK-LABEL: func.func @where_not_a_kernel
-// CHECK: hip.where
-// CHECK-NOT: tosa.select
-func.func @where_not_a_kernel(%ctx: !hip.context, %cond: tensor<2x8xi1>,
-                              %x: tensor<2x8xf16>, %y: tensor<2x8xf16>,
-                              %init: tensor<2x8xf16>) -> tensor<2x8xf16> {
-  %r = hip.where(%ctx) ins(%cond, %x, %y :
-                           tensor<2x8xi1>, tensor<2x8xf16>, tensor<2x8xf16>)
-                       outs(%init : tensor<2x8xf16>) : tensor<2x8xf16>
-  return %r : tensor<2x8xf16>
-}
-
 // -----
 
 func.func @dynamic_shape(%ctx: !hip.context, %cond: tensor<?x8xi1>,

--- a/test/lit/Conversion/hip-to-tosa/test_unary.mlir
+++ b/test/lit/Conversion/hip-to-tosa/test_unary.mlir
@@ -228,17 +228,6 @@ func.func @cast_outlined_kernel(%x: tensor<2x8xf32>, %init: tensor<2x8xf16>)
   return %r : tensor<2x8xf16>
 }
 
-// CHECK-LABEL: func.func @cast_not_a_kernel
-// CHECK: hip.cast
-// CHECK-NOT: tosa.cast
-func.func @cast_not_a_kernel(%ctx: !hip.context, %x: tensor<2x8xf32>,
-                             %init: tensor<2x8xf16>) -> tensor<2x8xf16> {
-  %r = hip.cast(%ctx) ins(%x : tensor<2x8xf32>)
-                      outs(%init : tensor<2x8xf16>) {to = 10 : i64}
-                      : tensor<2x8xf16>
-  return %r : tensor<2x8xf16>
-}
-
 // The shape hip-fuse-rocmlir actually produces: the !hip.context is a
 // ub.poison materialized inside the outlined kernel rather than a block
 // argument. The ConversionTarget marks ub.poison legal so it survives as dead

--- a/test/lit/Conversion/hip-to-tosa/test_unary.mlir
+++ b/test/lit/Conversion/hip-to-tosa/test_unary.mlir
@@ -18,6 +18,7 @@
 //
 // This test validates:
 // - Each of the twelve unary ops maps to its TOSA counterpart
+// - hip.cast maps to tosa.cast, or rocMLIR tosa.custom for float->int / unsigned
 // - The hip context and the DPS `y` operand are both dropped
 // - hip.neg picks up tosa.negate's materialized zero-point operands
 // - The pass is a no-op on functions without rock.kernel
@@ -165,6 +166,79 @@ func.func @reciprocal(%ctx: !hip.context, %x: tensor<2x8xf16>,
   return %r : tensor<2x8xf16>
 }
 
+// hip.cast is same-shape; float->float and int->float are tosa.cast.
+// CHECK-LABEL: func.func @cast_f32_to_f16
+// CHECK: tosa.cast %arg1 : (tensor<2x8xf32>) -> tensor<2x8xf16>
+// CHECK-NOT: hip.cast
+func.func @cast_f32_to_f16(%ctx: !hip.context, %x: tensor<2x8xf32>,
+                            %init: tensor<2x8xf16>) -> tensor<2x8xf16>
+    attributes {rock.kernel} {
+  %r = hip.cast(%ctx) ins(%x : tensor<2x8xf32>)
+                      outs(%init : tensor<2x8xf16>) {to = 10 : i64}
+                      : tensor<2x8xf16>
+  return %r : tensor<2x8xf16>
+}
+
+// CHECK-LABEL: func.func @cast_i8_to_f32
+// CHECK: tosa.cast %arg1 : (tensor<4xi8>) -> tensor<4xf32>
+// CHECK-NOT: hip.cast
+func.func @cast_i8_to_f32(%ctx: !hip.context, %x: tensor<4xi8>,
+                           %init: tensor<4xf32>) -> tensor<4xf32>
+    attributes {rock.kernel} {
+  %r = hip.cast(%ctx) ins(%x : tensor<4xi8>)
+                      outs(%init : tensor<4xf32>) {to = 1 : i64}
+                      : tensor<4xf32>
+  return %r : tensor<4xf32>
+}
+
+// rock-tosa-to-elementwise rejects tosa.cast float->int; emit rocMLIR custom.
+// CHECK-LABEL: func.func @cast_f32_to_i8
+// CHECK: tosa.custom %arg1 {{.*}}operator_name = "fp_to_int_cast"
+// CHECK-NOT: hip.cast
+func.func @cast_f32_to_i8(%ctx: !hip.context, %x: tensor<2x8xf32>,
+                           %init: tensor<2x8xi8>) -> tensor<2x8xi8>
+    attributes {rock.kernel} {
+  %r = hip.cast(%ctx) ins(%x : tensor<2x8xf32>)
+                      outs(%init : tensor<2x8xi8>) {to = 3 : i64}
+                      : tensor<2x8xi8>
+  return %r : tensor<2x8xi8>
+}
+
+// CHECK-LABEL: func.func @cast_ui8_to_f32
+// CHECK: tosa.custom %arg1 {{.*}}operator_name = "unsigned_cast"
+// CHECK-NOT: hip.cast
+func.func @cast_ui8_to_f32(%ctx: !hip.context, %x: tensor<4xui8>,
+                            %init: tensor<4xf32>) -> tensor<4xf32>
+    attributes {rock.kernel} {
+  %r = hip.cast(%ctx) ins(%x : tensor<4xui8>)
+                      outs(%init : tensor<4xf32>) {to = 1 : i64}
+                      : tensor<4xf32>
+  return %r : tensor<4xf32>
+}
+
+// CHECK-LABEL: func.func @cast_outlined_kernel
+// CHECK: tosa.cast
+// CHECK-NOT: hip.cast
+func.func @cast_outlined_kernel(%x: tensor<2x8xf32>, %init: tensor<2x8xf16>)
+    -> tensor<2x8xf16> attributes {rock.kernel} {
+  %ctx = ub.poison : !hip.context
+  %r = hip.cast(%ctx) ins(%x : tensor<2x8xf32>)
+                      outs(%init : tensor<2x8xf16>) {to = 10 : i64}
+                      : tensor<2x8xf16>
+  return %r : tensor<2x8xf16>
+}
+
+// CHECK-LABEL: func.func @cast_not_a_kernel
+// CHECK: hip.cast
+// CHECK-NOT: tosa.cast
+func.func @cast_not_a_kernel(%ctx: !hip.context, %x: tensor<2x8xf32>,
+                             %init: tensor<2x8xf16>) -> tensor<2x8xf16> {
+  %r = hip.cast(%ctx) ins(%x : tensor<2x8xf32>)
+                      outs(%init : tensor<2x8xf16>) {to = 10 : i64}
+                      : tensor<2x8xf16>
+  return %r : tensor<2x8xf16>
+}
+
 // The shape hip-fuse-rocmlir actually produces: the !hip.context is a
 // ub.poison materialized inside the outlined kernel rather than a block
 // argument. The ConversionTarget marks ub.poison legal so it survives as dead
@@ -233,4 +307,16 @@ func.func @integer_operand(%ctx: !hip.context, %x: tensor<4xi32>,
   %r = hip.sin(%ctx) ins(%x : tensor<4xi32>)
                      outs(%init : tensor<4xi32>) : tensor<4xi32>
   return %r : tensor<4xi32>
+}
+
+// -----
+
+func.func @cast_dynamic_shape(%ctx: !hip.context, %x: tensor<?x8xf32>,
+                               %init: tensor<?x8xf16>) -> tensor<?x8xf16>
+    attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.cast'}}
+  %r = hip.cast(%ctx) ins(%x : tensor<?x8xf32>)
+                      outs(%init : tensor<?x8xf16>) {to = 10 : i64}
+                      : tensor<?x8xf16>
+  return %r : tensor<?x8xf16>
 }


### PR DESCRIPTION
## Summary
- Convert `hip.where`, `hip.leaky_relu`, `hip.miopen.softmax`, `hip.reduce_sum` / `hip.reduce_mean`, `hip.sqrt`, `hip.cast`, and QuantizeLinear / DequantizeLinear to TOSA inside outlined `rock.kernel` functions.
- Outline where, softmax, and QDQ after a gemm/conv anchor in `hip-fuse-rocmlir`.

## Related issue or design
None. Built on the hip-to-tosa / rocMLIR fusion work already on `feat/rocmlirtriton_fusion`.

## Why
Those ops otherwise stay as hip IR in the outlined kernel and cannot be absorbed by rocMLIR.

## What
- Decompositions: where → select; leaky-relu → mul+maximum; softmax tree; reduce_sum / mean; sqrt → reciprocal(rsqrt); QDQ arithmetic.
- `hip.cast` → `tosa.cast`, or rocMLIR `tosa.custom` for float-to-int and unsigned.
- Reject packed_int4, blocked QDQ, `saturate=0`, and dynamic shapes.

## Test plan
- [x] LIT under `test/lit/Conversion/hip-to-tosa/` for the new ops (decompose, reduce, ternary, qdq, plus cast cases in unary).
