### PR TITLE
perf(allocator): pool large pinned buffers by capacity

### DIFF
--- a/morphizen/ort-bridge/src/morphizen-hip-gpu-allocator.cpp
+++ b/morphizen/ort-bridge/src/morphizen-hip-gpu-allocator.cpp
@@ -75,6 +75,60 @@ int SizeClassIndex(size_t size) noexcept {
   return -1;
 }
 
+constexpr size_t kPageSize = 4096;
+
+// Capacity for a large request that is known to be growing. The 1/64 headroom
+// is the reuse span: a Gemma-4 KV tensor is 64 MiB at a 16 K context and grows
+// 4096 bytes per token, so one capacity covers the next 256 tokens.
+//
+// Continuing the size-class table's geometry, whose steps go 1/2, 1/4, 1/16,
+// 1/32 as buffers grow, because the waste is proportional to the size.
+constexpr size_t LargeCapacity(size_t size) noexcept {
+  const size_t want = size + size / 64;
+  return (want + kPageSize - 1) / kPageSize * kPageSize;
+}
+
+// Checked at compile time because no unit-test target covers this file and
+// returning less than the request would overflow the buffer.
+constexpr bool LargeCapacityHolds() {
+  for (size_t n = 16ull << 20; n <= 16ull << 30; n += n / 8) {
+    const size_t c = LargeCapacity(n);
+    if (c < n + n / 64 || c > n + n / 64 + kPageSize) {
+      return false;
+    }
+  }
+  return true;
+}
+static_assert(LargeCapacityHolds(),
+              "LargeCapacity must cover the request with its growth headroom "
+              "and waste at most one page beyond it");
+static_assert(LargeCapacity(64ull << 20) - (64ull << 20) >= 128 * 4096,
+              "one capacity must span more than a 128-token generation at a "
+              "16 K context");
+
+int OctaveOf(size_t size) noexcept {
+  int octave = 0;
+  while (size > 1) {
+    size >>= 1;
+    ++octave;
+  }
+  return octave;
+}
+
+// Hand a batch of buffers back to the driver with pool_mutex_ released:
+// hipHostFree unpins pages and is as heavyweight as the hipHostMalloc that
+// pinned them, so holding the lock would serialize every other allocation
+// behind it.
+void ReleaseToDriver(const std::vector<void *> &buffers, int device_id) {
+  if (buffers.empty()) {
+    return;
+  }
+  ScopedDevice _(device_id);
+  for (void *p : buffers) {
+    (void)hipHostFree(p);
+  }
+}
+
 int TryGetDeviceId(const OrtMemoryInfo *memory_info) noexcept {
   if (memory_info == nullptr) {
     return -1;
@@ -107,6 +161,62 @@ HipGpuAllocator::HipGpuAllocator(const OrtMemoryInfo *memory_info,
   GetStats = nullptr;
 }
 
+// A capacity the model has just grown past cannot serve this request or any
+// later one, so its idle buffers are dead weight. Bounded to the immediate
+// neighbourhood below `size` so an unrelated, much smaller tensor pooled in
+// the same octave is left alone.
+void HipGpuAllocator::DropOutgrown(size_t size, std::vector<void *> &out) {
+  auto it = large_free_.lower_bound(size - size / 16);
+  while (it != large_free_.end() && it->first < size) {
+    for (void *ptr : it->second.free) {
+      ptr_to_size_.erase(ptr);
+      large_retained_bytes_ -= it->first;
+      out.push_back(ptr);
+    }
+    it = large_free_.erase(it);
+  }
+}
+
+// One buffer from the least-recently-used capacity, skipping `keep` because
+// evicting there would free a buffer of exactly the size being made room for.
+// Buffers nothing can ask for again are never touched, so they are always the
+// oldest and go first.
+bool HipGpuAllocator::EvictLruLarge(size_t keep, std::vector<void *> &out) {
+  auto victim = large_free_.end();
+  for (auto it = large_free_.begin(); it != large_free_.end(); ++it) {
+    if (it->first == keep) {
+      continue;
+    }
+    if (victim == large_free_.end() ||
+        it->second.last_used < victim->second.last_used) {
+      victim = it;
+    }
+  }
+  if (victim == large_free_.end()) {
+    return false;
+  }
+  void *ptr = victim->second.free.back();
+  victim->second.free.pop_back();
+  ptr_to_size_.erase(ptr);
+  large_retained_bytes_ -= victim->first;
+  out.push_back(ptr);
+  if (victim->second.free.empty()) {
+    large_free_.erase(victim);
+  }
+  return true;
+}
+
+void HipGpuAllocator::DrainLarge(std::vector<void *> &out) {
+  for (auto &entry : large_free_) {
+    for (void *ptr : entry.second.free) {
+      ptr_to_size_.erase(ptr);
+      out.push_back(ptr);
+    }
+  }
+  large_free_.clear();
+  large_retained_bytes_ = 0;
+}
+
 void *ORT_API_CALL HipGpuAllocator::AllocImpl(OrtAllocator *this_,
                                               size_t size) {
   if (size == 0) {
@@ -115,28 +225,59 @@ void *ORT_API_CALL HipGpuAllocator::AllocImpl(OrtAllocator *this_,
   auto *self = static_cast<HipGpuAllocator *>(this_);
 
   const int cls = SizeClassIndex(size);
+  // Bytes to allocate on a miss: the class capacity for a pooled request, and
+  // for a large one either the exact size or a grown capacity depending on
+  // whether its octave has been seen to move.
+  size_t alloc_size = (cls >= 0) ? kSizeClasses[cls] : size;
+  std::vector<void *> stale;
 
-  // Fast path: reuse a pooled buffer with no driver call. Only requests that
-  // map to a size class (<= 16 MB) are pooled; any buffer in that class fits
-  // (they are all the class capacity). Large requests (cls < 0, > 16 MB) are
-  // never pooled — they are allocated at exact size and released straight back
-  // to the driver in FreeImpl, so a one-off huge transient can't pin memory.
-  if (cls >= 0) {
+  // Fast path: reuse a buffer with no driver call. A size class holds buffers
+  // all at the class capacity, so any of them fits. A large request takes the
+  // smallest retained capacity that covers it, close enough that it cannot
+  // consume a buffer a much larger request will need.
+  {
     std::lock_guard<std::mutex> lk(self->pool_mutex_);
-    auto &fl = self->free_lists_[cls];
-    if (!fl.empty()) {
-      void *ptr = fl.back();
-      fl.pop_back();
-      return ptr;
+    if (cls >= 0) {
+      auto &fl = self->free_lists_[cls];
+      if (!fl.empty()) {
+        void *ptr = fl.back();
+        fl.pop_back();
+        return ptr;
+      }
+    } else {
+      ++self->large_ops_;
+      auto &octave = self->octaves_[OctaveOf(size)];
+      if (octave.high_water != 0 && size > octave.high_water) {
+        octave.growing = true;
+      }
+      if (size > octave.high_water) {
+        octave.high_water = size;
+      }
+
+      auto it = self->large_free_.lower_bound(size);
+      if (it != self->large_free_.end() && it->first <= size + size / 32) {
+        void *ptr = it->second.free.back();
+        it->second.free.pop_back();
+        it->second.last_used = self->large_ops_;
+        self->large_retained_bytes_ -= it->first;
+        self->large_live_bytes_ += it->first;
+        if (self->large_live_bytes_ > self->large_peak_live_bytes_) {
+          self->large_peak_live_bytes_ = self->large_live_bytes_;
+        }
+        if (it->second.free.empty()) {
+          self->large_free_.erase(it);
+        }
+        return ptr;
+      }
+      if (octave.growing) {
+        alloc_size = LargeCapacity(size);
+        self->DropOutgrown(size, stale);
+      }
     }
   }
+  ReleaseToDriver(stale, self->device_id_);
 
   ScopedDevice _(self->device_id_);
-
-  // Cold miss: allocate. Pooled requests are rounded up to the full class
-  // capacity so the buffer is reusable by any later request in the same class;
-  // large requests are allocated at their exact size.
-  const size_t alloc_size = (cls >= 0) ? kSizeClasses[cls] : size;
 
   // On AMD APU iGPU (the only hardware MorphiZen EP currently targets) the
   // GPU shares physical memory with the CPU, so we use hipHostMalloc(Mapped)
@@ -157,6 +298,21 @@ void *ORT_API_CALL HipGpuAllocator::AllocImpl(OrtAllocator *this_,
   hipError_t err = hipHostMalloc(&ptr, alloc_size,
                                  hipHostMallocMapped | hipHostMallocCoherent);
   if (err != hipSuccess) {
+    // The large pool may be sitting on pinned pages this allocation could use,
+    // and failing while holding reclaimable memory would be worse than not
+    // pooling at all.
+    std::vector<void *> drained;
+    {
+      std::lock_guard<std::mutex> lk(self->pool_mutex_);
+      self->DrainLarge(drained);
+    }
+    if (!drained.empty()) {
+      ReleaseToDriver(drained, self->device_id_);
+      err = hipHostMalloc(&ptr, alloc_size,
+                          hipHostMallocMapped | hipHostMallocCoherent);
+    }
+  }
+  if (err != hipSuccess) {
     LOG(ERROR) << "[MorphiZen HIP] hipHostMalloc(Mapped|Coherent) failed for "
                << alloc_size << " bytes (device " << self->device_id_
                << "): " << hipGetErrorString(err);
@@ -165,6 +321,12 @@ void *ORT_API_CALL HipGpuAllocator::AllocImpl(OrtAllocator *this_,
   {
     std::lock_guard<std::mutex> lk(self->pool_mutex_);
     self->ptr_to_size_[ptr] = alloc_size;
+    if (cls < 0) {
+      self->large_live_bytes_ += alloc_size;
+      if (self->large_live_bytes_ > self->large_peak_live_bytes_) {
+        self->large_peak_live_bytes_ = self->large_live_bytes_;
+      }
+    }
   }
   return ptr;
 }
@@ -174,30 +336,49 @@ void ORT_API_CALL HipGpuAllocator::FreeImpl(OrtAllocator *this_, void *p) {
     return;
   }
   auto *self = static_cast<HipGpuAllocator *>(this_);
+  // p itself when it cannot be retained, plus whatever eviction dropped to
+  // make room for it.
+  std::vector<void *> to_release;
   {
     std::lock_guard<std::mutex> lk(self->pool_mutex_);
     auto it = self->ptr_to_size_.find(p);
-    if (it != self->ptr_to_size_.end()) {
-      // The stored size is the class capacity for pooled buffers (so
-      // SizeClassIndex recovers the class) and the exact size for large ones.
-      const int cls = SizeClassIndex(it->second);
-      if (cls >= 0) {
-        // Pooled small/medium buffer (<= 16 MB): return to its free list for
-        // reuse; do NOT release to the driver here. Stays tracked in
-        // ptr_to_size_ so the destructor can release it. Safe to reuse without
-        // a stream sync: see the pool comment in the header.
-        self->free_lists_[cls].push_back(p);
+    if (it == self->ptr_to_size_.end()) {
+      // Defensive: a pointer we never handed out. Release rather than leak.
+      to_release.push_back(p);
+    } else if (const int cls = SizeClassIndex(it->second); cls >= 0) {
+      // Pooled small/medium buffer (<= 16 MB): return to its free list for
+      // reuse; do NOT release to the driver here. Stays tracked in
+      // ptr_to_size_ so the destructor can release it. Safe to reuse without
+      // a stream sync: see the pool comment in the header.
+      self->free_lists_[cls].push_back(p);
+      return;
+    } else {
+      const size_t capacity = it->second;
+      ++self->large_ops_;
+      self->large_live_bytes_ -= (self->large_live_bytes_ < capacity)
+                                     ? self->large_live_bytes_
+                                     : capacity;
+      // Retaining this would put the pool over a ceiling that tracks the most
+      // this model has had checked out at once, so evict the capacities that
+      // have gone longest without being asked for before giving up on it.
+      bool room = self->large_retained_bytes_ + capacity <=
+                  self->large_peak_live_bytes_;
+      while (!room && self->EvictLruLarge(capacity, to_release)) {
+        room = self->large_retained_bytes_ + capacity <=
+               self->large_peak_live_bytes_;
+      }
+      if (room) {
+        auto &bucket = self->large_free_[capacity];
+        bucket.free.push_back(p);
+        bucket.last_used = self->large_ops_;
+        self->large_retained_bytes_ += capacity;
         return;
       }
-      // Large buffer (> 16 MB): never pooled. Stop tracking it and release it
-      // to the driver below (outside the lock — hipHostFree is heavyweight).
       self->ptr_to_size_.erase(it);
+      to_release.push_back(p);
     }
-    // Fall through for a large buffer, or for a pointer we never handed out
-    // (defensive): in both cases release directly so we don't leak.
   }
-  ScopedDevice _(self->device_id_);
-  (void)hipHostFree(p);
+  ReleaseToDriver(to_release, self->device_id_);
 }
 
 HipGpuAllocator::~HipGpuAllocator() {
@@ -217,6 +398,9 @@ HipGpuAllocator::~HipGpuAllocator() {
   for (auto &fl : free_lists_) {
     fl.clear();
   }
+  large_free_.clear();
+  large_retained_bytes_ = 0;
+  large_live_bytes_ = 0;
   ptr_to_size_.clear();
 }
 

--- a/morphizen/ort-bridge/src/morphizen-hip-gpu-allocator.hpp
+++ b/morphizen/ort-bridge/src/morphizen-hip-gpu-allocator.hpp
@@ -15,6 +15,8 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
+#include <map>
 #include <mutex>
 #include <unordered_map>
 #include <vector>
@@ -24,9 +26,8 @@ namespace morphizen {
 // Fixed size-class boundaries (bytes). A request of N bytes is served from the
 // first class whose capacity is >= N, and the buffer is allocated at the full
 // class capacity so any later request mapping to the same class can reuse it.
-// Requests larger than the last class (> 16 MB) are NOT pooled: they are
-// allocated at their exact size and released straight back to the driver in
-// FreeImpl, so a one-off huge transient can never pin memory in a free list.
+// Requests larger than the last class (> 16 MB) do not use this table; they go
+// through the capacity-keyed large pool described on HipGpuAllocator.
 //
 // The class boundaries are generated at compile time in four tiers, with the
 // tier edges de-duplicated where they meet:
@@ -120,6 +121,12 @@ private:
   static const OrtMemoryInfo *ORT_API_CALL InfoImpl(const OrtAllocator *this_);
   static void *ORT_API_CALL ReserveImpl(OrtAllocator *this_, size_t size);
 
+  // All three expect pool_mutex_ held and append buffers the caller must hand
+  // to the driver after releasing it.
+  void DropOutgrown(size_t size, std::vector<void *> &out);
+  bool EvictLruLarge(size_t keep, std::vector<void *> &out);
+  void DrainLarge(std::vector<void *> &out);
+
   // Fixed size-class caching allocator. hipHostMalloc is a heavyweight
   // (page-pinning) call: ORT re-allocates the per-Run input device-copy
   // buffers and (allocator mode) the graph-output buffers on EVERY inference,
@@ -136,13 +143,18 @@ private:
   // project's per-session "grow-on-demand, never shrink, free at cleanup"
   // memory contract.
   //
-  // Requests larger than the largest size class (> 16 MB) are NOT pooled: they
-  // are allocated at their exact size and released straight back to the driver
-  // in FreeImpl. A model's largest transients are few and shape-specific, so
-  // pooling them buys little reuse while risking an unbounded pinned working
-  // set when a model grows its largest transient a little each Run. Treating
-  // them as one-shot allocations keeps peak memory bounded with no eviction
-  // bookkeeping.
+  // Requests above 16 MB are pooled separately, keyed by the buffer's capacity
+  // rather than by a class, because the allocation that matters there is a KV
+  // tensor that grows by one token's worth every decode step when a model runs
+  // with past_present_share_buffer=false. No two steps ask for the same size,
+  // so an exact-size pool never hits and every step page-pins a fresh buffer.
+  //
+  // A request is served by the smallest retained buffer that is big enough for
+  // it, which is what lets one buffer cover a whole run of growing requests. A
+  // buffer only gets growth headroom once a request has actually exceeded the
+  // largest size seen in its octave; until then it is allocated at exactly the
+  // requested size, so a model whose tensors never change size pays no waste
+  // and still reuses its buffers across generators.
   //
   // Reuse needs no per-handout stream sync: ORT only calls Free after Run
   // returns, and allocator-mode inference_compute ends with a full
@@ -158,6 +170,31 @@ private:
   // destructor can release them; a large buffer is erased from this map in
   // FreeImpl when it is freed back to the driver.
   std::unordered_map<void *, size_t> ptr_to_size_;
+
+  // Large pool. Ordered so a request can find the smallest capacity that fits
+  // it with one lower_bound; empty buckets are erased.
+  struct LargeBucket {
+    std::vector<void *> free;
+    uint64_t last_used = 0;
+  };
+  std::map<size_t, LargeBucket> large_free_;
+  // Per octave of the request size. `growing` latches the first time a request
+  // exceeds the largest already seen there, which a fixed-size tensor never
+  // does. It has to latch rather than be re-tested per request because every
+  // layer asks for the same size within one decode step, so only the first of
+  // them would see an increase.
+  struct OctaveState {
+    size_t high_water = 0;
+    bool growing = false;
+  };
+  std::array<OctaveState, 64> octaves_{};
+  uint64_t large_ops_ = 0;
+  size_t large_live_bytes_ = 0;
+  // Retention ceiling: the pool never holds more idle bytes than the most this
+  // model has had checked out at once, so it scales with the context the model
+  // is run at instead of with a fixed share of RAM.
+  size_t large_peak_live_bytes_ = 0;
+  size_t large_retained_bytes_ = 0;
 
   const OrtMemoryInfo *memory_info_;
   // Cached at construction time. -1 means "couldn't read it from memory_info"


### PR DESCRIPTION
## What

Pool pinned host buffers above 16 MB, keyed by the buffer's **capacity** rather than by a fixed size class. Two files, allocator only.

Requests above 16 MB were allocated at their exact size and released straight back to the driver on every `Free`. That is the right call for a one-off transient, but it is the wrong one for the allocation that actually dominates: a KV tensor under `past_present_share_buffer=false`, which grows by one token's worth every decode step. No two steps ask for the same size, so an exact-size pool could never hit and every step paid a fresh page-pin per tensor.

Both Gemma-4 models set `past_present_share_buffer=false` because they package `max_length=262144`, at which a shared cache would be 96.0 GiB (12B) and 60.0 GiB (26B). They cannot use the shared-buffer path, so this is the path that has to work.

## Mechanism

- **Reuse by capacity.** A request takes the smallest retained buffer that covers it, within `capacity <= size + size/32`. This is what lets one buffer absorb a whole run of growing requests instead of one step each, and the bound stops a small request from consuming a buffer a much larger one will need.
- **Headroom only on observed growth.** Buffers are allocated at exactly the requested size until a request exceeds the largest size seen in its octave. The growth flag latches per octave, because every layer asks for the same size within one decode step and only the first of them sees an increase. Once latched, capacity is `size + size/64` page-rounded — continuing the size-class table's own geometry, whose steps go 1/2, 1/4, 1/16, 1/32 as buffers grow.
- **Outgrown capacities are dropped** as soon as the next one is allocated, so a growth transition costs one set of buffers rather than two.
- **Retention is bounded by peak outstanding bytes**, with LRU eviction — the allocator's own high-water mark, so the bound scales with the context the model is run at instead of with a fixed share of RAM.
- **`hipHostMalloc` failure releases the whole pool and retries once.** Failing while holding reclaimable pinned pages would be worse than not pooling at all.

## Results

gfx1151, 16384-token prompt, 128 generated. Two arm orders interleaved and averaged, each arm with its own `TEMP` so autotune and MLIR caches cannot leak between them. Peak is process peak working set, which on this APU covers both CPU and GPU since pinned pages are shared.

| model | TPS before | TPS after | peak before | peak after |
| --- | --- | --- | --- | --- |
| gemma-4-26B-A4B-it-qmoe | 13.25 | **35.03** (+164%) | 21284 MB | **12901 MB** (−39.4%) |
| gemma-4-12b-it-kquant | 19.14 | 19.17 (+0.2%) | 25641 MB | **20338 MB** (−20.7%) |

The 12B does not speed up and is not expected to: at 16 K it is bound by the 7.29 GB of decoder weights it reads per token, not by allocation. It still gives back 5.2 GB of peak memory.

**At a 24 K context the 26B no longer runs at all on `main`** — the driver refuses a 100872192-byte pin part way through decode and the run dies with `hipHostMalloc(Mapped|Coherent) failed ... out of memory`. Pooled, it completes at 31.52 tok/s and 18344 MB.

### Neutrality

On models that share their KV buffer there is no churn for a pool to remove, so the only thing an allocator change can do is cost memory. Peak memory delta vs `main`:

| model | context | Δ peak |
| --- | --- | --- |
| DeepSeek-R1-Distill-Llama-70B | 16384 | −0.09% |
| Llama-3.1-8B-awq | 16384 | 0.00% |
| Mistral-7B-Instruct-v0.3 | 16384 | +0.09% |
| Qwen3.6-35B-A3B | 16384 | −0.15% |
| Qwen3.8-27B k_quant | 16384 | +0.16% |
| gpt-oss-20b | 4096 | +0.02% |
| qwen3-30b-a3b | 2048 | −0.00% |

TPS on these ranges −0.10% to +1.91%. The 70B swings ±6% between runs, but in both arm orders the arm that ran *first* got 5.25 tok/s and the arm that ran *second* got 4.93 regardless of which arm it was — it pages from disk (119 s TTFT at 5.5 GB resident), so that is position, not the allocator. `gemma3-4b-it` is not covered: it fails identically on both arms with an `image_features` input-rank error, unrelated to this change.

### Mechanism verification

Measured with temporary instrumentation (not in this diff):

| | buffers reused | driver calls | distinct capacities | peak retained |
| --- | --- | --- | --- | --- |
| Mistral-7B @ 16 K (shared KV) | 64 | 64 | 1, at the exact requested size | 2064 MB |
| Gemma-4 26B @ 16 K | 15180 | 182 | 7 | 7240 MB |
| Gemma-4 26B @ 24 K | 15180 | 182 | 7 | 10858 MB |

Mistral never rounds a buffer — the growth flag never latches, so a fixed-shape model pays no waste. The 26B reaches a 98.8% reuse rate, and its 182 driver calls across 60 KV tensors is exactly the 3 per tensor the design predicts: one exact-size probe plus a ping-pong pair. Both numbers are **identical at 24 K**, so the driver-call count does not grow with context, while retention scales exactly 1.5× with the 1.5× context.
