### PR TITLE
feat(hip-to-tosa): convert hip.div to TOSA

### DIFF
--- a/lib/Conversion/HipToTosa/HipToTosa.cpp
+++ b/lib/Conversion/HipToTosa/HipToTosa.cpp
@@ -229,23 +229,23 @@ struct BinaryConverter final : public OpConversionPattern<HipOpTy> {
 // i32 and i64 only, whereas hip.div carries anything the runtime can name --
 // ui8, i8, ui16 and i16 among them -- because nothing upstream narrows it: the
 // operand constraint is AnyRankedTensor and OnnxToHip copies the ONNX element
-// type through verbatim. Those widths have no TOSA spelling and stay hip.div
-// rather than failing the pass.
+// type through verbatim.
 //
-// MIGraphXToTosa does cover unsigned, via a tosa.custom "unsigned_div" that
-// RockTosaToElementwise understands. It can do that because it runs under a
-// type converter that has already rewritten unsigned to signless, leaving the
-// custom op's name to carry the signedness; this pass has no type converter,
-// so the same call would hand rocMLIR operands still typed unsigned.
-static bool isTosaExpressibleDiv(hip::DivOp op) {
-  // Memref mode (post-bufferization) has no SSA result to replace.
-  if (op.getNumResults() != 1)
-    return false;
-  auto resultType = dyn_cast<RankedTensorType>(op.getResult(0).getType());
-  if (!resultType)
-    return false;
-
-  Type elementType = resultType.getElementType();
+// Those widths are rejected here rather than left alone. Passing one through
+// looks like the conservative choice but is not available: this pass only runs
+// inside a rock.kernel, and rocMLIR compiles that kernel to an ELF, so a
+// surviving hip op fails there instead -- later, and reported as an op from a
+// dialect it has never heard of rather than as the unsupported element type it
+// actually is. Failing here names the type.
+//
+// MIGraphXToTosa reaches unsigned, which this pass cannot: its type converter
+// rewrites unsigned to signless and a tosa.custom "unsigned_div" carries the
+// signedness in its name instead, which works because arith.divui takes the
+// signless type that arrives. Reproducing that needs a type converter over the
+// whole pass, not a change to this pattern. On sub-32-bit signed integers
+// MIGraphXToTosa does no better than rejecting them: it emits a tosa.intdiv
+// that fails the verifier.
+static bool isTosaExpressibleDivType(Type elementType) {
   if (isa<FloatType>(elementType))
     return true;
   return elementType.isSignlessInteger(32) || elementType.isSignlessInteger(64);
@@ -257,9 +257,18 @@ struct DivConverter final : public OpConversionPattern<hip::DivOp> {
   LogicalResult
   matchAndRewrite(hip::DivOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    // Memref mode (post-bufferization) has no SSA result to replace.
+    if (op.getNumResults() != 1)
+      return rewriter.notifyMatchFailure(op, "expected tensor mode");
+
     auto resultType = dyn_cast<RankedTensorType>(op.getResult(0).getType());
     if (!resultType || !resultType.hasStaticShape())
       return rewriter.notifyMatchFailure(op, "expected a static ranked tensor");
+
+    Type elementType = resultType.getElementType();
+    if (!isTosaExpressibleDivType(elementType))
+      return op->emitError("hip.div has no TOSA spelling for element type ")
+             << elementType << ": tosa.intdiv takes signless i32 and i64 only";
 
     Value lhs = adaptor.getLhs();
     Value rhs = adaptor.getRhs();
@@ -269,7 +278,7 @@ struct DivConverter final : public OpConversionPattern<hip::DivOp> {
         !isTosaCompatibleOperand(rhs, resultType))
       return rewriter.notifyMatchFailure(op, "operands not tosa-broadcastable");
 
-    if (isa<IntegerType>(resultType.getElementType())) {
+    if (isa<IntegerType>(elementType)) {
       rewriter.replaceOpWithNewOp<tosa::IntDivOp>(op, resultType, lhs, rhs);
       return success();
     }
@@ -1102,10 +1111,11 @@ class HipToTosaPass : public impl::ConvertHipToTosaPassBase<HipToTosaPass> {
     conversion.addLegalDialect<tosa::TosaDialect, func::FuncDialect>();
     conversion
         .addIllegalOp<MatmulOp, TransposeOp, AddOp, SubOp, MinOp, MaxOp, MulOp,
-                      AbsOp, NegOp, CeilOp, FloorOp, ExpOp, LogOp, SinOp, CosOp,
-                      TanhOp, ErfOp, SigmoidOp, ReciprocalOp, SqrtOp, WhereOp,
-                      LeakyReluOp, MiopenSoftmaxOp, ReduceSumOp, ReduceMeanOp,
-                      CastOp, QuantizeLinearOp, DequantizeLinearOp>();
+                      DivOp, AbsOp, NegOp, CeilOp, FloorOp, ExpOp, LogOp, SinOp,
+                      CosOp, TanhOp, ErfOp, SigmoidOp, ReciprocalOp, SqrtOp,
+                      WhereOp, LeakyReluOp, MiopenSoftmaxOp, ReduceSumOp,
+                      ReduceMeanOp, CastOp, QuantizeLinearOp,
+                      DequantizeLinearOp>();
     // tosa.matmul (and other tosa ops) are not destination-passing, so
     // MatMulConverter drops each hip op's DPS `outs` operand. The
     // `tensor.empty` that fed it is then dead, but a full conversion still
@@ -1121,14 +1131,6 @@ class HipToTosaPass : public impl::ConvertHipToTosaPassBase<HipToTosaPass> {
         [](tensor::ExpandShapeOp op) { return !isStaticReshape(op); });
     conversion.addDynamicallyLegalOp<tensor::ExtractSliceOp>(
         [](tensor::ExtractSliceOp op) { return !isTosaExpressibleSlice(op); });
-
-    // hip.div is the one hip op here that is conditionally rather than
-    // unconditionally illegal: the element types it can carry are wider than
-    // the ones tosa.intdiv accepts, and an unsigned or narrow divide has no
-    // TOSA spelling at all. Only the shapes are left to the pattern, so a
-    // dynamically shaped divide still fails the way its hip.add sibling does.
-    conversion.addDynamicallyLegalOp<DivOp>(
-        [](DivOp op) { return !isTosaExpressibleDiv(op); });
 
     RewritePatternSet patterns(ctx);
     patterns.add<

--- a/lib/Conversion/HipToTosa/HipToTosa.cpp
+++ b/lib/Conversion/HipToTosa/HipToTosa.cpp
@@ -171,8 +171,7 @@ Value createSplatFloat(ConversionPatternRewriter &rewriter, Location loc,
 // counterpart preserves the element type. Comparisons (hip.equal, hip.less) do
 // not belong here: they produce i1, which isTosaCompatibleOperand's
 // element-type check rejects. hip.div does not either, since TOSA has no
-// floating-point divide (tosa.intdiv is i32/i64 only, and floats decompose
-// into tosa.reciprocal plus tosa.mul).
+// single divide; DivConverter below spells one out per element type.
 //
 // tosa.maximum and tosa.minimum additionally carry a nan_mode attribute, but
 // ODS defaults it to PROPAGATE, which is what ONNX Max/Min do, so the
@@ -216,6 +215,74 @@ struct BinaryConverter final : public OpConversionPattern<HipOpTy> {
           op, resultType, lhs, rhs, createZeroMulShift(rewriter, op.getLoc()));
     else
       rewriter.replaceOpWithNewOp<TosaOpTy>(op, resultType, lhs, rhs);
+    return success();
+  }
+};
+
+// TOSA has no single divide, so hip.div splits on element type. Integers get
+// tosa.intdiv; floats get the reciprocal-then-multiply that tosa.intdiv's own
+// description prescribes ("Floating point divide should use RECIPROCAL and
+// MUL"). MIGraphXToTosa lowers migraphx.div the same two ways.
+//
+// The split is also why hip.div is the one hip op here whose legality turns on
+// the element type. tosa.intdiv takes Tosa_Int32Or64Tensor, which is signless
+// i32 and i64 only, whereas hip.div carries anything the runtime can name --
+// ui8, i8, ui16 and i16 among them -- because nothing upstream narrows it: the
+// operand constraint is AnyRankedTensor and OnnxToHip copies the ONNX element
+// type through verbatim. Those widths have no TOSA spelling and stay hip.div
+// rather than failing the pass.
+//
+// MIGraphXToTosa does cover unsigned, via a tosa.custom "unsigned_div" that
+// RockTosaToElementwise understands. It can do that because it runs under a
+// type converter that has already rewritten unsigned to signless, leaving the
+// custom op's name to carry the signedness; this pass has no type converter,
+// so the same call would hand rocMLIR operands still typed unsigned.
+static bool isTosaExpressibleDiv(hip::DivOp op) {
+  // Memref mode (post-bufferization) has no SSA result to replace.
+  if (op.getNumResults() != 1)
+    return false;
+  auto resultType = dyn_cast<RankedTensorType>(op.getResult(0).getType());
+  if (!resultType)
+    return false;
+
+  Type elementType = resultType.getElementType();
+  if (isa<FloatType>(elementType))
+    return true;
+  return elementType.isSignlessInteger(32) || elementType.isSignlessInteger(64);
+}
+
+struct DivConverter final : public OpConversionPattern<hip::DivOp> {
+  using OpConversionPattern<hip::DivOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(hip::DivOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto resultType = dyn_cast<RankedTensorType>(op.getResult(0).getType());
+    if (!resultType || !resultType.hasStaticShape())
+      return rewriter.notifyMatchFailure(op, "expected a static ranked tensor");
+
+    Value lhs = adaptor.getLhs();
+    Value rhs = adaptor.getRhs();
+    if (failed(tosa::EqualizeRanks(rewriter, op.getLoc(), lhs, rhs)))
+      return rewriter.notifyMatchFailure(op, "operand ranks not equalizable");
+    if (!isTosaCompatibleOperand(lhs, resultType) ||
+        !isTosaCompatibleOperand(rhs, resultType))
+      return rewriter.notifyMatchFailure(op, "operands not tosa-broadcastable");
+
+    if (isa<IntegerType>(resultType.getElementType())) {
+      rewriter.replaceOpWithNewOp<tosa::IntDivOp>(op, resultType, lhs, rhs);
+      return success();
+    }
+
+    // The reciprocal is taken at the divisor's own rank-equalized shape rather
+    // than the result's, so a divisor that broadcasts is reciprocated once per
+    // distinct element instead of once per result element; the multiply
+    // broadcasts it back up.
+    Value recip =
+        tosa::ReciprocalOp::create(rewriter, op.getLoc(), rhs.getType(), rhs)
+            .getResult();
+    rewriter.replaceOpWithNewOp<tosa::MulOp>(
+        op, resultType, lhs, recip, createZeroMulShift(rewriter, op.getLoc()));
     return success();
   }
 };
@@ -1055,12 +1122,20 @@ class HipToTosaPass : public impl::ConvertHipToTosaPassBase<HipToTosaPass> {
     conversion.addDynamicallyLegalOp<tensor::ExtractSliceOp>(
         [](tensor::ExtractSliceOp op) { return !isTosaExpressibleSlice(op); });
 
+    // hip.div is the one hip op here that is conditionally rather than
+    // unconditionally illegal: the element types it can carry are wider than
+    // the ones tosa.intdiv accepts, and an unsigned or narrow divide has no
+    // TOSA spelling at all. Only the shapes are left to the pattern, so a
+    // dynamically shaped divide still fails the way its hip.add sibling does.
+    conversion.addDynamicallyLegalOp<DivOp>(
+        [](DivOp op) { return !isTosaExpressibleDiv(op); });
+
     RewritePatternSet patterns(ctx);
     patterns.add<
         MatMulConverter, TransposeConverter, ExpandConverter,
         ReshapeConverter<tensor::CollapseShapeOp>,
         ReshapeConverter<tensor::ExpandShapeOp>, ExtractSliceConverter,
-        BinaryConverter<AddOp, tosa::AddOp>,
+        DivConverter, BinaryConverter<AddOp, tosa::AddOp>,
         BinaryConverter<SubOp, tosa::SubOp>,
         BinaryConverter<MinOp, tosa::MinimumOp>,
         BinaryConverter<MaxOp, tosa::MaximumOp>,

--- a/test/lit/Conversion/hip-to-tosa/test_div.mlir
+++ b/test/lit/Conversion/hip-to-tosa/test_div.mlir
@@ -1,0 +1,233 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify that hip.div, the lowering of ONNX Div, becomes TOSA inside a
+// rock.kernel function, so a divide sitting behind a matmul or convolution is
+// absorbed into the fused kernel instead of stranding a hip op that rocMLIR
+// cannot read.
+//
+// TOSA has no single divide, so the conversion splits on element type the way
+// MIGraphXToTosa splits migraphx.div: integers become tosa.intdiv, and floats
+// become a tosa.reciprocal followed by a tosa.mul, which is what tosa.intdiv's
+// own description prescribes. That split is also why hip.div cannot join the
+// BinaryConverter template its add/sub/min/max/mul siblings share.
+//
+// COVERAGE:
+// - Floats become reciprocal-then-multiply, with the zero shift tosa.mul's
+//   verifier requires
+// - Signless i32 and i64, the only widths tosa.intdiv accepts, become intdiv
+// - The reciprocal is taken at the divisor's own shape, so a broadcasting
+//   divisor is reciprocated once per distinct element rather than once per
+//   result element
+// - A lower-rank divisor is reshaped with leading 1s first, since TOSA
+//   broadcasts size-1 dimensions only once both operands carry the result rank
+// - A divide behind a matmul anchor converts alongside it
+// - Element types with no TOSA spelling -- unsigned, and integer widths
+//   narrower than 32 -- stay hip.div rather than failing the pass
+// - The pass is a no-op on functions without rock.kernel
+// - Dynamic shapes are rejected, matching the hip.add sibling
+// ============================================================================
+
+// RUN: hip-mlir-opt --convert-hip-to-tosa --split-input-file \
+// RUN:   --verify-diagnostics %s | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Element types that convert.
+//===----------------------------------------------------------------------===//
+
+// The float spelling: reciprocate the divisor, then multiply. The shift is the
+// same zero tensor<1xi8> the other tosa.mul users build, required here because
+// tosa.mul's verifier rejects a non-zero shift on float operands.
+// CHECK-LABEL: func.func @div_f32
+// CHECK: %[[RECIP:.*]] = tosa.reciprocal %arg2 : (tensor<2x8xf32>) -> tensor<2x8xf32>
+// CHECK: %[[SHIFT:.*]] = "tosa.const"() <{values = dense<0> : tensor<1xi8>}>
+// CHECK: tosa.mul %arg1, %[[RECIP]], %[[SHIFT]] : (tensor<2x8xf32>, tensor<2x8xf32>, tensor<1xi8>) -> tensor<2x8xf32>
+// CHECK-NOT: hip.div
+func.func @div_f32(%ctx: !hip.context, %x: tensor<2x8xf32>, %y: tensor<2x8xf32>,
+                   %init: tensor<2x8xf32>) -> tensor<2x8xf32>
+    attributes {rock.kernel} {
+  %r = hip.div(%ctx) ins(%x, %y : tensor<2x8xf32>, tensor<2x8xf32>)
+                     outs(%init : tensor<2x8xf32>) : tensor<2x8xf32>
+  return %r : tensor<2x8xf32>
+}
+
+// -----
+
+// Integers take tosa.intdiv instead, which truncates towards zero the way ONNX
+// Div does on integer input.
+// CHECK-LABEL: func.func @div_i32
+// CHECK: tosa.intdiv %arg1, %arg2 : (tensor<2x8xi32>, tensor<2x8xi32>) -> tensor<2x8xi32>
+// CHECK-NOT: tosa.reciprocal
+// CHECK-NOT: hip.div
+func.func @div_i32(%ctx: !hip.context, %x: tensor<2x8xi32>, %y: tensor<2x8xi32>,
+                   %init: tensor<2x8xi32>) -> tensor<2x8xi32>
+    attributes {rock.kernel} {
+  %r = hip.div(%ctx) ins(%x, %y : tensor<2x8xi32>, tensor<2x8xi32>)
+                     outs(%init : tensor<2x8xi32>) : tensor<2x8xi32>
+  return %r : tensor<2x8xi32>
+}
+
+// -----
+
+// i64 is the other half of tosa.intdiv's Tosa_Int32Or64Tensor operand type.
+// CHECK-LABEL: func.func @div_i64
+// CHECK: tosa.intdiv %arg1, %arg2 : (tensor<4xi64>, tensor<4xi64>) -> tensor<4xi64>
+// CHECK-NOT: hip.div
+func.func @div_i64(%ctx: !hip.context, %x: tensor<4xi64>, %y: tensor<4xi64>,
+                   %init: tensor<4xi64>) -> tensor<4xi64>
+    attributes {rock.kernel} {
+  %r = hip.div(%ctx) ins(%x, %y : tensor<4xi64>, tensor<4xi64>)
+                     outs(%init : tensor<4xi64>) : tensor<4xi64>
+  return %r : tensor<4xi64>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Broadcasting divisors.
+//===----------------------------------------------------------------------===//
+
+// The reciprocal stays at tensor<4x1xf16>, the divisor's own shape, rather than
+// being widened to the result first: four reciprocals instead of thirty-two,
+// with the multiply broadcasting them back up. Taking it at the result shape
+// would verify just as well, which is why this is pinned.
+// CHECK-LABEL: func.func @div_broadcast_divisor
+// CHECK: %[[RECIP:.*]] = tosa.reciprocal %arg2 : (tensor<4x1xf16>) -> tensor<4x1xf16>
+// CHECK: tosa.mul %arg1, %[[RECIP]], %{{.*}} : (tensor<4x8xf16>, tensor<4x1xf16>, tensor<1xi8>) -> tensor<4x8xf16>
+// CHECK-NOT: hip.div
+func.func @div_broadcast_divisor(%ctx: !hip.context, %x: tensor<4x8xf16>,
+                                 %y: tensor<4x1xf16>, %init: tensor<4x8xf16>)
+    -> tensor<4x8xf16> attributes {rock.kernel} {
+  %r = hip.div(%ctx) ins(%x, %y : tensor<4x8xf16>, tensor<4x1xf16>)
+                     outs(%init : tensor<4x8xf16>) : tensor<4x8xf16>
+  return %r : tensor<4x8xf16>
+}
+
+// -----
+
+// Dividing by a scalar is the common shape -- an attention score divided by
+// sqrt(head_dim) arrives exactly like this. hip broadcasting rank-extends the
+// way ONNX does, so the rank-0 divisor is reshaped to 1x1x1x1 before TOSA can
+// broadcast it, and the whole division collapses to a single reciprocal.
+// CHECK-LABEL: func.func @div_rank_extending
+// CHECK: %[[SHAPE:.*]] = tosa.const_shape {values = dense<1> : tensor<4xindex>}
+// CHECK: %[[RESHAPED:.*]] = tosa.reshape %arg2, %[[SHAPE]] : (tensor<f16>, !tosa.shape<4>) -> tensor<1x1x1x1xf16>
+// CHECK: %[[RECIP:.*]] = tosa.reciprocal %[[RESHAPED]] : (tensor<1x1x1x1xf16>) -> tensor<1x1x1x1xf16>
+// CHECK: tosa.mul %arg1, %[[RECIP]], %{{.*}} : (tensor<1x64x112x112xf16>, tensor<1x1x1x1xf16>, tensor<1xi8>) -> tensor<1x64x112x112xf16>
+// CHECK-NOT: hip.div
+func.func @div_rank_extending(%ctx: !hip.context, %x: tensor<1x64x112x112xf16>,
+                              %y: tensor<f16>, %init: tensor<1x64x112x112xf16>)
+    -> tensor<1x64x112x112xf16> attributes {rock.kernel} {
+  %r = hip.div(%ctx) ins(%x, %y : tensor<1x64x112x112xf16>, tensor<f16>)
+                     outs(%init : tensor<1x64x112x112xf16>)
+                     : tensor<1x64x112x112xf16>
+  return %r : tensor<1x64x112x112xf16>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// A divide behind an anchor, in the shape hip-fuse-rocmlir produces.
+//===----------------------------------------------------------------------===//
+
+// The reason for converting hip.div at all, and what separates it from the
+// shape ops: hip.div is already in FuseROCMlir's pointwise list, so a divide
+// after a matmul is outlined into the kernel whether or not it can be lowered.
+// Left unconverted it reaches rocMLIR as a hip op fed by a ub.poison context,
+// neither of which rocMLIR knows. The ub.poison and the tensor.empty buffers
+// this pass does not claim survive untouched for the canonicalizer.
+// CHECK-LABEL: func.func @rocMlir0
+// CHECK: ub.poison : !hip.context
+// CHECK: tensor.empty() : tensor<8x64x64xf32>
+// CHECK: %[[MM:.*]] = tosa.matmul
+// CHECK: %[[OUT:.*]] = tosa.reshape %[[MM]], %{{.*}} -> tensor<8x64x64xf32>
+// CHECK: %[[RECIP:.*]] = tosa.reciprocal %arg2 : (tensor<8x64x64xf32>) -> tensor<8x64x64xf32>
+// CHECK: tosa.mul %[[OUT]], %[[RECIP]], %{{.*}} -> tensor<8x64x64xf32>
+// CHECK-NOT: hip.div
+// CHECK-NOT: hip.matmul
+func.func @rocMlir0(%a: tensor<8x64x64xf32>, %w: tensor<64x64xf32>,
+                    %d: tensor<8x64x64xf32>) -> tensor<8x64x64xf32>
+    attributes {rock.arch = "gfx1151", rock.kernel} {
+  %ctx = ub.poison : !hip.context
+  %m_init = tensor.empty() : tensor<8x64x64xf32>
+  %m = hip.matmul(%ctx) ins(%a, %w : tensor<8x64x64xf32>, tensor<64x64xf32>)
+                        outs(%m_init : tensor<8x64x64xf32>) : tensor<8x64x64xf32>
+  %d_init = tensor.empty() : tensor<8x64x64xf32>
+  %r = hip.div(%ctx) ins(%m, %d : tensor<8x64x64xf32>, tensor<8x64x64xf32>)
+                     outs(%d_init : tensor<8x64x64xf32>) : tensor<8x64x64xf32>
+  return %r : tensor<8x64x64xf32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Element types with no TOSA spelling.
+//===----------------------------------------------------------------------===//
+
+// tosa.intdiv takes signless integers only, and nothing upstream narrows what
+// hip.div can carry: the operand constraint is AnyRankedTensor and OnnxToHip
+// copies the ONNX element type through verbatim, so an unsigned divide reaches
+// this pass intact. Unlike the unconditionally illegal binary ops it is left
+// alone rather than failing the pass. MIGraphXToTosa covers this case with a
+// tosa.custom "unsigned_div", but only because its type converter has already
+// rewritten unsigned to signless and the name carries what was lost.
+// CHECK-LABEL: func.func @div_unsigned
+// CHECK: hip.div
+// CHECK-NOT: tosa.intdiv
+func.func @div_unsigned(%ctx: !hip.context, %x: tensor<4xui32>,
+                        %y: tensor<4xui32>, %init: tensor<4xui32>)
+    -> tensor<4xui32> attributes {rock.kernel} {
+  %r = hip.div(%ctx) ins(%x, %y : tensor<4xui32>, tensor<4xui32>)
+                     outs(%init : tensor<4xui32>) : tensor<4xui32>
+  return %r : tensor<4xui32>
+}
+
+// -----
+
+// The same holds for the widths below 32 that the runtime can name but
+// tosa.intdiv cannot take.
+// CHECK-LABEL: func.func @div_narrow_int
+// CHECK: hip.div
+// CHECK-NOT: tosa.intdiv
+func.func @div_narrow_int(%ctx: !hip.context, %x: tensor<4xi8>,
+                          %y: tensor<4xi8>, %init: tensor<4xi8>)
+    -> tensor<4xi8> attributes {rock.kernel} {
+  %r = hip.div(%ctx) ins(%x, %y : tensor<4xi8>, tensor<4xi8>)
+                     outs(%init : tensor<4xi8>) : tensor<4xi8>
+  return %r : tensor<4xi8>
+}
+
+// -----
+
+// Only outlined kernels are rewritten; the host graph keeps its runtime ops.
+// CHECK-LABEL: func.func @not_a_kernel
+// CHECK: hip.div
+// CHECK-NOT: tosa.reciprocal
+func.func @not_a_kernel(%ctx: !hip.context, %x: tensor<2x8xf32>,
+                        %y: tensor<2x8xf32>, %init: tensor<2x8xf32>)
+    -> tensor<2x8xf32> {
+  %r = hip.div(%ctx) ins(%x, %y : tensor<2x8xf32>, tensor<2x8xf32>)
+                     outs(%init : tensor<2x8xf32>) : tensor<2x8xf32>
+  return %r : tensor<2x8xf32>
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Rejected form.
+//===----------------------------------------------------------------------===//
+
+// Only the element type makes hip.div conditionally legal. Once the type is one
+// TOSA can express, the shape rules are the sibling binary ops': a dynamic
+// shape gives the pattern nothing to reason about and fails legalization rather
+// than passing through.
+func.func @div_dynamic_shape(%ctx: !hip.context, %x: tensor<?x8xf32>,
+                             %y: tensor<?x8xf32>, %init: tensor<?x8xf32>)
+    -> tensor<?x8xf32> attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.div'}}
+  %r = hip.div(%ctx) ins(%x, %y : tensor<?x8xf32>, tensor<?x8xf32>)
+                     outs(%init : tensor<?x8xf32>) : tensor<?x8xf32>
+  return %r : tensor<?x8xf32>
+}

--- a/test/lit/Conversion/hip-to-tosa/test_div.mlir
+++ b/test/lit/Conversion/hip-to-tosa/test_div.mlir
@@ -25,8 +25,10 @@
 //   broadcasts size-1 dimensions only once both operands carry the result rank
 // - A divide behind a matmul anchor converts alongside it
 // - Element types with no TOSA spelling -- unsigned, and integer widths
-//   narrower than 32 -- stay hip.div rather than failing the pass
-// - The pass is a no-op on functions without rock.kernel
+//   narrower than 32 -- are rejected with the type named, since a hip.div left
+//   inside a kernel is not something rocMLIR can compile either
+// - The pass is a no-op on functions without rock.kernel, so a host-graph
+//   divide keeps its runtime op whatever its element type
 // - Dynamic shapes are rejected, matching the hip.add sibling
 // ============================================================================
 
@@ -166,19 +168,20 @@ func.func @rocMlir0(%a: tensor<8x64x64xf32>, %w: tensor<64x64xf32>,
 // Element types with no TOSA spelling.
 //===----------------------------------------------------------------------===//
 
-// tosa.intdiv takes signless integers only, and nothing upstream narrows what
-// hip.div can carry: the operand constraint is AnyRankedTensor and OnnxToHip
-// copies the ONNX element type through verbatim, so an unsigned divide reaches
-// this pass intact. Unlike the unconditionally illegal binary ops it is left
-// alone rather than failing the pass. MIGraphXToTosa covers this case with a
-// tosa.custom "unsigned_div", but only because its type converter has already
-// rewritten unsigned to signless and the name carries what was lost.
-// CHECK-LABEL: func.func @div_unsigned
-// CHECK: hip.div
-// CHECK-NOT: tosa.intdiv
+// tosa.intdiv takes signless i32 and i64 only, and nothing upstream narrows
+// what hip.div can carry: the operand constraint is AnyRankedTensor and
+// OnnxToHip copies the ONNX element type through verbatim, so an unsigned
+// divide reaches this pass intact.
+//
+// Rejecting is the only option. This pass runs only inside a rock.kernel, and
+// rocMLIR compiles that kernel to an ELF, so a hip.div left behind fails there
+// anyway -- later, and reported as an op from an unknown dialect rather than as
+// the unsupported element type it is. The diagnostic here names the type.
 func.func @div_unsigned(%ctx: !hip.context, %x: tensor<4xui32>,
                         %y: tensor<4xui32>, %init: tensor<4xui32>)
     -> tensor<4xui32> attributes {rock.kernel} {
+  // expected-error @+2 {{hip.div has no TOSA spelling for element type 'ui32'}}
+  // expected-error @+1 {{failed to legalize operation 'hip.div'}}
   %r = hip.div(%ctx) ins(%x, %y : tensor<4xui32>, tensor<4xui32>)
                      outs(%init : tensor<4xui32>) : tensor<4xui32>
   return %r : tensor<4xui32>
@@ -187,13 +190,14 @@ func.func @div_unsigned(%ctx: !hip.context, %x: tensor<4xui32>,
 // -----
 
 // The same holds for the widths below 32 that the runtime can name but
-// tosa.intdiv cannot take.
-// CHECK-LABEL: func.func @div_narrow_int
-// CHECK: hip.div
-// CHECK-NOT: tosa.intdiv
+// tosa.intdiv cannot take. MIGraphXToTosa does no better here: on a sub-32-bit
+// signed divide it emits a tosa.intdiv that fails the verifier, rather than
+// rejecting it.
 func.func @div_narrow_int(%ctx: !hip.context, %x: tensor<4xi8>,
                           %y: tensor<4xi8>, %init: tensor<4xi8>)
     -> tensor<4xi8> attributes {rock.kernel} {
+  // expected-error @+2 {{hip.div has no TOSA spelling for element type 'i8'}}
+  // expected-error @+1 {{failed to legalize operation 'hip.div'}}
   %r = hip.div(%ctx) ins(%x, %y : tensor<4xi8>, tensor<4xi8>)
                      outs(%init : tensor<4xi8>) : tensor<4xi8>
   return %r : tensor<4xi8>
@@ -202,15 +206,18 @@ func.func @div_narrow_int(%ctx: !hip.context, %x: tensor<4xi8>,
 // -----
 
 // Only outlined kernels are rewritten; the host graph keeps its runtime ops.
+// The unsigned element type is the point: rejection above is a consequence of
+// being inside a kernel, not a judgement about the type, and the runtime names
+// ui32 perfectly well. Here the same divide is left alone.
 // CHECK-LABEL: func.func @not_a_kernel
 // CHECK: hip.div
 // CHECK-NOT: tosa.reciprocal
-func.func @not_a_kernel(%ctx: !hip.context, %x: tensor<2x8xf32>,
-                        %y: tensor<2x8xf32>, %init: tensor<2x8xf32>)
-    -> tensor<2x8xf32> {
-  %r = hip.div(%ctx) ins(%x, %y : tensor<2x8xf32>, tensor<2x8xf32>)
-                     outs(%init : tensor<2x8xf32>) : tensor<2x8xf32>
-  return %r : tensor<2x8xf32>
+func.func @not_a_kernel(%ctx: !hip.context, %x: tensor<4xui32>,
+                        %y: tensor<4xui32>, %init: tensor<4xui32>)
+    -> tensor<4xui32> {
+  %r = hip.div(%ctx) ins(%x, %y : tensor<4xui32>, tensor<4xui32>)
+                     outs(%init : tensor<4xui32>) : tensor<4xui32>
+  return %r : tensor<4xui32>
 }
 
 // -----


### PR DESCRIPTION
## Why

`hip.div` is already in `FuseROCMlir`'s `isaPointwiseOp` list, so a divide behind a matmul or convolution is outlined into the `rock.kernel` whether or not it can be lowered. Because nothing converted it, that kernel reached rocMLIR carrying a `hip.div` fed by a `ub.poison : !hip.context` — a dialect rocMLIR has never heard of.

Running a `MatMul` → `Div` graph through the real `--rocmlir-pipeline` before this change:

```mlir
%7  = tosa.matmul %5, %6, %1, %1 : (tensor<1x512x64xf32>, tensor<1x64x64xf32>, tensor<1xf32>, tensor<1xf32>) -> tensor<1x512x64xf32>
%8  = tosa.reshape %7, %0 : (tensor<1x512x64xf32>, !tosa.shape<3>) -> tensor<8x64x64xf32>
%9  = tensor.empty() : tensor<8x64x64xf32>
%10 = hip.div(%4) ins(%8, %arg2 : tensor<8x64x64xf32>, tensor<8x64x64xf32>) outs(%9 : tensor<8x64x64xf32>) : tensor<8x64x64xf32>
```

and after:

```mlir
%8  = tosa.reshape %7, %1 : (tensor<1x512x64xf32>, !tosa.shape<3>) -> tensor<8x64x64xf32>
%9  = tosa.reciprocal %arg2 : (tensor<8x64x64xf32>) -> tensor<8x64x64xf32>
%10 = tosa.mul %8, %9, %0 : (tensor<8x64x64xf32>, tensor<8x64x64xf32>, tensor<1xi8>) -> tensor<8x64x64xf32>
```

The `ub.poison` and `tensor.empty` that fed the divide go with it. This is a gap in what a fused kernel can contain, not a missed optimization — which is what separates it from the shape and broadcast ops, whose hip forms are never outlined in the first place.

## What

TOSA has no single divide, so the conversion splits on element type the same way `MIGraphXToTosa` splits `migraphx.div`:

| Element type | TOSA emitted |
| --- | --- |
| Float | `tosa.reciprocal` on the divisor, then `tosa.mul` |
| Signless i32, i64 | `tosa.intdiv` |

The float route is what `tosa.intdiv`'s own description prescribes: *"Floating point divide should use RECIPROCAL and MUL."* That split is why `hip.div` cannot join the `BinaryConverter` template its `add`/`sub`/`min`/`max`/`mul` siblings share, and the existing comment saying so is updated to point here.

## Everything else is rejected, with the type named

`hip.div` is unconditionally illegal inside a `rock.kernel`, exactly like its binary siblings. An element type with no TOSA spelling produces:

```
error: hip.div has no TOSA spelling for element type 'ui32': tosa.intdiv takes signless i32 and i64 only
error: failed to legalize operation 'hip.div' that was explicitly marked illegal
```

Nothing upstream narrows what `hip.div` can carry: the operand constraint is `AnyRankedTensor` with no element-type predicate, and `OnnxToHip` copies the ONNX type through verbatim. Feeding unsigned divides through `--convert-onnx-to-hip` confirms they arrive intact:

```mlir
%1 = hip.div(%arg0) ins(%arg1, %arg2 : tensor<4xui8>, tensor<4xui8>) outs(%0 : tensor<4xui8>) : tensor<4xui8>
%3 = hip.div(%arg0) ins(%arg3, %arg4 : tensor<4xui32>, tensor<4xui32>) outs(%2 : tensor<4xui32>) : tensor<4xui32>
```

And `tosa.intdiv` takes `Tosa_Int32Or64Tensor`, which is signless only — `ui32` is rejected outright:

```
error: 'tosa.intdiv' op operand #0 must be tosa-conformant tensor of 32-bit signless integer
or 64-bit signless integer values, but got 'tensor<4xui32>'
```

An earlier revision of this branch left those types as `hip.div` on the grounds that passing through is the conservative choice. It is not. This pass runs only inside a `rock.kernel`, and `RocMlirOpLowering` hands that kernel to rocMLIR to be compiled into an ELF (`wrap_rocmlir(state, kernel_binary_str, ...)`), so a surviving hip op fails there regardless — later, and reported as an op from an unknown dialect rather than as the unsupported element type it actually is. Failing here names the type.

**The host graph is unaffected.** `runOnOperation` returns early on any function without `rock.kernel`, so a divide outside a kernel keeps its `wrap_div` lowering at any element type the runtime can name. The `not_a_kernel` test case uses `ui32` deliberately, to pin that rejection follows from being inside a kernel rather than from a judgement about the type.

## How the MIGraphX path handles the same types

This pattern was modelled on `MIGraphXToTosa`, so for the record on where the two differ:

- **Unsigned:** MIGraphX reaches it and this pass cannot. Its type converter rewrites unsigned to signless, and a `tosa.custom` named `unsigned_div` carries the signedness in its *name* instead. That works because the consumer builds `arith.divui`, which takes the signless type that arrives — `arith` operands are `SignlessIntegerOrIndexLike`, so handing it a `ui32` would produce invalid IR. Reproducing this needs a `TypeConverter` over the whole pass, not a change to this pattern.
- **Sub-32-bit signed:** MIGraphX does no better than rejecting them. `migraphx.div` on `si8` emits a `tosa.intdiv` that fails the verifier:
  ```
  error: 'tosa.intdiv' op operand #0 must be tosa-conformant tensor of 32-bit signless integer
  or 64-bit signless integer values, but got 'tensor<4x8xi8>'
  ```
- **Coverage:** rocMLIR has no test for integer division at any width other than 32. `mixr-to-tosa-ops.mlir` covers f32, f16 and i32; `migraphx-to-tosa-signed-unsigned-ints.mlir` covers si32 and ui32.

## Two details the tests pin

Only the element type is checked before the shape rules. A dynamically shaped divide fails to legalize exactly as `hip.add` does today, matching the rejection the binary tests already pin rather than inventing a softer rule for `Div`.

The reciprocal is taken at the divisor's own rank-equalized shape rather than the result's, so a broadcasting divisor is reciprocated once per distinct element and the multiply broadcasts it back up. Dividing a `1x64x112x112` tensor by a scalar — an attention score over `sqrt(head_dim)` — costs one reciprocal instead of 802816. Both forms verify, which is why the cheaper one is checked explicitly.

## Testing

New `test/lit/Conversion/hip-to-tosa/test_div.mlir`, ten cases: the float and both integer mappings, a broadcasting divisor, a rank-extending scalar divisor, a divide behind a matmul anchor in the shape `hip-fuse-rocmlir` produces, the unsigned and narrow-integer rejections, a non-kernel function, and the dynamic-shape rejection.

Full lit suite: 479 passed. The one failure, `Conversion/onnx-to-hip/test_qadd.mlir`, is pre-existing and unrelated — it exercises only `--hip-add-context-arg --convert-onnx-to-hip`, and it reproduces on the base branch with this change reverted. It arrived with #907.

`clang-format` 16.0.1 clean.

## One unrelated hunk

The diff collapses a two-line `rewriter.replaceOp` call in `MatMulConverter` onto one line. That is not part of this change: it is the base branch's single `clang-format` violation in this file, arriving with the `reshapeTo` refactor in `b7634844`, which was pushed directly and so never ran pre-commit. Checking the base version of the file against the repo's pinned `clang-format` 16.0.1 reports it and nothing else:

```
lib/Conversion/HipToTosa/HipToTosa.cpp:116:24: error: code should be clang-formatted [-Wclang-format-violations]
    rewriter.replaceOp(
                       ^
```

Formatting the file as part of this change fixes it. Reverting the hunk would leave the file failing the format check, so it stays.

## Note on the failing pre-commit job

`lintrunner` runs `--all-files`, and three files on the base branch are unformatted: `lib/Conversion/HipToLLVM/RocMlirLowering.cpp`, `lib/Runtime/hipdnn_ep_runtime.h` and `tools/hip-rocmlir-compiler/hip-rocmlir-compiler.cpp`. They came in with the commits pushed straight to `feat/rocmlirtriton_fusion`, which never ran pre-commit. #950 fixes them in a dedicated commit; this branch is independent of that one, so the job stays red here until #950 lands or the same fix is duplicated. Happy to do either.
