### PR TITLE
feat(qmoe): support the optional router_weights input

### DIFF
--- a/include/hip/Dialect/IR/HipOps.td
+++ b/include/hip/Dialect/IR/HipOps.td
@@ -958,7 +958,11 @@ def Hip_QMoEOp : Hip_DpsOp<"qmoe",
       fc1_experts_bias, fc2_experts_bias: bias vectors (optional)
       fc3_*: unfused SwiGLU second GEMM weights/scales/bias (optional)
       fc1/fc2/fc3_zero_points: per-block zero points (optional)
-      router_weights: alternative aggregation weights (optional, ONNX v1.25+, takes precedence over router_probs)
+      router_weights: aggregation weights (optional, ONNX v1.25+). When present,
+        router_probs drives top-k selection only, and the mixing weights are
+        gathered from router_weights at the selected expert indices instead of
+        being derived from a softmax over router_probs. Same shape as
+        router_probs.
 
     Uses destination-passing style: output buffer is provided as argument.
 
@@ -992,7 +996,7 @@ def Hip_QMoEOp : Hip_DpsOp<"qmoe",
     Optional<Hip_TensorOrMemRef>:$fc1_zero_points,        // fc1 dequant zero points
     Optional<Hip_TensorOrMemRef>:$fc2_zero_points,        // fc2 dequant zero points
     Optional<Hip_TensorOrMemRef>:$fc3_zero_points,        // fc3 dequant zero points
-    Optional<Hip_TensorOrMemRef>:$router_weights,         // [num_tokens, num_experts] alternative routing weights (ONNX v1.25+)
+    Optional<Hip_TensorOrMemRef>:$router_weights,         // [num_tokens, num_experts] aggregation weights gathered at the selected experts (ONNX v1.25+)
     Hip_TensorOrMemRef:$output,                 // DPS init [batch, seq, hidden]
     I64Attr:$expert_weight_bits,
     I64Attr:$k,
@@ -1027,6 +1031,8 @@ def Hip_QMoEOp : Hip_DpsOp<"qmoe",
     `outs` `(` $output `:` type($output) `)`
     attr-dict (`:` type($result_tensors)^)?
   }];
+
+  let hasVerifier = 1;
 }
 
 def Hip_QMoEAmdOp : Hip_DpsOp<"qmoe_amd",

--- a/lib/Dialect/IR/HipDialect.cpp
+++ b/lib/Dialect/IR/HipDialect.cpp
@@ -14,6 +14,7 @@
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/SymbolTable.h"
+#include "mlir/IR/TypeUtilities.h"
 
 #include "hip/Dialect/IR/HipShapeUtils.h"
 
@@ -1547,6 +1548,46 @@ void QMoEOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
   emitDpsMemoryEffects(getDpsInputOperands(), getDpsInitsMutable(), effects);
