### PR TITLE
feat(matmul_nbits): support fp32 A/output via device-side fp16 cast for u2/u3/u4

### DIFF
--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -6192,6 +6192,94 @@ extern "C" void hip_matmul_nbits_dequant_b_fp16(
                        N, K, group_size, num_groups_k);
 }
 
+/* -----------------------------------------------------------------------
+ * fp32 A / fp32 output cast patch (element_size_bytes==4, bits != 8):
+ * device-side, vectorized float<->fp16 conversion so the existing fp16
+ * compute path (WMMA/GEMV/naive below) runs completely unchanged.
+ * ----------------------------------------------------------------------- */
+
+__global__ void cast_fp32_to_fp16_kernel(
+    const float* __restrict__ src, _Float16* __restrict__ dst,
+    int64_t n, int64_t num_vec2)
+{
+    int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx < num_vec2) {
+        float2 v = reinterpret_cast<const float2*>(src)[idx];
+        reinterpret_cast<__half2*>(dst)[idx] = __floats2half2_rn(v.x, v.y);
+    }
+    if (blockIdx.x == 0 && threadIdx.x == 0) {
+        for (int64_t i = num_vec2 * 2; i < n; ++i)
+            dst[i] = static_cast<_Float16>(src[i]);
+    }
+}
+
+__global__ void cast_fp16_to_fp32_kernel(
+    const _Float16* __restrict__ src, float* __restrict__ dst,
+    int64_t n, int64_t num_vec2)
+{
+    int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx < num_vec2) {
+        __half2 v = reinterpret_cast<const __half2*>(src)[idx];
+        reinterpret_cast<float2*>(dst)[idx] = __half22float2(v);
+    }
+    if (blockIdx.x == 0 && threadIdx.x == 0) {
+        for (int64_t i = num_vec2 * 2; i < n; ++i)
+            dst[i] = static_cast<float>(src[i]);
+    }
+}
+
+static void launchCastFp32ToFp16(hipStream_t stream, const float* src,
+                                 _Float16* dst, int64_t n)
+{
+    int64_t num_vec2 = n / 2;
+    constexpr int THR = 256;
+    int64_t blocks = (num_vec2 + THR - 1) / THR;
+    if (blocks < 1) blocks = 1;
+    hipLaunchKernelGGL(cast_fp32_to_fp16_kernel,
+                       dim3(static_cast<unsigned>(blocks)), dim3(THR), 0, stream,
+                       src, dst, n, num_vec2);
+}
+
+static void launchCastFp16ToFp32(hipStream_t stream, const _Float16* src,
+                                 float* dst, int64_t n)
+{
+    int64_t num_vec2 = n / 2;
+    constexpr int THR = 256;
+    int64_t blocks = (num_vec2 + THR - 1) / THR;
+    if (blocks < 1) blocks = 1;
+    hipLaunchKernelGGL(cast_fp16_to_fp32_kernel,
+                       dim3(static_cast<unsigned>(blocks)), dim3(THR), 0, stream,
+                       src, dst, n, num_vec2);
+}
+
+static _Float16* g_fp32cast_a_buf = nullptr;
+static size_t    g_fp32cast_a_elems = 0;
+static _Float16* ensureFp32CastABuffer(size_t elems) {
+    if (g_fp32cast_a_buf && g_fp32cast_a_elems >= elems) return g_fp32cast_a_buf;
+    if (g_fp32cast_a_buf) hipFree(g_fp32cast_a_buf);
+    g_fp32cast_a_buf = nullptr;
+    if (hipMalloc(&g_fp32cast_a_buf, elems * sizeof(_Float16)) != hipSuccess) {
+        g_fp32cast_a_elems = 0;
+        return nullptr;
+    }
+    g_fp32cast_a_elems = elems;
+    return g_fp32cast_a_buf;
+}
+
+static _Float16* g_fp32cast_c_buf = nullptr;
+static size_t    g_fp32cast_c_elems = 0;
+static _Float16* ensureFp32CastCBuffer(size_t elems) {
+    if (g_fp32cast_c_buf && g_fp32cast_c_elems >= elems) return g_fp32cast_c_buf;
+    if (g_fp32cast_c_buf) hipFree(g_fp32cast_c_buf);
+    g_fp32cast_c_buf = nullptr;
+    if (hipMalloc(&g_fp32cast_c_buf, elems * sizeof(_Float16)) != hipSuccess) {
+        g_fp32cast_c_elems = 0;
+        return nullptr;
+    }
+    g_fp32cast_c_elems = elems;
+    return g_fp32cast_c_buf;
+}
+
 extern "C" int hip_matmul_nbits(
     void* stream,
     const void* A,
@@ -6217,6 +6305,39 @@ extern "C" int hip_matmul_nbits(
   }
 
   if (M <= 0 || N <= 0 || K <= 0 || batch_count <= 0) return 0;
+
+  if (element_size_bytes == 4 && bits != 8) {
+    hipStream_t cast_stream = static_cast<hipStream_t>(stream);
+    const int64_t a_elems = batch_count * M * K;
+    const int64_t c_elems = batch_count * M * N;
+
+    _Float16* a_fp16 = ensureFp32CastABuffer(static_cast<size_t>(a_elems));
+    _Float16* c_fp16 = ensureFp32CastCBuffer(static_cast<size_t>(c_elems));
+    if (!a_fp16 || !c_fp16) {
+      fprintf(stderr,
+              "[custom_kernels] hip_matmul_nbits: fp32 cast scratch alloc failed\n");
+      return -1;
+    }
+
+    launchCastFp32ToFp16(cast_stream, static_cast<const float*>(A), a_fp16, a_elems);
+
+    int rc = hip_matmul_nbits(
+        stream, a_fp16, B, scales, zero_points, bias, c_fp16,
+        M, N, K, batch_count, bits, block_size,
+        /*element_size_bytes=*/2, zp_elem_size,
+        pre_unpacked_zp_u8, pre_unpacked_zp_fp16);
+    if (rc != 0) return rc;
+
+    launchCastFp16ToFp32(cast_stream, c_fp16, static_cast<float*>(output), c_elems);
+
+    hipError_t err = hipGetLastError();
+    if (err != hipSuccess) {
+      fprintf(stderr,
+              "[custom_kernels] hip_matmul_nbits: fp32 cast convert launch failed: %s\n",
+              hipGetErrorString(err));
+    }
+    return static_cast<int>(err);
+  }
 
   if (element_size_bytes != 2) {
     fprintf(stderr,

--- a/lib/Runtime/Kernels/test/example/gemm_fp16u2/Makefile
+++ b/lib/Runtime/Kernels/test/example/gemm_fp16u2/Makefile
@@ -137,6 +137,9 @@ run: direct
 test: gendata direct
 	$(call RUN_CMD,$(TARGET_DIRECT)) $(SIZE) $(GS) $(DATA_DIR) $(CXX_NZ_FLAG)
 
+test_fp32: gendata direct
+	$(call RUN_CMD,$(TARGET_DIRECT)) $(SIZE) $(GS) $(DATA_DIR) $(CXX_NZ_FLAG) --fp32
+
 run_custom: direct
 	$(call RUN_CMD,$(TARGET_DIRECT)) $(ARGS)
 
@@ -169,4 +172,4 @@ bench_decode:
 
 FORCE:
 
-.PHONY: all direct clean run run_custom gendata gendata_model test test_all test_model bench_decode asm FORCE
+.PHONY: all direct clean run run_custom gendata gendata_model test test_fp32 test_all test_model bench_decode asm FORCE

--- a/lib/Runtime/Kernels/test/example/gemm_fp16u2/test_matmul_nbits_u2.cpp
+++ b/lib/Runtime/Kernels/test/example/gemm_fp16u2/test_matmul_nbits_u2.cpp
@@ -461,6 +461,226 @@ static bool benchmarkFp16ZpPath(
 }
 
 // ============================================================
+// FP32 A / FP32 output benchmark + verify (bits=2 native kernel only)
+//
+// Mirrors benchmarkAndVerify above, but d_C is a float* buffer (the
+// phase-1 cast patch's fp32 output path) instead of __half*. The
+// reference stays the on-disk fp16 C_ref -- upcast per-element with
+// half_to_float() before comparing.
+// ============================================================
+static KernelStat benchmarkAndVerifyFp32(
+    const std::string& label,
+    hipStream_t stream,
+    const std::function<int()>& launch_checked,
+    const std::function<void()>& launch,
+    int M, int N, int K,
+    double mem_bytes,
+    float* d_C, size_t countC,
+    const std::vector<__half>& h_C_ref, bool has_ref)
+{
+    KernelStat st;
+    st.label   = label;
+    st.has_ref = has_ref;
+
+    std::cout << "\n  --- " << label << " ---" << std::endl;
+
+    constexpr int PRE_WARMUP = 500;
+    std::cout << "  Pre-warmup (" << PRE_WARMUP << " iters)..." << std::flush;
+    auto pw0 = std::chrono::steady_clock::now();
+    for(int w = 0; w < PRE_WARMUP; w++)
+        launch();
+    HIP_CHECK(hipStreamSynchronize(stream));
+    double pw_ms = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now() - pw0).count() / 1000.0;
+    std::cout << " done (" << std::fixed << std::setprecision(3)
+              << pw_ms / PRE_WARMUP << " ms/iter)" << std::endl;
+
+    std::cout << "  Warmup..." << std::flush;
+    auto tw0 = std::chrono::steady_clock::now();
+    int status = 0;
+    for(int w = 0; w < 3; w++)
+    {
+        status = launch_checked();
+        if(status != 0) break;
+    }
+    HIP_CHECK(hipStreamSynchronize(stream));
+    double warmup_ms = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now() - tw0).count() / 1000.0;
+
+    if(status != 0)
+    {
+        std::cout << " FAILED (status=" << status << ")" << std::endl;
+        return st;
+    }
+
+    int niters = calibrateIters(warmup_ms, 3);
+    std::cout << " OK (" << std::fixed << std::setprecision(2) << warmup_ms
+              << " ms), iters=" << niters << std::endl;
+
+    std::cout << "  Benchmarking (" << NROUNDS << " rounds x " << niters
+              << " iters)..." << std::flush;
+    auto mr = measureMedian(stream, niters, launch);
+    std::cout << " done" << std::endl;
+
+    st.launch_ok = true;
+    st.avg_ms    = mr.median_ms / niters;
+    st.min_ms    = mr.min_ms / niters;
+    st.max_ms    = mr.max_ms / niters;
+    st.gflops    = (2.0 * M * N * K) / (st.avg_ms * 1e6);
+    st.bw_gbs    = mem_bytes * niters / (mr.median_ms * 1e6);
+
+    std::cout << "  Median: " << std::setprecision(6) << st.avg_ms << " ms, "
+              << std::setprecision(2) << st.gflops << " GFLOPS, "
+              << st.bw_gbs << " GB/s   (range " << st.min_ms << " ~ "
+              << st.max_ms << " ms)" << std::endl;
+
+    if(has_ref)
+    {
+        std::vector<float> h_C(countC);
+        HIP_CHECK(hipMemcpy(h_C.data(), d_C, countC * sizeof(float),
+                            hipMemcpyDeviceToHost));
+        int errors = 0;
+        float max_diff = 0.0f, max_rdiff = 0.0f;
+        for(size_t i = 0; i < countC; i++)
+        {
+            float gpu_val = h_C[i];
+            float ref_val = half_to_float(h_C_ref[i]);
+            float diff    = std::fabs(gpu_val - ref_val);
+            float rdiff   = (std::fabs(ref_val) > 1e-6f) ? diff / std::fabs(ref_val) : diff;
+            if(diff > max_diff) max_diff = diff;
+            if(rdiff > max_rdiff) max_rdiff = rdiff;
+            float tol = std::fabs(ref_val) * 0.05f + 0.1f;
+            if(diff > tol) errors++;
+        }
+
+        st.errors    = errors;
+        st.total     = static_cast<int>(countC);
+        st.max_diff  = max_diff;
+        st.max_rdiff = max_rdiff;
+
+        std::cout << "  Verify: " << (st.total - errors) << "/" << st.total
+                  << " OK, max_abs_diff=" << std::setprecision(4) << max_diff
+                  << ", max_rel_diff=" << (max_rdiff * 100.0f) << "%   "
+                  << (errors == 0 ? "PASS" : "FAIL") << std::endl;
+    }
+
+    return st;
+}
+
+// ============================================================
+// FP32 A / FP32 output single-shape test (bits=2 native kernel only)
+//
+// Drives the phase-1 fp32 cast patch (element_size_bytes==4) for bits=2.
+// Reuses the same on-disk fp16 A/B/scales/zeros as the fp16 comparison
+// below -- A is upcast host-side (exact fp16->fp32), so the kernel's
+// internal fp32->fp16 downcast reproduces that exact fp16 A, making the
+// existing fp16 u2 C_ref the correct ground truth here too, just
+// compared through float containers.
+// ============================================================
+bool testFp32Shape(int M, int N, int K, int group_size,
+                   const std::string& data_dir, bool use_zeros)
+{
+    int num_groups_k = (K + group_size - 1) / group_size;
+
+    std::cout << "\n=== MatMulNBits u2 FP32  M=" << M << " N=" << N
+              << " K=" << K << " group_size=" << group_size
+              << (use_zeros ? "" : " (no zeros)") << " ===" << std::endl;
+
+    size_t countA     = static_cast<size_t>(M) * K;
+    size_t countC      = static_cast<size_t>(M) * N;
+    size_t rowBytesU2  = static_cast<size_t>(K) / 4;
+    size_t countB_u2   = static_cast<size_t>(N) * rowBytesU2;
+    size_t countS      = static_cast<size_t>(N) * num_groups_k;
+
+    std::vector<__half> h_A_fp16;
+    if(!readBin(data_dir + "/matmul_nbits_A.bin", h_A_fp16, countA))
+    {
+        std::cerr << "  ERROR: cannot read " << data_dir << "/matmul_nbits_A.bin" << std::endl;
+        return false;
+    }
+    std::vector<float> h_A(countA);
+    for(size_t i = 0; i < countA; i++)
+        h_A[i] = half_to_float(h_A_fp16[i]);
+
+    std::vector<uint8_t> h_B_u2;
+    std::vector<__half>  h_S_u2;
+    std::vector<uint8_t> h_Z_u2_u8;
+    std::vector<__half>  h_Cref_u2;
+    bool ok = readBin(data_dir + "/matmul_nbits_u2_B.bin", h_B_u2, countB_u2)
+           && readBin(data_dir + "/matmul_nbits_u2_scales.bin", h_S_u2, countS);
+    if(use_zeros)
+        ok = ok && readBin(data_dir + "/matmul_nbits_u2_zeros_u8.bin", h_Z_u2_u8, countS);
+    bool has_ref = readBin(data_dir + "/matmul_nbits_u2_C_ref.bin", h_Cref_u2, countC);
+
+    if(!ok)
+    {
+        std::cerr << "  ERROR: failed to read u2 input data from " << data_dir << "/" << std::endl;
+        return false;
+    }
+    std::cout << "  Loaded A (fp32-upcast) + u2 weights from " << data_dir << "/" << std::endl;
+
+    hipStream_t stream;
+    HIP_CHECK(hipStreamCreate(&stream));
+
+    float*   d_A       = nullptr;
+    float*   d_C       = nullptr;
+    uint8_t* d_B_u2    = nullptr;
+    __half*  d_S_u2    = nullptr;
+    uint8_t* d_Z_u2_u8 = nullptr;
+
+    HIP_CHECK(hipMalloc(&d_A, countA * sizeof(float)));
+    HIP_CHECK(hipMalloc(&d_C, countC * sizeof(float)));
+    HIP_CHECK(hipMalloc(&d_B_u2, countB_u2));
+    HIP_CHECK(hipMalloc(&d_S_u2, countS * sizeof(__half)));
+    HIP_CHECK(hipMemcpy(d_A, h_A.data(), countA * sizeof(float), hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemset(d_C, 0, countC * sizeof(float)));
+    HIP_CHECK(hipMemcpy(d_B_u2, h_B_u2.data(), countB_u2, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(d_S_u2, h_S_u2.data(), countS * sizeof(__half), hipMemcpyHostToDevice));
+    if(use_zeros)
+    {
+        HIP_CHECK(hipMalloc(&d_Z_u2_u8, countS));
+        HIP_CHECK(hipMemcpy(d_Z_u2_u8, h_Z_u2_u8.data(), countS, hipMemcpyHostToDevice));
+    }
+
+    auto launch_checked = [&]() -> int {
+        return hip_matmul_nbits(
+            stream, d_A, d_B_u2, d_S_u2,
+            use_zeros ? d_Z_u2_u8 : nullptr,
+            nullptr,           // bias
+            d_C,
+            M, N, K,
+            1,                 // batch_count
+            2,                 // bits
+            group_size,        // block_size
+            4,                 // element_size_bytes (fp32)
+            1,                 // zp_elem_size (uint8, one byte per group)
+            nullptr,           // pre_unpacked_zp_u8 (direct convention)
+            nullptr);          // pre_unpacked_zp_fp16 (unused for bits=2)
+    };
+    auto launch = [&]() { launch_checked(); };
+
+    double mem_bytes = static_cast<double>(countA) * 4 + static_cast<double>(countB_u2)
+                      + static_cast<double>(countS) * 2
+                      + (use_zeros ? static_cast<double>(countS) : 0.0)
+                      + static_cast<double>(countC) * 4;
+
+    KernelStat st = benchmarkAndVerifyFp32(
+        "u2(fp32)", stream, launch_checked, launch, M, N, K,
+        mem_bytes, d_C, countC, h_Cref_u2, has_ref);
+
+    bool pass = st.launch_ok && (!st.has_ref || st.errors == 0);
+
+    hipFree(d_A);
+    hipFree(d_C);
+    hipFree(d_B_u2);
+    hipFree(d_S_u2);
+    if(d_Z_u2_u8) hipFree(d_Z_u2_u8);
+    hipStreamDestroy(stream);
+
+    return pass;
+}
+
+// ============================================================
 // Single-shape comparison test
 // ============================================================
 bool testCompareShape(int M, int N, int K, int group_size,
@@ -868,32 +1088,39 @@ int main(int argc, char* argv[])
     int M = 128, N = 128, K = 128, gs = 128;
     std::string data_dir = "data";
     bool use_zeros = true;
+    bool fp32_mode = false;
 
     for(int i = 1; i < argc; i++)
     {
         if(std::string(argv[i]) == "--no-zeros")
             use_zeros = false;
+        else if(std::string(argv[i]) == "--fp32")
+            fp32_mode = true;
     }
 
-    if(argc >= 2 && std::string(argv[1]) != "--no-zeros")
+    if(argc >= 2 && std::string(argv[1]) != "--no-zeros" && std::string(argv[1]) != "--fp32")
     {
         if(sscanf(argv[1], "%dx%dx%d", &M, &K, &N) != 3)
         {
             std::cerr << "Usage: " << argv[0]
-                      << " [MxKxN] [group_size] [data_dir] [--no-zeros]" << std::endl;
+                      << " [MxKxN] [group_size] [data_dir] [--no-zeros] [--fp32]" << std::endl;
             std::cerr << "       " << argv[0]
                       << " --model <json> [--data-root DIR] [--group-size GS] [--no-zeros]" << std::endl;
             return 1;
         }
     }
-    if(argc >= 3 && std::string(argv[2]) != "--no-zeros") gs = atoi(argv[2]);
-    if(argc >= 4 && std::string(argv[3]) != "--no-zeros") data_dir = argv[3];
+    if(argc >= 3 && std::string(argv[2]) != "--no-zeros" && std::string(argv[2]) != "--fp32") gs = atoi(argv[2]);
+    if(argc >= 4 && std::string(argv[3]) != "--no-zeros" && std::string(argv[3]) != "--fp32") data_dir = argv[3];
 
     std::cout << "Data dir: " << data_dir << std::endl;
     if(!use_zeros)
         std::cout << "Zero points: disabled (--no-zeros)" << std::endl;
+    if(fp32_mode)
+        std::cout << "Mode: FP32 A / FP32 output (element_size_bytes=4, bits=2)" << std::endl;
 
-    bool all_pass = testCompareShape(M, N, K, gs, data_dir, use_zeros);
+    bool all_pass = fp32_mode
+        ? testFp32Shape(M, N, K, gs, data_dir, use_zeros)
+        : testCompareShape(M, N, K, gs, data_dir, use_zeros);
 
     std::cout << "\n==========================================================================" << std::endl;
     std::cout << "Overall: " << (all_pass ? "ALL PASSED" : "SOME FAILED") << std::endl;

--- a/lib/Runtime/Kernels/test/example/gemm_fp16u3/Makefile
+++ b/lib/Runtime/Kernels/test/example/gemm_fp16u3/Makefile
@@ -43,6 +43,7 @@ endif
 HIPCC       := $(HIP_SDK)/bin/hipcc.exe
 INCLUDE_DIR := ../../../include
 KERNEL_HIP  := ../../../hip/matmul_nbits_kernel.hip
+AUTOTUNE_DIR := ../../../hip/autotune/matmul_nbits
 
 TARGET_DIRECT := $(BUILD_DIR)/test_direct.exe
 
@@ -110,7 +111,7 @@ DIRECT_TEST_OBJ   := $(BUILD_DIR)/direct_test.obj
 DIRECT_KERNEL_OBJ := $(BUILD_DIR)/direct_kernel.obj
 
 direct: FORCE | $(BUILD_DIR)
-	$(HIPCC) -c $(CXXFLAGS) $(OFFLOAD) $(INCLUDES) -x hip test_matmul_nbits_u3.cpp -o $(DIRECT_TEST_OBJ)
+	$(HIPCC) -c $(CXXFLAGS) $(OFFLOAD) $(INCLUDES) -I$(AUTOTUNE_DIR) -x hip test_matmul_nbits_u3.cpp -o $(DIRECT_TEST_OBJ)
 	$(HIPCC) -c $(KERNEL_FLAGS) $(OFFLOAD) $(INCLUDES) $(KERNEL_HIP) -o $(DIRECT_KERNEL_OBJ)
 	$(HIPCC) $(OFFLOAD) $(DIRECT_TEST_OBJ) $(DIRECT_KERNEL_OBJ) -o $(TARGET_DIRECT)
 
@@ -129,6 +130,9 @@ run: direct
 
 test: gendata direct
 	$(call RUN_CMD,$(TARGET_DIRECT)) $(SIZE) $(GS) $(DATA_DIR) $(CXX_NZ_FLAG)
+
+test_fp32: gendata direct
+	$(call RUN_CMD,$(TARGET_DIRECT)) $(SIZE) $(GS) $(DATA_DIR) $(CXX_NZ_FLAG) --fp32
 
 run_custom: direct
 	$(call RUN_CMD,$(TARGET_DIRECT)) $(ARGS)
@@ -164,4 +168,4 @@ bench_decode:
 
 FORCE:
 
-.PHONY: all direct clean run run_custom gendata gendata_model test test_all test_model bench_decode asm FORCE
+.PHONY: all direct clean run run_custom gendata gendata_model test test_fp32 test_all test_model bench_decode asm FORCE

--- a/lib/Runtime/Kernels/test/example/gemm_fp16u3/test_matmul_nbits_u3.cpp
+++ b/lib/Runtime/Kernels/test/example/gemm_fp16u3/test_matmul_nbits_u3.cpp
@@ -35,6 +35,17 @@
 #include <hip/hip_runtime.h>
 #include <hip/hip_fp16.h>
 #include "hip_custom_kernels.h"
+#include "matmul_nbits_autotune.h"
+
+// Example `make direct` has no CMake FlatBuffers LUT. Empty resolve()
+// lets the kernel link and fall back to its runtime sweep.
+namespace hipdnn_ep {
+namespace matmul_nbits_autotune {
+Result resolve(const Request&, WmmaValidator, GemvValidator, void*) { return {}; }
+Stats stats() { return {}; }
+}  // namespace matmul_nbits_autotune
+}  // namespace hipdnn_ep
+
 #include <iostream>
 #include <fstream>
 #include <vector>
@@ -380,6 +391,226 @@ static bool benchmarkPackedZpPath(
 
     hipFree(d_Z_unpacked);
     return unpack_ok && st.launch_ok && (!has_ref || st.errors == 0);
+}
+
+// ============================================================
+// FP32 A / FP32 output benchmark + verify (bits=3 native kernel only)
+//
+// Mirrors benchmarkAndVerify above, but d_C is a float* buffer (the
+// phase-1 cast patch's fp32 output path) instead of __half*. The
+// reference stays the on-disk fp16 C_ref -- upcast per-element with
+// half_to_float() before comparing.
+// ============================================================
+static KernelStat benchmarkAndVerifyFp32(
+    const std::string& label,
+    hipStream_t stream,
+    const std::function<int()>& launch_checked,
+    const std::function<void()>& launch,
+    int M, int N, int K,
+    double mem_bytes,
+    float* d_C, size_t countC,
+    const std::vector<__half>& h_C_ref, bool has_ref)
+{
+    KernelStat st;
+    st.label   = label;
+    st.has_ref = has_ref;
+
+    std::cout << "\n  --- " << label << " ---" << std::endl;
+
+    constexpr int PRE_WARMUP = 500;
+    std::cout << "  Pre-warmup (" << PRE_WARMUP << " iters)..." << std::flush;
+    auto pw0 = std::chrono::steady_clock::now();
+    for(int w = 0; w < PRE_WARMUP; w++)
+        launch();
+    HIP_CHECK(hipStreamSynchronize(stream));
+    double pw_ms = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now() - pw0).count() / 1000.0;
+    std::cout << " done (" << std::fixed << std::setprecision(3)
+              << pw_ms / PRE_WARMUP << " ms/iter)" << std::endl;
+
+    std::cout << "  Warmup..." << std::flush;
+    auto tw0 = std::chrono::steady_clock::now();
+    int status = 0;
+    for(int w = 0; w < 3; w++)
+    {
+        status = launch_checked();
+        if(status != 0) break;
+    }
+    HIP_CHECK(hipStreamSynchronize(stream));
+    double warmup_ms = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now() - tw0).count() / 1000.0;
+
+    if(status != 0)
+    {
+        std::cout << " FAILED (status=" << status << ")" << std::endl;
+        return st;
+    }
+
+    int niters = calibrateIters(warmup_ms, 3);
+    std::cout << " OK (" << std::fixed << std::setprecision(2) << warmup_ms
+              << " ms), iters=" << niters << std::endl;
+
+    std::cout << "  Benchmarking (" << NROUNDS << " rounds x " << niters
+              << " iters)..." << std::flush;
+    auto mr = measureMedian(stream, niters, launch);
+    std::cout << " done" << std::endl;
+
+    st.launch_ok = true;
+    st.avg_ms    = mr.median_ms / niters;
+    st.min_ms    = mr.min_ms / niters;
+    st.max_ms    = mr.max_ms / niters;
+    st.gflops    = (2.0 * M * N * K) / (st.avg_ms * 1e6);
+    st.bw_gbs    = mem_bytes * niters / (mr.median_ms * 1e6);
+
+    std::cout << "  Median: " << std::setprecision(6) << st.avg_ms << " ms, "
+              << std::setprecision(2) << st.gflops << " GFLOPS, "
+              << st.bw_gbs << " GB/s   (range " << st.min_ms << " ~ "
+              << st.max_ms << " ms)" << std::endl;
+
+    if(has_ref)
+    {
+        std::vector<float> h_C(countC);
+        HIP_CHECK(hipMemcpy(h_C.data(), d_C, countC * sizeof(float),
+                            hipMemcpyDeviceToHost));
+        int errors = 0;
+        float max_diff = 0.0f, max_rdiff = 0.0f;
+        for(size_t i = 0; i < countC; i++)
+        {
+            float gpu_val = h_C[i];
+            float ref_val = half_to_float(h_C_ref[i]);
+            float diff    = std::fabs(gpu_val - ref_val);
+            float rdiff   = (std::fabs(ref_val) > 1e-6f) ? diff / std::fabs(ref_val) : diff;
+            if(diff > max_diff) max_diff = diff;
+            if(rdiff > max_rdiff) max_rdiff = rdiff;
+            float tol = std::fabs(ref_val) * 0.05f + 0.1f;
+            if(diff > tol) errors++;
+        }
+
+        st.errors    = errors;
+        st.total     = static_cast<int>(countC);
+        st.max_diff  = max_diff;
+        st.max_rdiff = max_rdiff;
+
+        std::cout << "  Verify: " << (st.total - errors) << "/" << st.total
+                  << " OK, max_abs_diff=" << std::setprecision(4) << max_diff
+                  << ", max_rel_diff=" << (max_rdiff * 100.0f) << "%   "
+                  << (errors == 0 ? "PASS" : "FAIL") << std::endl;
+    }
+
+    return st;
+}
+
+// ============================================================
+// FP32 A / FP32 output single-shape test (bits=3 native kernel only)
+//
+// Drives the phase-1 fp32 cast patch (element_size_bytes==4) for bits=3.
+// Reuses the same on-disk fp16 A/B/scales/zeros as the fp16 comparison
+// below -- A is upcast host-side (exact fp16->fp32), so the kernel's
+// internal fp32->fp16 downcast reproduces that exact fp16 A, making the
+// existing fp16 u3 C_ref the correct ground truth here too, just
+// compared through float containers.
+// ============================================================
+bool testFp32Shape(int M, int N, int K, int group_size,
+                   const std::string& data_dir, bool use_zeros)
+{
+    int num_groups_k = (K + group_size - 1) / group_size;
+
+    std::cout << "\n=== MatMulNBits u3 FP32  M=" << M << " N=" << N
+              << " K=" << K << " group_size=" << group_size
+              << (use_zeros ? "" : " (no zeros)") << " ===" << std::endl;
+
+    size_t countA     = static_cast<size_t>(M) * K;
+    size_t countC      = static_cast<size_t>(M) * N;
+    size_t rowBytesU3  = (static_cast<size_t>(K) * 3 + 7) / 8;
+    size_t countB_u3   = static_cast<size_t>(N) * rowBytesU3;
+    size_t countS      = static_cast<size_t>(N) * num_groups_k;
+
+    std::vector<__half> h_A_fp16;
+    if(!readBin(data_dir + "/matmul_nbits_A.bin", h_A_fp16, countA))
+    {
+        std::cerr << "  ERROR: cannot read " << data_dir << "/matmul_nbits_A.bin" << std::endl;
+        return false;
+    }
+    std::vector<float> h_A(countA);
+    for(size_t i = 0; i < countA; i++)
+        h_A[i] = half_to_float(h_A_fp16[i]);
+
+    std::vector<uint8_t> h_B_u3;
+    std::vector<__half>  h_S_u3;
+    std::vector<uint8_t> h_Z_u3;
+    std::vector<__half>  h_Cref_u3;
+    bool ok = readBin(data_dir + "/matmul_nbits_u3_B.bin", h_B_u3, countB_u3)
+           && readBin(data_dir + "/matmul_nbits_u3_scales.bin", h_S_u3, countS);
+    if(use_zeros)
+        ok = ok && readBin(data_dir + "/matmul_nbits_u3_zeros.bin", h_Z_u3, countS);
+    bool has_ref = readBin(data_dir + "/matmul_nbits_u3_C_ref.bin", h_Cref_u3, countC);
+
+    if(!ok)
+    {
+        std::cerr << "  ERROR: failed to read u3 input data from " << data_dir << "/" << std::endl;
+        return false;
+    }
+    std::cout << "  Loaded A (fp32-upcast) + u3 weights from " << data_dir << "/" << std::endl;
+
+    hipStream_t stream;
+    HIP_CHECK(hipStreamCreate(&stream));
+
+    float*   d_A    = nullptr;
+    float*   d_C    = nullptr;
+    uint8_t* d_B_u3 = nullptr;
+    __half*  d_S_u3 = nullptr;
+    uint8_t* d_Z_u3 = nullptr;
+
+    HIP_CHECK(hipMalloc(&d_A, countA * sizeof(float)));
+    HIP_CHECK(hipMalloc(&d_C, countC * sizeof(float)));
+    HIP_CHECK(hipMalloc(&d_B_u3, countB_u3));
+    HIP_CHECK(hipMalloc(&d_S_u3, countS * sizeof(__half)));
+    HIP_CHECK(hipMemcpy(d_A, h_A.data(), countA * sizeof(float), hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemset(d_C, 0, countC * sizeof(float)));
+    HIP_CHECK(hipMemcpy(d_B_u3, h_B_u3.data(), countB_u3, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(d_S_u3, h_S_u3.data(), countS * sizeof(__half), hipMemcpyHostToDevice));
+    if(use_zeros)
+    {
+        HIP_CHECK(hipMalloc(&d_Z_u3, countS));
+        HIP_CHECK(hipMemcpy(d_Z_u3, h_Z_u3.data(), countS, hipMemcpyHostToDevice));
+    }
+
+    auto launch_checked = [&]() -> int {
+        return hip_matmul_nbits(
+            stream, d_A, d_B_u3, d_S_u3,
+            use_zeros ? d_Z_u3 : nullptr,
+            nullptr,           // bias
+            d_C,
+            M, N, K,
+            1,                 // batch_count
+            3,                 // bits
+            group_size,        // block_size
+            4,                 // element_size_bytes (fp32)
+            1,                 // zp_elem_size (uint8, plain per-element)
+            nullptr,           // pre_unpacked_zp_u8 (unused for bits=3)
+            nullptr);          // pre_unpacked_zp_fp16 (unused for bits=3)
+    };
+    auto launch = [&]() { launch_checked(); };
+
+    double mem_bytes = static_cast<double>(countA) * 4 + static_cast<double>(countB_u3)
+                      + static_cast<double>(countS) * 2
+                      + (use_zeros ? static_cast<double>(countS) : 0.0)
+                      + static_cast<double>(countC) * 4;
+
+    KernelStat st = benchmarkAndVerifyFp32(
+        "u3(fp32)", stream, launch_checked, launch, M, N, K,
+        mem_bytes, d_C, countC, h_Cref_u3, has_ref);
+
+    bool pass = st.launch_ok && (!st.has_ref || st.errors == 0);
+
+    hipFree(d_A);
+    hipFree(d_C);
+    hipFree(d_B_u3);
+    hipFree(d_S_u3);
+    if(d_Z_u3) hipFree(d_Z_u3);
+    hipStreamDestroy(stream);
+
+    return pass;
 }
 
 // ============================================================
@@ -763,32 +994,39 @@ int main(int argc, char* argv[])
     int M = 128, N = 128, K = 128, gs = 128;
     std::string data_dir = "data";
     bool use_zeros = true;
+    bool fp32_mode = false;
 
     for(int i = 1; i < argc; i++)
     {
         if(std::string(argv[i]) == "--no-zeros")
             use_zeros = false;
+        else if(std::string(argv[i]) == "--fp32")
+            fp32_mode = true;
     }
 
-    if(argc >= 2 && std::string(argv[1]) != "--no-zeros")
+    if(argc >= 2 && std::string(argv[1]) != "--no-zeros" && std::string(argv[1]) != "--fp32")
     {
         if(sscanf(argv[1], "%dx%dx%d", &M, &K, &N) != 3)
         {
             std::cerr << "Usage: " << argv[0]
-                      << " [MxKxN] [group_size] [data_dir] [--no-zeros]" << std::endl;
+                      << " [MxKxN] [group_size] [data_dir] [--no-zeros] [--fp32]" << std::endl;
             std::cerr << "       " << argv[0]
                       << " --model <json> [--data-root DIR] [--group-size GS] [--no-zeros]" << std::endl;
             return 1;
         }
     }
-    if(argc >= 3 && std::string(argv[2]) != "--no-zeros") gs = atoi(argv[2]);
-    if(argc >= 4 && std::string(argv[3]) != "--no-zeros") data_dir = argv[3];
+    if(argc >= 3 && std::string(argv[2]) != "--no-zeros" && std::string(argv[2]) != "--fp32") gs = atoi(argv[2]);
+    if(argc >= 4 && std::string(argv[3]) != "--no-zeros" && std::string(argv[3]) != "--fp32") data_dir = argv[3];
 
     std::cout << "Data dir: " << data_dir << std::endl;
     if(!use_zeros)
         std::cout << "Zero points: disabled (--no-zeros)" << std::endl;
+    if(fp32_mode)
+        std::cout << "Mode: FP32 A / FP32 output (element_size_bytes=4, bits=3)" << std::endl;
 
-    bool all_pass = testCompareShape(M, N, K, gs, data_dir, use_zeros);
+    bool all_pass = fp32_mode
+        ? testFp32Shape(M, N, K, gs, data_dir, use_zeros)
+        : testCompareShape(M, N, K, gs, data_dir, use_zeros);
 
     std::cout << "\n==========================================================================" << std::endl;
     std::cout << "Overall: " << (all_pass ? "ALL PASSED" : "SOME FAILED") << std::endl;

--- a/lib/Runtime/Kernels/test/example/gemm_fp16u4/test_matmul_nbits.cpp
+++ b/lib/Runtime/Kernels/test/example/gemm_fp16u4/test_matmul_nbits.cpp
@@ -24,6 +24,17 @@
 #include <hip/hip_runtime.h>
 #include <hip/hip_fp16.h>
 #include "hip_custom_kernels.h"
+#include "matmul_nbits_autotune.h"
+
+// Example `make direct` has no CMake FlatBuffers LUT. Empty resolve()
+// lets the kernel link and fall back to its runtime sweep.
+namespace hipdnn_ep {
+namespace matmul_nbits_autotune {
+Result resolve(const Request&, WmmaValidator, GemvValidator, void*) { return {}; }
+Stats stats() { return {}; }
+}  // namespace matmul_nbits_autotune
+}  // namespace hipdnn_ep
+
 #include <iostream>
 #include <fstream>
 #include <vector>
@@ -571,6 +582,250 @@ bool test_matmul_nbits(int M, int N, int K, int group_size,
 }
 
 // ============================================================
+// FP32 A / FP32 output test: drives the phase-1 fp32 cast patch
+// (element_size_bytes==4, bits=4) in hip_matmul_nbits. A is upcast
+// host-side from the same on-disk fp16 A (exact fp16->fp32), so the
+// kernel's internal fp32->fp16 downcast reproduces that exact fp16 A --
+// the existing fp16 C_ref is therefore still the correct ground truth,
+// just compared through float containers.
+// ============================================================
+bool test_matmul_nbits_fp32(int M, int N, int K, int group_size,
+                            const std::string& data_dir, bool use_zeros,
+                            const TestFiles& tf = TestFiles{})
+{
+    int num_groups_k = (K + group_size - 1) / group_size;
+
+    std::cout << "\n=== Test MatMulNBits FP32 M=" << M << " N=" << N << " K=" << K
+              << " group_size=" << group_size
+              << (use_zeros ? "" : " (no zeros)") << " ===" << std::endl;
+
+    std::string fA = data_dir + "/" + tf.a;
+    std::string fB = data_dir + "/" + tf.b;
+    std::string fS = data_dir + "/" + tf.s;
+    std::string fZ = data_dir + "/" + tf.z;
+    std::string fC = data_dir + "/" + tf.c_ref;
+
+    std::vector<__half>  h_A_fp16;
+    std::vector<uint8_t> h_B_packed;
+    std::vector<__half>  h_scales;
+    std::vector<__half>  h_zeros;
+
+    size_t countA = static_cast<size_t>(M) * K;
+    size_t countB = static_cast<size_t>(N) * num_groups_k * (group_size / 2);
+    size_t countS = static_cast<size_t>(N) * num_groups_k;
+    size_t countZ = static_cast<size_t>(N) * num_groups_k;
+    size_t countC = static_cast<size_t>(M) * N;
+
+    bool data_ok = readBin(fA, h_A_fp16, countA) &&
+                   readBin(fB, h_B_packed, countB) &&
+                   readBin(fS, h_scales, countS);
+    if(use_zeros)
+        data_ok = data_ok && readBin(fZ, h_zeros, countZ);
+
+    if(!data_ok)
+    {
+        std::cerr << "  ERROR: Failed to read input data files from " << data_dir << "/" << std::endl;
+        return false;
+    }
+    std::cout << "  Loaded input data from " << data_dir << "/" << std::endl;
+
+    std::vector<float> h_A(countA);
+    for(size_t i = 0; i < countA; i++)
+        h_A[i] = half_to_float(h_A_fp16[i]);
+
+    std::vector<__half> h_C_ref;
+    bool has_ref = readBin(fC, h_C_ref, countC);
+    if(!has_ref)
+        std::cout << "  WARNING: No reference file (" << fC << "), skipping verification." << std::endl;
+
+    float*   d_A        = nullptr;
+    uint8_t* d_B_packed = nullptr;
+    __half*  d_scales   = nullptr;
+    __half*  d_zeros    = nullptr;
+    float*   d_C        = nullptr;
+
+    size_t size_A      = countA * sizeof(float);
+    size_t size_B      = countB;
+    size_t size_scales = countS * sizeof(__half);
+    size_t size_zeros  = countZ * sizeof(__half);
+    size_t size_C      = countC * sizeof(float);
+
+    HIP_CHECK(hipMalloc(&d_A, size_A));
+    HIP_CHECK(hipMalloc(&d_B_packed, size_B));
+    HIP_CHECK(hipMalloc(&d_scales, size_scales));
+    if(use_zeros)
+    {
+        HIP_CHECK(hipMalloc(&d_zeros, size_zeros));
+    }
+    HIP_CHECK(hipMalloc(&d_C, size_C));
+
+    HIP_CHECK(hipMemcpy(d_A, h_A.data(), size_A, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(d_B_packed, h_B_packed.data(), size_B, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(d_scales, h_scales.data(), size_scales, hipMemcpyHostToDevice));
+    if(use_zeros)
+    {
+        HIP_CHECK(hipMemcpy(d_zeros, h_zeros.data(), size_zeros, hipMemcpyHostToDevice));
+    }
+    HIP_CHECK(hipMemset(d_C, 0, size_C));
+
+    hipStream_t stream;
+    HIP_CHECK(hipStreamCreate(&stream));
+
+    auto launch_kernel = [&]() {
+        hip_matmul_nbits(
+            stream,
+            d_A,
+            d_B_packed,
+            d_scales,
+            use_zeros ? d_zeros : nullptr,
+            nullptr,   // no bias
+            d_C,
+            M, N, K,
+            1,         // batch_count
+            4,         // bits
+            group_size,// block_size
+            4,         // element_size_bytes (fp32)
+            2,         // zp_elem_size (fp16 zero_points, used as-is)
+            nullptr,   // pre_unpacked_zp_u8 (unused, zp_elem_size==2)
+            nullptr);  // pre_unpacked_zp_fp16 (unused, zero_points is already fp16)
+    };
+
+    constexpr int PRE_WARMUP = 2000;
+    std::cout << "  Pre-warmup (" << PRE_WARMUP << " iters)..." << std::flush;
+    auto pw0 = std::chrono::steady_clock::now();
+    for(int w = 0; w < PRE_WARMUP; w++)
+        launch_kernel();
+    HIP_CHECK(hipStreamSynchronize(stream));
+    double pw_ms = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now() - pw0).count() / 1000.0;
+    std::cout << " done (" << std::fixed << std::setprecision(0) << pw_ms << " ms, "
+              << std::setprecision(3) << pw_ms / PRE_WARMUP << " ms/iter)" << std::endl;
+
+    std::cout << "  Warmup..." << std::flush;
+    auto tw0 = std::chrono::steady_clock::now();
+    int status = 0;
+    for(int w = 0; w < 3; w++)
+    {
+        status = hip_matmul_nbits(
+            stream,
+            d_A,
+            d_B_packed,
+            d_scales,
+            use_zeros ? d_zeros : nullptr,
+            nullptr,
+            d_C,
+            M, N, K,
+            1, 4, group_size, 4, 2, nullptr, nullptr);
+        if(status != 0) break;
+    }
+    HIP_CHECK(hipStreamSynchronize(stream));
+    auto tw1 = std::chrono::steady_clock::now();
+    double warmup_ms =
+        std::chrono::duration_cast<std::chrono::microseconds>(tw1 - tw0).count() / 1000.0;
+
+    if(status != 0)
+    {
+        std::cout << " FAILED (status=" << status << ")" << std::endl;
+        hipFree(d_A);
+        hipFree(d_B_packed);
+        hipFree(d_scales);
+        if(d_zeros) hipFree(d_zeros);
+        hipFree(d_C);
+        hipStreamDestroy(stream);
+        return false;
+    }
+
+    int niters = calibrateIters(warmup_ms, 3);
+    std::cout << " OK (" << std::fixed << std::setprecision(2) << warmup_ms
+              << " ms), iters=" << niters << std::endl;
+
+    std::cout << "  Benchmarking (" << NROUNDS << " rounds x " << niters << " iters)..."
+              << std::flush;
+    auto mr = measureMedian(stream, niters, launch_kernel);
+
+    double avg_ms    = mr.median_ms / niters;
+    double gflops    = (2.0 * M * N * K) / (avg_ms * 1e6);
+    double mem_bytes = static_cast<double>(countA) * 4 + static_cast<double>(countB)
+                     + static_cast<double>(countS) * 2
+                     + (use_zeros ? static_cast<double>(countZ) * 2 : 0.0)
+                     + static_cast<double>(countC) * 4;
+    double bw_gbs    = mem_bytes * niters / (mr.median_ms * 1e6);
+    double range_pct = (mr.max_ms - mr.min_ms) / mr.median_ms * 100.0;
+
+    std::cout << " done" << std::endl;
+    std::cout << "\n  === Performance ===" << std::endl;
+    std::cout << std::fixed << std::setprecision(3);
+    std::cout << "  Median: "
+              << std::setprecision(6) << avg_ms << " ms, "
+              << gflops << " GFLOPS, "
+              << bw_gbs << " GB/s" << std::endl;
+    std::cout << "  Range:  " << mr.min_ms / niters << " ~ " << mr.max_ms / niters
+              << " ms  (jitter " << std::setprecision(1) << range_pct << "%)" << std::endl;
+
+    std::vector<float> h_C(countC);
+    HIP_CHECK(hipMemcpy(h_C.data(), d_C, size_C, hipMemcpyDeviceToHost));
+
+    bool pass = true;
+
+    if(has_ref)
+    {
+        int errors      = 0;
+        int total        = M * N;
+        float max_diff  = 0.0f;
+        float max_rdiff = 0.0f;
+
+        for(int i = 0; i < total; i++)
+        {
+            float gpu_val = h_C[i];
+            float ref_val = half_to_float(h_C_ref[i]);
+            float diff    = std::fabs(gpu_val - ref_val);
+            float rdiff   = (std::fabs(ref_val) > 1e-6f) ? diff / std::fabs(ref_val) : diff;
+
+            if(diff > max_diff) max_diff = diff;
+            if(rdiff > max_rdiff) max_rdiff = rdiff;
+
+            float tol = std::fabs(ref_val) * 0.05f + 0.1f;
+            if(diff > tol)
+                errors++;
+        }
+
+        std::cout << "\n  === GPU vs Python Reference ===" << std::endl;
+        std::cout << "  Verified " << total << " elements, " << errors << " errors" << std::endl;
+        std::cout << "  Max abs diff: " << max_diff << ", max rel diff: "
+                  << std::fixed << std::setprecision(4) << (max_rdiff * 100.0f) << "%" << std::endl;
+
+        std::cout << "  Sample C values (GPU vs Python):" << std::endl;
+        for(int i = 0; i < 5 && i < total; i++)
+        {
+            float gpu_val = h_C[i];
+            float ref_val = half_to_float(h_C_ref[i]);
+            std::cout << "    [" << i << "] GPU=" << std::setprecision(6) << gpu_val
+                      << "  Ref=" << ref_val
+                      << "  diff=" << std::fabs(gpu_val - ref_val) << std::endl;
+        }
+
+        pass = (errors == 0);
+        std::cout << "  Result: " << (pass ? "PASSED" : "FAILED") << std::endl;
+    }
+    else
+    {
+        std::cout << "  GPU output sample:" << std::endl;
+        int total = M * N;
+        for(int i = 0; i < 5 && i < total; i++)
+            std::cout << "    [" << i << "] = " << h_C[i] << std::endl;
+    }
+
+    hipFree(d_A);
+    hipFree(d_B_packed);
+    hipFree(d_scales);
+    if(d_zeros) hipFree(d_zeros);
+    hipFree(d_C);
+    hipStreamDestroy(stream);
+
+    return pass;
+}
+
+// ============================================================
 // Model sweep: pre-warmup once, then benchmark + verify all shapes
 // ============================================================
 
@@ -902,19 +1157,22 @@ int main(int argc, char* argv[])
     int M = 128, N = 128, K = 128, gs = 128;
     std::string data_dir = "data";
     bool use_zeros = true;
+    bool fp32_mode = false;
 
     for(int i = 1; i < argc; i++)
     {
         if(std::string(argv[i]) == "--no-zeros")
             use_zeros = false;
+        else if(std::string(argv[i]) == "--fp32")
+            fp32_mode = true;
     }
 
-    if(argc >= 2 && std::string(argv[1]) != "--no-zeros")
+    if(argc >= 2 && std::string(argv[1]) != "--no-zeros" && std::string(argv[1]) != "--fp32")
     {
         if(sscanf(argv[1], "%dx%dx%d", &M, &K, &N) != 3)
         {
             std::cerr << "Usage: " << argv[0]
-                      << " [MxKxN] [group_size] [data_dir] [--no-zeros]" << std::endl;
+                      << " [MxKxN] [group_size] [data_dir] [--no-zeros] [--fp32]" << std::endl;
             std::cerr << "       " << argv[0]
                       << " --true-data <folder>" << std::endl;
             std::cerr << "       " << argv[0]
@@ -922,15 +1180,19 @@ int main(int argc, char* argv[])
             return 1;
         }
     }
-    if(argc >= 3 && std::string(argv[2]) != "--no-zeros") gs = atoi(argv[2]);
-    if(argc >= 4 && std::string(argv[3]) != "--no-zeros") data_dir = argv[3];
+    if(argc >= 3 && std::string(argv[2]) != "--no-zeros" && std::string(argv[2]) != "--fp32") gs = atoi(argv[2]);
+    if(argc >= 4 && std::string(argv[3]) != "--no-zeros" && std::string(argv[3]) != "--fp32") data_dir = argv[3];
 
     std::cout << "Data dir: " << data_dir << std::endl;
     if(!use_zeros)
         std::cout << "Zero points: disabled (--no-zeros)" << std::endl;
+    if(fp32_mode)
+        std::cout << "Mode: FP32 A / FP32 output (element_size_bytes=4)" << std::endl;
 
     bool all_pass = true;
-    all_pass &= test_matmul_nbits(M, N, K, gs, data_dir, use_zeros);
+    all_pass &= fp32_mode
+        ? test_matmul_nbits_fp32(M, N, K, gs, data_dir, use_zeros)
+        : test_matmul_nbits(M, N, K, gs, data_dir, use_zeros);
 
     std::cout << "\n==========================================================================" << std::endl;
     std::cout << "Overall: " << (all_pass ? "ALL PASSED" : "SOME FAILED") << std::endl;


### PR DESCRIPTION
## Summary

MatMulNBits kernels (u2/u3/u4) previously required fp16 activations. This PR
adds transparent fp32 input/output support by inserting device-side cast
buffers around the existing fp16 dispatch path.

### Changes

**`matmul_nbits_kernel.hip`**
- When `element_size_bytes == 4` and `bits ∈ {2, 3, 4}`, allocate scratch
  buffers and launch a vectorised `float2→half2` cast kernel before the
  existing fp16 dispatch, then cast `C` back to fp32 afterwards.
- Scratch buffers are grown/reused from existing allocations; no extra
  `hipMalloc` per call.
- fp16 fast-path is unchanged. `bits=8` still rejects non-fp16.

**`test/example/gemm_fp16u2,u3,u4`**
- Add `--fp32` flag / `test_fp32` target; validates fp32 output against the
  dequant-to-fp16 reference.
- u3 example adds a stub `resolve()` so the kernel links without FlatBuffers.

## Test plan

- [ ] `make test_fp32` passes in gemm_fp16u2, gemm_fp16u3, gemm_fp16u4 examples
- [ ] Existing `make test` (fp16 path) unaffected
- [ ] Checked that `bits=8` fp32 input is still rejected
