### PR TITLE
feat(onnx-to-hip): canonicalize Microsoft Custom QuantizeLinear/DequantizeLinear

### DIFF
--- a/lib/Conversion/OnnxToHip/OnnxToHip.cpp
+++ b/lib/Conversion/OnnxToHip/OnnxToHip.cpp
@@ -477,6 +477,18 @@ void ConvertOnnxToHipPass::runOnOperation() {
     return signalPassFailure();
   logSubpass("metadata");
 
+  // MorphiZen may import com.microsoft Q/DQ function ops as onnx.Custom.
+  // Normalize them before PDLL so the existing native-ONNX QDQ fusion patterns
+  // can match the graph.
+  {
+    mlir::RewritePatternSet customQdqPatterns(ctx);
+    populateCustomQdqCanonicalizationPatterns(customQdqPatterns, ctx);
+    if (mlir::failed(
+            mlir::applyPatternsGreedily(module, std::move(customQdqPatterns))))
+      return signalPassFailure();
+  }
+  logSubpass("custom QDQ canonicalization");
+
   const std::string pdlFusionFile =
       (std::filesystem::path(dll_path()).parent_path() /
        "HipFusionPatterns.pdl.mlir")

--- a/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
+++ b/lib/Conversion/OnnxToHip/OnnxToHipUtils.h
@@ -470,6 +470,11 @@ void populateFlattenConversionPatterns(RewritePatternSet &patterns,
 void populateQdqConversionPatterns(RewritePatternSet &patterns,
                                    MLIRContext *ctx);
 
+/// Canonicalize com.microsoft QuantizeLinear / DequantizeLinear represented as
+/// onnx.Custom into native ONNX QDQ ops. Must run before the PDLL fusion pass.
+void populateCustomQdqCanonicalizationPatterns(RewritePatternSet &patterns,
+                                               MLIRContext *ctx);
+
 /// Pre-lowering pattern set: fold `Transpose(perm=[..,r,r-2])` into a
 /// consuming `onnx.MatMul` as `hipdnn.transA` / `hipdnn.transB` so the
 /// runtime can apply the swap inside hipBLASLt. Sibling of GatherShapeFold;

--- a/lib/Conversion/OnnxToHip/QdqConversion.cpp
+++ b/lib/Conversion/OnnxToHip/QdqConversion.cpp
@@ -14,6 +14,44 @@ namespace mlir {
 namespace hip {
 namespace {
 
+/// MorphiZen imports com.microsoft QuantizeLinear / DequantizeLinear function
+/// ops as generic onnx.Custom operations. Canonicalize them to the native ONNX
+/// operation names before the PDLL fusion pass runs so existing QDQ fusion and
+/// lowering patterns work for both importer representations.
+struct CustomQdqToNativeOnnx : public mlir::RewritePattern {
+  CustomQdqToNativeOnnx(mlir::MLIRContext *ctx)
+      : RewritePattern("onnx.Custom", /*benefit=*/1, ctx) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(mlir::Operation *op,
+                  mlir::PatternRewriter &rewriter) const override {
+    auto functionName = op->getAttrOfType<mlir::StringAttr>("function_name");
+    if (!functionName)
+      return mlir::failure();
+
+    llvm::StringRef nativeOpName;
+    if (functionName.getValue() == "QuantizeLinear")
+      nativeOpName = "onnx.QuantizeLinear";
+    else if (functionName.getValue() == "DequantizeLinear")
+      nativeOpName = "onnx.DequantizeLinear";
+    else
+      return mlir::failure();
+
+    mlir::OperationState state(op->getLoc(), nativeOpName);
+    state.addOperands(op->getOperands());
+    state.addTypes(op->getResultTypes());
+    for (mlir::NamedAttribute attr : op->getAttrs()) {
+      llvm::StringRef name = attr.getName().getValue();
+      if (name != "function_name" && name != "domain_name")
+        state.addAttribute(attr.getName(), attr.getValue());
+    }
+
+    mlir::Operation *nativeOp = rewriter.create(state);
+    rewriter.replaceOp(op, nativeOp->getResults());
+    return mlir::success();
+  }
+};
+
 mlir::Value getOptionalOperand(mlir::Operation *op, size_t idx) {
   if (idx >= op->getNumOperands())
     return nullptr;
@@ -39,8 +77,6 @@ struct QdqOperands {
   mlir::RankedTensorType resultType;
 };
 
-// The reason for bringing this up is that there might
-// be a future conversion from com.ms.qdq to hip.
 mlir::FailureOr<QdqOperands> matchQdqCommon(mlir::Operation *op,
                                             mlir::PatternRewriter &rewriter) {
   size_t numOperands = op->getNumOperands();
@@ -130,6 +166,11 @@ struct DequantizeLinearToHip : public mlir::RewritePattern {
 };
 
 } // namespace
+
+void populateCustomQdqCanonicalizationPatterns(RewritePatternSet &patterns,
+                                               MLIRContext *ctx) {
+  patterns.add<CustomQdqToNativeOnnx>(ctx);
+}
 
 void populateQdqConversionPatterns(RewritePatternSet &patterns,
                                    MLIRContext *ctx) {

--- a/test/lit/Conversion/onnx-to-hip/test_constant_packed_int4.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_constant_packed_int4.mlir
@@ -67,19 +67,15 @@ module {
 // CHECK: hip.constant
 // CHECK-SAME: size = 4 : i64
 
-// Its DequantizeLinear carries packed_int4; the real int8 one does not.
-// (DequantizeLinear is plugin-handled, so it survives convert-onnx-to-hip and
-// the marker rides on the surviving onnx.Custom op.)
-// CHECK: onnx.Custom
-// CHECK-SAME: onnx_node_name = "DQ_int4"
+// Its DequantizeLinear carries packed_int4; the real int8 one does not. Custom
+// Microsoft QDQ is canonicalized before ordinary ONNX-to-HIP lowering.
+// CHECK: hip.dequantize_linear
 // CHECK-SAME: packed_int4
 
-// CHECK: onnx.Custom
+// CHECK: hip.dequantize_linear
 // CHECK-NOT: packed_int4
-// CHECK-SAME: onnx_node_name = "DQ_int8"
 
 // The odd-count (7-element, size 4 = ceil(7/2)) packed weight is also accepted
 // and marked -- odd logical counts pack their last nibble into a padded byte.
-// CHECK: onnx.Custom
-// CHECK-SAME: onnx_node_name = "DQ_int4_odd"
+// CHECK: hip.dequantize_linear
 // CHECK-SAME: packed_int4

--- a/test/lit/Conversion/onnx-to-hip/test_qadd.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_qadd.mlir
@@ -53,6 +53,32 @@ module {
 
     return %result : tensor<1x128x32xi8>
   }
+
+  // The MorphiZen importer represents com.microsoft QDQ functions as
+  // onnx.Custom. Canonicalization must happen before PDLL so this graph fuses
+  // exactly like the native ONNX graph above.
+  func.func @custom_qdq_add(%lhs: tensor<4xui16>,
+                            %rhs: tensor<4xui16>) -> tensor<4xui16> {
+    %lhs_scale = "onnx.Constant"() {value = dense<0.1> : tensor<f32>} : () -> tensor<f32>
+    %lhs_zp = "onnx.Constant"() {value = dense<5> : tensor<ui16>} : () -> tensor<ui16>
+    %rhs_scale = "onnx.Constant"() {value = dense<0.05> : tensor<f32>} : () -> tensor<f32>
+    %rhs_zp = "onnx.Constant"() {value = dense<3> : tensor<ui16>} : () -> tensor<ui16>
+    %output_scale = "onnx.Constant"() {value = dense<0.2> : tensor<f32>} : () -> tensor<f32>
+    %output_zp = "onnx.Constant"() {value = dense<7> : tensor<ui16>} : () -> tensor<ui16>
+
+    %lhs_dq = "onnx.Custom"(%lhs, %lhs_scale, %lhs_zp) {
+      domain_name = "com.microsoft", function_name = "DequantizeLinear"
+    } : (tensor<4xui16>, tensor<f32>, tensor<ui16>) -> tensor<4xf32>
+    %rhs_dq = "onnx.Custom"(%rhs, %rhs_scale, %rhs_zp) {
+      domain_name = "com.microsoft", function_name = "DequantizeLinear"
+    } : (tensor<4xui16>, tensor<f32>, tensor<ui16>) -> tensor<4xf32>
+    %sum = "onnx.Add"(%lhs_dq, %rhs_dq)
+        : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+    %result = "onnx.Custom"(%sum, %output_scale, %output_zp) {
+      domain_name = "com.microsoft", function_name = "QuantizeLinear"
+    } : (tensor<4xf32>, tensor<f32>, tensor<ui16>) -> tensor<4xui16>
+    return %result : tensor<4xui16>
+  }
 }
 
 // CHECK-LABEL: module
@@ -61,4 +87,14 @@ module {
 // CHECK-NEXT:    %[[QADD:.*]] = hip.qadd(%[[CTX]]) ins(%[[LHS]], %[[RHS]] : tensor<1x128x32xi8>, tensor<1x128x32xi8>) outs(%[[EMPTY]] : tensor<1x128x32xi8>) {lhs_scale = 1.000000e-01 : f32, lhs_zp = -5 : i64, output_scale = 2.000000e-01 : f32, output_zp = 7 : i64, rhs_scale = 5.000000e-02 : f32, rhs_zp = 3 : i64} : tensor<1x128x32xi8>
 // CHECK-NEXT:    return %[[QADD]] : tensor<1x128x32xi8>
 // CHECK-NEXT:  }
+// CHECK-LABEL: func.func @custom_qdq_add
+// CHECK:       %[[QADD:.*]] = hip.qadd
+// CHECK-SAME:  lhs_scale = 1.000000e-01
+// CHECK-SAME:  lhs_zp = 5 : i64
+// CHECK-SAME:  output_scale = 2.000000e-01
+// CHECK-SAME:  output_zp = 7 : i64
+// CHECK-SAME:  rhs_scale = 5.000000e-02
+// CHECK-SAME:  rhs_zp = 3 : i64
+// CHECK-NOT:   onnx.Custom
+// CHECK:       return %[[QADD]]
 // CHECK-NEXT: }

--- a/test/lit/Conversion/onnx-to-hip/test_qdq.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_qdq.mlir
@@ -131,4 +131,30 @@ module {
     } : (tensor<128x64xf32>, tensor<f32>) -> tensor<128x64xui8>
     return %y : tensor<128x64xui8>
   }
+
+// ===== Test 5: com.microsoft Q/DQ imported as onnx.Custom =====
+// Canonicalization must remove the Custom container before ordinary QDQ
+// lowering. Attributes other than the Custom dispatch attrs are preserved.
+
+// CHECK-LABEL: func.func @test_custom_qdq
+// CHECK-SAME:  (%[[CTX:.*]]: !hip.context, %[[X:.*]]: tensor<4xf32>, %[[S:.*]]: tensor<f32>, %[[ZP:.*]]: tensor<ui16>)
+// CHECK-NEXT:  %[[QINIT:.*]] = tensor.empty() : tensor<4xui16>
+// CHECK-NEXT:  %[[Q:.*]] = hip.quantize_linear(%[[CTX]]) ins(%[[X]], %[[S]] : tensor<4xf32>, tensor<f32>) zero_point(%[[ZP]] : tensor<ui16>) outs(%[[QINIT]] : tensor<4xui16>) {axis = 0 : i64, block_size = 0 : i64, precision = 0 : i64, saturate = 1 : i64} : tensor<4xui16>
+// CHECK-NEXT:  %[[DQINIT:.*]] = tensor.empty() : tensor<4xf32>
+// CHECK-NEXT:  %[[DQ:.*]] = hip.dequantize_linear(%[[CTX]]) ins(%[[Q]], %[[S]] : tensor<4xui16>, tensor<f32>) zero_point(%[[ZP]] : tensor<ui16>) outs(%[[DQINIT]] : tensor<4xf32>) {axis = 0 : i64, block_size = 0 : i64} : tensor<4xf32>
+// CHECK-NEXT:  return %[[DQ]] : tensor<4xf32>
+  func.func @test_custom_qdq(%x: tensor<4xf32>, %scale: tensor<f32>,
+                             %zp: tensor<ui16>) -> tensor<4xf32> {
+    %q = "onnx.Custom"(%x, %scale, %zp) {
+      axis = 0 : si64,
+      domain_name = "com.microsoft",
+      function_name = "QuantizeLinear"
+    } : (tensor<4xf32>, tensor<f32>, tensor<ui16>) -> tensor<4xui16>
+    %dq = "onnx.Custom"(%q, %scale, %zp) {
+      axis = 0 : si64,
+      domain_name = "com.microsoft",
+      function_name = "DequantizeLinear"
+    } : (tensor<4xui16>, tensor<f32>, tensor<ui16>) -> tensor<4xf32>
+    return %dq : tensor<4xf32>
+  }
 }


### PR DESCRIPTION
## Summary

- Model: `PSU_ORC-Model-3.4.0` (`psu_orc_0.onnx` / `psu_orc_1.onnx`, 3173 nodes each) — QuantizeLinear/DequantizeLinear nodes use the `com.microsoft` domain (1165 DQ + 964 Q per graph).
- MorphiZen imports those as `onnx.Custom`, not native ONNX QDQ. hip-ep only matched native-domain `onnx.QuantizeLinear` / `onnx.DequantizeLinear`, so Custom Q/DQ survived into one-shot-bufferize (`op was not bufferized`) and GPU compile failed.
- Canonicalize Custom Q/DQ to native ONNX QDQ **before** PDLL fusion and lowering so existing QDQ patterns apply.
- Unblocks ORC GPU compile (hipgpu session creates). The 40 `com.microsoft` GroupQueryAttention nodes per graph still emit quantized-KV warnings; that is a separate runtime issue.

## Related issue or design

- None.

## Why

- Native QDQ patterns and PDLL fusions (`qadd` / `qmul`, and later `qconv`) never see `onnx.Custom`.
- Rewriting the container first is smaller than duplicating every QDQ pattern for Custom.

## What

- `CustomQdqToNativeOnnx` in `QdqConversion.cpp`: `function_name` QuantizeLinear / DequantizeLinear → native ONNX; drop `function_name` / `domain_name`; keep other attrs (including `packed_int4`).
- Run that rewrite at the start of `ConvertOnnxToHipPass`, before HipFusionPatterns PDLL.

## Test plan

- `pre-commit run --all-files --hook-stage manual` — all 9 hooks pass.
- `ninja check-hip-mlir-lit` — 484 passed, 12 unsupported, 0 failed.
- Lit: `test_qdq.mlir` Custom Q/DQ → `hip.quantize_linear` / `hip.dequantize_linear`; `test_qadd.mlir` Custom QDQ Add → `hip.qadd`; packed-int4 Custom DQ now expects `hip.dequantize_linear` with `packed_int4`.
- `hip-onnx-runner` on `psu_orc_0.onnx`: session created (~11 s); previously failed at bufferize.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
