### PR TITLE
fix(GQA): Fix d128 windowed fused GQA prefill

### DIFF
--- a/lib/Runtime/Kernels/hip/gqa_kernel.hip
+++ b/lib/Runtime/Kernels/hip/gqa_kernel.hip
@@ -3322,9 +3322,6 @@ static inline void dispatchPrefillV5(
                 scale, ablate, head_sink, num_heads, smooth_softmax,            \
                 local_window_size)
 
-    // Only d == 64 gets windowed instantiations: hip_gqa_flash_prefill
-    // rejects a window at any other head dim, so d == 128 with a window would
-    // be dead code.
     if (d == 64) {
         if (local_window_size > 0) {
             if (m_tiles == 2 && bkv == 64)  LAUNCH_V5(2, 64, 64, true);
@@ -3338,10 +3335,17 @@ static inline void dispatchPrefillV5(
             else                            LAUNCH_V5(1, 32, 64, false);
         }
     } else {
-        if (m_tiles == 2 && bkv == 64)      LAUNCH_V5(2, 64, 128, false);
-        else if (m_tiles == 2)              LAUNCH_V5(2, 32, 128, false);
-        else if (bkv == 64)                 LAUNCH_V5(1, 64, 128, false);
-        else                                LAUNCH_V5(1, 32, 128, false);
+        if (local_window_size > 0) {
+            if (m_tiles == 2 && bkv == 64)  LAUNCH_V5(2, 64, 128, true);
+            else if (m_tiles == 2)          LAUNCH_V5(2, 32, 128, true);
+            else if (bkv == 64)             LAUNCH_V5(1, 64, 128, true);
+            else                            LAUNCH_V5(1, 32, 128, true);
+        } else {
+            if (m_tiles == 2 && bkv == 64)  LAUNCH_V5(2, 64, 128, false);
+            else if (m_tiles == 2)          LAUNCH_V5(2, 32, 128, false);
+            else if (bkv == 64)             LAUNCH_V5(1, 64, 128, false);
+            else                            LAUNCH_V5(1, 32, 128, false);
+        }
     }
     #undef LAUNCH_V5
 }
