### PR TITLE
feat(hip-to-tosa): convert hip.gemm to tosa.matmul + tosa.add

### DIFF
--- a/lib/Conversion/HipToTosa/HipToTosa.cpp
+++ b/lib/Conversion/HipToTosa/HipToTosa.cpp
@@ -355,6 +355,24 @@ Value createSplatFloat(ConversionPatternRewriter &rewriter, Location loc,
       DenseElementsAttr::get(type, rewriter.getFloatAttr(elemType, ap)));
 }
 
+// Multiply by a scalar that ONNX carries as an f32 attribute. hipBLASLt scales
+// in f32 even when the data is f16 or bf16 (scaleType = HIP_R_32F while
+// dataType is HIP_R_16F), so for those types widen to f32 around the multiply
+// rather than rounding the scalar down to the data type and losing it there.
+static Value scaleByF32(Value value, float scale, RankedTensorType type,
+                        ConversionPatternRewriter &rewriter, Location loc) {
+  bool widen = !type.getElementType().isF32();
+  RankedTensorType mulType = widen ? type.clone(rewriter.getF32Type()) : type;
+  if (widen)
+    value = tosa::CastOp::create(rewriter, loc, mulType, value);
+  value = tosa::MulOp::create(rewriter, loc, mulType, value,
+                              createSplatFloat(rewriter, loc, mulType, scale),
+                              createZeroMulShift(rewriter, loc));
+  if (widen)
+    value = tosa::CastOp::create(rewriter, loc, type, value);
+  return value;
+}
+
 // hip.gemm is ONNX Gemm: Y = alpha * A' * B' + beta * C, where A and B are
 // optionally transposed and C broadcasts to [M, N]. TOSA has no fused
 // equivalent, so this spells the whole thing out. MIGraphX's ONNX parser
