### PR TITLE
feat(qdq): fuse DQ+LpNormalization+Q into hip.qlpnormalization

### DIFF
--- a/include/hip/Dialect/IR/HipBufferize.h
+++ b/include/hip/Dialect/IR/HipBufferize.h
@@ -214,6 +214,8 @@ registerHipBufferizableOpInterfaceModels(DialectRegistry &registry) {
     QMulOp::attachInterface<HipDstBufferizableModel<QMulOp>>(*ctx);
     QMatMulOp::attachInterface<HipDstBufferizableModel<QMatMulOp>>(*ctx);
     QConvOp::attachInterface<HipDstBufferizableModel<QConvOp>>(*ctx);
+    QLpNormalizationOp::attachInterface<
+        HipDstBufferizableModel<QLpNormalizationOp>>(*ctx);
     // hip.if is a DPS control-flow op (getDpsInitsMutable, results alias
     // o_init) just like hip.loop. Without this model one-shot-bufferize aborts
     // with "op was not bufferized: hip.if" for any graph containing onnx.If,

--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -5092,4 +5092,43 @@ def Hip_QConvOp : Hip_DpsOp<"qconv",
     attr-dict (`:` type($result_tensors)^)?
   }];
 }
+
+def Hip_QLpNormalizationOp : Hip_DpsOp<"qlpnormalization",
+                                       /*traits=*/[],
+                                       /*outsAccessor=*/"Output",
+                                       /*autoReify=*/1,
+                                       /*autoInfer=*/1,
+                                       /*declareInfer=*/1> {
+  let summary = "Quantized LpNormalization (L2) with integrated QDQ";
+  let description = [{
+    Fuses DequantizeLinear -> LpNormalization -> QuantizeLinear.
+
+    The match is UINT16 per-tensor input/output quantization, `p = 2`, and
+    normalization over the trailing axis. That is the same math as RMS norm
+    with `scale = 1/sqrt(N)` and `epsilon = 0`:
+
+      y = Q( L2(DQ(x)) )
+
+    Input and output scales/zero-points stay separate attributes: the models
+    almost never share them, so requantization is part of the fused op.
+  }];
+
+  let arguments = (ins
+    Hip_ContextType:$ctx,
+    Hip_TensorOrMemRef:$input,
+    Hip_TensorOrMemRef:$output,
+    F32Attr:$input_scale,
+    I64Attr:$input_zp,
+    F32Attr:$output_scale,
+    I64Attr:$output_zp,
+    I64Attr:$axis,
+    I64Attr:$p
+  );
+
+  let assemblyFormat = [{
+    `(` $ctx `)` `ins` `(` $input `:` type($input) `)`
+    `outs` `(` $output `:` type($output) `)`
+    attr-dict (`:` type($result_tensors)^)?
+  }];
+}
 #endif // HIP_OPS

--- a/lib/Conversion/HipToLLVM/CMakeLists.txt
+++ b/lib/Conversion/HipToLLVM/CMakeLists.txt
@@ -65,6 +65,7 @@ add_library(HipToLLVM STATIC
   QElementwiseLowering.cpp
   QMatMulLowering.cpp
   QConvLowering.cpp
+  QLpNormalizationLowering.cpp
 )
 
 add_dependencies(HipToLLVM

--- a/lib/Conversion/HipToLLVM/HipToLLVM.cpp
+++ b/lib/Conversion/HipToLLVM/HipToLLVM.cpp
@@ -291,6 +291,7 @@ void ConvertHipToLLVMPass::runOnOperation() {
   populateQElementwiseLoweringPatterns(typeConverter, patterns);
   populateQMatMulLoweringPatterns(typeConverter, patterns);
   populateQConvLoweringPatterns(typeConverter, patterns);
+  populateQLpNormalizationLoweringPatterns(typeConverter, patterns);
 
   // Standard dialect lowerings
   // Bundle func/memref/arith/cf lowering with HIP lowering to minimize

--- a/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
+++ b/lib/Conversion/HipToLLVM/HipToLLVMUtils.h
@@ -143,6 +143,7 @@ inline constexpr const char *kWrapSize = "wrap_size";
 inline constexpr const char *kWrapQElementwise = "wrap_qelementwise";
 inline constexpr const char *kWrapQMatMul = "wrap_qmatmul";
 inline constexpr const char *kWrapQConv = "wrap_qconv";
+inline constexpr const char *kWrapQLpNormalization = "wrap_qlpnormalization";
 // Synchronize the stream and read a device i32 scalar back to the host
 // (used by hip.readback_dim to materialise a data-dependent dynamic dim).
 inline constexpr const char *kHipReadbackI32 = "hipdnn_ep_readback_i32";
@@ -531,6 +532,8 @@ void populateQMatMulLoweringPatterns(const LLVMTypeConverter &converter,
                                      RewritePatternSet &patterns);
 void populateQConvLoweringPatterns(const LLVMTypeConverter &converter,
                                    RewritePatternSet &patterns);
+void populateQLpNormalizationLoweringPatterns(
+    const LLVMTypeConverter &converter, RewritePatternSet &patterns);
 } // namespace hip
 } // namespace mlir
 

