### PR TITLE
[DO NOT MERGE] test: PR 961 capacity-keyed large-buffer pool on PR 599's OGA build

### DIFF
--- a/.github/workflows/windows-deps.yml
+++ b/.github/workflows/windows-deps.yml
@@ -587,6 +587,11 @@ jobs:
         if: steps.cache-oga.outputs.cache-hit != 'true'
         shell: bash
         run: |
+          # build.py imports tools/python/util, whose dependency_resolver
+          # imports requests at module scope. --ort_home means nothing is
+          # actually downloaded, but the import still has to resolve.
+          python -m pip install -q requests
+
           python "${{ github.workspace }}/source-oga/build.py" \
             --config Release \
             --cmake_generator Ninja \

--- a/.github/workflows/windows-deps.yml
+++ b/.github/workflows/windows-deps.yml
@@ -30,8 +30,14 @@ env:
   LLVM_TAG: llvmorg-22.1.0
   ONNXRUNTIME_VERSION: "1.27.0"
   ONNXRUNTIME_PR_PATCHES: ""
-  OGA_VERSION: "0.14.0"
-  OGA_PR_PATCHES: "2194"
+  # Fork branch carrying the AMDGPU MorphiZen integration (former PR 2194) plus
+  # sliding_window support, which upstream v0.14.0 does not have.
+  OGA_REPO: "amd-genmingz/onnxruntime-genai"
+  OGA_REF: "test_0_3"
+  # Optional space-separated microsoft/onnxruntime-genai PR numbers applied on
+  # top of the fork checkout via pull/<n>.patch + git am. Empty because the fork
+  # branch already carries the integration that 2194 used to supply.
+  OGA_PR_PATCHES: ""
   ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
   AMDGPU_EP_REF: "05eaa2a938f71e98b49bd1be3fb03720167be5cc"
   # Space-separated onnxruntime/onnxruntime-ep-amdgpu PR numbers applied on top
@@ -473,7 +479,7 @@ jobs:
       - name: Compute cache key
         id: key
         shell: bash
-        run: echo "value=oga-dml-mm2-${{ env.OGA_VERSION }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}" >> "$GITHUB_OUTPUT"
+        run: echo "value=oga-dml-mm3-${{ env.OGA_REPO }}-${{ env.OGA_REF }}-pr${{ env.OGA_PR_PATCHES }}-ort${{ env.ONNXRUNTIME_VERSION }}-ortpr${{ env.ONNXRUNTIME_PR_PATCHES }}-2" >> "$GITHUB_OUTPUT"
 
       - name: Probe oga-artifacts
         id: cache-oga
@@ -525,8 +531,8 @@ jobs:
         if: steps.cache-oga.outputs.cache-hit != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: microsoft/onnxruntime-genai
-          ref: v${{ env.OGA_VERSION }}
+          repository: ${{ env.OGA_REPO }}
+          ref: ${{ env.OGA_REF }}
           path: source-oga
           submodules: true
           fetch-depth: 1

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -17,6 +17,9 @@ flatbuffers;https://github.com/google/flatbuffers.git;v25.12.19
 ## Crash-backtrace helper (always FetchContent; no find_package path).
 cpptrace;https://github.com/jeremy-rifkin/cpptrace.git;v0.8.3
 ##
-therock_windows;https://github.com/ROCm/hip-ep/releases/download/v0.3.0;therock-dist-windows-gfx11-all-7.14.0-hipblaslt-trimmed
+## ROCm SDK. Do not substitute a `-hipblaslt-trimmed` dist: it keeps 18 of the
+## 100 Tensile files per arch, and a GEMM whose solution was removed gets zero
+## algorithms from the heuristic rather than a slower one.
+therock_windows;https://github.com/ROCm/hip-ep/releases/download/v0.3.0;therock-dist-windows-gfx11-all-7.14.0
 therock_linux;https://repo.amd.com/rocm/tarball;therock-dist-linux-gfx1151-7.11.0
 migraphx_windows;https://github.com/ROCm/hip-ep/releases/download/v0.3.0;migraphx-sdk-windows-1217ce1d

--- a/morphizen/ort-bridge/src/morphizen-hip-gpu-allocator.cpp
+++ b/morphizen/ort-bridge/src/morphizen-hip-gpu-allocator.cpp
@@ -75,6 +75,60 @@ int SizeClassIndex(size_t size) noexcept {
   return -1;
 }
 
