### PR TITLE
feat: add QDQ Sigmoid fusion (hip.qsigmoid)

### DIFF
--- a/include/hip/Dialect/IR/HipBufferize.h
+++ b/include/hip/Dialect/IR/HipBufferize.h
@@ -212,6 +212,7 @@ registerHipBufferizableOpInterfaceModels(DialectRegistry &registry) {
     LoopOp::attachInterface<HipDstBufferizableModel<LoopOp>>(*ctx);
     QAddOp::attachInterface<HipDstBufferizableModel<QAddOp>>(*ctx);
     QMulOp::attachInterface<HipDstBufferizableModel<QMulOp>>(*ctx);
+    QSigmoidOp::attachInterface<HipDstBufferizableModel<QSigmoidOp>>(*ctx);
     QMatMulOp::attachInterface<HipDstBufferizableModel<QMatMulOp>>(*ctx);
     QConvOp::attachInterface<HipDstBufferizableModel<QConvOp>>(*ctx);
     // hip.if is a DPS control-flow op (getDpsInitsMutable, results alias

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -4951,6 +4951,45 @@ def Hip_QMulOp : Hip_DpsOp_Broadcast<"qmul",
   }];
 }
 
+def Hip_QSigmoidOp : Hip_DpsOp<"qsigmoid", /*traits=*/[],
+                                /*outsAccessor=*/"Y",
+                                /*autoReify=*/1,
+                                /*autoInfer=*/1,
+                                /*declareInfer=*/1> {
+  let summary = "Quantized sigmoid with integrated QDQ";
+  let description = [{
+    Fuses DequantizeLinear -> Sigmoid -> QuantizeLinear.
+
+    x = (X - x_zero_point) * x_scale
+    y = 1 / (1 + exp(-x))
+    Y = saturate(round(y / y_scale) + y_zero_point)
+
+    Example:
+    ```mlir
+    hip.qsigmoid(%ctx) ins(%x : memref<1x128x512xi8, 1>)
+                       outs(%y : memref<1x128x512xi8, 1>)
+                       {x_scale = 2.500000e-01 : f32, x_zero_point = -5 : i64,
+                        y_scale = 1.250000e-01 : f32, y_zero_point = 4 : i64}
+    ```
+  }];
+
+  let arguments = (ins
+    Hip_ContextType:$ctx,
+    Hip_TensorOrMemRef:$x,
+    Hip_TensorOrMemRef:$y,              // Output buffer (quant), DPS init
+    F32Attr:$x_scale,                   // Dequantization scale for input
+    I64Attr:$x_zero_point,              // Quantization zero point for input
+    F32Attr:$y_scale,                   // Quantization scale for output
+    I64Attr:$y_zero_point               // Quantization zero point for output
+  );
+
+  let assemblyFormat = [{
+    `(` $ctx `)` `ins` `(` $x `:` type($x) `)`
+    `outs` `(` $y `:` type($y) `)`
+    attr-dict (`:` type($result_tensors)^)?
+  }];
+}
+
 def Hip_QMatMulOp : Hip_DpsOp<"qmatmul", /*traits=*/[],
                               /*outsAccessor=*/"Y",
                               /*autoReify=*/0,