--- a/lib/Conversion/HipToLLVM/QLpNormalizationLowering.cpp
+++ b/lib/Conversion/HipToLLVM/QLpNormalizationLowering.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+#include "HipToLLVMUtils.h"
+
+namespace mlir {
+namespace hip {
+namespace {
+
+// hip.qlpnormalization(%ctx) ins(%x) outs(%y)
+//   -> wrap_qlpnormalization(state, x, y, numel, N, dtype,
+//                            input_scale, input_zp, output_scale, output_zp,
+//                            axis, p)
+struct QLpNormalizationOpLowering
+    : public ConvertOpToLLVMPattern<QLpNormalizationOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(QLpNormalizationOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    ModuleOp module = op->getParentOfType<ModuleOp>();
+    Type ptrType = getPtrType();
+    Type i64Type = rewriter.getI64Type();
+    Type f32Type = rewriter.getF32Type();
+
+    auto inputType = cast<MemRefType>(op.getInput().getType());
+    auto outputType = cast<MemRefType>(op.getOutput().getType());
+    if (inputType.getElementType() != outputType.getElementType())
+      return op.emitError(
+          "hip.qlpnormalization: input and output element types must match");
+    if (!inputType.getElementType().isUnsignedInteger(16))
+      return op.emitError("hip.qlpnormalization: activation must be ui16");
+    if (op.getP() != 2)
+      return op.emitError("hip.qlpnormalization: only p=2 is implemented");
+    if (op.getOutputScale().convertToFloat() == 0.0f)
+      return op.emitError(
+          "hip.qlpnormalization: output_scale must be non-zero");
+
+    int64_t rank = inputType.getRank();
+    int64_t normAxis = op.getAxis();
+    if (normAxis < 0)
+      normAxis += rank;
+    if (rank == 0 || normAxis < 0 || normAxis >= rank)
+      return op.emitError("hip.qlpnormalization: axis out of range");
+
+    Value inputPtr =
+        extractContiguousMemRefPtr(adaptor.getInput(), rewriter, loc);
+    Value outputPtr =
+        extractContiguousMemRefPtr(adaptor.getOutput(), rewriter, loc);
+    Value numElements =
+        computeNumElements(inputType, adaptor.getInput(), rewriter, loc);
+
+    Value normNumElements = LLVM::ConstantOp::create(
+        rewriter, loc, i64Type, rewriter.getI64IntegerAttr(1));
+    for (int64_t dimIdx = normAxis; dimIdx < rank; ++dimIdx)
+      normNumElements = LLVM::MulOp::create(
+          rewriter, loc, normNumElements,
+          getMemRefDimSize(inputType, static_cast<unsigned>(dimIdx),
+                           adaptor.getInput(), rewriter, loc));
+
+    auto createI64 = [&](int64_t v) -> Value {
+      return LLVM::ConstantOp::create(rewriter, loc, i64Type,
+                                      rewriter.getI64IntegerAttr(v));
+    };
+    Value dtype = createI64(getHipdnnDataType(inputType.getElementType()));
+    Value inputScale = LLVM::ConstantOp::create(rewriter, loc, f32Type,
+                                                op.getInputScaleAttr());
+    Value outputScale = LLVM::ConstantOp::create(rewriter, loc, f32Type,
+                                                 op.getOutputScaleAttr());
+
+    SmallVector<Type> paramTypes = {ptrType, ptrType, ptrType, i64Type,
+                                    i64Type, i64Type, f32Type, i64Type,
+                                    f32Type, i64Type, i64Type, i64Type};
+    FailureOr<LLVM::LLVMFuncOp> funcOp =
+        LLVM::lookupOrCreateFn(rewriter, module, kWrapQLpNormalization,
+                               paramTypes, rewriter.getI32Type());
+    if (failed(funcOp))
+      return failure();
+
+    SmallVector<Value> args = {adaptor.getCtx(),
+                               inputPtr,
+                               outputPtr,
+                               numElements,
+                               normNumElements,
+                               dtype,
+                               inputScale,
+                               createI64(op.getInputZp()),
+                               outputScale,
+                               createI64(op.getOutputZp()),
+                               createI64(op.getAxis()),
+                               createI64(op.getP())};
+    LLVM::CallOp::create(rewriter, loc, *funcOp, args);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+} // namespace
+
+void populateQLpNormalizationLoweringPatterns(
+    const LLVMTypeConverter &converter, RewritePatternSet &patterns) {
+  patterns.add<QLpNormalizationOpLowering>(converter);
+}
+
+} // namespace hip
+} // namespace mlir

--- a/lib/Conversion/OnnxToHip/pdl/HipFusionPatterns.pdll
+++ b/lib/Conversion/OnnxToHip/pdl/HipFusionPatterns.pdll
@@ -26,6 +26,7 @@ Constraint HasStaticShapedResults(op: Op);
 Constraint IsUint16Quantized(op: Op);
 Constraint IsFusableQConvGeometry(op: Op);
 Constraint IsPackedInt4PerChannelWeight(op: Op);
+Constraint IsFusableQLpNormalization(op: Op);
 
 Rewrite GetContextArg(op: Op) -> Value;
 Rewrite ExtractScaleValue(val: Value) -> Attr;
@@ -36,3 +37,4 @@ Rewrite ExtractAttrInt64(op: Op, name: Attr, defaultValue: Attr) -> Attr;
 #include "QDQMulFusion.pdll"
 #include "QDQMatMulFusion.pdll"
 #include "QDQConvFusion.pdll"
+#include "QDQLpNormalizationFusion.pdll"

--- a/lib/Conversion/OnnxToHip/pdl/QDQLpNormalizationFusion.pdll
+++ b/lib/Conversion/OnnxToHip/pdl/QDQLpNormalizationFusion.pdll
@@ -1,0 +1,46 @@
+//===- QDQLpNormalizationFusion.pdll --------------------------------------===//
+//
+// PDLL pattern for QDQ LpNormalization fusion (UINT16 L2 / RMS).
+//
+// Included by HipFusionPatterns.pdll, which declares the native constraints
+// used below. Not compilable on its own.
+//
+// Must run before convert-onnx-to-hip rewrites float LpNormalization into
+// SimplifiedLayerNormalization / hip.rms_norm. Input and output scales stay
+// separate attributes: LoRA/ORC almost never share them.
+//===----------------------------------------------------------------------===//
+
+Pattern QDQLpNormalization with benefit(10) {
+  let dquant = op<onnx.DequantizeLinear>(input: Value, input_scale: Value, input_tail: ValueRange);
+  let lpnorm = op<onnx.LpNormalization>(dquant.0);
+  let quant = op<onnx.QuantizeLinear>(lpnorm.0, output_scale: Value, output_tail: ValueRange) -> (output_type: Type);
+
+  HasContextArg(quant);
+  IsUint16Quantized(dquant);
+  IsUint16Quantized(quant);
+  HasStaticShapedResults(quant);
+  IsFusableQLpNormalization(lpnorm);
+  IsSplatConstantValue(input_scale);
+  IsSplatConstantValue(output_scale);
+  HasExtractableZeropoint(dquant, attr<"2 : i64">);
+  HasExtractableZeropoint(quant, attr<"2 : i64">);
+
+  rewrite quant with {
+    let ctx = GetContextArg(quant);
+    let input_scale_attr = ExtractScaleValue(input_scale);
+    let output_scale_attr = ExtractScaleValue(output_scale);
+    let input_zeropoint_attr = ExtractZeropointValue(dquant, attr<"2 : i64">, attr<"0 : i64">);
+    let output_zeropoint_attr = ExtractZeropointValue(quant, attr<"2 : i64">, attr<"0 : i64">);
+
+    let empty = op<tensor.empty> -> (output_type);
+    let qlp = op<hip.qlpnormalization>(ctx, input, empty.0) {
+      input_scale = input_scale_attr,
+      input_zp = input_zeropoint_attr,
+      output_scale = output_scale_attr,
+      output_zp = output_zeropoint_attr,
+      axis = attr<"-1 : i64">,
+      p = attr<"2 : i64">
+    } -> (output_type);
+    replace quant with qlp;
+  };
+}

--- a/lib/Conversion/OnnxToHip/pdl/qdq_fusion_pass.hpp
+++ b/lib/Conversion/OnnxToHip/pdl/qdq_fusion_pass.hpp
@@ -336,6 +336,34 @@ isPackedInt4PerChannelWeight(mlir::PatternRewriter &, mlir::PDLResultList &,
   return mlir::success(isPackedInt4Constant(zeroPoints));
 }
 
+// onnx.LpNormalization that matches the fused RMS path: p=2 over a static
+// trailing axis. Other cases keep the unfused DQ + float LpNorm + Q chain.
+inline mlir::LogicalResult
+isFusableQLpNormalization(mlir::PatternRewriter &, mlir::PDLResultList &,
+                          llvm::ArrayRef<mlir::PDLValue> args) {
+  if (args.size() != 1)
+    return mlir::failure();
+  mlir::Operation *op = args[0].dyn_cast<mlir::Operation *>();
+  if (!op || op->getNumOperands() != 1)
+    return mlir::failure();
+  if (!onnxIntAttrEquals(op, "p", 2, /*absentValue=*/2))
+    return mlir::failure();
+
+  auto inputType =
+      mlir::dyn_cast<mlir::RankedTensorType>(op->getOperand(0).getType());
+  if (!inputType || inputType.getRank() == 0)
+    return mlir::failure();
+  int64_t rank = inputType.getRank();
+  int64_t last = inputType.getDimSize(rank - 1);
+  if (last == mlir::ShapedType::kDynamic || last <= 0)
+    return mlir::failure();
+
+  auto axisAttr = op->getAttrOfType<mlir::IntegerAttr>("axis");
+  int64_t axis = axisAttr ? axisAttr.getValue().getSExtValue() : -1;
+  int64_t normAxis = axis < 0 ? axis + rank : axis;
+  return mlir::success(normAxis == rank - 1);
+}
+
 //===----------------------------------------------------------------------===//
 // Rewrite functions -- reached only after the constraints above accepted.
 //===----------------------------------------------------------------------===//
@@ -451,6 +479,8 @@ inline bool run(mlir::ModuleOp mlirModule, llvm::StringRef pdlBytecodeFile) {
                                          isFusableQConvGeometry);
   pdlPatterns.registerConstraintFunction("IsPackedInt4PerChannelWeight",
                                          isPackedInt4PerChannelWeight);
+  pdlPatterns.registerConstraintFunction("IsFusableQLpNormalization",
+                                         isFusableQLpNormalization);
   pdlPatterns.registerRewriteFunction("GetContextArg", getContextArg);
   pdlPatterns.registerRewriteFunction("ExtractScaleValue", extractScaleValue);
   pdlPatterns.registerRewriteFunction("ExtractZeropointValue",

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -682,6 +682,20 @@ void QConvOp::getEffects(
 }
 
 //===----------------------------------------------------------------------===//
+// QLpNormalizationOp: quantized ins(input), outs(output)
+//===----------------------------------------------------------------------===//
+
+MutableOperandRange QLpNormalizationOp::getDpsInitsMutable() {
+  return getOutputMutable();
+}
+
+void QLpNormalizationOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
+}
+
+//===----------------------------------------------------------------------===//
 // HipblasltMatmulOp: ins(A, B), outs(C)
 //===----------------------------------------------------------------------===//
 

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -379,6 +379,7 @@ if(NOT BUILD_MOCK_RUNTIME)
     compile_to_bitcode(real/qelementwise.cpp runtime_qelementwise.bc)
     compile_to_bitcode(real/qmatmul.cpp runtime_qmatmul.bc)
     compile_to_bitcode(real/qconv.cpp runtime_qconv.bc)
+    compile_to_bitcode(real/qlpnormalization.cpp runtime_qlpnormalization.bc)
 
     set(RUNTIME_BC_MODULES
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_state.bc
@@ -469,6 +470,7 @@ if(NOT BUILD_MOCK_RUNTIME)
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_qelementwise.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_qmatmul.bc
         ${CMAKE_CURRENT_BINARY_DIR}/runtime_qconv.bc
+        ${CMAKE_CURRENT_BINARY_DIR}/runtime_qlpnormalization.bc
     )
     # Vendor-symbol stubs (see the compile_to_bitcode above) join runtime.bc only
     # when the vendor BLAS/DNN backends are disabled.

--- a/lib/Runtime/Kernels/hip/qdq_kernel.hip
+++ b/lib/Runtime/Kernels/hip/qdq_kernel.hip
@@ -290,6 +290,28 @@ __global__ void dequantize_linear_kernel(
   output[tid] = FloatIO<OutT>::store(static_cast<float>(x - zp) * s);
 }
 
+// Materialize the device-side parameters consumed by the existing Q/DQ and
+// RMS kernels used by wrap_qlpnormalization. Keeping this stream-ordered avoids
+// synchronous hipMemcpy calls that would otherwise drain all preceding work
+// and incorrectly charge that GPU time to the wrapper's CPU profile.
+__global__ void qlpnormalization_prepare_params_kernel(
+    float *__restrict__ rms_scale, int64_t norm_num_elements,
+    float norm_scale, float *__restrict__ input_scale_device,
+    float input_scale, float *__restrict__ output_scale_device,
+    float output_scale, uint16_t *__restrict__ input_zp_device,
+    uint16_t input_zp, uint16_t *__restrict__ output_zp_device,
+    uint16_t output_zp) {
+  int64_t tid = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (tid < norm_num_elements)
+    rms_scale[tid] = norm_scale;
+  if (tid == 0) {
+    *input_scale_device = input_scale;
+    *output_scale_device = output_scale;
+    *input_zp_device = input_zp;
+    *output_zp_device = output_zp;
+  }
+}
+
 // ---- host-side plan ------------------------------------------------------
 
 // Returns 0 to launch, 1 when there is nothing to do (empty tensor), <0 on
@@ -601,6 +623,43 @@ int dispatch_dequantize_scale(hipStream_t stream, const void *input,
 }
 
 } // namespace
