### PR TITLE
feat(hip-to-tosa): convert hip.gemm to tosa.matmul + tosa.add

### DIFF
--- a/lib/Conversion/HipToTosa/HipToTosa.cpp
+++ b/lib/Conversion/HipToTosa/HipToTosa.cpp
@@ -167,6 +167,123 @@ Value createSplatFloat(ConversionPatternRewriter &rewriter, Location loc,
       DenseElementsAttr::get(type, rewriter.getFloatAttr(elemType, ap)));
 }
 
+// Swap the two dimensions of a rank-2 tensor.
+static Value transpose2D(Value input, ConversionPatternRewriter &rewriter,
+                         Location loc) {
+  auto type = cast<RankedTensorType>(input.getType());
+  ArrayRef<int64_t> shape = type.getShape();
+  return tosa::TransposeOp::create(rewriter, loc,
+                                   type.clone({shape[1], shape[0]}), input,
+                                   rewriter.getDenseI32ArrayAttr({1, 0}));
+}
+
+// hip.gemm is ONNX Gemm: Y = alpha * A' * B' + beta * C, where A and B are
+// optionally transposed and C broadcasts to [M, N]. TOSA has no fused
+// equivalent, so this spells the whole thing out. MIGraphX's ONNX parser
+// desugars Gemm the same way -- into a dot plus a broadcast add -- and rocMLIR
+// fuses the resulting chain back into one kernel, so the expansion costs
+// nothing downstream.
+struct GemmConverter final : public OpConversionPattern<hip::GemmOp> {
+  using OpConversionPattern<hip::GemmOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(hip::GemmOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (op.getNumResults() != 1)
+      return rewriter.notifyMatchFailure(op, "expected tensor mode");
+
+    auto resultType = dyn_cast<RankedTensorType>(op.getResult(0).getType());
+    auto aType = dyn_cast<RankedTensorType>(adaptor.getInputA().getType());
+    auto bType = dyn_cast<RankedTensorType>(adaptor.getInputB().getType());
+    if (!resultType || !resultType.hasStaticShape() || !aType ||
+        !aType.hasStaticShape() || !bType || !bType.hasStaticShape())
+      return rewriter.notifyMatchFailure(op, "expected static ranked tensors");
+    if (aType.getRank() != 2 || bType.getRank() != 2 ||
+        resultType.getRank() != 2)
+      return rewriter.notifyMatchFailure(op, "ONNX Gemm is 2-D");
+
+    Type elementType = resultType.getElementType();
+    if (aType.getElementType() != elementType ||
+        bType.getElementType() != elementType)
+      return rewriter.notifyMatchFailure(
+          op, "A, B, and result element types must match");
+    // alpha and beta are f32 attributes folded in as elementwise multiplies in
+    // the result type, so an integer gemm would silently round them away.
+    if (!isa<FloatType>(elementType))
+      return rewriter.notifyMatchFailure(op, "only float gemm is supported");
+
+    Location loc = op.getLoc();
+    bool transA = op.getTransA() != 0;
+    bool transB = op.getTransB() != 0;
+
+    // Once the optional transposes are applied the operands are [M,K] x [K,N].
+    int64_t m = aType.getDimSize(transA ? 1 : 0);
+    int64_t ka = aType.getDimSize(transA ? 0 : 1);
+    int64_t kb = bType.getDimSize(transB ? 1 : 0);
+    int64_t n = bType.getDimSize(transB ? 0 : 1);
+    if (ka != kb)
+      return rewriter.notifyMatchFailure(op, "A and B disagree on K");
+    if (resultType.getDimSize(0) != m || resultType.getDimSize(1) != n)
+      return rewriter.notifyMatchFailure(
+          op, "result shape disagrees with A and B");
+
+    Value a = adaptor.getInputA();
+    if (transA)
+      a = transpose2D(a, rewriter, loc);
+    Value b = adaptor.getInputB();
+    if (transB)
+      b = transpose2D(b, rewriter, loc);
+
+    // tosa.matmul is batched, so carry a batch of one through and drop it.
+    a = reshapeTo(a, {1, m, ka}, rewriter);
+    b = reshapeTo(b, {1, kb, n}, rewriter);
+    Value matmul =
+        tosa::MatMulOp::create(rewriter, loc, resultType.clone({1, m, n}), a, b)
+            .getResult();
+    Value result = reshapeTo(matmul, {m, n}, rewriter);
+
+    if (op.getAlpha().convertToFloat() != 1.0f)
+      result = tosa::MulOp::create(
+          rewriter, loc, resultType, result,
+          createSplatFloat(rewriter, loc, resultType,
+                           op.getAlpha().convertToFloat()),
+          createZeroMulShift(rewriter, loc));
+
+    if (Value c = adaptor.getInputC()) {
+      auto cType = dyn_cast<RankedTensorType>(c.getType());
+      if (!cType || !cType.hasStaticShape() ||
+          cType.getElementType() != elementType)
+        return rewriter.notifyMatchFailure(op, "unsupported C tensor");
+      ArrayRef<int64_t> cShape = cType.getShape();
+      if (cType.getRank() > 2)
+        return rewriter.notifyMatchFailure(op, "C rank exceeds the result");
+      // ONNX broadcasts C to [M, N] unidirectionally. TOSA expands only size-1
+      // dimensions and needs matching rank, so left-pad C's shape with ones.
+      SmallVector<int64_t> padded(2, 1);
+      for (auto [idx, dim] : llvm::enumerate(cShape))
+        padded[2 - cShape.size() + idx] = dim;
+      if ((padded[0] != 1 && padded[0] != m) ||
+          (padded[1] != 1 && padded[1] != n))
+        return rewriter.notifyMatchFailure(op, "C is not broadcastable to Y");
+      if (cShape != ArrayRef<int64_t>(padded))
+        c = reshapeTo(c, padded, rewriter);
+
+      if (op.getBeta().convertToFloat() != 1.0f) {
+        auto betaType = cType.clone(padded);
+        c = tosa::MulOp::create(
+            rewriter, loc, betaType, c,
+            createSplatFloat(rewriter, loc, betaType,
+                             op.getBeta().convertToFloat()),
+            createZeroMulShift(rewriter, loc));
+      }
+      result = tosa::AddOp::create(rewriter, loc, resultType, result, c);
+    }
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
 // Covers the hip ops whose operands are (ctx, lhs, rhs, output) and whose TOSA
 // counterpart preserves the element type. Comparisons (hip.equal, hip.less) do
 // not belong here: they produce i1, which isTosaCompatibleOperand's
@@ -1110,11 +1227,11 @@ class HipToTosaPass : public impl::ConvertHipToTosaPassBase<HipToTosaPass> {
     ConversionTarget conversion(*ctx);
     conversion.addLegalDialect<tosa::TosaDialect, func::FuncDialect>();
     conversion
-        .addIllegalOp<MatmulOp, TransposeOp, AddOp, SubOp, MinOp, MaxOp, MulOp,
-                      DivOp, AbsOp, NegOp, CeilOp, FloorOp, ExpOp, LogOp, SinOp,
-                      CosOp, TanhOp, ErfOp, SigmoidOp, ReciprocalOp, SqrtOp,
-                      WhereOp, LeakyReluOp, MiopenSoftmaxOp, ReduceSumOp,
-                      ReduceMeanOp, CastOp, QuantizeLinearOp,
+        .addIllegalOp<MatmulOp, GemmOp, TransposeOp, AddOp, SubOp, MinOp, MaxOp,
+                      MulOp, DivOp, AbsOp, NegOp, CeilOp, FloorOp, ExpOp, LogOp,
+                      SinOp, CosOp, TanhOp, ErfOp, SigmoidOp, ReciprocalOp,
+                      SqrtOp, WhereOp, LeakyReluOp, MiopenSoftmaxOp,
+                      ReduceSumOp, ReduceMeanOp, CastOp, QuantizeLinearOp,
                       DequantizeLinearOp>();
     // tosa.matmul (and other tosa ops) are not destination-passing, so
     // MatMulConverter drops each hip op's DPS `outs` operand. The
@@ -1134,7 +1251,7 @@ class HipToTosaPass : public impl::ConvertHipToTosaPassBase<HipToTosaPass> {
 
     RewritePatternSet patterns(ctx);
     patterns.add<
-        MatMulConverter, TransposeConverter, ExpandConverter,
+        MatMulConverter, GemmConverter, TransposeConverter, ExpandConverter,
         ReshapeConverter<tensor::CollapseShapeOp>,
         ReshapeConverter<tensor::ExpandShapeOp>, ExtractSliceConverter,
         DivConverter, BinaryConverter<AddOp, tosa::AddOp>,

--- a/test/lit/Conversion/hip-to-tosa/test_gemm.mlir
+++ b/test/lit/Conversion/hip-to-tosa/test_gemm.mlir
@@ -1,0 +1,181 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// Verify hip.gemm expands into the tosa.matmul + tosa.add chain that ONNX Gemm
+// means: optional transposes, a batch-of-one around the batched tosa.matmul,
+// the alpha/beta scales, and C broadcast to [M, N].
+//
+// RUN: hip-mlir-opt --convert-hip-to-tosa --split-input-file \
+// RUN:   --verify-diagnostics %s | FileCheck %s
+
+// CHECK-LABEL: func.func @gemm
+// CHECK: %[[A:.*]] = tosa.reshape %arg1, {{.*}} -> tensor<1x32x64xf32>
+// CHECK: %[[B:.*]] = tosa.reshape %arg2, {{.*}} -> tensor<1x64x128xf32>
+// CHECK: %[[MM:.*]] = tosa.matmul %[[A]], %[[B]]
+// CHECK-SAME: -> tensor<1x32x128xf32>
+// CHECK: %[[FLAT:.*]] = tosa.reshape %[[MM]], {{.*}} -> tensor<32x128xf32>
+// CHECK: %[[C:.*]] = tosa.reshape %arg3, {{.*}} -> tensor<1x128xf32>
+// CHECK: tosa.add %[[FLAT]], %[[C]]
+// CHECK-NOT: hip.gemm
+func.func @gemm(%ctx: !hip.context, %a: tensor<32x64xf32>,
+                %b: tensor<64x128xf32>, %c: tensor<128xf32>,
+                %init: tensor<32x128xf32>) -> tensor<32x128xf32>
+    attributes {rock.kernel} {
+  %r = hip.gemm(%ctx) ins(%a, %b, %c :
+      tensor<32x64xf32>, tensor<64x128xf32>, tensor<128xf32>)
+      outs(%init : tensor<32x128xf32>) : tensor<32x128xf32>
+  return %r : tensor<32x128xf32>
+}
+
+// -----
+
+// C is optional; without it the matmul result is returned directly.
+// CHECK-LABEL: func.func @gemm_no_c
+// CHECK: tosa.matmul
+// CHECK-NOT: tosa.add
+// CHECK-NOT: hip.gemm
+func.func @gemm_no_c(%ctx: !hip.context, %a: tensor<4x8xf32>,
+                     %b: tensor<8x16xf32>, %init: tensor<4x16xf32>)
+    -> tensor<4x16xf32> attributes {rock.kernel} {
+  %r = hip.gemm(%ctx) ins(%a, %b : tensor<4x8xf32>, tensor<8x16xf32>)
+      outs(%init : tensor<4x16xf32>) : tensor<4x16xf32>
+  return %r : tensor<4x16xf32>
+}
+
+// -----
+
+// transA swaps A's dims before the matmul; A is [K, M] on the way in.
+// CHECK-LABEL: func.func @gemm_trans_a
+// CHECK: %[[AT:.*]] = tosa.transpose %arg1 {perms = array<i32: 1, 0>} : (tensor<8x4xf32>) -> tensor<4x8xf32>
+// CHECK: tosa.reshape %[[AT]], {{.*}} -> tensor<1x4x8xf32>
+// CHECK: tosa.matmul
+// CHECK-NOT: hip.gemm
+func.func @gemm_trans_a(%ctx: !hip.context, %a: tensor<8x4xf32>,
+                        %b: tensor<8x16xf32>, %init: tensor<4x16xf32>)
+    -> tensor<4x16xf32> attributes {rock.kernel} {
+  %r = hip.gemm(%ctx) ins(%a, %b : tensor<8x4xf32>, tensor<8x16xf32>)
+      outs(%init : tensor<4x16xf32>) {transA = 1 : i64} : tensor<4x16xf32>
+  return %r : tensor<4x16xf32>
+}
+
+// -----
+
+// transB swaps B's dims; B is [N, K] on the way in.
+// CHECK-LABEL: func.func @gemm_trans_b
+// CHECK: %[[BT:.*]] = tosa.transpose %arg2 {perms = array<i32: 1, 0>} : (tensor<16x8xf32>) -> tensor<8x16xf32>
+// CHECK: tosa.reshape %[[BT]], {{.*}} -> tensor<1x8x16xf32>
+// CHECK: tosa.matmul
+// CHECK-NOT: hip.gemm
+func.func @gemm_trans_b(%ctx: !hip.context, %a: tensor<4x8xf32>,
+                        %b: tensor<16x8xf32>, %init: tensor<4x16xf32>)
+    -> tensor<4x16xf32> attributes {rock.kernel} {
+  %r = hip.gemm(%ctx) ins(%a, %b : tensor<4x8xf32>, tensor<16x8xf32>)
+      outs(%init : tensor<4x16xf32>) {transB = 1 : i64} : tensor<4x16xf32>
+  return %r : tensor<4x16xf32>
+}
+
+// -----
+
+// alpha scales the product and beta scales C, each as a splat multiply.
+// CHECK-LABEL: func.func @gemm_alpha_beta
+// CHECK: %[[ALPHA:.*]] = "tosa.const"() <{values = dense<2.000000e+00> : tensor<4x16xf32>}>
+// CHECK: %[[SCALED:.*]] = tosa.mul {{.*}}, %[[ALPHA]]
+// CHECK: %[[BETA:.*]] = "tosa.const"() <{values = dense<5.000000e-01> : tensor<1x16xf32>}>
+// CHECK: %[[CB:.*]] = tosa.mul {{.*}}, %[[BETA]]
+// CHECK: tosa.add %[[SCALED]], %[[CB]]
+// CHECK-NOT: hip.gemm
+func.func @gemm_alpha_beta(%ctx: !hip.context, %a: tensor<4x8xf32>,
+                           %b: tensor<8x16xf32>, %c: tensor<16xf32>,
+                           %init: tensor<4x16xf32>) -> tensor<4x16xf32>
+    attributes {rock.kernel} {
+  %r = hip.gemm(%ctx) ins(%a, %b, %c :
+      tensor<4x8xf32>, tensor<8x16xf32>, tensor<16xf32>)
+      outs(%init : tensor<4x16xf32>)
+      {alpha = 2.0 : f32, beta = 0.5 : f32} : tensor<4x16xf32>
+  return %r : tensor<4x16xf32>
+}
+
+// -----
+
+// A C that already has the result's rank and shape needs no reshape.
+// CHECK-LABEL: func.func @gemm_full_c
+// CHECK: %[[MM:.*]] = tosa.matmul
+// CHECK: %[[FLAT:.*]] = tosa.reshape %[[MM]], {{.*}} -> tensor<4x16xf32>
+// CHECK: tosa.add %[[FLAT]], %arg3 : (tensor<4x16xf32>, tensor<4x16xf32>) -> tensor<4x16xf32>
+// CHECK-NOT: hip.gemm
+func.func @gemm_full_c(%ctx: !hip.context, %a: tensor<4x8xf32>,
+                       %b: tensor<8x16xf32>, %c: tensor<4x16xf32>,
+                       %init: tensor<4x16xf32>) -> tensor<4x16xf32>
+    attributes {rock.kernel} {
+  %r = hip.gemm(%ctx) ins(%a, %b, %c :
+      tensor<4x8xf32>, tensor<8x16xf32>, tensor<4x16xf32>)
+      outs(%init : tensor<4x16xf32>) : tensor<4x16xf32>
+  return %r : tensor<4x16xf32>
+}
+
+// -----
+
+// A column vector C broadcasts along N.
+// CHECK-LABEL: func.func @gemm_column_c
+// CHECK: tosa.add {{.*}} : (tensor<4x16xf32>, tensor<4x1xf32>) -> tensor<4x16xf32>
+// CHECK-NOT: hip.gemm
+func.func @gemm_column_c(%ctx: !hip.context, %a: tensor<4x8xf32>,
+                         %b: tensor<8x16xf32>, %c: tensor<4x1xf32>,
+                         %init: tensor<4x16xf32>) -> tensor<4x16xf32>
+    attributes {rock.kernel} {
+  %r = hip.gemm(%ctx) ins(%a, %b, %c :
+      tensor<4x8xf32>, tensor<8x16xf32>, tensor<4x1xf32>)
+      outs(%init : tensor<4x16xf32>) : tensor<4x16xf32>
+  return %r : tensor<4x16xf32>
+}
+
+// -----
+
+// Outside a rock.kernel the pass is a no-op.
+// CHECK-LABEL: func.func @gemm_not_a_kernel
+// CHECK: hip.gemm
+// CHECK-NOT: tosa.matmul
+func.func @gemm_not_a_kernel(%ctx: !hip.context, %a: tensor<4x8xf32>,
+                             %b: tensor<8x16xf32>, %init: tensor<4x16xf32>)
+    -> tensor<4x16xf32> {
+  %r = hip.gemm(%ctx) ins(%a, %b : tensor<4x8xf32>, tensor<8x16xf32>)
+      outs(%init : tensor<4x16xf32>) : tensor<4x16xf32>
+  return %r : tensor<4x16xf32>
+}
+
+// -----
+
+func.func @gemm_dynamic(%ctx: !hip.context, %a: tensor<?x8xf32>,
+                        %b: tensor<8x16xf32>, %init: tensor<?x16xf32>)
+    -> tensor<?x16xf32> attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.gemm'}}
+  %r = hip.gemm(%ctx) ins(%a, %b : tensor<?x8xf32>, tensor<8x16xf32>)
+      outs(%init : tensor<?x16xf32>) : tensor<?x16xf32>
+  return %r : tensor<?x16xf32>
+}
+
+// -----
+
+func.func @gemm_integer(%ctx: !hip.context, %a: tensor<4x8xi32>,
+                        %b: tensor<8x16xi32>, %init: tensor<4x16xi32>)
+    -> tensor<4x16xi32> attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.gemm'}}
+  %r = hip.gemm(%ctx) ins(%a, %b : tensor<4x8xi32>, tensor<8x16xi32>)
+      outs(%init : tensor<4x16xi32>) : tensor<4x16xi32>
+  return %r : tensor<4x16xi32>
+}
+
+// -----
+
+// C must broadcast to [M, N]; a length that matches neither 1 nor N is a
+// mismatch ONNX would have rejected at shape inference.
+func.func @gemm_bad_c(%ctx: !hip.context, %a: tensor<4x8xf32>,
+                      %b: tensor<8x16xf32>, %c: tensor<7xf32>,
+                      %init: tensor<4x16xf32>) -> tensor<4x16xf32>
+    attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.gemm'}}
+  %r = hip.gemm(%ctx) ins(%a, %b, %c :
+      tensor<4x8xf32>, tensor<8x16xf32>, tensor<7xf32>)
+      outs(%init : tensor<4x16xf32>) : tensor<4x16xf32>
+  return %r : tensor<4x16xf32>
+}


### PR DESCRIPTION
`hip.gemm` is a registered fusion anchor in `FuseROCMlir`, but it had no TOSA
converter and no entry in `HipToTosa`'s illegal-op list. Since the pass uses
`applyPartialConversion`, an op that is neither listed as illegal nor matched by
a pattern is simply treated as legal and passed through without a diagnostic.

So `FuseROCMlir` outlined the gemm into a `rock.kernel`, `convert-hip-to-tosa`
converted everything around it and left the gemm alone, and rocMLIR was then
handed a hip dialect op it has never seen. It died with `0xC0000409`
(`STATUS_STACK_BUFFER_OVERRUN`) — no error message, no source location. Any
model containing an ONNX Gemm hit this.

The unconverted op reaching the kernel boundary looked like:

```mlir
func.func @rocMlir0(...) attributes {rock.arch = "gfx1151", rock.kernel} {
  %2 = hip.gemm(%0) ins(%arg0, %arg1, %arg2 : ...) outs(%1 : ...)
  %3 = tosa.sigmoid %2
  return %3
}
```

The sigmoid converted; the gemm did not.

## What this does

Expands `hip.gemm` the way ONNX defines it — `Y = alpha * A' * B' + beta * C`:

- optional `transA` / `transB` become `tosa.transpose`
- `tosa.matmul` is batched, so a batch of one is wrapped around the rank-2
  operands and stripped afterwards
- `alpha` and `beta` become splat `tosa.mul`s, elided entirely when they are
  1.0, which is the common case
- `C` is left-padded with ones to the result's rank, because TOSA expands only
  size-1 dimensions while ONNX broadcasts unidirectionally

The same kernel now converts to:

```mlir
%7  = tosa.matmul %5, %6, %2, %2 : (tensor<1x32x64xf32>, tensor<1x64x128xf32>, ...) -> tensor<1x32x128xf32>
%8  = tosa.reshape %7, %1 : (tensor<1x32x128xf32>, !tosa.shape<2>) -> tensor<32x128xf32>
%9  = tosa.reshape %arg2, %0 : (tensor<128xf32>, !tosa.shape<2>) -> tensor<1x128xf32>
%10 = tosa.add %8, %9 : (tensor<32x128xf32>, tensor<1x128xf32>) -> tensor<32x128xf32>
%11 = tosa.sigmoid %10 : (tensor<32x128xf32>) -> tensor<32x128xf32>
```

Expanding into separate ops costs nothing downstream: MIGraphX's ONNX parser
desugars `Gemm` into exactly the same dot plus broadcast add, and on gfx1151
rocMLIR fuses that chain back into a single kernel (`mlir_dot_add_sigmoid`).

Integer gemm is rejected rather than converted. `alpha` and `beta` are f32
attributes applied as elementwise multiplies in the result type, so an integer
result would round them away silently; failing legalization is the honest
outcome.

## Validation

- New `test/lit/Conversion/hip-to-tosa/test_gemm.mlir` covers the basic form,
  omitted `C`, `transA`, `transB`, non-unit alpha/beta, a full-rank `C`, a
  column-vector `C` broadcasting along N, the non-kernel no-op, and rejections
  for dynamic shapes, integer element types, and a non-broadcastable `C`.
- Full lit suite passes (the one failure, `onnx-to-hip/test_qadd.mlir`, is
  pre-existing on this base and unrelated — its RUN line never touches
  `HipToTosa`).
- End to end through `hip-rocmlir-compiler` against `librockCompiler`, the same
  model that previously crashed now compiles to a 5288-byte GPU binary
  (grid 16, block 64).
