### PR TITLE
fix(matmul_nbits): cast fp32 scales to fp16 before dequant dispatch

### DIFF
--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -901,7 +901,8 @@ def Hip_MatMulNBitsOp : Hip_DpsOp<"matmul_nbits",
     I64Attr:$bits,
     I64Attr:$block_size,
     I64Attr:$accuracy_level,
-    I64Attr:$zp_elem_size  // zero_points element size: 1=uint8 packed, 2=fp16
+    I64Attr:$zp_elem_size,  // zero_points element size: 1=uint8 packed, 2=fp16
+    DefaultValuedAttr<I64Attr, "2">:$scale_elem_size // scales element size in bytes: 2=fp16, 4=fp32
   );
 
   let assemblyFormat = [{

--- a/lib/Conversion/HipToLLVM/MatMulNBitsLowering.cpp
+++ b/lib/Conversion/HipToLLVM/MatMulNBitsLowering.cpp
@@ -64,8 +64,9 @@ struct MatMulNBitsOpLowering : public ConvertOpToLLVMPattern<MatMulNBitsOp> {
     Value blockSize = createI64Const(op.getBlockSize());
     Value elemSizeVal = createI64Const(elemSize);
     Value zpElemSizeVal = createI64Const(op.getZpElemSize());
+    Value scaleElemSizeVal = createI64Const(op.getScaleElemSize());
 
-    SmallVector<Type, 17> paramTypes = {
+    SmallVector<Type, 18> paramTypes = {
         ptrType, // state
         i32Type, // op_state_slot
         ptrType, // A
@@ -82,7 +83,8 @@ struct MatMulNBitsOpLowering : public ConvertOpToLLVMPattern<MatMulNBitsOp> {
         i64Type, // bits
         i64Type, // block_size
         i64Type, // elem_size
-        i64Type  // zp_elem_size
+        i64Type, // zp_elem_size
+        i64Type  // scale_elem_size
     };
 
     FailureOr<LLVM::LLVMFuncOp> funcOp = LLVM::lookupOrCreateFn(
@@ -91,7 +93,7 @@ struct MatMulNBitsOpLowering : public ConvertOpToLLVMPattern<MatMulNBitsOp> {
       return failure();
     }
 
-    SmallVector<Value, 17> args = {statePtr,
+    SmallVector<Value, 18> args = {statePtr,
                                    getOpStateSlotValue(op, rewriter, loc),
                                    APtr,
                                    BPtr,
@@ -107,7 +109,8 @@ struct MatMulNBitsOpLowering : public ConvertOpToLLVMPattern<MatMulNBitsOp> {
                                    bits,
                                    blockSize,
                                    elemSizeVal,
-                                   zpElemSizeVal};
+                                   zpElemSizeVal,
+                                   scaleElemSizeVal};
 
     LLVM::CallOp::create(rewriter, loc, *funcOp, args);
     rewriter.eraseOp(op);

--- a/lib/Conversion/OnnxToHip/MatMulNBitsConversion.cpp
+++ b/lib/Conversion/OnnxToHip/MatMulNBitsConversion.cpp
@@ -108,6 +108,33 @@ MatMulNBitsToHip::matchAndRewrite(mlir::Operation *op,
   }
   auto zpElemSizeAttr = rewriter.getI64IntegerAttr(zpElemSize);
 
+  // Validate and detect the scales element type. ONNX MatMulNBits allows
+  // scales to match either fp16 or fp32 activation/output dtype (this
+  // model-dependent choice is independent of the packed-weight dtype). The
+  // runtime always dequantizes with fp16 scales internally; a fp32 scales
+  // buffer is cast-and-cached to fp16 on first use (see
+  // lib/Runtime/real/matmul_nbits.cpp). Without this detection, a fp32
+  // scales buffer's raw bytes would be silently misread as fp16, producing
+  // garbage (NaN/Inf) dequantized weights.
+  int64_t scaleElemSize = 2; // default: fp16
+  {
+    auto scalesTy = mlir::cast<mlir::ShapedType>(scales.getType());
+    mlir::Type scalesElemTy = scalesTy.getElementType();
+    if (scalesElemTy.isF16()) {
+      scaleElemSize = 2;
+    } else if (scalesElemTy.isF32()) {
+      scaleElemSize = 4;
+    } else {
+      std::string msg;
+      llvm::raw_string_ostream os(msg);
+      os << "MatMulNBits: unsupported scales element type: ";
+      scalesElemTy.print(os);
+      os << ". Expected f16 or f32";
+      return rewriter.notifyMatchFailure(op, msg);
+    }
+  }
+  auto scaleElemSizeAttr = rewriter.getI64IntegerAttr(scaleElemSize);
+
   auto rt = mlir::cast<mlir::RankedTensorType>(op->getResult(0).getType());
   mlir::Value init = createEmptyTensor(rewriter, loc, rt, A);
 
@@ -115,7 +142,8 @@ MatMulNBitsToHip::matchAndRewrite(mlir::Operation *op,
   // result type == outs operand type.
   auto hipOp = mlir::hip::MatMulNBitsOp::create(
       rewriter, loc, context, A, B, scales, zeroPoints, gIdx, bias, init, KAttr,
-      NAttr, bitsAttr, blockSizeAttr, accuracyLevelAttr, zpElemSizeAttr);
+      NAttr, bitsAttr, blockSizeAttr, accuracyLevelAttr, zpElemSizeAttr,
+      scaleElemSizeAttr);
   rewriter.replaceOp(op, hipOp->getResults());
   return mlir::success();
 }

--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -6252,6 +6252,22 @@ static void launchCastFp16ToFp32(hipStream_t stream, const _Float16* src,
                        src, dst, n, num_vec2);
 }
 
+// Flat fp32 -> fp16 cast for a MatMulNBits `scales` buffer ([N, num_groups_k],
+// n_elems = N * num_groups_k). ONNX MatMulNBits allows scales to carry either
+// fp16 or fp32 (independent of the packed-weight dtype); every fast/naive path
+// below reads `scales` as a raw `__half`/`_Float16` array, so a fp32 scales
+// buffer must be converted once up front (see
+// lib/Runtime/real/matmul_nbits.cpp's lookup_or_convert_scale_fp16, which
+// caches the converted buffer per weight pointer -- scales are model
+// constants, so this is a one-time cost per session).
+extern "C" void hip_matmul_nbits_convert_scale_fp32_to_fp16(
+    void* stream, const void* scale_fp32, void* scale_fp16_out, int64_t n_elems)
+{
+    launchCastFp32ToFp16(static_cast<hipStream_t>(stream),
+                         static_cast<const float*>(scale_fp32),
+                         static_cast<_Float16*>(scale_fp16_out), n_elems);
+}
+
 static _Float16* g_fp32cast_a_buf = nullptr;
 static size_t    g_fp32cast_a_elems = 0;
 static _Float16* ensureFp32CastABuffer(size_t elems) {

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -2097,6 +2097,15 @@ HIP_KERNEL_API void hip_matmul_nbits_unpack_zp_u8_3bit(
 HIP_KERNEL_API void hip_matmul_nbits_convert_zp_fp16(
     void* stream, const void* zp_packed, void* dst_fp16, int N, int groups_k);
 
+/* Flat fp32 -> fp16 cast for a MatMulNBits `scales` buffer ([N, num_groups_k],
+ * n_elems = N * num_groups_k). Every dequant path reads `scales` as raw fp16;
+ * a fp32 scales buffer (ONNX MatMulNBits allows either dtype) must be
+ * converted once before use -- see lib/Runtime/real/matmul_nbits.cpp's
+ * lookup_or_convert_scale_fp16. */
+HIP_KERNEL_API void hip_matmul_nbits_convert_scale_fp32_to_fp16(
+    void* stream, const void* scale_fp32, void* scale_fp16_out,
+    int64_t n_elems);
+
 /* Dequantize a full packed int4 weight matrix into row-major fp16 [N, K].
  * Used by the CDNA/wave64 prefill fast path (no WMMA): dequantize B once
  * (weights are constant) then run a hipBLASLt fp16 GEMM. scales_fp16 and

--- a/lib/Runtime/hipdnn_ep_runtime.h
+++ b/lib/Runtime/hipdnn_ep_runtime.h
@@ -1310,7 +1310,8 @@ int wrap_matmul_nbits(
     int64_t bits,            // quantization bits (e.g. 4)
     int64_t block_size,      // quantization block size
     int64_t elem_size,       // element size in bytes
-    int64_t zp_elem_size);   // zero_points element size: 1=uint8 packed, 2=fp16
+    int64_t zp_elem_size,    // zero_points element size: 1=uint8 packed, 2=fp16
+    int64_t scale_elem_size); // scales element size in bytes: 2=fp16, 4=fp32
 
 // GatherBlockQuantized operation wrapper (com.microsoft).
 // Gather + block-wise dequantize: gather rows from `data` along

--- a/lib/Runtime/mock/mock_gpu.cpp
+++ b/lib/Runtime/mock/mock_gpu.cpp
@@ -1231,8 +1231,9 @@ int wrap_matmul_nbits(RuntimeState *state, int op_state_slot, const void *A,
                       const void *bias, void *output, int64_t M, int64_t N,
                       int64_t K, int64_t batch_count, int64_t bits,
                       int64_t block_size, int64_t elem_size,
-                      int64_t zp_elem_size) {
+                      int64_t zp_elem_size, int64_t scale_elem_size) {
   (void)op_state_slot;
+  (void)scale_elem_size;
   if (!state) {
     fprintf(stderr, "Invalid state in wrap_matmul_nbits\n");
     return -1;

--- a/lib/Runtime/real/matmul_nbits.cpp
+++ b/lib/Runtime/real/matmul_nbits.cpp
@@ -225,8 +225,19 @@ struct MatmulNbitsState : OpStateT<MatmulNbitsState> {
   std::mutex algo_mu;
   std::unordered_map<uint64_t, PrefillAlgo> prefill_algos;
 
+  // fp32 -> fp16 cast of the `scales` buffer, keyed by the packed-scales
+  // device pointer (stable for the model's lifetime, like `b_fp16` above).
+  // ONNX MatMulNBits allows scales to be fp16 or fp32 independent of the
+  // packed-weight dtype; every dequant kernel below reads `scales` as raw
+  // fp16, so a fp32 scales buffer is converted once and reused for every
+  // subsequent call. See lookup_or_convert_scale_fp16.
+  std::mutex scale_mu;
+  std::unordered_map<const void *, std::pair<void *, size_t>> scale_fp16;
+
   ~MatmulNbitsState() {
     for (auto &[k, v] : b_fp16)
+      hipFree(v.first);
+    for (auto &[k, v] : scale_fp16)
       hipFree(v.first);
   }
 };
@@ -310,6 +321,40 @@ const void *get_or_dequant_b_fp16(MatmulNbitsState *mst, void *stream,
     it->second = {dst, bytes};
   } else {
     mst->b_fp16.emplace(B, std::make_pair(dst, bytes));
+  }
+  return dst;
+}
+
+// Returns a cached fp16 cast of `scales_fp32` ([N, num_groups_k] flat, fp32),
+// converting on first use for this weight's scales pointer. scales are model
+// constants, so the conversion cost is a one-time hit per session (mirrors
+// get_or_dequant_b_fp16 above). Returns nullptr on hipMalloc failure.
+const void *lookup_or_convert_scale_fp16(MatmulNbitsState *mst, void *stream,
+                                         const void *scales_fp32,
+                                         int64_t n_elems) {
+  const size_t bytes = static_cast<size_t>(n_elems) * sizeof(__fp16);
+
+  std::lock_guard<std::mutex> lock(mst->scale_mu);
+  auto it = mst->scale_fp16.find(scales_fp32);
+  if (it != mst->scale_fp16.end() && it->second.second >= bytes)
+    return it->second.first;
+
+  void *dst = nullptr;
+  if (hipMalloc(&dst, bytes) != hipSuccess) {
+    fprintf(stderr,
+            "matmul_nbits: hipMalloc(%zu) for fp32->fp16 scale cache "
+            "failed\n",
+            bytes);
+    return nullptr;
+  }
+  hip_matmul_nbits_convert_scale_fp32_to_fp16(stream, scales_fp32, dst,
+                                              n_elems);
+
+  if (it != mst->scale_fp16.end()) {
+    hipFree(it->second.first);
+    it->second = {dst, bytes};
+  } else {
+    mst->scale_fp16.emplace(scales_fp32, std::make_pair(dst, bytes));
   }
   return dst;
 }
@@ -531,7 +576,7 @@ int wrap_matmul_nbits(RuntimeState *state, int op_state_slot, const void *A,
                       const void *bias, void *output, int64_t M, int64_t N,
                       int64_t K, int64_t batch_count, int64_t bits,
                       int64_t block_size, int64_t elem_size,
-                      int64_t zp_elem_size) {
+                      int64_t zp_elem_size, int64_t scale_elem_size) {
   OP_PROFILE(
       "matmul_nbits",
       [&] {
@@ -563,6 +608,41 @@ int wrap_matmul_nbits(RuntimeState *state, int op_state_slot, const void *A,
 
   if (g_idx) {
     fprintf(stderr, "wrap_matmul_nbits: g_idx not supported\n");
+    return -1;
+  }
+
+  // ONNX MatMulNBits allows `scales` to be fp16 or fp32 independent of the
+  // packed-weight dtype (this lm_head-style model uses fp32 activations +
+  // fp32 scales with fp16-free block quantization). Every dequant kernel
+  // below (GEMV/naive/WMMA/dp4a/prefill) reads `scales` as a raw fp16 array;
+  // without this conversion a fp32 scales buffer's bytes would be
+  // misinterpreted as fp16, producing garbage (NaN/Inf) dequantized weights
+  // and logits. Convert once and cache per weight pointer -- scales are model
+  // constants, so this is a one-time cost per session.
+  if (scale_elem_size == 4) {
+    if (block_size <= 0) {
+      fprintf(stderr,
+              "wrap_matmul_nbits: fp32 scales require block_size > 0\n");
+      return -1;
+    }
+    MatmulNbitsState *mst =
+        MatmulNbitsState::get_op_state(state, op_state_slot);
+    if (!mst) {
+      fprintf(stderr, "wrap_matmul_nbits: no MatmulNbitsState at slot %d\n",
+              op_state_slot);
+      return -1;
+    }
+    const int64_t ngk = (K + block_size - 1) / block_size;
+    const void *scales_fp16 =
+        lookup_or_convert_scale_fp16(mst, stream, scales, N * ngk);
+    if (!scales_fp16)
+      return -1;
+    scales = scales_fp16;
+  } else if (scale_elem_size != 2) {
+    fprintf(stderr,
+            "wrap_matmul_nbits: unsupported scale_elem_size %lld (expected "
+            "2=fp16 or 4=fp32)\n",
+            (long long)scale_elem_size);
     return -1;
   }
 

--- a/test/numeric/tests/test_matmul_nbits.py
+++ b/test/numeric/tests/test_matmul_nbits.py
@@ -114,6 +114,7 @@ def _make_matmul_nbits_model(
     block_size: int = 32,
     accuracy_level: int = 4,
     seed: int = 42,
+    fp32: bool = False,
 ):
     """Build a MatMulNBits ONNX model with random quantized weights.
 
@@ -127,6 +128,13 @@ def _make_matmul_nbits_model(
 
     ``scale_range`` controls the uniform distribution used to generate
     per-block quantization scales -- set it to match the target projection.
+
+    ``fp32``: when True, X/Y and the scales initializer are fp32 instead of
+    fp16 (ONNX MatMulNBits allows either dtype for scales, independent of the
+    packed-weight dtype -- e.g. the PSU_MF_LORA lm_head submodel uses fp32
+    activations with fp32 scales). Regression coverage for the bug where the
+    HIP EP always read `scales` as raw fp16 regardless of its actual dtype,
+    producing NaN/Inf logits for fp32-scale models.
     """
     if bits not in (4, 8):
         raise ValueError(f"bits must be 4 or 8, got {bits}")
@@ -140,14 +148,17 @@ def _make_matmul_nbits_model(
         weight_name = "weight_Q8"
     bytes_per_block = block_size // weights_per_byte
 
+    onnx_dtype = TensorProto.FLOAT if fp32 else TensorProto.FLOAT16
+    np_dtype = np.float32 if fp32 else np.float16
+
     x = helper.make_tensor_value_info(
         "X",
-        TensorProto.FLOAT16,
+        onnx_dtype,
         [batch, seq_len, K],
     )
     y = helper.make_tensor_value_info(
         "Y",
-        TensorProto.FLOAT16,
+        onnx_dtype,
         [batch, seq_len, N],
     )
 
@@ -162,7 +173,7 @@ def _make_matmul_nbits_model(
         scale_range[0],
         scale_range[1],
         [N, n_blocks],
-    ).astype(np.float16)
+    ).astype(np_dtype)
 
     initializers = [
         numpy_helper.from_array(q_weight, name=weight_name),
@@ -209,6 +220,35 @@ class TestMatMulNBits:
 
         actual, expected = model_runner.run_sample(model, [x])
         compare_outputs(actual, expected, atol=1e-2, rtol=1e-2)
+
+    @pytest.mark.parametrize("seq_len", [1, 8, 64])
+    def test_matmul_nbits_fp32_activation_fp32_scale(self, model_runner, seq_len):
+        """fp32 activation + fp32 scale (PSU_MF_LORA lm_head shape/dtype).
+
+        Regression test: ONNX MatMulNBits allows `scales` to be fp16 or fp32
+        independent of the packed-weight dtype. The HIP EP used to always
+        read `scales` as raw fp16 regardless of its declared dtype, so a
+        fp32-scale model (e.g. PSU_MF_LORA_lm_head.onnx: fp32 hidden states,
+        fp32 scales, K=2048, N=200029, bits=4, block_size=32) produced
+        NaN/Inf logits on GPU while the CPU EP was correct. Uses a smaller N
+        than the real model to keep the test fast.
+        """
+        K, N = 64, 256
+        model = _make_matmul_nbits_model(
+            1,
+            seq_len,
+            K,
+            N,
+            scale_range=(-0.01, 0.01),
+            fp32=True,
+        )
+
+        rng = np.random.default_rng(99)
+        x = rng.uniform(-1, 1, [1, seq_len, K]).astype(np.float32)
+
+        actual, expected = model_runner.run_sample(model, [x])
+        assert np.isfinite(actual[0]).all(), "GPU EP produced NaN/Inf logits"
+        compare_outputs(actual, expected, atol=2e-2, rtol=1e-2, cos_threshold=0.999)
 
     @pytest.mark.parametrize("seq_len", SEQ_LENS)
     def test_matmul_nbits_qkv_gpt_oss_shape(self, model_runner, seq_len):


### PR DESCRIPTION
## Summary

ONNX `MatMulNBits` allows `scales` to be fp16 **or** fp32, independent of the packed-weight dtype. Every dequant kernel (GEMV/naive/WMMA/dp4a/hipBLASLt prefill) read `scales` as a raw fp16 array unconditionally, so a fp32-scale model's raw bytes were misread as fp16, producing garbage (NaN/Inf) dequantized weights and logits on the GPU EP while the CPU EP was correct.

### Repro

`PSU_MF_LORA_lm_head.onnx`: fp32 activation, **fp32 scale**, K=2048, N=200029, bits=4, block_size=32 (a standalone lm_head submodel from a pipelined/split PSU_MF_LORA model). Comparing GPU EP vs CPU EP via `hip-onnx-runner`:

- Before fix: 1,600,100 / 1,600,232 output elements were NaN/Inf; finite values were garbage (magnitude up to ~65000 vs CPU's ~hundreds).
- After fix: 0 NaN/Inf; argmax matches CPU EP on every decoded token; residual L2 diff is normal int4/fp16 dequant noise (max abs diff ~7 on logits ranging ±2000).

### Fix

- Detect the `scales` element type at ONNX-to-HIP conversion time (`MatMulNBitsConversion.cpp`), mirroring the existing `zero_points` dtype check.
- Add a new `scale_elem_size` attribute to `Hip_MatMulNBitsOp` (`DefaultValuedAttr<I64Attr, "2">`, default fp16, so existing IR/LIT tests are unaffected), threaded through `MatMulNBitsLowering.cpp` and the runtime ABI (`hipdnn_ep_runtime.h`, `mock_gpu.cpp`).
- In `wrap_matmul_nbits` (`lib/Runtime/real/matmul_nbits.cpp`), when `scale_elem_size == 4`, cast `scales` to fp16 once via a new device kernel (`hip_matmul_nbits_convert_scale_fp32_to_fp16`) and cache the converted buffer per weight pointer (scales are model constants, so this is a one-time cost per session, same caching pattern as the existing `zp`/`b_fp16` caches) — before dispatching to any compute path.

This mirrors #957's existing fp32 A/output cast-to-fp16 pattern: the compute kernels only ever operate on fp16, and non-fp16 operands are cast in/out at the boundary. #957 covered A and the output; this closes the same gap for `scales`, the one operand it missed.

## Test plan

- [x] `hip-onnx-runner` A/B against `PSU_MF_LORA_lm_head.onnx` at decode (M=1) and prefill (M=8, M=64) shapes: zero NaN/Inf, argmax matches CPU EP.
- [x] New regression test `test_matmul_nbits_fp32_activation_fp32_scale` (fp32 activation + fp32 scale, seq_len in {1, 8, 64}) added to `test/numeric/tests/test_matmul_nbits.py`.
- [x] Full `test/numeric/tests/test_matmul_nbits.py` suite: 73/73 pass (70 pre-existing + 3 new), no regressions.
- [x] `ctest -R MorphizenMLIRLitTests`: pass, unchanged (no LIT test edits needed thanks to the default-valued attribute).
- [x] `pre-commit run --files ...`: pass.

## AI disclosure

This change was investigated and implemented with substantial AI assistance (Cursor, Claude Sonnet 5): root-cause analysis (tracing the GPU-only accuracy failure to the scale dtype misread), the fix implementation across the MLIR attribute/lowering/runtime/kernel layers, and the new regression test. All generated content was reviewed, and validated via the hip-onnx-runner A/B comparison and the full numeric/LIT test runs listed above.