--- a/lib/Conversion/HipToLLVM/CMakeLists.txt
+++ b/lib/Conversion/HipToLLVM/CMakeLists.txt
@@ -63,6 +63,7 @@ add_library(HipToLLVM STATIC
   GridSampleLowering.cpp
   GlobalPoolLowering.cpp
   QElementwiseLowering.cpp
+  QActivationLowering.cpp
   QMatMulLowering.cpp
   QConvLowering.cpp
 )

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -289,6 +289,7 @@ void ConvertHipToLLVMPass::runOnOperation() {
   populateGridSampleLoweringPatterns(typeConverter, patterns);
   populateGlobalPoolLoweringPatterns(typeConverter, patterns);
   populateQElementwiseLoweringPatterns(typeConverter, patterns);
+  populateQActivationLoweringPatterns(typeConverter, patterns);
   populateQMatMulLoweringPatterns(typeConverter, patterns);
   populateQConvLoweringPatterns(typeConverter, patterns);
 

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -141,6 +141,7 @@ inline constexpr const char *kWrapScatterND = "wrap_scatter_nd";
 inline constexpr const char *kWrapNonZero = "wrap_nonzero";
 inline constexpr const char *kWrapSize = "wrap_size";
 inline constexpr const char *kWrapQElementwise = "wrap_qelementwise";
+inline constexpr const char *kWrapQActivation = "wrap_qactivation";
 inline constexpr const char *kWrapQMatMul = "wrap_qmatmul";
 inline constexpr const char *kWrapQConv = "wrap_qconv";
 // Synchronize the stream and read a device i32 scalar back to the host
@@ -393,6 +394,14 @@ enum HipdnnQElementwiseKind : int64_t {
   kQElementwiseMul = 1,
 };
 
+// Must match HIPDNN_EP_QACTIVATION_* in lib/Runtime/hipdnn_ep_runtime.h.
+// One shared runtime entry (wrap_qactivation) dispatches on this kind, so
+// future family members (qtanh, qsoftplus, qgelu, ...) add an enumerator
+// here without changing the ABI shape.
+enum HipdnnQActivationKind : int64_t {
+  kQActivationSigmoid = 0,
+};
+
 // Must match HIPDNN_EP_TENSOR_OP_* in lib/Runtime/hipdnn_ep_runtime.h
 enum HipdnnTensorOp : int64_t {
   kTensorOpMul = 0,
@@ -527,6 +536,8 @@ void populateGlobalPoolLoweringPatterns(const LLVMTypeConverter &converter,
                                         RewritePatternSet &patterns);
 void populateQElementwiseLoweringPatterns(const LLVMTypeConverter &converter,
                                           RewritePatternSet &patterns);
+void populateQActivationLoweringPatterns(const LLVMTypeConverter &converter,
+                                         RewritePatternSet &patterns);
 void populateQMatMulLoweringPatterns(const LLVMTypeConverter &converter,
                                      RewritePatternSet &patterns);
 void populateQConvLoweringPatterns(const LLVMTypeConverter &converter,

--- a/lib/Conversion/HipToLLVM/QActivationLowering.cpp
+++ b/lib/Conversion/HipToLLVM/QActivationLowering.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "HipToLLVMUtils.h"
+
+namespace mlir {
+namespace hip {
+namespace {
+
+// Shared lowering for quantized unary activation ops:
+//   hip.qsigmoid (future family members: qtanh, qsoftplus, qgelu, ...)
+//     -> wrap_qactivation(state, input, output, kind, num_elements, data_type,
+//                         x_scale, x_zero_point, out_recip_scale, y_zero_point)
+//
+// Folding (compile time, mirrors QElementwiseLowering): unlike Add/Mul, the
+// activation itself is non-linear, so only the output-side division folds
+// into a reciprocal multiply -- there is no algebraic elimination across the
+// activation.
+//   x_fp = (X - x_zero_point) * x_scale
+//   y_fp = activation(x_fp)                 // kind selects the device function
+//   Y    = saturate(round(y_fp * out_recip_scale) + y_zero_point)
+//   out_recip_scale = 1.0f / y_scale        // division folded here, once,
+//                                           // at compile time
+template <typename OpTy, HipdnnQActivationKind Kind>
+struct QActivationLowering : public ConvertOpToLLVMPattern<OpTy> {
+  using ConvertOpToLLVMPattern<OpTy>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(OpTy op, typename OpTy::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    ModuleOp module = op->template getParentOfType<ModuleOp>();
+    Type ptrType = this->getPtrType();
+    Type i64Type = rewriter.getI64Type();
+    Type f32Type = rewriter.getF32Type();
+    Type i32Type = rewriter.getI32Type();
+
+    auto outputType = dyn_cast<MemRefType>(op.getY().getType());
+    if (!outputType)
+      return rewriter.notifyMatchFailure(
+          op, "hip.qsigmoid lowering expects ranked memref outs operand");
+
+    int64_t dataType = getHipdnnDataType(outputType.getElementType());
+    if (dataType < 0)
+      return rewriter.notifyMatchFailure(op, "unsupported element type");
+
+    float yScale = op.getYScale().convertToFloat();
+    if (yScale == 0.0f)
+      return rewriter.notifyMatchFailure(op, "y_scale must be non-zero");
+    float outRecipScale = 1.0f / yScale;
+
+    Value numElements =
+        computeNumElements(outputType, adaptor.getY(), rewriter, loc);
+
+    auto createI64Const = [&](int64_t v) -> Value {
+      return LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                      rewriter.getI64IntegerAttr(v));
+    };
+    auto createF32Const = [&](float v) -> Value {
+      return LLVM::ConstantOp::create(rewriter, loc, f32Type,
+                                      rewriter.getF32FloatAttr(v));
+    };
+
+    // int wrap_qactivation(RuntimeState* state, void* input, void* output,
+    //     int64_t kind, int64_t num_elements, int64_t data_type,
+    //     float x_scale, int64_t x_zero_point,
+    //     float out_recip_scale, int64_t y_zero_point)
+    SmallVector<Type, 10> paramTypes = {
+        ptrType, ptrType, ptrType, // state, input, output
+        i64Type,                   // kind
+        i64Type,                   // num_elements
+        i64Type,                   // data_type
+        f32Type, i64Type,          // x_scale, x_zero_point
+        f32Type, i64Type};         // out_recip_scale, y_zero_point
+
+    FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
+        rewriter, module, kWrapQActivation, paramTypes, i32Type);
+    if (failed(funcOp))
+      return failure();
+
+    SmallVector<Value, 10> args = {
+        adaptor.getCtx(),
+        extractContiguousMemRefPtr(adaptor.getX(), rewriter, loc),
+        extractContiguousMemRefPtr(adaptor.getY(), rewriter, loc),
+        createI64Const(Kind),
+        numElements,
+        createI64Const(dataType),
+        createF32Const(op.getXScale().convertToFloat()),
+        createI64Const(op.getXZeroPoint()),
+        createF32Const(outRecipScale),
+        createI64Const(op.getYZeroPoint())};
+
+    LLVM::CallOp::create(rewriter, loc, *funcOp, args);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct QSigmoidOpLowering
+    : public QActivationLowering<QSigmoidOp,
+                                 HipdnnQActivationKind::kQActivationSigmoid> {
+  using QActivationLowering::QActivationLowering;
+};
+
+} // namespace
+
+void populateQActivationLoweringPatterns(const LLVMTypeConverter &converter,
+                                         RewritePatternSet &patterns) {
+  patterns.add<QSigmoidOpLowering>(converter);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/OnnxToHip/pdl/HipFusionPatterns.pdll
+++ b/lib/Conversion/OnnxToHip/pdl/HipFusionPatterns.pdll
@@ -36,3 +36,4 @@ Rewrite ExtractAttrInt64(op: Op, name: Attr, defaultValue: Attr) -> Attr;
 #include "QDQMulFusion.pdll"
 #include "QDQMatMulFusion.pdll"
 #include "QDQConvFusion.pdll"
+#include "QDQSigmoidFusion.pdll"

--- a/lib/Conversion/OnnxToHip/pdl/QDQSigmoidFusion.pdll
+++ b/lib/Conversion/OnnxToHip/pdl/QDQSigmoidFusion.pdll
@@ -1,0 +1,47 @@
+//===- QDQSigmoidFusion.pdll -----------------------------------------------===//
+//
+// PDLL pattern for QDQ Sigmoid fusion - pure PDLL approach.
+//
+// Included by HipFusionPatterns.pdll, which declares the native constraints
+// used below. Not compilable on its own.
+//===----------------------------------------------------------------------===//
+
+Pattern QDQSigmoid with benefit(10) {
+  // Match the QDQ chain: DequantizeLinear -> Sigmoid -> QuantizeLinear
+  let dquant = op<onnx.DequantizeLinear>(input: Value, x_scale: Value, x_tail: ValueRange);
+  let sigmoid = op<onnx.Sigmoid>(dquant.0);
+  let quant = op<onnx.QuantizeLinear>(sigmoid.0, y_scale: Value, y_tail: ValueRange) -> (output_type: Type);
+
+  // Fusability only: every scale must be a per-tensor splat constant and every
+  // zero point must be readable (or absent, which means zero). The kernel
+  // only implements HIP_DTYPE_{INT,UINT}{8,16} (see qactivation_kernel.hip);
+  // an int32-quantized side falls through to the unfused DQ/Sigmoid/Q path
+  // instead of fusing into an op the runtime would reject.
+  HasContextArg(quant);
+  IsSplatConstantValue(x_scale);
+  IsSplatConstantValue(y_scale);
+  HasExtractableZeropoint(dquant, attr<"2 : i64">);
+  HasExtractableZeropoint(quant, attr<"2 : i64">);
+  IsEightOrSixteenBitQuantized(dquant);
+  IsEightOrSixteenBitQuantized(quant);
+
+  // Replace with fused operation. Sigmoid is non-linear, so unlike Add/Mul the
+  // scales cannot be algebraically folded into a single runtime coefficient --
+  // HipToLLVM only folds y_scale's division into a reciprocal multiply.
+  rewrite quant with {
+    let ctx = GetContextArg(quant);
+    let x_scale_attr = ExtractScaleValue(x_scale);
+    let y_scale_attr = ExtractScaleValue(y_scale);
+    let x_zero_point_attr = ExtractZeropointValue(dquant, attr<"2 : i64">, attr<"0 : i64">);
+    let y_zero_point_attr = ExtractZeropointValue(quant, attr<"2 : i64">, attr<"0 : i64">);
+
+    let empty = op<tensor.empty> -> (output_type);
+    let qsigmoid = op<hip.qsigmoid>(ctx, input, empty.0) {
+      x_scale = x_scale_attr,
+      x_zero_point = x_zero_point_attr,
+      y_scale = y_scale_attr,
+      y_zero_point = y_zero_point_attr
+    } -> (output_type);
+    replace quant with qsigmoid;
+  };
+}

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -669,6 +669,19 @@ void QMulOp::getEffects(
 }
 
 //===----------------------------------------------------------------------===//
+// QSigmoidOp: ins(x), outs(y)
+// Quantized sigmoid with integrated QDQ scales and zero points
+//===----------------------------------------------------------------------===//
+
+MutableOperandRange QSigmoidOp::getDpsInitsMutable() { return getYMutable(); }
+
+void QSigmoidOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
+}
+
+//===----------------------------------------------------------------------===//
 // QConvOp: quantized ins(input, weights, scales, zero-points, [bias]),
 // outs(output)
 //===----------------------------------------------------------------------===//

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -377,6 +377,7 @@ if(NOT BUILD_MOCK_RUNTIME)
     compile_to_bitcode(real/grid_sample.cpp runtime_grid_sample.bc)
     compile_to_bitcode(real/global_pool.cpp runtime_global_pool.bc)
     compile_to_bitcode(real/qelementwise.cpp runtime_qelementwise.bc)
+    compile_to_bitcode(real/qactivation.cpp runtime_qactivation.bc)
     compile_to_bitcode(real/qmatmul.cpp runtime_qmatmul.bc)
     compile_to_bitcode(real/qconv.cpp runtime_qconv.bc)
 
@@ -467,6 +468,7 @@ if(NOT BUILD_MOCK_RUNTIME)
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_gather_block_quantized.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_qdq.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_qelementwise.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_qactivation.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_qmatmul.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_qconv.bc
     )

--- a/lib/Runtime/Kernels/CMakeLists.txt
+++ b/lib/Runtime/Kernels/CMakeLists.txt
@@ -51,6 +51,7 @@ set(_kernel_sources
     hip/softplus_kernel.hip
     hip/elementwise_where_kernel.hip
     hip/qelementwise_kernel.hip
+    hip/qactivation_kernel.hip
     hip/qmatmul_kernel.hip
     hip/qconv_kernel.hip
     hip/elementwise_unary_kernel.hip

--- a/lib/Runtime/Kernels/hip/qactivation_kernel.hip
+++ b/lib/Runtime/Kernels/hip/qactivation_kernel.hip
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+// FusedOp(X) = Q(Sigmoid(DQ(X))) -- and, as the family grows, the same shape
+// for Q(Tanh(DQ(X))), Q(Softplus(DQ(X))), Q(Gelu(DQ(X))), etc.
+//
+// x = (X - x_zero_point) * x_scale
+// y = activation(x)          // kind selects the device function below
+// Y = saturate(round(y * out_recip_scale) + y_zero_point)
+//
+// out_recip_scale = 1 / y_scale, folded once by the host wrapper so the
+// kernel never performs a runtime division.
+#include "debug_log.h"
+#include "hip_custom_kernels.h"
+
+#include <hip/hip_runtime.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+
+#define HIP_QACTIVATION_SIGMOID 0
+
+// The HIP compile flags include `-Xclang -fno-cuda-host-device-constexpr`
+// (see lib/Runtime/Kernels/cmake/hip_utils.cmake), which makes
+// `std::numeric_limits<T>` members host-only. Device-side bounds therefore
+// come from the <cstdint> macros through explicitly annotated helpers.
+template <typename T>
+struct QActBounds;
+
+template <>
+struct QActBounds<int8_t> {
+  __device__ static float lowest() { return static_cast<float>(INT8_MIN); }
+  __device__ static float highest() { return static_cast<float>(INT8_MAX); }
+};
+
+template <>
+struct QActBounds<uint8_t> {
+  __device__ static float lowest() { return 0.0f; }
+  __device__ static float highest() { return static_cast<float>(UINT8_MAX); }
+};
+
+template <>
+struct QActBounds<int16_t> {
+  __device__ static float lowest() { return static_cast<float>(INT16_MIN); }
+  __device__ static float highest() { return static_cast<float>(INT16_MAX); }
+};
+
+template <>
+struct QActBounds<uint16_t> {
+  __device__ static float lowest() { return 0.0f; }
+  __device__ static float highest() { return static_cast<float>(UINT16_MAX); }
+};
+
+template <typename T>
+__device__ inline T q_act_saturate(float v) {
+  return static_cast<T>(
+      fminf(QActBounds<T>::highest(), fmaxf(QActBounds<T>::lowest(), v)));
+}
+
+// Matches the float sigmoid kernel body (elementwise_unary_kernel.hip)
+// exactly, so the quantized and float paths stay numerically identical for
+// the same dequantized input -- the only difference is the surrounding
+// dequant/requant.
+__device__ inline float qact_sigmoid_f(float x) {
+  return 1.0f / (1.0f + expf(-x));
+}
+
+template <typename T>
+__global__ void qactivation_kernel(const T *__restrict__ input,
+                                   T *__restrict__ output,
+                                   int64_t num_elements, int kind,
+                                   float x_scale, int32_t x_zero_point,
+                                   float out_recip_scale,
+                                   int32_t y_zero_point) {
+  int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= num_elements)
+    return;
+
+  float x =
+      (static_cast<float>(input[idx]) - static_cast<float>(x_zero_point)) *
+      x_scale;
+
+  float y;
+  switch (kind) {
+  case HIP_QACTIVATION_SIGMOID:
+    y = qact_sigmoid_f(x);
+    break;
+  default:
+    return; // Unsupported kind: no silent fallback.
+  }
+
+  output[idx] = q_act_saturate<T>(rintf(y * out_recip_scale) +
+                                  static_cast<float>(y_zero_point));
+}
+
+template <typename T>
+static int launch_qactivation(hipStream_t stream, const void *input,
+                              void *output, int64_t num_elements, int kind,
+                              float x_scale, int32_t x_zero_point,
+                              float out_recip_scale, int32_t y_zero_point) {
+  constexpr int kBlockSize = 256;
+  int grid_size =
+      static_cast<int>((num_elements + kBlockSize - 1) / kBlockSize);
+  (void)hipGetLastError();
+  hipLaunchKernelGGL(qactivation_kernel<T>, dim3(grid_size), dim3(kBlockSize),
+                     0, stream, static_cast<const T *>(input),
+                     static_cast<T *>(output), num_elements, kind, x_scale,
+                     x_zero_point, out_recip_scale, y_zero_point);
+  return 0;
+}
+
+extern "C" int hip_qactivation(void *stream, const void *input, void *output,
+                               int64_t kind, int64_t num_elements,
+                               int hip_dtype, float x_scale,
+                               int64_t x_zero_point, float out_recip_scale,
+                               int64_t y_zero_point) {
+  if (kind != HIP_QACTIVATION_SIGMOID) {
+    fprintf(stderr,
+            "[custom_kernels] hip_qactivation: unsupported kind=%lld\n",
+            (long long)kind);
+    return -1;
+  }
+  if (num_elements <= 0)
+    return 0;
+
+  hipStream_t hip_stream = static_cast<hipStream_t>(stream);
+  int32_t xzp = static_cast<int32_t>(x_zero_point);
+  int32_t yzp = static_cast<int32_t>(y_zero_point);
+
+  CUSTOM_KERNELS_DEBUG_LOG(
+      "[custom_kernels] hip_qactivation: dtype=%d kind=%lld num=%lld "
+      "x_scale=%g x_zp=%d out_recip_scale=%g y_zp=%d\n",
+      hip_dtype, (long long)kind, (long long)num_elements, x_scale, xzp,
+      out_recip_scale, yzp);
+
+  int rc = 0;
+  switch (hip_dtype) {
+  case HIP_DTYPE_INT8:
+    rc = launch_qactivation<int8_t>(hip_stream, input, output, num_elements,
+                                    (int)kind, x_scale, xzp, out_recip_scale,
+                                    yzp);
+    break;
+  case HIP_DTYPE_UINT8:
+    rc = launch_qactivation<uint8_t>(hip_stream, input, output, num_elements,
+                                     (int)kind, x_scale, xzp, out_recip_scale,
+                                     yzp);
+    break;
+  case HIP_DTYPE_INT16:
+    rc = launch_qactivation<int16_t>(hip_stream, input, output, num_elements,
+                                     (int)kind, x_scale, xzp, out_recip_scale,
+                                     yzp);
+    break;
+  case HIP_DTYPE_UINT16:
+    rc = launch_qactivation<uint16_t>(hip_stream, input, output, num_elements,
+                                      (int)kind, x_scale, xzp, out_recip_scale,
+                                      yzp);
+    break;
+  default:
+    fprintf(stderr, "[custom_kernels] hip_qactivation: unsupported dtype=%d\n",
+            hip_dtype);
+    return -1;
+  }
+
+  if (rc != 0)
+    return rc;
+
+  hipError_t err = hipGetLastError();
+  if (err != hipSuccess) {
+    fprintf(stderr, "[custom_kernels] hip_qactivation launch failed: %s\n",
+            hipGetErrorString(err));
+  }
+  return static_cast<int>(err);
+}

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -176,6 +176,35 @@ HIP_KERNEL_API int hip_qelementwise(
     int64_t output_zp);
 
 /* =========================================================================
+ * Quantized unary activation (Q(activation(DQ(X)))), e.g. Sigmoid
+ * =========================================================================
+ *
+ * input/output are integer quantized buffers of the same hip_dtype, sharing
+ * one flat shape -- unary activations never broadcast.
+ *
+ * kind: 0 = sigmoid (HIPDNN_EP_QACTIVATION_SIGMOID).
+ *
+ * out_recip_scale is folded by the host wrapper as 1.0f / y_scale, so the
+ * kernel never performs a runtime division:
+ *
+ *   x = (X - x_zero_point) * x_scale
+ *   y = activation(x)
+ *   Y = saturate(round(y * out_recip_scale) + y_zero_point)
+ *
+ * Supported hip_dtype: HIP_DTYPE_INT8, HIP_DTYPE_UINT8, HIP_DTYPE_INT16,
+ * HIP_DTYPE_UINT16.
+ */
+HIP_KERNEL_API int hip_qactivation(
+    void* stream,
+    const void* input,
+    void* output,
+    int64_t kind,
+    int64_t num_elements,
+    int hip_dtype,
+    float x_scale, int64_t x_zero_point,
+    float out_recip_scale, int64_t y_zero_point);
+
+/* =========================================================================
  * Quantized batched matmul (Q(DQ(A) @ DQ(B)))
  * =========================================================================
  *

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -36,6 +36,10 @@ extern "C" {
 #define HIPDNN_EP_QELEMENTWISE_ADD 0
 #define HIPDNN_EP_QELEMENTWISE_MUL 1
 
+// Must match HipdnnQActivationKind in
+// lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+#define HIPDNN_EP_QACTIVATION_SIGMOID 0
+
 static inline const char *hipdnn_ep_tensor_op_name(int64_t op) {
   switch (op) {
   case HIPDNN_EP_TENSOR_OP_MUL:
@@ -59,6 +63,15 @@ static inline const char *hipdnn_ep_qelementwise_kind_name(int64_t kind) {
     return "qmul";
   default:
     return "qelementwise_unknown";
+  }
+}
+
+static inline const char *hipdnn_ep_qactivation_kind_name(int64_t kind) {
+  switch (kind) {
+  case HIPDNN_EP_QACTIVATION_SIGMOID:
+    return "qsigmoid";
+  default:
+    return "qactivation_unknown";
   }
 }
 
@@ -940,6 +953,23 @@ int wrap_qelementwise(RuntimeState *state, void *lhs, void *rhs, void *output,
                       const int64_t *out_shape, int64_t out_rank,
                       int64_t data_type, float M_a, int64_t lhs_zp, float M_b,
                       int64_t rhs_zp, int64_t output_zp);
+
+// Quantized unary activation wrapper. `kind` selects the activation function
+// (HIPDNN_EP_QACTIVATION_*). Unlike wrap_qelementwise, input/output always
+// share one flat shape -- unary activations never broadcast, so only a
+// total element count is needed.
+//
+// input/output are quantized buffers of `data_type`.
+//
+// out_recip_scale is folded by lowering as 1.0f / y_scale, so the kernel
+// never performs a runtime division:
+//   x = (X - x_zero_point) * x_scale
+//   y = activation(x)                 // kind picks the device function
+//   Y = saturate(round(y * out_recip_scale) + y_zero_point)
+int wrap_qactivation(RuntimeState *state, void *input, void *output,
+                     int64_t kind, int64_t num_elements, int64_t data_type,
+                     float x_scale, int64_t x_zero_point, float out_recip_scale,
+                     int64_t y_zero_point);
 
 // Quantized batched matmul wrapper: the integer-domain form of the fused
 // DequantizeLinear x2 -> MatMul -> QuantizeLinear chain.

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -1610,6 +1610,24 @@ int wrap_qelementwise(RuntimeState *state, void *lhs, void *rhs, void *output,
   return 0;
 }
 
+int wrap_qactivation(RuntimeState *state, void *input, void *output,
+                     int64_t kind, int64_t num_elements, int64_t data_type,
+                     float x_scale, int64_t x_zero_point, float out_recip_scale,
+                     int64_t y_zero_point) {
+  (void)input;
+  (void)output;
+  (void)num_elements;
+  (void)data_type;
+  (void)x_scale;
+  (void)x_zero_point;
+  (void)out_recip_scale;
+  (void)y_zero_point;
+  if (!state)
+    return -1;
+  MOCK_PRINT("[MOCK] wrap_qactivation,kind=%lld", (long long)kind);
+  return 0;
+}
+
 int wrap_qmatmul(RuntimeState *state, const void *A, const void *B, void *Y,
                  int64_t M, int64_t N, int64_t K, int64_t batch_count,
                  int64_t b_batch_stride, int64_t trans_a, int64_t trans_b,

--- a/lib/Runtime/real/qactivation.cpp
+++ b/lib/Runtime/real/qactivation.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+// FusedOp(X) = Q(Sigmoid(DQ(X)))
+//
+// x = (X - x_zero_point) * x_scale
+// y = 1 / (1 + exp(-x))
+// Y = saturate(round(y / y_scale) + y_zero_point)
+// --->
+// let out_recip_scale = 1 / y_scale   (folded once by HipToLLVM lowering)
+// Y = saturate(round(y * out_recip_scale) + y_zero_point)
+#include "../debug_log.h"
+#include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
+#include "hip_custom_kernels.h"
+
+#include <cstdio>
+
+static int hipdnn_to_hip_dtype_qact(int64_t hipdnn_type) {
+  switch (hipdnn_type) {
+  case HIPDNN_EP_DATATYPE_INT8:
+    return HIP_DTYPE_INT8;
+  case HIPDNN_EP_DATATYPE_UINT8:
+    return HIP_DTYPE_UINT8;
+  case HIPDNN_EP_DATATYPE_INT16:
+    return HIP_DTYPE_INT16;
+  case HIPDNN_EP_DATATYPE_UINT16:
+    return HIP_DTYPE_UINT16;
+  default:
+    return -1;
+  }
+}
+
+// Notes on function reuse: every future family member (qtanh, qsoftplus,
+// qgelu, ...) reuses this declaration unchanged -- only `kind` and the
+// device-side math differ, so the ABI shape stays fixed as the family grows.
+int wrap_qactivation(RuntimeState *state, void *input, void *output,
+                     int64_t kind, int64_t num_elements, int64_t data_type,
+                     float x_scale, int64_t x_zero_point, float out_recip_scale,
+                     int64_t y_zero_point) {
+  OP_PROFILE(
+      hipdnn_ep_qactivation_kind_name(kind),
+      [&] {
+        char b[48];
+        snprintf(b, sizeof(b), "%s:%lld", hipdnn_ep_datatype_name(data_type),
+                 (long long)num_elements);
+        return std::string(b);
+      },
+      state);
+
+  if (!state || !input || !output) {
+    fprintf(stderr, "wrap_qactivation: null tensor argument\n");
+    return -1;
+  }
+  if (num_elements <= 0)
+    return 0;
+  if (kind != HIPDNN_EP_QACTIVATION_SIGMOID) {
+    fprintf(stderr, "wrap_qactivation: unsupported kind=%lld\n",
+            (long long)kind);
+    return -1;
+  }
+
+  int hip_dtype = hipdnn_to_hip_dtype_qact(data_type);
+  if (hip_dtype < 0) {
+    fprintf(stderr,
+            "[REAL] wrap_qactivation: unsupported data_type %lld (%s)\n",
+            (long long)data_type, hipdnn_ep_datatype_name(data_type));
+    return -1;
+  }
+
+  void *stream = hipdnn_ep_state_get_stream(state);
+
+  RUNTIME_DEBUG_LOG(
+      "[REAL] wrap_qactivation: kind=%lld dtype=%s(%lld) num_elements=%lld "
+      "x_scale=%g x_zp=%lld out_recip_scale=%g y_zp=%lld\n",
+      (long long)kind, hipdnn_ep_datatype_name(data_type), (long long)data_type,
+      (long long)num_elements, (double)x_scale, (long long)x_zero_point,
+      (double)out_recip_scale, (long long)y_zero_point);
+
+  return hip_qactivation(stream, input, output, kind, num_elements, hip_dtype,
+                         x_scale, x_zero_point, out_recip_scale, y_zero_point);
+}

--- a/test/lit/Conversion/hip-to-llvm/test_qsigmoid.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_qsigmoid.mlir
@@ -1,0 +1,27 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s --convert-hip-to-llvm | FileCheck %s
+
+// CHECK: llvm.func @wrap_qactivation(!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32, i64, f32, i64) -> i32
+
+module {
+  func.func @qsigmoid_i8(
+      %ctx: !hip.context,
+      %x: memref<1x128x32xi8, 1>,
+      %y: memref<1x128x32xi8, 1>) {
+    // CHECK-LABEL: llvm.func @qsigmoid_i8
+
+    hip.qsigmoid(%ctx) ins(%x : memref<1x128x32xi8, 1>)
+                       outs(%y : memref<1x128x32xi8, 1>)
+                       {x_scale = 2.500000e-01 : f32, x_zero_point = -5 : i64,
+                        y_scale = 1.250000e-01 : f32, y_zero_point = 4 : i64}
+
+    // out_recip_scale folds y_scale's division into a compile-time constant:
+    // out_recip_scale = 1 / y_scale = 1 / 0.125 = 8.0
+    // CHECK-DAG: llvm.mlir.constant(8.000000e+00 : f32)
+    // CHECK-DAG: llvm.mlir.constant(2.500000e-01 : f32)
+    // CHECK: llvm.call @wrap_qactivation({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32, i64, f32, i64) -> i32
+    return
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_qsigmoid.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_qsigmoid.mlir
@@ -1,0 +1,56 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST: QDQ Sigmoid Fusion Pattern (Pure PDLL approach)
+//
+// Demonstrates pure PDLL fusion with native constraints:
+// - PDLL matches the QDQ chain pattern
+// - PDLL calls native constraints to get the context, extract the f32 scales
+//   and extract the i64 zero points
+// - PDLL creates the fused hip.qsigmoid operation
+//
+// Pattern fuses:
+//   onnx.DequantizeLinear -> onnx.Sigmoid -> onnx.QuantizeLinear
+// into:
+//   hip.qsigmoid
+//
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s --check-prefix=NOLEFTOVER
+// ============================================================================
+
+// The exhaustive CHECK-NEXT chain below already pins every surviving op, but
+// spell the fusion contract out once so a partial match cannot pass silently.
+// NOLEFTOVER-NOT: onnx.DequantizeLinear
+// NOLEFTOVER-NOT: onnx.Sigmoid
+// NOLEFTOVER-NOT: onnx.QuantizeLinear
+// NOLEFTOVER-NOT: onnx.Constant
+// NOLEFTOVER-NOT: hip.constant
+
+module {
+
+// CHECK-LABEL: func.func @main_graph
+// CHECK-SAME:  (%[[CTX:.*]]: !hip.context, %[[X:.*]]: tensor<1x128x32xi8>) -> tensor<1x128x32xi8> {
+// CHECK-NEXT:    %[[EMPTY:.*]] = tensor.empty() : tensor<1x128x32xi8>
+// CHECK-NEXT:    %[[QSIGMOID:.*]] = hip.qsigmoid(%[[CTX]]) ins(%[[X]] : tensor<1x128x32xi8>) outs(%[[EMPTY]] : tensor<1x128x32xi8>) {x_scale = 2.500000e-01 : f32, x_zero_point = -5 : i64, y_scale = 1.250000e-01 : f32, y_zero_point = 4 : i64} : tensor<1x128x32xi8>
+// CHECK-NEXT:    return %[[QSIGMOID]] : tensor<1x128x32xi8>
+// CHECK-NEXT:  }
+  func.func @main_graph(%x: tensor<1x128x32xi8>) -> tensor<1x128x32xi8> {
+    %x_scale = "onnx.Constant"() {value = dense<0.25> : tensor<f32>} : () -> tensor<f32>
+    %x_zero_point = "onnx.Constant"() {value = dense<-5> : tensor<i8>} : () -> tensor<i8>
+    %y_scale = "onnx.Constant"() {value = dense<0.125> : tensor<f32>} : () -> tensor<f32>
+    %y_zero_point = "onnx.Constant"() {value = dense<4> : tensor<i8>} : () -> tensor<i8>
+
+    %dequantized = "onnx.DequantizeLinear"(%x, %x_scale, %x_zero_point)
+                  : (tensor<1x128x32xi8>, tensor<f32>, tensor<i8>) -> tensor<1x128x32xf32>
+
+    %sigmoid = "onnx.Sigmoid"(%dequantized)
+              : (tensor<1x128x32xf32>) -> tensor<1x128x32xf32>
+
+    %result = "onnx.QuantizeLinear"(%sigmoid, %y_scale, %y_zero_point)
+              : (tensor<1x128x32xf32>, tensor<f32>, tensor<i8>) -> tensor<1x128x32xi8>
+
+    return %result : tensor<1x128x32xi8>
+  }
+
+}


### PR DESCRIPTION
## Summary

Adds QDQ (Quantize-Dequantize) fusion support for `Sigmoid`, the first
activation in a planned family (`hip.qsigmoid` now; `hip.qtanh` /
`hip.qsoftplus` / `hip.qgelu` etc. to follow with the same runtime ABI).

`DequantizeLinear -> Sigmoid -> QuantizeLinear` is fused at the ONNX->HIP
conversion stage into a single `hip.qsigmoid` op, eliminating the
intermediate fp32 tensor materialization while keeping the computation
numerically identical to the unfused reference path.

## Design

- **Dialect**: `hip.qsigmoid` is a DPS op (`x`, `y` tensors + `x_scale`,
  `x_zero_point`, `y_scale`, `y_zero_point` attributes), mirroring the
  float `hip.sigmoid` op's shape-inference/bufferization plumbing.
- **PDLL fusion** (`QDQSigmoidFusion.pdll`): matches the DQ->Sigmoid->Q
  chain, gated by `IsSplatConstantValue`, `HasExtractableZeropoint`, and
  `IsEightOrSixteenBitQuantized` (kernel only supports int8/uint8/int16/
  uint16 — int32-quantized graphs correctly fall back to the unfused path
  instead of hitting an unsupported-dtype error at runtime).
- **Scale folding**: unlike Add/Mul, Sigmoid is non-linear so the scales
  can't fully collapse algebraically. Only the output-side division folds
  into a compile-time `out_recip_scale = 1.0f / y_scale` constant; the
  input dequant multiply stays a runtime float op, same as the float
  sigmoid kernel's structure.
- **Runtime ABI**: a single `wrap_qactivation(state, input, output, kind,
  num_elements, data_type, x_scale, x_zero_point, out_recip_scale,
  y_zero_point)` entry point with a `kind` enum
  (`HipdnnQActivationKind`), so future activations reuse the same
  HipToLLVM lowering template and runtime wrapper — only a new enum value
  and a new dialect op are needed.
- **Kernel**: dequantizes to fp32 in registers, computes
  `1/(1+exp(-x))`, requantizes via `round + saturate`. Bandwidth-bound
  elementwise op on GPU, so this is a straight compute (not LUT) design —
  see PR discussion / commit history for the roofline rationale.

## Validation

Built a minimal int8 `DequantizeLinear -> Sigmoid -> QuantizeLinear`
ONNX model (`x_scale=0.25/x_zero_point=-5`, `y_scale=0.125/y_zero_point=4`,
input spanning the full int8 range incl. saturation edges) and:

1. Dumped IR before/after `convert-onnx-to-hip` — confirms the three ONNX
   ops are fully replaced by one `hip.qsigmoid` with correctly extracted
   attributes, no leftover DQ/Sigmoid/Q ops.
2. Dumped IR before/after `convert-hip-to-llvm` — confirms the
   `wrap_qactivation` call is emitted with `out_recip_scale = 8.0`
   (`1/0.125`) folded as a compile-time constant.
3. Ran the model on the real GPU path (`hip-onnx-runner`, `HIPDNN_EP_STRICT=1`,
   `HIPDNN_EP_DEBUG=1`) and confirmed the new runtime/kernel code paths
   fire (`[REAL] wrap_qactivation ...`, `[custom_kernels] hip_qactivation ...`)
   with no strict-mode abort (i.e. no silent CPU fallback).
4. Compared GPU EP output vs. ORT CPU EP (unfused DQ+Sigmoid+Q) vs. a
   numpy fp32 reference — all three match bit-for-bit
   (`hip-onnx-runner -L`: `L2(diff) = 0`).

## Status

Opening as **draft** for review before marking ready — no CI run
requested yet.