+constexpr size_t kPageSize = 4096;
+
+// Capacity for a large request that is known to be growing. The 1/64 headroom
+// is the reuse span: a Gemma-4 KV tensor is 64 MiB at a 16 K context and grows
+// 4096 bytes per token, so one capacity covers the next 256 tokens.
+//
+// Continuing the size-class table's geometry, whose steps go 1/2, 1/4, 1/16,
+// 1/32 as buffers grow, because the waste is proportional to the size.
+constexpr size_t LargeCapacity(size_t size) noexcept {
+  const size_t want = size + size / 64;
+  return (want + kPageSize - 1) / kPageSize * kPageSize;
+}
+
+// Checked at compile time because no unit-test target covers this file and
+// returning less than the request would overflow the buffer.
+constexpr bool LargeCapacityHolds() {
+  for (size_t n = 16ull << 20; n <= 16ull << 30; n += n / 8) {
+    const size_t c = LargeCapacity(n);
+    if (c < n + n / 64 || c > n + n / 64 + kPageSize) {
+      return false;
+    }
+  }
+  return true;
+}
+static_assert(LargeCapacityHolds(),
+              "LargeCapacity must cover the request with its growth headroom "
+              "and waste at most one page beyond it");
+static_assert(LargeCapacity(64ull << 20) - (64ull << 20) >= 128 * 4096,
+              "one capacity must span more than a 128-token generation at a "
+              "16 K context");
+
+int OctaveOf(size_t size) noexcept {
+  int octave = 0;
+  while (size > 1) {
+    size >>= 1;
+    ++octave;
+  }
+  return octave;
+}
+
+// Hand a batch of buffers back to the driver with pool_mutex_ released:
+// hipHostFree unpins pages and is as heavyweight as the hipHostMalloc that
+// pinned them, so holding the lock would serialize every other allocation
+// behind it.
+void ReleaseToDriver(const std::vector<void *> &buffers, int device_id) {
+  if (buffers.empty()) {
+    return;
+  }
+  ScopedDevice _(device_id);
+  for (void *p : buffers) {
+    (void)hipHostFree(p);
+  }
+}
+
 int TryGetDeviceId(const OrtMemoryInfo *memory_info) noexcept {
   if (memory_info == nullptr) {
     return -1;
@@ -107,6 +161,62 @@ HipGpuAllocator::HipGpuAllocator(const OrtMemoryInfo *memory_info,
   GetStats = nullptr;
 }
 
+// A capacity the model has just grown past cannot serve this request or any
+// later one, so its idle buffers are dead weight. Bounded to the immediate
+// neighbourhood below `size` so an unrelated, much smaller tensor pooled in
+// the same octave is left alone.
+void HipGpuAllocator::DropOutgrown(size_t size, std::vector<void *> &out) {
+  auto it = large_free_.lower_bound(size - size / 16);
+  while (it != large_free_.end() && it->first < size) {
+    for (void *ptr : it->second.free) {
+      ptr_to_size_.erase(ptr);
+      large_retained_bytes_ -= it->first;
+      out.push_back(ptr);
+    }
+    it = large_free_.erase(it);
+  }
+}
+
+// One buffer from the least-recently-used capacity, skipping `keep` because
+// evicting there would free a buffer of exactly the size being made room for.
+// Buffers nothing can ask for again are never touched, so they are always the
+// oldest and go first.
+bool HipGpuAllocator::EvictLruLarge(size_t keep, std::vector<void *> &out) {
+  auto victim = large_free_.end();
+  for (auto it = large_free_.begin(); it != large_free_.end(); ++it) {
+    if (it->first == keep) {
+      continue;
+    }
+    if (victim == large_free_.end() ||
+        it->second.last_used < victim->second.last_used) {
+      victim = it;
+    }
+  }
+  if (victim == large_free_.end()) {
+    return false;
+  }
+  void *ptr = victim->second.free.back();
+  victim->second.free.pop_back();
+  ptr_to_size_.erase(ptr);
+  large_retained_bytes_ -= victim->first;
+  out.push_back(ptr);
+  if (victim->second.free.empty()) {
+    large_free_.erase(victim);
+  }
+  return true;
+}
+
+void HipGpuAllocator::DrainLarge(std::vector<void *> &out) {
+  for (auto &entry : large_free_) {
+    for (void *ptr : entry.second.free) {
+      ptr_to_size_.erase(ptr);
+      out.push_back(ptr);
+    }
+  }
+  large_free_.clear();
+  large_retained_bytes_ = 0;
+}
+
 void *ORT_API_CALL HipGpuAllocator::AllocImpl(OrtAllocator *this_,
                                               size_t size) {
   if (size == 0) {
@@ -115,28 +225,59 @@ void *ORT_API_CALL HipGpuAllocator::AllocImpl(OrtAllocator *this_,
   auto *self = static_cast<HipGpuAllocator *>(this_);
 
   const int cls = SizeClassIndex(size);
+  // Bytes to allocate on a miss: the class capacity for a pooled request, and
+  // for a large one either the exact size or a grown capacity depending on
+  // whether its octave has been seen to move.
+  size_t alloc_size = (cls >= 0) ? kSizeClasses[cls] : size;
+  std::vector<void *> stale;
 
-  // Fast path: reuse a pooled buffer with no driver call. Only requests that
-  // map to a size class (<= 16 MB) are pooled; any buffer in that class fits
-  // (they are all the class capacity). Large requests (cls < 0, > 16 MB) are
-  // never pooled — they are allocated at exact size and released straight back
-  // to the driver in FreeImpl, so a one-off huge transient can't pin memory.
-  if (cls >= 0) {
+  // Fast path: reuse a buffer with no driver call. A size class holds buffers
+  // all at the class capacity, so any of them fits. A large request takes the
+  // smallest retained capacity that covers it, close enough that it cannot
+  // consume a buffer a much larger request will need.
+  {
     std::lock_guard<std::mutex> lk(self->pool_mutex_);
-    auto &fl = self->free_lists_[cls];
-    if (!fl.empty()) {
-      void *ptr = fl.back();
-      fl.pop_back();
-      return ptr;
+    if (cls >= 0) {
+      auto &fl = self->free_lists_[cls];
+      if (!fl.empty()) {
+        void *ptr = fl.back();
+        fl.pop_back();
+        return ptr;
+      }
+    } else {
+      ++self->large_ops_;
+      auto &octave = self->octaves_[OctaveOf(size)];
+      if (octave.high_water != 0 && size > octave.high_water) {
+        octave.growing = true;
+      }
+      if (size > octave.high_water) {
+        octave.high_water = size;
+      }
+
+      auto it = self->large_free_.lower_bound(size);
+      if (it != self->large_free_.end() && it->first <= size + size / 32) {
+        void *ptr = it->second.free.back();
+        it->second.free.pop_back();
+        it->second.last_used = self->large_ops_;
+        self->large_retained_bytes_ -= it->first;
+        self->large_live_bytes_ += it->first;
+        if (self->large_live_bytes_ > self->large_peak_live_bytes_) {
+          self->large_peak_live_bytes_ = self->large_live_bytes_;
+        }
+        if (it->second.free.empty()) {
+          self->large_free_.erase(it);
+        }
+        return ptr;
+      }
+      if (octave.growing) {
+        alloc_size = LargeCapacity(size);
+        self->DropOutgrown(size, stale);
+      }
     }
   }
+  ReleaseToDriver(stale, self->device_id_);
 
   ScopedDevice _(self->device_id_);
-
-  // Cold miss: allocate. Pooled requests are rounded up to the full class
-  // capacity so the buffer is reusable by any later request in the same class;
-  // large requests are allocated at their exact size.
-  const size_t alloc_size = (cls >= 0) ? kSizeClasses[cls] : size;
 
   // On AMD APU iGPU (the only hardware MorphiZen EP currently targets) the
   // GPU shares physical memory with the CPU, so we use hipHostMalloc(Mapped)
@@ -157,6 +298,21 @@ void *ORT_API_CALL HipGpuAllocator::AllocImpl(OrtAllocator *this_,
   hipError_t err = hipHostMalloc(&ptr, alloc_size,
                                  hipHostMallocMapped | hipHostMallocCoherent);
   if (err != hipSuccess) {
+    // The large pool may be sitting on pinned pages this allocation could use,
+    // and failing while holding reclaimable memory would be worse than not
+    // pooling at all.
+    std::vector<void *> drained;
+    {
+      std::lock_guard<std::mutex> lk(self->pool_mutex_);
+      self->DrainLarge(drained);
+    }
+    if (!drained.empty()) {
+      ReleaseToDriver(drained, self->device_id_);
+      err = hipHostMalloc(&ptr, alloc_size,
+                          hipHostMallocMapped | hipHostMallocCoherent);
+    }
+  }
+  if (err != hipSuccess) {
     LOG(ERROR) << "[MorphiZen HIP] hipHostMalloc(Mapped|Coherent) failed for "
                << alloc_size << " bytes (device " << self->device_id_
                << "): " << hipGetErrorString(err);
@@ -165,6 +321,12 @@ void *ORT_API_CALL HipGpuAllocator::AllocImpl(OrtAllocator *this_,
   {
     std::lock_guard<std::mutex> lk(self->pool_mutex_);
     self->ptr_to_size_[ptr] = alloc_size;
+    if (cls < 0) {
+      self->large_live_bytes_ += alloc_size;
+      if (self->large_live_bytes_ > self->large_peak_live_bytes_) {
+        self->large_peak_live_bytes_ = self->large_live_bytes_;
+      }
+    }
   }
   return ptr;
 }
@@ -174,30 +336,49 @@ void ORT_API_CALL HipGpuAllocator::FreeImpl(OrtAllocator *this_, void *p) {
     return;
   }
   auto *self = static_cast<HipGpuAllocator *>(this_);
+  // p itself when it cannot be retained, plus whatever eviction dropped to
+  // make room for it.
+  std::vector<void *> to_release;
   {
     std::lock_guard<std::mutex> lk(self->pool_mutex_);
     auto it = self->ptr_to_size_.find(p);
-    if (it != self->ptr_to_size_.end()) {
-      // The stored size is the class capacity for pooled buffers (so
-      // SizeClassIndex recovers the class) and the exact size for large ones.
-      const int cls = SizeClassIndex(it->second);
-      if (cls >= 0) {
-        // Pooled small/medium buffer (<= 16 MB): return to its free list for
-        // reuse; do NOT release to the driver here. Stays tracked in
-        // ptr_to_size_ so the destructor can release it. Safe to reuse without
-        // a stream sync: see the pool comment in the header.
-        self->free_lists_[cls].push_back(p);
+    if (it == self->ptr_to_size_.end()) {
+      // Defensive: a pointer we never handed out. Release rather than leak.
+      to_release.push_back(p);
+    } else if (const int cls = SizeClassIndex(it->second); cls >= 0) {
+      // Pooled small/medium buffer (<= 16 MB): return to its free list for
+      // reuse; do NOT release to the driver here. Stays tracked in
+      // ptr_to_size_ so the destructor can release it. Safe to reuse without
+      // a stream sync: see the pool comment in the header.
+      self->free_lists_[cls].push_back(p);
+      return;
+    } else {
+      const size_t capacity = it->second;
+      ++self->large_ops_;
+      self->large_live_bytes_ -= (self->large_live_bytes_ < capacity)
+                                     ? self->large_live_bytes_
+                                     : capacity;
+      // Retaining this would put the pool over a ceiling that tracks the most
+      // this model has had checked out at once, so evict the capacities that
+      // have gone longest without being asked for before giving up on it.
+      bool room = self->large_retained_bytes_ + capacity <=
+                  self->large_peak_live_bytes_;
+      while (!room && self->EvictLruLarge(capacity, to_release)) {
+        room = self->large_retained_bytes_ + capacity <=
+               self->large_peak_live_bytes_;
+      }
+      if (room) {
+        auto &bucket = self->large_free_[capacity];
+        bucket.free.push_back(p);
+        bucket.last_used = self->large_ops_;
+        self->large_retained_bytes_ += capacity;
         return;
       }
-      // Large buffer (> 16 MB): never pooled. Stop tracking it and release it
-      // to the driver below (outside the lock — hipHostFree is heavyweight).
       self->ptr_to_size_.erase(it);
+      to_release.push_back(p);
     }
-    // Fall through for a large buffer, or for a pointer we never handed out
-    // (defensive): in both cases release directly so we don't leak.
   }
-  ScopedDevice _(self->device_id_);
-  (void)hipHostFree(p);
+  ReleaseToDriver(to_release, self->device_id_);
 }
 
 HipGpuAllocator::~HipGpuAllocator() {
@@ -217,6 +398,9 @@ HipGpuAllocator::~HipGpuAllocator() {
   for (auto &fl : free_lists_) {
     fl.clear();
   }
+  large_free_.clear();
+  large_retained_bytes_ = 0;
+  large_live_bytes_ = 0;
   ptr_to_size_.clear();
 }
 

--- a/morphizen/ort-bridge/src/morphizen-hip-gpu-allocator.hpp
+++ b/morphizen/ort-bridge/src/morphizen-hip-gpu-allocator.hpp
@@ -15,6 +15,8 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
+#include <map>
 #include <mutex>
 #include <unordered_map>
 #include <vector>
@@ -24,9 +26,8 @@ namespace morphizen {
 // Fixed size-class boundaries (bytes). A request of N bytes is served from the
 // first class whose capacity is >= N, and the buffer is allocated at the full
 // class capacity so any later request mapping to the same class can reuse it.
-// Requests larger than the last class (> 16 MB) are NOT pooled: they are
-// allocated at their exact size and released straight back to the driver in
-// FreeImpl, so a one-off huge transient can never pin memory in a free list.
+// Requests larger than the last class (> 16 MB) do not use this table; they go
+// through the capacity-keyed large pool described on HipGpuAllocator.
 //
 // The class boundaries are generated at compile time in four tiers, with the
 // tier edges de-duplicated where they meet:
@@ -120,6 +121,12 @@ private:
   static const OrtMemoryInfo *ORT_API_CALL InfoImpl(const OrtAllocator *this_);
   static void *ORT_API_CALL ReserveImpl(OrtAllocator *this_, size_t size);
 
+  // All three expect pool_mutex_ held and append buffers the caller must hand
+  // to the driver after releasing it.
+  void DropOutgrown(size_t size, std::vector<void *> &out);
+  bool EvictLruLarge(size_t keep, std::vector<void *> &out);
+  void DrainLarge(std::vector<void *> &out);
+
   // Fixed size-class caching allocator. hipHostMalloc is a heavyweight
   // (page-pinning) call: ORT re-allocates the per-Run input device-copy
   // buffers and (allocator mode) the graph-output buffers on EVERY inference,
@@ -136,13 +143,18 @@ private:
   // project's per-session "grow-on-demand, never shrink, free at cleanup"
   // memory contract.
   //
-  // Requests larger than the largest size class (> 16 MB) are NOT pooled: they
-  // are allocated at their exact size and released straight back to the driver
-  // in FreeImpl. A model's largest transients are few and shape-specific, so
-  // pooling them buys little reuse while risking an unbounded pinned working
-  // set when a model grows its largest transient a little each Run. Treating
-  // them as one-shot allocations keeps peak memory bounded with no eviction
-  // bookkeeping.
+  // Requests above 16 MB are pooled separately, keyed by the buffer's capacity
+  // rather than by a class, because the allocation that matters there is a KV
+  // tensor that grows by one token's worth every decode step when a model runs
+  // with past_present_share_buffer=false. No two steps ask for the same size,
+  // so an exact-size pool never hits and every step page-pins a fresh buffer.
+  //
+  // A request is served by the smallest retained buffer that is big enough for
+  // it, which is what lets one buffer cover a whole run of growing requests. A
+  // buffer only gets growth headroom once a request has actually exceeded the
+  // largest size seen in its octave; until then it is allocated at exactly the
+  // requested size, so a model whose tensors never change size pays no waste
+  // and still reuses its buffers across generators.
   //
   // Reuse needs no per-handout stream sync: ORT only calls Free after Run
   // returns, and allocator-mode inference_compute ends with a full
@@ -158,6 +170,31 @@ private:
   // destructor can release them; a large buffer is erased from this map in
   // FreeImpl when it is freed back to the driver.
   std::unordered_map<void *, size_t> ptr_to_size_;
+
+  // Large pool. Ordered so a request can find the smallest capacity that fits
+  // it with one lower_bound; empty buckets are erased.
+  struct LargeBucket {
+    std::vector<void *> free;
+    uint64_t last_used = 0;
+  };
+  std::map<size_t, LargeBucket> large_free_;
+  // Per octave of the request size. `growing` latches the first time a request
+  // exceeds the largest already seen there, which a fixed-size tensor never
+  // does. It has to latch rather than be re-tested per request because every
+  // layer asks for the same size within one decode step, so only the first of
+  // them would see an increase.
+  struct OctaveState {
+    size_t high_water = 0;
+    bool growing = false;
+  };
+  std::array<OctaveState, 64> octaves_{};
+  uint64_t large_ops_ = 0;
+  size_t large_live_bytes_ = 0;
+  // Retention ceiling: the pool never holds more idle bytes than the most this
+  // model has had checked out at once, so it scales with the context the model
+  // is run at instead of with a fixed share of RAM.
+  size_t large_peak_live_bytes_ = 0;
+  size_t large_retained_bytes_ = 0;
 
   const OrtMemoryInfo *memory_info_;
   // Cached at construction time. -1 means "couldn't read it from memory_info"


### PR DESCRIPTION
[DO NOT MERGE] CI-only. Runs PR #961's rewritten large-buffer pool on PR #599's OGA build, which is what actually exercises the Gemma-4 models the pool targets. Not for merge; #961 is the change under review.

- `761edb30`, `54f5ea29` -- PR #599, build OGA from the AMDGPU fork
- `2bda665b` -- PR #961, pool large pinned buffers by capacity

Rebuilt on current `main`. The allocator commit is byte-identical to #961's head.