### PR TITLE
ci(deps): pin trimmed gfx11-all TheRock dist with CK headers

### DIFF
--- a/.github/workflows/windows-build-real.yml
+++ b/.github/workflows/windows-build-real.yml
@@ -188,36 +188,6 @@ jobs:
             cp $THEROCK_DIR/bin/$pat staging/bin/ 2>/dev/null || true
           done
           cp -r "$THEROCK_DIR/bin/hipblaslt" staging/bin/ 2>/dev/null || true
-          HIPBLASLT_LIBRARY_DIR="staging/bin/hipblaslt/library"
-          HIPBLASLT_ARCHS=(gfx1150 gfx1151 gfx1152 gfx1153)
-          for arch_dir in "$HIPBLASLT_LIBRARY_DIR"/gfx*; do
-            [ -d "$arch_dir" ] || continue
-            arch=$(basename "$arch_dir")
-            if [[ ! " ${HIPBLASLT_ARCHS[*]} " =~ " $arch " ]]; then
-              rm -rf "$arch_dir"
-            fi
-          done
-          for arch in "${HIPBLASLT_ARCHS[@]}"; do
-            arch_dir="$HIPBLASLT_LIBRARY_DIR/$arch"
-            if [ ! -d "$arch_dir" ]; then
-              echo "ERROR: hipBLASLt library directory missing: $arch_dir"
-              exit 1
-            fi
-            find "$arch_dir" -maxdepth 1 -type f -name '*.co' \
-              ! -name "TensileLibrary_HH_HH_HA_Bias_SAV_UA_Type_HH_HPA_Contraction_l_Ailk_Bljk_Cijk_Dijk_${arch}.co" \
-              ! -name "TensileLibrary_HH_HH_HA_Bias_SAV_UA_Type_HH_HPA_Contraction_l_Alik_Bljk_Cijk_Dijk_${arch}.co" \
-              ! -name "TensileLibrary_HH_SH_HA_Bias_SAV_UA_Type_HS_HPA_Contraction_l_Ailk_Bljk_Cijk_Dijk_${arch}.co" \
-              ! -name "TensileLibrary_HH_SH_HA_Bias_SAV_UA_Type_HS_HPA_Contraction_l_Alik_Bljk_Cijk_Dijk_${arch}.co" \
-              ! -name "TensileLibrary_HH_SH_HA_Bias_Type_HS_HPA_Contraction_l_Alik_Bljk_Cijk_Dijk_${arch}.co" \
-              ! -name "TensileLibrary_SS_SS_HA_Bias_SAV_UA_Type_SS_Contraction_l_Ailk_Bljk_Cijk_Dijk_${arch}.co" \
-              -delete
-            co_count=$(find "$arch_dir" -maxdepth 1 -type f -name '*.co' | wc -l)
-            if [ "$co_count" -ne 6 ]; then
-              echo "ERROR: expected 6 hipBLASLt code objects for $arch, found $co_count"
-              find "$arch_dir" -maxdepth 1 -type f -name '*.co' -print
-              exit 1
-            fi
-          done
           for pat in 'amdhip64*.lib' hipblaslt.lib libhipblaslt.dll.a; do
             cp $THEROCK_DIR/lib/$pat staging/lib/ 2>/dev/null || true
           done

--- a/cmake/deps.txt
+++ b/cmake/deps.txt
@@ -17,6 +17,6 @@ flatbuffers;https://github.com/google/flatbuffers.git;v25.12.19
 ## Crash-backtrace helper (always FetchContent; no find_package path).
 cpptrace;https://github.com/jeremy-rifkin/cpptrace.git;v0.8.3
 ##
-therock_windows;https://github.com/ROCm/hip-ep/releases/download/v0.3.0;therock-dist-windows-gfx11-all-7.14.0
+therock_windows;https://github.com/ROCm/hip-ep/releases/download/v0.3.0;therock-dist-windows-gfx11-all-7.14.0-hipblaslt-trimmed
 therock_linux;https://repo.amd.com/rocm/tarball;therock-dist-linux-gfx1151-7.11.0
 migraphx_windows;https://github.com/ROCm/hip-ep/releases/download/v0.3.0;migraphx-sdk-windows-1217ce1d


### PR DESCRIPTION
## Summary

Repin `therock_windows` to `therock-dist-windows-gfx11-all-7.14.0-hipblaslt-trimmed`, a single-build TheRock dist that ships the gfx115x keep-set hipBLASLt Tensile data plus Composable Kernel headers (`include/ck`), and drop the now-redundant hipBLASLt Tensile prune/assert from the Windows gpu-test staging step.

## Related issue or design

None.

## Why

The prior `therock-dist-windows-gfx11-all-7.14.0` carried full 8-arch hipBLASLt Tensile data and no CK headers, so the staging step pruned the Tensile objects to a keep-set at package time. Moving that trim into the dist makes the package self-describing and lets the downstream CK GEMM work consume `include/ck` without a separate dist. The staging-time `expect 6 code objects` assert also no longer holds: the keep-set ships 7 objects for gfx1151.

## What

- `cmake/deps.txt`: repin `therock_windows` to the `-hipblaslt-trimmed` dist.
- `.github/workflows/windows-build-real.yml`: remove the hipBLASLt Tensile prune-and-assert block from "Stage GPU test package" (the dist already ships the keep-set: gfx115x only, gfx1151=7 / others=6 `.co`).

The dist is assembled from one local TheRock 7.14 build (gfx115x keep-set hipBLASLt library + full `include/ck`), stripping the LLVM/CK static archives and unused runtime libraries (rocBLAS/hipBLAS/rocRAND/fftw/OpenCL/openblas). It keeps TheRock's native (non-flattened) layout, which `find_package(hip)` resolves directly.

## Test plan

- [ ] build-windows CI green: hip-ep builds against the downloaded dist and gpu-test staging copies the hipBLASLt library without the prune step.
- [x] Local: `find_package(hip)`=7.14.60850 and `find_package(hipblaslt)`=1.4.1 resolve against the dist.
- [x] Local: `hipcc` compiles a gfx1151 `.hip` against the dist (headers + `amdgcn/bitcode` + toolchain complete).

## Notes for reviewers

Dist uploaded to the v0.3.0 release (`therock-dist-windows-gfx11-all-7.14.0-hipblaslt-trimmed.tar.gz`). `therock_linux` is unchanged. Follow-up: repin the CK GEMM PR from the single-arch `-ck` dist to this one.

## Checklist

- [x] The change is focused, or links a design/series explaining its scope.
- [x] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [x] Substantial AI assistance is disclosed, and I reviewed and understand the result.
