### PR TITLE
[DO NOT MERGE] test: PR 599 with matmul_nbits K-padding zero-point fix (2f549bd)

### DIFF
--- a/.github/workflows/windows-deps.yml
+++ b/.github/workflows/windows-deps.yml
@@ -587,6 +587,11 @@ jobs:
         if: steps.cache-oga.outputs.cache-hit != 'true'
         shell: bash
         run: |
+          # build.py imports tools/python/util, whose dependency_resolver
+          # imports requests at module scope. --ort_home means nothing is
+          # actually downloaded, but the import still has to resolve.
+          python -m pip install -q requests
+
           python "${{ github.workspace }}/source-oga/build.py" \
             --config Release \
             --cmake_generator Ninja \

--- a/.github/workflows/windows-deps.yml
+++ b/.github/workflows/windows-deps.yml
@@ -30,8 +30,14 @@ env:
   LLVM_TAG: llvmorg-22.1.0
   ONNXRUNTIME_VERSION: "1.27.0"
   ONNXRUNTIME_PR_PATCHES: ""
-  OGA_VERSION: "0.14.0"
-  OGA_PR_PATCHES: "2194"
+  # Fork branch carrying the AMDGPU MorphiZen integration (former PR 2194) plus
+  # sliding_window support, which upstream v0.14.0 does not have.
+  OGA_REPO: "amd-genmingz/onnxruntime-genai"
+  OGA_REF: "test_0_3"
+  # Optional space-separated microsoft/onnxruntime-genai PR numbers applied on
+  # top of the fork checkout via pull/<n>.patch + git am. Empty because the fork
+  # branch already carries the integration that 2194 used to supply.
+  OGA_PR_PATCHES: ""
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
   AMDGPU_EP_REF: "05eaa2a938f71e98b49bd1be3fb03720167be5cc"
   # Space-separated onnxruntime/onnxruntime-ep-amdgpu PR numbers applied on top
@@ -473,7 +479,7 @@ jobs:
       - name: Compute cache key
         id: key
         shell: bash
-        run: echo "value=oga-dml-mm2-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}" >> "$GITHUB_OUTPUT"
+        run: echo "value=oga-dml-mm3-${{ env.OGA_REPO }}-${{ env.OGA_REF }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}-2" >> "$GITHUB_OUTPUT"
 
       - name: Probe oga-artifacts
         id: cache-oga
@@ -525,8 +531,8 @@ jobs:
         if: steps.cache-oga.outputs.cache-hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: microsoft/onnxruntime-genai
-          ref: v${{ env.OGA_VERSION }}
+          repository: ${{ env.OGA_REPO }}
+          ref: ${{ env.OGA_REF }}
           path: source-oga
           submodules: true
           fetch-depth: 1

--- a/lib/Runtime/Kernels/hip/autotune/matmul_nbits/tools/matmul_nbits_kpad_test.cpp
+++ b/lib/Runtime/Kernels/hip/autotune/matmul_nbits/tools/matmul_nbits_kpad_test.cpp
@@ -9,6 +9,14 @@
  * that path against a CPU reference, and a K%32==0 control shape to confirm the
  * ordinary WMMA path is unchanged.
  *
