### PR TITLE
Separate HIP-IR as a separate export surface from HIP-EP 

### DIFF
--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -155,6 +155,22 @@ set(BUILD_SHARED_LIBS ${_saved_bsl_cpptrace})
 # tree, and a plain find_package(MLIR) on the next configure would then fail in
 # the build-tree LLVMConfig includes -- so once embedded we skip find_package
 # entirely and clear those stale cache entries.
+# Opt-in: build the from-source LLVM as a full distribution and publish it to a
+# prefix downstream repos can find_package() against. Only adds targets -- the
+# cost is paid when `publish-llvm-toolchain` is built, not on a normal build.
+option(HIPDNN_PUBLISH_LLVM_TOOLCHAIN
+       "Publish the from-source LLVM/MLIR as a prefix for downstream repos" OFF)
+set(HIPDNN_TOOLCHAIN_PREFIX "${CMAKE_BINARY_DIR}/toolchain" CACHE PATH
+    "Where publish-llvm-toolchain installs LLVM/MLIR")
+# Everything hip-ir and CGC-IR-Converter need: MLIR + LLVM libs and headers,
+# the CMake package exports, and the LIT tooling (FileCheck/not/count/llvm-lit)
+# that CGC-IR-Converter currently keeps an llvm-project submodule for.
+set(HIPDNN_LLVM_DISTRIBUTION_COMPONENTS
+    cmake-exports llvm-headers llvm-libraries
+    mlir-cmake-exports mlir-headers mlir-libraries
+    llvm-tblgen mlir-tblgen FileCheck not count llvm-lit
+    CACHE STRING "Components published by publish-llvm-toolchain")
+
 if(HIPDNN_LLVM_EMBEDDED)
   unset(MLIR_DIR CACHE)
   unset(LLVM_DIR CACHE)
@@ -166,6 +182,11 @@ endif()
 
 if(MLIR_FOUND AND NOT HIPDNN_LLVM_EMBEDDED)
   find_package(LLVM REQUIRED CONFIG)
+  if(HIPDNN_PUBLISH_LLVM_TOOLCHAIN)
+    message(STATUS
+      "HIPDNN_PUBLISH_LLVM_TOOLCHAIN is ignored: LLVM/MLIR came from a prefix "
+      "(${LLVM_DIR}), so there is nothing to publish.")
+  endif()
 else()
   message(STATUS "LLVM/MLIR not found; building from source (${DEP_HASH_llvm})")
   # clang is built in-tree so a from-source bootstrap is fully self-contained:
@@ -188,6 +209,13 @@ else()
   set(LLVM_INCLUDE_EXAMPLES OFF CACHE BOOL "" FORCE)
   set(LLVM_INCLUDE_BENCHMARKS OFF CACHE BOOL "" FORCE)
   set(LLVM_INSTALL_UTILS ON CACHE BOOL "" FORCE)  # FileCheck/not/count for LIT
