### PR TITLE
fix(build): don't build hip-rocmlir-compiler on Windows

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -5,7 +5,14 @@
 
 add_subdirectory(hip-mlir-opt)
 add_subdirectory(hip-compiler)
-add_subdirectory(hip-rocmlir-compiler)
+
+# hip-rocmlir-compiler hands serialized IR to rocMLIR's high-level pipeline
+# inside librockCompiler.so, loaded with RTLD_LOCAL so the .so's own embedded
+# copy of LLVM/MLIR stays out of the global symbol namespace. Neither the
+# library nor that scoping exists on Windows, so the tool is Linux-only.
+if(NOT WIN32)
+  add_subdirectory(hip-rocmlir-compiler)
+endif()
 
 # hip-inspect parses the IR with `llvm::parseBitcodeFile` and reads
 # the `@__metadata_json` global directly -- no JIT, no GPU dependency.


### PR DESCRIPTION
## What's broken

Every Windows build on this branch fails to compile `hip-rocmlir-compiler`, which includes `<dlfcn.h>` unconditionally:

```
tools\hip-rocmlir-compiler\hip-rocmlir-compiler.cpp(58): fatal error C1083:
Cannot open include file: 'dlfcn.h': No such file or directory
```

CMake even reports `Looking for C++ include dlfcn.h - not found` earlier in the same configure, then builds the tool anyway.

This arrived with `da995e06` ("Add hip-rocmlir-compiler"), one of the commits pushed straight to `feat/rocmlirtriton_fusion`, so no PR ever ran Windows CI over it. It is not caused by any of the open PRs, but it is red on all of them: `build_mock` and `build_real` fail on #950, #954 and #955 alike. The one PR still showing green Windows checks, #930, last ran on Sep 8 — a day before `da995e06` landed — so that green reflects an older base rather than a healthier branch.

## Why guard instead of porting the dlopen calls

Porting to `llvm::sys::DynamicLibrary` would make the tool compile without making it work, and would break the reason the `dlopen` boundary exists.

The tool hands serialized IR to rocMLIR's high-level pipeline inside `librockCompiler.so`, which is not built for Windows. More importantly, its own header comment explains that the `.so` statically embeds a complete second copy of LLVM/MLIR, and that passing anything but bytes across the boundary aborts with `Trying to register different dialects for the same namespace: tosa`. It therefore loads the library with `RTLD_NOW | RTLD_LOCAL`, and the comment at the call site is explicit about why:

> `RTLD_LOCAL` keeps the .so's ~769 exported `mlir*` symbols out of the global [namespace]

`llvm::sys::DynamicLibrary::getPermanentLibrary` opens with `RTLD_GLOBAL`, so routing through it would reintroduce exactly the symbol collision with this executable's own statically linked MLIR that the boundary was built to prevent.

The tool is Linux-only by construction, so this guards the subdirectory:

```cmake
# hip-rocmlir-compiler hands serialized IR to rocMLIR's high-level pipeline
# inside librockCompiler.so, loaded with RTLD_LOCAL so the .so's own embedded
# copy of LLVM/MLIR stays out of the global symbol namespace. Neither the
# library nor that scoping exists on Windows, so the tool is Linux-only.
if(NOT WIN32)
  add_subdirectory(hip-rocmlir-compiler)
endif()
```

`if(NOT WIN32)` around a whole subdirectory is the existing convention here — `python/`, `test/e2e/`, `test/plugin/sample_plugin/` and `tools/hip-test/` all do the same.

## Nothing else needs adjusting

- No test, lit config or workflow references the target. The Windows jobs build the default target through `build.sh --cmake_generator Ninja`; the only explicitly named target anywhere is `test_static_plugins`.
- The only other mention of it in the build is the harden-comgr-safe loop in the top-level `CMakeLists.txt`, which already tests `if(TARGET ${_host_exe})` before touching each executable, so it simply skips the target when it isn't defined.

## Testing

Verified on an MSVC 14.44 / Ninja tree on Windows, against the same compiler family CI uses.

Without the guard, the target is in the build graph (22 ninja edges) and reproduces the CI error at the same line:

```
FAILED: tools/hip-rocmlir-compiler/CMakeFiles/hip-rocmlir-compiler.dir/hip-rocmlir-compiler.cpp.obj
...hip-rocmlir-compiler.cpp(58): fatal error C1083: Cannot open include file: 'dlfcn.h'
```

With the guard, `hip-rocmlir-compiler` appears nowhere in the build graph, configure succeeds, and the other host tools still build and link:

```
[195/202] Linking CXX executable bin\hip-inspect.exe
[200/202] Linking CXX executable bin\hip-mlir-opt.exe
[201/202] Linking CXX executable bin\hip-compiler.exe
```

Linux is unaffected — the subdirectory is added exactly as before.

## The pre-commit job will be red here too

For an unrelated reason, and not one this PR introduces. `lintrunner` runs `--all-files`, and three files on the base branch fail the repo's pinned `clang-format` 16.0.1:

```
lib/Conversion/HipToLLVM/RocMlirLowering.cpp            10 violations
lib/Runtime/hipdnn_ep_runtime.h                          4 violations
tools/hip-rocmlir-compiler/hip-rocmlir-compiler.cpp     34 violations
```

These came in with the same batch of directly-pushed commits, which never ran pre-commit either. #950 already fixes all of them in a dedicated commit, which is why its pre-commit is green. Rather than duplicate that commit here and create a conflict, this PR leaves them alone — but I'm happy to fold the formatting fix in if you'd prefer this to land independently of #950.