+ * Zero-point coverage matters as much as the shape here. The K-padding path
+ * reads zp_for_fp16_paths, which degrades to the packed-nibble zero_points when
+ * the caller supplies no pre-unpacked fp16 buffer. An earlier version of this
+ * test only ever passed zero_points=nullptr, so has_zp was false, the pointer
+ * was never dereferenced, and it reported the path correct while every real
+ * asymmetric model (gemma-4's SigLIP, K=4304) produced garbage. Every shape is
+ * now run in three zero-point modes -- see Zp below.
+ *
  * GPU required (runs the kernel). Build from the repo root, e.g.:
  *   flatc --cpp -o <gen> lib/Runtime/Kernels/hip/autotune/matmul_nbits/matmul_nbits_autotune.fbs
  *   clang++ -x hip --offload-arch=gfx1151 -O3 -std=c++17 -w \
@@ -58,12 +66,36 @@ static float h2f(uint16_t o) {
   return (float)h;
 }
 
+/* How the caller presents zero_points, mirroring what the runtime wrapper
+ * (lib/Runtime/real/matmul_nbits.cpp) hands the kernel:
+ *
+ *   Symmetric  - no zero_points at all; the kernel's implicit zp of 8.
+ *   AsymU8Only - packed nibbles + pre_unpacked_zp_u8, no fp16 buffer. This is
+ *                what the wrapper used to pass for K%32!=0, and the case the
+ *                K-padding path silently mis-read. The kernel must now decline
+ *                the fp16-zp paths and land on one that reads the uint8 buffer.
+ *   AsymFp16   - packed nibbles + both pre-unpacked buffers, i.e. what the
+ *                wrapper passes now. This is the case that must stay on WMMA.
+ *
+ * Both asym modes must agree with the same reference: which kernel serves the
+ * shape is a performance decision, never a numerical one. */
+enum class Zp { Symmetric, AsymU8Only, AsymFp16 };
+
+static const char* zpName(Zp z) {
+  switch (z) {
+    case Zp::Symmetric:  return "sym";
+    case Zp::AsymU8Only: return "asym u8-only";
+    default:             return "asym +fp16";
+  }
+}
+
 // One shape: row-major A[M,K] fp16, packed int4 B[N, ngk*(gs/2)], fp16
-// scales[N,ngk], symmetric (default zp=8). Returns max abs and max rel error
-// of hip_matmul_nbits against a CPU fp32 reference.
-static bool check(int M, int N, int K, int gs) {
+// scales[N,ngk], and zero-points per `mode`. Compares hip_matmul_nbits against
+// a CPU fp32 reference.
+static bool check(int M, int N, int K, int gs, Zp mode) {
   const int ngk = (K + gs - 1) / gs;
   const int row_bytes = ngk * (gs / 2);
+  const bool asym = (mode != Zp::Symmetric);
 
   std::vector<uint16_t> hA((size_t)M * K), hSc((size_t)N * ngk);
   std::vector<uint8_t> hB((size_t)N * row_bytes);
@@ -73,24 +105,57 @@ static bool check(int M, int N, int K, int gs) {
     hSc[i] = f2h(0.01f + 0.001f * float(i % 7));
   for (size_t i = 0; i < hB.size(); ++i) hB[i] = uint8_t(i * 31 + 7);
 
+  // Asymmetric zero-points, in all three layouts the kernel can be handed.
+  // Packed is [N, (ngk+1)/2] with the low nibble the even group and the high
+  // nibble the odd one; the u8 and fp16 forms are one value per group [N, ngk].
+  // Values deliberately stray from 8 so a path that ignores them, or reads the
+  // packed bytes as fp16, cannot accidentally match.
+  const int packed_cols = (ngk + 1) / 2;
+  std::vector<uint8_t> hZpPacked(asym ? (size_t)N * packed_cols : 0);
+  std::vector<uint8_t> hZpU8(asym ? (size_t)N * ngk : 0);
+  std::vector<uint16_t> hZpFp16(asym ? (size_t)N * ngk : 0);
+  auto zp_of = [&](int n, int g) -> int {
+    if (!asym) return 8;
+    return (int)hZpU8[(size_t)n * ngk + g];
+  };
+  if (asym) {
+    for (int n = 0; n < N; ++n)
+      for (int g = 0; g < ngk; ++g) {
+        const int v = (n * 7 + g * 5 + 1) % 16;
+        hZpU8[(size_t)n * ngk + g] = (uint8_t)v;
+        hZpFp16[(size_t)n * ngk + g] = f2h((float)v);
+        uint8_t& p = hZpPacked[(size_t)n * packed_cols + g / 2];
+        if (g % 2 == 0)
+          p = (uint8_t)((p & 0xF0) | v);
+        else
+          p = (uint8_t)((p & 0x0F) | (v << 4));
+      }
+  }
+
   auto wof = [&](int n, int k) -> int {
     const int g = k / gs, loc = k % gs;
     uint8_t p = hB[(size_t)n * row_bytes + (size_t)g * (gs / 2) + loc / 2];
     return (loc & 1) ? (p >> 4) : (p & 0xF);
   };
 
-  // CPU reference: out[m,n] = sum_k A[m,k] * (w-8) * scale[n, k/gs]
+  // CPU reference: out[m,n] = sum_k A[m,k] * (w - zp[n, k/gs]) * scale[n, k/gs].
+  // Dequantizing each B row once and reusing it across all M keeps this
+  // affordable at the full prefill M (the M=2268 case below is ~11e9 MACs).
   std::vector<float> ref((size_t)M * N, 0.0f);
-  for (int m = 0; m < M; ++m)
-    for (int n = 0; n < N; ++n) {
+  std::vector<float> brow((size_t)K);
+  for (int n = 0; n < N; ++n) {
+    for (int k = 0; k < K; ++k) {
+      const int g = k / gs;
+      brow[(size_t)k] =
+          (float(wof(n, k)) - float(zp_of(n, g))) * h2f(hSc[(size_t)n * ngk + g]);
+    }
+    for (int m = 0; m < M; ++m) {
+      const uint16_t* arow = &hA[(size_t)m * K];
       float acc = 0.0f;
-      for (int k = 0; k < K; ++k) {
-        float a = h2f(hA[(size_t)m * K + k]);
-        float sc = h2f(hSc[(size_t)n * ngk + k / gs]);
-        acc += a * (float(wof(n, k)) - 8.0f) * sc;
-      }
+      for (int k = 0; k < K; ++k) acc += h2f(arow[k]) * brow[(size_t)k];
       ref[(size_t)m * N + n] = acc;
     }
+  }
 
   void *dA, *dB, *dSc, *dOut;
   HIP_OK(hipMalloc(&dA, hA.size() * 2));
@@ -101,11 +166,26 @@ static bool check(int M, int N, int K, int gs) {
   HIP_OK(hipMemcpy(dB, hB.data(), hB.size(), hipMemcpyHostToDevice));
   HIP_OK(hipMemcpy(dSc, hSc.data(), hSc.size() * 2, hipMemcpyHostToDevice));
 
-  int rc = hip_matmul_nbits(nullptr, dA, dB, dSc, /*zp=*/nullptr, nullptr, dOut,
-                            M, N, K, 1, 4, gs, 2, 2, nullptr, nullptr);
+  void *dZpPacked = nullptr, *dZpU8 = nullptr, *dZpFp16 = nullptr;
+  if (asym) {
+    HIP_OK(hipMalloc(&dZpPacked, hZpPacked.size()));
+    HIP_OK(hipMemcpy(dZpPacked, hZpPacked.data(), hZpPacked.size(),
+                     hipMemcpyHostToDevice));
+    HIP_OK(hipMalloc(&dZpU8, hZpU8.size()));
+    HIP_OK(hipMemcpy(dZpU8, hZpU8.data(), hZpU8.size(), hipMemcpyHostToDevice));
+    if (mode == Zp::AsymFp16) {
+      HIP_OK(hipMalloc(&dZpFp16, hZpFp16.size() * 2));
+      HIP_OK(hipMemcpy(dZpFp16, hZpFp16.data(), hZpFp16.size() * 2,
+                       hipMemcpyHostToDevice));
+    }
+  }
+
+  int rc = hip_matmul_nbits(nullptr, dA, dB, dSc, dZpPacked, nullptr, dOut, M, N,
+                            K, 1, 4, gs, 2, asym ? 1 : 2, dZpU8, dZpFp16);
   HIP_OK(hipDeviceSynchronize());
   if (rc != 0) {
-    std::printf("  hip_matmul_nbits rc=%d\n", rc);
+    std::printf("  M=%-5d N=%-6d K=%-6d gs=%-3d %-13s hip_matmul_nbits rc=%d\n",
+                M, N, K, gs, zpName(mode), rc);
     return false;
   }
 
@@ -123,13 +203,28 @@ static bool check(int M, int N, int K, int gs) {
     max_ref = std::max(max_ref, std::fabs(ref[i]));
   }
   hipFree(dA); hipFree(dB); hipFree(dSc); hipFree(dOut);
+  if (dZpPacked) hipFree(dZpPacked);
+  if (dZpU8) hipFree(dZpU8);
+  if (dZpFp16) hipFree(dZpFp16);
 
   const float rel = max_abs / (max_ref + 1e-6f);
   const bool ok = rel < 0.02f;   // 2% of signal scale; fp16 tile-order rounding
-  std::printf("  M=%-5d N=%-6d K=%-6d gs=%-3d  max_abs=%.4f peak=%.3f "
+  std::printf("  M=%-5d N=%-6d K=%-6d gs=%-3d %-13s max_abs=%.4f peak=%.3f "
               "rel=%.4f  %s\n",
-              M, N, K, gs, max_abs, max_ref, rel, ok ? "OK" : "FAIL");
+              M, N, K, gs, zpName(mode), max_abs, max_ref, rel,
+              ok ? "OK" : "FAIL");
   return ok;
+}
+
+// Every shape in all three zero-point modes. The asym modes are the point:
+// AsymU8Only is the combination that used to reach the K-padding path with the
+// packed nibbles reinterpreted as fp16.
+static int checkAll(int M, int N, int K, int gs) {
+  int fails = 0;
+  fails += !check(M, N, K, gs, Zp::Symmetric);
+  fails += !check(M, N, K, gs, Zp::AsymU8Only);
+  fails += !check(M, N, K, gs, Zp::AsymFp16);
+  return fails;
 }
 
 int main() {
@@ -139,13 +234,20 @@ int main() {
 
   int fails = 0;
   std::printf("-- K%%32!=0 (new K-padding WMMA path) --\n");
-  fails += !check(32,  1152, 4304, 32);   // gemma-4 down_proj, prefill
-  fails += !check(128, 1152, 4304, 32);
-  fails += !check(17,  1152, 4304, 32);   // M not a multiple of the tile
+  fails += checkAll(32,  1152, 4304, 32);   // gemma-4 down_proj, prefill
+  fails += checkAll(128, 1152, 4304, 32);
+  fails += checkAll(17,  1152, 4304, 32);   // M not a multiple of the tile
+
+  // The shipped geometry: gemma-4's SigLIP down_proj at a 2268-token image
+  // prefill, the shape whose asym output was garbage. Slowest case here by far
+  // (the reference is ~11e9 MACs), and the one that actually reproduced the bug
+  // end to end.
+  std::printf("\n-- shipped SigLIP down_proj geometry --\n");
+  fails += checkAll(2268, 1152, 4304, 32);
 
   std::printf("\n-- K%%32==0 control (unchanged WMMA path) --\n");
-  fails += !check(32,  4096, 4096, 32);
-  fails += !check(128, 14336, 4096, 128);
+  fails += checkAll(32,  4096, 4096, 32);
+  fails += checkAll(128, 14336, 4096, 128);
 
   std::printf("\n%s\n", fails ? "FAILED" : "ALL PASSED");
   return fails ? 1 : 0;

--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -6875,9 +6875,18 @@ extern "C" int hip_matmul_nbits(
    * cropping, since only the contraction dim is padded. The weight rows are
    * already stored padded to full groups (num_groups_k*(group_size/2) bytes),
    * so B needs nothing. K%32==0 shapes never enter here and are byte-for-byte
-   * unaffected. Verified against the CPU reference for K=4304. */
+   * unaffected. Verified against the CPU reference for K=4304.
+   *
+   * fp16_zp_ready is load-bearing, not belt-and-braces: this branch reads
+   * zp_for_fp16_paths, which falls back to the packed-nibble zero_points when
+   * the wrapper did not pre-build an fp16 buffer. The wrapper's build gate used
+   * to be K%32==0 -- the exact complement of this predicate -- so every asym
+   * K%32!=0 prefill landed here and read nibbles as fp16, wrong values plus an
+   * over-read (packed is [N,(ngk+1)/2] bytes, this indexes [N,ngk] fp16). The
+   * wrapper now supplies the buffer; without it, fall through to the naive
+   * kernel's uint8 zp rather than compute silent garbage. */
   if ((batch_count == 1) && (K % 32 != 0) && M >= kWmmaMinM &&
-      !hipdnn_device_is_wave64()) {
+      fp16_zp_ready && !hipdnn_device_is_wave64()) {
     int iM = static_cast<int>(M);
     int iN = static_cast<int>(N);
     int iK = static_cast<int>(K);
@@ -6943,7 +6952,15 @@ extern "C" int hip_matmul_nbits(
   // M>=kWmmaMinM is instead served by the dequant-once + hipBLASLt path in
   // lib/Runtime/real/matmul_nbits.cpp, and any residual case falls through to
   // the correct GEMV/naive fallback below.
-  if (wmma_data_format && M >= kWmmaMinM && !hipdnn_device_is_wave64()) {
+  //
+  // fp16_zp_ready is redundant today -- the wrapper builds the fp16 zp for
+  // every batch==1, M>1 asym shape, which covers this predicate -- but it is
+  // stated rather than inferred: this branch reads zp_for_fp16_paths, and that
+  // pointer silently degrades to the packed nibbles when the buffer is absent.
+  // The K-padding branch above shipped that exact bug by leaning on a
+  // coincidence between the two gates.
+  if (wmma_data_format && M >= kWmmaMinM && fp16_zp_ready &&
+      !hipdnn_device_is_wave64()) {
     CUSTOM_KERNELS_DEBUG_LOG(
         "[custom_kernels] hip_matmul_nbits: WMMA fast path M=%lld N=%lld "
         "K=%lld bs=%lld zp=%s bias=%s\n",

--- a/lib/Runtime/real/matmul_nbits.cpp
+++ b/lib/Runtime/real/matmul_nbits.cpp
@@ -602,14 +602,22 @@ int wrap_matmul_nbits(RuntimeState *state, int op_state_slot, const void *A,
                   mst->zp, stream, zero_points, static_cast<int>(N), ngk);
     if (!pre_zp_u8)
       return -1;
-    // The fp16 buffer is consumed only by the bits=4 WMMA (batch==1 &&
-    // K%32==0 && M>=16) and col-major GEMV M>1 fallback (same predicate on K,
-    // M>1). Build it eagerly when those preconditions are met — the cache
-    // makes the cost a one-time hit per zero_points pointer. The u2 WMMA path
-    // consumes uint8 zp directly, so bits=2 never needs the fp16 buffer (and
-    // the converter is nibble-specific anyway).
-    bool wmma_data_format = (batch_count == 1) && (K % 32 == 0);
-    if (bits == 4 && wmma_data_format && M > 1) {
+    // The fp16 buffer is consumed by the bits=4 WMMA prefill and by the
+    // col-major GEMV M>1 fallback. Build it eagerly when those preconditions
+    // are met — the cache makes the cost a one-time hit per zero_points
+    // pointer. The u2 WMMA path consumes uint8 zp directly, so bits=2 never
+    // needs the fp16 buffer (and the converter is nibble-specific anyway).
+    //
+    // Deliberately NOT gated on K%32==0. The WMMA prefill has two entries: the
+    // K%32==0 path and the K-padding path, which zero-pads K up to a multiple
+    // of 32 and runs the same kernel (see hip_matmul_nbits). Both read
+    // zp_for_fp16_paths. A K%32==0 gate here is the exact complement of the
+    // K-padding path's predicate, so every asym K%32!=0 prefill reached that
+    // path with zp_for_fp16_paths still pointing at the packed nibbles and
+    // silently computed against them reinterpreted as fp16 (gemma-4's SigLIP
+    // down_proj, K=4304). The kernel now also refuses that combination, but
+    // supplying the buffer is what keeps the shape on the fast path.
+    if (bits == 4 && batch_count == 1 && M > 1) {
       pre_zp_fp16 = hipdnn_ep_real::lookup_or_convert_zp_fp16(
           mst->zp, stream, zero_points, static_cast<int>(N), ngk);
       if (!pre_zp_fp16)


### PR DESCRIPTION
## DO NOT MERGE

Throwaway branch to exercise gemma4-unified CI (#599) together with the matmul_nbits K-padding zero-point fix (`2f549bd`). Nothing here should land on `main` as-is — the workflow change belongs to #599 and the kernel fix needs its own PR once validated.

## What it stacks

| Commit | Source | What |
|---|---|---|
| `test: build OGA from the AMDGPU fork so gemma4-unified features are exercised` | #599 | repins CI to `amd-genmingz/onnxruntime-genai@test_0_3` |
| `ci(windows): install requests before building OGA from the fork` | #599 | fork `build.py` needs `requests` |
| `fix(matmul_nbits): supply the fp16 zero-points the K-padding path reads` | `2f549bd` | fixes asymmetric `K % 32 != 0` int4 prefill on the WMMA K-padding path (#903 regression) |

#599's two commits are cherry-picked unmodified with authorship intact onto current `main`. The matmul fix is the same commit as on `test/gqa-kv-span-gemma4-oga` (#953), rebased here without the #933 GQA base.

## What to look at

- **Build jobs:** confirm the fork's OGA builds on Windows (`windows-deps`, `windows-build-*`).
- **`Run VLM benchmark` / `Run OGA benchmark`:** with a gemma4-unified model staged on the GPU runner, the vision path should emit coherent text instead of fluent nonsense. The bug only hits SigLIP `down_proj` shapes where `K % 32 != 0` (e.g. K=4304 on gemma-4-26B).

## Caveats

- The OGA fork pin is personal; fine for a throwaway branch, not for `main`.
- GPU test jobs only exercise gemma4 if the runner has a suitable model under the persisted asset directories — same caveat as #901/#953.
- #599 is still a draft; the fork/ref it pins may move.
