### PR TITLE
fix(matmul_nbits): convert uint8 zero-points to fp16 for asym prefill when K%block_size != 0

### DIFF
--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -6865,6 +6865,27 @@ extern "C" int hip_matmul_nbits(
   // the bounds-checked variant whenever M is not a multiple of the tile.
   static constexpr int kWmmaMinM = 8;
 
+  // Defensive guard: the M>1 bits=4 asymmetric prefill paths below (WMMA, the
+  // WMMA K-pad variant for K%32!=0, and the col-major GEMV for 1<M<8) all read
+  // zero_points as FP16 via zp_for_fp16_paths. If the caller passed packed
+  // nibble zero_points (zp_elem_size==1) but no converted FP16 buffer, that
+  // pointer is the raw packed-uint8 bytes; reading it as FP16 silently yields
+  // garbage zero-points and catastrophically wrong output (this is exactly the
+  // K%32!=0 down_proj failure). Fail loudly so the caller converts first via
+  // hip_matmul_nbits_convert_zp_fp16. The 1<M<8 && K%32!=0 case is excluded: it
+  // uses the row-major uint8 GEMV and legitimately needs no FP16 zp.
+  if (bits == 4 && batch_count == 1 && zero_points && zp_elem_size == 1 &&
+      pre_unpacked_zp_fp16 == nullptr &&
+      (M >= kWmmaMinM || (M > 1 && (K % 32 == 0)))) {
+    fprintf(stderr,
+            "[custom_kernels] hip_matmul_nbits: bits=4 M>1 asymmetric prefill "
+            "(M=%lld N=%lld K=%lld) requires pre_unpacked_zp_fp16; packed-uint8 "
+            "zero_points cannot be reinterpreted as FP16. Caller must convert "
+            "via hip_matmul_nbits_convert_zp_fp16.\n",
+            (long long)M, (long long)N, (long long)K);
+    return -1;
+  }
+
   /* int4 prefill with K%32!=0 (e.g. a model whose intermediate_size is not a
    * multiple of 32, so down_proj has K=4304): the WMMA kernel requires K%32==0,
    * so this shape would otherwise fall to the naive kernel on every prefill.

--- a/lib/Runtime/real/matmul_nbits.cpp
+++ b/lib/Runtime/real/matmul_nbits.cpp
@@ -602,14 +602,20 @@ int wrap_matmul_nbits(RuntimeState *state, int op_state_slot, const void *A,
                   mst->zp, stream, zero_points, static_cast<int>(N), ngk);
     if (!pre_zp_u8)
       return -1;
-    // The fp16 buffer is consumed only by the bits=4 WMMA (batch==1 &&
-    // K%32==0 && M>=16) and col-major GEMV M>1 fallback (same predicate on K,
-    // M>1). Build it eagerly when those preconditions are met — the cache
-    // makes the cost a one-time hit per zero_points pointer. The u2 WMMA path
-    // consumes uint8 zp directly, so bits=2 never needs the fp16 buffer (and
-    // the converter is nibble-specific anyway).
-    bool wmma_data_format = (batch_count == 1) && (K % 32 == 0);
-    if (bits == 4 && wmma_data_format && M > 1) {
+    // Every M>1 bits=4 path consumes the FP16 zero_points, not the uint8 one:
+    //   - WMMA fast path   (batch==1, K%32==0, M>=8)
+    //   - WMMA K-pad path  (batch==1, K%32!=0, M>=8)  <-- also needs it
+    //   - col-major GEMV   (batch==1, K%32==0, 1<M<8)
+    // The gate must therefore NOT depend on K%32==0. The old K%32==0 gate
+    // starved the K-pad path (K not a multiple of block_size, e.g. the vision
+    // encoder's down_proj K=4304) of its FP16 zp; the kernel then reinterpreted
+    // the packed-uint8 zp bytes as FP16 and produced catastrophically wrong
+    // prefill output. Build it for every M>1: the pointer-keyed cache makes it
+    // a one-time cost per weight, and the 1<M<8 K%32!=0 case that ends up on
+    // the row-major GEMV (uint8 zp) simply never reads this buffer. bits=2 WMMA
+    // consumes uint8 zp directly and the converter is nibble-specific, so this
+    // stays scoped to bits=4.
+    if (bits == 4 && batch_count == 1 && M > 1) {
       pre_zp_fp16 = hipdnn_ep_real::lookup_or_convert_zp_fp16(
           mst->zp, stream, zero_points, static_cast<int>(N), ngk);
       if (!pre_zp_fp16)

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -360,8 +360,12 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
           result = -1;
           goto cleanup;
         }
-        bool wmma_data_format = (hidden_size % 32 == 0);
-        if (wmma_data_format && count > 1) {
+        // Provide the FP16 zp for every count>1 (not only hidden%32==0): the
+        // fc1 GEMM's WMMA K-pad path (hidden not a multiple of block_size)
+        // also consumes it, and gating on hidden%32==0 would let the kernel
+        // read packed-uint8 zp bytes as FP16 -> garbage. See the matching fix
+        // in wrap_matmul_nbits (matmul_nbits.cpp).
+        if (count > 1) {
           fc1_pre_zp_fp16 = hipdnn_ep_real::lookup_or_convert_zp_fp16(
               *zpc, stream, fc1_zp_e, static_cast<int>(fusion_inter), ngk);
           if (!fc1_pre_zp_fp16) {
@@ -413,8 +417,10 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
           result = -1;
           goto cleanup;
         }
-        bool wmma_data_format = (inter_size % 32 == 0);
-        if (wmma_data_format && count > 1) {
+        // Same fix as fc1 above: the fc2 GEMM's WMMA K-pad path (inter not a
+        // multiple of block_size) also needs the FP16 zp, so do not gate on
+        // inter_size%32==0.
+        if (count > 1) {
           fc2_pre_zp_fp16 = hipdnn_ep_real::lookup_or_convert_zp_fp16(
               *zpc, stream, fc2_zp_e, static_cast<int>(hidden_size), ngk);
           if (!fc2_pre_zp_fp16) {


### PR DESCRIPTION
## Summary
MatMulNBits (and QMoE's fc1/fc2, which call into it) produced catastrophically
wrong output for **4-bit asymmetric weights whose K is not a multiple of
`block_size`**, during **prefill (M>1)**. In this model that is the vision
encoder's `K=4304` layers (e.g. down_proj); the decoder (all K multiples of 32)
and QMoE (symmetric here) were unaffected. Output errors were on the order of
`max_abs ~3e4` (garbage), which manifested as accuracy failures on image inputs.

## Why
The M>1 bits=4 asymmetric kernels — the WMMA fast path, the WMMA **K-pad**
path (added later for `K%32!=0`), and the col-major GEMV — all read
`zero_points` as FP16. The wrapper converted the ONNX packed-uint8
`zero_points` to FP16 only when `K % 32 == 0`:

```cpp
bool wmma_data_format = (batch_count == 1) && (K % 32 == 0);
if (bits == 4 && wmma_data_format && M > 1) { /* convert zp -> fp16 */ }