@@ -4422,12 +4426,11 @@ extern "C" void hip_gqa_flash_prefill_v8_set_ablate(int mask) {
 // on top of v2. v2 stays the narrow ABI so the standalone harnesses and shim
 // headers that redeclare it keep linking unchanged.
 //
-// Both features are implemented for d == 64 (the v5 kernel) only. For any other
-// d we return -1 rather than silently ignoring them, so the runtime keeps
-// routing those shapes to the decomposed path, which does implement both. A
-// request carrying neither is forwarded to v2 and keeps v2's head-dim coverage
-// and its v5/v7/v8 selection; d == 64 lands on v5 either way, so a sink or a
-// window never changes which kernel runs.
+// Attention sinks are implemented for d == 64. Sliding-window attention is
+// also implemented for d == 128 by v5. Unsupported feature/head
+// combinations return -1 rather than silently dropping the requested feature.
+// A request carrying neither is forwarded to v2 and keeps v2's head-dim
+// coverage and its v5/v7/v8 selection.
 extern "C" int hip_gqa_flash_prefill(
     void* stream_ptr,
     const void* Q, const void* Kcache, const void* Vcache, void* O,
@@ -4437,10 +4440,16 @@ extern "C" int hip_gqa_flash_prefill(
 {
     const bool wants_sink   = (head_sink != nullptr) || (smooth_softmax != 0);
     const bool wants_window = local_window_size > 0;
-    if ((wants_sink || wants_window) && d != 64) return -1;
+    if (wants_sink && d != 64) return -1;
+    if (wants_window && d != 64 && d != 128) return -1;
     if (!wants_sink && !wants_window) {
         return hip_gqa_flash_prefill_v2(stream_ptr, Q, Kcache, Vcache, O, B, Hq,
                                         G, sq, skv, d, max_seq, past_len, scale);
+    }
+    if (d == 128) {
+        return prefillV5Run(stream_ptr, Q, Kcache, Vcache, O, B, Hq, G, sq,
+                            skv, d, max_seq, past_len, scale, nullptr, Hq, 0,
+                            local_window_size);
     }
     return prefillV5Run(stream_ptr, Q, Kcache, Vcache, O, B, Hq, G, sq, skv, d,
                         max_seq, past_len, scale, head_sink, num_heads,
@@ -4501,7 +4510,8 @@ extern "C" int hip_gqa_flash_prefill_v3_configured(
 {
     const bool wants_sink = head_sink != nullptr || smooth_softmax != 0;
     const bool wants_window = local_window_size > 0;
-    if ((wants_sink || wants_window) && d != 64) return -1;
+    if (wants_sink && d != 64) return -1;
+    if (wants_window && d != 64 && d != 128) return -1;
 
     hipStream_t stream = static_cast<hipStream_t>(stream_ptr);
     const _Float16* Q_ptr = static_cast<const _Float16*>(Q);
@@ -4524,6 +4534,13 @@ extern "C" int hip_gqa_flash_prefill_v3_configured(
         return 0;
     }
     if (d == 128) {
+        if (wants_window) {
+            if (bkv != 32 && bkv != 64) return -1;
+            dispatchPrefillV5(1, bkv, d, stream, Q_ptr, K_ptr, V_ptr, O_ptr,
+                              B, Hq, G, sq, skv, max_seq, past_len, scale,
+                              nullptr, Hq, 0, local_window_size);
+            return 0;
+        }
         PrefillV7Cfg candidates[12];
         const int count = prefillV7Candidates(d, candidates);
         bool valid = false;

--- a/lib/Runtime/real/gqa.cpp
+++ b/lib/Runtime/real/gqa.cpp
@@ -733,6 +733,9 @@ static int gqa_forward_fused(
     attn_max_seq = static_cast<int>(total_seq);
   }
 
+  const bool d128_window_prefill = d == 128 && local_window_size > 0;
+  const int fused_prefill_version =
+      (d == 64 || d128_window_prefill) ? 5 : (d == 128 ? 7 : 8);
   int fp_rc;
   if (hip_gqa_autotune_mode(state->gqa_autotune_policy) ==
       static_cast<int>(hipdnn_ep::GqaAutotuneMode::Online)) {
@@ -780,12 +783,13 @@ static int gqa_forward_fused(
       selected = {heuristic, hipdnn_ep::GqaTuneSource::Heuristic, 0.0f};
       fp_rc = launch_configured(selected.config);
     }
-    RUNTIME_DEBUG_LOG("[REAL] GQA prefill config source=%s v%d "
-                      "m_tiles=%d bkv=%d nw=%d mt=%d nd=%d\n",
-                      hipdnn_ep::gqa_tune_source_name(selected.source),
-                      d == 64 ? 5 : (d == 128 ? 7 : 8), selected.config.m_tiles,
-                      selected.config.bkv, selected.config.nw,
-                      selected.config.mt, selected.config.nd);
+    RUNTIME_DEBUG_LOG(
+        "[REAL] GQA prefill config source=%s v%d "
+        "m_tiles=%d bkv=%d nw=%d mt=%d nd=%d\n",
+        hipdnn_ep::gqa_tune_source_name(selected.source), fused_prefill_version,
+        d128_window_prefill ? 1 : selected.config.m_tiles, selected.config.bkv,
+        d128_window_prefill ? 0 : selected.config.nw,
+        d128_window_prefill ? 0 : selected.config.mt, selected.config.nd);
   }
   // window is logged because it selects the HAS_WINDOW instantiation, so a
   // dispatch that looks identical here can be two different kernels.
@@ -793,10 +797,9 @@ static int gqa_forward_fused(
       "[REAL] GQA fused prefill (%s d=%lld -> v%d): B=%lld sq=%lld "
       "total_seq=%lld H=%lld G=%lld past_len=%lld sink=%d smooth=%d window=%d "
       "rc=%d\n",
-      kv_quantized ? "quant" : "fp16", (long long)d,
-      (d == 64 ? 5 : (d == 128 ? 7 : 8)), (long long)B, (long long)sq,
-      (long long)total_seq, (long long)H, (long long)G, (long long)past_len,
-      static_cast<int>(head_sink != nullptr),
+      kv_quantized ? "quant" : "fp16", (long long)d, fused_prefill_version,
+      (long long)B, (long long)sq, (long long)total_seq, (long long)H,
+      (long long)G, (long long)past_len, static_cast<int>(head_sink != nullptr),
       static_cast<int>(use_smooth_softmax), local_window_size, fp_rc);
   return fp_rc != 0 ? -1 : 0;
 }
@@ -2431,8 +2434,9 @@ int wrap_group_query_attention(
   // Path selection. The optimized fused/flash kernels are fp16 causal GQA with
   // head_dim in {64,128,256} and a templated decode geometry (HpG in
   // {1,2,3,4,5,8,16}). Decode supports sink/window for every templated
-  // geometry; prefill v3 supports them at head_dim == 64. Everything else uses
-  // the feature-complete decomposed hipBLASLt fallback.
+  // geometry; prefill v3 supports sinks at head_dim == 64 and windows at
+  // head_dim == 64 or 128. Everything else uses the feature-complete
+  // decomposed hipBLASLt fallback.
   //===------------------------------------------------------------------===//
   const bool is_decode = (seq_len_q == 1);
   const bool decode_geometry_ok =
@@ -2453,12 +2457,13 @@ int wrap_group_query_attention(
   // use_smooth_softmax_ || head_sink != nullptr).
   const bool has_smooth_softmax = (head_sink != nullptr || smooth_softmax == 1);
   // Sink/window are first-class decode features. Prefill v3 implements both at
-  // D64; D128/D256 prefill must fall back rather than silently drop them.
+  // D64, and v5 implements the window at D128. D128 sinks and all D256
+  // prefill features must fall back rather than silently drop them.
   const bool sink_ok = !has_smooth_softmax || is_decode || head_dim == 64;
   // Decode handles the window itself (kv_lo clamp), so it is allowed for any
-  // supported geometry; prefill only implements it at D64. This subsumes the
-  // narrower prefill-only form, so nothing prefill accepted before is widened.
-  const bool window_ok = is_decode || local_window_size <= 0 || head_dim == 64;
+  // supported geometry; prefill implements it at D64 and D128.
+  const bool window_ok =
+      is_decode || local_window_size <= 0 || head_dim == 64 || head_dim == 128;
   // The whole fused path (gqa_forward_fused, including the sink and windowed
   // prefill kernels above) is built on the RDNA-only WMMA intrinsics, which
   // trap on CDNA (wave64, e.g. MI350). Route wave64 to the decomposed hipBLASLt


### PR DESCRIPTION
## Summary

Enable fused GroupQueryAttention prefill for FP16 `head_dim=128` models that use a local sliding window.

## Related issue or design

None.

## Why

Windowed d=128 prefill was rejected by the fused-path eligibility check and routed to the decomposed hipBLASLt pipeline. This caused severe output degradation in PSU models using sliding-window attention, including repeated `a` tokens and repeated numeric rows.

## What

- Instantiate the fused v5 prefill kernel for d=128 with `HAS_WINDOW=true`.
- Allow d=128 windowed prefill through the fused dispatch checks.
- Route online and configured d=128 windowed requests to v5 while retaining v7 for non-windowed d=128 prefill.
- Report the selected fused kernel version correctly in runtime diagnostics.

## Test plan

- Release build and install completed successfully on Windows with gfx1151/gfx1152 targets.
- `GqaAutotuneUnitTest` passed.
- `PSU_MF_LORA_GEMM-model-2.1.1`: completed with exit code 0; repeated `a a a...` output is gone.
- `PSU_ORC-model-3.5.0`: completed with exit code 0; repeated `[12] = 0.0...` output is gone.
- Re-ran the six previously affected PSU models; all completed with exit code 0 and no NaN, fused-path, or crash diagnostics.

## Notes for reviewers

The standalone randomized fixed-cache numeric fixture currently produces NaNs on the existing non-windowed fused d=128 baseline as well, so validation here uses the target end-to-end model workloads. Some E2E CTest targets also fail to link in the local Windows environment because HIP runtime symbols are unresolved; this is unrelated to the change.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [ ] Relevant tests were added or updated and the results are documented.
- [x] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.