+}
+
+LogicalResult QMoEOp::verify() {
+  // router_weights is indexed with the same [token, expert] coordinates as
+  // router_probs (selection reads one, aggregation gathers from the other), so
+  // a mismatch would silently read out of bounds at runtime. num_tokens is
+  // dynamic in real graphs, so only statically-known dims are compared.
+  Value routerWeights = getRouterWeights();
+  if (!routerWeights)
+    return success();
+
+  ArrayRef<int64_t> probsShape = getShapeOf(getRouterProbs());
+  ArrayRef<int64_t> weightsShape = getShapeOf(routerWeights);
+  if (probsShape.empty() || weightsShape.empty())
+    return success();
+
+  if (probsShape.size() != weightsShape.size())
+    return emitOpError("router_weights rank (")
+           << weightsShape.size() << ") must match router_probs rank ("
+           << probsShape.size() << ")";
+
+  for (int64_t dim : llvm::seq<int64_t>(0, probsShape.size())) {
+    int64_t probsDim = probsShape[dim];
+    int64_t weightsDim = weightsShape[dim];
+    if (ShapedType::isDynamic(probsDim) || ShapedType::isDynamic(weightsDim))
+      continue;
+    if (probsDim != weightsDim)
+      return emitOpError("router_weights dim ")
+             << dim << " (" << weightsDim << ") must match router_probs dim "
+             << dim << " (" << probsDim << ")";
+  }
+
+  Type weightsElemTy = getElementTypeOrSelf(routerWeights);
+  Type probsElemTy = getElementTypeOrSelf(getRouterProbs());
+  if (weightsElemTy != probsElemTy)
+    return emitOpError("router_weights element type (")
+           << weightsElemTy << ") must match router_probs element type ("
+           << probsElemTy << ")";
+
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Runtime/Kernels/hip/qmoe_kernel.hip
+++ b/lib/Runtime/Kernels/hip/qmoe_kernel.hip
@@ -28,9 +28,15 @@ static constexpr int kRoutingBlock = 256;
 // ---------------------------------------------------------------------------
 // Top-k routing (fp16 only): for each token, find top-k experts by
 // probability. Uses insertion sort — k is small (typically 2-8).
+//
+// router_weights is nullable. When non-null it decouples selection from
+// aggregation: router_probs still drives the top-k choice, but the mixing
+// weight is gathered from router_weights[token, selected_expert] instead of
+// the softmax of router_probs. Both are [num_tokens, num_experts].
 // ---------------------------------------------------------------------------
 __global__ void topk_routing_kernel(
     const __half* __restrict__ router_probs,
+    const __half* __restrict__ router_weights,
     int32_t* __restrict__ expert_indices,
     __half* __restrict__ expert_weights,
     int64_t num_tokens,
@@ -46,6 +52,9 @@ __global__ void topk_routing_kernel(
 
   const __half* logits =
       router_probs + static_cast<int64_t>(token) * num_experts;
+  const __half* weights_row =
+      router_weights ? router_weights + static_cast<int64_t>(token) * num_experts
+                     : nullptr;
   const int tid = static_cast<int>(threadIdx.x);
   const int nthreads = static_cast<int>(blockDim.x);
   const int ik = static_cast<int>(k < kMaxK ? k : kMaxK);
@@ -118,7 +127,11 @@ __global__ void topk_routing_kernel(
     if (tid == 0) {
       const int win = s_idx[0];
       expert_indices[token * k + i] = win;
-      expert_weights[token * k + i] = static_cast<__half>(s_red[0] / exp_sum);
+      // router_probs selected the expert; router_weights, when supplied,
+      // provides the mixing weight at that index instead of the softmax prob.
+      expert_weights[token * k + i] =
+          weights_row ? weights_row[win]
+                      : static_cast<__half>(s_red[0] / exp_sum);
       s_exp[win] = -1e30f;
     }
     __syncthreads();
@@ -314,6 +327,7 @@ __global__ void bucket_tokens_kernel(
 extern "C" int hip_qmoe_topk_routing(
     void* stream,
     const void* router_probs,
+    const void* router_weights,
     void* expert_indices,
     void* expert_weights,
     int64_t num_tokens,
@@ -343,6 +357,7 @@ extern "C" int hip_qmoe_topk_routing(
                      dim3(static_cast<unsigned>(num_tokens)),
                      dim3(kRoutingBlock), shmem, s,
                      static_cast<const __half*>(router_probs),
+                     static_cast<const __half*>(router_weights),
                      static_cast<int32_t*>(expert_indices),
                      static_cast<__half*>(expert_weights), num_tokens,
                      num_experts, k, normalize);

--- a/lib/Runtime/Kernels/include/hip_custom_kernels.h
+++ b/lib/Runtime/Kernels/include/hip_custom_kernels.h
@@ -2318,6 +2318,11 @@ HIP_KERNEL_API int hip_dequantize_linear(
 
 /* Top-k routing: find top-k experts per token from router_probs.
  *   router_probs   - GPU [num_tokens, num_experts]
+ *   router_weights - GPU [num_tokens, num_experts] or nullptr. When supplied,
+ *                    router_probs is used only to select the experts and the
+ *                    mixing weights are gathered from router_weights at the
+ *                    selected indices; otherwise the softmax of router_probs
+ *                    supplies them.
  *   expert_indices - GPU [num_tokens, k] int32 (output)
  *   expert_weights - GPU [num_tokens, k] (output, same type as probs)
  *   normalize      - 1 to normalize selected weights (sum-to-one)
@@ -2325,6 +2330,7 @@ HIP_KERNEL_API int hip_dequantize_linear(
 HIP_KERNEL_API int hip_qmoe_topk_routing(
     void* stream,
     const void* router_probs,
+    const void* router_weights,
     void* expert_indices,
     void* expert_weights,
     int64_t num_tokens,

--- a/lib/Runtime/real/qmoe.cpp
+++ b/lib/Runtime/real/qmoe.cpp
@@ -46,10 +46,6 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
         return std::string(b);
       },
       state);
-  if (router_weights) {
-    fprintf(stderr, "wrap_qmoe: router_weights is not supported yet\n");
-    return -1;
-  }
   if (!state || !input || !router_probs || !output) {
     fprintf(stderr, "wrap_qmoe: null argument\n");
     return -1;
@@ -188,12 +184,13 @@ int wrap_qmoe(RuntimeState *state, const void *input, const void *router_probs,
   void *d_a_scale_mid = scratch_base + off_a_scale_mid;
 
   RUNTIME_DEBUG_LOG("[REAL] wrap_qmoe: topk_routing(tokens=%lld, experts=%lld, "
-                    "k=%lld, normalize=%lld)\n",
+                    "k=%lld, normalize=%lld, router_weights=%s)\n",
                     (long long)num_tokens, (long long)num_experts, (long long)k,
-                    (long long)normalize_routing_weights);
-  HIP_CHECK(hip_qmoe_topk_routing(stream, router_probs, d_expert_indices,
-                                  d_expert_weights, num_tokens, num_experts, k,
-                                  normalize_routing_weights, elem_size));
+                    (long long)normalize_routing_weights,
+                    router_weights ? "yes" : "no");
+  HIP_CHECK(hip_qmoe_topk_routing(
+      stream, router_probs, router_weights, d_expert_indices, d_expert_weights,
+      num_tokens, num_experts, k, normalize_routing_weights, elem_size));
 
   // Fused decode fast path: single-token MoE collapses to three back-to-back
   // kernel launches (FC1+SwiGLU, FC2, weighted reduce) with zero D2H,

--- a/test/lit/Conversion/hip-to-llvm/test_qmoe.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_qmoe.mlir
@@ -51,10 +51,11 @@ module {
   // CHECK-LABEL: llvm.func @test_qmoe_with_bias
   // CHECK: llvm.call @wrap_qmoe({{.*}}) :
   // CHECK-SAME: (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
-  // CHECK-SAME:  !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
+  // CHECK-SAME:  !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
   // CHECK-SAME:  i64, i64, i64, i64, i64, i64, i64, i64, i64, f32, f32, f32, i64, i64) -> i32
-  // Verify 30 parameters:
-  // - 16 pointers: state, input, router, fc1_w, fc1_s, fc1_b, fc2_w, fc2_s, fc2_b,
+  // Verify 31 parameters:
+  // - 17 pointers: state, input, router_probs, router_weights(null), fc1_w, fc1_s, fc1_b,
+  //                fc2_w, fc2_s, fc2_b,
   //                fc3_w(null), fc3_s(null), fc3_b(null), fc1_zp(null), fc2_zp(null), fc3_zp(null), output
   // - 11 i64 + 3 f32: num_tokens, hidden_size, inter_size, num_experts, k,
   //                    expert_weight_bits, block_size, swiglu_fusion, activation_type,
@@ -90,7 +91,7 @@ module {
   // CHECK-LABEL: llvm.func @test_qmoe_no_bias
   // CHECK: llvm.call @wrap_qmoe({{.*}}) :
   // CHECK-SAME: (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
-  // CHECK-SAME:  !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
+  // CHECK-SAME:  !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
   // CHECK-SAME:  i64, i64, i64, i64, i64, i64, i64, i64, i64, f32, f32, f32, i64, i64) -> i32
-  // Optional pointers (fc1_b, fc2_b, fc3_*, zero_points) should be null
+  // Optional pointers (router_weights, fc1_b, fc2_b, fc3_*, zero_points) should be null
 }

--- a/test/lit/Conversion/hip-to-llvm/test_qmoe_router_weights.mlir
+++ b/test/lit/Conversion/hip-to-llvm/test_qmoe_router_weights.mlir
@@ -1,0 +1,56 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify hip.qmoe's optional router_weights operand reaches wrap_qmoe as a
+// real pointer in argument slot 4 (0-based: state, input, router_probs,
+// router_weights), rather than the null pointer emitted when it is absent.
+//
+// Companion: test_qmoe.mlir covers the absent case, where slot 4 is null.
+// ============================================================================
+
+// RUN: hip-mlir-opt --convert-hip-to-llvm %s | FileCheck %s
+
+module {
+  func.func @test_qmoe_router_weights(%ctx: !hip.context,
+      %input: memref<1x128x2880xf16, 1>,
+      %router: memref<128x32xf16, 1>,
+      %fc1_w: memref<32x5760x1440xui8, 1>,
+      %fc1_s: memref<32x5760x90xf16, 1>,
+      %fc2_w: memref<32x2880x1440xui8, 1>,
+      %fc2_s: memref<32x2880x90xf16, 1>,
+      %router_w: memref<128x32xf16, 1>,
+      %output: memref<1x128x2880xf16, 1>) {
+    hip.qmoe(%ctx) ins(
+        %input, %router,
+        %fc1_w, %fc1_s,
+        %fc2_w, %fc2_s :
+        memref<1x128x2880xf16, 1>, memref<128x32xf16, 1>,
+        memref<32x5760x1440xui8, 1>, memref<32x5760x90xf16, 1>,
+        memref<32x2880x1440xui8, 1>, memref<32x2880x90xf16, 1>)
+        router_weights(%router_w : memref<128x32xf16, 1>)
+        outs(%output : memref<1x128x2880xf16, 1>)
+        {expert_weight_bits = 4 : i64, k = 4 : i64, block_size = 32 : i64,
+         normalize_routing_weights = 1 : i64, swiglu_fusion = 1 : i64,
+         use_sparse_mixer = 0 : i64,
+         activation_alpha = 1.702000e+00 : f32, activation_beta = 1.000000e+00 : f32,
+         swiglu_limit = 7.000000e+00 : f32, activation_type = "swiglu"}
+    return
+  }
+
+  // CHECK-LABEL: llvm.func @test_qmoe_router_weights
+
+  // Only router_probs and router_weights are 2-D here, and the lowering
+  // extracts router_probs first, so the second 2-D extract is router_weights.
+  // CHECK: llvm.extractvalue %{{.*}}[1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+  // CHECK: %[[RW_PTR:.*]] = llvm.extractvalue %{{.*}}[1] : !llvm.struct<(ptr<1>, ptr<1>, i64, array<2 x i64>, array<2 x i64>)>
+  // CHECK: %[[RW:.*]] = llvm.addrspacecast %[[RW_PTR]] : !llvm.ptr<1> to !llvm.ptr
+
+  // Slot 4 (state, input, router_probs, router_weights) carries that pointer
+  // instead of the llvm.mlir.zero used when router_weights is absent.
+  // CHECK: llvm.call @wrap_qmoe(%{{[^,]+}}, %{{[^,]+}}, %{{[^,]+}}, %[[RW]],
+  // CHECK-SAME: (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
+  // CHECK-SAME:  !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
+  // CHECK-SAME:  i64, i64, i64, i64, i64, i64, i64, i64, i64, f32, f32, f32, i64, i64) -> i32
+}

--- a/test/lit/Conversion/onnx-to-hip/test_qmoe_router_weights.mlir
+++ b/test/lit/Conversion/onnx-to-hip/test_qmoe_router_weights.mlir
@@ -1,0 +1,75 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// ============================================================================
+// TEST PURPOSE:
+// Verify the optional com.microsoft.QMoE router_weights input (operand index
+// 14) is lowered to hip.qmoe's router_weights operand group.
+//
+// router_weights decouples selection from aggregation: router_probs still
+// drives Top-K selection, while the mixing weights are gathered from
+// router_weights at the selected expert indices. Both tensors therefore have
+// the same [num_tokens, num_experts] shape, so this test also pins that the
+// conversion reads index 14 rather than aliasing router_probs.
+//
+// The fc3_* slots (8, 9, 10) and the zero_point slots (11, 12, 13) are
+// bypassed with onnx.NoValue placeholders so router_weights lands at 14.
+// ============================================================================
+
+// RUN: hip-mlir-opt --hip-add-context-arg --convert-onnx-to-hip %s | FileCheck %s
+
+module {
+  func.func @main_graph(
+      %input: tensor<1x128x2880xf16>,
+      %router_probs: tensor<128x32xf16>,
+      %router_weights: tensor<128x32xf16>) -> tensor<1x128x2880xf16> {
+    %fc1_w = "onnx.Constant"() {value = dense<1> : tensor<32x5760x1440xui8>} : () -> tensor<32x5760x1440xui8>
+    %fc1_s = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<32x5760x90xf16>} : () -> tensor<32x5760x90xf16>
+    %fc2_w = "onnx.Constant"() {value = dense<1> : tensor<32x2880x1440xui8>} : () -> tensor<32x2880x1440xui8>
+    %fc2_s = "onnx.Constant"() {value = dense<1.000000e+00> : tensor<32x2880x90xf16>} : () -> tensor<32x2880x90xf16>
+    // None placeholders for fc1_bias, fc2_bias, fc3_w, fc3_s, fc3_bias and the
+    // three zero_point slots.
+    %none_fc1b = "onnx.NoValue"() {value} : () -> none
+    %none_fc2b = "onnx.NoValue"() {value} : () -> none
+    %none_fc3w = "onnx.NoValue"() {value} : () -> none
+    %none_fc3s = "onnx.NoValue"() {value} : () -> none
+    %none_fc3b = "onnx.NoValue"() {value} : () -> none
+    %none_fc1zp = "onnx.NoValue"() {value} : () -> none
+    %none_fc2zp = "onnx.NoValue"() {value} : () -> none
+    %none_fc3zp = "onnx.NoValue"() {value} : () -> none
+    %Y = "onnx.Custom"(%input, %router_probs,
+                        %fc1_w, %fc1_s, %none_fc1b,
+                        %fc2_w, %fc2_s, %none_fc2b,
+                        %none_fc3w, %none_fc3s, %none_fc3b,
+                        %none_fc1zp, %none_fc2zp, %none_fc3zp,
+                        %router_weights) {
+      function_name = "QMoE",
+      domain_name = "com.microsoft",
+      activation_alpha = 1.702000e+00 : f32, activation_beta = 1.000000e+00 : f32,
+      activation_type = "swiglu",
+      block_size = 32 : si64, expert_weight_bits = 4 : si64, k = 4 : si64,
+      normalize_routing_weights = 1 : si64, swiglu_fusion = 1 : si64,
+      swiglu_limit = 7.000000e+00 : f32, use_sparse_mixer = 0 : si64,
+      onnx_node_name = "QMoE_router_weights"
+    } : (tensor<1x128x2880xf16>, tensor<128x32xf16>,
+         tensor<32x5760x1440xui8>, tensor<32x5760x90xf16>, none,
+         tensor<32x2880x1440xui8>, tensor<32x2880x90xf16>, none,
+         none, none, none,
+         none, none, none,
+         tensor<128x32xf16>) -> tensor<1x128x2880xf16>
+    return %Y : tensor<1x128x2880xf16>
+  }
+
+  // CHECK-LABEL: func.func @main_graph
+  // CHECK-SAME: (%[[CTX:.*]]: !hip.context, %[[INPUT:.*]]: tensor<1x128x2880xf16>, %[[PROBS:.*]]: tensor<128x32xf16>, %[[WEIGHTS:.*]]: tensor<128x32xf16>)
+  // CHECK: %[[INIT:.*]] = tensor.empty() : tensor<1x128x2880xf16>
+  // CHECK: hip.qmoe(%[[CTX]]) ins(%[[INPUT]], %[[PROBS]]
+  // CHECK-SAME: tensor<1x128x2880xf16>, tensor<128x32xf16>,
+  // CHECK-SAME: tensor<32x5760x1440xui8>, tensor<32x5760x90xf16>,
+  // CHECK-SAME: tensor<32x2880x1440xui8>, tensor<32x2880x90xf16>)
+  // router_weights must reach its own operand group, distinct from the
+  // router_probs value threaded into ins(...).
+  // CHECK-SAME: router_weights(%[[WEIGHTS]] : tensor<128x32xf16>)
+  // CHECK-SAME: outs(%[[INIT]] : tensor<1x128x2880xf16>)
+  // CHECK-NOT: onnx.Custom
+}

--- a/test/numeric/tests/test_qmoe.py
+++ b/test/numeric/tests/test_qmoe.py
@@ -22,7 +22,11 @@ Weight statistics (from real model, layer 0):
 
 Input context:
   hidden input:   post-layernorm, approximately normalised (range [-1, 1])
-  router weights: raw logits from router projection (range [-5, 5], std ~ 1.2)
+  router probs:   raw logits from router projection (range [-5, 5], std ~ 1.2)
+
+The optional router_weights input (index 14) decouples selection from
+aggregation: router_probs still picks the top-k experts, but the mixing
+weights are gathered from router_weights at those indices.
 """
 
 import numpy as np
@@ -54,6 +58,8 @@ def _make_qmoe_model(
     down_scale_range: tuple[float, float] = (0.001, 0.02),
     down_bias_range: tuple[float, float] = (-0.5, 0.5),
     seed: int = 42,
+    with_router_weights: bool = False,
+    normalize_routing_weights: int = 1,
 ):
     """Build a QMoE ONNX model with random quantized expert weights.
 
@@ -76,6 +82,11 @@ def _make_qmoe_model(
         [batch, seq_len, hidden],
     )
     router = helper.make_tensor_value_info(
+        "router_probs",
+        TensorProto.FLOAT16,
+        [seq_len, num_experts],
+    )
+    router_weights = helper.make_tensor_value_info(
         "router_weights",
         TensorProto.FLOAT16,
         [seq_len, num_experts],
@@ -131,21 +142,32 @@ def _make_qmoe_model(
         numpy_helper.from_array(down_bias, name="down_bias"),
     ]
 
+    node_inputs = [
+        "input",
+        "router_probs",
+        "gate_up_qweight",
+        "gate_up_scales",
+        "gate_up_bias",
+        "down_qweight",
+        "down_scales",
+        "down_bias",
+        "",  # 8: fc3_experts_weights
+        "",  # 9: fc3_scales
+        "",  # 10: fc3_experts_bias
+    ]
+    graph_inputs = [x, router]
+    if with_router_weights:
+        node_inputs += [
+            "",  # 11: fc1_zero_points
+            "",  # 12: fc2_zero_points
+            "",  # 13: fc3_zero_points
+            "router_weights",  # 14
+        ]
+        graph_inputs.append(router_weights)
+
     node = helper.make_node(
         "QMoE",
-        [
-            "input",
-            "router_weights",
-            "gate_up_qweight",
-            "gate_up_scales",
-            "gate_up_bias",
-            "down_qweight",
-            "down_scales",
-            "down_bias",
-            "",
-            "",
-            "",
-        ],
+        node_inputs,
         ["output"],
         domain="com.microsoft",
         activation_type="swiglu",
@@ -153,7 +175,7 @@ def _make_qmoe_model(
         activation_beta=1.0,
         expert_weight_bits=4,
         k=top_k,
-        normalize_routing_weights=1,
+        normalize_routing_weights=normalize_routing_weights,
         swiglu_fusion=1,
         use_sparse_mixer=0,
         block_size=block_size,
@@ -163,7 +185,7 @@ def _make_qmoe_model(
     ms_opset = helper.make_opsetid("com.microsoft", 1)
     return make_model_from_nodes(
         [node],
-        [x, router],
+        graph_inputs,
         [output],
         initializers=initializers,
         opset=21,
@@ -236,3 +258,41 @@ class TestQMoE:
 
         actual, expected = model_runner.run_sample(model, [x, router])
         compare_outputs(actual, expected, atol=1e-1, rtol=1e-2, cos_threshold=0.99)
+
+    @pytest.mark.parametrize("normalize", [0, 1])
+    @pytest.mark.parametrize("seq_len", [1, 8])
+    def test_qmoe_router_weights(self, model_runner, seq_len, normalize):
+        """QMoE with the optional router_weights input (index 14).
+
+        router_probs and router_weights are drawn independently, so a build
+        that ignored the gather and kept using softmax(router_probs) would
+        produce different mixing weights and fail the comparison.
+
+        router_weights stays strictly positive: ORT's CPU kernel drops routes
+        whose gathered weight falls to <= 1e-8, which this runtime does not
+        replicate, and that divergence is out of scope here.
+        """
+        hidden, intermediate, num_experts, top_k = 64, 128, 4, 2
+        model = _make_qmoe_model(
+            1,
+            seq_len,
+            hidden,
+            intermediate,
+            num_experts,
+            top_k,
+            with_router_weights=True,
+            normalize_routing_weights=normalize,
+        )
+
+        rng = np.random.default_rng(99)
+        x = rng.uniform(-1, 1, [1, seq_len, hidden]).astype(np.float16)
+        router_probs = rng.standard_normal([seq_len, num_experts]).astype(np.float16)
+        router_weights = rng.uniform(0.05, 1.0, [seq_len, num_experts]).astype(
+            np.float16,
+        )
+
+        actual, expected = model_runner.run_sample(
+            model,
+            [x, router_probs, router_weights],
+        )
+        compare_outputs(actual, expected, atol=5e-2, rtol=1e-2, cos_threshold=0.999)


### PR DESCRIPTION
## Summary

Implements the optional `router_weights` input (index 14) of `com.microsoft.QMoE`. The real runtime previously rejected it outright, so any model using it failed at the first MoE layer:

```
wrap_qmoe: router_weights is not supported yet
```

Microsoft's schema (`contrib_defs.cc`, input 14) specifies a split between selection and aggregation:

> When provided, router_probs is used only for Top-K expert selection, and router_weights is used for aggregating expert outputs (the values at the selected expert indices are gathered and used as mixing weights).

The CPU reference in `moe_quantization_cpu.cc` confirms it: Top-K always comes from `router_probs`; when `router_weights` is present the softmax is skipped and weights are gathered from the full `[num_tokens, num_experts]` matrix, then renormalized only if `normalize_routing_weights == 1`.

## Why the change is small

The compiler stack was already fully plumbed — conversion reads index 14, the op carries an optional `$router_weights` operand, and `QMoELowering.cpp` passes it as `wrap_qmoe`'s 4th pointer (null when absent). Only the runtime and the routing kernel needed work.

Critically, hip-ep's selection already matches ORT's. `topk_routing_kernel` argmaxes over `exp(logit - max)`, and `exp` is monotonic, so it picks the same experts as ORT's `partial_sort` over raw logits. **Selection needs no change at all** — only the value written into `expert_weights`:

```cpp
expert_indices[token * k + i] = win;
// router_probs selected the expert; router_weights, when supplied,
// provides the mixing weight at that index instead of the softmax prob.
expert_weights[token * k + i] =
    weights_row ? weights_row[win]
                : static_cast<__half>(s_red[0] / exp_sum);
```

The pre-existing `normalize` block then reproduces ORT's `normalize_routing_weights` semantics for both paths unchanged. Everything downstream — `hip_qmoe_bucket_tokens`, `hip_qmoe_scatter_add`, the fused decode path, and the dp4a decode path — consumes `expert_weights` and needed no edits.

## Changes

| Area | Change |
|---|---|
| `lib/Runtime/Kernels/hip/qmoe_kernel.hip` | Nullable `router_weights` on `topk_routing_kernel` and the `hip_qmoe_topk_routing` launcher; gather at the selected expert index |
| `lib/Runtime/Kernels/include/hip_custom_kernels.h` | Declaration updated, parameter documented as nullable |
| `lib/Runtime/real/qmoe.cpp` | Rejection removed, pointer forwarded, debug log extended |
| `include/hip/Dialect/IR/HipOps.td` | Corrected doc; `hasVerifier = 1` |
| `lib/Dialect/IR/HipDialect.cpp` | `QMoEOp::verify()` |
| `test/numeric/tests/test_qmoe.py` | New conformance test; index-1 input renamed |
| `test/lit/Conversion/**` | Two new tests; existing arity check tightened |

### Corrected dialect documentation

The dialect doc claimed `router_weights` "takes precedence over router_probs", which would lead an implementer to replace selection too. It now states the selection/aggregation split.

### New verifier

`QMoEOp::verify()` checks `router_weights` against `router_probs` on rank, statically-known dims, and element type, mirroring ORT's explicit shape check. `num_tokens` is dynamic in real graphs, so dynamic dims are skipped.

### Tightened LIT arity check

`test/lit/Conversion/hip-to-llvm/test_qmoe.mlir` enumerated 16 `!llvm.ptr` when the lowering emits 17. It passed regardless, because `CHECK-SAME` permits skipped text on the line — meaning it would also have passed with a pointer *dropped*. The real arity is now pinned.

## Validation

**Numeric conformance (ORT CPU 1.27.0 oracle).** Four new cases, `seq_len` 1 and 8 crossed with `normalize_routing_weights` 0 and 1, feed `router_probs` and `router_weights` from independent draws. A build that ignored the gather and kept using `softmax(router_probs)` would produce different mixing weights and fail. All pass.

```
test_qmoe_router_weights[1-0] PASSED
test_qmoe_router_weights[1-1] PASSED
test_qmoe_router_weights[8-0] PASSED
test_qmoe_router_weights[8-1] PASSED
```

**LIT.** Full suite green. The new hip-to-llvm checks were generated from real `hip-mlir-opt` output rather than written by hand. The verifier was confirmed to fire on a mismatched shape:

```
error: 'hip.qmoe' op router_weights dim 1 (64) must match router_probs dim 1 (32)
```

**End-to-end.** `model_benchmark` on `qwen3-30b-a3b-rtn_int4_128gs_fp16_pruned_amdgpu` (48 QMoE nodes, `k=8`, 128 experts, `normalize_routing_weights=1`) now completes and produces coherent text. This model's `router_weights` is `Softmax(router_probs)`, so the result should equal standard Qwen3 `norm_topk_prob` routing, and the output reads that way.

| Metric | Value |
|---|---|
| Prompt processing | 337.2 tok/s |
| Token generation | 59.0 tok/s |
| Peak working set | 30.2 GB |

Hardware: gfx1151 (Radeon 8050S, Strix Halo), Windows, Release build, Ninja + MSVC 2022.

### Pre-existing failure, not caused by this change

`test_qmoe_gpt_oss_shape[1]` fails. Rather than assume it was unrelated, I stashed the changes, rebuilt, and reran: it reproduces **bit-for-bit** on unmodified `main` (`max=6.152344e-01, mean=1.354230e-01, cosine=0.999961`). It is fp16 accumulation noise tripping `atol=0.1` while cosine sits far above its threshold. This change is a numerical no-op when `router_weights` is absent — the stored value is the identical expression.

## Deliberately out of scope

- **Near-zero weights.** ORT CPU drops routes with `route_scale <= 1e-8` from the expert map; hip-ep's `scatter_add` adds them. Identical for the strictly positive weights real routers produce; matters only for zero or negative `router_weights`. The numeric tests stay in the positive regime.
- **`normalize_routing_weights` in the default path.** ORT CPU ignores the attribute and always normalizes over top-k; ORT CUDA and hip-ep both honor it. hip-ep matches the CUDA reference, so this is left alone — changing it would alter existing working models.
- **`k > 16`** is silently truncated by `kMaxK` in the routing kernel with no guard in `wrap_qmoe`. Pre-existing; the target model uses `k=8`.

## AI assistance

Developed with Cursor (Claude Opus 5). The model semantics were derived from the ONNX Runtime schema and CPU reference implementation, and the result was validated against ORT CPU as a numeric oracle, through the LIT suite, and end-to-end on a real model, as described above. I have reviewed all generated content and own every claim in this description.
