### PR TITLE
feat(matmul_nbits): support fp32 A/output for bits=8 via the shared fp16 cast path

### DIFF
--- a/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
+++ b/lib/Runtime/Kernels/hip/matmul_nbits_kernel.hip
@@ -6193,9 +6193,13 @@ extern "C" void hip_matmul_nbits_dequant_b_fp16(
 }
 
 /* -----------------------------------------------------------------------
- * fp32 A / fp32 output cast patch (element_size_bytes==4, bits != 8):
+ * fp32 A / fp32 output cast patch (element_size_bytes==4, all bits incl. 8):
  * device-side, vectorized float<->fp16 conversion so the existing fp16
- * compute path (WMMA/GEMV/naive below) runs completely unchanged.
+ * compute path (WMMA/GEMV/naive below, and the bits=8 dispatch) runs
+ * completely unchanged. Trading a persistent (cached, grow-on-demand) fp16
+ * scratch pair for zero per-kernel code duplication -- fp32 is a cold input
+ * type, so this keeps the binary small instead of templating every hot
+ * int8/int4 kernel on the element type.
  * ----------------------------------------------------------------------- */
 
 __global__ void cast_fp32_to_fp16_kernel(
@@ -6306,7 +6310,11 @@ extern "C" int hip_matmul_nbits(
 
   if (M <= 0 || N <= 0 || K <= 0 || batch_count <= 0) return 0;
 
-  if (element_size_bytes == 4 && bits != 8) {
+  // All bits widths (2/3/4/8) route fp32 A/C through the shared fp16 cast
+  // scratch: cast A to fp16, run the unchanged fp16 compute path, cast the
+  // fp16 result back to fp32. bits=8 is included so the int8 dispatch below
+  // stays fp16-only (no element-type template, no code-size growth).
+  if (element_size_bytes == 4) {
     hipStream_t cast_stream = static_cast<hipStream_t>(stream);
     const int64_t a_elems = batch_count * M * K;
     const int64_t c_elems = batch_count * M * N;

--- a/lib/Runtime/Kernels/test/example/gemm_fp16i8/Makefile
+++ b/lib/Runtime/Kernels/test/example/gemm_fp16i8/Makefile
@@ -1,0 +1,163 @@
+# ============================================================
+# custom_kernels MatMulNBits bits=8 (uint8, unpacked) Test
+#
+# Works in both WSL and Windows CMD/PowerShell.
+#
+# Benchmarks and verifies hip_matmul_nbits(bits=8) -- B is one byte per
+# weight (NOT bit-packed, unlike bits=2/3/4).
+#
+# Usage:
+#   make test SIZE=128x2880x5120 GS=128            # single shape (with zeros)
+#   make test SIZE=1x4096x2880   GS=128 NO_ZEROS=1  # decode shape (no zeros)
+#   make test_fp32 SIZE=128x2880x5120 GS=128        # fp32 A/output
+#   make test_all                                    # preset shapes
+# ============================================================
+
+# ---- OS detection ----
+
+ifeq ($(OS),Windows_NT)
+    DETECTED_OS := Windows
+    SHELL := cmd.exe
+    .SHELLFLAGS := /c
+else
+    DETECTED_OS := WSL
+endif
+
+# ---- User-configurable ----
+
+OFFLOAD := --offload-arch=gfx1150
+
+BUILD_DIR ?= build
+
+ifeq ($(DETECTED_OS),Windows)
+    HIP_SDK ?= C:\AMD\Rocm\7.1
+    PYTHON  ?= python
+else
+    HIP_SDK ?= /mnt/c/AMD/ROCm/7.1
+    PYTHON  ?= python3
+endif
+
+# ---- Paths ----
+
+HIPCC        := $(HIP_SDK)/bin/hipcc.exe
+INCLUDE_DIR  := ../../../include
+KERNEL_HIP   := ../../../hip/matmul_nbits_kernel.hip
+AUTOTUNE_DIR := ../../../hip/autotune/matmul_nbits
+# No-LUT autotune resolver stub: the kernel references
+# hipdnn_ep::matmul_nbits_autotune::resolve(), whose real definition pulls in
+# flatbuffers + a CMake-generated header. This HIP-SDK-only build links the stub
+# instead so the kernel falls back to its runtime autotune sweep.
+AUTOTUNE_STUB := autotune_stub.cpp
+
+TARGET_DIRECT := $(BUILD_DIR)/test_direct.exe
+
+# ---- Build settings ----
+
+KERNEL_FLAGS := -O3 -std=c++17 -x hip -ffp-contract=fast
+CXXFLAGS     := -O3 -std=c++17
+INCLUDES     := -I$(INCLUDE_DIR)
+
+# ---- Test parameters ----
+
+SIZE     ?= 128x2880x5120
+GS       ?= 128
+DATA_DIR ?= data
+NO_ZEROS ?=
+
+ifeq ($(NO_ZEROS),1)
+    PY_NZ_FLAG  := --no-zeros
+    CXX_NZ_FLAG := --no-zeros
+else
+    PY_NZ_FLAG  :=
+    CXX_NZ_FLAG :=
+endif
+
+# ---- OS-specific: run command + clean ----
+
+ifeq ($(DETECTED_OS),Windows)
+    HIP_SDK_WIN := $(subst /,\,$(HIP_SDK))
+    RUN_CMD     = set "PATH=$(HIP_SDK_WIN)\bin;%PATH%" && $(subst /,\,.\$(1))
+    define DO_CLEAN
+	if exist $(BUILD_DIR) rmdir /s /q $(BUILD_DIR)
+	if exist $(DATA_DIR) rmdir /s /q $(DATA_DIR)
+    endef
+else
+    HIP_SDK_WIN := $(shell wslpath -w "$(HIP_SDK)")
+    RUN_CMD     = cmd.exe /c "set PATH=$(HIP_SDK_WIN)\bin;%PATH% && %CD%\$(1)"
+    define DO_CLEAN
+	rm -rf $(BUILD_DIR) $(DATA_DIR)
+    endef
+endif
+
+# ============================================================
+# Build targets
+# ============================================================
+
+all: direct
+
+ifeq ($(DETECTED_OS),Windows)
+$(BUILD_DIR):
+	@if not exist $(BUILD_DIR) mkdir $(BUILD_DIR)
+else
+$(BUILD_DIR):
+	@mkdir -p $@
+endif
+
+# Generate ISA assembly for inspection
+asm: | $(BUILD_DIR)
+	$(HIPCC) -c $(KERNEL_FLAGS) --save-temps $(OFFLOAD) $(INCLUDES) $(KERNEL_HIP) -o $(BUILD_DIR)/matmul_nbits_kernel_asm.obj
+	@echo "[asm] ISA saved -- look for .s files in $(BUILD_DIR)/"
+
+# ---- Direct mode (compile each TU separately, then link) ----
+
+DIRECT_TEST_OBJ   := $(BUILD_DIR)/direct_test.obj
+DIRECT_KERNEL_OBJ := $(BUILD_DIR)/direct_kernel.obj
+DIRECT_STUB_OBJ   := $(BUILD_DIR)/direct_autotune_stub.obj
+
+direct: FORCE | $(BUILD_DIR)
+	$(HIPCC) -c $(CXXFLAGS) $(OFFLOAD) $(INCLUDES) -x hip test_matmul_nbits_i8.cpp -o $(DIRECT_TEST_OBJ)
+	$(HIPCC) -c $(KERNEL_FLAGS) $(OFFLOAD) $(INCLUDES) $(KERNEL_HIP) -o $(DIRECT_KERNEL_OBJ)
+	$(HIPCC) -c $(CXXFLAGS) -I$(AUTOTUNE_DIR) $(AUTOTUNE_STUB) -o $(DIRECT_STUB_OBJ)
+	$(HIPCC) $(OFFLOAD) $(DIRECT_TEST_OBJ) $(DIRECT_KERNEL_OBJ) $(DIRECT_STUB_OBJ) -o $(TARGET_DIRECT)
+
+# ============================================================
+# Run / test targets
+# ============================================================
+
+clean:
+	$(DO_CLEAN)
+
+gendata:
+	$(PYTHON) gen_matmul_nbits_i8_data.py $(SIZE) --group-size $(GS) --dir $(DATA_DIR) $(PY_NZ_FLAG)
+
+run: direct
+	$(call RUN_CMD,$(TARGET_DIRECT)) $(SIZE) $(GS) $(DATA_DIR) $(CXX_NZ_FLAG)
+
+test: gendata direct
+	$(call RUN_CMD,$(TARGET_DIRECT)) $(SIZE) $(GS) $(DATA_DIR) $(CXX_NZ_FLAG)
+
+test_fp32: gendata direct
+	$(call RUN_CMD,$(TARGET_DIRECT)) $(SIZE) $(GS) $(DATA_DIR) $(CXX_NZ_FLAG) --fp32
+
+run_custom: direct
+	$(call RUN_CMD,$(TARGET_DIRECT)) $(ARGS)
+
+# ---- Preset test suite ----
+
+test_all:
+	$(MAKE) test SIZE=1x2880x2880   GS=128
+	$(MAKE) test SIZE=128x2880x2880 GS=128
+	$(MAKE) test SIZE=1x2880x5120   GS=128
+	$(MAKE) test SIZE=128x2880x5120 GS=128
+	$(MAKE) test SIZE=1x4096x2880   GS=128
+	$(MAKE) test SIZE=128x4096x2880 GS=128
+
+bench_decode:
+	$(MAKE) test SIZE=1x2880x2880   GS=128 NO_ZEROS=1
+	$(MAKE) test SIZE=1x2880x5120   GS=128 NO_ZEROS=1
+	$(MAKE) test SIZE=1x4096x2880   GS=128 NO_ZEROS=1
+	$(MAKE) test SIZE=1x2880x201088 GS=128 NO_ZEROS=1
+
+FORCE:
+
+.PHONY: all direct clean run run_custom gendata test test_fp32 test_all bench_decode asm FORCE

--- a/lib/Runtime/Kernels/test/example/gemm_fp16i8/autotune_stub.cpp
+++ b/lib/Runtime/Kernels/test/example/gemm_fp16i8/autotune_stub.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+/* No-LUT MatMulNBits autotune resolver for the standalone single-kernel test.
+ *
+ * matmul_nbits_kernel.hip calls hipdnn_ep::matmul_nbits_autotune::resolve() (the
+ * offline-LUT lookup shared by the bits=4/8 WMMA and GEMV configs). The real
+ * implementation (hip/autotune/matmul_nbits/matmul_nbits_autotune.cpp) reads a
+ * FlatBuffers table whose generated header and flatbuffers runtime are
+ * produced by the CMake build. This example builds with only the HIP SDK (no
+ * CMake, no flatbuffers), so it links this stub instead.
+ *
+ * resolve() returns Source::None, i.e. "no table" — exactly the path taken on
+ * any GPU arch without a compiled LUT. The kernel then runs its normal runtime
+ * autotune sweep to pick the best config, so correctness and the benchmarked
+ * timings are unaffected; only the one-time first-encounter LUT shortcut is
+ * skipped, which is irrelevant to a benchmark that already warms up per shape.
+ */
+#include "matmul_nbits_autotune.h"
+
+namespace hipdnn_ep {
+namespace matmul_nbits_autotune {
+
+Result resolve(const Request&, WmmaValidator, GemvValidator, void*) {
+  return Result{};  // Source::None -> caller runs the runtime sweep
+}
+
+Stats stats() { return Stats{}; }
+
+}  // namespace matmul_nbits_autotune
+}  // namespace hipdnn_ep

--- a/lib/Runtime/Kernels/test/example/gemm_fp16i8/gen_matmul_nbits_i8_data.py
+++ b/lib/Runtime/Kernels/test/example/gemm_fp16i8/gen_matmul_nbits_i8_data.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# Licensed under the MIT License.
+#
+
+"""
+MatMulNBits bits=8 (uint8, NOT bit-packed) test data generator + NumPy reference
+
+Unlike bits=2/3/4, the bits=8 B matrix is one byte per weight -- no nibble
+or sub-byte packing at all. This generates:
+  A       : FP16  [M, K]
+  B       : uint8 [N, K]                     (one byte per weight, 0..255)
+  scales  : FP16  [N, num_groups_k]
+  zeros   : uint8 [N, num_groups_k]          (optional; default zp=128 when
+                                               absent, values drawn near 128
+                                               when present)
+  C_ref   : FP16  [M, N]                     (fp32-accumulated reference,
+                                               rounded to fp16 at the end --
+                                               used as ground truth for BOTH
+                                               the fp16 and fp32 element_size
+                                               instantiations; see README /
+                                               gemm_fp16u2's testFp32Shape for
+                                               why the same fp16 ref is valid
+                                               ground truth for the fp32 path)
+
+Dequant: w_fp = (uint8_weight - zero_point) * scale
+Reference matmul: C[m,n] = sum_k A[m,k] * w_fp[n,k]
+
+Usage:
+    python3 gen_matmul_nbits_i8_data.py [MxKxN] [--group-size GS] [--dir DIR]
+"""
+
+import numpy as np
+import argparse
+import os
+import time
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Generate MatMulNBits bits=8 (uint8, unpacked) test data')
+    parser.add_argument('size', nargs='?', type=str, default='128x128x128',
+                        help='Matrix size MxKxN (default: 128x128x128)')
+    parser.add_argument('--group-size', type=int, default=128,
+                        help='Quantization group size along K (default: 128)')
+    parser.add_argument('--no-ref', action='store_true',
+                        help='Skip computing reference C')
+    parser.add_argument('--no-zeros', action='store_true',
+                        help='Skip generating zero_points (use default zp=128)')
+    parser.add_argument('--dir', type=str, default='data',
+                        help='Output directory (default: data/)')
+    parser.add_argument('--seed', type=int, default=42,
+                        help='Random seed (default: 42)')
+    args = parser.parse_args()
+
+    parts = args.size.split('x')
+    if len(parts) != 3:
+        parser.error(f"Size must be MxKxN (got '{args.size}')")
+    M, K, N = int(parts[0]), int(parts[1]), int(parts[2])
+    group_size = args.group_size
+    num_groups_k = (K + group_size - 1) // group_size
+
+    out_dir = args.dir
+    os.makedirs(out_dir, exist_ok=True)
+
+    zp_str = "no-zeros" if args.no_zeros else "with-zeros"
+    print(f"Generating M={M} N={N} K={K} gs={group_size} groups={num_groups_k} "
+          f"({zp_str}, seed={args.seed})")
+
+    np.random.seed(args.seed)
+
+    # ---- A (shared by fp16 and fp32 instantiations; fp32 test upcasts this
+    # exact fp16 value host-side, matching the kernel's internal fp32->fp16
+    # downcast at the load boundary) ----
+    A = np.random.uniform(-0.5, 0.5, (M, K)).astype(np.float16)
+    A.flatten(order='C').tofile(os.path.join(out_dir, "matmul_nbits_i8_A.bin"))
+
+    group_idx = np.arange(K) // group_size
+
+    # ---- B: one byte per weight, NOT packed ----
+    B = np.random.randint(0, 256, (N, K), dtype=np.uint8)
+    B.flatten(order='C').tofile(os.path.join(out_dir, "matmul_nbits_i8_B.bin"))
+
+    scales = np.random.uniform(0.01, 0.05, (N, num_groups_k)).astype(np.float16)
+    scales.flatten(order='C').tofile(
+        os.path.join(out_dir, "matmul_nbits_i8_scales.bin"))
+
+    zeros = None
+    if not args.no_zeros:
+        # Default (symmetric) zero point for 8-bit is 128 = 2^(8-1); vary
+        # around it per group to exercise the asymmetric path.
+        zeros = np.random.randint(120, 137, (N, num_groups_k), dtype=np.uint8)
+        zeros.flatten(order='C').tofile(
+            os.path.join(out_dir, "matmul_nbits_i8_zeros_u8.bin"))
+
+    if not args.no_ref:
+        print("Computing reference...", end=" ", flush=True)
+        t0 = time.time()
+
+        scales_f32 = scales.astype(np.float32)
+        if zeros is not None:
+            zp_f32 = zeros.astype(np.float32)
+            B_dq = (B.astype(np.float32) - zp_f32[:, group_idx]) \
+                * scales_f32[:, group_idx]
+        else:
+            B_dq = (B.astype(np.float32) - 128.0) * scales_f32[:, group_idx]
+        C_ref = (A.astype(np.float32) @ B_dq.T).astype(np.float16)
+        C_ref.flatten(order='C').tofile(
+            os.path.join(out_dir, "matmul_nbits_i8_C_ref.bin"))
+
+        elapsed = time.time() - t0
+        print(f"done ({elapsed:.2f}s)")
+    else:
+        print("Skipping reference (--no-ref)")
+
+    print(f"B size: {N * K} bytes (uint8, unpacked)")
+
+    meta_file = os.path.join(out_dir, "matmul_nbits_meta.txt")
+    with open(meta_file, 'w') as f:
+        f.write(f"M={M}\nN={N}\nK={K}\ngroup_size={group_size}\n")
+        f.write(f"num_groups_k={num_groups_k}\nseed={args.seed}\n")
+        f.write(f"use_zeros={'true' if not args.no_zeros else 'false'}\n")
+
+    print(f"Data saved to {out_dir}/")
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/Runtime/Kernels/test/example/gemm_fp16i8/test_matmul_nbits_i8.cpp
+++ b/lib/Runtime/Kernels/test/example/gemm_fp16i8/test_matmul_nbits_i8.cpp
@@ -1,0 +1,644 @@
+/*
+ * Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// ============================================================
+// custom_kernels MatMulNBits bits=8 (uint8, unpacked) Verification + Benchmark
+//
+// Exercises the hip_matmul_nbits() API for the bits=8 quantized-weight
+// kernel: B is one byte per weight (NOT bit-packed, unlike bits=2/3/4).
+//
+//   C[M×N] = A[M×K] × dequant(B)^T
+//
+// Public API tensors -- all ROW-MAJOR:
+//   A       : FP16 or FP32 [batch, M, K]  (element_size_bytes selects dtype)
+//   B       : uint8 [N, K]                 one byte per weight, no packing
+//   scales  : FP16  [N, num_groups_k]
+//   zeros   : uint8 [N, num_groups_k]      (optional, one byte per group;
+//                                            default zp=128 when null)
+//   C       : FP16 or FP32 [batch, M, N]   (same dtype as A)
+//
+// Three internal dispatch paths (selected automatically by shape):
+//   - WMMA  (prefill): batch=1, K%32==0, M>=16, block_size>=32 & %32==0
+//   - GEMV  (decode) : not WMMA-eligible, block_size>=16
+//   - naive          : fallback (e.g. block_size<16)
+//
+// The fp32 (element_size_bytes==4) instantiation rounds A through fp16 at
+// the load boundary (no separate cast kernel/scratch buffer), accumulates
+// in fp32, and stores raw fp32 -- see testFp32Shape() below for how that
+// maps onto the on-disk fp16 reference.
+//
+// Workflow:
+//   1) python gen_matmul_nbits_i8_data.py MxKxN --group-size GS --dir data
+//   2) build and run the test executable
+// ============================================================
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include "hip_custom_kernels.h"
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <cmath>
+#include <cstdint>
+#include <iomanip>
+#include <chrono>
+#include <string>
+#include <algorithm>
+#include <functional>
+#include <cstring>
+#include <cstdlib>
+
+static float half_to_float(__half h)
+{
+    uint16_t bits;
+    std::memcpy(&bits, &h, sizeof(bits));
+    uint32_t sign = (bits >> 15) & 1;
+    uint32_t exp  = (bits >> 10) & 0x1F;
+    uint32_t mant = bits & 0x3FF;
+    uint32_t f;
+    if(exp == 0)
+    {
+        if(mant == 0)
+            f = sign << 31;
+        else
+        {
+            exp = 1;
+            while(!(mant & 0x400)) { mant <<= 1; exp--; }
+            mant &= 0x3FF;
+            f = (sign << 31) | ((exp + 127 - 15) << 23) | (mant << 13);
+        }
+    }
+    else if(exp == 31)
+        f = (sign << 31) | (0xFFu << 23) | (mant << 13);
+    else
+        f = (sign << 31) | ((exp + 127 - 15) << 23) | (mant << 13);
+    float result;
+    std::memcpy(&result, &f, sizeof(result));
+    return result;
+}
+
+#define HIP_CHECK(call)                                                     \
+    do                                                                      \
+    {                                                                       \
+        hipError_t err = (call);                                            \
+        if(err != hipSuccess)                                               \
+        {                                                                   \
+            std::cerr << "HIP error at " << __FILE__ << ":" << __LINE__     \
+                      << " code=" << err << " \""                           \
+                      << hipGetErrorString(err) << "\"" << std::endl;       \
+            exit(1);                                                        \
+        }                                                                   \
+    } while(0)
+
+template <typename T>
+static bool readBin(const std::string& path, std::vector<T>& data, size_t count)
+{
+    std::ifstream f(path, std::ios::binary);
+    if(!f.is_open())
+        return false;
+    data.resize(count);
+    f.read(reinterpret_cast<char*>(data.data()), count * sizeof(T));
+    return f.good();
+}
+
+// ============================================================
+// Benchmark helpers
+// ============================================================
+static int calibrateIters(double warmup_ms, int warmup_count,
+                          double target_ms = 1500.0, int lo = 5, int hi = 200)
+{
+    double per_iter = warmup_ms / warmup_count;
+    if(per_iter <= 0) return lo;
+    return std::max(lo, std::min(hi, static_cast<int>(target_ms / per_iter)));
+}
+
+constexpr int NROUNDS = 5;
+
+struct MeasureResult {
+    double median_ms;
+    double min_ms;
+    double max_ms;
+};
+
+static MeasureResult measureMedian(hipStream_t stream, int niters,
+                                   const std::function<void()>& launch)
+{
+    hipEvent_t ev0, ev1;
+    hipEventCreate(&ev0);
+    hipEventCreate(&ev1);
+    std::vector<float> round_ms(NROUNDS);
+    for(int r = 0; r < NROUNDS; r++)
+    {
+        hipEventRecord(ev0, stream);
+        for(int i = 0; i < niters; i++)
+            launch();
+        hipEventRecord(ev1, stream);
+        hipEventSynchronize(ev1);
+        hipEventElapsedTime(&round_ms[r], ev0, ev1);
+    }
+    hipEventDestroy(ev0);
+    hipEventDestroy(ev1);
+
+    std::sort(round_ms.begin(), round_ms.end());
+    return {round_ms[NROUNDS / 2], round_ms[0], round_ms[NROUNDS - 1]};
+}
+
+// ============================================================
+// Per-kernel benchmark + verify
+// ============================================================
+struct KernelStat {
+    std::string label;
+    bool launch_ok  = false;
+    double avg_ms   = 0.0;
+    double gflops   = 0.0;
+    double bw_gbs   = 0.0;
+    double min_ms   = 0.0;
+    double max_ms   = 0.0;
+    bool   has_ref  = false;
+    int    errors   = -1;
+    int    total    = 0;
+    float  max_diff = 0.0f;
+    float  max_rdiff = 0.0f;
+};
+
+static int verifyAgainstRef(const std::vector<__half>& h_C,
+                            const std::vector<__half>& h_C_ref, size_t countC,
+                            float& max_diff_out, float& max_rdiff_out)
+{
+    int errors = 0;
+    float max_diff = 0.0f, max_rdiff = 0.0f;
+    for(size_t i = 0; i < countC; i++)
+    {
+        float gpu_val = half_to_float(h_C[i]);
+        float ref_val = half_to_float(h_C_ref[i]);
+        float diff    = std::fabs(gpu_val - ref_val);
+        float rdiff   = (std::fabs(ref_val) > 1e-6f) ? diff / std::fabs(ref_val) : diff;
+        if(diff > max_diff) max_diff = diff;
+        if(rdiff > max_rdiff) max_rdiff = rdiff;
+        float tol = std::fabs(ref_val) * 0.05f + 0.1f;
+        if(diff > tol) errors++;
+    }
+    max_diff_out = max_diff;
+    max_rdiff_out = max_rdiff;
+    return errors;
+}
+
+static KernelStat benchmarkAndVerify(
+    const std::string& label,
+    hipStream_t stream,
+    const std::function<int()>& launch_checked,
+    const std::function<void()>& launch,
+    int M, int N, int K,
+    double mem_bytes,
+    __half* d_C, size_t countC,
+    const std::vector<__half>& h_C_ref, bool has_ref)
+{
+    KernelStat st;
+    st.label   = label;
+    st.has_ref = has_ref;
+
+    std::cout << "\n  --- " << label << " ---" << std::endl;
+
+    constexpr int PRE_WARMUP = 500;
+    std::cout << "  Pre-warmup (" << PRE_WARMUP << " iters)..." << std::flush;
+    auto pw0 = std::chrono::steady_clock::now();
+    for(int w = 0; w < PRE_WARMUP; w++)
+        launch();
+    HIP_CHECK(hipStreamSynchronize(stream));
+    double pw_ms = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now() - pw0).count() / 1000.0;
+    std::cout << " done (" << std::fixed << std::setprecision(3)
+              << pw_ms / PRE_WARMUP << " ms/iter)" << std::endl;
+
+    std::cout << "  Warmup..." << std::flush;
+    auto tw0 = std::chrono::steady_clock::now();
+    int status = 0;
+    for(int w = 0; w < 3; w++)
+    {
+        status = launch_checked();
+        if(status != 0) break;
+    }
+    HIP_CHECK(hipStreamSynchronize(stream));
+    double warmup_ms = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now() - tw0).count() / 1000.0;
+
+    if(status != 0)
+    {
+        std::cout << " FAILED (status=" << status << ")" << std::endl;
+        return st;
+    }
+
+    int niters = calibrateIters(warmup_ms, 3);
+    std::cout << " OK (" << std::fixed << std::setprecision(2) << warmup_ms
+              << " ms), iters=" << niters << std::endl;
+
+    std::cout << "  Benchmarking (" << NROUNDS << " rounds x " << niters
+              << " iters)..." << std::flush;
+    auto mr = measureMedian(stream, niters, launch);
+    std::cout << " done" << std::endl;
+
+    st.launch_ok = true;
+    st.avg_ms    = mr.median_ms / niters;
+    st.min_ms    = mr.min_ms / niters;
+    st.max_ms    = mr.max_ms / niters;
+    st.gflops    = (2.0 * M * N * K) / (st.avg_ms * 1e6);
+    st.bw_gbs    = mem_bytes * niters / (mr.median_ms * 1e6);
+
+    std::cout << "  Median: " << std::setprecision(6) << st.avg_ms << " ms, "
+              << std::setprecision(2) << st.gflops << " GFLOPS, "
+              << st.bw_gbs << " GB/s   (range " << st.min_ms << " ~ "
+              << st.max_ms << " ms)" << std::endl;
+
+    if(has_ref)
+    {
+        std::vector<__half> h_C(countC);
+        HIP_CHECK(hipMemcpy(h_C.data(), d_C, countC * sizeof(__half),
+                            hipMemcpyDeviceToHost));
+        float max_diff = 0.0f, max_rdiff = 0.0f;
+        int errors = verifyAgainstRef(h_C, h_C_ref, countC, max_diff, max_rdiff);
+
+        st.errors    = errors;
+        st.total     = static_cast<int>(countC);
+        st.max_diff  = max_diff;
+        st.max_rdiff = max_rdiff;
+
+        std::cout << "  Verify: " << (st.total - errors) << "/" << st.total
+                  << " OK, max_abs_diff=" << std::setprecision(4) << max_diff
+                  << ", max_rel_diff=" << (max_rdiff * 100.0f) << "%   "
+                  << (errors == 0 ? "PASS" : "FAIL") << std::endl;
+    }
+
+    return st;
+}
+
+// ============================================================
+// FP32 A / FP32 output benchmark + verify
+//
+// Mirrors benchmarkAndVerify above, but d_C is a float* buffer
+// (element_size_bytes==4) instead of __half*. The reference stays the
+// on-disk fp16 C_ref -- upcast per-element with half_to_float() before
+// comparing.
+// ============================================================
+static KernelStat benchmarkAndVerifyFp32(
+    const std::string& label,
+    hipStream_t stream,
+    const std::function<int()>& launch_checked,
+    const std::function<void()>& launch,
+    int M, int N, int K,
+    double mem_bytes,
+    float* d_C, size_t countC,
+    const std::vector<__half>& h_C_ref, bool has_ref)
+{
+    KernelStat st;
+    st.label   = label;
+    st.has_ref = has_ref;
+
+    std::cout << "\n  --- " << label << " ---" << std::endl;
+
+    constexpr int PRE_WARMUP = 500;
+    std::cout << "  Pre-warmup (" << PRE_WARMUP << " iters)..." << std::flush;
+    auto pw0 = std::chrono::steady_clock::now();
+    for(int w = 0; w < PRE_WARMUP; w++)
+        launch();
+    HIP_CHECK(hipStreamSynchronize(stream));
+    double pw_ms = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now() - pw0).count() / 1000.0;
+    std::cout << " done (" << std::fixed << std::setprecision(3)
+              << pw_ms / PRE_WARMUP << " ms/iter)" << std::endl;
+
+    std::cout << "  Warmup..." << std::flush;
+    auto tw0 = std::chrono::steady_clock::now();
+    int status = 0;
+    for(int w = 0; w < 3; w++)
+    {
+        status = launch_checked();
+        if(status != 0) break;
+    }
+    HIP_CHECK(hipStreamSynchronize(stream));
+    double warmup_ms = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now() - tw0).count() / 1000.0;
+
+    if(status != 0)
+    {
+        std::cout << " FAILED (status=" << status << ")" << std::endl;
+        return st;
+    }
+
+    int niters = calibrateIters(warmup_ms, 3);
+    std::cout << " OK (" << std::fixed << std::setprecision(2) << warmup_ms
+              << " ms), iters=" << niters << std::endl;
+
+    std::cout << "  Benchmarking (" << NROUNDS << " rounds x " << niters
+              << " iters)..." << std::flush;
+    auto mr = measureMedian(stream, niters, launch);
+    std::cout << " done" << std::endl;
+
+    st.launch_ok = true;
+    st.avg_ms    = mr.median_ms / niters;
+    st.min_ms    = mr.min_ms / niters;
+    st.max_ms    = mr.max_ms / niters;
+    st.gflops    = (2.0 * M * N * K) / (st.avg_ms * 1e6);
+    st.bw_gbs    = mem_bytes * niters / (mr.median_ms * 1e6);
+
+    std::cout << "  Median: " << std::setprecision(6) << st.avg_ms << " ms, "
+              << std::setprecision(2) << st.gflops << " GFLOPS, "
+              << st.bw_gbs << " GB/s   (range " << st.min_ms << " ~ "
+              << st.max_ms << " ms)" << std::endl;
+
+    if(has_ref)
+    {
+        std::vector<float> h_C(countC);
+        HIP_CHECK(hipMemcpy(h_C.data(), d_C, countC * sizeof(float),
+                            hipMemcpyDeviceToHost));
+        int errors = 0;
+        float max_diff = 0.0f, max_rdiff = 0.0f;
+        for(size_t i = 0; i < countC; i++)
+        {
+            float gpu_val = h_C[i];
+            float ref_val = half_to_float(h_C_ref[i]);
+            float diff    = std::fabs(gpu_val - ref_val);
+            float rdiff   = (std::fabs(ref_val) > 1e-6f) ? diff / std::fabs(ref_val) : diff;
+            if(diff > max_diff) max_diff = diff;
+            if(rdiff > max_rdiff) max_rdiff = rdiff;
+            float tol = std::fabs(ref_val) * 0.05f + 0.1f;
+            if(diff > tol) errors++;
+        }
+
+        st.errors    = errors;
+        st.total     = static_cast<int>(countC);
+        st.max_diff  = max_diff;
+        st.max_rdiff = max_rdiff;
+
+        std::cout << "  Verify: " << (st.total - errors) << "/" << st.total
+                  << " OK, max_abs_diff=" << std::setprecision(4) << max_diff
+                  << ", max_rel_diff=" << (max_rdiff * 100.0f) << "%   "
+                  << (errors == 0 ? "PASS" : "FAIL") << std::endl;
+    }
+
+    return st;
+}
+
+// ============================================================
+// FP16 A / FP16 output single-shape test (bits=8)
+// ============================================================
+bool testShape(int M, int N, int K, int group_size,
+              const std::string& data_dir, bool use_zeros)
+{
+    int num_groups_k = (K + group_size - 1) / group_size;
+
+    std::cout << "\n=== MatMulNBits i8 (fp16)  M=" << M << " N=" << N
+              << " K=" << K << " group_size=" << group_size
+              << (use_zeros ? "" : " (no zeros)") << " ===" << std::endl;
+
+    size_t countA = static_cast<size_t>(M) * K;
+    size_t countC = static_cast<size_t>(M) * N;
+    size_t countB = static_cast<size_t>(N) * K;
+    size_t countS = static_cast<size_t>(N) * num_groups_k;
+
+    std::vector<__half>  h_A;
+    std::vector<uint8_t> h_B;
+    std::vector<__half>  h_S;
+    std::vector<uint8_t> h_Z;
+    std::vector<__half>  h_Cref;
+
+    bool ok = readBin(data_dir + "/matmul_nbits_i8_A.bin", h_A, countA)
+           && readBin(data_dir + "/matmul_nbits_i8_B.bin", h_B, countB)
+           && readBin(data_dir + "/matmul_nbits_i8_scales.bin", h_S, countS);
+    if(use_zeros)
+        ok = ok && readBin(data_dir + "/matmul_nbits_i8_zeros_u8.bin", h_Z, countS);
+    bool has_ref = readBin(data_dir + "/matmul_nbits_i8_C_ref.bin", h_Cref, countC);
+
+    if(!ok)
+    {
+        std::cerr << "  ERROR: failed to read i8 input data from " << data_dir << "/" << std::endl;
+        std::cerr << "  Run: python gen_matmul_nbits_i8_data.py " << M << "x" << K << "x" << N
+                  << " --group-size " << group_size
+                  << (use_zeros ? "" : " --no-zeros") << " --dir " << data_dir << std::endl;
+        return false;
+    }
+    std::cout << "  Loaded A + i8 weights from " << data_dir << "/" << std::endl;
+
+    hipStream_t stream;
+    HIP_CHECK(hipStreamCreate(&stream));
+
+    __half*  d_A = nullptr;
+    __half*  d_C = nullptr;
+    uint8_t* d_B = nullptr;
+    __half*  d_S = nullptr;
+    uint8_t* d_Z = nullptr;
+
+    HIP_CHECK(hipMalloc(&d_A, countA * sizeof(__half)));
+    HIP_CHECK(hipMalloc(&d_C, countC * sizeof(__half)));
+    HIP_CHECK(hipMalloc(&d_B, countB));
+    HIP_CHECK(hipMalloc(&d_S, countS * sizeof(__half)));
+    HIP_CHECK(hipMemcpy(d_A, h_A.data(), countA * sizeof(__half), hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemset(d_C, 0, countC * sizeof(__half)));
+    HIP_CHECK(hipMemcpy(d_B, h_B.data(), countB, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(d_S, h_S.data(), countS * sizeof(__half), hipMemcpyHostToDevice));
+    if(use_zeros)
+    {
+        HIP_CHECK(hipMalloc(&d_Z, countS));
+        HIP_CHECK(hipMemcpy(d_Z, h_Z.data(), countS, hipMemcpyHostToDevice));
+    }
+
+    auto launch_checked = [&]() -> int {
+        return hip_matmul_nbits(
+            stream, d_A, d_B, d_S,
+            use_zeros ? d_Z : nullptr,
+            nullptr,           // bias
+            d_C,
+            M, N, K,
+            1,                 // batch_count
+            8,                 // bits
+            group_size,        // block_size
+            2,                 // element_size_bytes (fp16)
+            1,                 // zp_elem_size (uint8, one byte per group)
+            nullptr,           // pre_unpacked_zp_u8 (direct convention)
+            nullptr);          // pre_unpacked_zp_fp16 (unused for bits=8)
+    };
+    auto launch = [&]() { launch_checked(); };
+
+    double mem_bytes = static_cast<double>(countA) * 2 + static_cast<double>(countB)
+                      + static_cast<double>(countS) * 2
+                      + (use_zeros ? static_cast<double>(countS) : 0.0)
+                      + static_cast<double>(countC) * 2;
+
+    KernelStat st = benchmarkAndVerify(
+        "i8", stream, launch_checked, launch, M, N, K,
+        mem_bytes, d_C, countC, h_Cref, has_ref);
+
+    bool pass = st.launch_ok && (!st.has_ref || st.errors == 0);
+
+    hipFree(d_A);
+    hipFree(d_C);
+    hipFree(d_B);
+    hipFree(d_S);
+    if(d_Z) hipFree(d_Z);
+    hipStreamDestroy(stream);
+
+    return pass;
+}
+
+// ============================================================
+// FP32 A / FP32 output single-shape test (bits=8)
+//
+// Reuses the same on-disk fp16 A/B/scales/zeros as the fp16 test above --
+// A is upcast host-side (exact fp16->fp32), so the kernel's internal
+// fp32->fp16 downcast reproduces that exact fp16 A, making the existing
+// fp16 i8 C_ref the correct ground truth here too, just compared through
+// float containers (mirrors gemm_fp16u2's testFp32Shape()).
+// ============================================================
+bool testFp32Shape(int M, int N, int K, int group_size,
+                   const std::string& data_dir, bool use_zeros)
+{
+    int num_groups_k = (K + group_size - 1) / group_size;
+
+    std::cout << "\n=== MatMulNBits i8 (fp32)  M=" << M << " N=" << N
+              << " K=" << K << " group_size=" << group_size
+              << (use_zeros ? "" : " (no zeros)") << " ===" << std::endl;
+
+    size_t countA = static_cast<size_t>(M) * K;
+    size_t countC = static_cast<size_t>(M) * N;
+    size_t countB = static_cast<size_t>(N) * K;
+    size_t countS = static_cast<size_t>(N) * num_groups_k;
+
+    std::vector<__half> h_A_fp16;
+    if(!readBin(data_dir + "/matmul_nbits_i8_A.bin", h_A_fp16, countA))
+    {
+        std::cerr << "  ERROR: cannot read " << data_dir << "/matmul_nbits_i8_A.bin" << std::endl;
+        return false;
+    }
+    std::vector<float> h_A(countA);
+    for(size_t i = 0; i < countA; i++)
+        h_A[i] = half_to_float(h_A_fp16[i]);
+
+    std::vector<uint8_t> h_B;
+    std::vector<__half>  h_S;
+    std::vector<uint8_t> h_Z;
+    std::vector<__half>  h_Cref;
+    bool ok = readBin(data_dir + "/matmul_nbits_i8_B.bin", h_B, countB)
+           && readBin(data_dir + "/matmul_nbits_i8_scales.bin", h_S, countS);
+    if(use_zeros)
+        ok = ok && readBin(data_dir + "/matmul_nbits_i8_zeros_u8.bin", h_Z, countS);
+    bool has_ref = readBin(data_dir + "/matmul_nbits_i8_C_ref.bin", h_Cref, countC);
+
+    if(!ok)
+    {
+        std::cerr << "  ERROR: failed to read i8 input data from " << data_dir << "/" << std::endl;
+        return false;
+    }
+    std::cout << "  Loaded A (fp32-upcast) + i8 weights from " << data_dir << "/" << std::endl;
+
+    hipStream_t stream;
+    HIP_CHECK(hipStreamCreate(&stream));
+
+    float*   d_A = nullptr;
+    float*   d_C = nullptr;
+    uint8_t* d_B = nullptr;
+    __half*  d_S = nullptr;
+    uint8_t* d_Z = nullptr;
+
+    HIP_CHECK(hipMalloc(&d_A, countA * sizeof(float)));
+    HIP_CHECK(hipMalloc(&d_C, countC * sizeof(float)));
+    HIP_CHECK(hipMalloc(&d_B, countB));
+    HIP_CHECK(hipMalloc(&d_S, countS * sizeof(__half)));
+    HIP_CHECK(hipMemcpy(d_A, h_A.data(), countA * sizeof(float), hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemset(d_C, 0, countC * sizeof(float)));
+    HIP_CHECK(hipMemcpy(d_B, h_B.data(), countB, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(d_S, h_S.data(), countS * sizeof(__half), hipMemcpyHostToDevice));
+    if(use_zeros)
+    {
+        HIP_CHECK(hipMalloc(&d_Z, countS));
+        HIP_CHECK(hipMemcpy(d_Z, h_Z.data(), countS, hipMemcpyHostToDevice));
+    }
+
+    auto launch_checked = [&]() -> int {
+        return hip_matmul_nbits(
+            stream, d_A, d_B, d_S,
+            use_zeros ? d_Z : nullptr,
+            nullptr,           // bias
+            d_C,
+            M, N, K,
+            1,                 // batch_count
+            8,                 // bits
+            group_size,        // block_size
+            4,                 // element_size_bytes (fp32)
+            1,                 // zp_elem_size (uint8, one byte per group)
+            nullptr,           // pre_unpacked_zp_u8 (direct convention)
+            nullptr);          // pre_unpacked_zp_fp16 (unused for bits=8)
+    };
+    auto launch = [&]() { launch_checked(); };
+
+    double mem_bytes = static_cast<double>(countA) * 4 + static_cast<double>(countB)
+                      + static_cast<double>(countS) * 2
+                      + (use_zeros ? static_cast<double>(countS) : 0.0)
+                      + static_cast<double>(countC) * 4;
+
+    KernelStat st = benchmarkAndVerifyFp32(
+        "i8(fp32)", stream, launch_checked, launch, M, N, K,
+        mem_bytes, d_C, countC, h_Cref, has_ref);
+
+    bool pass = st.launch_ok && (!st.has_ref || st.errors == 0);
+
+    hipFree(d_A);
+    hipFree(d_C);
+    hipFree(d_B);
+    hipFree(d_S);
+    if(d_Z) hipFree(d_Z);
+    hipStreamDestroy(stream);
+
+    return pass;
+}
+
+// ============================================================
+
+int main(int argc, char* argv[])
+{
+    std::cout << "custom_kernels MatMulNBits bits=8 (uint8, unpacked) Verification" << std::endl;
+    std::cout << "==========================================================================" << std::endl;
+
+    hipDeviceProp_t prop;
+    HIP_CHECK(hipGetDeviceProperties(&prop, 0));
+    std::cout << "GPU: " << prop.name << " (arch: " << prop.gcnArchName << ")" << std::endl;
+
+    int M = 128, N = 128, K = 128, gs = 128;
+    std::string data_dir = "data";
+    bool use_zeros = true;
+    bool fp32_mode = false;
+
+    for(int i = 1; i < argc; i++)
+    {
+        if(std::string(argv[i]) == "--no-zeros")
+            use_zeros = false;
+        else if(std::string(argv[i]) == "--fp32")
+            fp32_mode = true;
+    }
+
+    if(argc >= 2 && std::string(argv[1]) != "--no-zeros" && std::string(argv[1]) != "--fp32")
+    {
+        if(sscanf(argv[1], "%dx%dx%d", &M, &K, &N) != 3)
+        {
+            std::cerr << "Usage: " << argv[0]
+                      << " [MxKxN] [group_size] [data_dir] [--no-zeros] [--fp32]" << std::endl;
+            return 1;
+        }
+    }
+    if(argc >= 3 && std::string(argv[2]) != "--no-zeros" && std::string(argv[2]) != "--fp32") gs = atoi(argv[2]);
+    if(argc >= 4 && std::string(argv[3]) != "--no-zeros" && std::string(argv[3]) != "--fp32") data_dir = argv[3];
+
+    std::cout << "Data dir: " << data_dir << std::endl;
+    if(!use_zeros)
+        std::cout << "Zero points: disabled (--no-zeros, default zp=128)" << std::endl;
+    if(fp32_mode)
+        std::cout << "Mode: FP32 A / FP32 output (element_size_bytes=4, bits=8)" << std::endl;
+
+    bool all_pass = fp32_mode
+        ? testFp32Shape(M, N, K, gs, data_dir, use_zeros)
+        : testShape(M, N, K, gs, data_dir, use_zeros);
+
+    std::cout << "\n==========================================================================" << std::endl;
+    std::cout << "Overall: " << (all_pass ? "ALL PASSED" : "SOME FAILED") << std::endl;
+
+    return all_pass ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
Extends fp32 A / fp32 output support to `bits=8` MatMulNBits, reusing the
device-side fp16 cast path introduced for u2/u3/u4 in #957. int8 MatMulNBits
now accepts `element_size_bytes==4` (fp32) inputs/outputs, previously only
fp16 was allowed for bits=8.

## Why
#957 added fp32 A/C for bits=2/3/4 by casting A→fp16, running the unchanged
fp16 compute path, and casting the result back to fp32, but its dispatch was
gated `element_size_bytes==4 && bits != 8`, explicitly excluding int8. So
bits=8 with fp32 activations fell through to the "only fp16 supported" error.
Nothing in the cast path is bits-specific, so int8 only needed to be let in.

Overwriting the activation buffer in place (to avoid the fp16 scratch) was
considered and rejected: in the target model 55% of MatMulNBits activations
are shared by multiple consumers (QKV projections share the input LayerNorm
output; gate/up projections share the pre-feedforward LayerNorm output), so an
in-place fp32→fp16 cast would corrupt the peer ops reading the same tensor.

## What
- `matmul_nbits_kernel.hip`: drop `&& bits != 8` from the fp32 cast-wrapper
  gate (`element_size_bytes == 4`). fp32 bits=8 now casts A→fp16, calls the
  unchanged fp16 int8 dispatch (WMMA/GEMV/naive), and casts the fp16 result
  back to fp32. Reuses the existing `g_fp32cast_a/c` scratch, so the int8
  kernels stay fp16-only — no element-type template, no code-size growth.
- Add `gemm_fp16i8/`: standalone HIP-SDK test (Makefile, data generator,
  no-LUT autotune stub, GPU-vs-CPU driver with a `--fp32` mode).

## Test plan
On gfx1151:
- **i8**: fp16 (regression) and fp32, prefill (WMMA) and decode (GEMV),
  with and without zero_points — all pass.
- **u2/u3/u4 regression**: the change is a no-op for bits 2/3/4 (`bits != 8`
  is always true there, so the gate is unchanged); spot-checked u4 fp16/fp32
  to confirm no regression.

## AI assistance
Investigation, the one-line gate change, and the test program were developed
with AI assistance (Cursor) and reviewed by the author; commit carries the
`Co-Authored-By` / `Made-with` trailers per CONTRIBUTING.md.