+  if(HIPDNN_PUBLISH_LLVM_TOOLCHAIN)
+    # Naming the components is what makes them buildable as a set. Without this
+    # only the pieces hip-ep links get built, and `cmake --install` then either
+    # fails on a missing artefact or installs nothing at all.
+    set(LLVM_DISTRIBUTION_COMPONENTS "${HIPDNN_LLVM_DISTRIBUTION_COMPONENTS}"
+        CACHE STRING "" FORCE)
+  endif()
   FetchContent_Declare(llvm-project
     GIT_REPOSITORY ${DEP_URL_llvm}
     GIT_TAG ${DEP_HASH_llvm}
@@ -238,6 +266,36 @@ else()
   # functions (mlir_tablegen, llvm_map_components_to_libnames, add_mlir_dialect,
   # ...) globally, so downstream just needs the consumer variables set by hand.
   set(HIPDNN_LLVM_EMBEDDED ON CACHE BOOL "LLVM provided via FetchContent subdirectory" FORCE)
+
+  # Publish the in-tree LLVM/MLIR as a consumable prefix for downstream repos
+  # (hip-ir, CGC-IR-Converter), so they take the find_package path above rather
+  # than each rebuilding LLVM against a different commit.
+  #
+  # EXCLUDE_FROM_ALL keeps this off the default build: the distribution targets
+  # are only built when the publish target is asked for.
+  if(HIPDNN_PUBLISH_LLVM_TOOLCHAIN)
+    set(_hipdnn_publish_cmds "")
+    foreach(_c IN LISTS HIPDNN_LLVM_DISTRIBUTION_COMPONENTS)
+      list(APPEND _hipdnn_publish_cmds
+        COMMAND "${CMAKE_COMMAND}" --install "${llvm-project_BINARY_DIR}"
+                --component "${_c}" --prefix "${HIPDNN_TOOLCHAIN_PREFIX}")
+    endforeach()
+    add_custom_target(publish-llvm-toolchain ${_hipdnn_publish_cmds}
+      COMMENT "Publishing LLVM/MLIR toolchain to ${HIPDNN_TOOLCHAIN_PREFIX}"
+      VERBATIM)
+    # LLVM defines `distribution` from LLVM_DISTRIBUTION_COMPONENTS; it builds
+    # the components, which EXCLUDE_FROM_ALL otherwise leaves unbuilt (and an
+    # unbuilt component installs nothing, silently).
+    if(TARGET distribution)
+      add_dependencies(publish-llvm-toolchain distribution)
+    else()
+      message(WARNING
+        "HIPDNN_PUBLISH_LLVM_TOOLCHAIN=ON but LLVM did not define a `distribution` "
+        "target; build the components yourself before publish-llvm-toolchain, or "
+        "the published prefix will be missing libraries.")
+    endif()
+    unset(_hipdnn_publish_cmds)
+  endif()
   set(LLVM_INCLUDE_DIRS
     "${llvm-project_SOURCE_DIR}/llvm/include"
     "${llvm-project_BINARY_DIR}/include" CACHE PATH "" FORCE)

--- a/cmake/hip-ir-config.cmake.in
+++ b/cmake/hip-ir-config.cmake.in
@@ -1,0 +1,63 @@
+##
+# ** Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# ** Licensed under the MIT License.
+##
+#
+# CMake package config for `hip-ir`: the HIP dialect, consumed standalone.
+#
+#   find_package(hip-ir 1.0 CONFIG REQUIRED)
+#   target_link_libraries(mylib PUBLIC hip::HipDialectIR)
+#
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+set(HIP_IR_VERSION        "@HIP_IR_VERSION@")
+set(HIP_IR_LLVM_VERSION   "@LLVM_PACKAGE_VERSION@")
+set(HIP_IR_BUILD_LLVM_DIR "@LLVM_DIR@")
+set(HIP_IR_BUILD_MLIR_DIR "@MLIR_DIR@")
+
+# --- MLIR / LLVM ----------------------------------------------------------
+# HipDialect.h includes mlir/* and HipDialectIR links MLIR PUBLIC, so MLIR must
+# resolve before the targets file is read. Honour the consumer's choice of
+# toolchain; fall back to the one hip-ir was built against.
+if(NOT LLVM_DIR AND HIP_IR_BUILD_LLVM_DIR)
+  set(LLVM_DIR "${HIP_IR_BUILD_LLVM_DIR}")
+endif()
+if(NOT MLIR_DIR AND HIP_IR_BUILD_MLIR_DIR)
+  set(MLIR_DIR "${HIP_IR_BUILD_MLIR_DIR}")
+endif()
+
+find_dependency(LLVM CONFIG)
+find_dependency(MLIR CONFIG)
+
+# Static MLIR libs plus TableGen'd dialect registries are neither ABI- nor
+# ODR-safe across LLVM versions. A mismatch surfaces as undefined
+# mlir::detail::TypeIDResolver symbols at link time, or as a dialect
+# registering twice at runtime. Fail here, where the message is actionable.
+if(NOT LLVM_PACKAGE_VERSION VERSION_EQUAL HIP_IR_LLVM_VERSION)
+  message(FATAL_ERROR
+    "hip-ir ${HIP_IR_VERSION} was built against LLVM/MLIR ${HIP_IR_LLVM_VERSION}, "
+    "but this project resolved LLVM ${LLVM_PACKAGE_VERSION}.\n"
+    "  LLVM_DIR = ${LLVM_DIR}\n"
+    "  MLIR_DIR = ${MLIR_DIR}\n"
+    "Point at the matching toolchain, or build hip-ir from a hip-ep checkout.")
+endif()
+
+# --- Targets --------------------------------------------------------------
+if(NOT TARGET hip::HipDialectIR)
+  include("${CMAKE_CURRENT_LIST_DIR}/hip-ir-targets.cmake")
+endif()
+
+# --- Paths ----------------------------------------------------------------
+set_and_check(HIP_IR_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+
+# The .td sources ship alongside the headers so downstreams can run their own
+# mlir_tablegen against the HIP ops. HipOps.td includes its siblings by the
+# "hip/Dialect/IR/..." path, so this must be on the TableGen include path:
+#   list(APPEND LLVM_TABLEGEN_FLAGS "-I${HIP_IR_TABLEGEN_INCLUDE_DIR}")
+set(HIP_IR_TABLEGEN_INCLUDE_DIR "${HIP_IR_INCLUDE_DIR}")
+
+set(HIP_IR_LIBRARIES hip::HipDialectIR)
+
+check_required_components(hip-ir)

--- a/cmake/hip-ir-install.cmake
+++ b/cmake/hip-ir-install.cmake
@@ -1,0 +1,57 @@
+##
+# ** Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# ** Licensed under the MIT License.
+##
+
+# Install/export rules for the `hip-ir` package. Included from
+# lib/Dialect/IR/CMakeLists.txt when HIP_IR_INSTALL is ON (default: only when
+# hip-ir is the top-level project, so a full hip-ep build is unaffected).
+#
+# Requires, from the dialect subdirectories:
+#   HIP_IR_SOURCE_INCLUDE_ROOT    <hip-ep>/include
+#   HIP_IR_GENERATED_INCLUDE_ROOT TableGen output root (embedder-dependent)
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+if(NOT HIP_IR_VERSION)
+  set(HIP_IR_VERSION "1.0.0")
+endif()
+
+install(TARGETS HipDialectIR
+        EXPORT  hip-ir-targets
+        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+
+# Public headers plus the .td sources: downstreams run mlir_tablegen against
+# HipOps.td, which includes its siblings by "hip/Dialect/IR/..." path.
+install(DIRECTORY "${HIP_IR_SOURCE_INCLUDE_ROOT}/hip/Dialect/IR/"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/hip/Dialect/IR"
+        FILES_MATCHING PATTERN "*.h" PATTERN "*.td")
+
+# HipDialect.h includes the generated .inc files, so they are part of the
+# public surface and must ship too.
+install(DIRECTORY "${HIP_IR_GENERATED_INCLUDE_ROOT}/hip/Dialect/IR/"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/hip/Dialect/IR"
+        FILES_MATCHING PATTERN "*.inc")
+
+install(EXPORT hip-ir-targets
+        FILE        hip-ir-targets.cmake
+        NAMESPACE   hip::
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/hip-ir")
+
+configure_package_config_file(
+  "${CMAKE_CURRENT_LIST_DIR}/hip-ir-config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/hip-ir-config.cmake"
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/hip-ir"
+  PATH_VARS CMAKE_INSTALL_INCLUDEDIR)
+
+# Additive ops are a minor bump, op-semantics changes are a major bump.
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/hip-ir-config-version.cmake"
+  VERSION       "${HIP_IR_VERSION}"
+  COMPATIBILITY SameMajorVersion)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/hip-ir-config.cmake"
+              "${CMAKE_CURRENT_BINARY_DIR}/hip-ir-config-version.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/hip-ir")

--- a/cmake/hip-ir/CMakeLists.txt
+++ b/cmake/hip-ir/CMakeLists.txt
@@ -1,0 +1,72 @@
+##
+# ** Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# ** Licensed under the MIT License.
+##
+
+# Standalone entry point for the `hip-ir` component: the HIP dialect and
+# nothing else. No ONNX Runtime EP, no runtime, no MorphiZen, no Python, no
+# ROCm -- only LLVM/MLIR. This is what makes the dialect contributable by
+# teams that do not build the full EP.
+#
+# Three ways in:
+#   1. Direct configure, to build and install the hip-ir package:
+#        cmake -S cmake/hip-ir -B build/hip-ir -DMLIR_DIR=...
+#        cmake --build build/hip-ir --target install
+#   2. add_subdirectory() from a downstream repo wanting a source build.
+#   3. FetchContent with SOURCE_SUBDIR cmake/hip-ir.
+
+cmake_minimum_required(VERSION 3.20)
+
+project(hip-ir VERSION 1.0.0 LANGUAGES C CXX)
+
+# Version of the HIP-IR *contract*, deliberately independent of the
+# onnx-hipdnn-ep product version: additive ops bump minor, op-semantics
+# changes bump major.
+set(HIP_IR_VERSION "${PROJECT_VERSION}")
+
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  set(HIP_IR_STANDALONE TRUE)
+else()
+  set(HIP_IR_STANDALONE FALSE)
+endif()
+
+option(HIP_IR_INSTALL "Generate install/export rules for the hip-ir package"
+       ${HIP_IR_STANDALONE})
+
+# Only impose a toolchain when we own the build. Embedders keep their own
+# settings; HipDialectIR declares cxx_std_17 as a usage requirement instead.
+if(HIP_IR_STANDALONE)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif()
+
+get_filename_component(HIP_EP_ROOT "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+
+if(NOT MLIR_FOUND)
+  find_package(MLIR CONFIG REQUIRED)
+endif()
+if(NOT LLVM_FOUND)
+  find_package(LLVM CONFIG REQUIRED)
+endif()
+
+if(NOT COMMAND mlir_tablegen)
+  list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}" "${MLIR_CMAKE_DIR}")
+  include(TableGen)
+  include(AddLLVM)
+  include(AddMLIR)
+endif()
+
+include_directories(SYSTEM ${LLVM_INCLUDE_DIRS} ${MLIR_INCLUDE_DIRS})
+
+# HipOps.td and HipTypes.td include their siblings as "hip/Dialect/IR/*.td".
+# tablegen() forwards this directory's INCLUDE_DIRECTORIES as -I, but set the
+# flag explicitly too so the resolution does not depend on that behaviour.
+include_directories("${HIP_EP_ROOT}/include")
+list(APPEND LLVM_TABLEGEN_FLAGS "-I${HIP_EP_ROOT}/include")
+
+add_subdirectory("${HIP_EP_ROOT}/include/hip/Dialect/IR"
+                 "${CMAKE_CURRENT_BINARY_DIR}/include/hip/Dialect/IR")
+add_subdirectory("${HIP_EP_ROOT}/lib/Dialect/IR"
+                 "${CMAKE_CURRENT_BINARY_DIR}/lib/Dialect/IR")

--- a/include/hip/Dialect/IR/CMakeLists.txt
+++ b/include/hip/Dialect/IR/CMakeLists.txt
@@ -37,3 +37,14 @@ set(LLVM_TARGET_DEFINITIONS HipOps.td)
 mlir_tablegen(HipOps.h.inc -gen-op-decls)
 mlir_tablegen(HipOps.cpp.inc -gen-op-defs)
 add_public_tablegen_target(HipOpsIncGen)
+
+# The public header HipDialect.h includes the generated files as
+# "hip/Dialect/IR/*.inc", so consumers need the root three levels above this
+# binary dir on their include path. Embedders remap that dir -- hip-ep uses
+# <build>/include, CGC-IR-Converter uses <build>/hip-generated -- so derive it
+# here rather than assuming a layout.
+get_filename_component(_hip_ir_generated_root
+  "${CMAKE_CURRENT_BINARY_DIR}/../../.." ABSOLUTE)
+set(HIP_IR_GENERATED_INCLUDE_ROOT "${_hip_ir_generated_root}" CACHE INTERNAL
+    "Include root for the TableGen-generated HIP dialect headers")
+unset(_hip_ir_generated_root)

--- a/lib/Dialect/IR/CMakeLists.txt
+++ b/lib/Dialect/IR/CMakeLists.txt
@@ -47,3 +47,29 @@ target_link_libraries(HipDialectIR PUBLIC
 if(MSVC)
   target_compile_options(HipDialectIR PRIVATE /bigobj)
 endif()
+
+# --- hip-ir packaging -------------------------------------------------------
+# Usage requirements. Previously these came from the enclosing project's global
+# include_directories(), which works in-tree but cannot be exported.
+get_filename_component(HIP_IR_SOURCE_INCLUDE_ROOT
+  "${CMAKE_CURRENT_LIST_DIR}/../../../include" ABSOLUTE)
+
+target_include_directories(HipDialectIR PUBLIC
+  $<BUILD_INTERFACE:${HIP_IR_SOURCE_INCLUDE_ROOT}>
+  $<BUILD_INTERFACE:${HIP_IR_GENERATED_INCLUDE_ROOT}>
+  $<INSTALL_INTERFACE:include>)
+
+target_compile_features(HipDialectIR PUBLIC cxx_std_17)
+
+# Consumers link the namespaced name whether hip-ir comes from this source tree
+# or from the installed package, so they never branch on how it was obtained.
+if(NOT TARGET hip::HipDialectIR)
+  add_library(hip::HipDialectIR ALIAS HipDialectIR)
+endif()
+
+if(HIP_IR_INSTALL)
+  get_filename_component(_hip_ir_cmake_dir
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake" ABSOLUTE)
+  include("${_hip_ir_cmake_dir}/hip-ir-install.cmake")
+  unset(_hip_ir_cmake_dir)
+endif()


### PR DESCRIPTION
Downstreams (CGC-IR-Converter) consume only the HIP dialect, but had to add_subdirectory() into this source tree to get it, which forced a git submodule pinned to a feature branch. Export it as a CMake package instead.

- cmake/hip-ir/CMakeLists.txt: standalone entry point building only the dialect. LLVM/MLIR only: no ORT EP, runtime, MorphiZen, Python or ROCm, so teams that do not build the full EP can still contribute to the dialect.
- cmake/hip-ir-config.cmake.in, cmake/hip-ir-install.cmake: package config plus install/export rules. The config hard-fails on an LLVM version mismatch; static MLIR libs and TableGen-generated dialect registries are neither ABI- nor ODR-safe across versions, and the resulting undefined TypeIDResolver symbols are otherwise very hard to trace back here.
- HipDialectIR gains its own include paths (they previously came from the enclosing project's global include_directories(), which cannot be exported), a cxx_std_17 usage requirement, and a hip::HipDialectIR alias so consumers link the same name from source or from the package.

HipDialect.h includes the generated .inc files, so those are public surface and ship with the package. The TableGen output root is derived rather than assumed, because embedders remap it: hip-ep uses <build>/include, CGC-IR-Converter uses <build>/hip-generated.

Additive. HIP_IR_INSTALL defaults ON only when hip-ir is the top-level project, so a full hip-ep build is unchanged.

<!--
Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
Licensed under the MIT License.
-->

<!--
Thank you for contributing. Keep the description proportional to the change
and review it for accuracy before requesting review. See CONTRIBUTING.md for
the full workflow and AI-assistance disclosure requirements.
-->

## Summary

<!-- What changed and what user- or developer-visible effect it has. -->

## Related issue or design

<!-- Link the issue/design discussion, use "Fixes #123", or write "None". -->

## Why

<!-- Explain the problem and rationale when the design choice is not obvious. -->

## What

<!-- Optional for small changes. List concrete implementation details. -->

## Test plan

<!-- List commands run and results, or explain why testing was not needed. -->

## Notes for reviewers

<!-- Optional: limitations, follow-ups, important assumptions, or ordering constraints. -->

<!--
Optional sections: remove this comment and keep the sections that apply.

## Compiler IR

<details>
<summary>Before / after</summary>

```mlir
// Before
```

```mlir
// After
```

</details>

## Performance

| Metric | Before | After |
|---|---:|---:|
| | | |

Hardware, workload, build configuration, and measurement method:
-->

## Checklist

- [ ] The change is focused, or links a design/series explaining its scope.
- [ ] Relevant tests were added or updated and the results are documented.
- [ ] User-facing or design documentation was updated when needed.
- [ ] Substantial AI assistance is disclosed, and I reviewed and understand the result.