+
+extern "C" int hip_qlpnormalization_prepare_params(
+    void *stream, void *rms_scale, int64_t norm_num_elements, float norm_scale,
+    void *input_scale_device, float input_scale, void *output_scale_device,
+    float output_scale, void *input_zp_device, uint16_t input_zp,
+    void *output_zp_device, uint16_t output_zp) {
+  if (!rms_scale || !input_scale_device || !output_scale_device ||
+      !input_zp_device || !output_zp_device || norm_num_elements <= 0) {
+    fprintf(stderr,
+            "[custom_kernels] hip_qlpnormalization_prepare_params: invalid "
+            "argument\n");
+    return -1;
+  }
+
+  constexpr int kBlockSize = 256;
+  int grid = 0;
+  if (qdq_grid_size("hip_qlpnormalization_prepare_params", norm_num_elements,
+                    kBlockSize, &grid) != 0)
+    return -1;
+
+  (void)hipGetLastError();
+  hipLaunchKernelGGL(
+      qlpnormalization_prepare_params_kernel, dim3(grid), dim3(kBlockSize), 0,
+      static_cast<hipStream_t>(stream), static_cast<float *>(rms_scale),
+      norm_num_elements, norm_scale, static_cast<float *>(input_scale_device),
+      input_scale, static_cast<float *>(output_scale_device), output_scale,
+      static_cast<uint16_t *>(input_zp_device), input_zp,
+      static_cast<uint16_t *>(output_zp_device), output_zp);
+  hipError_t err = hipGetLastError();
+  if (err != hipSuccess) {
+    fprintf(stderr,
+            "[custom_kernels] hip_qlpnormalization_prepare_params launch "
+            "failed: %s\n",
+            hipGetErrorString(err));
+  }
+  return static_cast<int>(err);
+}
 
 extern "C" int
 hip_quantize_linear(void *stream, const void *input, const void *scale,

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -2235,6 +2235,20 @@ HIP_KERNEL_API int hip_gather_block_quantized(
  * integer target supported here is unconditional. It would have to be
  * forwarded again if float8 support is added.
  */
+HIP_KERNEL_API int hip_qlpnormalization_prepare_params(
+    void* stream,
+    void* rms_scale,
+    int64_t norm_num_elements,
+    float norm_scale,
+    void* input_scale_device,
+    float input_scale,
+    void* output_scale_device,
+    float output_scale,
+    void* input_zp_device,
+    uint16_t input_zp,
+    void* output_zp_device,
+    uint16_t output_zp);
+
 HIP_KERNEL_API int hip_quantize_linear(
     void* stream,
     const void* input,           // high precision

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -368,6 +368,13 @@ void *hipdnn_ep_state_get_conv_scratch(RuntimeState *state);
 int hipdnn_ep_state_ensure_conv_scratch(RuntimeState *state,
                                         size_t needed_size);
 
+// Per-session scratch for wrap_qlpnormalization intermediate tensors and
+// scalar parameters. A single contiguous device allocation is shared by all
+// instances on the session stream, grows on demand, and never shrinks.
+void *hipdnn_ep_state_get_qlpnormalization_scratch(RuntimeState *state);
+int hipdnn_ep_state_ensure_qlpnormalization_scratch(RuntimeState *state,
+                                                    size_t needed_size);
+
 // Per-session scratch for the W4A8 dp4a matmul_nbits decode path
 // (hip_matmul_nbits_dp4a). One contiguous device buffer holding the quantized
 // activation row (int8) plus the per-group activation scales (float). Lazily
@@ -991,6 +998,14 @@ int wrap_qconv(RuntimeState *state, const void *input, const void *weights,
                int64_t activation_dtype, int64_t weight_dtype,
                int64_t weight_bits, int64_t bias_dtype, float input_scale,
                int64_t input_zp, float output_scale, int64_t output_zp);
+
+// Fused Q(LpNormalization(DQ(x))) for UINT16 per-tensor QDQ, p=2, last axis.
+// Inside: dequant -> RMS (scale = 1/sqrt(N), epsilon = 0) -> quant.
+int wrap_qlpnormalization(RuntimeState *state, const void *input, void *output,
+                          int64_t num_elements, int64_t norm_num_elements,
+                          int64_t data_type, float input_scale,
+                          int64_t input_zp, float output_scale,
+                          int64_t output_zp, int64_t axis, int64_t p);
 
 // Element-wise Where wrapper (NumPy-style multidirectional broadcasting,
 // arbitrary rank). Computes output[i] = condition[i] ? x[i] : y[i] with

--- a/lib/Runtime/hipdnn_ep_runtime_state.cpp
+++ b/lib/Runtime/hipdnn_ep_runtime_state.cpp
@@ -177,6 +177,8 @@ static int initialize_state_handles(RuntimeState **out_state) {
   state->qmoe_amd_host_scratch_size = 0;
   state->conv_scratch = nullptr;
   state->conv_scratch_size = 0;
+  state->qlpnormalization_scratch = nullptr;
+  state->qlpnormalization_scratch_size = 0;
   state->matmul_dp4a_scratch = nullptr;
   state->matmul_dp4a_scratch_size = 0;
   state->la_scratch = nullptr;
@@ -723,6 +725,11 @@ int hipdnn_ep_state_cleanup(RuntimeState *state) {
   // sync above has drained any in-flight conv that may still be reading it.
   if (state->conv_scratch) {
     HIP_CLEANUP(hipFree(state->conv_scratch));
+  }
+
+  // Free the QDQ LpNormalization intermediates and scalar parameters.
+  if (state->qlpnormalization_scratch) {
+    HIP_CLEANUP(hipFree(state->qlpnormalization_scratch));
   }
 
   // Free the W4A8 dp4a matmul_nbits scratch (if allocated).
@@ -1462,6 +1469,47 @@ int hipdnn_ep_state_ensure_conv_scratch(RuntimeState *state,
     return -1;
   }
   state->conv_scratch_size = alloc_size;
+  return 0;
+}
+
+void *hipdnn_ep_state_get_qlpnormalization_scratch(RuntimeState *state) {
+  return state ? state->qlpnormalization_scratch : nullptr;
+}
+
+int hipdnn_ep_state_ensure_qlpnormalization_scratch(RuntimeState *state,
+                                                    size_t needed_size) {
+  if (!state)
+    return -1;
+  if (needed_size == 0)
+    return 0;
+  if (state->qlpnormalization_scratch_size >= needed_size)
+    return 0;
+
+  size_t alloc_size = needed_size;
+  if (state->qlpnormalization_scratch_size > 0) {
+    size_t grown = state->qlpnormalization_scratch_size +
+                   state->qlpnormalization_scratch_size / 2;
+    if (grown > alloc_size)
+      alloc_size = grown;
+  }
+
+  if (state->qlpnormalization_scratch) {
+    if (state->stream) {
+      HIP_CLEANUP(hipStreamSynchronize(state->stream));
+    }
+    HIP_CLEANUP(hipFree(state->qlpnormalization_scratch));
+    state->qlpnormalization_scratch = nullptr;
+    state->qlpnormalization_scratch_size = 0;
+  }
+
+  if (hipMalloc(&state->qlpnormalization_scratch, alloc_size) != hipSuccess) {
+    fprintf(stderr,
+            "hipdnn_ep_state_ensure_qlpnormalization_scratch: hipMalloc "
+            "failed for %zu bytes\n",
+            alloc_size);
+    return -1;
+  }
+  state->qlpnormalization_scratch_size = alloc_size;
   return 0;
 }
 

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -1663,6 +1663,26 @@ int wrap_qconv(RuntimeState *state, const void *input, const void *weights,
   return 0;
 }
 
+int wrap_qlpnormalization(RuntimeState *state, const void *input, void *output,
+                          int64_t num_elements, int64_t norm_num_elements,
+                          int64_t data_type, float input_scale,
+                          int64_t input_zp, float output_scale,
+                          int64_t output_zp, int64_t axis, int64_t p) {
+  (void)input;
+  (void)output;
+  (void)input_scale;
+  (void)input_zp;
+  (void)output_scale;
+  (void)output_zp;
+  if (!state)
+    return -1;
+  MOCK_PRINT("[MOCK] wrap_qlpnormalization numel=%lld N=%lld dtype=%s "
+             "axis=%lld p=%lld\n",
+             (long long)num_elements, (long long)norm_num_elements,
+             hipdnn_ep_datatype_name(data_type), (long long)axis, (long long)p);
+  return 0;
+}
+
 int wrap_and(RuntimeState *state, void *a, void *b, void *output, int64_t a_n,
              int64_t a_c, int64_t a_h, int64_t a_w, int64_t b_n, int64_t b_c,
              int64_t b_h, int64_t b_w, int64_t out_n, int64_t out_c,

--- a/lib/Runtime/real/qlpnormalization.cpp
+++ b/lib/Runtime/real/qlpnormalization.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// wrap_qlpnormalization: Q(LpNormalization(DQ(x))) for UINT16, p=2, last axis.
+//
+//   dq = (x - zp_in) * scale_in
+//   y  = dq / ||dq||_2  ==  RMS(dq, scale=1/sqrt(N), epsilon=0)
+//   out = saturate(round(y / scale_out) + zp_out)
+
+#include "../debug_log.h"
+#include "../hipdnn_ep_runtime.h"
+#include "../op_profile.h"
+#include "hip_custom_kernels.h"
+#include "runtime_types.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+
+int wrap_qlpnormalization(RuntimeState *state, const void *input, void *output,
+                          int64_t num_elements, int64_t norm_num_elements,
+                          int64_t data_type, float input_scale,
+                          int64_t input_zp, float output_scale,
+                          int64_t output_zp, int64_t axis, int64_t p) {
+  OP_PROFILE(
+      "qlpnormalization",
+      [&] {
+        char b[64];
+        snprintf(b, sizeof(b), "%lldx%lld",
+                 (long long)(norm_num_elements > 0
+                                 ? num_elements / norm_num_elements
+                                 : 0),
+                 (long long)norm_num_elements);
+        return std::string(b);
+      },
+      state);
+
+  (void)axis;
+  if (!state || !input || !output) {
+    fprintf(stderr, "[REAL] wrap_qlpnormalization: null argument\n");
+    return -1;
+  }
+  if (p != 2) {
+    fprintf(stderr, "[REAL] wrap_qlpnormalization: only p=2 is supported\n");
+    return -1;
+  }
+  if (data_type != HIPDNN_EP_DATATYPE_UINT16) {
+    fprintf(stderr, "[REAL] wrap_qlpnormalization: expected UINT16, got %s\n",
+            hipdnn_ep_datatype_name(data_type));
+    return -1;
+  }
+  if (num_elements <= 0 || norm_num_elements <= 0 ||
+      num_elements % norm_num_elements != 0) {
+    fprintf(stderr,
+            "[REAL] wrap_qlpnormalization: bad extents numel=%lld N=%lld\n",
+            (long long)num_elements, (long long)norm_num_elements);
+    return -1;
+  }
+  if (output_scale == 0.0f) {
+    fprintf(stderr, "[REAL] wrap_qlpnormalization: output_scale is 0\n");
+    return -1;
+  }
+  if (input_zp < 0 || input_zp > 65535 || output_zp < 0 || output_zp > 65535) {
+    fprintf(stderr, "[REAL] wrap_qlpnormalization: zp out of UINT16 range\n");
+    return -1;
+  }
+
+  const int64_t num_rows = num_elements / norm_num_elements;
+  void *stream = hipdnn_ep_state_get_stream(state);
+
+  const size_t f32_bytes = static_cast<size_t>(num_elements) * sizeof(float);
+  const size_t scale_bytes =
+      static_cast<size_t>(norm_num_elements) * sizeof(float);
+  const size_t scratch_bytes =
+      2 * f32_bytes + scale_bytes + 2 * sizeof(float) + 2 * sizeof(uint16_t);
+  if (hipdnn_ep_state_ensure_qlpnormalization_scratch(state, scratch_bytes) !=
+      0) {
+    fprintf(stderr,
+            "[REAL] wrap_qlpnormalization: scratch allocation failed\n");
+    return -1;
+  }
+
+  auto *scratch = static_cast<uint8_t *>(
+      hipdnn_ep_state_get_qlpnormalization_scratch(state));
+  void *dq = scratch;
+  void *rms = scratch + f32_bytes;
+  void *scale_vec = scratch + 2 * f32_bytes;
+  void *in_scale = scratch + 2 * f32_bytes + scale_bytes;
+  void *out_scale = static_cast<uint8_t *>(in_scale) + sizeof(float);
+  void *in_zp = static_cast<uint8_t *>(out_scale) + sizeof(float);
+  void *out_zp = static_cast<uint8_t *>(in_zp) + sizeof(uint16_t);
+
+  int rc = hip_qlpnormalization_prepare_params(
+      stream, scale_vec, norm_num_elements,
+      1.0f / std::sqrt(static_cast<float>(norm_num_elements)), in_scale,
+      input_scale, out_scale, output_scale, in_zp,
+      static_cast<uint16_t>(input_zp), out_zp,
+      static_cast<uint16_t>(output_zp));
+  if (rc != 0) {
+    fprintf(stderr,
+            "[REAL] wrap_qlpnormalization: parameter preparation failed "
+            "(%d)\n",
+            rc);
+    return rc;
+  }
+
+  const int64_t flat_shape[1] = {num_elements};
+  const int64_t scalar_shape[1] = {1};
+
+  rc = hip_dequantize_linear(
+      stream, input, in_scale, in_zp, dq, flat_shape, 1, scalar_shape, 0,
+      /*axis=*/0, /*block_size=*/0, HIP_DTYPE_UINT16, HIP_DTYPE_FLOAT32,
+      HIP_DTYPE_FLOAT32, /*in_bits=*/16);
+  if (rc != 0) {
+    fprintf(stderr, "[REAL] wrap_qlpnormalization: dequant failed (%d)\n", rc);
+    return rc;
+  }
+
+  rc = hip_rms_norm(stream, dq, scale_vec, rms, num_rows, norm_num_elements,
+                    /*scale_rows=*/1, /*epsilon=*/0.0f, HIP_DTYPE_FLOAT32);
+  if (rc != 0) {
+    fprintf(stderr, "[REAL] wrap_qlpnormalization: rms_norm failed (%d)\n", rc);
+    return rc;
+  }
+
+  rc = hip_quantize_linear(
+      stream, rms, out_scale, out_zp, output, flat_shape, 1, scalar_shape, 0,
+      /*axis=*/0, /*block_size=*/0, /*precision=*/0, HIP_DTYPE_FLOAT32,
+      HIP_DTYPE_FLOAT32, HIP_DTYPE_UINT16, /*out_bits=*/16);
+  if (rc != 0) {
+    fprintf(stderr, "[REAL] wrap_qlpnormalization: quant failed (%d)\n", rc);
+    return rc;
+  }
+  return 0;
+}

--- a/lib/Runtime/runtime_state_internal.h
+++ b/lib/Runtime/runtime_state_internal.h
@@ -138,6 +138,14 @@ struct RuntimeState {
   void *conv_scratch;
   size_t conv_scratch_size;
 
+  // Per-session scratch for wrap_qlpnormalization. One contiguous device
+  // buffer holds the dequantized input, RMS output, normalization scale, and
+  // Q/DQ scalar parameters. Shared by all qlpnormalization instances because
+  // they execute on the same serial stream. Grows on demand, never shrinks,
+  // and is released at session teardown.
+  void *qlpnormalization_scratch;
+  size_t qlpnormalization_scratch_size;
+
   // Per-session scratch for the W4A8 dp4a matmul_nbits decode path
   // (hip_matmul_nbits_dp4a). One contiguous device buffer holding the
   // per-token quantized activation (int8, K bytes, nibble-deinterleaved) plus

--- a/test/lit/Conversion/hip-to-llvm/test_qlpnormalization.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_qlpnormalization.mlir
@@ -1,0 +1,27 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// RUN: hip-mlir-opt %s --convert-hip-to-llvm | FileCheck %s
+
+module {
+  func.func @qlpnormalization_u16(
+      %ctx: !hip.context,
+      %x: memref<1x8x16xui16, 1>,
+      %y: memref<1x8x16xui16, 1>) {
+    // CHECK-LABEL: llvm.func @qlpnormalization_u16
+    // N = 16, UINT16 = 9, zp 3 / 7, p = 2, axis = -1
+    // CHECK-DAG: llvm.mlir.constant(16 : i64)
+    // CHECK-DAG: llvm.mlir.constant(9 : i64)
+    // CHECK-DAG: llvm.mlir.constant(3 : i64)
+    // CHECK-DAG: llvm.mlir.constant(7 : i64)
+    // CHECK-DAG: llvm.mlir.constant(-1 : i64)
+    // CHECK-DAG: llvm.mlir.constant(2 : i64)
+    // CHECK: llvm.call @wrap_qlpnormalization({{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64, i64, i64, f32, i64, f32, i64, i64, i64) -> i32
+    hip.qlpnormalization(%ctx) ins(%x : memref<1x8x16xui16, 1>)
+                               outs(%y : memref<1x8x16xui16, 1>)
+                               {axis = -1 : i64, input_scale = 1.000000e-01 : f32,
+                                input_zp = 3 : i64, output_scale = 2.000000e-01 : f32,
+                                output_zp = 7 : i64, p = 2 : i64}
+    return
+  }
+}

--- a/test/lit/Conversion/onnx-to-hip/test_qlpnormalization.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_qlpnormalization.mlir
@@ -1,0 +1,77 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST: QDQ LpNormalization fusion (UINT16 L2 / RMS)
+//
+// Pattern fuses:
+//   onnx.DequantizeLinear -> onnx.LpNormalization -> onnx.QuantizeLinear
+// into:
+//   hip.qlpnormalization
+//
+// Scales and zero points are deliberately different on the DQ vs Q sides so
+// the checks prove both pairs fold into attributes (requant is required).
+//
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+// ============================================================================
+
+module {
+
+// CHECK-LABEL: func.func @main_graph
+// CHECK-NEXT:    %[[EMPTY:.*]] = tensor.empty() : tensor<1x128x2048xui16>
+// CHECK-NEXT:    %[[QLP:.*]] = hip.qlpnormalization(%{{.*}}) ins(%{{.*}} : tensor<1x128x2048xui16>) outs(%[[EMPTY]] : tensor<1x128x2048xui16>) {axis = -1 : i64, input_scale = 9.99999974E-6 : f32, input_zp = 35189 : i64, output_scale = 2.50000012E-5 : f32, output_zp = 35274 : i64, p = 2 : i64} : tensor<1x128x2048xui16>
+// CHECK-NEXT:    return %[[QLP]] : tensor<1x128x2048xui16>
+  func.func @main_graph(%x: tensor<1x128x2048xui16>) -> tensor<1x128x2048xui16> {
+    %in_s = "onnx.Constant"() {value = dense<9.99999975E-6> : tensor<f32>} : () -> tensor<f32>
+    %in_z = "onnx.Constant"() {value = dense<35189> : tensor<ui16>} : () -> tensor<ui16>
+    %out_s = "onnx.Constant"() {value = dense<2.50000004E-5> : tensor<f32>} : () -> tensor<f32>
+    %out_z = "onnx.Constant"() {value = dense<35274> : tensor<ui16>} : () -> tensor<ui16>
+    %dq = "onnx.DequantizeLinear"(%x, %in_s, %in_z)
+        : (tensor<1x128x2048xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x128x2048xf32>
+    %n = "onnx.LpNormalization"(%dq) {axis = -1 : si64, p = 2 : si64}
+        : (tensor<1x128x2048xf32>) -> tensor<1x128x2048xf32>
+    %q = "onnx.QuantizeLinear"(%n, %out_s, %out_z)
+        : (tensor<1x128x2048xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x128x2048xui16>
+    return %q : tensor<1x128x2048xui16>
+  }
+
+// CHECK-LABEL: func.func @custom_qdq_lpnorm
+// CHECK:       hip.qlpnormalization
+// CHECK-SAME:  input_scale = 3.16281967E-6 : f32
+// CHECK-SAME:  input_zp = 33443 : i64
+// CHECK-SAME:  output_scale = 2.33214701E-6 : f32
+// CHECK-SAME:  output_zp = 33422 : i64
+// CHECK-SAME:  p = 2 : i64
+  func.func @custom_qdq_lpnorm(%x: tensor<1x1x8x32xui16>) -> tensor<1x1x8x32xui16> {
+    %in_s = "onnx.Constant"() {value = dense<3.16281967E-6> : tensor<f32>} : () -> tensor<f32>
+    %in_z = "onnx.Constant"() {value = dense<33443> : tensor<ui16>} : () -> tensor<ui16>
+    %out_s = "onnx.Constant"() {value = dense<2.33214700E-6> : tensor<f32>} : () -> tensor<f32>
+    %out_z = "onnx.Constant"() {value = dense<33422> : tensor<ui16>} : () -> tensor<ui16>
+    %dq = "onnx.Custom"(%x, %in_s, %in_z) {
+      domain_name = "com.microsoft", function_name = "DequantizeLinear"
+    } : (tensor<1x1x8x32xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x1x8x32xf32>
+    %n = "onnx.LpNormalization"(%dq) {axis = -1 : si64, p = 2 : si64}
+        : (tensor<1x1x8x32xf32>) -> tensor<1x1x8x32xf32>
+    %q = "onnx.Custom"(%n, %out_s, %out_z) {
+      domain_name = "com.microsoft", function_name = "QuantizeLinear"
+    } : (tensor<1x1x8x32xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x1x8x32xui16>
+    return %q : tensor<1x1x8x32xui16>
+  }
+
+// p=1 is not the fused RMS path.
+// CHECK-LABEL: func.func @lpnorm_p1
+// CHECK-NOT:   hip.qlpnormalization
+  func.func @lpnorm_p1(%x: tensor<1x8x16xui16>) -> tensor<1x8x16xui16> {
+    %in_s = "onnx.Constant"() {value = dense<0.1> : tensor<f32>} : () -> tensor<f32>
+    %in_z = "onnx.Constant"() {value = dense<0> : tensor<ui16>} : () -> tensor<ui16>
+    %out_s = "onnx.Constant"() {value = dense<0.2> : tensor<f32>} : () -> tensor<f32>
+    %out_z = "onnx.Constant"() {value = dense<1> : tensor<ui16>} : () -> tensor<ui16>
+    %dq = "onnx.DequantizeLinear"(%x, %in_s, %in_z)
+        : (tensor<1x8x16xui16>, tensor<f32>, tensor<ui16>) -> tensor<1x8x16xf32>
+    %n = "onnx.LpNormalization"(%dq) {axis = -1 : si64, p = 1 : si64}
+        : (tensor<1x8x16xf32>) -> tensor<1x8x16xf32>
+    %q = "onnx.QuantizeLinear"(%n, %out_s, %out_z)
+        : (tensor<1x8x16xf32>, tensor<f32>, tensor<ui16>) -> tensor<1x8x16xui16>
+    return %q : tensor<1x8x16xui16>
+  }
+}

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -73,3 +73,24 @@ add_test(NAME MlirDtypeMappingUnit
 set_target_properties(test-dtype-mapping PROPERTIES
   FOLDER "mlir/Test/Dialect/Hipsr"
 )
+
+# GPU-free numeric reference for fused QDQ LpNormalization (L2 == RMS/sqrt(N)).
+add_executable(test-qlpnormalization-ref test_qlpnormalization_ref.cpp)
+
+target_compile_features(test-qlpnormalization-ref PRIVATE cxx_std_17)
+
+target_include_directories(test-qlpnormalization-ref PRIVATE
+  ${LLVM_INCLUDE_DIRS}
+)
+
+target_link_libraries(test-qlpnormalization-ref PRIVATE
+  LLVMSupport
+)
+
+add_test(NAME QLpNormalizationRefUnit
+  COMMAND test-qlpnormalization-ref
+)
+
+set_target_properties(test-qlpnormalization-ref PROPERTIES
+  FOLDER "mlir/Test/Dialect/Hipsr"
+)

--- a/test/unit/test_qlpnormalization_ref.cpp
+++ b/test/unit/test_qlpnormalization_ref.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// GPU-free numeric reference for hip.qlpnormalization:
+//   y = Q( L2(DQ(x)) )  with  L2 = RMS * (1/sqrt(N)), epsilon = 0
+// Matches the fused wrap's math (not the GPU kernels).
+
+#include "llvm/Support/raw_ostream.h"
+
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool cond, llvm::StringRef what) {
+  if (cond)
+    llvm::outs() << "[ OK ] " << what << "\n";
+  else {
+    llvm::errs() << "[FAIL] " << what << "\n";
+    ++g_failures;
+  }
+}
+
+float dequant(uint16_t x, float scale, int64_t zp) {
+  return scale * (static_cast<float>(x) - static_cast<float>(zp));
+}
+
+uint16_t quant(float x, float scale, int64_t zp) {
+  float q = std::round(x / scale) + static_cast<float>(zp);
+  if (q < 0.0f)
+    q = 0.0f;
+  if (q > 65535.0f)
+    q = 65535.0f;
+  return static_cast<uint16_t>(q);
+}
+
+std::vector<uint16_t> fused_l2(const std::vector<uint16_t> &x, int64_t n,
+                               float s_in, int64_t z_in, float s_out,
+                               int64_t z_out) {
+  const int64_t numel = static_cast<int64_t>(x.size());
+  std::vector<float> dq(static_cast<size_t>(numel));
+  for (int64_t i = 0; i < numel; ++i)
+    dq[static_cast<size_t>(i)] = dequant(x[static_cast<size_t>(i)], s_in, z_in);
+
+  std::vector<uint16_t> y(static_cast<size_t>(numel));
+  for (int64_t row = 0; row < numel / n; ++row) {
+    float sum_sq = 0.0f;
+    for (int64_t j = 0; j < n; ++j) {
+      float v = dq[static_cast<size_t>(row * n + j)];
+      sum_sq += v * v;
+    }
+    for (int64_t j = 0; j < n; ++j) {
+      float v = dq[static_cast<size_t>(row * n + j)];
+      float l2 = (sum_sq == 0.0f) ? 0.0f : v / std::sqrt(sum_sq);
+      y[static_cast<size_t>(row * n + j)] = quant(l2, s_out, z_out);
+    }
+  }
+  return y;
+}
+
+} // namespace
+
+int main() {
+  // One row of 4, asymmetric UINT16 QDQ with different in/out scale+zp.
+  const int64_t n = 4;
+  const float s_in = 0.1f;
+  const int64_t z_in = 100;
+  const float s_out = 0.05f;
+  const int64_t z_out = 200;
+  const std::vector<uint16_t> x = {110, 120, 90, 130};
+
+  std::vector<float> dq(4);
+  float sum_sq = 0.0f;
+  for (int i = 0; i < 4; ++i) {
+    dq[i] = dequant(x[i], s_in, z_in);
+    sum_sq += dq[i] * dq[i];
+  }
+  std::vector<uint16_t> expected(4);
+  for (int i = 0; i < 4; ++i)
+    expected[i] = quant(dq[i] / std::sqrt(sum_sq), s_out, z_out);
+
+  auto got = fused_l2(x, n, s_in, z_in, s_out, z_out);
+  bool match = got == expected;
+  check(match, "Q(L2(DQ(x))) matches fused reference (different in/out scale)");
+  if (!match) {
+    for (int i = 0; i < 4; ++i)
+      llvm::errs() << "  [" << i << "] got " << got[i] << " want "
+                   << expected[i] << "\n";
+  }
+
+  // RMS * 1/sqrt(N) equals L2 on this row.
+  float rms = std::sqrt(sum_sq / 4.0f);
+  float inv_sqrt_n = 1.0f / std::sqrt(4.0f);
+  bool rms_is_l2 = true;
+  for (int i = 0; i < 4; ++i) {
+    float l2 = dq[i] / std::sqrt(sum_sq);
+    float via_rms = dq[i] / rms * inv_sqrt_n;
+    if (std::fabs(l2 - via_rms) > 1e-5f)
+      rms_is_l2 = false;
+  }
+  check(rms_is_l2, "L2(x) == RMS(x) * 1/sqrt(N)");
+
+  return g_failures ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- Fuse UINT16 per-tensor `DequantizeLinear -> LpNormalization(p=2, last axis) -> QuantizeLinear` into `hip.qlpnormalization`.
- Lower to `wrap_qlpnormalization` (`DQ` + RMS with `1/sqrt(N)` + `Q`) and reuse a session scratch buffer so the wrapper does not stall on per-call `hipMalloc` / synchronous H2D copies.

## Related issue or design
None.

## Why
LoRA/ORC spend many layers in this QDQ LpNormalization sandwich. Unfused they become float `layernorm` plus separate Q/DQ. Fusion is the right compile path, but an early wrapper that allocated and memcpy'd every call charged ~17 s of preceding `qconv` GPU time to `qlpnormalization` CPU. Session scratch plus a stream-ordered parameter kernel removes that stall.

## What
- PDLL fusion (`IsFusableQLpNormalization`: `p=2`, static trailing axis) before float LpNorm -> `hip.rms_norm`.
- Dialect op, DPS/bufferize, HipToLLVM lowering, mock + real wrappers.
- Grow-on-demand `qlpnormalization_scratch` on `RuntimeState`; fill RMS scale and Q/DQ scalars on-device.

## Test plan
- [x] `pre-commit run --all-files` (passed; lintrunner first applied format on 4 files)
- [x] `test-qlpnormalization-ref` (CPU L2 == RMS/`sqrt(N)` reference)
- [x] Incremental Windows Ninja Release install
- [x] ORC `HIPDNN_EP_PERF=1`: 81 fused calls; after scratch fix GPU ~9.6 ms / CPU ~0.8 ms (was GPU ~107 ms / CPU ~16.9 s)

## Notes for reviewers
- Input and output scale/zp stay separate attributes; these models almost never share them, so requant stays inside the fused op.
- Scratch reuse is safe because all wrappers run on the same serial stream.

## Performance
ORC `psu_orc_0.onnx`, hipgpu EP, `HIPDNN_EP_PERF=1`:

| Path | qlpnormalization GPU | qlpnormalization CPU |
|---|---:|---:|
| Fused, per-call alloc + sync memcpy | ~107 ms | ~16.9 s |
| Fused, pooled scratch + stream params | ~9.6 ms | ~0.8 ms |

## Checklist
- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