@@ -386,9 +404,12 @@ struct GemmConverter final : public OpConversionPattern<hip::GemmOp> {
       return rewriter.notifyMatchFailure(
           op, "A, B, and result element types must match");
     // alpha and beta are f32 attributes folded in as elementwise multiplies in
-    // the result type, so an integer gemm would silently round them away.
-    if (!isa<FloatType>(elementType))
-      return rewriter.notifyMatchFailure(op, "only float gemm is supported");
+    // the result type, so an integer gemm would silently round them away. f64
+    // is excluded separately: the hipBLASLt path accepts it, but TOSA has no
+    // f64 tensor type, and failing legalization beats emitting invalid TOSA.
+    if (!elementType.isF32() && !elementType.isF16() && !elementType.isBF16())
+      return rewriter.notifyMatchFailure(
+          op, "only f32, f16, and bf16 gemm are supported");
 
     Location loc = op.getLoc();
     bool transA = op.getTransA() != 0;
@@ -421,11 +442,8 @@ struct GemmConverter final : public OpConversionPattern<hip::GemmOp> {
     Value result = reshapeTo(matmul, {m, n}, rewriter);
 
     if (op.getAlpha().convertToFloat() != 1.0f)
-      result =
-          tosa::MulOp::create(rewriter, loc, resultType, result,
-                              createSplatFloat(rewriter, loc, resultType,
-                                               op.getAlpha().convertToFloat()),
-                              createZeroMulShift(rewriter, loc));
+      result = scaleByF32(result, op.getAlpha().convertToFloat(), resultType,
+                          rewriter, loc);
 
     if (Value c = adaptor.getInputC()) {
       auto cType = dyn_cast<RankedTensorType>(c.getType());
@@ -446,13 +464,10 @@ struct GemmConverter final : public OpConversionPattern<hip::GemmOp> {
       if (cShape != ArrayRef<int64_t>(padded))
         c = reshapeTo(c, padded, rewriter);
 
-      if (op.getBeta().convertToFloat() != 1.0f) {
-        auto betaType = cType.clone(padded);
-        c = tosa::MulOp::create(rewriter, loc, betaType, c,
-                                createSplatFloat(rewriter, loc, betaType,
-                                                 op.getBeta().convertToFloat()),
-                                createZeroMulShift(rewriter, loc));
-      }
+      if (op.getBeta().convertToFloat() != 1.0f)
+        c = scaleByF32(c, op.getBeta().convertToFloat(),
+                       cast<RankedTensorType>(cType.clone(padded)), rewriter,
+                       loc);
       result = tosa::AddOp::create(rewriter, loc, resultType, result, c);
     }
 

--- a/lib/Conversion/HipToTosa/HipToTosa.cpp
+++ b/lib/Conversion/HipToTosa/HipToTosa.cpp
@@ -355,6 +355,112 @@ Value createSplatFloat(ConversionPatternRewriter &rewriter, Location loc,
       DenseElementsAttr::get(type, rewriter.getFloatAttr(elemType, ap)));
 }
 
+// hip.gemm is ONNX Gemm: Y = alpha * A' * B' + beta * C, where A and B are
+// optionally transposed and C broadcasts to [M, N]. TOSA has no fused
+// equivalent, so this spells the whole thing out. MIGraphX's ONNX parser
+// desugars Gemm the same way -- into a dot plus a broadcast add -- and rocMLIR
+// fuses the resulting chain back into one kernel, so the expansion costs
+// nothing downstream.
+struct GemmConverter final : public OpConversionPattern<hip::GemmOp> {
+  using OpConversionPattern<hip::GemmOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(hip::GemmOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (op.getNumResults() != 1)
+      return rewriter.notifyMatchFailure(op, "expected tensor mode");
+
+    auto resultType = dyn_cast<RankedTensorType>(op.getResult(0).getType());
+    auto aType = dyn_cast<RankedTensorType>(adaptor.getInputA().getType());
+    auto bType = dyn_cast<RankedTensorType>(adaptor.getInputB().getType());
+    if (!resultType || !resultType.hasStaticShape() || !aType ||
+        !aType.hasStaticShape() || !bType || !bType.hasStaticShape())
+      return rewriter.notifyMatchFailure(op, "expected static ranked tensors");
+    if (aType.getRank() != 2 || bType.getRank() != 2 ||
+        resultType.getRank() != 2)
+      return rewriter.notifyMatchFailure(op, "ONNX Gemm is 2-D");
+
+    Type elementType = resultType.getElementType();
+    if (aType.getElementType() != elementType ||
+        bType.getElementType() != elementType)
+      return rewriter.notifyMatchFailure(
+          op, "A, B, and result element types must match");
+    // alpha and beta are f32 attributes folded in as elementwise multiplies in
+    // the result type, so an integer gemm would silently round them away.
+    if (!isa<FloatType>(elementType))
+      return rewriter.notifyMatchFailure(op, "only float gemm is supported");
+
+    Location loc = op.getLoc();
+    bool transA = op.getTransA() != 0;
+    bool transB = op.getTransB() != 0;
+
+    // Once the optional transposes are applied the operands are [M,K] x [K,N].
+    int64_t m = aType.getDimSize(transA ? 1 : 0);
+    int64_t ka = aType.getDimSize(transA ? 0 : 1);
+    int64_t kb = bType.getDimSize(transB ? 1 : 0);
+    int64_t n = bType.getDimSize(transB ? 0 : 1);
+    if (ka != kb)
+      return rewriter.notifyMatchFailure(op, "A and B disagree on K");
+    if (resultType.getDimSize(0) != m || resultType.getDimSize(1) != n)
+      return rewriter.notifyMatchFailure(op,
+                                         "result shape disagrees with A and B");
+
+    Value a = adaptor.getInputA();
+    if (transA)
+      a = transposeTo(a, {m, ka}, {1, 0}, rewriter, loc);
+    Value b = adaptor.getInputB();
+    if (transB)
+      b = transposeTo(b, {kb, n}, {1, 0}, rewriter, loc);
+
+    // tosa.matmul is batched, so carry a batch of one through and drop it.
+    a = reshapeTo(a, {1, m, ka}, rewriter);
+    b = reshapeTo(b, {1, kb, n}, rewriter);
+    Value matmul =
+        tosa::MatMulOp::create(rewriter, loc, resultType.clone({1, m, n}), a, b)
+            .getResult();
+    Value result = reshapeTo(matmul, {m, n}, rewriter);
+
+    if (op.getAlpha().convertToFloat() != 1.0f)
+      result =
+          tosa::MulOp::create(rewriter, loc, resultType, result,
+                              createSplatFloat(rewriter, loc, resultType,
+                                               op.getAlpha().convertToFloat()),
+                              createZeroMulShift(rewriter, loc));
+
+    if (Value c = adaptor.getInputC()) {
+      auto cType = dyn_cast<RankedTensorType>(c.getType());
+      if (!cType || !cType.hasStaticShape() ||
+          cType.getElementType() != elementType)
+        return rewriter.notifyMatchFailure(op, "unsupported C tensor");
+      ArrayRef<int64_t> cShape = cType.getShape();
+      if (cType.getRank() > 2)
+        return rewriter.notifyMatchFailure(op, "C rank exceeds the result");
+      // ONNX broadcasts C to [M, N] unidirectionally. TOSA expands only size-1
+      // dimensions and needs matching rank, so left-pad C's shape with ones.
+      SmallVector<int64_t> padded(2, 1);
+      for (auto [idx, dim] : llvm::enumerate(cShape))
+        padded[2 - cShape.size() + idx] = dim;
+      if ((padded[0] != 1 && padded[0] != m) ||
+          (padded[1] != 1 && padded[1] != n))
+        return rewriter.notifyMatchFailure(op, "C is not broadcastable to Y");
+      if (cShape != ArrayRef<int64_t>(padded))
+        c = reshapeTo(c, padded, rewriter);
+
+      if (op.getBeta().convertToFloat() != 1.0f) {
+        auto betaType = cType.clone(padded);
+        c = tosa::MulOp::create(rewriter, loc, betaType, c,
+                                createSplatFloat(rewriter, loc, betaType,
+                                                 op.getBeta().convertToFloat()),
+                                createZeroMulShift(rewriter, loc));
+      }
+      result = tosa::AddOp::create(rewriter, loc, resultType, result, c);
+    }
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
 // Covers the hip ops whose operands are (ctx, lhs, rhs, output) and whose TOSA
 // counterpart preserves the element type. Comparisons (hip.equal, hip.less) do
 // not belong here: they produce i1, which isTosaCompatibleOperand's
@@ -1297,9 +1403,9 @@ class HipToTosaPass : public impl::ConvertHipToTosaPassBase<HipToTosaPass> {
     ConversionTarget conversion(*ctx);
     conversion.addLegalDialect<tosa::TosaDialect, func::FuncDialect>();
     conversion.addIllegalOp<
-        ConvOp, MatmulOp, TransposeOp, AddOp, SubOp, MinOp, MaxOp, MulOp, DivOp,
-        AbsOp, NegOp, CeilOp, FloorOp, ExpOp, LogOp, SinOp, CosOp, TanhOp,
-        ErfOp, SigmoidOp, ReciprocalOp, SqrtOp, WhereOp, LeakyReluOp,
+        ConvOp, MatmulOp, GemmOp, TransposeOp, AddOp, SubOp, MinOp, MaxOp,
+        MulOp, DivOp, AbsOp, NegOp, CeilOp, FloorOp, ExpOp, LogOp, SinOp, CosOp,
+        TanhOp, ErfOp, SigmoidOp, ReciprocalOp, SqrtOp, WhereOp, LeakyReluOp,
         MiopenSoftmaxOp, ReduceSumOp, ReduceMeanOp, CastOp, QuantizeLinearOp,
         DequantizeLinearOp>();
     // tosa.matmul (and other tosa ops) are not destination-passing, so
@@ -1320,8 +1426,8 @@ class HipToTosaPass : public impl::ConvertHipToTosaPassBase<HipToTosaPass> {
 
     RewritePatternSet patterns(ctx);
     patterns.add<
-        ConvConverter, MatMulConverter, TransposeConverter, ExpandConverter,
-        ReshapeConverter<tensor::CollapseShapeOp>,
+        ConvConverter, MatMulConverter, GemmConverter, TransposeConverter,
+        ExpandConverter, ReshapeConverter<tensor::CollapseShapeOp>,
         ReshapeConverter<tensor::ExpandShapeOp>, ExtractSliceConverter,
         DivConverter, BinaryConverter<AddOp, tosa::AddOp>,
         BinaryConverter<SubOp, tosa::SubOp>,

--- a/test/lit/Conversion/hip-to-tosa/test_gemm.mlir
+++ b/test/lit/Conversion/hip-to-tosa/test_gemm.mlir
@@ -1,0 +1,181 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// Licensed under the MIT License.
+
+// Verify hip.gemm expands into the tosa.matmul + tosa.add chain that ONNX Gemm
+// means: optional transposes, a batch-of-one around the batched tosa.matmul,
+// the alpha/beta scales, and C broadcast to [M, N].
+//
+// RUN: hip-mlir-opt --convert-hip-to-tosa --split-input-file \
+// RUN:   --verify-diagnostics %s | FileCheck %s
+
+// CHECK-LABEL: func.func @gemm
+// CHECK: %[[A:.*]] = tosa.reshape %arg1, {{.*}} -> tensor<1x32x64xf32>
+// CHECK: %[[B:.*]] = tosa.reshape %arg2, {{.*}} -> tensor<1x64x128xf32>
+// CHECK: %[[MM:.*]] = tosa.matmul %[[A]], %[[B]]
+// CHECK-SAME: -> tensor<1x32x128xf32>
+// CHECK: %[[FLAT:.*]] = tosa.reshape %[[MM]], {{.*}} -> tensor<32x128xf32>
+// CHECK: %[[C:.*]] = tosa.reshape %arg3, {{.*}} -> tensor<1x128xf32>
+// CHECK: tosa.add %[[FLAT]], %[[C]]
+// CHECK-NOT: hip.gemm
+func.func @gemm(%ctx: !hip.context, %a: tensor<32x64xf32>,
+                %b: tensor<64x128xf32>, %c: tensor<128xf32>,
+                %init: tensor<32x128xf32>) -> tensor<32x128xf32>
+    attributes {rock.kernel} {
+  %r = hip.gemm(%ctx) ins(%a, %b, %c :
+      tensor<32x64xf32>, tensor<64x128xf32>, tensor<128xf32>)
+      outs(%init : tensor<32x128xf32>) : tensor<32x128xf32>
+  return %r : tensor<32x128xf32>
+}
+
+// -----
+
+// C is optional; without it the matmul result is returned directly.
+// CHECK-LABEL: func.func @gemm_no_c
+// CHECK: tosa.matmul
+// CHECK-NOT: tosa.add
+// CHECK-NOT: hip.gemm
+func.func @gemm_no_c(%ctx: !hip.context, %a: tensor<4x8xf32>,
+                     %b: tensor<8x16xf32>, %init: tensor<4x16xf32>)
+    -> tensor<4x16xf32> attributes {rock.kernel} {
+  %r = hip.gemm(%ctx) ins(%a, %b : tensor<4x8xf32>, tensor<8x16xf32>)
+      outs(%init : tensor<4x16xf32>) : tensor<4x16xf32>
+  return %r : tensor<4x16xf32>
+}
+
+// -----
+
+// transA swaps A's dims before the matmul; A is [K, M] on the way in.
+// CHECK-LABEL: func.func @gemm_trans_a
+// CHECK: %[[AT:.*]] = tosa.transpose %arg1 {perms = array<i32: 1, 0>} : (tensor<8x4xf32>) -> tensor<4x8xf32>
+// CHECK: tosa.reshape %[[AT]], {{.*}} -> tensor<1x4x8xf32>
+// CHECK: tosa.matmul
+// CHECK-NOT: hip.gemm
+func.func @gemm_trans_a(%ctx: !hip.context, %a: tensor<8x4xf32>,
+                        %b: tensor<8x16xf32>, %init: tensor<4x16xf32>)
+    -> tensor<4x16xf32> attributes {rock.kernel} {
+  %r = hip.gemm(%ctx) ins(%a, %b : tensor<8x4xf32>, tensor<8x16xf32>)
+      outs(%init : tensor<4x16xf32>) {transA = 1 : i64} : tensor<4x16xf32>
+  return %r : tensor<4x16xf32>
+}
+
+// -----
+
+// transB swaps B's dims; B is [N, K] on the way in.
+// CHECK-LABEL: func.func @gemm_trans_b
+// CHECK: %[[BT:.*]] = tosa.transpose %arg2 {perms = array<i32: 1, 0>} : (tensor<16x8xf32>) -> tensor<8x16xf32>
+// CHECK: tosa.reshape %[[BT]], {{.*}} -> tensor<1x8x16xf32>
+// CHECK: tosa.matmul
+// CHECK-NOT: hip.gemm
+func.func @gemm_trans_b(%ctx: !hip.context, %a: tensor<4x8xf32>,
+                        %b: tensor<16x8xf32>, %init: tensor<4x16xf32>)
+    -> tensor<4x16xf32> attributes {rock.kernel} {
+  %r = hip.gemm(%ctx) ins(%a, %b : tensor<4x8xf32>, tensor<16x8xf32>)
+      outs(%init : tensor<4x16xf32>) {transB = 1 : i64} : tensor<4x16xf32>
+  return %r : tensor<4x16xf32>
+}
+
+// -----
+
+// alpha scales the product and beta scales C, each as a splat multiply.
+// CHECK-LABEL: func.func @gemm_alpha_beta
+// CHECK: %[[ALPHA:.*]] = "tosa.const"() <{values = dense<2.000000e+00> : tensor<4x16xf32>}>
+// CHECK: %[[SCALED:.*]] = tosa.mul {{.*}}, %[[ALPHA]]
+// CHECK: %[[BETA:.*]] = "tosa.const"() <{values = dense<5.000000e-01> : tensor<1x16xf32>}>
+// CHECK: %[[CB:.*]] = tosa.mul {{.*}}, %[[BETA]]
+// CHECK: tosa.add %[[SCALED]], %[[CB]]
+// CHECK-NOT: hip.gemm
+func.func @gemm_alpha_beta(%ctx: !hip.context, %a: tensor<4x8xf32>,
+                           %b: tensor<8x16xf32>, %c: tensor<16xf32>,
+                           %init: tensor<4x16xf32>) -> tensor<4x16xf32>
+    attributes {rock.kernel} {
+  %r = hip.gemm(%ctx) ins(%a, %b, %c :
+      tensor<4x8xf32>, tensor<8x16xf32>, tensor<16xf32>)
+      outs(%init : tensor<4x16xf32>)
+      {alpha = 2.0 : f32, beta = 0.5 : f32} : tensor<4x16xf32>
+  return %r : tensor<4x16xf32>
+}
+
+// -----
+
+// A C that already has the result's rank and shape needs no reshape.
+// CHECK-LABEL: func.func @gemm_full_c
+// CHECK: %[[MM:.*]] = tosa.matmul
+// CHECK: %[[FLAT:.*]] = tosa.reshape %[[MM]], {{.*}} -> tensor<4x16xf32>
+// CHECK: tosa.add %[[FLAT]], %arg3 : (tensor<4x16xf32>, tensor<4x16xf32>) -> tensor<4x16xf32>
+// CHECK-NOT: hip.gemm
+func.func @gemm_full_c(%ctx: !hip.context, %a: tensor<4x8xf32>,
+                       %b: tensor<8x16xf32>, %c: tensor<4x16xf32>,
+                       %init: tensor<4x16xf32>) -> tensor<4x16xf32>
+    attributes {rock.kernel} {
+  %r = hip.gemm(%ctx) ins(%a, %b, %c :
+      tensor<4x8xf32>, tensor<8x16xf32>, tensor<4x16xf32>)
+      outs(%init : tensor<4x16xf32>) : tensor<4x16xf32>
+  return %r : tensor<4x16xf32>
+}
+
+// -----
+
+// A column vector C broadcasts along N.
+// CHECK-LABEL: func.func @gemm_column_c
+// CHECK: tosa.add {{.*}} : (tensor<4x16xf32>, tensor<4x1xf32>) -> tensor<4x16xf32>
+// CHECK-NOT: hip.gemm
+func.func @gemm_column_c(%ctx: !hip.context, %a: tensor<4x8xf32>,
+                         %b: tensor<8x16xf32>, %c: tensor<4x1xf32>,
+                         %init: tensor<4x16xf32>) -> tensor<4x16xf32>
+    attributes {rock.kernel} {
+  %r = hip.gemm(%ctx) ins(%a, %b, %c :
+      tensor<4x8xf32>, tensor<8x16xf32>, tensor<4x1xf32>)
+      outs(%init : tensor<4x16xf32>) : tensor<4x16xf32>
+  return %r : tensor<4x16xf32>
+}
+
+// -----
+
+// Outside a rock.kernel the pass is a no-op.
+// CHECK-LABEL: func.func @gemm_not_a_kernel
+// CHECK: hip.gemm
+// CHECK-NOT: tosa.matmul
+func.func @gemm_not_a_kernel(%ctx: !hip.context, %a: tensor<4x8xf32>,
+                             %b: tensor<8x16xf32>, %init: tensor<4x16xf32>)
+    -> tensor<4x16xf32> {
+  %r = hip.gemm(%ctx) ins(%a, %b : tensor<4x8xf32>, tensor<8x16xf32>)
+      outs(%init : tensor<4x16xf32>) : tensor<4x16xf32>
+  return %r : tensor<4x16xf32>
+}
+
+// -----
+
+func.func @gemm_dynamic(%ctx: !hip.context, %a: tensor<?x8xf32>,
+                        %b: tensor<8x16xf32>, %init: tensor<?x16xf32>)
+    -> tensor<?x16xf32> attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.gemm'}}
+  %r = hip.gemm(%ctx) ins(%a, %b : tensor<?x8xf32>, tensor<8x16xf32>)
+      outs(%init : tensor<?x16xf32>) : tensor<?x16xf32>
+  return %r : tensor<?x16xf32>
+}
+
+// -----
+
+func.func @gemm_integer(%ctx: !hip.context, %a: tensor<4x8xi32>,
+                        %b: tensor<8x16xi32>, %init: tensor<4x16xi32>)
+    -> tensor<4x16xi32> attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.gemm'}}
+  %r = hip.gemm(%ctx) ins(%a, %b : tensor<4x8xi32>, tensor<8x16xi32>)
+      outs(%init : tensor<4x16xi32>) : tensor<4x16xi32>
+  return %r : tensor<4x16xi32>
+}
+
+// -----
+
+// C must broadcast to [M, N]; a length that matches neither 1 nor N is a
+// mismatch ONNX would have rejected at shape inference.
+func.func @gemm_bad_c(%ctx: !hip.context, %a: tensor<4x8xf32>,
+                      %b: tensor<8x16xf32>, %c: tensor<7xf32>,
+                      %init: tensor<4x16xf32>) -> tensor<4x16xf32>
+    attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.gemm'}}
+  %r = hip.gemm(%ctx) ins(%a, %b, %c :
+      tensor<4x8xf32>, tensor<8x16xf32>, tensor<7xf32>)
+      outs(%init : tensor<4x16xf32>) : tensor<4x16xf32>
+  return %r : tensor<4x16xf32>
+}

--- a/test/lit/Conversion/hip-to-tosa/test_gemm.mlir
+++ b/test/lit/Conversion/hip-to-tosa/test_gemm.mlir
@@ -167,6 +167,38 @@ func.func @gemm_integer(%ctx: !hip.context, %a: tensor<4x8xi32>,
 
 // -----
 
+// hipBLASLt runs f64 gemm (HIP_R_64F), but TOSA has no f64 tensor type, so
+// legalization must fail here rather than emit an unrepresentable tosa.matmul.
+func.func @gemm_f64(%ctx: !hip.context, %a: tensor<4x8xf64>,
+                    %b: tensor<8x16xf64>, %init: tensor<4x16xf64>)
+    -> tensor<4x16xf64> attributes {rock.kernel} {
+  // expected-error @+1 {{failed to legalize operation 'hip.gemm'}}
+  %r = hip.gemm(%ctx) ins(%a, %b : tensor<4x8xf64>, tensor<8x16xf64>)
+      outs(%init : tensor<4x16xf64>) : tensor<4x16xf64>
+  return %r : tensor<4x16xf64>
+}
+
+// -----
+
+// hipBLASLt keeps scaleType f32 for f16 data, so a non-unit alpha is applied
+// in f32 instead of being rounded to f16 first.
+// CHECK-LABEL: func.func @gemm_f16_alpha
+// CHECK: %[[MM:.*]] = tosa.matmul
+// CHECK: %[[R:.*]] = tosa.reshape %[[MM]]
+// CHECK: %[[UP:.*]] = tosa.cast %[[R]] : (tensor<4x16xf16>) -> tensor<4x16xf32>
+// CHECK: %[[MUL:.*]] = tosa.mul %[[UP]]
+// CHECK: tosa.cast %[[MUL]] : (tensor<4x16xf32>) -> tensor<4x16xf16>
+func.func @gemm_f16_alpha(%ctx: !hip.context, %a: tensor<4x8xf16>,
+                          %b: tensor<8x16xf16>, %init: tensor<4x16xf16>)
+    -> tensor<4x16xf16> attributes {rock.kernel} {
+  %r = hip.gemm(%ctx) ins(%a, %b : tensor<4x8xf16>, tensor<8x16xf16>)
+      outs(%init : tensor<4x16xf16>)
+      {alpha = 2.000000e+00 : f32} : tensor<4x16xf16>
+  return %r : tensor<4x16xf16>
+}
+
+// -----
+
 // C must broadcast to [M, N]; a length that matches neither 1 nor N is a
 // mismatch ONNX would have rejected at shape inference.
 func.func @gemm_bad_c(%ctx: !hip.context, %a: tensor<4x8xf32>,

--- a/tools/hip-rocmlir-compiler/hip-rocmlir-compiler.cpp
+++ b/tools/hip-rocmlir-compiler/hip-rocmlir-compiler.cpp
@@ -55,8 +55,17 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
-#include <dlfcn.h>
 #include <string>
+
+#ifdef _WIN32
+// Included after the LLVM/MLIR headers above, and with the two macro guards,
+// so windows.h's min/max and its wider macro surface cannot rewrite them.
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
 
 // ---------------------------------------------------------------------------
 // Minimal mlir-c type/function declarations for the symbols we resolve out of
@@ -167,6 +176,43 @@ struct Api {
   void (*getKernelAttrs)(MlirModule, uint32_t *); // [block, grid, cluster]
   bool (*getBinary)(MlirModule, size_t *, char *);
 };
+
+#ifdef _WIN32
+// Win32 stand-ins for the three POSIX loader calls used below, so the loading
+// logic itself stays platform-independent.
+//
+// RTLD_LOCAL has no Win32 counterpart because it needs none: a DLL never
+// contributes its exports to a process-global namespace, so the symbol
+// isolation that RTLD_LOCAL buys on ELF -- keeping the library's MLIR from
+// interposing this executable's own copy -- is simply how the loader already
+// behaves. The mode argument is therefore ignored.
+static void *dlopen(const char *path, int /*mode*/) {
+  return reinterpret_cast<void *>(LoadLibraryA(path));
+}
+
+static void *dlsym(void *handle, const char *name) {
+  return reinterpret_cast<void *>(
+      GetProcAddress(reinterpret_cast<HMODULE>(handle), name));
+}
+
+static std::string dlerror() {
+  DWORD err = GetLastError();
+  char *text = nullptr;
+  DWORD n = FormatMessageA(
+      FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+          FORMAT_MESSAGE_IGNORE_INSERTS,
+      nullptr, err, 0, reinterpret_cast<char *>(&text), 0, nullptr);
+  std::string msg = n && text ? std::string(text, n) : std::string();
+  if (text)
+    LocalFree(text);
+  while (!msg.empty() && (msg.back() == '\n' || msg.back() == '\r'))
+    msg.pop_back();
+  return msg.empty() ? "error " + std::to_string(err) : msg;
+}
+
+#define RTLD_NOW 0
+#define RTLD_LOCAL 0
+#endif
 
 template <typename T> static bool bind(void *handle, T &fn, const char *name) {
   fn = reinterpret_cast<T>(dlsym(handle, name));
@@ -468,12 +514,32 @@ static bool runRocmlirInSo(const std::string &moduleText,
   return true;
 }
 
+// Write a module as MLIR text for --dump-hip / --dump-tosa. Those dumps are
+// diagnostics on the way to `-o`, so a failure to write one is reported but
+// does not fail the compile.
+static void dumpModule(mlir::ModuleOp mod, llvm::StringRef label,
+                       llvm::StringRef path) {
+  std::error_code ec;
+  llvm::raw_fd_ostream os(path, ec);
+  if (ec) {
+    llvm::errs() << "warning: cannot open '" << path << "' to dump " << label
+                 << " MLIR: " << ec.message() << "\n";
+    return;
+  }
+  mod->print(os);
+  os << "\n";
+  llvm::errs() << "[hip-rocmlir-compiler] wrote " << label << " MLIR to "
+               << path << "\n";
+}
+
 int main(int argc, char **argv) {
   hip::install_crash_handlers("hip-rocmlir-compiler");
 
   std::string inputFilename;
   std::string outputPath;
   std::string userPerfConfig;
+  std::string dumpHipPath;
+  std::string dumpTosaPath;
   bool dumpHighLevel = false;
   for (int i = 1; i < argc; ++i) {
     std::string arg = argv[i];
@@ -481,6 +547,10 @@ int main(int argc, char **argv) {
       outputPath = argv[++i];
     } else if (arg == "--perf-config" && i + 1 < argc) {
       userPerfConfig = argv[++i];
+    } else if (arg == "--dump-hip" && i + 1 < argc) {
+      dumpHipPath = argv[++i];
+    } else if (arg == "--dump-tosa" && i + 1 < argc) {
+      dumpTosaPath = argv[++i];
     } else if (arg == "--dump-high-level") {
       dumpHighLevel = true;
     } else if (argv[i][0] != '-') {
@@ -500,6 +570,12 @@ int main(int argc, char **argv) {
            "instead of\n"
         << "                       enumerating the tuning space and taking "
            "the first.\n"
+        << "  --dump-hip <file>    Write the hip MLIR after the ONNX->HIP head "
+           "passes\n"
+        << "                       and fuse-rocmlir, then keep going.\n"
+        << "  --dump-tosa <file>   Write the TOSA MLIR handed to the rocMLIR "
+           "pipeline,\n"
+        << "                       then keep going.\n"
         << "  --dump-high-level    Stop after the rocMLIR high-level pipeline "
            "and\n"
         << "                       write the rock MLIR (text) to <output> "
@@ -554,6 +630,9 @@ int main(int argc, char **argv) {
     return 1;
   }
 
+  if (!dumpHipPath.empty())
+    dumpModule(*module, "hip", dumpHipPath);
+
   // Stage 2: on a CLONE, run the hip->tosa conversion (front of
   // buildRocMlirPipeline, minus its terminal hipEpAddHighLevelPipeline -- that
   // runs in the .so), then serialize only the `rock.kernel` funcs and compile
@@ -570,6 +649,12 @@ int main(int argc, char **argv) {
       return 1;
     }
   }
+
+  // Dumped before the non-kernel funcs are dropped below, so the dump shows the
+  // whole module (and matches what `hip-mlir-opt --convert-hip-to-tosa` prints)
+  // rather than just the kernels that cross into the .so.
+  if (!dumpTosaPath.empty())
+    dumpModule(*tosaModule, "tosa", dumpTosaPath);
 
   // The rocMLIR high-level pipeline errors on any non-kernel func (its
   // tosa->rock passes assert a `rock.kernel` attribute and walk ops assuming

--- a/tools/hip-rocmlir-compiler/hip-rocmlir-compiler.cpp
+++ b/tools/hip-rocmlir-compiler/hip-rocmlir-compiler.cpp
@@ -218,7 +218,7 @@ template <typename T> static bool bind(void *handle, T &fn, const char *name) {
   fn = reinterpret_cast<T>(dlsym(handle, name));
   if (!fn) {
     llvm::errs() << "error: symbol '" << name
-                 << "' not found in librockCompiler.so\n";
+                 << "' not found in the rock compiler library\n";
     return false;
   }
   return true;
@@ -281,13 +281,23 @@ static bool load(Api &api, const std::string &soPath) {
 
 } // namespace rockcapi
 
-// Resolve the librockCompiler.so path: ROCK_COMPILER_SO wins, else the
+// Platform-specific because an MSVC shared-library build emits
+// rockCompiler.dll, not librockCompiler.so.
+static const char *defaultSoPath() {
+#ifdef _WIN32
+  return "build/rockCompiler.dll";
+#else
+  return "build/librockCompiler.so";
+#endif
+}
+
+// Resolve the rock compiler library path: ROCK_COMPILER_SO wins, else the
 // in-tree build location.
 static std::string resolveSoPath() {
   if (const char *env = std::getenv("ROCK_COMPILER_SO"))
     if (env[0] != '\0')
       return env;
-  return "build/librockCompiler.so";
+  return defaultSoPath();
 }
 
 // Run the rocMLIR high-level pipeline inside the .so on the serialized module,
@@ -528,6 +538,16 @@ static void dumpModule(mlir::ModuleOp mod, llvm::StringRef label,
   }
   mod->print(os);
   os << "\n";
+  // raw_fd_ostream defers write and flush failures (a full disk, say) rather
+  // than reporting them at open time, so check before claiming success --
+  // otherwise a truncated dump reads as a good one.
+  os.flush();
+  if (os.has_error()) {
+    llvm::errs() << "warning: failed writing " << label << " MLIR to " << path
+                 << ": " << os.error().message() << "\n";
+    os.clear_error();
+    return;
+  }
   llvm::errs() << "[hip-rocmlir-compiler] wrote " << label << " MLIR to "
                << path << "\n";
 }
@@ -581,8 +601,9 @@ int main(int argc, char **argv) {
         << "                       write the rock MLIR (text) to <output> "
            "instead of\n"
         << "                       the compiled bitcode.\n"
-        << "  Set ROCK_COMPILER_SO to override the .so path "
-           "(default: build/librockCompiler.so).\n";
+        << "  Set ROCK_COMPILER_SO to override the rock compiler library path "
+           "(default: "
+        << defaultSoPath() << ").\n";
     return 1;
   }
 
@@ -651,8 +672,10 @@ int main(int argc, char **argv) {
   }
 
   // Dumped before the non-kernel funcs are dropped below, so the dump shows the
-  // whole module (and matches what `hip-mlir-opt --convert-hip-to-tosa` prints)
-  // rather than just the kernels that cross into the .so.
+  // whole module rather than just the kernels that cross into the .so. Note
+  // this is the *canonicalized* TOSA: `tpm` ran the canonicalizer above, so
+  // dead ops that `hip-mlir-opt --convert-hip-to-tosa` alone would print (the
+  // orphaned `tensor.empty` feeding a dropped DPS `outs`, for one) are gone.
   if (!dumpTosaPath.empty())
     dumpModule(*tosaModule, "tosa", dumpTosaPath);
 


### PR DESCRIPTION
﻿`hip.gemm` is a registered fusion anchor in `FuseROCMlir`, but it had no TOSA
converter and no entry in `HipToTosa`'s illegal-op list. Since the pass uses
`applyPartialConversion`, an op that is neither listed as illegal nor matched by
a pattern is simply treated as legal and passed through without a diagnostic.

So `FuseROCMlir` outlined the gemm into a `rock.kernel`, `convert-hip-to-tosa`
converted everything around it and left the gemm alone, and rocMLIR was then
handed a hip dialect op it has never seen. It died with `0xC0000409`
(`STATUS_STACK_BUFFER_OVERRUN`) ΓÇö no error message, no source location. Any
model containing an ONNX Gemm hit this.

The unconverted op reaching the kernel boundary looked like:

```mlir
func.func @rocMlir0(...) attributes {rock.arch = "gfx1151", rock.kernel} {
  %2 = hip.gemm(%0) ins(%arg0, %arg1, %arg2 : ...) outs(%1 : ...)
  %3 = tosa.sigmoid %2
  return %3
}
```

The sigmoid converted; the gemm did not.

## What this does

Expands `hip.gemm` the way ONNX defines it ΓÇö `Y = alpha * A' * B' + beta * C`:

- optional `transA` / `transB` become `tosa.transpose`
- `tosa.matmul` is batched, so a batch of one is wrapped around the rank-2
  operands and stripped afterwards
- `alpha` and `beta` become splat `tosa.mul`s, elided entirely when they are
  1.0, which is the common case
- `C` is left-padded with ones to the result's rank, because TOSA expands only
  size-1 dimensions while ONNX broadcasts unidirectionally

The same kernel now converts to:

```mlir
%7  = tosa.matmul %5, %6, %2, %2 : (tensor<1x32x64xf32>, tensor<1x64x128xf32>, ...) -> tensor<1x32x128xf32>
%8  = tosa.reshape %7, %1 : (tensor<1x32x128xf32>, !tosa.shape<2>) -> tensor<32x128xf32>
%9  = tosa.reshape %arg2, %0 : (tensor<128xf32>, !tosa.shape<2>) -> tensor<1x128xf32>
%10 = tosa.add %8, %9 : (tensor<32x128xf32>, tensor<1x128xf32>) -> tensor<32x128xf32>
%11 = tosa.sigmoid %10 : (tensor<32x128xf32>) -> tensor<32x128xf32>
```

Expanding into separate ops costs nothing downstream: MIGraphX's ONNX parser
desugars `Gemm` into exactly the same dot plus broadcast add, and on gfx1151
rocMLIR fuses that chain back into a single kernel (`mlir_dot_add_sigmoid`).

Integer gemm is rejected rather than converted. `alpha` and `beta` are f32
attributes applied as elementwise multiplies in the result type, so an integer
result would round them away silently; failing legalization is the honest
outcome.

## Validation

- New `test/lit/Conversion/hip-to-tosa/test_gemm.mlir` covers the basic form,
  omitted `C`, `transA`, `transB`, non-unit alpha/beta, a full-rank `C`, a
  column-vector `C` broadcasting along N, the non-kernel no-op, and rejections
  for dynamic shapes, integer element types, and a non-broadcastable `C`.
- Full lit suite passes (the one failure, `onnx-to-hip/test_qadd.mlir`, is
  pre-existing on this base and unrelated ΓÇö its RUN line never touches
  `HipToTosa`).
- End to end through `hip-rocmlir-compiler` against `librockCompiler`, the same
  model that previously crashed now compiles to a 5288-byte GPU binary
  (grid 16, block 64).


## Also here: hip-rocmlir-compiler on Windows

Folded in because CI's `build_mock` and `build_real` jobs run on `windows-2022`
and this was breaking them independently of the change above.

`tools/hip-rocmlir-compiler` reaches `librockCompiler`'s pipeline symbols
through the POSIX loader, and included `<dlfcn.h>` unconditionally. MSVC has no
such header, so the tool could not compile on Windows at all. The include is now
guarded, with `dlopen` / `dlsym` / `dlerror` stand-ins over `LoadLibraryA`,
`GetProcAddress` and `FormatMessageA`, so the loading logic itself stays
platform-independent.

`windows.h` is included after the LLVM/MLIR headers and behind
`WIN32_LEAN_AND_MEAN` and `NOMINMAX` so its macro surface cannot rewrite them.
`RTLD_LOCAL` is a no-op: a DLL never contributes its exports to a process-global
namespace, so the symbol isolation it buys on ELF â€” keeping the library's own
MLIR from interposing this executable's copy â€” is already how the Win32 loader
behaves.

The same commit adds `--dump-hip` and `--dump-tosa`, which write the module at
the two points where the pipeline hands work across a stage boundary. They were
what made the silent pass-through above visible in the first place. Both are
diagnostics on the way to `-o`, so failing to write one is reported without
failing the compile. The TOSA dump is taken before the non-kernel funcs are
dropped, so it matches what `hip-mlir-opt --convert-hip-to-tosa` prints rather
than showing only the kernels that cross into the `.so`.
